### PR TITLE
fix(generate): reject non-empty output directory without --force

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -103,6 +103,11 @@ func newGenerateCmd() *cobra.Command {
 					if err := os.RemoveAll(absOut); err != nil {
 						return fmt.Errorf("removing existing output dir: %w", err)
 					}
+				} else if info, err := os.Stat(absOut); err == nil && info.IsDir() {
+					entries, _ := os.ReadDir(absOut)
+					if len(entries) > 0 {
+						return fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
+					}
 				}
 
 				gen := generator.New(parsed, absOut)
@@ -186,6 +191,11 @@ func newGenerateCmd() *cobra.Command {
 			if force {
 				if err := os.RemoveAll(absOut); err != nil {
 					return fmt.Errorf("removing existing output dir: %w", err)
+				}
+			} else if info, err := os.Stat(absOut); err == nil && info.IsDir() {
+				entries, _ := os.ReadDir(absOut)
+				if len(entries) > 0 {
+					return fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
 				}
 			}
 


### PR DESCRIPTION
The generate command silently overwrites files when run twice on the same output directory without `--force`, because `os.MkdirAll` succeeds on existing directories. This adds a guard that checks whether the output directory is non-empty before proceeding — matching the existing collision-detection pattern in `pipeline.Init`.

Empty pre-existing directories (e.g., from `mktemp -d`) are still accepted, so the guard only fires when there are actual files at risk of being overwritten.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)