### PR TITLE
feat(cli): add Example fields to all Cobra commands

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -20,6 +20,11 @@ func newDogfoodCmd() *cobra.Command {
 		Use:   "dogfood",
 		Short: "Validate a generated CLI against its source spec",
 		Long:  "Mechanically verify that a generated CLI's commands hit valid API paths, auth matches the spec protocol, no dead flags/functions exist, and the data pipeline is wired correctly.",
+		Example: `  # Evaluate a generated CLI directory
+  printing-press dogfood --dir ./generated/stripe-cli
+
+  # Output as JSON for programmatic use
+  printing-press dogfood --dir ./generated/stripe-cli --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			report, err := pipeline.RunDogfood(dir, specPath)
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,17 @@ func newGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a Go CLI project from an API spec",
+		Example: `  # Generate from a local OpenAPI spec
+  printing-press generate --spec ./openapi.yaml
+
+  # Generate from a URL with force overwrite
+  printing-press generate --spec https://api.example.com/openapi.json --force
+
+  # Generate from API documentation
+  printing-press generate --docs https://docs.stripe.com/api --name stripe
+
+  # Multiple specs merged into one CLI
+  printing-press generate --spec api-v1.yaml --spec api-v2.yaml --name myapi`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if docsURL != "" {
 				apiName := cliName
@@ -341,8 +352,9 @@ func fetchOrCacheSpec(specURL string, refresh bool) ([]byte, error) {
 
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version",
+		Use:     "version",
+		Short:   "Print version",
+		Example: `  printing-press version`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("printing-press %s\n", version)
 		},
@@ -358,7 +370,15 @@ func newPrintCmd() *cobra.Command {
 		Use:   "print <api-name>",
 		Short: "Create an autonomous CLI generation pipeline",
 		Long:  "Creates a pipeline directory with plan seeds for each phase. Use /ce:work on each plan to execute.",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # Run full pipeline for a catalog API
+  printing-press print stripe
+
+  # Force overwrite existing pipeline
+  printing-press print stripe --force
+
+  # Resume an interrupted pipeline
+  printing-press print stripe --resume`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiName := args[0]
 

--- a/internal/cli/scorecard.go
+++ b/internal/cli/scorecard.go
@@ -17,6 +17,11 @@ func newScorecardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scorecard",
 		Short: "Score a generated CLI against the Steinberger bar",
+		Example: `  # Score a generated CLI directory
+  printing-press scorecard --dir ./generated/stripe-cli
+
+  # Output as JSON
+  printing-press scorecard --dir ./generated/stripe-cli --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dir == "" {
 				return fmt.Errorf("--dir is required")

--- a/internal/cli/vision.go
+++ b/internal/cli/vision.go
@@ -22,6 +22,8 @@ which uses LLM + web search to discover usage patterns, non-wrapper tools,
 workflows, and architecture decisions.
 
 The vision command produces the structure; Phase 0 fills it with intelligence.`,
+		Example: `  # Generate visionary research for an API
+  printing-press vision --api stripe --output ./research`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if apiName == "" {
 				return fmt.Errorf("--api is required")


### PR DESCRIPTION
Adds `Example` fields to all six Cobra commands (generate, dogfood, scorecard, print, vision, version) so `--help` output shows concrete usage examples. Each example uses real, existing flags.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)