### PR TITLE
fix(skills): add cd to publish-repo before gh pr create/edit

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -422,6 +422,7 @@ $ <cli-name> --help
 **If updating an existing PR** (`EXISTING_PR_NUMBER` is set):
 
 ```bash
+cd "$PUBLISH_REPO_DIR"
 gh pr edit "$EXISTING_PR_NUMBER" \
   --repo mvanhorn/printing-press-library \
   --body "<constructed PR body>"
@@ -432,6 +433,7 @@ Display: "Updated PR #N: <EXISTING_PR_URL>"
 **If creating a new PR:**
 
 ```bash
+cd "$PUBLISH_REPO_DIR"
 gh pr create \
   --repo mvanhorn/printing-press-library \
   --title "feat(<api-name>): add <cli-name>" \


### PR DESCRIPTION
The publish skill's PR creation step runs `gh pr create` and `gh pr edit` without first changing to the `.publish-repo` directory. When the skill runs from a worktree of cli-printing-press, `gh` infers the head branch from the wrong repo and fails with "you must first push the current branch to a remote" — even though the push already succeeded in `.publish-repo`.

Adds `cd "$PUBLISH_REPO_DIR"` before both `gh pr create` and `gh pr edit` commands, matching the pattern already used by the commit and push commands in the same step.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)