### PR TITLE
feat(cli): add --json flag to generate, print, and vision

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,6 +56,7 @@ func newGenerateCmd() *cobra.Command {
 	var lenient bool
 	var docsURL string
 	var polish bool
+	var asJSON bool
 
 	cmd := &cobra.Command{
 		Use:   "generate",
@@ -115,6 +117,7 @@ func newGenerateCmd() *cobra.Command {
 					}
 				}
 
+				polished := false
 				if polish {
 					fmt.Fprintln(os.Stderr, "Running LLM polish pass...")
 					polishResult, polishErr := llmpolish.Polish(llmpolish.PolishRequest{
@@ -126,12 +129,22 @@ func newGenerateCmd() *cobra.Command {
 					} else if polishResult.Skipped {
 						fmt.Fprintf(os.Stderr, "polish skipped: %s\n", polishResult.SkipReason)
 					} else {
+						polished = true
 						fmt.Fprintf(os.Stderr, "Polish: %d help texts improved, %d examples added, README %v\n",
 							polishResult.HelpTextsImproved, polishResult.ExamplesAdded, polishResult.READMERewritten)
 					}
 				}
 
 				fmt.Fprintf(os.Stderr, "Generated %s-cli at %s (from docs)\n", parsed.Name, absOut)
+				if asJSON {
+					json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+						"name":       parsed.Name,
+						"output_dir": absOut,
+						"spec_files": specFiles,
+						"validated":  validate,
+						"polished":   polished,
+					})
+				}
 				return nil
 			}
 
@@ -199,6 +212,7 @@ func newGenerateCmd() *cobra.Command {
 				}
 			}
 
+			polished := false
 			if polish {
 				fmt.Fprintln(os.Stderr, "Running LLM polish pass...")
 				polishResult, polishErr := llmpolish.Polish(llmpolish.PolishRequest{
@@ -210,12 +224,22 @@ func newGenerateCmd() *cobra.Command {
 				} else if polishResult.Skipped {
 					fmt.Fprintf(os.Stderr, "polish skipped: %s\n", polishResult.SkipReason)
 				} else {
+					polished = true
 					fmt.Fprintf(os.Stderr, "Polish: %d help texts improved, %d examples added, README %v\n",
 						polishResult.HelpTextsImproved, polishResult.ExamplesAdded, polishResult.READMERewritten)
 				}
 			}
 
 			fmt.Fprintf(os.Stderr, "Generated %s-cli at %s\n", apiSpec.Name, absOut)
+			if asJSON {
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"name":       apiSpec.Name,
+					"output_dir": absOut,
+					"spec_files": specFiles,
+					"validated":  validate,
+					"polished":   polished,
+				})
+			}
 			return nil
 		},
 	}
@@ -229,6 +253,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
 	cmd.Flags().StringVar(&docsURL, "docs", "", "API documentation URL to generate spec from")
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd
 }
@@ -353,6 +378,7 @@ func newPrintCmd() *cobra.Command {
 	var outputDir string
 	var force bool
 	var resume bool
+	var asJSON bool
 
 	cmd := &cobra.Command{
 		Use:   "print <api-name>",
@@ -380,6 +406,14 @@ func newPrintCmd() *cobra.Command {
 			}
 			fmt.Fprintf(os.Stderr, "\nStart with: /ce:work %s\n", state.PlanPath(pipeline.PhasePreflight))
 
+			if asJSON {
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"api_name":         apiName,
+					"pipeline_dir":     state.OutputDir,
+					"phases_completed": countCompletedPhases(state),
+					"state_file":       pipeline.StatePath(apiName),
+				})
+			}
 			return nil
 		},
 	}
@@ -387,6 +421,17 @@ func newPrintCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputDir, "output", "", "Output directory (default: ./<api-name>-cli)")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing pipeline")
 	cmd.Flags().BoolVar(&resume, "resume", false, "Resume from existing checkpoint")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+func countCompletedPhases(state *pipeline.PipelineState) int {
+	n := 0
+	for _, p := range state.Phases {
+		if p.Status == pipeline.StatusCompleted {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/cli/vision.go
+++ b/internal/cli/vision.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 func newVisionCmd() *cobra.Command {
 	var apiName string
 	var outputDir string
+	var asJSON bool
 
 	cmd := &cobra.Command{
 		Use:   "vision",
@@ -75,12 +77,19 @@ The vision command produces the structure; Phase 0 fills it with intelligence.`,
 
 			fmt.Fprintf(os.Stderr, "Visionary research template written to %s/visionary-research.md\n", absOut)
 			fmt.Fprintf(os.Stderr, "Run Phase 0 (SKILL.md) to fill it with real research.\n")
+			if asJSON {
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"api_name":    apiName,
+					"output_file": filepath.Join(absOut, "visionary-research.md"),
+				})
+			}
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&apiName, "api", "", "API name to research")
 	cmd.Flags().StringVar(&outputDir, "output", "", "Output directory (default: <api>-cli)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Adds `--json` flag to the three mutating commands (`generate`, `print`, `vision`) so agents can programmatically extract results like output paths and resource counts. JSON is emitted to stdout via `json.NewEncoder`, matching the existing pattern in `dogfood` and `scorecard`. All existing stderr output is unchanged.

## Details

- **generate**: Emits `{name, output_dir, spec_files, validated, polished}`. The `polished` field reflects the actual polish outcome — `false` if polish was skipped or failed, `true` only on success.
- **print**: Emits `{api_name, pipeline_dir, phases_completed, state_file}`. `phases_completed` is derived from `state.Phases` so `--resume` correctly reports progress.
- **vision**: Emits `{api_name, output_file}`.

## Test plan

- `go vet ./...` and `go build` pass
- `generate --help`, `print --help`, `vision --help` all show the `--json` flag
- JSON output goes to stdout only; stderr prose is unchanged

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)