### PR TITLE
fix(cli): write .printing-press.json manifest during generate command

### DIFF
--- a/cmd/printing-press/main.go
+++ b/cmd/printing-press/main.go
@@ -10,11 +10,14 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
 		var exitErr *cli.ExitError
 		if errors.As(err, &exitErr) {
+			if !exitErr.Silent {
+				fmt.Fprintln(os.Stderr, err.Error())
+			}
 			os.Exit(exitErr.Code)
 		}
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(cli.ExitUnknownError)
 	}
 }

--- a/internal/cli/exitcodes.go
+++ b/internal/cli/exitcodes.go
@@ -11,9 +11,13 @@ const (
 )
 
 // ExitError wraps an error with a specific exit code.
+// When Silent is true, main should exit with the code but not print the
+// error message — used when structured output (--json) already contains
+// the failure details.
 type ExitError struct {
-	Code int
-	Err  error
+	Code   int
+	Err    error
+	Silent bool
 }
 
 func (e *ExitError) Error() string { return e.Err.Error() }

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -90,7 +90,7 @@ func newPublishValidateCmd() *cobra.Command {
 					return encErr
 				}
 				if !result.Passed {
-					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("validation failed")}
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("validation failed"), Silent: true}
 				}
 				return nil
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -177,6 +177,14 @@ func newGenerateCmd() *cobra.Command {
 					}
 				}
 
+				if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+					APIName:   parsed.Name,
+					DocsURL:   docsURL,
+					OutputDir: absOut,
+				}); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
+				}
+
 				fmt.Fprintf(os.Stderr, "Generated %s at %s (from docs)\n", naming.CLI(parsed.Name), absOut)
 				if asJSON {
 					if err := json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
@@ -307,6 +315,14 @@ func newGenerateCmd() *cobra.Command {
 				} else {
 					absOut = finalPath
 				}
+			}
+
+			if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+				APIName:   apiSpec.Name,
+				SpecSrcs:  specFiles,
+				OutputDir: absOut,
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 			}
 
 			fmt.Fprintf(os.Stderr, "Generated %s at %s\n", naming.CLI(apiSpec.Name), absOut)

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -7,9 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/mvanhorn/cli-printing-press/catalog"
+	catalogpkg "github.com/mvanhorn/cli-printing-press/internal/catalog"
+	"github.com/mvanhorn/cli-printing-press/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/internal/version"
 )
 
 // CLIManifestFilename is the name of the manifest file written to each
@@ -61,6 +66,69 @@ func specChecksum(path string) (string, error) {
 	}
 	h := sha256.Sum256(data)
 	return "sha256:" + hex.EncodeToString(h[:]), nil
+}
+
+// GenerateManifestParams holds the information available at generate time
+// for writing a CLI manifest. Unlike PublishWorkingCLI (which has full
+// PipelineState), the standalone generate command only knows the spec
+// sources and output directory.
+type GenerateManifestParams struct {
+	APIName  string
+	SpecSrcs []string // --spec args (URLs or file paths)
+	DocsURL  string   // --docs URL, if used
+	OutputDir string
+}
+
+// WriteManifestForGenerate writes a .printing-press.json manifest into the
+// generated CLI directory. This is the generate-command counterpart of
+// writeCLIManifestForPublish (which operates on PipelineState).
+func WriteManifestForGenerate(p GenerateManifestParams) error {
+	m := CLIManifest{
+		SchemaVersion:        1,
+		GeneratedAt:          time.Now().UTC(),
+		PrintingPressVersion: version.Version,
+		APIName:              p.APIName,
+		CLIName:              naming.CLI(p.APIName),
+	}
+
+	// Populate spec_url / spec_path from the first spec source.
+	if p.DocsURL != "" {
+		m.SpecURL = p.DocsURL
+		m.SpecFormat = "docs"
+	} else if len(p.SpecSrcs) > 0 {
+		src := p.SpecSrcs[0]
+		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+			m.SpecURL = src
+		} else {
+			m.SpecPath = src
+		}
+	}
+
+	// Detect format and checksum from any spec file cached in the output dir.
+	for _, name := range []string{"spec.json", "spec.yaml", "spec.yml"} {
+		specFile := filepath.Join(p.OutputDir, name)
+		data, err := os.ReadFile(specFile)
+		if err != nil {
+			continue
+		}
+		if m.SpecFormat == "" {
+			m.SpecFormat = detectSpecFormat(data)
+		}
+		cs, err := specChecksum(specFile)
+		if err == nil {
+			m.SpecChecksum = cs
+		}
+		break
+	}
+
+	// Look up catalog entry for category/description enrichment.
+	if entry, err := catalogpkg.LookupFS(catalog.FS, p.APIName); err == nil {
+		m.CatalogEntry = entry.Name
+		m.Category = entry.Category
+		m.Description = entry.Description
+	}
+
+	return WriteCLIManifest(p.OutputDir, m)
 }
 
 // detectSpecFormat examines the raw spec bytes and returns a format

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -73,9 +73,9 @@ func specChecksum(path string) (string, error) {
 // PipelineState), the standalone generate command only knows the spec
 // sources and output directory.
 type GenerateManifestParams struct {
-	APIName  string
-	SpecSrcs []string // --spec args (URLs or file paths)
-	DocsURL  string   // --docs URL, if used
+	APIName   string
+	SpecSrcs  []string // --spec args (URLs or file paths)
+	DocsURL   string   // --docs URL, if used
 	OutputDir string
 }
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -290,6 +290,98 @@ func TestPublishWorkingCLIManifestWithoutSpec(t *testing.T) {
 	assert.Empty(t, got.SpecFormat)
 }
 
+func TestWriteManifestForGenerateWithSpecURL(t *testing.T) {
+	dir := t.TempDir()
+
+	// Place an OpenAPI spec in the output dir so format/checksum are detected.
+	specContent := []byte(`{"openapi": "3.0.0", "info": {"title": "Test"}}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.json"), specContent, 0o644))
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "test-api",
+		SpecSrcs:  []string{"https://example.com/openapi.json"},
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, 1, got.SchemaVersion)
+	assert.Equal(t, "test-api", got.APIName)
+	assert.Equal(t, "test-api-pp-cli", got.CLIName)
+	assert.Equal(t, version.Version, got.PrintingPressVersion)
+	assert.Equal(t, "https://example.com/openapi.json", got.SpecURL)
+	assert.Empty(t, got.SpecPath)
+	assert.Equal(t, "openapi3", got.SpecFormat)
+	assert.NotEmpty(t, got.SpecChecksum)
+	assert.False(t, got.GeneratedAt.IsZero())
+}
+
+func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "local-test",
+		SpecSrcs:  []string{"/tmp/my-spec.yaml"},
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Empty(t, got.SpecURL, "local path should not appear in spec_url")
+	assert.Equal(t, "/tmp/my-spec.yaml", got.SpecPath)
+}
+
+func TestWriteManifestForGenerateWithDocsURL(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "docs-api",
+		DocsURL:   "https://docs.example.com/api",
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "https://docs.example.com/api", got.SpecURL)
+	assert.Equal(t, "docs", got.SpecFormat)
+}
+
+func TestWriteManifestForGenerateNoSpec(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "bare-api",
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "bare-api", got.APIName)
+	assert.Empty(t, got.SpecURL)
+	assert.Empty(t, got.SpecPath)
+	assert.Empty(t, got.SpecChecksum)
+}
+
 func TestDetectSpecFormat(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Fix bug where `printing-press generate` never wrote `.printing-press.json` manifests — only the fullrun pipeline's `PublishWorkingCLI` did, so any CLI generated via the `/printing-press` skill was missing its manifest and failed `publish validate`
- Add `WriteManifestForGenerate` to the pipeline package, called from both `--spec` and `--docs` code paths in the generate command
- Suppress redundant "validation failed" stderr when `--json` mode already contains structured failure details (`Silent` field on `ExitError`)

## Test plan

- [x] `go test ./...` — 556 tests pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — no issues
- [x] Manual verification: `printing-press publish validate --dir <cli-dir> --json` now exits silently (no stderr noise) with exit code 5
- [ ] Generate a new CLI and verify `.printing-press.json` exists in the output directory
- [ ] Run `publish validate` against a freshly generated CLI and confirm manifest check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)