### PR TITLE
docs(cli): add local build and plugin dev instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,27 @@ Safety: GET only, --limit 1, 10s timeout, stops on 401. Never creates, posts, or
 
 ## Development
 
-After cloning, install git hooks so lint errors are caught before they reach CI:
+### Build locally
+
+```bash
+go build -o ./printing-press ./cmd/printing-press
+```
+
+Always use `./printing-press` (relative path). Multiple worktrees may run concurrently - absolute paths like `/tmp/printing-press` will collide.
+
+### Use local skills
+
+The repo is a Claude Code plugin. To test your local skill changes instead of the marketplace version:
+
+```bash
+claude --plugin-dir .
+```
+
+This loads skills, agents, and hooks from your working copy. Inside the session, `/printing-press` runs your local `SKILL.md`, not the installed marketplace version. After editing a skill, run `/reload-plugins` to pick up changes without restarting.
+
+### Lint setup
+
+Install git hooks so lint errors are caught before they reach CI:
 
 ```bash
 brew install lefthook
@@ -396,14 +416,14 @@ lefthook install
 
 This adds a pre-push hook that runs `golangci-lint` on changed files. The same linter config (`.golangci.yml`) runs in CI - lefthook just catches failures locally first.
 
-If you also want `golangci-lint` locally:
+If you also want `golangci-lint` locally (v2 required — the config uses `version: "2"`):
 
 ```bash
 # macOS
 brew install golangci-lint
 
-# or via go
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+# or via the official install script
+curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin
 ```
 
 ## Credits


### PR DESCRIPTION
The Development section only had lint setup — nothing about rebuilding the binary or testing local skill changes. Contributors cloning the repo had to discover these workflows on their own.

Adds two subsections: **Build locally** (`go build -o ./printing-press ./cmd/printing-press` with the relative-path warning) and **Use local skills** (`claude --plugin-dir .` to load the repo as a plugin during development). Also fixes the golangci-lint install instructions — the old `go install` path pointed at the v1 module, but the config requires v2.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)