### PR TITLE
docs: prevent concurrent worktree build collisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ go build -o ./printing-press ./cmd/printing-press
 go test ./...
 ```
 
+**IMPORTANT: Always use relative paths for build output.** Never build to `/tmp` or any shared absolute path. Multiple worktrees run concurrently and will stomp on each other. Use `./printing-press` exactly as shown above.
+
 ## Project Structure
 
 - `cmd/printing-press/` - CLI entry point


### PR DESCRIPTION
Agents running in parallel worktrees were all building to the same `/tmp/printing-press-review` path, causing race conditions. Added explicit guidance in CLAUDE.md to always use relative `./printing-press` for build output.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)