### PR TITLE
fix(cli): raise resource limit from 50 to 500 and add --max-resources flag

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -74,6 +74,7 @@ func newGenerateCmd() *cobra.Command {
 	var clientPattern string
 	var researchDir string
 	var maxEndpointsPerResource int
+	var maxResources int
 	var specURL string
 
 	cmd := &cobra.Command{
@@ -215,6 +216,9 @@ func newGenerateCmd() *cobra.Command {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--spec is required")}
 			}
 
+			if maxResources > 0 {
+				openapi.SetMaxResources(maxResources)
+			}
 			if maxEndpointsPerResource > 0 {
 				openapi.SetMaxEndpointsPerResource(maxEndpointsPerResource)
 			}
@@ -389,6 +393,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&specSource, "spec-source", "", "Spec provenance: official, community, sniffed, docs (affects generated client defaults like rate limiting)")
 	cmd.Flags().StringVar(&clientPattern, "client-pattern", "", "HTTP client pattern: rest (default), proxy-envelope (wraps requests in POST envelope)")
 	cmd.Flags().StringVar(&researchDir, "research-dir", "", "Pipeline directory containing research.json and discovery/ for README source credits")
+	cmd.Flags().IntVar(&maxResources, "max-resources", 0, "Maximum resource groups to generate (default 500, raise for enormous APIs)")
 	cmd.Flags().IntVar(&maxEndpointsPerResource, "max-endpoints-per-resource", 0, "Maximum endpoints per resource (default 50, raise for large APIs)")
 	cmd.Flags().StringVar(&specURL, "spec-url", "", "Original spec URL for provenance (use when --spec is a local file downloaded from a URL)")
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -19,10 +19,20 @@ import (
 )
 
 var (
-	maxResources            = 50
+	maxResources            = 500
 	maxEndpointsPerResource = 50
 	endpointLimitExplicit   = false // true when user set --max-endpoints-per-resource
+	resourceLimitExplicit   = false // true when user set --max-resources
 )
+
+// SetMaxResources overrides the default resource limit. When not called,
+// the parser uses a default of 500 which accommodates all known APIs.
+func SetMaxResources(n int) {
+	if n > 0 {
+		maxResources = n
+		resourceLimitExplicit = true
+	}
+}
 
 // SetMaxEndpointsPerResource overrides the default limit and disables
 // auto-calibration. When not called, the parser auto-calibrates the limit


### PR DESCRIPTION
## Summary
- Raises `maxResources` default from 50 to 500, accommodating all known APIs (Slack ~25, Stripe ~70, GitHub ~150 resource groups)
- Adds `--max-resources` flag mirroring the existing `--max-endpoints-per-resource` pattern
- Adds `SetMaxResources()` function for programmatic control

The 50-resource cap silently dropped endpoints for large APIs. Slack's 174 endpoints span 25+ resource groups, but alphabetical ordering meant admin.* endpoints filled all 50 slots and user-facing endpoints (chat, conversations, users, search) were skipped entirely.

## Test plan
- [x] `go test ./...` passes (all packages green)
- [x] `go build ./cmd/printing-press` succeeds
- [x] `printing-press generate --help` shows `--max-resources` flag
- [ ] Re-run Slack spec generation to verify all 25 resource groups appear

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this is a generator-side change that only affects spec parsing at generation time. No runtime impact on printed CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)