### PR TITLE
docs(cli): fix Trevin article link in credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Synthesized from post-mortems on Notion and Linear runs. 14 changes to the skill
 ## Credits
 
 - **Peter Steinberger** ([@steipete](https://github.com/steipete)) - [discrawl](https://github.com/steipete/discrawl) and [gogcli](https://github.com/steipete/gogcli) set the bar. The quality scoring system is inspired by his work. discrawl v0.2.0's sync architecture directly influenced the printing press templates.
-- **Trevin Chow** ([@trevin](https://x.com/trevin)) - [7 Principles for Agent-Friendly CLIs](https://x.com/trevin) shaped the agent-first template design.
+- **Trevin Chow** ([@trevin](https://x.com/trevin)) - [7 Principles for Agent-Friendly CLIs](https://x.com/trevin/status/2037250000821059933) shaped the agent-first template design.
 - **Ramp** ([@tryramp](https://github.com/ramp-public/ramp-cli)) - Their agent-first CLI inspired auto-JSON piping, --no-input, and --compact output.
 ## License
 


### PR DESCRIPTION
## Summary

- Fixes the article link for Trevin Chow's "7 Principles for Agent-Friendly CLIs" in the Credits section — was linking to x.com/trevin (profile) instead of the actual tweet

## Test plan

- [x] Verify link resolves to the correct tweet

🤖 Generated with [Claude Code](https://claude.com/claude-code)