### PR TITLE
docs: add testing guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,14 @@ Catalog entries in `catalog/` must pass `internal/catalog` validation:
 - category must be: auth, payments, email, developer-tools, project-management, communication, crm, example
 - tier must be: official or community
 
+## Testing
+
+**When you change code, check for a `_test.go` file in the same package.** If one exists, read it — your change likely requires a test update. If tests fail after your change, investigate whether it's a bug in your code or a stale test — don't just delete.
+
+Add tests for new non-trivial logic. Match the package's existing style (typically table-driven with `testify/assert`). Skip tests for CLI glue, trivial wrappers, and code only meaningfully tested via integration (`FULL_RUN=1`).
+
+Run `go test ./...` before considering your work done.
+
 ## Quality Gates
 
 Generated CLIs must pass 7 gates: go mod tidy, go vet, go build, binary build, --help, version, doctor.


### PR DESCRIPTION
## Summary

Adds a Testing section to AGENTS.md so AI agents consistently check for existing tests when modifying code. The guidance covers three things: look for `_test.go` files before considering work done, add tests for non-trivial new logic matching existing style, and skip tests for glue code and integration-only paths.

## Test plan

- [ ] Verify AGENTS.md parses correctly and reads naturally in context of the full file
- [ ] Confirm agents in subsequent sessions pick up the testing guidance when modifying packages with existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)