### PR TITLE
feat(cli): use local module path at generation, rewrite at publish

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -62,6 +62,7 @@ type PackageResult struct {
 	CLIName             string `json:"cli_name"`
 	APIName             string `json:"api_name"`
 	Category            string `json:"category"`
+	ModulePath          string `json:"module_path,omitempty"`
 	ManuscriptsIncluded bool   `json:"manuscripts_included"`
 	RunID               string `json:"run_id,omitempty"`
 }
@@ -131,6 +132,7 @@ func newPublishPackageCmd() *cobra.Command {
 	var dir string
 	var category string
 	var target string
+	var modulePath string
 	var asJSON bool
 
 	cmd := &cobra.Command{
@@ -205,12 +207,22 @@ func newPublishPackageCmd() *cobra.Command {
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("copying CLI: %w", err)}
 			}
 
+			// Rewrite go.mod module path if --module-path is set
+			if modulePath != "" {
+				oldModPath := cliName // generated CLIs use bare CLI name as module path
+				if err := pipeline.RewriteModulePath(stagingCLIDir, oldModPath, modulePath); err != nil {
+					cleanupTarget()
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("rewriting module path: %w", err)}
+				}
+			}
+
 			// Resolve and copy manuscripts
 			result := PackageResult{
-				StagedDir: stagingCLIDir,
-				CLIName:   cliName,
-				APIName:   vResult.APIName,
-				Category:  category,
+				StagedDir:  stagingCLIDir,
+				CLIName:    cliName,
+				APIName:    vResult.APIName,
+				Category:   category,
+				ModulePath: modulePath,
 			}
 
 			apiName := vResult.APIName
@@ -254,6 +266,7 @@ func newPublishPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dir, "dir", "", "CLI directory to package (required)")
 	cmd.Flags().StringVar(&category, "category", "", "Category for the CLI (required)")
 	cmd.Flags().StringVar(&target, "target", "", "Staging directory to create (required)")
+	cmd.Flags().StringVar(&modulePath, "module-path", "", "Go module path to set (e.g., github.com/org/repo/library/category/cli-name)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -84,6 +84,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"safeTypeName":       safeTypeName,
 		"exampleLine":        g.exampleLine,
 		"currentYear":        func() string { return strconv.Itoa(time.Now().Year()) },
+		"modulePath":         func() string { return naming.CLI(s.Name) },
 	}
 	return g
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -187,7 +187,12 @@ func TestGenerateWithOwnerField(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "github.com/testowner/")
+	// Module path uses bare CLI name (no github.com/owner prefix)
+	assert.Contains(t, string(gomod), "module owned-pp-cli")
+	// Owner is still used for copyright
+	mainGo, err := os.ReadFile(filepath.Join(outputDir, "cmd", "owned-pp-cli", "main.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(mainGo), "testowner")
 }
 
 func TestGenerateWithEmptyOwner(t *testing.T) {
@@ -228,7 +233,10 @@ func TestGenerateWithEmptyOwner(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "github.com/")
+	// Module path uses bare CLI name regardless of Owner
+	assert.Contains(t, string(gomod), "module unowned-pp-cli")
+	// Module line should not have a github.com prefix
+	assert.NotContains(t, string(gomod), "module github.com/")
 }
 
 // --- Unit 7: Feature Verification Tests ---

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -193,6 +193,9 @@ func TestGenerateWithOwnerField(t *testing.T) {
 	mainGo, err := os.ReadFile(filepath.Join(outputDir, "cmd", "owned-pp-cli", "main.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(mainGo), "testowner")
+	readme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(readme), "go install github.com/testowner/owned-pp-cli/cmd/owned-pp-cli@latest")
 }
 
 func TestGenerateWithEmptyOwner(t *testing.T) {

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"os"
 {{- end}}
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/config"
 )
 
 type Client struct {

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -1,4 +1,4 @@
-module github.com/{{.Owner}}/{{.Name}}-pp-cli
+module {{modulePath}}
 
 go 1.23
 

--- a/internal/generator/templates/goreleaser.yaml.tmpl
+++ b/internal/generator/templates/goreleaser.yaml.tmpl
@@ -9,7 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/cli.version={{"{{"}} .Version {{"}}"}}
+      - -s -w -X {{modulePath}}/internal/cli.version={{"{{"}} .Version {{"}}"}}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/internal/generator/templates/insights/health_score.go.tmpl
+++ b/internal/generator/templates/insights/health_score.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/insights/similar.go.tmpl
+++ b/internal/generator/templates/insights/similar.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/main.go.tmpl
+++ b/internal/generator/templates/main.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/cli"
+	"{{modulePath}}/internal/cli"
 )
 
 func main() {

--- a/internal/generator/templates/main_mcp.go.tmpl
+++ b/internal/generator/templates/main_mcp.go.tmpl
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/mark3labs/mcp-go/server"
-	mcptools "github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/mcp"
+	mcptools "{{modulePath}}/internal/mcp"
 )
 
 func main() {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -14,10 +14,10 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/client"
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/client"
+	"{{modulePath}}/internal/config"
 {{- if .VisionSet.Store}}
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 {{- end}}
 )
 

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -13,7 +13,7 @@ brew install {{.Owner}}/tap/{{.Name}}-pp-cli
 ### Go
 
 ```
-go install {{modulePath}}/cmd/{{.Name}}-pp-cli@latest
+go install github.com/{{.Owner}}/{{.Name}}-pp-cli/cmd/{{.Name}}-pp-cli@latest
 ```
 
 ### Binary

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -13,7 +13,7 @@ brew install {{.Owner}}/tap/{{.Name}}-pp-cli
 ### Go
 
 ```
-go install github.com/{{.Owner}}/{{.Name}}-pp-cli/cmd/{{.Name}}-pp-cli@latest
+go install {{modulePath}}/cmd/{{.Name}}-pp-cli@latest
 ```
 
 ### Binary

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -10,8 +10,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/client"
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/config"
+	"{{modulePath}}/internal/client"
+	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/workflows/pm_load.go.tmpl
+++ b/internal/generator/templates/workflows/pm_load.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/workflows/pm_orphans.go.tmpl
+++ b/internal/generator/templates/workflows/pm_orphans.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/{{.Owner}}/{{.Name}}-pp-cli/internal/store"
+	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -45,7 +46,6 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 	// config paths, and other runtime literals that contain the CLI name.
 	replacements := []struct{ old, new string }{
 		{oldPath + "/internal/", newPath + "/internal/"}, // Go imports, goreleaser ldflags
-		{oldPath + "/cmd/", newPath + "/cmd/"},           // go install paths in README
 	}
 
 	return filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
@@ -69,6 +69,8 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 		for _, r := range replacements {
 			result = strings.ReplaceAll(result, r.old, r.new)
 		}
+		result = rewriteModuleInstallPaths(result, oldPath, newPath)
+		result = rewriteGitHubRepoURLs(result, oldPath, newPath)
 		if result == string(content) {
 			return nil // no changes needed
 		}
@@ -84,4 +86,31 @@ func hasRewriteExtension(path string) bool {
 		}
 	}
 	return false
+}
+
+func rewriteModuleInstallPaths(content, oldPath, newPath string) string {
+	pattern := regexp.MustCompile(`(?:github\.com/[^/\s"]+/)?` + regexp.QuoteMeta(oldPath) + `/cmd/`)
+	return pattern.ReplaceAllString(content, newPath+"/cmd/")
+}
+
+func rewriteGitHubRepoURLs(content, oldPath, newPath string) string {
+	newRepoURL, ok := githubRepoURL(newPath)
+	if !ok {
+		return content
+	}
+
+	releasesPattern := regexp.MustCompile(`https://github\.com/[^/\s"]+/` + regexp.QuoteMeta(oldPath) + `/releases\b`)
+	content = releasesPattern.ReplaceAllString(content, newRepoURL+"/releases")
+
+	repoPattern := regexp.MustCompile(`https://github\.com/[^/\s"]+/` + regexp.QuoteMeta(oldPath) + `\b`)
+	return repoPattern.ReplaceAllString(content, newRepoURL)
+}
+
+func githubRepoURL(modulePath string) (string, bool) {
+	parts := strings.Split(modulePath, "/")
+	if len(parts) < 3 || parts[0] != "github.com" {
+		return "", false
+	}
+
+	return "https://" + strings.Join(parts[:3], "/"), true
 }

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -1,0 +1,56 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RewriteModulePath replaces the Go module path in a CLI directory.
+// It rewrites the module declaration in go.mod and all import paths
+// in .go files from oldPath to newPath.
+func RewriteModulePath(dir, oldPath, newPath string) error {
+	if oldPath == newPath {
+		return nil
+	}
+
+	// Rewrite go.mod module line
+	gomodPath := filepath.Join(dir, "go.mod")
+	gomod, err := os.ReadFile(gomodPath)
+	if err != nil {
+		return fmt.Errorf("reading go.mod: %w", err)
+	}
+
+	oldModule := "module " + oldPath
+	newModule := "module " + newPath
+	updated := strings.Replace(string(gomod), oldModule, newModule, 1)
+	if updated == string(gomod) {
+		return fmt.Errorf("go.mod does not contain expected module path %q", oldPath)
+	}
+	if err := os.WriteFile(gomodPath, []byte(updated), 0o644); err != nil {
+		return fmt.Errorf("writing go.mod: %w", err)
+	}
+
+	// Rewrite import paths in all .go files
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		replaced := strings.ReplaceAll(string(content), oldPath, newPath)
+		if replaced == string(content) {
+			return nil // no changes needed
+		}
+
+		return os.WriteFile(path, []byte(replaced), 0o644)
+	})
+}

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -7,9 +7,17 @@ import (
 	"strings"
 )
 
+// rewriteExtensions lists file extensions that may contain Go import paths
+// or module-path references (e.g., goreleaser ldflags).
+var rewriteExtensions = []string{".go", ".yaml", ".yml"}
+
 // RewriteModulePath replaces the Go module path in a CLI directory.
-// It rewrites the module declaration in go.mod and all import paths
-// in .go files from oldPath to newPath.
+// It rewrites the module declaration in go.mod and import paths
+// (oldPath/internal/...) in .go and .yaml files from oldPath to newPath.
+//
+// Only import-style references (oldPath + "/internal/") are replaced in
+// source files. Bare CLI name occurrences in command strings, User-Agent
+// headers, and config paths are intentionally left untouched.
 func RewriteModulePath(dir, oldPath, newPath string) error {
 	if oldPath == newPath {
 		return nil
@@ -32,12 +40,21 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 		return fmt.Errorf("writing go.mod: %w", err)
 	}
 
-	// Rewrite import paths in all .go files
+	// Only replace import-path references: oldPath/internal/...
+	// This avoids corrupting command Use strings, User-Agent headers,
+	// config paths, and other runtime literals that contain the CLI name.
+	oldImport := oldPath + "/internal/"
+	newImport := newPath + "/internal/"
+
 	return filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+		if d.IsDir() {
+			return nil
+		}
+
+		if !hasRewriteExtension(path) {
 			return nil
 		}
 
@@ -46,11 +63,20 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		replaced := strings.ReplaceAll(string(content), oldPath, newPath)
+		replaced := strings.ReplaceAll(string(content), oldImport, newImport)
 		if replaced == string(content) {
 			return nil // no changes needed
 		}
 
 		return os.WriteFile(path, []byte(replaced), 0o644)
 	})
+}
+
+func hasRewriteExtension(path string) bool {
+	for _, ext := range rewriteExtensions {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-// rewriteExtensions lists file extensions that may contain Go import paths
-// or module-path references (e.g., goreleaser ldflags).
-var rewriteExtensions = []string{".go", ".yaml", ".yml"}
+// rewriteExtensions lists file extensions that may contain Go import paths,
+// module-path references (e.g., goreleaser ldflags), or install instructions.
+var rewriteExtensions = []string{".go", ".yaml", ".yml", ".md"}
 
 // RewriteModulePath replaces the Go module path in a CLI directory.
 // It rewrites the module declaration in go.mod and import paths
@@ -40,11 +40,13 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 		return fmt.Errorf("writing go.mod: %w", err)
 	}
 
-	// Only replace import-path references: oldPath/internal/...
+	// Only replace subpath references: oldPath/internal/... and oldPath/cmd/...
 	// This avoids corrupting command Use strings, User-Agent headers,
 	// config paths, and other runtime literals that contain the CLI name.
-	oldImport := oldPath + "/internal/"
-	newImport := newPath + "/internal/"
+	replacements := []struct{ old, new string }{
+		{oldPath + "/internal/", newPath + "/internal/"}, // Go imports, goreleaser ldflags
+		{oldPath + "/cmd/", newPath + "/cmd/"},           // go install paths in README
+	}
 
 	return filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -63,12 +65,15 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		replaced := strings.ReplaceAll(string(content), oldImport, newImport)
-		if replaced == string(content) {
+		result := string(content)
+		for _, r := range replacements {
+			result = strings.ReplaceAll(result, r.old, r.new)
+		}
+		if result == string(content) {
 			return nil // no changes needed
 		}
 
-		return os.WriteFile(path, []byte(replaced), 0o644)
+		return os.WriteFile(path, []byte(result), 0o644)
 	})
 }
 

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -1,0 +1,69 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteModulePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rewrites go.mod and go imports", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Write a go.mod with the old module path
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		// Write a .go file with import paths
+		goFile := `package main
+
+import (
+	"notion-pp-cli/internal/cli"
+	"notion-pp-cli/internal/config"
+)
+
+func main() {}
+`
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "notion-pp-cli"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "cmd", "notion-pp-cli", "main.go"), []byte(goFile), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli")
+		require.NoError(t, err)
+
+		// Check go.mod
+		updatedMod, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+		require.NoError(t, err)
+		assert.Contains(t, string(updatedMod), "module github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli")
+		assert.NotContains(t, string(updatedMod), "module notion-pp-cli\n")
+
+		// Check .go file imports
+		updatedGo, err := os.ReadFile(filepath.Join(dir, "cmd", "notion-pp-cli", "main.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(updatedGo), `"github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli/internal/cli"`)
+		assert.Contains(t, string(updatedGo), `"github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli/internal/config"`)
+	})
+
+	t.Run("noop when paths are equal", func(t *testing.T) {
+		dir := t.TempDir()
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "notion-pp-cli")
+		require.NoError(t, err)
+	})
+
+	t.Run("error when go.mod missing old path", func(t *testing.T) {
+		dir := t.TempDir()
+		gomod := "module other-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/org/repo/notion-pp-cli")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not contain expected module path")
+	})
+}

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -48,6 +48,89 @@ func main() {}
 		assert.Contains(t, string(updatedGo), `"github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli/internal/config"`)
 	})
 
+	t.Run("does not corrupt non-import strings", func(t *testing.T) {
+		dir := t.TempDir()
+
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		// Simulate a generated root.go with both imports AND runtime literals
+		goFile := `package cli
+
+import (
+	"notion-pp-cli/internal/client"
+	"notion-pp-cli/internal/config"
+)
+
+var version = "0.1.0"
+
+func Execute() {
+	rootCmd := &cobra.Command{
+		Use:   "notion-pp-cli",
+		Short: "CLI for Notion API",
+	}
+	rootCmd.SetVersionTemplate("notion-pp-cli {{ .Version }}\n")
+}
+`
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "cli", "root.go"), []byte(goFile), 0o644))
+
+		// Simulate a client.go with User-Agent
+		clientFile := `package client
+
+func (c *Client) do() {
+	req.Header.Set("User-Agent", "notion-pp-cli/0.1.0")
+}
+`
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "client", "client.go"), []byte(clientFile), 0o644))
+
+		newPath := "github.com/acme/library/notion-pp-cli"
+		err := RewriteModulePath(dir, "notion-pp-cli", newPath)
+		require.NoError(t, err)
+
+		// Imports should be rewritten
+		updatedRoot, err := os.ReadFile(filepath.Join(dir, "internal", "cli", "root.go"))
+		require.NoError(t, err)
+		rootContent := string(updatedRoot)
+		assert.Contains(t, rootContent, `"github.com/acme/library/notion-pp-cli/internal/client"`)
+		assert.Contains(t, rootContent, `"github.com/acme/library/notion-pp-cli/internal/config"`)
+
+		// Command Use string must NOT be rewritten
+		assert.Contains(t, rootContent, `Use:   "notion-pp-cli"`)
+		assert.NotContains(t, rootContent, `Use:   "github.com/acme/library/notion-pp-cli"`)
+
+		// Version template must NOT be rewritten
+		assert.Contains(t, rootContent, `"notion-pp-cli {{ .Version }}\n"`)
+
+		// User-Agent must NOT be rewritten
+		updatedClient, err := os.ReadFile(filepath.Join(dir, "internal", "client", "client.go"))
+		require.NoError(t, err)
+		assert.Contains(t, string(updatedClient), `"notion-pp-cli/0.1.0"`)
+	})
+
+	t.Run("rewrites goreleaser ldflags", func(t *testing.T) {
+		dir := t.TempDir()
+
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		goreleaser := `version: 2
+builds:
+  - ldflags:
+      - -s -w -X notion-pp-cli/internal/cli.version={{ .Version }}
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".goreleaser.yaml"), []byte(goreleaser), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/acme/library/notion-pp-cli")
+		require.NoError(t, err)
+
+		updatedGR, err := os.ReadFile(filepath.Join(dir, ".goreleaser.yaml"))
+		require.NoError(t, err)
+		assert.Contains(t, string(updatedGR), "-X github.com/acme/library/notion-pp-cli/internal/cli.version=")
+		assert.NotContains(t, string(updatedGR), "-X notion-pp-cli/internal/cli.version=")
+	})
+
 	t.Run("noop when paths are equal", func(t *testing.T) {
 		dir := t.TempDir()
 		gomod := "module notion-pp-cli\n\ngo 1.23\n"

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -137,7 +137,7 @@ builds:
 		gomod := "module notion-pp-cli\n\ngo 1.23\n"
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
 
-		readme := "# notion-pp-cli\n\n## Install\n\n```\ngo install notion-pp-cli/cmd/notion-pp-cli@latest\n```\n\n```bash\nnotion-pp-cli doctor\nnotion-pp-cli users list\n```\n"
+		readme := "# notion-pp-cli\n\n## Install\n\n```\ngo install github.com/testowner/notion-pp-cli/cmd/notion-pp-cli@latest\n```\n\n### Binary\n\nDownload from [Releases](https://github.com/testowner/notion-pp-cli/releases).\n\n```bash\nnotion-pp-cli doctor\nnotion-pp-cli users list\n```\n"
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte(readme), 0o644))
 
 		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/acme/library/notion-pp-cli")
@@ -149,11 +149,33 @@ builds:
 
 		// go install path should be rewritten
 		assert.Contains(t, content, "go install github.com/acme/library/notion-pp-cli/cmd/notion-pp-cli@latest")
+		assert.Contains(t, content, "https://github.com/acme/library/releases")
 
 		// Bare CLI name in usage examples must NOT be rewritten
 		assert.Contains(t, content, "notion-pp-cli doctor")
 		assert.Contains(t, content, "notion-pp-cli users list")
 		assert.Contains(t, content, "# notion-pp-cli")
+	})
+
+	t.Run("rewrites goreleaser homepage to published repo", func(t *testing.T) {
+		dir := t.TempDir()
+
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		goreleaser := `version: 2
+brews:
+  - homepage: "https://github.com/testowner/notion-pp-cli"
+`
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".goreleaser.yaml"), []byte(goreleaser), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/acme/library/notion-pp-cli")
+		require.NoError(t, err)
+
+		updatedGR, err := os.ReadFile(filepath.Join(dir, ".goreleaser.yaml"))
+		require.NoError(t, err)
+		assert.Contains(t, string(updatedGR), `homepage: "https://github.com/acme/library"`)
+		assert.NotContains(t, string(updatedGR), `homepage: "https://github.com/testowner/notion-pp-cli"`)
 	})
 
 	t.Run("noop when paths are equal", func(t *testing.T) {

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -131,6 +131,31 @@ builds:
 		assert.NotContains(t, string(updatedGR), "-X notion-pp-cli/internal/cli.version=")
 	})
 
+	t.Run("rewrites README go install path", func(t *testing.T) {
+		dir := t.TempDir()
+
+		gomod := "module notion-pp-cli\n\ngo 1.23\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644))
+
+		readme := "# notion-pp-cli\n\n## Install\n\n```\ngo install notion-pp-cli/cmd/notion-pp-cli@latest\n```\n\n```bash\nnotion-pp-cli doctor\nnotion-pp-cli users list\n```\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte(readme), 0o644))
+
+		err := RewriteModulePath(dir, "notion-pp-cli", "github.com/acme/library/notion-pp-cli")
+		require.NoError(t, err)
+
+		updatedReadme, err := os.ReadFile(filepath.Join(dir, "README.md"))
+		require.NoError(t, err)
+		content := string(updatedReadme)
+
+		// go install path should be rewritten
+		assert.Contains(t, content, "go install github.com/acme/library/notion-pp-cli/cmd/notion-pp-cli@latest")
+
+		// Bare CLI name in usage examples must NOT be rewritten
+		assert.Contains(t, content, "notion-pp-cli doctor")
+		assert.Contains(t, content, "notion-pp-cli users list")
+		assert.Contains(t, content, "# notion-pp-cli")
+	})
+
 	t.Run("noop when paths are equal", func(t *testing.T) {
 		dir := t.TempDir()
 		gomod := "module notion-pp-cli\n\ngo 1.23\n"

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -71,6 +71,22 @@ PUBLISH_REPO_DIR="$PRESS_HOME/.publish-repo"
 PUBLISH_CONFIG="$PRESS_HOME/.publish-config.json"
 ```
 
+### Publish config
+
+`$PUBLISH_CONFIG` stores persistent publish settings as JSON. On first publish, create it with defaults. The user can edit it to change the library repo or module path base.
+
+```json
+{
+  "repo_url": "https://github.com/mvanhorn/printing-press-library",
+  "access": "push",
+  "protocol": "ssh",
+  "clone_path": "~/printing-press/.publish-repo",
+  "module_path_base": "github.com/mvanhorn/printing-press-library/library"
+}
+```
+
+The `module_path_base` field sets the Go module path prefix for published CLIs. During packaging, the full module path is constructed as `<module_path_base>/<category>/<cli-name>`. If the user wants CLIs published to a different repo or path, they edit this field.
+
 ## Step 1: Prerequisites
 
 Verify `gh` is authenticated:
@@ -149,6 +165,14 @@ Save the `help_output` field from the result — it's used in the PR description
 
 ## Step 5: Package
 
+Read `$PUBLISH_CONFIG` to get `module_path_base`. Construct the full module path:
+
+```
+MODULE_PATH="<module_path_base>/<category>/<cli-name>"
+```
+
+For example: `github.com/mvanhorn/printing-press-library/library/productivity/notion-pp-cli`
+
 Create a temporary staging directory and run:
 
 ```bash
@@ -156,10 +180,11 @@ printing-press publish package \
   --dir <cli-dir> \
   --category <category> \
   --target <staging-dir> \
+  --module-path "$MODULE_PATH" \
   --json
 ```
 
-Parse the JSON result. Note the `staged_dir`, `manuscripts_included`, and `run_id`.
+Parse the JSON result. Note the `staged_dir`, `module_path`, `manuscripts_included`, and `run_id`. The `module_path` field confirms the Go module path that was set in the packaged CLI's `go.mod` and import paths.
 
 ## Step 6: Managed Clone
 
@@ -190,7 +215,8 @@ If `$PUBLISH_REPO_DIR` does not exist:
      "repo_url": "https://github.com/mvanhorn/printing-press-library",
      "access": "push",
      "protocol": "ssh",
-     "clone_path": "~/printing-press/.publish-repo"
+     "clone_path": "~/printing-press/.publish-repo",
+     "module_path_base": "github.com/mvanhorn/printing-press-library/library"
    }
    ```
    Write to `$PUBLISH_CONFIG`.


### PR DESCRIPTION
## Summary

Generated CLIs used a placeholder module path (`github.com/user/notion-pp-cli`) that wouldn't work for `go install`. This PR defers the real module path to publish time — generation uses a bare local path, and `publish package --module-path` rewrites it to the configured library repo URL.

## How it works

**Generation time:** Templates use a `{{modulePath}}` function that returns the bare CLI name (e.g., `notion-pp-cli`). The `go.mod` module declaration and all internal import paths use this local-only path. `Owner` is still used for copyright notices and Homebrew branding.

**Publish time:** `printing-press publish package --module-path <full-path>` calls `RewriteModulePath` which:
- Rewrites the `module` line in `go.mod`
- Replaces `oldPath/internal/` in `.go` and `.yaml` files (imports + goreleaser ldflags)
- Replaces `oldPath/cmd/` in `.md` files (README install instructions)
- Leaves bare CLI name occurrences untouched (command `Use:` strings, User-Agent, config paths)

**Configuration:** The publish skill config gains a `module_path_base` field (default: `github.com/mvanhorn/printing-press-library/library`). The full path is constructed as `<module_path_base>/<category>/<cli-name>` during the publish flow.

## What changed

| Area | Files | Change |
|------|-------|--------|
| Templates | 18 `.tmpl` files | `github.com/{{.Owner}}/{{.Name}}-pp-cli` → `{{modulePath}}` for Go imports; `Owner` retained for copyright |
| Generator | `generator.go` | Added `modulePath` template function |
| Publish CLI | `publish.go` | Added `--module-path` flag, calls `RewriteModulePath` on staged dir |
| Module rewriter | `modulepath.go` (new) | Targeted find-and-replace scoped to `/internal/` and `/cmd/` subpaths |
| Publish skill | `SKILL.md` | Configurable `module_path_base`, `--module-path` in packaging step |

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint` clean
- [x] `TestRewriteModulePath` — 6 subtests covering imports, go.mod, goreleaser ldflags, README install path, noop, and error cases
- [x] `TestRewriteModulePath/does_not_corrupt_non-import_strings` — verifies command `Use:`, version template, and User-Agent survive untouched
- [x] `TestGenerateWithOwnerField` — bare module path + Owner still used for copyright
- [x] `TestGenerateWithEmptyOwner` — no `github.com/` in module line

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)