### PR TITLE
feat(pipeline): atomic auto-incrementing output directories

### DIFF
--- a/internal/cli/claim_integration_test.go
+++ b/internal/cli/claim_integration_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimOrForce_DefaultAutoIncrements(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "myapi-pp-cli")
+
+	// First call claims the base
+	got, err := claimOrForce(base, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, base, got)
+
+	// Second call auto-increments to -2
+	got, err = claimOrForce(base, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, base+"-2", got)
+
+	// Third call auto-increments to -3
+	got, err = claimOrForce(base, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, base+"-3", got)
+}
+
+func TestClaimOrForce_ForceOverwrites(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "myapi-pp-cli")
+
+	// Create base with a file in it
+	require.NoError(t, os.MkdirAll(base, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "main.go"), []byte("package main"), 0o644))
+
+	// Force should blow it away and recreate
+	got, err := claimOrForce(base, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, base, got)
+
+	// Old contents should be gone
+	entries, err := os.ReadDir(base)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestClaimOrForce_ExplicitOutputErrorsOnCollision(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "myapi-pp-cli")
+
+	// Create base with content
+	require.NoError(t, os.MkdirAll(base, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "main.go"), []byte("package main"), 0o644))
+
+	// Explicit output without force should error
+	_, err := claimOrForce(base, false, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestClaimOrForce_ExplicitOutputWithForce(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "myapi-pp-cli")
+
+	// Create base with content
+	require.NoError(t, os.MkdirAll(base, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "main.go"), []byte("package main"), 0o644))
+
+	// Explicit output with force should succeed
+	got, err := claimOrForce(base, true, true)
+	require.NoError(t, err)
+	assert.Equal(t, base, got)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -350,7 +350,10 @@ func claimOrForce(absOut string, force bool, explicitOutput bool) (string, error
 
 	if explicitOutput {
 		if info, err := os.Stat(absOut); err == nil && info.IsDir() {
-			entries, _ := os.ReadDir(absOut)
+			entries, readErr := os.ReadDir(absOut)
+			if readErr != nil {
+				return "", fmt.Errorf("reading output directory: %w", readErr)
+			}
 			if len(entries) > 0 {
 				return "", fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -118,15 +118,9 @@ func newGenerateCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("resolving output path: %w", err)
 				}
-				if force {
-					if err := os.RemoveAll(absOut); err != nil {
-						return fmt.Errorf("removing existing output dir: %w", err)
-					}
-				} else if info, err := os.Stat(absOut); err == nil && info.IsDir() {
-					entries, _ := os.ReadDir(absOut)
-					if len(entries) > 0 {
-						return fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
-					}
+				absOut, err = claimOrForce(absOut, force, outputDir != "")
+				if err != nil {
+					return &ExitError{Code: ExitInputError, Err: err}
 				}
 
 				gen := generator.New(parsed, absOut)
@@ -221,15 +215,9 @@ func newGenerateCmd() *cobra.Command {
 			if dryRun {
 				return printDryRun(apiSpec, absOut, specFiles)
 			}
-			if force {
-				if err := os.RemoveAll(absOut); err != nil {
-					return fmt.Errorf("removing existing output dir: %w", err)
-				}
-			} else if info, err := os.Stat(absOut); err == nil && info.IsDir() {
-				entries, _ := os.ReadDir(absOut)
-				if len(entries) > 0 {
-					return fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
-				}
+			absOut, err = claimOrForce(absOut, force, outputDir != "")
+			if err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
 			}
 
 			gen := generator.New(apiSpec, absOut)
@@ -340,6 +328,35 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 	}
 
 	return merged
+}
+
+// claimOrForce resolves the output directory based on --force and --output flags.
+//
+//   - force=true:  RemoveAll the target, then create it fresh (claims exact slot)
+//   - explicit output (--output set) without force: error if exists and non-empty
+//   - default (no --output, no --force): auto-increment via ClaimOutputDir
+func claimOrForce(absOut string, force bool, explicitOutput bool) (string, error) {
+	if force {
+		if err := os.RemoveAll(absOut); err != nil {
+			return "", fmt.Errorf("removing existing output dir: %w", err)
+		}
+		if err := os.MkdirAll(absOut, 0o755); err != nil {
+			return "", fmt.Errorf("creating output dir: %w", err)
+		}
+		return absOut, nil
+	}
+
+	if explicitOutput {
+		if info, err := os.Stat(absOut); err == nil && info.IsDir() {
+			entries, _ := os.ReadDir(absOut)
+			if len(entries) > 0 {
+				return "", fmt.Errorf("output directory %s already exists (use --force to overwrite)", absOut)
+			}
+		}
+		return absOut, nil
+	}
+
+	return pipeline.ClaimOutputDir(absOut)
 }
 
 func fetchOrCacheSpec(specURL string, refresh bool, skipCache bool) ([]byte, error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -111,6 +111,7 @@ func newGenerateCmd() *cobra.Command {
 					return &ExitError{Code: ExitSpecError, Err: fmt.Errorf("parsing generated spec: %w", err)}
 				}
 
+				explicitOutput := outputDir != ""
 				if outputDir == "" {
 					outputDir = pipeline.DefaultOutputDir(parsed.Name)
 				}
@@ -118,7 +119,7 @@ func newGenerateCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("resolving output path: %w", err)
 				}
-				absOut, err = claimOrForce(absOut, force, outputDir != "")
+				absOut, err = claimOrForce(absOut, force, explicitOutput)
 				if err != nil {
 					return &ExitError{Code: ExitInputError, Err: err}
 				}
@@ -204,6 +205,7 @@ func newGenerateCmd() *cobra.Command {
 				apiSpec = mergeSpecs(specs, cliName)
 			}
 
+			explicitOutput := outputDir != ""
 			if outputDir == "" {
 				outputDir = pipeline.DefaultOutputDir(apiSpec.Name)
 			}
@@ -215,7 +217,7 @@ func newGenerateCmd() *cobra.Command {
 			if dryRun {
 				return printDryRun(apiSpec, absOut, specFiles)
 			}
-			absOut, err = claimOrForce(absOut, force, outputDir != "")
+			absOut, err = claimOrForce(absOut, force, explicitOutput)
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: err}
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -269,7 +269,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&outputDir, "output", "", "Output directory (default: library/<name>-cli)")
 	cmd.Flags().BoolVar(&validate, "validate", true, "Run quality gates on the generated project")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh cached remote spec before generating")
-	cmd.Flags().BoolVar(&force, "force", false, "Remove existing output directory before generating")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite the base output directory (e.g. library/notion-pp-cli) instead of auto-incrementing")
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
 	cmd.Flags().StringVar(&docsURL, "docs", "", "API documentation URL to generate spec from")
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")

--- a/internal/pipeline/claim_test.go
+++ b/internal/pipeline/claim_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +65,43 @@ func TestClaimOutputDir_PermissionError(t *testing.T) {
 	assert.Error(t, err)
 	// Should NOT contain "could not claim" — should be the underlying OS error
 	assert.NotContains(t, err.Error(), "could not claim")
+}
+
+func TestClaimOutputDir_ConcurrentClaims(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "notion-pp-cli")
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	results := make(chan string, goroutines)
+	errs := make(chan error, goroutines)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			claimed, err := ClaimOutputDir(base)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- claimed
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	// No errors
+	for err := range errs {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// All claimed paths must be unique
+	seen := map[string]bool{}
+	for path := range results {
+		assert.False(t, seen[path], "duplicate claim: %s", path)
+		seen[path] = true
+	}
+	assert.Len(t, seen, goroutines)
 }

--- a/internal/pipeline/claim_test.go
+++ b/internal/pipeline/claim_test.go
@@ -1,0 +1,67 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimOutputDir_Fresh(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "notion-pp-cli")
+
+	claimed, err := ClaimOutputDir(base)
+	require.NoError(t, err)
+	assert.Equal(t, base, claimed)
+
+	// Directory should exist
+	info, err := os.Stat(claimed)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestClaimOutputDir_Increments(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "notion-pp-cli")
+
+	// Pre-create base and -2
+	require.NoError(t, os.Mkdir(base, 0o755))
+	require.NoError(t, os.Mkdir(base+"-2", 0o755))
+
+	claimed, err := ClaimOutputDir(base)
+	require.NoError(t, err)
+	assert.Equal(t, base+"-3", claimed)
+}
+
+func TestClaimOutputDir_MaxRetries(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "notion-pp-cli")
+
+	// Pre-create base + -2 through -99
+	require.NoError(t, os.Mkdir(base, 0o755))
+	for i := 2; i <= 99; i++ {
+		require.NoError(t, os.Mkdir(base+"-"+fmt.Sprintf("%d", i), 0o755))
+	}
+
+	_, err := ClaimOutputDir(base)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not claim")
+}
+
+func TestClaimOutputDir_PermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root")
+	}
+	// Parent dir that doesn't exist and can't be created — on macOS /proc doesn't exist,
+	// so use a path that will fail os.MkdirAll
+	base := "/nonexistent-root-dir/fakedir/notion-pp-cli"
+
+	_, err := ClaimOutputDir(base)
+	assert.Error(t, err)
+	// Should NOT contain "could not claim" — should be the underlying OS error
+	assert.NotContains(t, err.Error(), "could not claim")
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,15 +1,50 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 // DefaultOutputDir returns the default output directory for a given API name.
 // All commands should use this when --output is not specified.
 func DefaultOutputDir(apiName string) string {
 	return filepath.Join("library", apiName+"-cli")
+}
+
+// ClaimOutputDir atomically claims an output directory. If base already exists,
+// it tries base-2, base-3, ... up to base-99. Uses os.Mkdir (not MkdirAll) for
+// the leaf directory so exactly one concurrent caller wins each slot.
+func ClaimOutputDir(base string) (string, error) {
+	parent := filepath.Dir(base)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("creating parent directory: %w", err)
+	}
+
+	// Try the base name first
+	err := os.Mkdir(base, 0o755)
+	if err == nil {
+		return base, nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return "", fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// Base exists — try -2 through -99
+	for i := 2; i <= 99; i++ {
+		candidate := base + "-" + strconv.Itoa(i)
+		err := os.Mkdir(candidate, 0o755)
+		if err == nil {
+			return candidate, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return "", fmt.Errorf("creating output directory: %w", err)
+		}
+	}
+
+	return "", fmt.Errorf("could not claim output directory: all slots %s through %s-99 are taken", base, base)
 }
 
 // Options configures a pipeline run.


### PR DESCRIPTION
## Summary

When generating a CLI for an API that already has a `library/<name>-cli/` directory, the `generate` command now auto-increments the directory name (`-2`, `-3`, ... `-99`) instead of erroring. This enables iterative comparison of different generation approaches and safe concurrent generation by multiple Claude Code instances.

## What changed

**New `ClaimOutputDir` function** (`internal/pipeline/pipeline.go`) — uses `os.Mkdir` (not `MkdirAll`) for the leaf directory, making each claim atomic at the syscall level. Two processes racing for the same slot: exactly one wins, the other bumps to the next number. No locks needed.

**New `claimOrForce` helper** (`internal/cli/root.go`) — routes between three modes:

| Flags | Behavior |
|-------|----------|
| (none) | Auto-increment: `notion-pp-cli` → `-2` → `-3` via atomic `os.Mkdir` |
| `--force` | Claim base name specifically, `RemoveAll` if exists |
| `--output ./x` | Use exact path, error if exists and non-empty |
| `--output ./x --force` | Use exact path, `RemoveAll` if exists |

**Key design decision:** The folder suffix (`-2`, `-3`) is only for the directory. The CLI identity inside each folder (binary name, module path, help text) is always `<name>-cli` regardless of which slot was claimed.

## Guard rails

- `os.IsExist(err)` checked specifically — permission errors and disk full are hard stops, not retries
- Retry capped at 99 slots
- `explicitOutput` captured before default assignment to avoid always-true evaluation bug
- `os.ReadDir` error propagated (not silently discarded) in collision guard

## Test plan

- `TestClaimOutputDir_Fresh/Increments/MaxRetries/PermissionError` — unit tests for all `ClaimOutputDir` branches
- `TestClaimOutputDir_ConcurrentClaims` — 20 goroutines, all unique, passes with `-race -count=5`
- `TestClaimOrForce_DefaultAutoIncrements/ForceOverwrites/ExplicitOutputErrorsOnCollision/ExplicitOutputWithForce` — integration tests for the routing helper
- Full suite: 287 tests pass

---

[![Compound Engineering v2.55.0](https://img.shields.io/badge/Compound_Engineering-v2.55.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)