### PR TITLE
fix(cli): eliminate dogfood false positives and MarkFlagRequired/stdin conflict

### DIFF
--- a/docs/plans/2026-04-01-007-fix-dogfood-fps-and-stdin-required-plan.md
+++ b/docs/plans/2026-04-01-007-fix-dogfood-fps-and-stdin-required-plan.md
@@ -1,0 +1,193 @@
+---
+title: "fix: Eliminate dogfood false positives and MarkFlagRequired/stdin conflict"
+type: fix
+status: active
+date: 2026-04-01
+origin: docs/retros/2026-04-01-dominos-retro.md
+---
+
+# fix: Eliminate dogfood false positives and MarkFlagRequired/stdin conflict
+
+## Overview
+
+Two systemic issues affect every generated CLI: (1) dogfood reports false-positive dead functions and dead flags, producing a misleading FAIL verdict, and (2) the generator emits `MarkFlagRequired` on body fields for POST commands that also have `--stdin`, breaking the primary agent/script input path.
+
+## Problem Frame
+
+Every CLI that ships through the printing press gets a dogfood FAIL that is wrong. Users and Claude both spend time investigating false positives. Separately, every generated CLI with POST endpoints breaks `echo '{}' | cli cmd --stdin` because the body field is marked required even when stdin provides the data. Both issues were flagged in the Domino's retro (findings #1, #2, #4) and the dead function issue was also present in the Redfin retro. (see origin: docs/retros/2026-04-01-dominos-retro.md)
+
+## Requirements Trace
+
+- R1. Dogfood must not flag functions as dead when they are called transitively by other helpers that ARE called from command files
+- R2. Dogfood must not flag framework-level flags (agent, noCache, noInput, rateLimit, timeout, yes) as dead when they are read in root.go PreRunE, client construction, or other non-RunE code paths
+- R3. Dogfood must still correctly flag genuinely unused functions and flags
+- R4. Generated POST/PUT/PATCH commands must accept `--stdin` without requiring the body field flag
+- R5. Generated POST/PUT/PATCH commands must error clearly when neither `--stdin` nor the body field is provided
+
+## Scope Boundaries
+
+- Does not change verify, scorecard, or the generated CLI runtime
+- Does not add new dogfood checks (only fixes existing ones)
+- Does not change how the generator handles GET commands or path parameters
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/pipeline/dogfood.go` lines 365-475: `checkDeadFlags` and `checkDeadFunctions`
+- `internal/pipeline/dogfood_test.go`: Table-driven tests creating temp dirs with mock CLI files
+- `internal/generator/templates/command_endpoint.go.tmpl` lines 235-254: Flag registration and MarkFlagRequired
+- `internal/generator/generator_test.go`: `TestGeneratedOutput_MutatingCommandsHaveEnvelope` and similar POST-related tests
+
+### Root Cause: Dead Functions
+
+The `checkDeadFunctions` scanner (line 420) extracts function names from `helpers.go`, strips definition lines, and searches all `internal/cli/*.go` files for call sites. The stripped helpers.go IS included in the search corpus. However, the scanner does not do **transitive reachability**. If `apiErr` is only called by `classifyAPIError` (within helpers.go), and `classifyAPIError` IS called from command files, `apiErr` is still flagged as dead because the scanner sees no direct external call to `apiErr`. The scanner needs a second pass: after identifying "live" functions (called from outside helpers.go), mark any function called by a live function as also live.
+
+### Root Cause: Dead Flags
+
+The `checkDeadFlags` scanner (line 365) extracts field names from `&flags.<field>` patterns in root.go, removes declaration lines, then searches for `flags.<field>` or `.<field>` access patterns. Investigation confirmed all 6 flags ARE found by this scan in the dominos CLI. The false positives may be version-dependent or the scanning may miss patterns when flags are accessed through a renamed receiver. Need to verify the exact failure mode with a targeted test.
+
+### Root Cause: MarkFlagRequired
+
+The template at lines 243-247 unconditionally emits `cmd.MarkFlagRequired("<flagName>")` for required body fields. Lines 252-254 also emit the `--stdin` flag for POST/PUT/PATCH. The `--stdin` handler (lines 84-94) reads from stdin and bypasses body flags entirely, but cobra's required-flag validation runs before RunE, so the command fails before stdin is ever read.
+
+## Key Technical Decisions
+
+- **Transitive reachability via iterative marking, not full call-graph**: Building a proper call graph is overkill. Instead, after the initial scan identifies "live" functions, do a second pass: scan the (stripped) bodies of live functions for calls to other helpers. Mark those as live. Repeat until no new functions are marked. This is a simple fixed-point iteration that handles chains of any depth.
+- **Skip MarkFlagRequired for body fields on mutation commands, add RunE guard instead**: Rather than trying to make cobra understand "required unless --stdin," remove the required constraint and add an explicit check at the top of RunE. This is the same pattern used across the CLI ecosystem for "either --file or --stdin" commands.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Does the dead flag scanner actually produce false positives on the dominos CLI?** Investigation during this session confirmed all 6 flags have matching access patterns. The false positives may be specific to how the dominos CLI was modified during Phase 3 (Codex added files that use different patterns). Need to write a test that reproduces the exact false positive to confirm the root cause before fixing.
+
+### Deferred to Implementation
+
+- **Q: How many iterations does the transitive reachability loop need in practice?** The helpers.go call chain is typically 2-3 deep. The loop should converge in 2-3 iterations. Verify empirically during implementation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add transitive reachability to checkDeadFunctions**
+
+**Goal:** Functions called by other helper functions that ARE externally used should not be flagged as dead.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/pipeline/dogfood.go` (`checkDeadFunctions` at line 420)
+- Test: `internal/pipeline/dogfood_test.go`
+
+**Approach:**
+After the initial scan that identifies which functions have external call sites ("live set"), add an iterative expansion step:
+1. Build a map of intra-helpers calls: for each function in helpers.go, which other helper functions does it call?
+2. Seed the "live set" with functions that have external callers
+3. Iterate: for each live function, add any helpers it calls to the live set
+4. Repeat until the live set stops growing
+5. Only report functions NOT in the live set as dead
+
+The intra-helpers call map can reuse the same regex (`\b<funcname>\s*\(`) against each function's body (extracted between its `func` line and the next `func` line).
+
+**Patterns to follow:**
+- Existing `checkDeadFunctions` already uses regex-based scanning and `sortedKeys` iteration
+- Test file uses `writeTestFile` helper and temp dirs
+
+**Test scenarios:**
+- Happy path: helpers.go has funcA (called from command files), funcB (called only by funcA), funcC (genuinely unused). Dogfood reports only funcC as dead.
+- Edge case: chain of 3 (funcA calls funcB calls funcC, only funcA called externally). All three should be live.
+- Edge case: mutual recursion (funcA calls funcB, funcB calls funcA, funcA called externally). Both should be live.
+- Error path: helpers.go is empty or missing. Should return empty result (existing behavior preserved).
+- Negative test: funcD is defined but never called by any function (neither from command files nor from other helpers). funcD should be flagged as dead.
+
+**Verification:**
+- Run `go test ./internal/pipeline/...` and all tests pass
+- Run `printing-press dogfood --dir ~/printing-press/library/dominos-pp-cli` and no helper functions are flagged as dead (since all 12 are transitively reachable)
+
+- [ ] **Unit 2: Investigate and fix dead flag false positives**
+
+**Goal:** Framework-level flags should not be reported as dead.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None (parallel with Unit 1)
+
+**Files:**
+- Modify: `internal/pipeline/dogfood.go` (`checkDeadFlags` at line 365)
+- Test: `internal/pipeline/dogfood_test.go`
+
+**Approach:**
+First, write a test that reproduces the false positive by creating a mock root.go matching the generated pattern (flags declared with `&flags.agent`, read via `if flags.agent {` in PreRunE). If the test passes (no false positive), the issue may be environmental. If it fails, inspect the regex patterns for edge cases:
+- Does `.noCache` matching fail when the receiver is `f` instead of `flags`? (The scanner checks for `.<field>` which should match `f.noCache`)
+- Does line-stripping accidentally remove usage lines that also contain `&flags.`?
+
+If the false positives cannot be reproduced in a clean test, document that they are environment-specific and add the known framework flags to an allowlist instead.
+
+**Patterns to follow:**
+- Existing `checkDeadFlags` test in dogfood_test.go creates a mock root.go with `&flags.jsonOutput` declarations and `flags.jsonOutput = true` usage
+
+**Test scenarios:**
+- Happy path: root.go declares `&flags.agent` and reads it via `if flags.agent {`. Should not be flagged.
+- Happy path: root.go declares `&flags.rateLimit` and passes it via `client.New(cfg, f.timeout, f.rateLimit)`. Should not be flagged (`.rateLimit` access pattern).
+- Edge case: flag declared with `&flags.noCache`, read in a DIFFERENT file (export.go) via `flags.noCache`. Should not be flagged.
+- Negative test: `&flags.deadOnly` declared but never referenced anywhere. Should be flagged.
+
+**Verification:**
+- Run `go test ./internal/pipeline/...` and all tests pass
+- Run `printing-press dogfood --dir ~/printing-press/library/dominos-pp-cli` and no framework flags are flagged
+
+- [ ] **Unit 3: Replace MarkFlagRequired with RunE guard for stdin commands**
+
+**Goal:** Generated POST/PUT/PATCH commands accept `--stdin` without requiring body field flags.
+
+**Requirements:** R4, R5
+
+**Dependencies:** None (parallel with Units 1-2)
+
+**Files:**
+- Modify: `internal/generator/templates/command_endpoint.go.tmpl` (lines 243-254)
+- Test: `internal/generator/generator_test.go`
+
+**Approach:**
+In the template, conditionally skip `MarkFlagRequired` for body fields when the command method is POST, PUT, or PATCH (since those methods always get the `--stdin` flag). Instead, emit a guard at the top of RunE:
+
+Template change at lines 243-247: wrap the `MarkFlagRequired` call in a condition that checks whether `--stdin` will be emitted (i.e., the method is POST/PUT/PATCH). For body fields on those methods, skip MarkFlagRequired.
+
+Template addition near the top of RunE (after the `if flags.dryRun` block at approximately line 37): emit a guard that checks whether at least one body field or stdin was provided. The guard should list the required body field names in the error message.
+
+**Patterns to follow:**
+- Template already uses `{{- if or (eq .Endpoint.Method "POST") ...}}` conditionals
+- Existing tests in generator_test.go verify generated output with `strings.Contains` assertions
+
+**Test scenarios:**
+- Happy path: Generate a CLI from a spec with a POST endpoint having a required body field. The generated command file should NOT contain `MarkFlagRequired` for the body field. It should contain a RunE guard checking `!stdinBody && body<Field> == ""`.
+- Happy path: The generated command should contain the `--stdin` flag registration.
+- Edge case: POST endpoint with NO required body fields. No guard needed, no MarkFlagRequired emitted.
+- Edge case: GET endpoint with required params. `MarkFlagRequired` should still be emitted (GET commands don't get --stdin).
+- Integration: Generate a full CLI, build it, and verify `echo '{}' | <cli> <cmd> --stdin --dry-run` exits 0.
+- Integration: Generate a full CLI, build it, and verify `<cli> <cmd>` (no --stdin, no body flag) exits non-zero with a helpful error message.
+
+**Verification:**
+- Run `go test ./internal/generator/...` and all tests pass
+- Generate a test CLI from a spec with POST endpoints and verify no `MarkFlagRequired` appears for body fields in mutation commands
+
+## System-Wide Impact
+
+- **Interaction graph:** Dogfood results feed into the shipcheck proof, which gates publishing. Fixing false positives means more CLIs will pass dogfood, changing the ship recommendation from `ship-with-gaps` to `ship` in some cases.
+- **Error propagation:** The MarkFlagRequired fix changes the error source from cobra's flag validation (pre-RunE) to the RunE guard (during execution). Error messages will be more helpful ("provide data via --order or --stdin" vs "required flag not set").
+- **Unchanged invariants:** Scorecard, verify, and the generated CLI's runtime behavior for valid inputs remain identical. Only invalid-input error handling changes for mutation commands.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Transitive reachability loop doesn't terminate | Helpers.go is finite and small (~500 lines, ~20 functions). Add a safety cap of 50 iterations. |
+| Dead flag fix changes behavior for genuinely dead flags | Every test includes a negative case with a truly dead flag that must still be caught. |
+| Template change breaks non-mutation commands | Guard condition is scoped to POST/PUT/PATCH only. GET/DELETE commands are unaffected. Template tests verify both paths. |
+
+## Sources & References
+
+- **Origin document:** [docs/retros/2026-04-01-dominos-retro.md](docs/retros/2026-04-01-dominos-retro.md) findings #1, #2, #4
+- Related code: `internal/pipeline/dogfood.go` lines 365-475, `internal/generator/templates/command_endpoint.go.tmpl` lines 235-254
+- Prior art: Redfin retro also flagged dead helper false positives

--- a/docs/retros/2026-04-01-dominos-retro.md
+++ b/docs/retros/2026-04-01-dominos-retro.md
@@ -1,0 +1,239 @@
+# Printing Press Retro: Domino's Pizza
+
+## Session Stats
+- API: Domino's Pizza (food ordering, delivery/carryout)
+- Spec source: Sniffed (HAR from authenticated browser session) + community wrapper research (no official OpenAPI spec exists)
+- Scorecard: 83 -> 85/100 (Grade A)
+- Verify pass rate: N/A (verify cannot parse internal YAML spec format)
+- Fix loops: 2
+- Manual code edits: 5 (order commands MarkFlagRequired fix, stores example, README rewrite)
+- Features built from scratch: 18 (cart, template, address, deals, rewards, menu search, compare-prices, nutrition, menu diff, track watch, analytics insight subcommands)
+
+## Findings
+
+### 1. Dogfood false-positives on intra-file function calls (Tool limitation)
+
+- **What happened:** Dogfood flagged 12 functions as "dead" (defined, never called). All 12 are actually called by other functions within the same file (helpers.go). For example, `classifyAPIError()` calls `apiErr()`, `rateLimitErr()`, and `sanitizeErrorBody()`. Dogfood's static analysis only looks for call sites in OTHER files.
+- **Root cause:** `internal/pipeline/dogfood.go` -- the dead function scanner likely uses a per-function grep that matches the definition but doesn't follow internal call chains within the same file.
+- **Cross-API check:** This happens on every generated CLI. The helpers.go file always contains helper functions that call each other. The redfin retro also flagged dead helpers.
+- **Frequency:** Every API
+- **Fallback if machine doesn't fix it:** Claude has to manually verify each "dead" function, find it's a false positive, explain it to the user, and skip it. Claude catches it reliably but the false FAIL verdict confuses users and erodes trust in dogfood.
+- **Worth a machine fix?** Yes. A FAIL verdict that's always wrong trains users to ignore dogfood entirely.
+- **Inherent or fixable:** Fixable. The dead function scanner can be improved to follow call chains within the same file.
+- **Durable fix:** In `internal/pipeline/dogfood.go`, when checking if a function is "dead," also search for call sites from OTHER functions defined in the same file. If function A calls function B, and A is itself called from outside, B is not dead. Alternatively, use `go vet` or `staticcheck`'s unused analysis which handles this correctly.
+- **Test:** Generate a CLI with helpers that call each other (the default pattern). Dogfood should NOT flag them as dead. Negative test: a genuinely unused function (not called by anything) should still be flagged.
+- **Evidence:** Dogfood reported 12 dead functions; grep confirmed all 12 have call-site references within helpers.go.
+
+### 2. Dogfood false-positives on framework-level flag reads (Tool limitation)
+
+- **What happened:** Dogfood flagged 6 flags as "dead" (declared, never read): agent, noCache, noInput, rateLimit, timeout, yes. All 6 are read -- `agent` sets other flags in root.go, `rateLimit` is passed to `client.New()`, `noCache` is checked in export.go, etc. Dogfood only looks for flag reads inside individual command RunE functions.
+- **Root cause:** `internal/pipeline/dogfood.go` -- dead flag detection only scans RunE bodies, not root-level PreRun logic, client construction, or other commands.
+- **Cross-API check:** These same 6 flags are emitted for every CLI. They are always read at the framework level, never inside individual RunE functions. This is a universal false positive.
+- **Frequency:** Every API
+- **Fallback if machine doesn't fix it:** Claude explains to every user that the FAIL verdict is wrong. Reliable but wasteful.
+- **Worth a machine fix?** Yes. Same trust erosion issue as finding #1.
+- **Inherent or fixable:** Fixable. Expand the scan to include root.go PreRunE, client construction, and other non-RunE code paths.
+- **Durable fix:** In the dead flag scanner, also search for flag variable usage in root.go (especially the PreRunE block and client construction) and in files outside the command file. Any reference to the flag variable outside its declaration counts as "read."
+- **Test:** Generate any CLI. Flags `agent`, `noCache`, `noInput`, `rateLimit`, `timeout`, `yes` should NOT be flagged as dead. Negative test: add a flag that is truly never referenced anywhere -- it should still be flagged.
+- **Evidence:** grep confirmed all 6 flags are read in root.go, export.go, and track_watch.go.
+
+### 3. Verify cannot parse internal YAML spec format (Tool limitation)
+
+- **What happened:** `printing-press verify` failed with "validating parsed spec: at least one resource is required" when given the internal YAML spec, and "invalid character" when given the sniff-generated spec. Verify only accepts OpenAPI 3.0+ JSON/YAML.
+- **Root cause:** `internal/cli/verify.go` -- spec loading uses the OpenAPI parser, not the internal spec parser. The internal YAML format (used by `printing-press generate`) has a different structure than OpenAPI.
+- **Cross-API check:** This affects any CLI generated from a sniffed spec, crowd-sniffed spec, or internal YAML spec -- which is the majority of non-catalog APIs. Only CLIs generated from OpenAPI specs can run verify.
+- **Frequency:** Most APIs (any without an OpenAPI spec)
+- **Fallback if machine doesn't fix it:** Verify is skipped entirely. The CLI ships without runtime behavioral testing. This is the most expensive fallback -- verify catches real bugs that scorecard and dogfood miss.
+- **Worth a machine fix?** Yes. Critical. Verify is the only tool that catches runtime command failures. Skipping it for non-OpenAPI specs means a large fraction of generated CLIs ship without behavioral testing.
+- **Inherent or fixable:** Fixable. Verify should accept the internal YAML spec format (which the generator already parses successfully) in addition to OpenAPI.
+- **Durable fix:** In `internal/cli/verify.go`, add a spec format detection step: if the file starts with `name:` and contains `resources:`, parse it with `internal/spec/` instead of `internal/openapi/`. Both parsers produce an API surface that verify can test against. Alternatively, add a `--spec-format` flag to verify: `--spec-format openapi|internal|auto`.
+- **Test:** Generate a CLI from an internal YAML spec. Run `printing-press verify --dir <cli> --spec <internal.yaml>`. All commands should be tested. Negative test: an OpenAPI spec should still work as before.
+- **Evidence:** `printing-press verify --dir . --spec dominos-combined-spec.yaml` → "validating parsed spec: at least one resource is required"
+
+### 4. Generator emits `MarkFlagRequired("order")` on POST commands with `--stdin` alternative (Bug)
+
+- **What happened:** All three order commands (validate, price, place) had `cmd.MarkFlagRequired("order")`, which prevented `--stdin` from working. Users had to pass both `--order` and `--stdin`, or got "required flag not set" errors.
+- **Root cause:** `internal/generator/` -- when generating POST commands with body parameters, the generator marks the first body field as required without considering the `--stdin` escape hatch. The generator emits both `--<field>` and `--stdin` flags but makes the field required unconditionally.
+- **Cross-API check:** This affects ANY generated CLI with POST/PUT/PATCH commands that accept JSON bodies. That's most APIs.
+- **Frequency:** Most APIs (any with mutation endpoints)
+- **Fallback if machine doesn't fix it:** Claude has to manually remove MarkFlagRequired from every POST command. Moderate reliability -- Claude might miss some if there are many POST commands.
+- **Worth a machine fix?** Yes. The --stdin pattern is the primary way agents and scripts interact with mutation commands. Breaking it is a functional defect.
+- **Inherent or fixable:** Fixable. When a command has both `--<field>` and `--stdin`, don't mark the field as required. Instead, add a validation in RunE: `if !stdinBody && bodyField == "" { return error }`.
+- **Durable fix:** In the generator template for POST commands, replace:
+  ```go
+  _ = cmd.MarkFlagRequired("<field>")
+  ```
+  with a RunE guard:
+  ```go
+  if !stdinBody && body<Field> == "" {
+      return fmt.Errorf("provide data via --%s or --stdin", "<field>")
+  }
+  ```
+- **Test:** Generate a CLI for any API with POST endpoints. Run `echo '{}' | <cli> <cmd> --stdin --dry-run`. Should succeed without "required flag" errors. Negative test: running without --stdin or --<field> should show the error message.
+- **Evidence:** `echo '{"Order":...}' | dominos-pp-cli orders validate_order --stdin` → "required flag(s) \"order\" not set"
+
+### 5. Sniff spec captures infrastructure noise instead of API traffic (Recurring friction)
+
+- **What happened:** The HAR capture contained 654 requests, but `printing-press sniff` generated a spec with Google Maps RPC endpoints, LaunchDarkly event endpoints, Next.js static data routes, and Adobe analytics -- not the actual Domino's API. The real API traffic was a single GraphQL endpoint (`/api/web-bff/graphql`) that sniff missed or couldn't properly decompose.
+- **Root cause:** `printing-press sniff` (or the HAR parsing in `internal/pipeline/`) doesn't filter by the target domain aggressively enough. It also doesn't handle single-endpoint GraphQL APIs where all operations go to the same path.
+- **Cross-API check:** Any modern SPA sniff will capture analytics, maps, CDN, and third-party traffic alongside API calls. Sites using GraphQL BFFs (increasingly common) will have a single endpoint that sniff can't decompose.
+- **Frequency:** Most APIs sniffed from SPAs. GraphQL BFF is a growing pattern.
+- **Fallback if machine doesn't fix it:** Claude manually writes a spec from HAR analysis + community research. High effort but Claude caught it this session.
+- **Worth a machine fix?** Yes for the domain filtering. The GraphQL decomposition is harder but high value.
+- **Inherent or fixable:** Partially fixable.
+  - Domain filtering: fixable. Sniff should accept a `--domain` flag or auto-detect the target domain from the API name and filter aggressively.
+  - GraphQL decomposition: fixable with effort. When sniff detects all XHR going to a single path with POST method and `operationName` in request bodies, it should extract each operation as a separate spec endpoint.
+- **Durable fix:**
+  1. Add `--domain` flag to `printing-press sniff`: `--domain order.dominos.com,www.dominos.com`. Only include HAR entries matching these domains.
+  2. Add GraphQL detection: if >50% of API requests go to a single path with POST and the request bodies contain `operationName`, classify as GraphQL. Extract each unique `operationName` as a separate endpoint in the spec with its variables as parameters.
+  - **Condition:** HAR contains POST requests to a single path with `operationName` in bodies
+  - **Guard:** Standard REST APIs with diverse paths skip GraphQL extraction
+  - **Frequency estimate:** ~20-30% of modern web apps use GraphQL BFFs
+- **Test:** Sniff a HAR from a Next.js GraphQL app. Spec should contain one endpoint per GraphQL operation, not one endpoint for the single `/graphql` path. Negative test: REST API HAR should produce normal path-based endpoints.
+- **Evidence:** `printing-press sniff --har sniff-capture.har` produced 18 endpoints across 6 resources, none of which were real API operations. The 24 GraphQL operations were only discovered by manual HAR parsing.
+
+### 6. Generator emits generic analytics command without domain-specific insight (Template gap)
+
+- **What happened:** The generated `analytics` command was a generic "count by type, group by field" utility. It scored 2/10 on insight because it had no domain-specific queries. Had to manually add `analytics summary`, `analytics popular`, and `analytics spending` subcommands.
+- **Root cause:** `internal/generator/` -- the analytics template is static. It doesn't use the spec's resource types or the research brief to generate domain-relevant queries.
+- **Cross-API check:** Every generated CLI gets the same generic analytics command. The insight score is consistently low unless Claude manually adds domain queries.
+- **Frequency:** Every API
+- **Fallback if machine doesn't fix it:** Claude builds custom analytics subcommands during Phase 3. Medium reliability -- Claude usually does it but the commands are inconsistent across CLIs.
+- **Worth a machine fix?** Yes. The generator has access to the entity types and their fields. It could generate at least `summary` (table counts) and entity-specific queries automatically.
+- **Inherent or fixable:** Partially fixable. The generator can emit:
+  1. `analytics summary` that counts each entity table (derived from spec resources)
+  2. Entity-specific "top N" queries when a field looks like a frequency candidate (e.g., status fields, category fields)
+  The truly domain-specific insight ("popular orders," "spending trends") requires understanding the domain, which is Claude's job in Phase 3.
+- **Durable fix:** In the analytics template, iterate over the spec's resources and generate:
+  - `analytics summary` that queries each resource table for count + last synced
+  - For resources with string fields, a `analytics <resource> top --field <field>` subcommand
+  This gets insight from 2/10 to ~5/10 automatically. Claude's Phase 3 work raises it higher.
+- **Test:** Generate a CLI for any API with 3+ resources. `analytics summary` should show counts for each. `analytics <resource> top --field status` should work. Negative test: none needed -- more analytics is always better.
+- **Evidence:** Scorecard insight scored 2/10 both before and after polish. The generated analytics command had no domain awareness.
+
+### 7. Entity-specific store tables must always be built manually (Missing scaffolding)
+
+- **What happened:** The generator emitted a generic `resources` table with FTS5 and entity stubs (stores, menu, orders, tracking, auth). But the actual entity-specific tables (menu_items, toppings, carts, order_templates, deals, loyalty, addresses) with proper columns and typed methods had to be built entirely by hand (375 lines via Codex). This was the single largest manual task.
+- **Root cause:** `internal/generator/` -- the store template uses a generic resource pattern. It doesn't derive table schemas from the spec's response types.
+- **Cross-API check:** Every CLI needs entity-specific tables. The generator always emits generic tables. This was also flagged in the redfin retro.
+- **Frequency:** Every API
+- **Fallback if machine doesn't fix it:** Claude/Codex builds 300-500 lines of store code. Medium reliability -- the code works but column choices are inconsistent.
+- **Worth a machine fix?** Yes. This is consistently the largest Phase 3 task. The spec contains response schemas (or can be inferred from endpoint descriptions) that would let the generator create typed tables.
+- **Inherent or fixable:** Fixable. The spec's `response.item` types and the `body` field definitions contain the column types. The generator already uses these for command parameters -- it should also use them for store table DDL.
+- **Durable fix:** In `internal/generator/`, when emitting the store template:
+  1. For each resource in the spec, generate a `CREATE TABLE IF NOT EXISTS <resource>` with columns derived from the response fields.
+  2. For resources with text fields, generate an FTS5 virtual table.
+  3. Generate typed Upsert/Get/List/Search methods instead of generic ones.
+  The internal YAML spec's `body` and `response` sections already have field names and types -- pipe them through.
+- **Test:** Generate from a spec with 3+ resources, each with 3+ response fields. Each resource should get its own table with typed columns. Generic `resources` table remains as fallback. Negative test: a minimal spec with no response fields should still get the generic table.
+- **Evidence:** 375 lines of store.go enhancements added manually via Codex (the single largest Phase 3 task).
+
+### 8. README generated with placeholder examples (Template gap)
+
+- **What happened:** The generated README used `dominos-pp-cli auth list` as the example throughout, including in the Output Formats section. The Quick Start said "Get your API key from your API provider's developer portal" -- generic text not specific to Domino's. README scored 5/10.
+- **Root cause:** `internal/generator/readme_augment.go` -- README template uses the first command alphabetically for all examples, and the auth setup section is static.
+- **Cross-API check:** Every generated CLI gets the same placeholder examples and generic auth text. README consistently scores 5/10 before manual rewrite.
+- **Frequency:** Every API
+- **Fallback if machine doesn't fix it:** Claude rewrites the README during polish. High reliability but 10-15 minutes of manual work.
+- **Worth a machine fix?** Yes. The generator has access to all command names and can pick representative ones. The auth setup section can use the spec's auth config (env var names, auth type).
+- **Inherent or fixable:** Fixable. The generator knows the commands, the auth type, the env var name, and the base URL. It can produce:
+  1. Quick Start with the first GET command (not auth list)
+  2. Auth setup referencing the actual env var from the spec
+  3. Example sections using 3-4 different commands across different resources
+- **Durable fix:** In `internal/generator/readme_augment.go`:
+  1. Select example commands by resource variety (one from each resource group, prefer GET over POST)
+  2. Use the spec's `auth.env_vars[0]` in the credential setup section
+  3. Use the spec's `config.path` in the configuration section
+  4. Replace "your API provider's developer portal" with context from the spec (or at minimum, the API name)
+- **Test:** Generate a CLI from any spec with 3+ resources. README Quick Start should reference 3+ different commands. Auth section should mention the correct env var. Negative test: a spec with no auth should skip the auth setup section.
+- **Evidence:** README scored 5/10 before rewrite. After manual rewrite with domain-specific examples, scored 9/10.
+
+## Prioritized Improvements
+
+### Do Now
+| # | Fix | Component | Frequency | Fallback Reliability | Complexity | Guards |
+|---|-----|-----------|-----------|---------------------|------------|--------|
+| 4 | Don't MarkFlagRequired when --stdin exists | Generator templates | Most APIs | Medium | Small | Only for POST commands with --stdin |
+| 1 | Fix dogfood intra-file dead function FPs | pipeline/dogfood.go | Every API | Always caught but wastes time | Small | None needed |
+| 2 | Fix dogfood framework-level flag read FPs | pipeline/dogfood.go | Every API | Always caught but wastes time | Small | None needed |
+
+### Do Next (needs design/planning)
+| # | Fix | Component | Frequency | Fallback Reliability | Complexity | Guards |
+|---|-----|-----------|-----------|---------------------|------------|--------|
+| 3 | Verify accepts internal YAML spec format | cli/verify.go + spec/ | Most APIs | Verify skipped entirely | Medium | Auto-detect format |
+| 7 | Schema-driven entity store tables | Generator templates | Every API | Medium (Codex builds it) | Large | Spec must have response fields |
+| 5 | Sniff domain filtering + GraphQL decomposition | pipeline/sniff | Most sniffed APIs | Medium (manual HAR analysis) | Large | GraphQL guard: only when single-path POST pattern |
+| 6 | Domain-aware analytics template | Generator templates | Every API | Medium (Claude adds subcommands) | Medium | Requires resource list from spec |
+| 8 | Context-aware README examples | generator/readme_augment | Every API | High (Claude rewrites) | Medium | None needed |
+
+### Skip
+| # | Fix | Why unlikely to recur |
+|---|-----|----------------------|
+| (none) | | All findings are cross-API patterns |
+
+## Work Units
+
+### WU-1: Fix dogfood false positives (findings #1, #2)
+- **Goal:** Eliminate all false-positive FAIL verdicts from dogfood for standard generated CLIs
+- **Target files:** `internal/pipeline/dogfood.go`
+- **Acceptance criteria:**
+  - Generate any CLI. Dogfood should not flag helpers that call each other within helpers.go.
+  - Generate any CLI. Dogfood should not flag agent, noCache, noInput, rateLimit, timeout, yes as dead.
+  - A genuinely unused function should still be flagged.
+- **Scope boundary:** Does not change verify or scorecard. Does not change the generated code.
+- **Complexity:** Small (1 file, straightforward logic change in dead-code scanner)
+
+### WU-2: Fix MarkFlagRequired for --stdin commands (finding #4)
+- **Goal:** Generated POST commands accept either --<field> or --stdin without requiring both
+- **Target files:** `internal/generator/` (command template for POST endpoints)
+- **Acceptance criteria:**
+  - Generate a CLI with POST endpoints. `echo '{}' | <cli> <cmd> --stdin --dry-run` succeeds.
+  - Running without --stdin or --<field> shows "provide data via --<field> or --stdin" error.
+- **Scope boundary:** Only affects POST/PUT/PATCH commands with body parameters.
+- **Complexity:** Small (1 template change)
+
+### WU-3: Verify supports internal YAML spec format (finding #3)
+- **Goal:** `printing-press verify` works with internal YAML specs, not just OpenAPI
+- **Target files:** `internal/cli/verify.go`, potentially `internal/spec/spec.go`
+- **Acceptance criteria:**
+  - `printing-press verify --dir <cli> --spec <internal.yaml>` runs all commands.
+  - `printing-press verify --dir <cli> --spec <openapi.yaml>` still works.
+- **Scope boundary:** Does not change the spec format itself. Does not affect generate or dogfood.
+- **Dependencies:** None
+- **Complexity:** Medium (2-3 files, needs format detection + adapter pattern)
+
+### WU-4: Schema-driven store generation (finding #7)
+- **Goal:** Generator emits entity-specific SQLite tables with typed columns derived from spec response schemas
+- **Target files:** `internal/generator/` (store template), `internal/spec/spec.go` (response field extraction)
+- **Acceptance criteria:**
+  - Generate from a spec with 3+ resources. Each resource gets its own table with typed columns.
+  - FTS5 virtual table generated for resources with text fields.
+  - Typed Upsert/Get/List methods generated (not generic).
+  - Minimal spec with no response fields still generates generic fallback.
+- **Scope boundary:** Does not change the CLI runtime. Only changes what the generator emits.
+- **Dependencies:** None
+- **Complexity:** Large (generator template changes + schema inference logic)
+
+### WU-5: Sniff domain filtering and GraphQL decomposition (finding #5)
+- **Goal:** `printing-press sniff` produces clean API specs by filtering noise and decomposing GraphQL
+- **Target files:** `internal/pipeline/` (sniff logic), potentially `internal/cli/sniff.go`
+- **Acceptance criteria:**
+  - Sniff a HAR with mixed domains. Only target-domain requests appear in spec.
+  - Sniff a HAR from a GraphQL app. Each `operationName` becomes a separate spec endpoint.
+  - Sniff a REST API HAR. Normal path-based endpoints generated (GraphQL guard works).
+- **Scope boundary:** Does not change the generator or the internal spec format.
+- **Dependencies:** None
+- **Complexity:** Large (domain filtering is small, GraphQL decomposition is medium-large)
+
+## Anti-patterns
+
+- **Trusting dogfood FAIL verdicts at face value.** In this session, every dogfood FAIL was a false positive. The correct response was to verify each finding, not to try to "fix" them. Future sessions should grep for actual usage before accepting dogfood's dead-code findings.
+- **Using `printing-press sniff` output directly for generation when the target site is an SPA.** The sniff tool captures all traffic, not just API traffic. For SPAs, the HAR must be manually filtered before feeding to sniff, or the skill should instruct Claude to write a spec from the GraphQL operations rather than using the raw sniff output.
+
+## What the Machine Got Right
+
+- **Generator quality gates (7/7 pass).** The generated CLI built, ran, and passed all 7 quality gates on the first try. No build failures from generation.
+- **Codex delegation.** The codex mode successfully delegated 4 large coding tasks (store enhancement, cart commands, deals/rewards, transcendence features). All 4 built on first try with no circuit breaker triggers.
+- **Scorecard accuracy.** The scorecard correctly identified the real quality gaps (insight 2/10, README 5/10) and correctly scored the strengths (agent native 10/10, error handling 10/10). The 83->85 improvement tracked the actual fixes.
+- **Live API reachability.** Store finder, menu, order validation, and order pricing all worked against the live Domino's API on the first try. The generated client correctly handled the `/power/` REST endpoints.
+- **Auth detection.** The research phase correctly identified that Domino's read-only endpoints don't need auth, which saved time by skipping the API key gate for the main ordering flow.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1207,3 +1207,72 @@ func TestGeneratedHelpers_DeadCodeRemoved(t *testing.T) {
 	assert.Contains(t, content, "filterFields")
 	assert.Contains(t, content, "classifyAPIError")
 }
+
+// --- Unit 3: Stdin Guard Tests ---
+
+func TestGeneratedOutput_POSTWithRequiredBodyUsesRunEGuard(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "stdinguard",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "api_key", Header: "X-Api-Key", EnvVars: []string{"SG_API_KEY"}},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/stdinguard-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method:      "POST",
+						Path:        "/items",
+						Description: "Create an item",
+						Body: []spec.Param{
+							{Name: "name", Type: "string", Required: true, Description: "Item name"},
+							{Name: "description", Type: "string", Required: false, Description: "Item description"},
+						},
+					},
+					"list": {
+						Method:      "GET",
+						Path:        "/items",
+						Description: "List items",
+						Params: []spec.Param{
+							{Name: "status", Type: "string", Required: true, Description: "Filter by status"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "stdinguard-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	t.Run("POST command does not use MarkFlagRequired for body fields", func(t *testing.T) {
+		createGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_create.go"))
+		require.NoError(t, err)
+		content := string(createGo)
+		assert.NotContains(t, content, "MarkFlagRequired", "POST body fields should not use MarkFlagRequired (stdin alternative exists)")
+	})
+
+	t.Run("POST command has RunE stdin guard", func(t *testing.T) {
+		createGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_create.go"))
+		require.NoError(t, err)
+		content := string(createGo)
+		assert.Contains(t, content, "!stdinBody", "POST with required body should have a stdin guard in RunE")
+		assert.Contains(t, content, "provide required fields via flags or --stdin", "guard should mention --stdin")
+	})
+
+	t.Run("GET command still uses MarkFlagRequired for required params", func(t *testing.T) {
+		listGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_list.go"))
+		require.NoError(t, err)
+		content := string(listGo)
+		assert.Contains(t, content, "MarkFlagRequired", "GET params should still use MarkFlagRequired")
+	})
+
+	t.Run("generated project compiles", func(t *testing.T) {
+		runGoCommand(t, outputDir, "mod", "tidy")
+		runGoCommand(t, outputDir, "build", "./...")
+	})
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -60,6 +60,13 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 {{- end}}
 
+{{- $isMutation := or (eq .Endpoint.Method "POST") (eq .Endpoint.Method "PUT") (eq .Endpoint.Method "PATCH")}}
+{{- $hasReqBody := false}}{{range .Endpoint.Body}}{{if .Required}}{{$hasReqBody = true}}{{end}}{{end}}
+{{- if and $isMutation $hasReqBody}}
+			if !stdinBody {{range .Endpoint.Body}}{{if .Required}}&& body{{camel .Name}} == {{zeroVal .Type}} {{end}}{{end}}{
+				return fmt.Errorf("provide required fields via flags or --stdin")
+			}
+{{- end}}
 {{- if or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")}}
 {{- if .Endpoint.Pagination}}
 			data, err := paginatedGet(c, path, map[string]string{
@@ -242,7 +249,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 {{- range .Endpoint.Body}}
 	cmd.Flags().{{cobraFlagFunc .Type}}(&body{{camel .Name}}, "{{flagName .Name}}", {{defaultVal .}}, "{{oneline .Description}}")
-{{- if .Required}}
+{{- if and .Required (not (or (eq $.Endpoint.Method "POST") (eq $.Endpoint.Method "PUT") (eq $.Endpoint.Method "PATCH")))}}
 	_ = cmd.MarkFlagRequired("{{flagName .Name}}")
 {{- end}}
 {{- end}}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -455,23 +455,100 @@ func checkDeadFunctions(dir string) DeadCodeResult {
 		otherSources = append(otherSources, string(content))
 	}
 
-	result := DeadCodeResult{Total: len(names)}
+	// Build external call set: functions called from non-helpers files.
+	// Also build intra-helpers call map for transitive reachability.
+	externalSources := make([]string, 0, len(otherSources))
+	for _, file := range files {
+		if filepath.Base(file) == "helpers.go" {
+			continue
+		}
+		content, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		externalSources = append(externalSources, string(content))
+	}
+
+	liveSet := make(map[string]bool)
 	for _, name := range sortedKeys(names) {
 		callRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\(`)
-		used := false
-		for _, source := range otherSources {
+		for _, source := range externalSources {
 			if callRe.MatchString(source) {
-				used = true
+				liveSet[name] = true
 				break
 			}
 		}
-		if used {
+	}
+
+	// Build intra-helpers call map: for each helper function, which other
+	// helper functions does its body call?
+	helperBodies := extractFunctionBodies(string(data))
+	callsMap := make(map[string][]string)
+	for _, caller := range sortedKeys(names) {
+		body, ok := helperBodies[caller]
+		if !ok {
+			continue
+		}
+		for _, callee := range sortedKeys(names) {
+			if callee == caller {
+				continue
+			}
+			callRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(callee) + `\s*\(`)
+			if callRe.MatchString(body) {
+				callsMap[caller] = append(callsMap[caller], callee)
+			}
+		}
+	}
+
+	// Iterative expansion: mark transitively reachable helpers as live.
+	for i := 0; i < 50; i++ {
+		changed := false
+		for _, fn := range sortedKeys(names) {
+			if !liveSet[fn] {
+				continue
+			}
+			for _, callee := range callsMap[fn] {
+				if !liveSet[callee] {
+					liveSet[callee] = true
+					changed = true
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	result := DeadCodeResult{Total: len(names)}
+	for _, name := range sortedKeys(names) {
+		if liveSet[name] {
 			continue
 		}
 		result.Dead++
 		result.Items = append(result.Items, name)
 	}
 	return result
+}
+
+// extractFunctionBodies returns a map from function name to its body text
+// (everything between its func line and the next top-level func line).
+func extractFunctionBodies(source string) map[string]string {
+	bodies := make(map[string]string)
+	funcLineRe := regexp.MustCompile(`(?m)^func\s+([A-Za-z_]\w*)\s*\(`)
+	locs := funcLineRe.FindAllStringIndex(source, -1)
+	nameMatches := funcLineRe.FindAllStringSubmatch(source, -1)
+	for i, match := range nameMatches {
+		name := match[1]
+		start := locs[i][1] // end of func line match
+		var end int
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		} else {
+			end = len(source)
+		}
+		bodies[name] = source[start:end]
+	}
+	return bodies
 }
 
 func checkPipelineIntegrity(dir string) PipelineResult {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -325,6 +325,136 @@ func TestExtractFlagNames(t *testing.T) {
 	}
 }
 
+func TestDeadFunctions_TransitiveReachability(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "helpers.go"), `package cli
+
+func funcA() {
+	funcB()
+}
+
+func funcB() {
+	// only called by funcA
+}
+
+func funcC() {
+	// never called by anything
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "cmd.go"), `package cli
+
+func runCmd() {
+	funcA()
+}
+`)
+
+	result := checkDeadFunctions(dir)
+	assert.Equal(t, 3, result.Total)
+	assert.Equal(t, 1, result.Dead)
+	assert.Equal(t, []string{"funcC"}, result.Items)
+}
+
+func TestDeadFunctions_ChainOfThree(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "helpers.go"), `package cli
+
+func funcA() {
+	funcB()
+}
+
+func funcB() {
+	funcC()
+}
+
+func funcC() {
+	// end of chain
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "cmd.go"), `package cli
+
+func runCmd() {
+	funcA()
+}
+`)
+
+	result := checkDeadFunctions(dir)
+	assert.Equal(t, 3, result.Total)
+	assert.Equal(t, 0, result.Dead)
+	assert.Empty(t, result.Items)
+}
+
+func TestDeadFunctions_GenuinelyDead(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "helpers.go"), `package cli
+
+func funcD() {
+	// defined but never called
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "cmd.go"), `package cli
+
+func runCmd() {
+	// does not call funcD
+}
+`)
+
+	result := checkDeadFunctions(dir)
+	assert.Equal(t, 1, result.Total)
+	assert.Equal(t, 1, result.Dead)
+	assert.Equal(t, []string{"funcD"}, result.Items)
+}
+
+func TestDeadFlags_FrameworkFlags(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "root.go"), `package cli
+
+type rootFlags struct {
+	agent     bool
+	rateLimit int
+	noCache   bool
+	deadOnly  bool
+}
+
+func initFlags(flags *rootFlags) {
+	_ = &flags.agent
+	_ = &flags.rateLimit
+	_ = &flags.noCache
+	_ = &flags.deadOnly
+}
+
+func (f *rootFlags) newClient() {
+	client.New(cfg, f.rateLimit)
+}
+
+func execute(flags *rootFlags) {
+	if flags.agent {
+		enableAgent()
+	}
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "export.go"), `package cli
+
+func runExport(flags *rootFlags) {
+	if flags.noCache {
+		skipCache()
+	}
+}
+`)
+
+	result := checkDeadFlags(dir)
+	assert.Equal(t, 4, result.Total)
+	assert.Equal(t, 1, result.Dead)
+	assert.Equal(t, []string{"deadOnly"}, result.Items)
+}
+
 func writeTestFile(t *testing.T, path string, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))


### PR DESCRIPTION
## Summary
- Dogfood dead function scanner now does transitive reachability within helpers.go, eliminating 12 false-positive "dead function" reports on every generated CLI
- Dogfood dead flag scanner confirmed working correctly via new tests (dominos session false positives were environment-specific)
- Generator template no longer emits `MarkFlagRequired` for body fields on POST/PUT/PATCH commands, replacing it with a RunE guard that allows `--stdin` to work alone

## Test plan
- [x] 4 new dogfood tests (transitive chain, chain-of-3, genuinely dead, framework flags)
- [x] 4 new generator tests (no MarkFlagRequired on POST, RunE guard present, GET still has MarkFlagRequired, compiles)
- [x] Verified against real dominos-pp-cli: dogfood verdict FAIL -> WARN (dead code checks now PASS)

## Origin
docs/retros/2026-04-01-dominos-retro.md (findings #1, #2, #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)