### PR TITLE
docs: add compound engineering plugin to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,24 @@ printing-press dogfood --dir ./discord-cli --spec /tmp/discord-spec.json
 /install-skill https://github.com/mvanhorn/cli-printing-press
 ```
 
-Then build the binary (needed for scorecard, verify, and dogfood commands):
+### Install the Compound Engineering Plugin
+
+The printing press leverages agents from the [Compound Engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) to improve generated CLI quality and agent readiness. Install it before running the press:
+
+```bash
+/plugin marketplace add EveryInc/compound-engineering-plugin
+/plugin install compound-engineering
+```
+
+After installing both the skill and plugin, reload:
+
+```bash
+/reload-plugins
+```
+
+### Build the Binary
+
+Build the binary (needed for scorecard, verify, and dogfood commands):
 
 ```bash
 cd ~/cli-printing-press


### PR DESCRIPTION
Adds the [Compound Engineering plugin](https://github.com/EveryInc/compound-engineering-plugin) as a setup dependency in the Quick Start section. The printing press uses agents from this plugin to evaluate CLI quality and agent readiness, so users need it installed before running the press.

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)