### PR TITLE
fix(cli): sync version files to 1.1.0 and fix release-please config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "cli-printing-press",
-      "version": "0.4.0",
+      "version": "1.1.0",
       "description": "Describe your API. Get a production CLI. Generates Go CLI tools from OpenAPI specs or natural language descriptions.",
       "author": {
         "name": "mvanhorn"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-printing-press",
-  "version": "0.4.0",
+  "version": "1.1.0",
   "description": "Generate production Go CLIs from API descriptions or OpenAPI specs",
   "repository": "mvanhorn/cli-printing-press"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
-        with:
-          release-type: go
 
   goreleaser:
     needs: release-please

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // Version is the current printing-press version. It is set at build time
 // via ldflags for tagged releases, or falls back to the hardcoded value.
-var Version = "0.4.0" // x-release-please-version
+var Version = "1.1.0" // x-release-please-version
 
 func init() {
 	info, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
## Summary

- Bumped version.go, plugin.json, and marketplace.json from 0.4.0 to 1.1.0 to match the actual release
- Removed inline `release-type: go` from release.yml so release-please reads from release-please-config.json

## Root Cause

The release.yml workflow passed `release-type: go` directly to `googleapis/release-please-action@v4`. When release-type is set inline, the action uses "simple mode" and ignores `release-please-config.json` entirely. The `extra-files` entries (which use jsonpath to bump plugin.json and marketplace.json, and generic type to bump version.go) were never processed. All three releases (1.0.0, 1.1.0, 1.2.0) only updated the manifest and changelog.

## Fix

Remove the inline `release-type` from the action so it reads from `release-please-config.json`, where `release-type: go` is already set alongside the `extra-files` config.

## Testing

- `TestVersionConsistencyAcrossFiles` passes
- Full test suite passes
- `grep -r "0.4.0" .claude-plugin/ internal/version/version.go` returns nothing

## Post-Deploy Monitoring & Validation

- After merge, the pending 1.2.0 release-please PR should regenerate and include bumps to all three version files
- Verify by checking the release-please PR diff after this merges
- No runtime impact - this only affects the release automation

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)