### PR TITLE
fix(ci): auto-rebuild printing-press binary on worktree creation

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,8 @@
+post-checkout:
+  commands:
+    build:
+      run: go build -o ./printing-press ./cmd/printing-press 2>/dev/null && echo "printing-press binary rebuilt" || true
+
 pre-commit:
   commands:
     fmt:


### PR DESCRIPTION
Git's `post-checkout` hook fires on `git worktree add`, `git checkout`, and `git switch`. Adding a lefthook post-checkout command that rebuilds the printing-press binary ensures the generator templates match the current branch — no more stale binaries generating CLIs with old templates.

Silently succeeds if Go is not installed (`|| true`) so it doesn't break non-Go workflows.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — local git hook only.