### PR TITLE
fix(ci): make validate-catalog fail loud on missing base ref

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
@@ -24,11 +26,36 @@ jobs:
 
       - name: Validate changed catalog entries
         run: |
-          for file in $(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- 'catalog/*.yaml'); do
+          set -euo pipefail
+
+          # Ensure the base ref is fetched locally so the diff below resolves.
+          # actions/checkout with fetch-depth: 0 should cover this, but fetch
+          # explicitly to guard against partial-clone edge cases on fork PRs.
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- 'catalog/*.yaml')
+
+          if [ ${#CHANGED[@]} -eq 0 ]; then
+            echo "FAIL: workflow triggered on catalog/** changes but git diff found no changed catalog/*.yaml files."
+            echo "This usually means the base ref was not fetched. Check actions/checkout fetch-depth."
+            exit 1
+          fi
+
+          echo "Found ${#CHANGED[@]} changed catalog file(s):"
+          printf '  - %s\n' "${CHANGED[@]}"
+
+          for file in "${CHANGED[@]}"; do
             echo "=== Validating $file ==="
 
+            # Wrapper-only entries (no spec_url) have nothing to fetch or generate.
+            # The schema test above already validated them against catalog rules.
+            if ! grep -q '^spec_url:' "$file"; then
+              echo "SKIP: wrapper-only entry (no spec_url)"
+              continue
+            fi
+
             # Extract spec_url
-            SPEC_URL=$(grep 'spec_url:' "$file" | sed 's/spec_url: *//')
+            SPEC_URL=$(grep '^spec_url:' "$file" | sed 's/spec_url: *//')
 
             # Verify HTTPS
             if [[ ! "$SPEC_URL" =~ ^https:// ]]; then
@@ -47,7 +74,7 @@ jobs:
 
             # Download and generate
             curl -sL -o /tmp/spec-validate.yaml "$SPEC_URL"
-            NAME=$(grep 'name:' "$file" | head -1 | sed 's/name: *//')
+            NAME=$(grep '^name:' "$file" | head -1 | sed 's/name: *//')
 
             ./printing-press generate \
               --spec /tmp/spec-validate.yaml \


### PR DESCRIPTION
## Summary
- `actions/checkout`'s default shallow clone often lacks the base ref, so `git diff origin/<base>...HEAD` returned empty and the per-entry loop silently skipped every changed catalog file — step exited 0 and reported success without validating anything (exactly what happened on #177).
- Set `fetch-depth: 0`, add an explicit `git fetch` of the base ref, and fail loudly if the resulting diff is empty (the workflow only fires on `catalog/**`, so an empty diff is always a bug).
- Skip wrapper-only entries (no `spec_url`) cleanly and anchor the `spec_url` / `name` greps to column 0 so nested keys in descriptions can't leak in.

Fixes #178

## Test plan
- [ ] CI's `Validate Catalog` job now prints the list of changed files and runs the URL + generate checks on spec-based entries.
- [ ] Wrapper-only entries log `SKIP: wrapper-only entry (no spec_url)` and don't fail.
- [ ] If the diff ever comes back empty, the step fails with a clear message instead of passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)