### PR TITLE
fix(plugin): remove invalid skills field from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,5 @@
   "name": "cli-printing-press",
   "version": "0.4.0",
   "description": "Generate production Go CLIs from API descriptions or OpenAPI specs",
-  "repository": "mvanhorn/cli-printing-press",
-  "skills": ["printing-press", "printing-press-catalog"]
+  "repository": "mvanhorn/cli-printing-press"
 }


### PR DESCRIPTION
Removes the `skills` array from `plugin.json`, which is not a valid manifest field. Claude Code auto-discovers skills from the `skills/` directory — the explicit array caused installation to fail with `skills: Invalid input`.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)