### PR TITLE
fix(cli): always emit usageErr helper

### DIFF
--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -94,9 +94,7 @@ type cliError struct {
 func (e *cliError) Error() string { return e.err.Error() }
 func (e *cliError) Unwrap() error { return e.err }
 
-{{- if .HasMultiPositional}}
 func usageErr(err error) error    { return &cliError{code: 2, err: err} }
-{{- end}}
 func notFoundErr(err error) error { return &cliError{code: 3, err: err} }
 func authErr(err error) error     { return &cliError{code: 4, err: err} }
 func apiErr(err error) error      { return &cliError{code: 5, err: err} }


### PR DESCRIPTION
## Summary

Drop the \`HasMultiPositional\` gate on the \`usageErr\` helper. The gate was misaligned with actual template usage: \`command_promoted.go.tmpl\` calls \`usageErr\` unconditionally for promoted commands with a single positional arg, but \`helpers.go.tmpl\` only emitted the helper when the spec had at least one endpoint with 2+ positional params. This caused \`undefined: usageErr\` build failures.

Caught while generating \`archive-is-pp-cli\`, which has only single-positional promoted commands (\`save <url>\`, etc.), so the gate never triggered and the helper was missing from the generated \`helpers.go\`.

## Why always-emit is safe

Go permits unused package-level functions, so emitting \`usageErr\` when no template calls it costs nothing. The previous gate tried to be clever about when to emit it, but the cleverness is not worth a class of "missing helper" bugs.

## Test plan

- [x] Regenerated archive-is-pp-cli and all 7 quality gates pass
- [x] \`go test ./internal/generator/...\` passes
- [x] \`go vet ./...\` clean

## Post-Deploy Monitoring & Validation

No operational impact. Template-level change that affects future generated CLIs.

Compound Engineered with Claude Opus 4.6 (1M context) <noreply@anthropic.com>