### PR TITLE
feat(cli): add smart-default output format to generator templates

### DIFF
--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -192,6 +192,20 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 				return printOutput(cmd.OutOrStdout(), json.RawMessage(envelopeJSON), true)
 			}
 {{- end}}
+{{- if or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")}}
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
+						return err
+					}
+					if len(items) >= 25 {
+						fmt.Fprintf(os.Stderr, "\nShowing %d results. To narrow: add --limit, --json --select, or filter flags.\n", len(items))
+					}
+					return nil
+				}
+			}
+{{- end}}
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		},
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -519,6 +519,35 @@ func suggestFlag(unknown string, cmd *cobra.Command) string {
 	return best
 }
 
+// wantsHumanTable returns true when output should be a human-friendly table.
+// Smart default: terminal=table, pipe=JSON.
+// - Human in terminal: isTerminal()=true → table
+// - Claude Code/Codex bash tool: stdout piped → JSON
+// - --json/--csv/--compact/--agent: machine format → JSON
+func wantsHumanTable(w io.Writer, flags *rootFlags) bool {
+	if flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain {
+		return false
+	}
+	if flags.selectFields != "" {
+		return false
+	}
+	return isTerminal(w)
+}
+
+// formatCompact formats large numbers compactly (e.g., 1.2M, 728K).
+func formatCompact(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 10_000:
+		return fmt.Sprintf("%.0fK", float64(n)/1_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+
 func printAutoTable(w io.Writer, items []map[string]any) error {
 	if len(items) == 0 {
 		return nil


### PR DESCRIPTION
## Summary
- Generated CLIs now auto-detect terminal vs pipe for output format: terminal = human-friendly table, pipe = JSON
- Adds `wantsHumanTable()` helper and `formatCompact()` to `helpers.go.tmpl`
- Adds table rendering path for GET/HEAD endpoints in `command_endpoint.go.tmpl`
- Only applies to GET/HEAD endpoints with array responses; POST/PUT/DELETE unchanged

## Why this works for agents
Claude Code, Codex, and scripts capture stdout as a pipe — `isTerminal()` returns false automatically, so agents always get JSON without needing `--json` or `--agent`. The `--agent` flag remains as an explicit safety net.

## Test plan
- [ ] `go test ./...` passes (540 tests)
- [ ] Generate a CLI from a test spec, verify terminal shows table
- [ ] Pipe output through `| cat`, verify JSON
- [ ] `--json` flag forces JSON in terminal
- [ ] `--agent` flag forces compact JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)