### PR TITLE
fix(skills): use git-subdir source for library plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "printing-press-library",
-      "version": "1.0.0",
+      "version": "1.1.2",
       "description": "Discover, install, and use Printing Press CLI tools and MCP servers for hundreds of APIs",
       "author": {
         "name": "mvanhorn"
@@ -39,8 +39,10 @@
         "printing-press"
       ],
       "source": {
-        "source": "github",
-        "repo": "mvanhorn/printing-press-library"
+        "source": "git-subdir",
+        "url": "https://github.com/mvanhorn/printing-press-library.git",
+        "path": "plugin",
+        "ref": "main"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Switches `printing-press-library` plugin source from `github` (full repo clone) to `git-subdir` (sparse checkout of `plugin/` subdir)
- Bumps library plugin version to 1.1.2

Companion to mvanhorn/printing-press-library PR that moves plugin files into `plugin/` subdirectory. Together these fix the `EINVAL: invalid argument, mkdir` error when caching the library plugin.

## Test plan
- [ ] After both PRs merge, run `/plugin` and install `printing-press-library` — should cache without error
- [ ] Verify skills from the library plugin load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)