### PR TITLE
fix(cli): address remaining ESPN retro findings

### DIFF
--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -260,6 +260,8 @@ func collectTextFieldNames(r spec.Resource) []string {
 		"title": true, "name": true, "description": true,
 		"body": true, "content": true, "summary": true, "subject": true,
 		"text": true, "message": true, "comment": true, "note": true,
+		"notes": true, "tag": true, "tags": true, "label": true, "labels": true,
+		"category": true, "categories": true, "metadata": true,
 	}
 
 	seen := make(map[string]bool)

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/internal/spec"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,6 +33,68 @@ func TestToSnakeCase(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			assert.Equal(t, tt.expected, toSnakeCase(tt.input))
+		})
+	}
+}
+
+func TestCollectTextFieldNames(t *testing.T) {
+	// Fields like tag/label/category/metadata should be picked up for FTS5
+	// alongside the core text fields. Motivated by the ESPN retro where
+	// "notes" (event tags) were unsearchable until manually added.
+	mkResource := func(paramNames ...string) spec.Resource {
+		params := make([]spec.Param, 0, len(paramNames))
+		for _, n := range paramNames {
+			params = append(params, spec.Param{Name: n, Type: "string"})
+		}
+		return spec.Resource{
+			Endpoints: map[string]spec.Endpoint{
+				"get": {Params: params},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		params   []string
+		wantIncl []string
+		wantExcl []string
+	}{
+		{
+			name:     "picks up core text fields",
+			params:   []string{"title", "description", "body"},
+			wantIncl: []string{"title", "description", "body"},
+		},
+		{
+			name:     "picks up tag-family fields",
+			params:   []string{"name", "tag", "tags", "label", "labels"},
+			wantIncl: []string{"name", "tag", "tags", "label", "labels"},
+		},
+		{
+			name:     "picks up category and metadata fields",
+			params:   []string{"title", "category", "categories", "metadata"},
+			wantIncl: []string{"title", "category", "categories", "metadata"},
+		},
+		{
+			name:     "picks up notes and note",
+			params:   []string{"note", "notes"},
+			wantIncl: []string{"note", "notes"},
+		},
+		{
+			name:     "ignores non-text fields",
+			params:   []string{"id", "created_at", "price"},
+			wantExcl: []string{"id", "created_at", "price"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectTextFieldNames(mkResource(tt.params...))
+			for _, want := range tt.wantIncl {
+				assert.Contains(t, got, want)
+			}
+			for _, exc := range tt.wantExcl {
+				assert.NotContains(t, got, exc)
+			}
 		})
 	}
 }

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -211,6 +211,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				indicator := green("OK")
 				if strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") {
 					indicator = red("FAIL")
+				} else if s == "not required" {
+					// Public APIs: no auth needed is a healthy state, not a warning.
+					indicator = green("OK")
 				} else if strings.Contains(s, "not ") || strings.Contains(s, "skipped") || strings.Contains(s, "inferred") {
 					indicator = yellow("WARN")
 				}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -625,14 +625,107 @@ func classifyCommandKind(cmd *discoveredCommand, spec *openAPISpec) {
 }
 
 // workflowTestFlags returns flags needed for workflow commands that require --org or --repo.
+// Retained for explicit positional-arg patterns (e.g., changelog takes two positional
+// args, not flags — cobra won't surface them through the "required flag(s) not set"
+// error). Flag-shaped requirements are now discovered dynamically via inferRequiredFlags.
 func workflowTestFlags(cmdName string) []string {
 	switch cmdName {
-	case "pr-triage", "stale", "actions-health", "security", "contributors":
-		return []string{"--repo", "mock-owner/mock-repo"}
 	case "changelog":
 		return []string{"mock-owner", "mock-repo", "--since", "v0.0.1"}
 	default:
 		return nil
+	}
+}
+
+// requiredFlagsRe matches cobra's standard "required flag(s) ... not set" error.
+// Cobra emits the flag names quoted, comma-separated: required flag(s) "event", "year" not set
+var requiredFlagsRe = regexp.MustCompile(`required flag\(s\) ((?:"[^"]+"(?:, )?)+) not set`)
+
+// flagNameRe extracts quoted flag names from the required-flags error payload.
+var flagNameRe = regexp.MustCompile(`"([^"]+)"`)
+
+// inferRequiredFlags probes a command by running it with no args, parses cobra's
+// "required flag(s) ... not set" error if present, and returns synthetic --flag value
+// pairs the verifier can use to exercise the command. Returns nil when the command
+// has no required flags (or when probing fails — the caller falls back gracefully).
+func inferRequiredFlags(binary, cmdName string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	probe := exec.CommandContext(ctx, binary, cmdName)
+	out, _ := probe.CombinedOutput() // error expected when flags are missing
+
+	m := requiredFlagsRe.FindSubmatch(out)
+	if m == nil {
+		return nil
+	}
+
+	nameMatches := flagNameRe.FindAllSubmatch(m[1], -1)
+	if len(nameMatches) == 0 {
+		return nil
+	}
+
+	var args []string
+	for _, nm := range nameMatches {
+		flag := string(nm[1])
+		args = append(args, "--"+flag, syntheticFlagValue(flag))
+	}
+	return args
+}
+
+// syntheticFlagValue maps a required flag name to a synthetic test value. Shares
+// its philosophy with syntheticArgValue but keyed on flag names that appear in
+// "required flag(s)" errors. The mock server doesn't validate values, so any
+// non-empty string of the right shape works.
+func syntheticFlagValue(name string) string {
+	n := strings.ToLower(name)
+	switch n {
+	case "org", "organization", "owner":
+		return "mock-owner"
+	case "repo", "repository":
+		return "mock-owner/mock-repo"
+	case "team", "workspace", "project", "workspace-id", "project-id":
+		return "mock-project"
+	case "user", "username", "user-id", "account", "account-id":
+		return "mock-user"
+	case "event", "event-id", "game", "game-id", "match", "match-id":
+		return "mock-event-123"
+	case "season", "year":
+		return "2026"
+	case "sport", "league", "competition":
+		return "mock-league"
+	case "id", "uid", "uuid":
+		return "mock-id-123"
+	case "ticker", "symbol":
+		return "MOCK"
+	case "region", "location", "city":
+		return "mock-city"
+	case "date", "day":
+		return "2026-04-11"
+	case "since", "from", "start", "start-date":
+		return "2026-01-01"
+	case "until", "to", "end", "end-date":
+		return "2026-12-31"
+	case "query", "q", "search", "term":
+		return "mock-query"
+	case "name", "slug", "key":
+		return "mock-name"
+	case "type", "kind", "category":
+		return "mock-type"
+	case "status", "state":
+		return "active"
+	case "limit", "count", "size":
+		return "10"
+	case "format", "output":
+		return "json"
+	case "url", "endpoint", "base-url":
+		return "https://mock.example.com"
+	case "path", "file", "output-file":
+		return "/tmp/mock-file"
+	case "token", "api-key", "key-id", "secret":
+		return "mock-secret"
+	default:
+		return "mock-value"
 	}
 }
 
@@ -646,8 +739,13 @@ func runCommandTests(binary string, cmd discoveredCommand, mode string, env []st
 	// Test 1: --help
 	result.Help = runCLI(binary, []string{cmd.Name, "--help"}, env, 10*time.Second) == nil
 
-	// Get any required flags/args for this command
-	extraFlags := workflowTestFlags(cmd.Name)
+	// Get any required flags/args for this command.
+	// First, probe the binary for cobra-declared required flags (generic, spec-agnostic).
+	// Then fall back to the positional-arg map for commands that take bare positionals.
+	extraFlags := inferRequiredFlags(binary, cmd.Name)
+	if extraFlags == nil {
+		extraFlags = workflowTestFlags(cmd.Name)
+	}
 
 	// Build positional args + flags for test invocations
 	buildTestArgs := func(cmdName string, positionalArgs, flags []string, extra ...string) []string {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -245,6 +245,91 @@ func TestSyntheticArgValue(t *testing.T) {
 	}
 }
 
+func TestSyntheticFlagValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"org", "mock-owner"},
+		{"repo", "mock-owner/mock-repo"},
+		{"event", "mock-event-123"},
+		{"game-id", "mock-event-123"},
+		{"season", "2026"},
+		{"sport", "mock-league"},
+		{"ticker", "MOCK"},
+		{"date", "2026-04-11"},
+		{"since", "2026-01-01"},
+		{"limit", "10"},
+		{"status", "active"},
+		// Case insensitive
+		{"Event", "mock-event-123"},
+		{"ORG", "mock-owner"},
+		// Unknown falls back to mock-value
+		{"unknown-flag", "mock-value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, syntheticFlagValue(tt.name))
+		})
+	}
+}
+
+func TestRequiredFlagsRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected []string
+	}{
+		{
+			name:     "single flag",
+			output:   `Error: required flag(s) "event" not set`,
+			expected: []string{"event"},
+		},
+		{
+			name:     "multiple flags",
+			output:   `Error: required flag(s) "event", "year" not set`,
+			expected: []string{"event", "year"},
+		},
+		{
+			name:     "three flags",
+			output:   `Error: required flag(s) "org", "repo", "branch" not set`,
+			expected: []string{"org", "repo", "branch"},
+		},
+		{
+			name:     "no required-flags error",
+			output:   `Error: unknown command "foo"`,
+			expected: nil,
+		},
+		{
+			name:     "surrounded by other output",
+			output:   "Usage: cli foo [flags]\n\nError: required flag(s) \"event\" not set\nRun 'cli foo --help'",
+			expected: []string{"event"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := requiredFlagsRe.FindStringSubmatch(tt.output)
+			if tt.expected == nil {
+				assert.Nil(t, m)
+				return
+			}
+			require.NotNil(t, m)
+			nameMatches := flagNameRe.FindAllStringSubmatch(m[1], -1)
+			got := make([]string, 0, len(nameMatches))
+			for _, nm := range nameMatches {
+				got = append(got, nm[1])
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestInferRequiredFlags_UnknownBinaryReturnsNil(t *testing.T) {
+	// Probing a non-existent binary should return nil cleanly, not panic or hang.
+	result := inferRequiredFlags("/nonexistent/binary/path", "somecmd")
+	assert.Nil(t, result)
+}
+
 func TestParseSQLOutput(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Closes the remaining 3 work units from the ESPN retro (#153). The first two work units (populating \`defaultSyncResources\`/\`syncResourcePath\` and adding a \`--dates\` flag for temporal APIs) already shipped in prior PRs. This PR handles WU-3, WU-4, and WU-5.

## What changed

**WU-3: Generic required-flag inference for verify.** The verifier's \`workflowTestFlags\` used to be a hardcoded switch (\`pr-triage\`, \`stale\`, \`--repo mock-owner/mock-repo\`) that only understood GitHub-shaped commands. Any other API with required flags scored 1/3 on every such command — ESPN lost 4 commands this way. Replaced with \`inferRequiredFlags\` which probes each command with no args, parses cobra's standard \`required flag(s) "X", "Y" not set\` error, and supplies synthetic values from a name-keyed map (\`event\` -> \`mock-event-123\`, \`season\` -> \`2026\`, \`repo\` -> \`mock-owner/mock-repo\`, etc.). The mock server doesn't validate values, so shape-appropriate placeholders are enough to get the command past flag validation and into the actual code path verify cares about.

The positional-args path for \`changelog\` is preserved because cobra's required-flags error doesn't cover positional requirements.

**WU-4: Expand FTS5 text-field keywords.** \`collectTextFieldNames\` now recognizes \`tag\`, \`tags\`, \`label\`, \`labels\`, \`category\`, \`categories\`, \`metadata\`, and \`notes\` in addition to the existing set. The ESPN retro surfaced this when \"Super Bowl\" was unsearchable because events carried their marquee identity in \`notes\`, which wasn't in the keyword set.

**WU-5: Doctor shows OK for no-auth APIs.** The doctor template's status classifier used \`strings.Contains(s, \"not \")\` as a WARN trigger, which caught both \`\"not configured\"\` (legitimate warning) and \`\"not required\"\` (healthy state for public APIs). Added a specific check so \`\"not required\"\` renders as green OK.

## Test plan

- [ ] Run verify against a non-GitHub API with required flags (e.g., ESPN) and confirm previously-failing commands now execute their dry-run and JSON paths
- [ ] Generate a CLI for a spec that has \`tag\`/\`label\`/\`notes\` fields and confirm FTS5 tables are created over those columns
- [ ] Run \`doctor\` on a \`auth: none\` CLI and confirm the Auth line shows green OK instead of yellow WARN

\`go test ./...\` passes (1575 tests, +28 new). \`golangci-lint\` clean.

Closes #153.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)