### PR TITLE
docs(cli): use brew for lefthook install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,11 +356,9 @@ Synthesized from post-mortems on Notion and Linear runs. 14 changes to the skill
 After cloning, install git hooks so lint errors are caught before they reach CI:
 
 ```bash
-go install github.com/evilmartians/lefthook@latest
-~/go/bin/lefthook install
+brew install lefthook
+lefthook install
 ```
-
-> **Note:** If `lefthook` isn't found after `go install`, your `$GOPATH/bin` (`~/go/bin` by default) may not be in your `PATH`. Either use the full path as shown above, or add `export PATH="$HOME/go/bin:$PATH"` to your `~/.zshrc`.
 
 This adds a pre-push hook that runs `golangci-lint` on changed files. The same linter config (`.golangci.yml`) runs in CI — lefthook just catches failures locally first.
 


### PR DESCRIPTION
## Summary
- Switch lefthook install instructions from `go install` to `brew install`
- `go install` puts the binary in `~/go/bin` which isn't reliably in PATH for git hooks (especially when invoked by GUI apps or agent tools like Conductor)
- `brew install` puts it in `/opt/homebrew/bin` which is universally available, removing the need for PATH workarounds

## Test plan
- [ ] Verify `brew install lefthook && lefthook install` works on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)