### PR TITLE
fix(cli): deduplicate config env var tags and add operations shorthand

### DIFF
--- a/docs/plans/2026-04-09-001-fix-config-tag-collision-and-operations-shorthand-plan.md
+++ b/docs/plans/2026-04-09-001-fix-config-tag-collision-and-operations-shorthand-plan.md
@@ -1,0 +1,230 @@
+---
+title: "fix: Deduplicate config env var tags and add operations shorthand"
+type: fix
+status: active
+date: 2026-04-09
+origin: manuscripts/hubspot-pp-cli/20260408-231505/proofs/2026-04-09-hubspot-retro.md
+---
+
+# fix: Deduplicate config env var tags and add operations shorthand
+
+## Overview
+
+Two generator bugs surfaced during the HubSpot session that affect 20-30% of future CLIs. Both are build-blocking: they cause `go vet` failures or generation rejections. This plan addresses retro findings #1, #4, and #6 (WU-1 and WU-2).
+
+## Problem Frame
+
+1. **Config tag collision (WU-1, findings #1 + #6):** `config.go.tmpl` emits a hardcoded `AccessToken string ... "access_token"` field AND then loops over `Auth.EnvVars` to emit additional fields. When an env var like `HUBSPOT_ACCESS_TOKEN` produces placeholder `access_token` via `envVarPlaceholder()`, the Go struct has two fields with the same JSON tag. `go vet` rejects this, blocking the build. Additionally, when no `Config.Format` is set (common for internal YAML specs), the config file path renders as `config.` with a trailing dot.
+
+2. **Operations shorthand (WU-2, finding #4):** The internal YAML spec format requires explicit `endpoints:` map entries for every operation. For APIs with uniform CRUD patterns (HubSpot has 14 resources, each needing list/get/create/update/delete), this means writing 70+ endpoint definitions by hand. An `operations` shorthand that auto-expands to standard CRUD endpoints would eliminate 80% of this boilerplate.
+
+## Requirements Trace
+
+- R1. A CLI generated with `HUBSPOT_ACCESS_TOKEN` or `DISCORD_TOKEN` env vars must pass `go vet` without manual edits
+- R2. A CLI generated with `STRIPE_SECRET_KEY` (no collision) must still work identically
+- R3. Config file path must never end with a trailing dot when format is unset
+- R4. An internal YAML spec with `operations: [list, get, create, update, delete]` and a `path` must generate the equivalent of 5 explicit endpoints
+- R5. Explicit `endpoints:` definitions must still work (no regression)
+- R6. When both `operations` and `endpoints` are present, explicit endpoints override operations-generated defaults
+
+## Scope Boundaries
+
+- Does NOT change auth logic or env var resolution order
+- Does NOT affect the OpenAPI parser (operations shorthand is internal YAML only)
+- Does NOT add new operations beyond the standard CRUD set (list, get, create, update, delete, search)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `internal/generator/templates/config.go.tmpl` lines 18-30: Struct field generation with hardcoded fields + env var loop
+- `internal/generator/generator.go` lines 1039-1049: `envVarField()` converts env var names to Go field names
+- `internal/generator/generator.go` lines 1331-1343: `envVarPlaceholder()` strips prefix for tag values
+- `internal/spec/spec.go` lines 60-64: `Resource` struct (Endpoints map, no Operations field)
+- `internal/spec/spec.go` lines 153-191: `Validate()` method, line 165 rejects resources with no endpoints
+- `testdata/loops.yaml`: Reference internal YAML spec format
+
+### Institutional Learnings
+
+- AGENTS.md: "Default to machine changes." Both fixes are clearly machine-level.
+- AGENTS.md: "Add tests for new non-trivial logic. Match the package's existing style (typically table-driven with `testify/assert`)."
+
+## Key Technical Decisions
+
+- **Dedup strategy for config tags:** Skip emitting the env-var-derived field when its `envVarPlaceholder` matches a hardcoded field's tag. Instead, add the `os.Getenv` call to populate the existing hardcoded field. This preserves the existing field names that `AuthHeader()`, `SaveTokens()`, and `ClearTokens()` reference. The alternative (removing hardcoded fields entirely) would require rewriting all auth methods to use dynamic field names, which is higher risk.
+
+- **Operations expansion location:** Expand operations to endpoints in `ParseBytes()` after YAML unmarshaling but before `Validate()`. This keeps the expansion logic in one place and means validation sees fully-formed endpoints regardless of whether they came from explicit definitions or operations shorthand.
+
+- **Config format default:** Use Go template `or` function: `{{or .Config.Format "json"}}`. Simple, zero-risk, consistent with how Go templates handle defaults.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Should env var fields use the hardcoded field name or a new name?** Resolution: Use the existing hardcoded field name. When `envVarPlaceholder("HUBSPOT_ACCESS_TOKEN")` = `"access_token"`, the env var populates `cfg.AccessToken` directly instead of creating a `cfg.HubspotAccessToken` that duplicates it. This avoids downstream changes to `AuthHeader()`, `SaveTokens()`, etc.
+
+- **Q: What CRUD operations map to which HTTP methods?** Resolution: Standard REST conventions:
+  - `list` -> `GET /path` (collection)
+  - `get` -> `GET /path/{id}` (by ID, positional)
+  - `create` -> `POST /path`
+  - `update` -> `PATCH /path/{id}` (positional)
+  - `delete` -> `DELETE /path/{id}` (positional)
+  - `search` -> `POST /path/search`
+
+- **Q: How should the `{id}` path param be named?** Resolution: Derive from the resource name: singular form + "Id" (e.g., resource "contacts" -> `contactId`, resource "deals" -> `dealId`). Use the existing `singularize()` helper if available, or simple trailing-s strip.
+
+### Deferred to Implementation
+
+- Exact singularization logic for irregular plurals (e.g., "properties" -> "property"). May need a small lookup table.
+- Whether `batch_create`, `batch_update`, `batch_read` operations should be supported. Not needed for this fix; can be added later.
+
+## Implementation Units
+
+- [ ] **Unit 1: Deduplicate env var config fields (finding #1)**
+
+**Goal:** Prevent duplicate JSON/TOML tags when env var placeholders collide with hardcoded field tags.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `internal/generator/templates/config.go.tmpl`
+- Modify: `internal/generator/generator.go`
+- Test: `internal/generator/generator_test.go`
+
+**Approach:**
+- Add a template helper function `envVarIsBuiltinField(envVar string) bool` that checks if `envVarPlaceholder(envVar)` matches any hardcoded config tag (`access_token`, `refresh_token`, `client_id`, `client_secret`, `base_url`, `auth_header`)
+- In the struct field loop (lines 28-30), skip emitting the field when `envVarIsBuiltinField` returns true
+- In the env var override loop (lines 65-70), when `envVarIsBuiltinField` is true, populate the existing hardcoded field (e.g., `cfg.AccessToken`) instead of the computed field name
+- Register the new helper in the template FuncMap alongside `envVarField` and `envVarPlaceholder`
+
+**Patterns to follow:**
+- Existing template helper registration pattern in `generator.go` (line 110: `"envVarField": envVarField`)
+- Existing `envVarPlaceholder` function for the comparison logic
+
+**Test scenarios:**
+- Happy path: Generate config with `STRIPE_SECRET_KEY` env var -> struct has both `AccessToken` and `StripeSecretKey` fields with unique tags, `go vet` passes
+- Edge case: Generate config with `HUBSPOT_ACCESS_TOKEN` env var -> struct has `AccessToken` field only (no `HubspotAccessToken`), env var override populates `cfg.AccessToken`, `go vet` passes
+- Edge case: Generate config with `DISCORD_TOKEN` env var -> if placeholder is `token`, no collision (no hardcoded `Token` field). Verify no false positive dedup
+- Edge case: Generate config with two env vars, one colliding and one not -> colliding one uses builtin field, non-colliding one gets its own field
+- Error path: Generate with `MY_API_CLIENT_ID` -> placeholder `client_id` collides with hardcoded `ClientID`, env var populates `cfg.ClientID` directly
+
+**Verification:**
+- `go test ./internal/generator/...` passes
+- Generate a CLI with `HUBSPOT_ACCESS_TOKEN` env var, run `go vet ./...` in generated CLI -> passes
+
+- [ ] **Unit 2: Default config format to "json" (finding #6)**
+
+**Goal:** Prevent truncated config file path when `Config.Format` is empty.
+
+**Requirements:** R3
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `internal/generator/templates/config.go.tmpl`
+- Test: `internal/generator/generator_test.go`
+
+**Approach:**
+- Replace `config.{{.Config.Format}}` with `config.{{or .Config.Format "json"}}` in the path construction (line 47)
+- Also check for any other template locations that reference `.Config.Format` and apply the same default
+
+**Patterns to follow:**
+- Go template `or` function is already available in text/template
+
+**Test scenarios:**
+- Happy path: Generate with `Config.Format = "toml"` -> path ends with `config.toml`
+- Edge case: Generate with `Config.Format = ""` (empty) -> path ends with `config.json`, not `config.`
+- Edge case: Generate with no Config section at all -> path ends with `config.json`
+
+**Verification:**
+- Generated config.go contains `config.json` or `config.toml`, never `config.`
+
+- [ ] **Unit 3: Add Operations field to Resource struct**
+
+**Goal:** Allow internal YAML specs to use `operations: [list, get, create, update, delete]` as shorthand.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** None (independent of Units 1-2)
+
+**Files:**
+- Modify: `internal/spec/spec.go`
+- Test: `internal/spec/spec_test.go`
+
+**Approach:**
+- Add `Operations []string` field to `Resource` struct with yaml tag `operations,omitempty`
+- Add an `expandOperations()` method on `APISpec` that runs after `ParseBytes()` unmarshaling
+- For each resource with non-empty `Operations` and a `Path`:
+  - For each operation string, generate the corresponding `Endpoint` entry
+  - If the resource already has an explicit endpoint with the same key name, the explicit one wins (no override)
+  - Derive the ID path param name from the resource key (e.g., "contacts" -> `contactId`)
+- Call `expandOperations()` in `ParseBytes()` between unmarshal and `Validate()`
+
+**Patterns to follow:**
+- Existing `Resource` struct field pattern (line 60-64 of spec.go)
+- Existing `ParseBytes()` flow (unmarshal -> return) at lines 125-151
+
+**Test scenarios:**
+- Happy path: Spec with `operations: [list, get]` on resource "items" with `path: /api/items` -> produces `list` (GET /api/items) and `get` (GET /api/items/{itemId}) endpoints
+- Happy path: Spec with `operations: [list, get, create, update, delete]` -> produces all 5 standard endpoints with correct methods and paths
+- Happy path: `operations: [search]` -> produces POST /path/search endpoint
+- Edge case: Spec with both `operations: [list, get]` and explicit `endpoints: {list: {method: GET, path: /custom}}` -> explicit `list` wins, `get` is generated from operations
+- Edge case: Spec with `endpoints:` only (no operations) -> works exactly as before (regression test)
+- Edge case: Spec with `operations: [list]` but no `path` on the resource -> validation error (path is required for expansion)
+- Error path: Spec with `operations: [invalid_op]` -> ignored or validation error
+
+**Verification:**
+- `go test ./internal/spec/...` passes
+- Parse a YAML spec with `operations` field -> endpoints are populated correctly
+
+- [ ] **Unit 4: Add testdata fixture for operations shorthand**
+
+**Goal:** Provide a reference spec using the new operations shorthand for future skill authors.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Create: `testdata/operations-shorthand.yaml`
+- Modify: `internal/spec/spec_test.go` (add integration test using the fixture)
+
+**Approach:**
+- Create a minimal internal YAML spec using `operations` on 2-3 resources
+- Include one resource with both `operations` and explicit `endpoints` to test the merge behavior
+- Add a test in `spec_test.go` that parses this fixture and verifies the expanded endpoints
+
+**Patterns to follow:**
+- Existing `testdata/loops.yaml` fixture style
+- Existing `TestParseBytesYAMLVariations` test pattern
+
+**Test scenarios:**
+- Integration: Parse `testdata/operations-shorthand.yaml` -> all resources have the expected number of endpoints with correct methods, paths, and param names
+- Integration: Resource with both operations and explicit endpoints -> explicit endpoints preserved, operations fill gaps
+
+**Verification:**
+- `go test ./internal/spec/... -run TestOperationsShorthand` passes
+
+## System-Wide Impact
+
+- **Interaction graph:** Config template change affects every generated CLI's config.go. Operations shorthand affects only CLIs generated from internal YAML specs.
+- **Error propagation:** No change to runtime error behavior. These are generation-time fixes.
+- **Unchanged invariants:** OpenAPI parser is not touched. Auth resolution order is preserved. Existing internal YAML specs with explicit endpoints work identically.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Dedup logic has false positives (skips fields that shouldn't be skipped) | Hardcoded list of builtin tags makes the match explicit, not heuristic. Test with non-colliding env vars. |
+| Operations expansion produces wrong HTTP methods | Standard REST conventions are well-defined. Explicit mapping table in code, not inference. |
+| Operations expansion breaks when resource name is irregular (e.g., "data") | ID param derivation uses simple singular + "Id". Add test for edge cases. Implementer may need a small lookup table. |
+
+## Sources & References
+
+- **Origin document:** [HubSpot Retro](manuscripts/hubspot-pp-cli/20260408-231505/proofs/2026-04-09-hubspot-retro.md)
+- Config template: `internal/generator/templates/config.go.tmpl`
+- Spec parser: `internal/spec/spec.go`
+- Generator helpers: `internal/generator/generator.go` (envVarField, envVarPlaceholder)
+- Reference spec: `testdata/loops.yaml`

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -101,19 +101,22 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return zeroVal(t)
 		},
-		"positionalArgs":     positionalArgs,
-		"configTag":          configTag,
-		"camelToJSON":        camelToJSON,
-		"columnNames":        columnNames,
-		"columnPlaceholders": columnPlaceholders,
-		"updateSet":          updateSet,
-		"envVarField":        envVarField,
-		"envVarPlaceholder":  envVarPlaceholder,
-		"add":                func(a, b int) int { return a + b },
-		"oneline":            oneline,
-		"mcpDescription":     mcpDescription,
-		"flagName":           flagName,
-		"safeTypeName":       safeTypeName,
+		"positionalArgs":         positionalArgs,
+		"configTag":              configTag,
+		"camelToJSON":            camelToJSON,
+		"columnNames":            columnNames,
+		"columnPlaceholders":     columnPlaceholders,
+		"updateSet":              updateSet,
+		"envVarField":            envVarField,
+		"envVarPlaceholder":      envVarPlaceholder,
+		"envVarIsBuiltinField":   envVarIsBuiltinField,
+		"envVarBuiltinFieldName": envVarBuiltinFieldName,
+		"resolveEnvVarField":     resolveEnvVarField,
+		"add":                    func(a, b int) int { return a + b },
+		"oneline":                oneline,
+		"mcpDescription":         mcpDescription,
+		"flagName":               flagName,
+		"safeTypeName":           safeTypeName,
 		"hasNonScalarType": func(types map[string]spec.TypeDef) bool {
 			for _, td := range types {
 				for _, f := range td.Fields {
@@ -1046,6 +1049,44 @@ func envVarField(envVar string) string {
 		}
 	}
 	return result
+}
+
+// builtinConfigTags lists the JSON/TOML tags of hardcoded Config struct fields
+// in config.go.tmpl. When an env var's placeholder matches one of these, the
+// env var should populate the existing field instead of creating a duplicate.
+var builtinConfigTags = map[string]string{
+	"access_token":  "AccessToken",
+	"refresh_token": "RefreshToken",
+	"client_id":     "ClientID",
+	"client_secret": "ClientSecret",
+	"base_url":      "BaseURL",
+	"auth_header":   "AuthHeaderVal",
+}
+
+// envVarIsBuiltinField returns true if the env var's placeholder tag would
+// collide with a hardcoded Config struct field tag.
+func envVarIsBuiltinField(envVar string) bool {
+	placeholder := envVarPlaceholder(envVar)
+	_, ok := builtinConfigTags[placeholder]
+	return ok
+}
+
+// envVarBuiltinFieldName returns the Go field name of the hardcoded Config
+// struct field that matches this env var's placeholder, or empty string if none.
+func envVarBuiltinFieldName(envVar string) string {
+	placeholder := envVarPlaceholder(envVar)
+	return builtinConfigTags[placeholder]
+}
+
+// resolveEnvVarField returns the correct Go field name for an env var,
+// accounting for builtin field collisions. If the env var's placeholder
+// matches a hardcoded field, returns that field name; otherwise returns
+// the computed field name from envVarField.
+func resolveEnvVarField(envVar string) string {
+	if name := envVarBuiltinFieldName(envVar); name != "" {
+		return name
+	}
+	return envVarField(envVar)
 }
 
 func oneline(s string) string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1645,3 +1645,27 @@ func TestMCPDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvVarBuiltinFieldDedup(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		envVar    string
+		isBuiltin bool
+		resolved  string
+	}{
+		{"HUBSPOT_ACCESS_TOKEN", true, "AccessToken"},
+		{"DISCORD_ACCESS_TOKEN", true, "AccessToken"},
+		{"MY_CLIENT_ID", true, "ClientID"},
+		{"STRIPE_SECRET_KEY", false, "StripeSecretKey"},
+		{"LINEAR_API_KEY", false, "LinearApiKey"},
+		{"MY_REFRESH_TOKEN", true, "RefreshToken"},
+		{"NOTION_TOKEN", false, "NotionToken"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.envVar, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.isBuiltin, envVarIsBuiltinField(tt.envVar))
+			assert.Equal(t, tt.resolved, resolveEnvVarField(tt.envVar))
+		})
+	}
+}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -26,7 +26,9 @@ type Config struct {
 	ClientSecret   string `{{configTag .Config.Format}}:"client_secret"`
 	Path           string `{{configTag .Config.Format}}:"-"`
 {{- range .Auth.EnvVars}}
+{{- if not (envVarIsBuiltinField .)}}
 	{{envVarField .}} string `{{configTag $.Config.Format}}:"{{envVarPlaceholder .}}"`
+{{- end}}
 {{- end}}
 }
 
@@ -44,7 +46,7 @@ func Load(configPath string) (*Config, error) {
 	}
 	if path == "" {
 		home, _ := os.UserHomeDir()
-		path = filepath.Join(home, ".config", "{{.Name}}-pp-cli", "config.{{.Config.Format}}")
+		path = filepath.Join(home, ".config", "{{.Name}}-pp-cli", "config.{{or .Config.Format "json"}}")
 	}
 	cfg.Path = path
 
@@ -64,7 +66,7 @@ func Load(configPath string) (*Config, error) {
 {{- end}}
 {{- range .Auth.EnvVars}}
 	if v := os.Getenv("{{.}}"); v != "" {
-		cfg.{{envVarField .}} = v
+		cfg.{{resolveEnvVarField .}} = v
 		cfg.AuthSource = "env:{{.}}"
 	}
 {{- end}}
@@ -83,21 +85,21 @@ func (c *Config) AuthHeader() string {
 	}
 {{- if eq .Auth.Type "api_key"}}
 	{{- if gt (len .Auth.EnvVars) 0}}
-	token := c.{{envVarField (index .Auth.EnvVars 0)}}
+	token := c.{{resolveEnvVarField (index .Auth.EnvVars 0)}}
 	if token == "" {
 		return ""
 	}
 	{{- end}}
 {{- range .Auth.EnvVars}}
-	if c.{{envVarField .}} == "" {
+	if c.{{resolveEnvVarField .}} == "" {
 		return ""
 	}
 {{- end}}
 	{{- if .Auth.Format}}
 	replacements := map[string]string{
 	{{- range .Auth.EnvVars}}
-		"{{envVarPlaceholder .}}": c.{{envVarField .}},
-		"{{.}}": c.{{envVarField .}},
+		"{{envVarPlaceholder .}}": c.{{resolveEnvVarField .}},
+		"{{.}}": c.{{resolveEnvVarField .}},
 	{{- end}}
 	}
 	return applyAuthFormat("{{.Auth.Format}}", replacements)
@@ -116,15 +118,15 @@ func (c *Config) AuthHeader() string {
 		{{- end}}
 	}
 	{{- if gt (len .Auth.EnvVars) 0}}
-	if c.{{envVarField (index .Auth.EnvVars 0)}} != "" {
+	if c.{{resolveEnvVarField (index .Auth.EnvVars 0)}} != "" {
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{
-			"{{envVarPlaceholder (index .Auth.EnvVars 0)}}": c.{{envVarField (index .Auth.EnvVars 0)}},
-			"{{index .Auth.EnvVars 0}}": c.{{envVarField (index .Auth.EnvVars 0)}},
-			"token": c.{{envVarField (index .Auth.EnvVars 0)}},
+			"{{envVarPlaceholder (index .Auth.EnvVars 0)}}": c.{{resolveEnvVarField (index .Auth.EnvVars 0)}},
+			"{{index .Auth.EnvVars 0}}": c.{{resolveEnvVarField (index .Auth.EnvVars 0)}},
+			"token": c.{{resolveEnvVarField (index .Auth.EnvVars 0)}},
 		})
 		{{- else}}
-		return "Bearer " + c.{{envVarField (index .Auth.EnvVars 0)}}
+		return "Bearer " + c.{{resolveEnvVarField (index .Auth.EnvVars 0)}}
 		{{- end}}
 	}
 	{{- end}}
@@ -135,8 +137,8 @@ func (c *Config) AuthHeader() string {
 		return c.AccessToken
 	}
 	{{- if gt (len .Auth.EnvVars) 0}}
-	if c.{{envVarField (index .Auth.EnvVars 0)}} != "" {
-		return c.{{envVarField (index .Auth.EnvVars 0)}}
+	if c.{{resolveEnvVarField (index .Auth.EnvVars 0)}} != "" {
+		return c.{{resolveEnvVarField (index .Auth.EnvVars 0)}}
 	}
 	{{- end}}
 	return ""
@@ -146,8 +148,8 @@ func (c *Config) AuthHeader() string {
 		return c.AccessToken
 	}
 	{{- if gt (len .Auth.EnvVars) 0}}
-	if c.{{envVarField (index .Auth.EnvVars 0)}} != "" {
-		return c.{{envVarField (index .Auth.EnvVars 0)}}
+	if c.{{resolveEnvVarField (index .Auth.EnvVars 0)}} != "" {
+		return c.{{resolveEnvVarField (index .Auth.EnvVars 0)}}
 	}
 	{{- end}}
 	return ""

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -59,6 +60,8 @@ type ConfigSpec struct {
 
 type Resource struct {
 	Description  string              `yaml:"description" json:"description"`
+	Path         string              `yaml:"path,omitempty" json:"path,omitempty"`             // base path for operations shorthand (e.g., /api/items)
+	Operations   []string            `yaml:"operations,omitempty" json:"operations,omitempty"` // shorthand: list, get, create, update, delete, search
 	Endpoints    map[string]Endpoint `yaml:"endpoints" json:"endpoints"`
 	SubResources map[string]Resource `yaml:"sub_resources,omitempty" json:"sub_resources,omitempty"`
 }
@@ -144,10 +147,127 @@ func ParseBytes(data []byte) (*APISpec, error) {
 	if yamlErr != nil {
 		return nil, fmt.Errorf("parsing yaml: %w", yamlErr)
 	}
+	s.expandOperations()
 	if err := s.Validate(); err != nil {
 		return nil, fmt.Errorf("validation: %w", err)
 	}
 	return &s, nil
+}
+
+// expandOperations converts operations shorthand (e.g., [list, get, create])
+// into explicit Endpoint entries for each resource that has Operations set.
+// Explicit endpoints take precedence over generated ones.
+func (s *APISpec) expandOperations() {
+	for name, r := range s.Resources {
+		if len(r.Operations) == 0 || r.Path == "" {
+			continue
+		}
+		if r.Endpoints == nil {
+			r.Endpoints = make(map[string]Endpoint)
+		}
+		idParam := singularize(name) + "Id"
+		for _, op := range r.Operations {
+			// Skip if an explicit endpoint already exists with this name
+			if _, exists := r.Endpoints[op]; exists {
+				continue
+			}
+			switch op {
+			case "list":
+				r.Endpoints["list"] = Endpoint{
+					Method:       "GET",
+					Path:         r.Path,
+					Description:  "List " + name,
+					ResponsePath: "results",
+				}
+			case "get":
+				r.Endpoints["get"] = Endpoint{
+					Method:      "GET",
+					Path:        r.Path + "/{" + idParam + "}",
+					Description: "Get a " + singularize(name) + " by ID",
+					Params: []Param{{
+						Name:        idParam,
+						Type:        "string",
+						Required:    true,
+						Positional:  true,
+						Description: singularize(name) + " ID",
+					}},
+				}
+			case "create":
+				r.Endpoints["create"] = Endpoint{
+					Method:      "POST",
+					Path:        r.Path,
+					Description: "Create a new " + singularize(name),
+				}
+			case "update":
+				r.Endpoints["update"] = Endpoint{
+					Method:      "PATCH",
+					Path:        r.Path + "/{" + idParam + "}",
+					Description: "Update a " + singularize(name),
+					Params: []Param{{
+						Name:        idParam,
+						Type:        "string",
+						Required:    true,
+						Positional:  true,
+						Description: singularize(name) + " ID",
+					}},
+				}
+			case "delete":
+				r.Endpoints["delete"] = Endpoint{
+					Method:      "DELETE",
+					Path:        r.Path + "/{" + idParam + "}",
+					Description: "Delete a " + singularize(name),
+					Params: []Param{{
+						Name:        idParam,
+						Type:        "string",
+						Required:    true,
+						Positional:  true,
+						Description: singularize(name) + " ID",
+					}},
+				}
+			case "search":
+				r.Endpoints["search"] = Endpoint{
+					Method:       "POST",
+					Path:         r.Path + "/search",
+					Description:  "Search " + name,
+					ResponsePath: "results",
+					Body: []Param{{
+						Name:        "query",
+						Type:        "string",
+						Description: "Search query string",
+					}},
+				}
+			}
+		}
+		s.Resources[name] = r
+	}
+}
+
+// singularize returns a simple singular form of a plural noun.
+// Handles common patterns; irregular forms use a lookup table.
+func singularize(s string) string {
+	irregulars := map[string]string{
+		"properties": "property",
+		"companies":  "company",
+		"categories": "category",
+		"entries":    "entry",
+		"statuses":   "status",
+		"addresses":  "address",
+		"analyses":   "analysis",
+	}
+	lower := strings.ToLower(s)
+	if singular, ok := irregulars[lower]; ok {
+		return singular
+	}
+	if strings.HasSuffix(lower, "ies") {
+		return lower[:len(lower)-3] + "y"
+	}
+	if strings.HasSuffix(lower, "ses") || strings.HasSuffix(lower, "xes") || strings.HasSuffix(lower, "zes") {
+		return lower[:len(lower)-2]
+	}
+	if strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") {
+		return lower[:len(lower)-1]
+	}
+	return lower
 }
 
 func (s *APISpec) Validate() error {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -458,3 +458,123 @@ description: Missing base_url and resources
 		assert.Contains(t, err.Error(), "base_url is required")
 	})
 }
+
+func TestOperationsShorthand(t *testing.T) {
+	s, err := Parse("../../testdata/operations-shorthand.yaml")
+	require.NoError(t, err)
+
+	assert.Equal(t, "testapi", s.Name)
+	assert.Len(t, s.Resources, 3)
+
+	t.Run("full CRUD operations expand to 5 endpoints", func(t *testing.T) {
+		items := s.Resources["items"]
+		assert.Len(t, items.Endpoints, 5)
+
+		// list
+		list := items.Endpoints["list"]
+		assert.Equal(t, "GET", list.Method)
+		assert.Equal(t, "/api/items", list.Path)
+
+		// get
+		get := items.Endpoints["get"]
+		assert.Equal(t, "GET", get.Method)
+		assert.Equal(t, "/api/items/{itemId}", get.Path)
+		require.Len(t, get.Params, 1)
+		assert.Equal(t, "itemId", get.Params[0].Name)
+		assert.True(t, get.Params[0].Required)
+		assert.True(t, get.Params[0].Positional)
+
+		// create
+		create := items.Endpoints["create"]
+		assert.Equal(t, "POST", create.Method)
+		assert.Equal(t, "/api/items", create.Path)
+
+		// update
+		update := items.Endpoints["update"]
+		assert.Equal(t, "PATCH", update.Method)
+		assert.Equal(t, "/api/items/{itemId}", update.Path)
+
+		// delete
+		del := items.Endpoints["delete"]
+		assert.Equal(t, "DELETE", del.Method)
+		assert.Equal(t, "/api/items/{itemId}", del.Path)
+	})
+
+	t.Run("partial operations expand correctly", func(t *testing.T) {
+		cats := s.Resources["categories"]
+		assert.Len(t, cats.Endpoints, 3)
+
+		assert.Equal(t, "GET", cats.Endpoints["list"].Method)
+		assert.Equal(t, "GET", cats.Endpoints["get"].Method)
+		assert.Equal(t, "/api/categories/{categoryId}", cats.Endpoints["get"].Path)
+		assert.Equal(t, "POST", cats.Endpoints["search"].Method)
+		assert.Equal(t, "/api/categories/search", cats.Endpoints["search"].Path)
+	})
+
+	t.Run("explicit endpoints override operations", func(t *testing.T) {
+		mixed := s.Resources["mixed"]
+		// operations: [list, get] + explicit: [list, special] = 3 total
+		assert.Len(t, mixed.Endpoints, 3)
+
+		// Explicit list overrides operations-generated list
+		list := mixed.Endpoints["list"]
+		assert.Equal(t, "/api/mixed/custom-list", list.Path)
+		assert.Equal(t, "Custom list endpoint overrides operations-generated one", list.Description)
+
+		// Operations-generated get
+		get := mixed.Endpoints["get"]
+		assert.Equal(t, "/api/mixed/{mixedId}", get.Path)
+
+		// Explicit-only special
+		special := mixed.Endpoints["special"]
+		assert.Equal(t, "POST", special.Method)
+		assert.Equal(t, "/api/mixed/special", special.Path)
+	})
+}
+
+func TestSingularize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"items", "item"},
+		{"contacts", "contact"},
+		{"companies", "company"},
+		{"categories", "category"},
+		{"properties", "property"},
+		{"addresses", "address"},
+		{"statuses", "status"},
+		{"deals", "deal"},
+		{"data", "data"},
+		{"entries", "entry"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, singularize(tt.input))
+		})
+	}
+}
+
+func TestExpandOperationsNoPath(t *testing.T) {
+	// Operations without a path should not expand
+	input := `name: nopath
+description: "Test"
+base_url: "https://api.example.com"
+resources:
+  items:
+    description: "No path"
+    operations:
+      - list
+    endpoints:
+      fallback:
+        method: GET
+        path: /items
+        description: "Explicit fallback"
+`
+	s, err := ParseBytes([]byte(input))
+	require.NoError(t, err)
+	items := s.Resources["items"]
+	// Only the explicit endpoint should exist, operations not expanded
+	assert.Len(t, items.Endpoints, 1)
+	assert.Contains(t, items.Endpoints, "fallback")
+}

--- a/testdata/operations-shorthand.yaml
+++ b/testdata/operations-shorthand.yaml
@@ -1,0 +1,44 @@
+name: testapi
+description: "Test API for operations shorthand"
+version: "1.0.0"
+base_url: "https://api.example.com"
+
+auth:
+  type: bearer_token
+  env_vars:
+    - TESTAPI_TOKEN
+
+resources:
+  items:
+    description: "Manage items"
+    path: /api/items
+    operations:
+      - list
+      - get
+      - create
+      - update
+      - delete
+
+  categories:
+    description: "Manage categories"
+    path: /api/categories
+    operations:
+      - list
+      - get
+      - search
+
+  mixed:
+    description: "Resource with both operations and explicit endpoints"
+    path: /api/mixed
+    operations:
+      - list
+      - get
+    endpoints:
+      list:
+        method: GET
+        path: /api/mixed/custom-list
+        description: "Custom list endpoint overrides operations-generated one"
+      special:
+        method: POST
+        path: /api/mixed/special
+        description: "An explicit-only endpoint"


### PR DESCRIPTION
## Summary

- Fix build-blocking duplicate JSON tags in generated config.go when env var placeholders collide with hardcoded fields (e.g., `HUBSPOT_ACCESS_TOKEN` producing `access_token` tag that duplicates the hardcoded `AccessToken` field)
- Default config file extension to `json` when `Config.Format` is empty, preventing truncated paths like `config.`
- Add `operations` shorthand to the internal YAML spec parser, allowing `operations: [list, get, create, update, delete]` instead of writing 5 explicit endpoint definitions per resource

## Test plan

- [x] `go test ./...` passes (all existing + new tests)
- [x] `go vet ./...` clean
- [x] `TestEnvVarBuiltinFieldDedup` covers collision detection for 7 env var patterns
- [x] `TestOperationsShorthand` covers full CRUD, partial ops, and explicit endpoint override
- [x] `TestSingularize` covers 10 noun patterns including irregulars
- [x] `TestExpandOperationsNoPath` verifies operations without path don't expand
- [ ] Generate a CLI with `HUBSPOT_ACCESS_TOKEN` env var and verify `go vet` passes on generated code
- [ ] Generate a CLI with `STRIPE_SECRET_KEY` and verify no regression

## Origin

From HubSpot retro findings #1, #4, #6. These bugs affected 20-30% of CLI generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)