### PR TITLE
chore(cli): add lefthook pre-push lint and deny --no-verify bypass

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,12 @@
   "enabledPlugins": {
     "compound-engineering@every-marketplace": true
   },
+  "permissions": {
+    "deny": [
+      "Bash(git commit --no-verify:*)",
+      "Bash(git push --no-verify:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,14 @@
 # CLI Printing Press - Development Conventions
 
-## Build & Test
+## Build, Test & Lint
 
 ```bash
 go build -o ./printing-press ./cmd/printing-press
 go test ./...
+golangci-lint run --new-from-rev=origin/main ./...
 ```
+
+Run `golangci-lint` before pushing. The CI `lint` job runs the same checks — catching issues locally saves a round-trip. Config is in `.golangci.yml` (errcheck, govet, staticcheck, unused).
 
 **IMPORTANT: Always use relative paths for build output.** Never build to `/tmp` or any shared absolute path. Multiple worktrees run concurrently and will stomp on each other. Use `./printing-press` exactly as shown above.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ go test ./...
 golangci-lint run --new-from-rev=origin/main ./...
 ```
 
-Run `golangci-lint` before pushing. The CI `lint` job runs the same checks — catching issues locally saves a round-trip. Config is in `.golangci.yml` (errcheck, govet, staticcheck, unused).
+A pre-push hook runs `golangci-lint` automatically on `git push`. The same config (`.golangci.yml`: errcheck, govet, staticcheck, unused) runs in CI. To run lint manually: `golangci-lint run --new-from-rev=origin/main ./...`
 
 **IMPORTANT: Always use relative paths for build output.** Never build to `/tmp` or any shared absolute path. Multiple worktrees run concurrently and will stomp on each other. Use `./printing-press` exactly as shown above.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,27 @@ Synthesized from post-mortems on Notion and Linear runs. 14 changes to the skill
 
 **Emboss:** Now opt-in only. Offered at end of run, never triggered automatically.
 
+## Development
+
+After cloning, install git hooks so lint errors are caught before they reach CI:
+
+```bash
+go install github.com/evilmartians/lefthook@latest
+lefthook install
+```
+
+This adds a pre-push hook that runs `golangci-lint` on changed files. The same linter config (`.golangci.yml`) runs in CI — lefthook just catches failures locally first.
+
+If you also want `golangci-lint` locally:
+
+```bash
+# macOS
+brew install golangci-lint
+
+# or via go
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+```
+
 ## Credits
 
 - **Peter Steinberger** ([@steipete](https://github.com/steipete)) - [discrawl](https://github.com/steipete/discrawl) and [gogcli](https://github.com/steipete/gogcli) set the bar. The quality scoring system is inspired by his work. discrawl v0.2.0's sync architecture directly influenced the printing press templates.

--- a/README.md
+++ b/README.md
@@ -357,8 +357,10 @@ After cloning, install git hooks so lint errors are caught before they reach CI:
 
 ```bash
 go install github.com/evilmartians/lefthook@latest
-lefthook install
+~/go/bin/lefthook install
 ```
+
+> **Note:** If `lefthook` isn't found after `go install`, your `$GOPATH/bin` (`~/go/bin` by default) may not be in your `PATH`. Either use the full path as shown above, or add `export PATH="$HOME/go/bin:$PATH"` to your `~/.zshrc`.
 
 This adds a pre-push hook that runs `golangci-lint` on changed files. The same linter config (`.golangci.yml`) runs in CI — lefthook just catches failures locally first.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-push:
+  commands:
+    lint:
+      glob: "*.go"
+      run: golangci-lint run --new-from-rev=origin/main ./...
+      fail_text: "golangci-lint failed. Fix lint errors before pushing."


### PR DESCRIPTION
## Summary

Adds local lint enforcement so `golangci-lint` errors are caught before they reach CI.

**Before:** lint failures only surfaced after pushing and waiting for the CI `lint` job (~3 min round-trip).

**After:** `lefthook` runs `golangci-lint` on changed files at pre-push time (~2 seconds).

## What changed

- **`lefthook.yml`** — pre-push hook runs `golangci-lint run --new-from-rev=origin/main` (changed files only, fast)
- **AGENTS.md** — added `golangci-lint` to the Build & Test section so all agents (Claude Code, Codex, Gemini CLI) know to run it
- **`.claude/settings.json`** — denies `git commit --no-verify` and `git push --no-verify` so agents can't bypass hooks
- **README** — new Development section with `lefthook install` and `golangci-lint` setup instructions

## Setup (one-time after clone)

```bash
go install github.com/evilmartians/lefthook@latest
~/go/bin/lefthook install
```

---

[![Compound Engineering v2.58.1](https://img.shields.io/badge/Compound_Engineering-v2.58.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)