### PR TITLE
fix(skills): add secret leak prevention rules

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -442,6 +442,50 @@ gh pr create \
 
 Display the PR URL prominently.
 
+## Secret & PII Protection
+
+Before creating the PR, verify that no secrets leaked into the packaged CLI.
+
+**This matters because the library repo is public.** A leaked API key in a PR is
+a security incident — anyone can see it, even if the PR is later closed.
+
+### What the machine checks (deterministic)
+
+The generation skill (`/printing-press`) runs an exact-value scan during Phase 5.5
+if the user provided an API key. By the time publish runs, the machine's own
+mistakes should already be caught. But the user may have edited files between
+generation and publish.
+
+### What publish checks (best-effort, warn-only)
+
+1. **If `gitleaks` or `trufflehog` is installed**, run it on the staged directory:
+   ```bash
+   if command -v gitleaks >/dev/null 2>&1; then
+     gitleaks detect --source "<staging-dir>/library" --no-git --verbose 2>&1
+   elif command -v trufflehog >/dev/null 2>&1; then
+     trufflehog filesystem "<staging-dir>/library" 2>&1
+   fi
+   ```
+   These tools use vendor-specific patterns (Steam keys, Stripe keys, GitHub
+   tokens) with low false-positive rates. Their findings are warnings — the
+   user reviews and decides.
+
+2. **If no scanning tool is installed**, do a lightweight check:
+   - Verify no `.env` files, `session-state.json`, or `config.toml` with
+     real credentials exist in the staged directory
+   - Check README examples use `"your-key-here"` placeholders, not real values
+   - Check manuscripts (if included) don't contain auth headers or cookie values
+
+3. **Never include** in the staged directory:
+   - `.env` files
+   - `session-state.json`
+   - Config files with real credentials
+   - HAR captures with un-stripped auth headers
+
+If any issues are found, warn the user and ask whether to proceed. The user
+makes the final call — they may have intentionally included something the scan
+flagged (e.g., a test fixture with a fake key). Don't block silently.
+
 ## Error Handling
 
 - **`gh` not authenticated:** Detect in Step 1, tell user to run `gh auth login`

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -90,6 +90,22 @@ See the `printing-press-polish` skill for details. It runs diagnostics, fixes ve
 - YAML, JSON, local paths, and URLs are all valid spec inputs for the verification tools.
 - Maximum 2 verification fix loops unless the user explicitly asks for more.
 
+## Secret & PII Protection (Cardinal Rules)
+
+**These rules are non-negotiable. They apply at ALL times during a run.**
+
+API key **values**, token **values**, passwords, and session cookies must NEVER
+appear in any artifact: source code, manuscripts, proofs, READMEs, HARs, or
+anything committed to git. Env var **names** (e.g., `STEAM_API_KEY`) and
+placeholders (e.g., `"your-key-here"`) are safe.
+
+During Phase 5.5 (archiving) and before publishing, read and apply
+[references/secret-protection.md](references/secret-protection.md) for:
+- Exact-value scanning and auto-redaction of artifacts
+- HAR auth stripping (headers, query strings, cookies)
+- API key handling rules during the run
+- Session state cleanup ordering
+
 ## Orientation & Briefing
 
 Before setup, check whether the user provided arguments. Handle two cases:

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -1,0 +1,81 @@
+# Secret & PII Protection — Implementation Details
+
+Read this file during Phase 5.5 (Archive Manuscripts) and before any publish step.
+The cardinal rules in SKILL.md apply at all times. This file has the implementation.
+
+## Exact-value scan before archiving
+
+The skill knows the API key if the user provided one. Before archiving manuscripts,
+scan all artifacts for the exact key value. This has zero false positives — it checks
+for the specific string, not guessed patterns.
+
+Use `grep -F` (fixed string) and `awk` for replacement — NOT bare `grep`/`sed` —
+because API keys often contain regex metacharacters (`+`, `/`, `.`, `=`) that would
+cause `grep` to match wrong text and `sed` to corrupt files.
+
+```bash
+if [ -n "$API_KEY_VALUE" ]; then
+  LEAK_FOUND=false
+  for dir in "$RESEARCH_DIR" "$PROOFS_DIR" "$DISCOVERY_DIR"; do
+    if [ -d "$dir" ] && grep -rF "$API_KEY_VALUE" "$dir" 2>/dev/null; then
+      LEAK_FOUND=true
+    fi
+  done
+  if [ "$LEAK_FOUND" = true ]; then
+    echo "BLOCKING: API key value found in manuscript artifacts. Auto-redacting."
+    REDACT_TO="\$${API_KEY_ENV_VAR:-API_KEY}"
+    for dir in "$RESEARCH_DIR" "$PROOFS_DIR" "$DISCOVERY_DIR"; do
+      [ -d "$dir" ] || continue
+      find "$dir" -type f -print0 | while IFS= read -r -d '' f; do
+        if grep -qF "$API_KEY_VALUE" "$f" 2>/dev/null; then
+          awk -v old="$API_KEY_VALUE" -v new="$REDACT_TO" '{gsub(old, new)}1' "$f" > "${f}.redacted" && mv "${f}.redacted" "$f"
+        fi
+      done
+    done
+    echo "Auto-redacted. Verify before proceeding."
+  fi
+fi
+```
+
+## Strip auth from HAR captures before archiving
+
+Credentials can appear in three locations within HAR files:
+- **Headers:** `Authorization: Bearer <token>`, `Cookie: session=...`
+- **Query strings:** `?key=<value>`, `?api_key=<value>`, `?access_token=<value>`
+- **Cookies:** session tokens, auth cookies
+
+The archive step must strip all three, plus response bodies (for size):
+
+```bash
+jq 'del(.log.entries[].response.content.text) |
+    # Remove auth headers
+    (.log.entries[].request.headers) |= [.[] |
+      select(.name | test("^(Authorization|Cookie|Set-Cookie|X-API-Key|X-Auth-Token)$"; "i") | not)
+    ] |
+    # Redact auth-like query string params
+    (.log.entries[].request.queryString) |= [.[] |
+      if (.name | test("^(key|api_key|apikey|token|secret|access_token|password)$"; "i"))
+      then .value = "<REDACTED>"
+      else . end
+    ] |
+    # Remove cookies entirely (they often contain session tokens)
+    (.log.entries[].request.cookies) |= []
+    ' "$har" > "${har}.stripped" 2>/dev/null && mv "${har}.stripped" "$har"
+```
+
+## API key handling during the run
+
+When the user provides an API key (Phase 0 API Key Gate or inline):
+- Store it only in a shell variable, never in a file
+- Pass it to commands via environment variable, not via flags visible in process lists
+- In dry-run output, the key may appear in query params — this is expected for
+  debugging but must NOT be captured in proof artifacts
+- When writing live smoke results to proofs, write the test outcomes (PASS/FAIL)
+  but never the request URLs that contain the key in query params
+
+## Session state cleanup
+
+Session state files (`session-state.json`) contain browser cookies and auth tokens.
+The Phase 5.5 archive block removes them with `rm -f "$DISCOVERY_DIR/session-state.json"`.
+This removal is mandatory and must happen BEFORE the `cp -r "$DISCOVERY_DIR"` command.
+If the order is reversed, cookies leak into manuscripts.

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -28,7 +28,15 @@ if [ -n "$API_KEY_VALUE" ]; then
       [ -d "$dir" ] || continue
       find "$dir" -type f -print0 | while IFS= read -r -d '' f; do
         if grep -qF "$API_KEY_VALUE" "$f" 2>/dev/null; then
-          awk -v old="$API_KEY_VALUE" -v new="$REDACT_TO" '{gsub(old, new)}1' "$f" > "${f}.redacted" && mv "${f}.redacted" "$f"
+          # Use python for truly literal replacement — awk's gsub and perl's
+          # s/// both interpret regex metacharacters (+, ., /) in the key,
+          # which breaks on JWT tokens and base64-encoded secrets.
+          REDACT_OLD="$API_KEY_VALUE" REDACT_NEW="$REDACT_TO" python3 -c "
+import sys, os
+old, new, path = os.environ['REDACT_OLD'], os.environ['REDACT_NEW'], sys.argv[1]
+with open(path) as f: content = f.read()
+with open(path, 'w') as f: f.write(content.replace(old, new))
+" "$f"
         fi
       done
     done

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -49,18 +49,23 @@ fi
 
 ## Strip auth from HAR captures before archiving
 
-Credentials can appear in three locations within HAR files:
-- **Headers:** `Authorization: Bearer <token>`, `Cookie: session=...`
+Credentials can appear in four locations within HAR files:
+- **Request headers:** `Authorization: Bearer <token>`, `Cookie: session=...`
+- **Response headers:** `Set-Cookie: session=<token>` (from auth flows)
 - **Query strings:** `?key=<value>`, `?api_key=<value>`, `?access_token=<value>`
-- **Cookies:** session tokens, auth cookies
+- **Cookies:** session tokens, auth cookies (both request and response)
 
-The archive step must strip all three, plus response bodies (for size):
+The archive step must strip all four, plus response bodies (for size):
 
 ```bash
 jq 'del(.log.entries[].response.content.text) |
-    # Remove auth headers
+    # Remove auth headers from requests
     (.log.entries[].request.headers) |= [.[] |
       select(.name | test("^(Authorization|Cookie|Set-Cookie|X-API-Key|X-Auth-Token)$"; "i") | not)
+    ] |
+    # Remove Set-Cookie from responses (contains session tokens from auth flows)
+    (.log.entries[].response.headers) |= [.[] |
+      select(.name | test("^(Set-Cookie)$"; "i") | not)
     ] |
     # Redact auth-like query string params
     (.log.entries[].request.queryString) |= [.[] |
@@ -69,7 +74,8 @@ jq 'del(.log.entries[].response.content.text) |
       else . end
     ] |
     # Remove cookies entirely (they often contain session tokens)
-    (.log.entries[].request.cookies) |= []
+    (.log.entries[].request.cookies) |= [] |
+    (.log.entries[].response.cookies) |= []
     ' "$har" > "${har}.stripped" 2>/dev/null && mv "${har}.stripped" "$har"
 ```
 

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -14,7 +14,9 @@ because API keys often contain regex metacharacters (`+`, `/`, `.`, `=`) that wo
 cause `grep` to match wrong text and `sed` to corrupt files.
 
 ```bash
-if [ -n "$API_KEY_VALUE" ]; then
+# Guard: skip if key is empty or too short (< 16 chars). Short strings
+# would over-redact legitimate content. Real API keys are 20+ chars.
+if [ -n "$API_KEY_VALUE" ] && [ ${#API_KEY_VALUE} -ge 16 ]; then
   LEAK_FOUND=false
   for dir in "$RESEARCH_DIR" "$PROOFS_DIR" "$DISCOVERY_DIR"; do
     if [ -d "$dir" ] && grep -rF "$API_KEY_VALUE" "$dir" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Two-layer defense against API keys leaking into published CLIs, manuscripts, and library PRs.

## The problem

The printing press handles real API keys during live smoke testing. These keys could leak into:
- Generated source code (agent hardcodes instead of using env var)
- README examples (real key in `export STEAM_API_KEY=BBB38...`)
- Manuscript artifacts (proof logs containing request URLs with key in query params)
- HAR captures (auth headers in request entries)

## Layer 1: Generation time (deterministic, zero false positives)

If the user provided an API key, the skill scans all manuscript artifacts for the **exact key value** before archiving. No regex guessing — it checks for the specific string. If found, auto-redacts by replacing the value with the env var name.

This catches the machine's own mistakes. It runs during Phase 5.5 (archive manuscripts).

## Layer 2: Publish time (best-effort, warn-only)

At publish time, the machine may not know the key (different session). The publish skill:
1. Runs `gitleaks` or `trufflehog` if installed (vendor-specific patterns, low false positives)
2. Falls back to lightweight checks (no `.env` files, README uses placeholders)
3. Warns but doesn't block — the user decides on flagged items

## Other protections

- HAR stripping now removes auth **request headers** (Authorization, Cookie, X-API-Key), not just response bodies
- Session state cleanup order documented as mandatory (must happen BEFORE directory copy)
- Cardinal rules section: never write secret VALUES (env var names are fine)

## Design decisions

- **Exact-value scan over regex:** Regex scanning produces false positives (go.sum hashes, UUIDs). The machine knows the key — use the exact value.
- **Warn-only at publish:** The user may have edited files between generation and publish. Generic scans will have false positives. The user makes the final call.
- **Instruction + scan:** The skill tells the agent not to write secrets (defense in depth), but from the Run 5 retro we know instructions are ~80% reliable. The scan is the deterministic safety net.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — skill instruction changes only.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)