### PR TITLE
fix(marketplace): align marketplace.json with Claude Code schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,24 +1,22 @@
 {
+  "name": "cli-printing-press",
+  "owner": {
+    "name": "mvanhorn"
+  },
   "plugins": [
     {
       "name": "cli-printing-press",
       "version": "0.4.0",
       "description": "Describe your API. Get a production CLI. Generates Go CLI tools from OpenAPI specs or natural language descriptions.",
-      "author": "mvanhorn",
+      "author": {
+        "name": "mvanhorn"
+      },
       "repository": "mvanhorn/cli-printing-press",
       "tags": ["cli", "codegen", "openapi", "go", "api"],
-      "skills": [
-        {
-          "name": "printing-press",
-          "command": "/printing-press",
-          "description": "Generate a CLI from an API name or spec file"
-        },
-        {
-          "name": "printing-press-catalog",
-          "command": "/printing-press-catalog",
-          "description": "Browse and install pre-built CLIs for popular APIs"
-        }
-      ]
+      "source": {
+        "source": "github",
+        "repo": "mvanhorn/cli-printing-press"
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes marketplace.json validation errors when installing the plugin. The file was missing required fields and using incorrect types per the Claude Code marketplace schema.

**Changes:**
- Added required top-level `name` and `owner` fields
- Changed `author` from string to object format
- Removed `skills` array (skills are auto-discovered from plugin.json)
- Added required `source` field pointing to the GitHub repo