### PR TITLE
fix(skill): preserve codex fix delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Phase 5.9   Offer Emboss              (prompt)     [NEW] Opt-in second pass to i
 ### Codex Mode (opt-in)
 
 ```bash
-/printing-press Discord codex    # Offload code generation to Codex CLI (~60% Opus token savings)
+/printing-press Discord codex    # Offload code generation + fix patches to Codex CLI (~60% Opus token savings)
 /printing-press Discord          # Standard Opus mode (default)
 ```
 
-When you add `codex`, Phase 4's code generation tasks are delegated to Codex CLI. Claude stays the brain (research, planning, scoring, review). Codex does the hands (writing Go code from scoped prompts). Same quality, 60% fewer Opus tokens.
+When you add `codex`, Phase 4's code generation tasks and later fix-application passes are delegated to Codex CLI. Claude stays the brain (research, planning, scoring, review). Codex does the hands (writing Go code from scoped prompts). Same quality, 60% fewer Opus tokens.
 
 ## What Gets Generated
 

--- a/internal/pipeline/seeds.go
+++ b/internal/pipeline/seeds.go
@@ -338,6 +338,7 @@ and implement its fixes in a severity-gated loop (max 2 passes) until no Blocker
 - Reviewer agent: compound-engineering:cli-agent-readiness-reviewer (external plugin)
 - Plugin dependency declared in .claude/settings.json
 - Phase 4.8 analog: SKILL.md Phase 4.8 (Runtime Verification)
+- If the run started in codex mode, preserve that mode here: reviewer runs in Claude, but each accepted fix patch is delegated to Codex and then verified in Claude
 `,
 	PhaseShip: `---
 title: "{{.APIName}} CLI Pipeline - Phase 5: Ship"

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -128,7 +128,7 @@ If verify pass rate DECREASED, something broke. Revert the last improvement and 
 
 ## Codex Mode (Opt-In)
 
-Add `codex` to the command to offload code generation (Phase 4, 4.5, 5.7) to Codex CLI. Claude stays the brain (research, planning, scoring, review). Codex does the hands (writing Go code). Saves ~60% Opus tokens per run.
+Add `codex` to the command to offload code generation and fix application (Phase 4, 4.5, 4.9, 5.7) to Codex CLI. Claude stays the brain (research, planning, scoring, review). Codex does the hands (writing Go code). Saves ~60% Opus tokens per run.
 
 **Default is OFF.** Standard Opus mode runs unless you explicitly type `codex`.
 
@@ -188,6 +188,7 @@ cd ~/cli-printing-press && echo "$CODEX_PROMPT" | codex exec --yolo -
 | Writing workflow commands (sync, search, sql, etc.) | Phase 0.7: Architecture decisions |
 | Writing insight commands (health, trends, etc.) | Phase 3: Non-Obvious Insight Review |
 | Applying scorecard fixes (dead code, wiring flags) | Phase 4.7: Proof of Behavior verification |
+| Applying reviewer fixes from Phase 4.9 | Reviewer dispatch, fix prioritization, acceptance decision |
 | README cookbook section | Phase 5: Ship Readiness Assessment |
 | Fix cycle patches (5-50 lines each) | Phase 5.5: Live API Testing |
 
@@ -1948,12 +1949,19 @@ For each fix in the reviewer's ranked recommended fixes list:
 
 1. Read the fix description and target file:line
 2. If the referenced file does not exist or the line is out of bounds: skip this fix, log a warning
-3. Make the code change
-4. Run `go build ./... && go vet ./...` to verify the change compiles and passes vet
-5. If build or vet fails: revert the change, skip this fix, continue to next
-6. Move to the next fix
+3. If `CODEX_MODE` is true, treat this fix as a **separate Codex call** using the Codex Delegation Pattern from the top of this skill:
+   - Claude assembles a prompt with the exact reviewer finding, exact file:line, current code snippet, expected behavioral change, repo conventions, and the same constraints (`no git`, listed files only, `go build ./... && go vet ./...` at the end)
+   - Scope the call to the smallest possible patch, ideally 1 file and under 100 lines
+   - After Codex returns, immediately verify the target file still exists and is non-empty before reviewing the diff
+   - If Codex fails, empties/deletes the file, edits outside scope, or fails verification: revert that attempted change and apply the fix directly in Claude as a fallback
+4. If `CODEX_MODE` is false, make the code change directly in Claude
+5. Run `go build ./... && go vet ./...` to verify the change compiles and passes vet
+6. If build or vet fails: revert the change, skip this fix, continue to next
+7. Move to the next fix
 
 All listed fixes are attempted — the reviewer already ranks by impact.
+
+**Important:** The reviewer agent itself always runs inside Claude Code. Only the code-writing step is delegated. This preserves the same split as Phase 4: Claude reviews, prioritizes, and verifies; Codex writes the patch when the run started in Codex mode.
 
 ### Step 4.9d: Termination Check
 
@@ -2158,7 +2166,7 @@ If ANY test fails (WARN or FAIL verdict), automatically enter Phase 5.7 Ship Loo
 
 2. Write a targeted fix plan listing each bug with file:line and proposed fix
 3. Present the plan to the user: "Live testing found N bugs. Here's the fix plan. Proceed?"
-4. If yes: fix all bugs, then re-run Phase 5.5 live tests to verify
+4. If yes: fix all bugs (delegate each code-writing patch to Codex if `CODEX_MODE` is true, otherwise fix directly in Claude), then re-run Phase 5.5 live tests to verify
 5. If all tests pass after fix: proceed to Final Report with PASS
 6. If still failing: report remaining issues, max 2 fix cycles for live test bugs
 
@@ -2186,13 +2194,15 @@ When the user asks "is this shippable?", "can we ship this?", "is it ready?", or
    - Present: "Not yet. Found N issues. Top 3:"
    - List each issue with severity, file, and proposed fix
    - Ask: "Want me to fix these and re-test?"
-   - If yes: write fix plan -> apply fixes -> re-run verification + live tests -> present updated score
+   - If yes: write fix plan -> apply fixes (delegate code-writing patches to Codex if `CODEX_MODE` is true) -> re-run verification + live tests -> present updated score
    - If no: present issues for manual review
 
 ## Fix Loop Rules
 
 - Max 3 fix-loop iterations per session
 - Each iteration targets only the top 3 highest-impact issues
+- If `CODEX_MODE` is true, each fix is a separate Codex call using the same Codex Delegation Pattern as Phase 4 and Phase 4.9
+- Claude still owns the bug triage, fix plan, verification, and go/no-go decision; Codex only writes the scoped patch
 - After each fix: `go build ./... && go vet ./...` must pass
 - After each fix: re-run Proof of Behavior verification
 - After each fix: if API key available, re-run live tests


### PR DESCRIPTION
This keeps the skill from silently switching back to Claude for later fix-writing passes after a run started in `codex` mode. Phase 4.9 now uses the same Claude-brain/Codex-hands split as Phase 4, Phase 5.7 now explicitly follows that same pattern, and the agent-readiness seed plus README reflect the preserved behavior. Verified with `go test ./...` and `go build -o ./printing-press ./cmd/printing-press`.

---

[![Compound Engineering v0.4.0](https://img.shields.io/badge/Compound_Engineering-v0.4.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (200K context, extended thinking) via [Codex](https://openai.com/codex)
