### PR TITLE
feat(cli): add printing-press-library plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     {
       "name": "printing-press-library",
       "version": "1.0.0",
-      "description": "Discover, install, and use Printing Press CLI tools and MCP servers for dozens of APIs",
+      "description": "Discover, install, and use Printing Press CLI tools and MCP servers for hundreds of APIs",
       "author": {
         "name": "mvanhorn"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,25 @@
         "source": "github",
         "repo": "mvanhorn/cli-printing-press"
       }
+    },
+    {
+      "name": "printing-press-library",
+      "version": "1.0.0",
+      "description": "Discover, install, and use Printing Press CLI tools and MCP servers for dozens of APIs",
+      "author": {
+        "name": "mvanhorn"
+      },
+      "repository": "mvanhorn/printing-press-library",
+      "tags": [
+        "cli",
+        "mcp",
+        "api",
+        "printing-press"
+      ],
+      "source": {
+        "source": "github",
+        "repo": "mvanhorn/printing-press-library"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the printing-press-library plugin to the cli-printing-press marketplace. Users who install this marketplace now also get `/printing-press-library`, a unified skill for discovering, installing, and using any Printing Press CLI or MCP server conversationally.

See mvanhorn/printing-press-library#35 for the plugin implementation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M_context)-D97757?logo=claude&logoColor=white)