### PR TITLE
fix(cli): add smart-default table output for POST endpoints

### DIFF
--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -159,13 +159,17 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any
 				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
-					if err := printAutoTable(cmd.OutOrStdout(), items); err == nil {
+					if err := printAutoTable(cmd.OutOrStdout(), items); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
+					} else {
 						return nil
 					}
 				} else {
 					var wrapped struct{ Data []map[string]any `json:"data"` }
 					if json.Unmarshal(data, &wrapped) == nil && len(wrapped.Data) > 0 {
-						if err := printAutoTable(cmd.OutOrStdout(), wrapped.Data); err == nil {
+						if err := printAutoTable(cmd.OutOrStdout(), wrapped.Data); err != nil {
+							fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
+						} else {
 							return nil
 						}
 					}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -155,6 +155,22 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 
 {{- if not (or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD"))}}
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				// Check if response contains an array (directly or wrapped in "data")
+				var items []map[string]any
+				if json.Unmarshal(data, &items) == nil && len(items) > 0 {
+					if err := printAutoTable(cmd.OutOrStdout(), items); err == nil {
+						return nil
+					}
+				} else {
+					var wrapped struct{ Data []map[string]any `json:"data"` }
+					if json.Unmarshal(data, &wrapped) == nil && len(wrapped.Data) > 0 {
+						if err := printAutoTable(cmd.OutOrStdout(), wrapped.Data); err == nil {
+							return nil
+						}
+					}
+				}
+			}
 			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
 				if flags.quiet {
 					return nil


### PR DESCRIPTION
POST endpoints that return browseable arrays (like search) got raw JSON in the terminal while GET endpoints got tables. Now POST responses are also checked with a heuristic: if the response is an array of objects (directly or wrapped in a `data` field), it renders as a table. Non-array POST responses still use the envelope path.

Discovered during postman-explore-pp-cli testing — `search espn` dumped raw JSON in the terminal instead of a readable table.

## Test plan
- [x] `go test ./internal/generator/...` passes
- [x] `golangci-lint` clean
- [ ] Generate a CLI with a POST search endpoint, run in terminal — should show table
- [ ] Same command piped — should show JSON envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)