### PR TITLE
docs(cli): update README install for standalone binary + plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,23 @@ Claude Code, Codex, Gemini CLI, Cursor - they call CLIs thousands of times a day
 /printing-press Discord
 /printing-press Stripe
 /printing-press Linear
-/printing-press emboss ./library/notion-cli   # Second pass: improve an existing CLI
+/printing-press emboss ~/printing-press/library/notion-pp-cli   # Second pass: improve an existing CLI
 ```
 
 One command. Lean loop. Produces a Go CLI + MCP server that absorbs every feature from every competing tool, then transcends with compound use cases only possible with local data. REST or GraphQL.
 
 ### Get it
 
+Install the binary, then start a Claude Code session and run each command one after another:
+
 ```bash
-/install-skill https://github.com/mvanhorn/cli-printing-press
+go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest
+```
+
+```
+/plugin marketplace add mvanhorn/cli-printing-press
+/plugin install cli-printing-press@cli-printing-press
+/reload-plugins
 ```
 
 ## Every Endpoint. Every Insight. One Command.
@@ -150,7 +158,7 @@ When you add `codex`, Phase 3's code generation tasks are delegated to Codex CLI
 ### Emboss Mode (second pass)
 
 ```bash
-/printing-press emboss ./library/notion-cli   # Improve an existing CLI
+/printing-press emboss ~/printing-press/library/notion-pp-cli   # Improve an existing CLI
 ```
 
 Already generated a CLI? Emboss runs a 30-minute improvement cycle: audit baseline (verify + scorecard), re-research what's changed, identify top 5 improvements, build them, re-verify, report the delta. The binary handles the bookkeeping (`printing-press emboss --audit-only`), the skill handles the creative work.
@@ -236,18 +244,23 @@ printing-press dogfood --dir ./discord-pp-cli --spec /tmp/discord-spec.json
 
 ## Quick Start
 
-### Install the Skill (Claude Code)
+### Install
+
+Install the binary (requires Go 1.22+):
 
 ```bash
-/install-skill https://github.com/mvanhorn/cli-printing-press
+go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest
 ```
 
-Then build the binary (needed for scorecard, verify, and dogfood commands):
+Then start a Claude Code session and run each command one after another:
 
-```bash
-cd "$(git rev-parse --show-toplevel)"
-go build -o ./printing-press ./cmd/printing-press
 ```
+/plugin marketplace add mvanhorn/cli-printing-press
+/plugin install cli-printing-press@cli-printing-press
+/reload-plugins
+```
+
+No repo checkout needed. The binary embeds its own catalog data and the plugin provides the `/printing-press` skill.
 
 ### Run It
 


### PR DESCRIPTION
## Summary

Updates README install instructions to reflect PR #32 (standalone binary via `go install`) and PR #30 (`~/printing-press/` output layout with `-pp-cli` naming).

- **Install flow**: Replaced `/install-skill` with `go install` + marketplace plugin install (`/plugin marketplace add`, `/plugin install`, `/reload-plugins`). No repo checkout needed.
- **Emboss paths**: Fixed two emboss examples from `./library/notion-cli` to `~/printing-press/library/notion-pp-cli`
- **Quick Start**: Consolidated "Install the Skill" + "build the binary" into a single "Install" section

---

[![Compound Engineering v2.58.1](https://img.shields.io/badge/Compound_Engineering-v2.58.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)