### PR TITLE
fix(skill): use AskUserQuestion in Phase 5.9 emboss prompt

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2057,7 +2057,7 @@ When the user asks "is this shippable?", "can we ship this?", "is it ready?", or
 
 # PHASE 5.9: OFFER EMBOSS
 
-After presenting the final report (Phase 5), ask the user:
+After presenting the final report (Phase 5), use AskUserQuestion to ask:
 
 "The CLI scored [X]/100 (Grade [Y]). Want me to run an emboss pass to improve it further? This re-researches the landscape, finds the top 5 improvements, builds them, and re-scores."
 
@@ -2066,7 +2066,7 @@ Options:
 - "No, I'm done" -> end the run
 - "I'll emboss later" -> tell user they can run `/printing-press emboss ./<api>-pp-cli`
 
-**Emboss is a FOLLOW-UP, not an automatic step. The user decides.**
+**WAIT for the user's answer before proceeding.** Do NOT continue or end the run until answered. Emboss is a FOLLOW-UP, not an automatic step. The user decides.
 
 ---
 


### PR DESCRIPTION
Phase 5.9 told the agent to "ask the user" about emboss, which agents interpreted as printing the question as text output — no interactive prompt, no blocking. Phase 0.1 (API key detection) works correctly because it explicitly says "Use AskUserQuestion to ask:" and includes a "WAIT for the user's answer" instruction.

This applies the same pattern to Phase 5.9: names the tool explicitly and adds the blocking WAIT instruction.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)