### PR TITLE
fix(ci): shared build cache and Go module caching to prevent test timeouts

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
@@ -61,7 +61,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -13,7 +13,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
+          cache: true
 
       - name: Build printing-press
         run: go build -o ./printing-press ./cmd/printing-press
@@ -64,7 +65,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
+          cache: true
 
       - name: Run all tests
-        run: go test ./...
+        run: go test -p 2 ./...

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -3,8 +3,6 @@ package generator
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -146,13 +144,12 @@ func runCommand(dir string, timeout time.Duration, name string, args ...string) 
 }
 
 func goBuildCacheDir(dir string) (string, error) {
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolving build cache path: %w", err)
-	}
-
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
+		absDir, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			return "", fmt.Errorf("resolving build cache path: %w", absErr)
+		}
 		fallback := filepath.Join(absDir, ".cache", "go-build")
 		if mkErr := os.MkdirAll(fallback, 0o755); mkErr != nil {
 			return "", fmt.Errorf("creating fallback build cache dir: %w", mkErr)
@@ -160,8 +157,10 @@ func goBuildCacheDir(dir string) (string, error) {
 		return fallback, nil
 	}
 
-	sum := sha256.Sum256([]byte(absDir))
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press", "go-build", hex.EncodeToString(sum[:]))
+	// Use a single shared cache for all generated CLIs.
+	// Per-project caches forced each parallel test to compile the Go
+	// standard library from scratch, causing CI timeouts.
+	cacheDir := filepath.Join(homeDir, ".cache", "printing-press", "go-build")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return "", fmt.Errorf("creating build cache dir: %w", err)
 	}


### PR DESCRIPTION
## Summary

Generator tests run 4+ parallel Go compilations on CI's 2-vCPU runner. Each used a per-project build cache (SHA of output dir), forcing every test to compile the Go standard library from scratch. Combined with no Go module caching, this caused `go vet` to timeout after 2 minutes — the flaky `TestGenerateWithNoAuth` failure.

## Changes

**`internal/generator/validate.go`** — `goBuildCacheDir()` now returns a single shared cache (`~/.cache/printing-press/go-build`) instead of per-project caches. Parallel tests share compiled stdlib and dependencies instead of each rebuilding from scratch.

**`.github/workflows/validate-catalog.yml`**:
- `go-version-file: go.mod` instead of hardcoded `1.22` (repo uses 1.26.1)
- `cache: true` on `setup-go` for Go module caching between runs
- `go test -p 2 ./...` limits package parallelism to match CI's 2 vCPUs

---

[![Compound Engineering v2.58.1](https://img.shields.io/badge/Compound_Engineering-v2.58.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)