### PR TITLE
fix(skills): auto-install printing-press binary in setup contract

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -115,13 +115,17 @@ Before doing anything else:
 # min-binary-version: 0.2.0
 if ! command -v printing-press >/dev/null 2>&1; then
   if [ -x "$HOME/go/bin/printing-press" ]; then
-    echo "printing-press found at ~/go/bin/printing-press but not on PATH."
-    echo "Add GOPATH/bin to your PATH:  export PATH=\"\$HOME/go/bin:\$PATH\""
+    export PATH="$HOME/go/bin:$PATH"
+    echo "Added ~/go/bin to PATH"
+  elif command -v go >/dev/null 2>&1; then
+    echo "printing-press not found. Installing..."
+    GOPRIVATE=github.com/mvanhorn/* go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest
+    export PATH="$HOME/go/bin:$PATH"
   else
-    echo "printing-press binary not found."
-    echo "Install with:  go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest"
+    echo "printing-press binary not found and Go is not installed."
+    echo "Install Go first, then run:  go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest"
+    return 1 2>/dev/null || exit 1
   fi
-  return 1 2>/dev/null || exit 1
 fi
 
 # Derive scope: prefer git repo root, fall back to CWD

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -206,7 +206,17 @@ Before new research:
    - `$PRESS_MANUSCRIPTS/<api>/*/research/*`
    - `$REPO_ROOT/docs/plans/*<api>*` (legacy fallback)
 3. Reuse good prior work instead of redoing it.
-4. **API Key Gate (MANDATORY STOP)** — Check for an API key and get explicit user consent before proceeding to Phase 1.
+4. **API Key Gate** — Check whether this API requires authentication, then handle accordingly.
+
+**First, determine if the API needs auth.** Use these signals:
+- The spec has no `security` or `securityDefinitions` section → likely no auth needed
+- The API is known to be public/unauthenticated (e.g., ESPN, weather APIs, public data APIs)
+- No env var matching the API name exists AND no known token pattern applies
+- Community docs or npm/PyPI wrappers describe the API as "no auth required"
+
+**If the API does NOT require auth** (public/unauthenticated), skip the key gate entirely. Proceed silently — do not ask the user about API keys for a public API. Live smoke testing in Phase 5 will work without a key.
+
+**If the API DOES require auth**, run the key gate:
 
 Token detection order:
 - GitHub: `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`
@@ -230,7 +240,7 @@ Token detection order:
 - If the user provides a key → proceed with the key available for Phase 5.
 - If the user declines → proceed without the key and display: "Live smoke testing (Phase 5) will be skipped. The CLI will still be generated and verified against mock responses."
 
-Always resolve the API key gate before moving to Phase 1.
+Resolve the API key gate (or skip it for public APIs) before moving to Phase 1.
 
 ## Phase 1: Research Brief
 


### PR DESCRIPTION
## Summary

The setup contract now auto-installs the printing-press binary instead of dumping instructions and exiting. Three cases:

1. **Binary at ~/go/bin but not on PATH** → adds to PATH automatically
2. **Go installed but binary missing** → runs `go install` automatically  
3. **Go not installed** → only case that still fails with instructions

Before: user had to copy-paste install commands and re-run the skill.
After: skill handles it and continues.

## Test plan

- [x] Tested: binary exists at ~/go/bin → PATH updated, skill continues
- [ ] Test: fresh machine with Go but no binary → auto-installs
- [ ] Test: no Go installed → clear error message