### PR TITLE
feat(cli): add travel and food-and-dining categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Releases are fully automated. No manual steps required.
 Catalog entries in `catalog/` must pass `internal/catalog` validation:
 - Required fields: name, display_name, description, category, spec_url, spec_format, tier
 - spec_url must use HTTPS
-- category must be: developer-tools, monitoring, cloud, project-management, productivity, social-and-messaging, sales-and-crm, marketing, payments, auth, commerce, ai, media-and-entertainment, devices, other
+- category must be: ai, auth, cloud, commerce, developer-tools, devices, food-and-dining, marketing, media-and-entertainment, monitoring, payments, productivity, project-management, sales-and-crm, social-and-messaging, travel, or other
 - tier must be: official or community
 
 ## Testing

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -14,21 +14,25 @@ import (
 
 var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
+// Public categories first, alphabetized. "other" and "example" are explicitly
+// special (catch-all / test-only) and kept at the end.
 var validCategories = map[string]struct{}{
-	"developer-tools":         {},
-	"monitoring":              {},
-	"cloud":                   {},
-	"project-management":      {},
-	"productivity":            {},
-	"social-and-messaging":    {},
-	"sales-and-crm":           {},
-	"marketing":               {},
-	"payments":                {},
-	"auth":                    {},
-	"commerce":                {},
 	"ai":                      {},
-	"media-and-entertainment": {},
+	"auth":                    {},
+	"cloud":                   {},
+	"commerce":                {},
+	"developer-tools":         {},
 	"devices":                 {},
+	"food-and-dining":         {},
+	"marketing":               {},
+	"media-and-entertainment": {},
+	"monitoring":              {},
+	"payments":                {},
+	"productivity":            {},
+	"project-management":      {},
+	"sales-and-crm":           {},
+	"social-and-messaging":    {},
+	"travel":                  {},
 	"other":                   {},
 	"example":                 {},
 }

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -142,10 +142,10 @@ func TestValidateEntry(t *testing.T) {
 
 func TestAllPublicCategoriesAreValid(t *testing.T) {
 	publicCategories := []string{
-		"developer-tools", "monitoring", "cloud", "project-management",
-		"productivity", "social-and-messaging", "sales-and-crm", "marketing",
-		"payments", "auth", "commerce", "ai", "media-and-entertainment",
-		"devices", "other",
+		"ai", "auth", "cloud", "commerce", "developer-tools", "devices",
+		"food-and-dining", "marketing", "media-and-entertainment", "monitoring",
+		"payments", "productivity", "project-management", "sales-and-crm",
+		"social-and-messaging", "travel", "other",
 	}
 	base := Entry{
 		Name:        "test-api",


### PR DESCRIPTION
## Summary

- Add two new catalog categories: \`travel\` and \`food-and-dining\`.
- Alphabetize the full category list in \`catalog.go\`, \`catalog_test.go\`, and \`AGENTS.md\` for easier maintenance. \`other\` and \`example\` intentionally kept at the end as special cases.

## Why

\"other\" is a weak catch-all. It currently buckets together genuinely unrelated CLIs — a pizza-ordering CLI (pagliacci), a flight-tracking CLI (flightgoat), and a weather utility (weather-goat) all end up in the same folder with no signal about what kind of thing they are.

Two categories cover the obvious near-term gaps:
- **\`travel\`** — flights, hotels, maps, transit. Immediate use: flightgoat. Future: kayak, google-flights.
- **\`food-and-dining\`** — restaurants, recipes, delivery, reviews. Future candidates: Yelp, Allrecipes, DoorDash, Instacart, Pagliacci.

Skipped a broader \`lifestyle\` — it becomes the new \"other\" within 5 CLIs.

\`weather-goat\` stays in \`other\` intentionally. Weather is reference/utility, not cleanly lifestyle or travel.

## Alphabetization

The current order is loosely domain-grouped (business → fintech → tech → consumer → catch-all) but the boundaries are fuzzy (why is \`marketing\` after \`sales-and-crm\` but \`payments\` after \`marketing\`?). Alphabetical is easier to scan, harder to mess up when adding new entries, and future category additions just slot in.

\`other\` and \`example\` stay at the end — they're explicit special cases (catch-all, test-only) that don't belong in the alphabetical run.

## Breaking changes / migration

None for the new categories (they're additions). No existing CLI changes category. Users aren't affected.

## Downstream

A companion doc-only update to the library repo's README.md adds the two rows to its \"Categories\" table and alphabetizes it to match. No code change needed there — \`registry.json\` has no category enum and \`generate-skills\` doesn't validate category strings.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/catalog/\` — 52 pass, including \`TestAllPublicCategoriesAreValid\` with new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)