### PR TITLE
feat(cli): add spec_source, auth_required, client_pattern to catalog schema

### DIFF
--- a/catalog/postman-explore.yaml
+++ b/catalog/postman-explore.yaml
@@ -1,0 +1,17 @@
+name: postman-explore
+display_name: Postman Explore
+description: Public API network directory for discovering community collections, workspaces, and APIs
+category: developer-tools
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/postman-explore-spec.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: community
+spec_source: sniffed
+auth_required: false
+client_pattern: proxy-envelope
+verified_date: "2026-03-29"
+homepage: https://www.postman.com/explore
+notes: >
+  Spec reverse-engineered from postman.com/explore by intercepting fetch/XHR calls to
+  _api/ws/proxy. The proxy envelope wraps all requests as POST with {service, method,
+  path, body?}. Search uses POST /search-all with queryIndices to filter entity types.

--- a/catalog/specs/postman-explore-spec.yaml
+++ b/catalog/specs/postman-explore-spec.yaml
@@ -1,0 +1,598 @@
+openapi: "3.0.3"
+info:
+  title: Postman Explore API
+  description: |
+    Undocumented internal API powering the Postman API Network explore site (postman.com/explore).
+    All requests go through a proxy endpoint as POST requests with a JSON body containing
+    {service, method, path, body?}. This spec models the logical endpoints directly.
+
+    No authentication required for public browsing and search.
+  version: "1.0.0"
+  contact:
+    name: Postman Explore (Community)
+
+servers:
+  - url: https://www.postman.com/_api/ws/proxy
+    description: Postman web proxy (all requests are POST with service/method/path body)
+
+tags:
+  - name: browse
+    description: Browse public collections, workspaces, APIs, and flows
+  - name: search
+    description: Full-text search across the public API network
+  - name: categories
+    description: API categories for filtering
+  - name: teams
+    description: Publisher teams on the API network
+  - name: stats
+    description: Network-wide statistics
+
+paths:
+  /v1/api/networkentity:
+    get:
+      operationId: listNetworkEntities
+      summary: Browse public entities on the API network
+      description: |
+        List public collections, workspaces, APIs, or flows with optional sorting,
+        category filtering, and pagination. This is the primary browse endpoint
+        powering postman.com/explore/collections.
+      tags: [browse]
+      parameters:
+        - name: entityType
+          in: query
+          required: true
+          description: Type of entity to browse
+          schema:
+            type: string
+            enum: [collection, workspace, api, flow]
+        - name: limit
+          in: query
+          description: Number of results per page
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          description: Pagination offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: sort
+          in: query
+          description: Sort order for results
+          schema:
+            type: string
+            enum: [popular, recent, featured, new, week, alltime]
+            default: popular
+        - name: categoryId
+          in: query
+          description: Filter by category ID (numeric, from categories endpoint)
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Paginated list of entities
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NetworkEntityListResponse"
+        "400":
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limited
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitError"
+
+  /v1/api/networkentity/count:
+    get:
+      operationId: getNetworkEntityCounts
+      summary: Get total counts of entities on the network
+      description: Returns aggregate counts of collections, workspaces, APIs, flows, notebooks, and teams.
+      tags: [stats]
+      parameters:
+        - name: flattenAPIVersions
+          in: query
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: Entity counts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityCountResponse"
+
+  /search-all:
+    post:
+      operationId: searchAll
+      summary: Full-text search across the public API network
+      description: |
+        Search for collections, workspaces, requests, flows, and teams by text query.
+        Supports filtering by entity type via queryIndices and pagination via from/size.
+        This powers the search bar at postman.com/search.
+      tags: [search]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+
+  /v2/api/category:
+    get:
+      operationId: listCategories
+      summary: List all API categories
+      description: Returns all categories used to organize the API network (e.g., AI, Communication, DevOps).
+      tags: [categories]
+      parameters:
+        - name: sort
+          in: query
+          description: Sort order
+          schema:
+            type: string
+            enum: [spotlighted]
+            default: spotlighted
+      responses:
+        "200":
+          description: List of categories
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CategoryListResponse"
+
+  /v2/api/category/{slug}:
+    get:
+      operationId: getCategory
+      summary: Get details for a specific category
+      description: Returns full details for a category by its URL slug.
+      tags: [categories]
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: Category URL slug (e.g., artificial-intelligence, devops)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Category details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CategoryDetailResponse"
+
+  /v1/api/team:
+    get:
+      operationId: listTeams
+      summary: List publisher teams on the API network
+      description: Returns teams that publish collections and APIs on the network.
+      tags: [teams]
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [popular]
+            default: popular
+      responses:
+        "200":
+          description: List of teams
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamListResponse"
+
+components:
+  schemas:
+    NetworkEntity:
+      type: object
+      description: A public entity (collection, workspace, API, or flow) on the Postman API Network
+      properties:
+        id:
+          type: integer
+          description: Internal network entity ID
+        entityId:
+          type: string
+          description: Unique entity identifier (format varies by type)
+        entityType:
+          type: string
+          enum: [collection, workspace, api, flow]
+        name:
+          type: string
+          description: Display name of the entity
+        summary:
+          type: string
+          description: Short summary
+        description:
+          type: string
+          description: Full description (may contain HTML/Markdown)
+        type:
+          type: string
+          enum: [public]
+        metrics:
+          type: array
+          items:
+            $ref: "#/components/schemas/Metric"
+        publisherType:
+          type: string
+          enum: [team, user]
+        publisherId:
+          type: integer
+        createdBy:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/CategorySummary"
+        tags:
+          type: array
+          items:
+            type: string
+        meta:
+          type: object
+          properties:
+            publisherId:
+              type: string
+            workspaceId:
+              type: string
+            publisherType:
+              type: string
+            workspaceSlug:
+              type: string
+        redirectURL:
+          type: string
+          format: uri
+          description: URL to view this entity on postman.com
+        redirectURLV2:
+          type: string
+          format: uri
+          description: V2 URL with slug-based path
+
+    Metric:
+      type: object
+      properties:
+        metricName:
+          type: string
+          enum:
+            - forkCount
+            - monthForkCount
+            - monthViewCount
+            - monthWatchCount
+            - publicViewCount
+            - viewCount
+            - watchCount
+            - weekForkCount
+            - weekViewCount
+            - weekWatchCount
+        metricValue:
+          type: integer
+
+    CategorySummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        slug:
+          type: string
+        name:
+          type: string
+        isDeleted:
+          type: boolean
+
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+        heroImageURL:
+          type: string
+          format: uri
+        iconURL:
+          type: string
+          format: uri
+        slug:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        publicURL:
+          type: string
+          format: uri
+
+    Team:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/CategorySummary"
+        tags:
+          type: array
+          items:
+            type: string
+        profileURL:
+          type: string
+          format: uri
+        publicURL:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        metrics:
+          type: array
+          items:
+            type: object
+            properties:
+              team:
+                type: string
+              viewCount:
+                type: integer
+              teamPublisherScore:
+                type: integer
+              apinetworkentityCount:
+                type: integer
+              collectionCount:
+                type: integer
+              apiCount:
+                type: integer
+              workspaceCount:
+                type: integer
+
+    SearchRequest:
+      type: object
+      required: [queryText, size, queryIndices]
+      properties:
+        queryText:
+          type: string
+          description: Search query text
+        size:
+          type: integer
+          description: Number of results to return
+          default: 10
+        from:
+          type: integer
+          description: Pagination offset
+          default: 0
+        domain:
+          type: string
+          description: Search domain scope
+          enum: [all, public]
+          default: public
+        queryIndices:
+          type: array
+          description: Entity types to search across
+          items:
+            type: string
+            enum:
+              - runtime.collection
+              - collaboration.workspace
+              - runtime.request
+              - flow.flow
+              - apinetwork.team
+        mergeEntities:
+          type: boolean
+          default: true
+        nested:
+          type: boolean
+          default: false
+        nonNestedRequests:
+          type: boolean
+          default: true
+        filter:
+          type: object
+          description: Additional filters (empty object for no filters)
+
+    SearchResult:
+      type: object
+      properties:
+        score:
+          type: number
+          description: Relevance score
+        normalizedScore:
+          type: number
+          description: Normalized relevance score
+        document:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Entity ID
+            name:
+              type: string
+            summary:
+              type: string
+            entityType:
+              type: string
+              enum: [collection, workspace, request, flow, team]
+            documentType:
+              type: string
+            isPublic:
+              type: boolean
+            isPublisherVerified:
+              type: boolean
+            publisherName:
+              type: string
+            publisherHandle:
+              type: string
+            publisherType:
+              type: string
+              enum: [team, user]
+            publisherLogo:
+              type: string
+            categories:
+              type: array
+              items:
+                type: object
+            tags:
+              type: array
+              items:
+                type: string
+            views:
+              type: integer
+            forkCount:
+              type: integer
+            watcherCount:
+              type: integer
+            requestCount:
+              type: integer
+            workspaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  slug:
+                    type: string
+                  visibilityStatus:
+                    type: string
+
+    NetworkEntityListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/NetworkEntity"
+        meta:
+          type: object
+          properties:
+            limit:
+              type: integer
+            offset:
+              type: integer
+            count:
+              type: integer
+            totalCount:
+              type: integer
+            publisherInfo:
+              type: object
+              description: Map of publisher type to array of publisher details
+            model:
+              type: string
+            action:
+              type: string
+
+    EntityCountResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            apiCount:
+              type: integer
+            collectionCount:
+              type: integer
+            flowCount:
+              type: integer
+            notebookCount:
+              type: integer
+            workspaceCount:
+              type: integer
+            teamCount:
+              type: integer
+        meta:
+          type: object
+
+    CategoryListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Category"
+
+    CategoryDetailResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/Category"
+
+    TeamListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Team"
+
+    SearchResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchResult"
+        meta:
+          type: object
+          properties:
+            total:
+              type: integer
+            nextCursor:
+              type: string
+
+    ErrorResponse:
+      type: object
+      properties:
+        name:
+          type: string
+        message:
+          type: string
+
+    RateLimitError:
+      type: object
+      properties:
+        error:
+          type: string
+          enum: [rateLimited]
+        message:
+          type: string

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -78,9 +78,9 @@ type Entry struct {
 	SandboxEndpoint   string     `yaml:"sandbox_endpoint,omitempty"`
 	// SpecSource describes how the spec was obtained. Empty defaults to "official".
 	// Values: official, community, sniffed, docs.
-	SpecSource    string `yaml:"spec_source,omitempty"`
+	SpecSource string `yaml:"spec_source,omitempty"`
 	// AuthRequired indicates whether the API needs authentication. Empty means unknown.
-	AuthRequired  *bool  `yaml:"auth_required,omitempty"`
+	AuthRequired *bool `yaml:"auth_required,omitempty"`
 	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
 	// Values: rest, proxy-envelope, graphql.
 	ClientPattern string `yaml:"client_pattern,omitempty"`

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -43,6 +43,19 @@ var validTiers = map[string]struct{}{
 	"community": {},
 }
 
+var validSpecSources = map[string]struct{}{
+	"official":  {}, // Published by API vendor (Stripe, GitHub, Discord)
+	"community": {}, // Third-party maintained (apis-guru, community OpenAPI repos)
+	"sniffed":   {}, // Reverse-engineered from browser traffic capture
+	"docs":      {}, // Generated from documentation pages (--docs mode)
+}
+
+var validClientPatterns = map[string]struct{}{
+	"rest":           {}, // Standard REST — default, no special client needed
+	"proxy-envelope": {}, // All requests wrapped in a POST envelope (e.g., Postman _api/ws/proxy)
+	"graphql":        {}, // GraphQL endpoint, needs query/mutation wrapper
+}
+
 type KnownAlt struct {
 	Name     string `yaml:"name"`
 	URL      string `yaml:"url"`
@@ -63,6 +76,14 @@ type Entry struct {
 	Notes             string     `yaml:"notes"`
 	KnownAlternatives []KnownAlt `yaml:"known_alternatives,omitempty"`
 	SandboxEndpoint   string     `yaml:"sandbox_endpoint,omitempty"`
+	// SpecSource describes how the spec was obtained. Empty defaults to "official".
+	// Values: official, community, sniffed, docs.
+	SpecSource    string `yaml:"spec_source,omitempty"`
+	// AuthRequired indicates whether the API needs authentication. Empty means unknown.
+	AuthRequired  *bool  `yaml:"auth_required,omitempty"`
+	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
+	// Values: rest, proxy-envelope, graphql.
+	ClientPattern string `yaml:"client_pattern,omitempty"`
 }
 
 func ParseEntry(data []byte) (*Entry, error) {
@@ -162,6 +183,18 @@ func (e *Entry) Validate() error {
 	}
 	if _, ok := validTiers[e.Tier]; !ok {
 		return fmt.Errorf("tier must be one of: official, community")
+	}
+
+	if e.SpecSource != "" {
+		if _, ok := validSpecSources[e.SpecSource]; !ok {
+			return fmt.Errorf("spec_source must be one of: official, community, sniffed, docs")
+		}
+	}
+
+	if e.ClientPattern != "" {
+		if _, ok := validClientPatterns[e.ClientPattern]; !ok {
+			return fmt.Errorf("client_pattern must be one of: rest, proxy-envelope, graphql")
+		}
 	}
 
 	return nil

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -112,6 +112,20 @@ func TestValidateEntry(t *testing.T) {
 			},
 			wantErr: "description is required",
 		},
+		{
+			name: "invalid spec_source",
+			mutate: func(e *Entry) {
+				e.SpecSource = "guessed"
+			},
+			wantErr: "spec_source must be one of",
+		},
+		{
+			name: "invalid client_pattern",
+			mutate: func(e *Entry) {
+				e.ClientPattern = "soap"
+			},
+			wantErr: "client_pattern must be one of",
+		},
 	}
 
 	for _, tt := range tests {
@@ -196,6 +210,40 @@ func TestCategoryErrorMessageExcludesExample(t *testing.T) {
 	err := entry.Validate()
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "example")
+}
+
+func TestSniffedEntryValid(t *testing.T) {
+	f := false
+	entry := Entry{
+		Name:          "test-sniffed",
+		DisplayName:   "Test Sniffed API",
+		Description:   "A sniffed catalog entry",
+		Category:      "developer-tools",
+		SpecURL:       "https://example.com/specs/sniffed.yaml",
+		SpecFormat:    "yaml",
+		Tier:          "community",
+		SpecSource:    "sniffed",
+		AuthRequired:  &f,
+		ClientPattern: "proxy-envelope",
+	}
+	assert.NoError(t, entry.Validate())
+}
+
+func TestOptionalFieldsOmittedValid(t *testing.T) {
+	// spec_source, auth_required, and client_pattern should all be optional
+	entry := Entry{
+		Name:        "test-minimal",
+		DisplayName: "Minimal API",
+		Description: "A minimal catalog entry without new fields",
+		Category:    "developer-tools",
+		SpecURL:     "https://example.com/openapi.yaml",
+		SpecFormat:  "yaml",
+		Tier:        "official",
+	}
+	assert.NoError(t, entry.Validate())
+	assert.Empty(t, entry.SpecSource)
+	assert.Nil(t, entry.AuthRequired)
+	assert.Empty(t, entry.ClientPattern)
 }
 
 func TestPublicCategoriesExcludeExample(t *testing.T) {

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -116,6 +116,15 @@ func newCatalogShowCmd() *cobra.Command {
 			if entry.Homepage != "" {
 				fmt.Printf("Homepage:       %s\n", entry.Homepage)
 			}
+			if entry.SpecSource != "" {
+				fmt.Printf("Spec Source:    %s\n", entry.SpecSource)
+			}
+			if entry.ClientPattern != "" {
+				fmt.Printf("Client Pattern: %s\n", entry.ClientPattern)
+			}
+			if entry.AuthRequired != nil {
+				fmt.Printf("Auth Required:  %v\n", *entry.AuthRequired)
+			}
 			if entry.Notes != "" {
 				fmt.Printf("Notes:          %s\n", entry.Notes)
 			}


### PR DESCRIPTION
## Summary
- Adds three optional fields to the catalog entry schema to support sniff-based and non-standard CLIs
- Adds `postman-explore` as the first sniffed API in the catalog, with its reverse-engineered spec

## New fields

| Field | Values | Purpose |
|-------|--------|---------|
| `spec_source` | official, community, sniffed, docs | How the spec was obtained. Sniffed specs are reverse-engineered from browser traffic. |
| `auth_required` | true/false | Whether the API needs auth. Replaces burying this in notes. |
| `client_pattern` | rest, proxy-envelope, graphql | HTTP client pattern needed. Signals extra work for non-REST APIs. |

All three are optional with backward-compatible defaults. Existing entries are unchanged.

## Why
Building `postman-explore-pp-cli` exposed that the catalog schema had no way to express:
- That a spec was sniffed (different trust/regeneration story than vendor-published)
- That an API is public/no-auth (important for the skill's API key gate)
- That the API uses a proxy envelope pattern (the generator can't produce a working client without manual work)

## Test plan
- [ ] `go test ./internal/catalog/...` — 2 new tests for valid sniffed entry + optional fields
- [ ] `go test ./...` — full suite passes
- [ ] `printing-press catalog show postman-explore` shows new fields
- [ ] Existing catalog entries still validate (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)