### PR TITLE
fix(cli): path-aware dogfood novel-feature matcher

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -218,16 +218,23 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 // Match strategies in both modes: exact match, then hyphen-prefix on
 // the last segment (sibling specialization — "auth login" → "auth
 // login-chrome"). Aliases run the same rules.
+//
+// Paths and leaves are both consulted. Path matching is preferred when
+// it fires because it's more specific, but leaf matching runs as a
+// fallback on every planned command — tree reconstruction only sees
+// commands wired via direct `rootCmd.AddCommand(newFooCmd())` /
+// `cmd.AddCommand(newFooCmd())` literals, so any CLI using variable-
+// based or late-bound registration (`sub := newFooCmd(); parent.
+// AddCommand(sub)`) will have a partial paths map. Treating a
+// non-empty paths map as "complete" would false-negative legitimate
+// built commands.
 func matchNovelFeature(nf NovelFeature, paths, leaves map[string]bool) bool {
 	plan := commandPath(nf.Command)
 	if plan == "" {
 		return false
 	}
 	try := func(p string) bool {
-		if len(paths) > 0 {
-			return matchPath(p, paths)
-		}
-		return matchLeaf(p, leaves)
+		return matchPath(p, paths) || matchLeaf(p, leaves)
 	}
 	if try(plan) {
 		return true

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -184,15 +184,22 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 		return NovelFeaturesCheckResult{Skipped: true}
 	}
 
-	// Build set of registered command Use: names from the CLI source.
-	registeredCmds := collectRegisteredCommands(cliDir)
+	// Build set of registered full command PATHS from the CLI source.
+	// Paths are space-separated (e.g. "portfolio perf", "auth login-chrome")
+	// so the matcher can distinguish sibling commands that share a leaf
+	// name and correctly require hyphen-prefix matches to live under the
+	// same parent. Fall back to a flat leaf set when tree construction
+	// produces nothing (edge cases, unusual CLI layouts).
+	registeredPaths := collectRegisteredCommandPaths(cliDir)
+	registeredLeaves := collectRegisteredCommands(cliDir)
 
 	result := NovelFeaturesCheckResult{
 		Planned: len(research.NovelFeatures),
 	}
 	built := make([]NovelFeature, 0)
 	for _, nf := range research.NovelFeatures {
-		if matchNovelFeature(nf, registeredCmds) {
+		matched, _ := matchNovelFeature(nf, registeredPaths, registeredLeaves)
+		if matched {
 			result.Found++
 			built = append(built, nf)
 		} else {
@@ -209,90 +216,159 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 	return result
 }
 
-// matchNovelFeature runs the three-pass matcher — exact, prefix, alias —
-// against the set of registered command Use: names. Returns true if the
-// planned feature has a plausible corresponding built command.
+// matchNovelFeature runs a path-aware matcher with a leaf-only fallback.
+// Returns (matched, reason) where reason explains the match (or the
+// failure mode) — useful for logging and diagnostic output.
 //
-// Why this is three passes:
-//   - Exact: planned command leaf equals a registered Use: name. The happy
-//     path (e.g. planned "portfolio perf", built "perf" subcommand).
-//   - Prefix: during implementation, planners frequently hyphenate or
-//     specialize the command. Planned "auth login --chrome" becomes built
-//     "login-chrome"; planned "options --moneyness" becomes built
-//     "options-chain". Either direction of prefix relationship counts.
-//   - Alias: escape hatch for cases the matcher can't infer — planner records
-//     alternate names in research.json's `aliases: []`.
+// Strategy, in order:
 //
-// The matcher strips flag tokens (anything starting with "-") from the planned
-// command before extracting the leaf, because flags aren't command names.
-// "options --moneyness otm --max-dte 45" reduces to leaf "options".
-func matchNovelFeature(nf NovelFeature, registered map[string]bool) bool {
-	leaf := strings.ToLower(commandLeaf(nf.Command))
-	if leaf == "" {
-		return false
+//  1. Exact full-path match. Planned "portfolio perf" matches registered
+//     "portfolio perf". Planned "auth login-chrome" matches registered
+//     "auth login-chrome".
+//  2. Hyphen-prefix match on the LAST path segment, ONLY when the parent
+//     path agrees. Planned "auth login --chrome" (path "auth login")
+//     matches registered "auth login-chrome" because both are under
+//     parent "auth" and the leaves are hyphen-related. Planned "options"
+//     would NOT match a sibling "portfolio-options" because the parents
+//     differ. This is the critical accuracy fix over the old leaf-only
+//     matcher, which could match any "perf" anywhere in the tree.
+//  3. Aliases declared in research.json, matched with the same rules.
+//  4. Leaf-only fallback: when the registered-paths set is empty or
+//     doesn't find a path-aware match, fall back to the legacy leaf
+//     matcher against registeredLeaves. This preserves the old behavior
+//     on CLIs where path construction fails (unusual layouts) and
+//     on test fixtures that don't parse AddCommand wiring.
+//
+// Flags are always stripped from the planned command before path
+// extraction — "options --moneyness otm" reduces to path "options",
+// "auth login --chrome" reduces to "auth login". Flag values that
+// happen to be bare words (like "otm") are discarded because they
+// follow a flag token.
+func matchNovelFeature(nf NovelFeature, registeredPaths, registeredLeaves map[string]bool) (bool, string) {
+	plannedPath := commandPath(nf.Command)
+	if plannedPath == "" {
+		return false, "planned command produced no path"
 	}
 
-	// Pass 1: exact
-	if registered[leaf] {
-		return true
+	// Strategy 1 + 2: path-aware matching against the full tree.
+	if matched, reason := matchPath(plannedPath, registeredPaths); matched {
+		return true, reason
 	}
 
-	// Pass 2: prefix — either direction. Built command may be a hyphenated
-	// specialization (planned "options" → built "options-chain") or the planner
-	// may have been more specific than the actual binding (planned "earnings-
-	// calendar" is substring-matched by built "earnings"). Only hyphen
-	// boundaries count as prefix to avoid substring false positives like
-	// "options" matching "op".
-	for use := range registered {
-		if strings.HasPrefix(use, leaf+"-") || strings.HasPrefix(leaf, use+"-") {
-			return true
-		}
-	}
-
-	// Pass 3: aliases declared in research.json. Each alias is matched with
-	// the same exact + prefix rules so planners don't need to list every
-	// hyphen variant.
+	// Strategy 3: aliases with path-aware matching.
 	for _, alias := range nf.Aliases {
-		aliasLeaf := strings.ToLower(commandLeaf(alias))
-		if aliasLeaf == "" {
+		aliasPath := commandPath(alias)
+		if aliasPath == "" {
 			continue
 		}
-		if registered[aliasLeaf] {
-			return true
+		if matched, reason := matchPath(aliasPath, registeredPaths); matched {
+			return true, reason + " (via alias " + alias + ")"
 		}
-		for use := range registered {
-			if strings.HasPrefix(use, aliasLeaf+"-") || strings.HasPrefix(aliasLeaf, use+"-") {
-				return true
+	}
+
+	// Strategy 4: leaf-only fallback for CLIs where path construction
+	// produced nothing (empty registeredPaths) OR the path-aware match
+	// failed but a leaf match would still signal presence. Preserves
+	// backward compatibility with the old matcher's behavior on simple
+	// layouts and test fixtures.
+	if len(registeredPaths) == 0 && len(registeredLeaves) > 0 {
+		leaf := lastPathSegment(plannedPath)
+		if leaf != "" && registeredLeaves[leaf] {
+			return true, "leaf-only fallback: " + leaf
+		}
+		for use := range registeredLeaves {
+			if strings.HasPrefix(use, leaf+"-") || strings.HasPrefix(leaf, use+"-") {
+				return true, "leaf-only fallback with hyphen-prefix: " + leaf + " <-> " + use
+			}
+		}
+		for _, alias := range nf.Aliases {
+			aLeaf := lastPathSegment(commandPath(alias))
+			if aLeaf == "" {
+				continue
+			}
+			if registeredLeaves[aLeaf] {
+				return true, "leaf-only fallback via alias: " + aLeaf
+			}
+			for use := range registeredLeaves {
+				if strings.HasPrefix(use, aLeaf+"-") || strings.HasPrefix(aLeaf, use+"-") {
+					return true, "leaf-only fallback with hyphen-prefix via alias: " + aLeaf + " <-> " + use
+				}
 			}
 		}
 	}
 
-	return false
+	return false, "no registered command matches planned path \"" + plannedPath + "\""
 }
 
-// commandLeaf strips flag tokens (anything beginning with "-") from a command
-// string and returns the last remaining token. "auth login --chrome" → "login";
-// "options --moneyness otm" → "options" (subsequent tokens are flag values).
+// matchPath tries exact and sibling-hyphen-prefix matches for a single
+// planned path against the registered-paths set.
+func matchPath(planned string, registered map[string]bool) (bool, string) {
+	if registered[planned] {
+		return true, "exact: " + planned
+	}
+	parent, leaf := splitCommandPath(planned)
+	for path := range registered {
+		rp, rl := splitCommandPath(path)
+		if rp != parent {
+			continue
+		}
+		if leaf == "" || rl == "" {
+			continue
+		}
+		if strings.HasPrefix(rl, leaf+"-") || strings.HasPrefix(leaf, rl+"-") {
+			return true, "hyphen-prefix: " + planned + " <-> " + path
+		}
+	}
+	return false, ""
+}
+
+// commandPath strips flag tokens and joins the remaining non-flag tokens
+// into a space-separated path. "auth login --chrome" → "auth login";
+// "options --moneyness otm" → "options" (the "otm" bare word comes
+// after a flag, so it's a flag value, not a command token).
 //
-// The rule "stop at first flag" mirrors how users describe commands in plans —
-// the command itself appears before any flag annotation.
-func commandLeaf(cmd string) string {
-	tokens := strings.Fields(cmd)
-	base := make([]string, 0, len(tokens))
+// The rule "stop at first flag" mirrors how planners describe commands —
+// the command path appears before any flag annotation.
+func commandPath(cmd string) string {
+	tokens := strings.Fields(strings.ToLower(cmd))
+	path := make([]string, 0, len(tokens))
 	for _, t := range tokens {
 		if strings.HasPrefix(t, "-") {
 			break
 		}
-		base = append(base, t)
+		path = append(path, t)
 	}
-	if len(base) == 0 {
-		return ""
+	return strings.Join(path, " ")
+}
+
+// splitCommandPath separates a command path into its parent and leaf segments.
+// "portfolio perf" → ("portfolio", "perf"). "digest" → ("", "digest").
+func splitCommandPath(path string) (parent, leaf string) {
+	i := strings.LastIndex(path, " ")
+	if i < 0 {
+		return "", path
 	}
-	return base[len(base)-1]
+	return path[:i], path[i+1:]
+}
+
+// lastPathSegment returns the final space-separated segment of a path,
+// used by the leaf-only fallback matcher. Empty string for empty input.
+func lastPathSegment(path string) string {
+	_, leaf := splitCommandPath(path)
+	return leaf
+}
+
+// commandLeaf is preserved for backward compatibility with any external
+// callers. It returns the last non-flag token of a command string, the
+// same behavior the old matcher relied on. New code should use
+// commandPath (for the full path) or lastPathSegment (for just the leaf).
+func commandLeaf(cmd string) string {
+	return lastPathSegment(commandPath(cmd))
 }
 
 // collectRegisteredCommands returns a set of cobra Use: names found in the
-// CLI's internal/cli/*.go files.
+// CLI's internal/cli/*.go files. This is the flat, leaf-only view used as
+// a fallback when full-path construction isn't possible.
 func collectRegisteredCommands(dir string) map[string]bool {
 	cliDir := filepath.Join(dir, "internal", "cli")
 	files := listGoFiles(cliDir)
@@ -311,6 +387,139 @@ func collectRegisteredCommands(dir string) map[string]bool {
 		}
 	}
 	return cmds
+}
+
+// collectRegisteredCommandPaths walks the CLI's command tree and returns a
+// set of full space-separated command paths (e.g. "portfolio perf",
+// "auth login-chrome"). Used by the path-aware novel-feature matcher.
+//
+// The walker is regex-based (not a full Go AST parser) for consistency
+// with the rest of dogfood's static analysis. It:
+//
+//  1. Finds every function that returns *cobra.Command, captures its Use
+//     field, and records each AddCommand(newXxxCmd(...)) call inside the
+//     function body as a child edge.
+//  2. Finds the root command — the func that registers subcommands onto
+//     rootCmd (conventionally `newRootCmd`, `Execute`, or any func calling
+//     rootCmd.AddCommand).
+//  3. BFS from the root, emitting a path for every node visited.
+//
+// Returns an empty map if the CLI source is unparseable or the root
+// isn't identifiable; callers fall back to leaf-only matching.
+func collectRegisteredCommandPaths(dir string) map[string]bool {
+	cliDir := filepath.Join(dir, "internal", "cli")
+	files := listGoFiles(cliDir)
+
+	// Per-function: Use field + list of child constructor names.
+	type cmdFunc struct {
+		use      string
+		children []string
+	}
+	funcs := map[string]*cmdFunc{}
+	// Funcs that appear as children of rootCmd.AddCommand — the roots
+	// of the command tree.
+	var rootFuncs []string
+	// Detect constructors that appear as `rootCmd.AddCommand(newXxxCmd(...))`
+	// or `rootCmd.AddCommand(newXxxCmd)`. Capture the constructor name.
+	rootAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(new\w+Cmd)\b`)
+
+	// Per-function body extractor. Match `func newXxxCmd(...)` and capture
+	// the body up to the matching closing brace (heuristic: use balanced
+	// brace counting).
+	funcHeaderRe := regexp.MustCompile(`func\s+(new\w+Cmd)\s*\(`)
+	useRe := regexp.MustCompile(`Use:\s*"([^"\s]+)`)
+	addChildRe := regexp.MustCompile(`\.AddCommand\(\s*(new\w+Cmd)\b`)
+
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		src := string(data)
+
+		// Root detection runs on the FULL file source — the function that
+		// wires subcommands onto rootCmd may be Execute() or any helper,
+		// not necessarily a new*Cmd constructor.
+		for _, rm := range rootAddRe.FindAllStringSubmatch(src, -1) {
+			rootFuncs = append(rootFuncs, rm[1])
+		}
+
+		// Per-function Use + children extraction.
+		for _, m := range funcHeaderRe.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			braceIdx := strings.Index(src[m[1]:], "{")
+			if braceIdx < 0 {
+				continue
+			}
+			bodyStart := m[1] + braceIdx + 1
+			depth := 1
+			bodyEnd := bodyStart
+			for bodyEnd < len(src) && depth > 0 {
+				switch src[bodyEnd] {
+				case '{':
+					depth++
+				case '}':
+					depth--
+				}
+				bodyEnd++
+			}
+			body := src[bodyStart:bodyEnd]
+
+			entry := &cmdFunc{}
+			if useMatch := useRe.FindStringSubmatch(body); useMatch != nil {
+				entry.use = strings.Fields(useMatch[1])[0]
+			}
+			for _, cm := range addChildRe.FindAllStringSubmatch(body, -1) {
+				entry.children = append(entry.children, cm[1])
+			}
+			funcs[name] = entry
+		}
+	}
+
+	// No roots identified — we can't reliably build a tree. Caller will
+	// fall back to leaf-only matching.
+	if len(rootFuncs) == 0 || len(funcs) == 0 {
+		return map[string]bool{}
+	}
+
+	// BFS from each root, emitting full paths.
+	paths := map[string]bool{}
+	type qItem struct {
+		funcName string
+		prefix   string
+	}
+	queue := make([]qItem, 0, len(rootFuncs))
+	for _, rf := range rootFuncs {
+		queue = append(queue, qItem{funcName: rf, prefix: ""})
+	}
+	seen := map[string]bool{}
+	for len(queue) > 0 {
+		it := queue[0]
+		queue = queue[1:]
+		// Dedupe by (funcName, prefix) below. A pure funcName dedupe would
+		// drop legitimate re-traversals under different parents; a cycle
+		// would keep pushing new (funcName, new-prefix) pairs and the
+		// `seen[key]` check catches it.
+		fn, ok := funcs[it.funcName]
+		if !ok || fn.use == "" {
+			continue
+		}
+		path := fn.use
+		if it.prefix != "" {
+			path = it.prefix + " " + fn.use
+		}
+		paths[path] = true
+		// Dedupe traversal by (funcName, prefix).
+		key := it.funcName + "@" + it.prefix
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		for _, child := range fn.children {
+			queue = append(queue, qItem{funcName: child, prefix: path})
+		}
+	}
+	return paths
 }
 
 func LoadDogfoodResults(dir string) (*DogfoodReport, error) {

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -184,22 +184,14 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 		return NovelFeaturesCheckResult{Skipped: true}
 	}
 
-	// Build set of registered full command PATHS from the CLI source.
-	// Paths are space-separated (e.g. "portfolio perf", "auth login-chrome")
-	// so the matcher can distinguish sibling commands that share a leaf
-	// name and correctly require hyphen-prefix matches to live under the
-	// same parent. Fall back to a flat leaf set when tree construction
-	// produces nothing (edge cases, unusual CLI layouts).
-	registeredPaths := collectRegisteredCommandPaths(cliDir)
-	registeredLeaves := collectRegisteredCommands(cliDir)
+	paths, leaves := collectRegisteredCommands(cliDir)
 
 	result := NovelFeaturesCheckResult{
 		Planned: len(research.NovelFeatures),
 	}
 	built := make([]NovelFeature, 0)
 	for _, nf := range research.NovelFeatures {
-		matched, _ := matchNovelFeature(nf, registeredPaths, registeredLeaves)
-		if matched {
+		if matchNovelFeature(nf, paths, leaves) {
 			result.Found++
 			built = append(built, nf)
 		} else {
@@ -216,119 +208,82 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 	return result
 }
 
-// matchNovelFeature runs a path-aware matcher with a leaf-only fallback.
-// Returns (matched, reason) where reason explains the match (or the
-// failure mode) — useful for logging and diagnostic output.
+// matchNovelFeature reports whether a planned novel feature has a
+// corresponding built command. When paths are available it matches on
+// full command paths (so "portfolio perf" does not collide with
+// "analytics perf"); when paths are empty it falls back to leaf-only
+// matching against the flat leaves set for CLIs where the tree walker
+// couldn't construct a tree.
 //
-// Strategy, in order:
-//
-//  1. Exact full-path match. Planned "portfolio perf" matches registered
-//     "portfolio perf". Planned "auth login-chrome" matches registered
-//     "auth login-chrome".
-//  2. Hyphen-prefix match on the LAST path segment, ONLY when the parent
-//     path agrees. Planned "auth login --chrome" (path "auth login")
-//     matches registered "auth login-chrome" because both are under
-//     parent "auth" and the leaves are hyphen-related. Planned "options"
-//     would NOT match a sibling "portfolio-options" because the parents
-//     differ. This is the critical accuracy fix over the old leaf-only
-//     matcher, which could match any "perf" anywhere in the tree.
-//  3. Aliases declared in research.json, matched with the same rules.
-//  4. Leaf-only fallback: when the registered-paths set is empty or
-//     doesn't find a path-aware match, fall back to the legacy leaf
-//     matcher against registeredLeaves. This preserves the old behavior
-//     on CLIs where path construction fails (unusual layouts) and
-//     on test fixtures that don't parse AddCommand wiring.
-//
-// Flags are always stripped from the planned command before path
-// extraction — "options --moneyness otm" reduces to path "options",
-// "auth login --chrome" reduces to "auth login". Flag values that
-// happen to be bare words (like "otm") are discarded because they
-// follow a flag token.
-func matchNovelFeature(nf NovelFeature, registeredPaths, registeredLeaves map[string]bool) (bool, string) {
-	plannedPath := commandPath(nf.Command)
-	if plannedPath == "" {
-		return false, "planned command produced no path"
+// Match strategies in both modes: exact match, then hyphen-prefix on
+// the last segment (sibling specialization — "auth login" → "auth
+// login-chrome"). Aliases run the same rules.
+func matchNovelFeature(nf NovelFeature, paths, leaves map[string]bool) bool {
+	plan := commandPath(nf.Command)
+	if plan == "" {
+		return false
 	}
-
-	// Strategy 1 + 2: path-aware matching against the full tree.
-	if matched, reason := matchPath(plannedPath, registeredPaths); matched {
-		return true, reason
+	try := func(p string) bool {
+		if len(paths) > 0 {
+			return matchPath(p, paths)
+		}
+		return matchLeaf(p, leaves)
 	}
-
-	// Strategy 3: aliases with path-aware matching.
+	if try(plan) {
+		return true
+	}
 	for _, alias := range nf.Aliases {
-		aliasPath := commandPath(alias)
-		if aliasPath == "" {
-			continue
-		}
-		if matched, reason := matchPath(aliasPath, registeredPaths); matched {
-			return true, reason + " (via alias " + alias + ")"
+		if ap := commandPath(alias); ap != "" && try(ap) {
+			return true
 		}
 	}
-
-	// Strategy 4: leaf-only fallback for CLIs where path construction
-	// produced nothing (empty registeredPaths) OR the path-aware match
-	// failed but a leaf match would still signal presence. Preserves
-	// backward compatibility with the old matcher's behavior on simple
-	// layouts and test fixtures.
-	if len(registeredPaths) == 0 && len(registeredLeaves) > 0 {
-		leaf := lastPathSegment(plannedPath)
-		if leaf != "" && registeredLeaves[leaf] {
-			return true, "leaf-only fallback: " + leaf
-		}
-		for use := range registeredLeaves {
-			if strings.HasPrefix(use, leaf+"-") || strings.HasPrefix(leaf, use+"-") {
-				return true, "leaf-only fallback with hyphen-prefix: " + leaf + " <-> " + use
-			}
-		}
-		for _, alias := range nf.Aliases {
-			aLeaf := lastPathSegment(commandPath(alias))
-			if aLeaf == "" {
-				continue
-			}
-			if registeredLeaves[aLeaf] {
-				return true, "leaf-only fallback via alias: " + aLeaf
-			}
-			for use := range registeredLeaves {
-				if strings.HasPrefix(use, aLeaf+"-") || strings.HasPrefix(aLeaf, use+"-") {
-					return true, "leaf-only fallback with hyphen-prefix via alias: " + aLeaf + " <-> " + use
-				}
-			}
-		}
-	}
-
-	return false, "no registered command matches planned path \"" + plannedPath + "\""
+	return false
 }
 
-// matchPath tries exact and sibling-hyphen-prefix matches for a single
-// planned path against the registered-paths set.
-func matchPath(planned string, registered map[string]bool) (bool, string) {
-	if registered[planned] {
-		return true, "exact: " + planned
+// matchPath matches a planned path against a set of built paths:
+// exact match, or sibling hyphen-prefix (same parent, leaf ↔ leaf-foo).
+func matchPath(plan string, paths map[string]bool) bool {
+	if paths[plan] {
+		return true
 	}
-	parent, leaf := splitCommandPath(planned)
-	for path := range registered {
-		rp, rl := splitCommandPath(path)
-		if rp != parent {
+	parent, leaf := splitCommandPath(plan)
+	if leaf == "" {
+		return false
+	}
+	for path := range paths {
+		pp, pl := splitCommandPath(path)
+		if pp != parent || pl == "" {
 			continue
 		}
-		if leaf == "" || rl == "" {
-			continue
-		}
-		if strings.HasPrefix(rl, leaf+"-") || strings.HasPrefix(leaf, rl+"-") {
-			return true, "hyphen-prefix: " + planned + " <-> " + path
+		if strings.HasPrefix(pl, leaf+"-") || strings.HasPrefix(leaf, pl+"-") {
+			return true
 		}
 	}
-	return false, ""
+	return false
 }
 
-// commandPath strips flag tokens and joins the remaining non-flag tokens
-// into a space-separated path. "auth login --chrome" → "auth login";
-// "options --moneyness otm" → "options" (the "otm" bare word comes
-// after a flag, so it's a flag value, not a command token).
-//
-// The rule "stop at first flag" mirrors how planners describe commands —
-// the command path appears before any flag annotation.
+// matchLeaf is the legacy leaf-only matcher used as a fallback when the
+// built command tree can't be reconstructed. Ignores nesting.
+func matchLeaf(plan string, leaves map[string]bool) bool {
+	_, leaf := splitCommandPath(plan)
+	if leaf == "" {
+		return false
+	}
+	if leaves[leaf] {
+		return true
+	}
+	for use := range leaves {
+		if strings.HasPrefix(use, leaf+"-") || strings.HasPrefix(leaf, use+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+// commandPath strips flag tokens from a command string and joins the
+// remaining leading non-flag tokens into a space-separated path. Stops
+// at the first flag because any bare word that follows is a flag value,
+// not a command token — "options --moneyness otm" → "options".
 func commandPath(cmd string) string {
 	tokens := strings.Fields(strings.ToLower(cmd))
 	path := make([]string, 0, len(tokens))
@@ -341,8 +296,9 @@ func commandPath(cmd string) string {
 	return strings.Join(path, " ")
 }
 
-// splitCommandPath separates a command path into its parent and leaf segments.
-// "portfolio perf" → ("portfolio", "perf"). "digest" → ("", "digest").
+// splitCommandPath returns the parent and leaf segments of a space-
+// separated path. "portfolio perf" → ("portfolio", "perf"), "digest" →
+// ("", "digest").
 func splitCommandPath(path string) (parent, leaf string) {
 	i := strings.LastIndex(path, " ")
 	if i < 0 {
@@ -351,81 +307,34 @@ func splitCommandPath(path string) (parent, leaf string) {
 	return path[:i], path[i+1:]
 }
 
-// lastPathSegment returns the final space-separated segment of a path,
-// used by the leaf-only fallback matcher. Empty string for empty input.
-func lastPathSegment(path string) string {
-	_, leaf := splitCommandPath(path)
-	return leaf
-}
-
-// commandLeaf is preserved for backward compatibility with any external
-// callers. It returns the last non-flag token of a command string, the
-// same behavior the old matcher relied on. New code should use
-// commandPath (for the full path) or lastPathSegment (for just the leaf).
-func commandLeaf(cmd string) string {
-	return lastPathSegment(commandPath(cmd))
-}
-
-// collectRegisteredCommands returns a set of cobra Use: names found in the
-// CLI's internal/cli/*.go files. This is the flat, leaf-only view used as
-// a fallback when full-path construction isn't possible.
-func collectRegisteredCommands(dir string) map[string]bool {
-	cliDir := filepath.Join(dir, "internal", "cli")
-	files := listGoFiles(cliDir)
-	useFieldRe := regexp.MustCompile(`(?m)Use:\s*"([^"\s]+)`)
-	cmds := make(map[string]bool)
-	for _, file := range files {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		for _, m := range useFieldRe.FindAllStringSubmatch(string(data), -1) {
-			name := strings.Fields(m[1])[0]
-			if name != "" {
-				cmds[name] = true
-			}
-		}
-	}
-	return cmds
-}
-
-// collectRegisteredCommandPaths walks the CLI's command tree and returns a
-// set of full space-separated command paths (e.g. "portfolio perf",
-// "auth login-chrome"). Used by the path-aware novel-feature matcher.
+// collectRegisteredCommands reads the CLI's internal/cli/*.go files once
+// and returns two views of its registered cobra commands:
 //
-// The walker is regex-based (not a full Go AST parser) for consistency
-// with the rest of dogfood's static analysis. It:
+//   - paths: full space-separated command paths (e.g. "portfolio perf",
+//     "auth login-chrome"), reconstructed by walking AddCommand edges.
+//     Empty when the tree walker can't identify roots or the source
+//     doesn't follow the expected pattern.
+//   - leaves: a flat set of every Use: name (e.g. "perf", "login-chrome")
+//     regardless of nesting. Used by callers as a leaf-only fallback
+//     when paths is empty.
 //
-//  1. Finds every function that returns *cobra.Command, captures its Use
-//     field, and records each AddCommand(newXxxCmd(...)) call inside the
-//     function body as a child edge.
-//  2. Finds the root command — the func that registers subcommands onto
-//     rootCmd (conventionally `newRootCmd`, `Execute`, or any func calling
-//     rootCmd.AddCommand).
-//  3. BFS from the root, emitting a path for every node visited.
-//
-// Returns an empty map if the CLI source is unparseable or the root
-// isn't identifiable; callers fall back to leaf-only matching.
-func collectRegisteredCommandPaths(dir string) map[string]bool {
+// Callers prefer paths when non-empty for accuracy, and fall through to
+// leaves when the tree walker produced nothing.
+func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 	cliDir := filepath.Join(dir, "internal", "cli")
 	files := listGoFiles(cliDir)
 
-	// Per-function: Use field + list of child constructor names.
 	type cmdFunc struct {
 		use      string
 		children []string
 	}
 	funcs := map[string]*cmdFunc{}
-	// Funcs that appear as children of rootCmd.AddCommand — the roots
-	// of the command tree.
 	var rootFuncs []string
-	// Detect constructors that appear as `rootCmd.AddCommand(newXxxCmd(...))`
-	// or `rootCmd.AddCommand(newXxxCmd)`. Capture the constructor name.
-	rootAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(new\w+Cmd)\b`)
+	leaves = map[string]bool{}
 
-	// Per-function body extractor. Match `func newXxxCmd(...)` and capture
-	// the body up to the matching closing brace (heuristic: use balanced
-	// brace counting).
+	// Root detection scans the full file because the wiring function
+	// (Execute / helpers) isn't a new*Cmd constructor.
+	rootAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(new\w+Cmd)\b`)
 	funcHeaderRe := regexp.MustCompile(`func\s+(new\w+Cmd)\s*\(`)
 	useRe := regexp.MustCompile(`Use:\s*"([^"\s]+)`)
 	addChildRe := regexp.MustCompile(`\.AddCommand\(\s*(new\w+Cmd)\b`)
@@ -436,38 +345,23 @@ func collectRegisteredCommandPaths(dir string) map[string]bool {
 			continue
 		}
 		src := string(data)
-
-		// Root detection runs on the FULL file source — the function that
-		// wires subcommands onto rootCmd may be Execute() or any helper,
-		// not necessarily a new*Cmd constructor.
 		for _, rm := range rootAddRe.FindAllStringSubmatch(src, -1) {
 			rootFuncs = append(rootFuncs, rm[1])
 		}
-
-		// Per-function Use + children extraction.
+		for _, u := range useRe.FindAllStringSubmatch(src, -1) {
+			if name := strings.Fields(u[1])[0]; name != "" {
+				leaves[name] = true
+			}
+		}
 		for _, m := range funcHeaderRe.FindAllStringSubmatchIndex(src, -1) {
 			name := src[m[2]:m[3]]
-			braceIdx := strings.Index(src[m[1]:], "{")
-			if braceIdx < 0 {
+			body := extractFuncBody(src, m[1])
+			if body == "" {
 				continue
 			}
-			bodyStart := m[1] + braceIdx + 1
-			depth := 1
-			bodyEnd := bodyStart
-			for bodyEnd < len(src) && depth > 0 {
-				switch src[bodyEnd] {
-				case '{':
-					depth++
-				case '}':
-					depth--
-				}
-				bodyEnd++
-			}
-			body := src[bodyStart:bodyEnd]
-
 			entry := &cmdFunc{}
-			if useMatch := useRe.FindStringSubmatch(body); useMatch != nil {
-				entry.use = strings.Fields(useMatch[1])[0]
+			if u := useRe.FindStringSubmatch(body); u != nil {
+				entry.use = strings.Fields(u[1])[0]
 			}
 			for _, cm := range addChildRe.FindAllStringSubmatch(body, -1) {
 				entry.children = append(entry.children, cm[1])
@@ -476,30 +370,24 @@ func collectRegisteredCommandPaths(dir string) map[string]bool {
 		}
 	}
 
-	// No roots identified — we can't reliably build a tree. Caller will
-	// fall back to leaf-only matching.
+	paths = map[string]bool{}
 	if len(rootFuncs) == 0 || len(funcs) == 0 {
-		return map[string]bool{}
+		return paths, leaves
 	}
 
-	// BFS from each root, emitting full paths.
-	paths := map[string]bool{}
-	type qItem struct {
-		funcName string
-		prefix   string
-	}
+	type qItem struct{ funcName, prefix string }
 	queue := make([]qItem, 0, len(rootFuncs))
 	for _, rf := range rootFuncs {
-		queue = append(queue, qItem{funcName: rf, prefix: ""})
+		queue = append(queue, qItem{funcName: rf})
 	}
-	seen := map[string]bool{}
+	seen := map[qItem]bool{}
 	for len(queue) > 0 {
 		it := queue[0]
 		queue = queue[1:]
-		// Dedupe by (funcName, prefix) below. A pure funcName dedupe would
-		// drop legitimate re-traversals under different parents; a cycle
-		// would keep pushing new (funcName, new-prefix) pairs and the
-		// `seen[key]` check catches it.
+		if seen[it] {
+			continue
+		}
+		seen[it] = true
 		fn, ok := funcs[it.funcName]
 		if !ok || fn.use == "" {
 			continue
@@ -509,17 +397,34 @@ func collectRegisteredCommandPaths(dir string) map[string]bool {
 			path = it.prefix + " " + fn.use
 		}
 		paths[path] = true
-		// Dedupe traversal by (funcName, prefix).
-		key := it.funcName + "@" + it.prefix
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
 		for _, child := range fn.children {
 			queue = append(queue, qItem{funcName: child, prefix: path})
 		}
 	}
-	return paths
+	return paths, leaves
+}
+
+// extractFuncBody returns the balanced-brace body of a Go function given
+// the position of its header (regex match end). Empty string if no body
+// is found.
+func extractFuncBody(src string, headerEnd int) string {
+	i := strings.Index(src[headerEnd:], "{")
+	if i < 0 {
+		return ""
+	}
+	start := headerEnd + i + 1
+	depth := 1
+	end := start
+	for end < len(src) && depth > 0 {
+		switch src[end] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+		end++
+	}
+	return src[start:end]
 }
 
 func LoadDogfoodResults(dir string) (*DogfoodReport, error) {

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -99,6 +99,25 @@ func TestMatchNovelFeature_NoFalsePositive_BareLeaf(t *testing.T) {
 	}
 }
 
+// Tree reconstruction only captures commands wired via direct
+// `parent.AddCommand(newFooCmd())` literals; CLIs that use variable
+// indirection (`sub := newFooCmd(); parent.AddCommand(sub)`) produce a
+// partial paths map. The matcher must still fall back to the
+// Use-field-scanned leaves so legitimately-built features aren't
+// reported missing. Regression guard for a pattern shipped in yahoo-
+// finance and hackernews.
+func TestMatchNovelFeature_FallsBackToLeavesWhenPathsPartial(t *testing.T) {
+	// paths has the directly-wired command only; `ask` is present in
+	// the source but wired through a variable, so it shows up in leaves
+	// but not paths.
+	paths := map[string]bool{"show": true}
+	leaves := map[string]bool{"show": true, "ask": true}
+	nf := NovelFeature{Command: "ask"}
+	if !matchNovelFeature(nf, paths, leaves) {
+		t.Error("'ask' (present in leaves, absent from partial paths) should still match")
+	}
+}
+
 func TestCommandPath(t *testing.T) {
 	cases := map[string]string{
 		"portfolio perf":                       "portfolio perf",

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -6,171 +6,99 @@ import (
 	"testing"
 )
 
-// TestMatchNovelFeature_LeafFallback covers the leaf-only fallback path
-// (empty registeredPaths). This exercises the same scenarios the previous
-// flat-map matcher handled: exact leaf, hyphen-prefix, aliases, case
-// folding. Preserves backward compatibility for CLI layouts where the
-// path-aware command-tree walker produces nothing.
+// Cases that should match identically under both matching modes.
+var matcherCommonCases = []struct {
+	name    string
+	feature NovelFeature
+	want    bool
+}{
+	{"exact leaf match", NovelFeature{Command: "digest"}, true},
+	{"exact after flag strip", NovelFeature{Command: "digest --watchlist tech"}, true},
+	{"no match when absent", NovelFeature{Command: "insiders --recent 30d"}, false},
+	{"empty command", NovelFeature{Command: ""}, false},
+	{"flag-only command", NovelFeature{Command: "--json"}, false},
+	{"case insensitive", NovelFeature{Command: "DIGEST"}, true},
+	{"alias exact", NovelFeature{Command: "portfolio dividends", Aliases: []string{"digest"}}, true},
+}
+
 func TestMatchNovelFeature_LeafFallback(t *testing.T) {
 	leaves := map[string]bool{
-		"perf":          true,
-		"gains":         true,
-		"digest":        true,
-		"login-chrome":  true,
-		"options":       true,
-		"options-chain": true,
-		"sparkline":     true,
-		"earnings":      true,
+		"perf": true, "gains": true, "digest": true, "login-chrome": true,
+		"options": true, "options-chain": true, "sparkline": true, "earnings": true,
 	}
-	var emptyPaths map[string]bool
-
-	cases := []struct {
+	cases := append([]struct {
 		name    string
 		feature NovelFeature
 		want    bool
 	}{
-		{"exact leaf (portfolio perf → perf)", NovelFeature{Command: "portfolio perf"}, true},
-		{"exact after flag strip (digest --watchlist tech → digest)", NovelFeature{Command: "digest --watchlist tech"}, true},
-		{"hyphen-prefix (auth login --chrome → login-chrome)", NovelFeature{Command: "auth login --chrome"}, true},
-		{"exact when bare command is registered (options)", NovelFeature{Command: "options --moneyness otm"}, true},
-		{"no match when truly absent", NovelFeature{Command: "insiders --recent 30d"}, false},
-		{"alias rescues a rename", NovelFeature{Command: "portfolio dividends", Aliases: []string{"portfolio gains"}}, true},
-		{"alias exact (login-chrome registered)", NovelFeature{Command: "portfolio dividends", Aliases: []string{"auth login-chrome"}}, true},
-		{"empty command returns false", NovelFeature{Command: ""}, false},
-		{"flag-only command returns false", NovelFeature{Command: "--json"}, false},
-		{"case insensitive", NovelFeature{Command: "PORTFOLIO PERF"}, true},
-	}
+		{"leaf-only: portfolio perf matches perf regardless of parent", NovelFeature{Command: "portfolio perf"}, true},
+		{"leaf-only hyphen-prefix: auth login → login-chrome", NovelFeature{Command: "auth login --chrome"}, true},
+		{"bare leaf registered: options", NovelFeature{Command: "options --moneyness otm"}, true},
+	}, matcherCommonCases...)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason := matchNovelFeature(tc.feature, emptyPaths, leaves)
-			if got != tc.want {
-				t.Errorf("matchNovelFeature(%q) = %v, want %v (reason: %s)",
-					tc.feature.Command, got, tc.want, reason)
+			if got := matchNovelFeature(tc.feature, nil, leaves); got != tc.want {
+				t.Errorf("matchNovelFeature(%q) = %v, want %v", tc.feature.Command, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestMatchNovelFeature_PathAware covers the core new behavior:
-// path-aware matching against a real command tree, with hyphen-prefix
-// restricted to sibling commands (same parent path).
 func TestMatchNovelFeature_PathAware(t *testing.T) {
-	// Full command tree with parent context. `perf` lives under
-	// `portfolio`. `sparkline` and `login-chrome` are at similar depths
-	// but in different subtrees.
 	paths := map[string]bool{
-		"portfolio":         true,
-		"portfolio perf":    true,
-		"portfolio gains":   true,
-		"portfolio add":     true,
-		"auth":              true,
-		"auth login":        true,
-		"auth login-chrome": true,
-		"auth logout":       true,
-		"options":           true,
-		"options-chain":     true, // top-level sibling of `options`
-		"digest":            true,
-		"watchlist":         true,
-		"watchlist create":  true,
-		"watchlist add":     true,
+		"portfolio": true, "portfolio perf": true, "portfolio gains": true, "portfolio add": true,
+		"auth": true, "auth login": true, "auth login-chrome": true, "auth logout": true,
+		"options": true, "options-chain": true,
+		"digest":    true,
+		"watchlist": true, "watchlist create": true, "watchlist add": true,
 	}
-
-	cases := []struct {
+	cases := append([]struct {
 		name    string
 		feature NovelFeature
 		want    bool
 	}{
-		{
-			name:    "exact full path",
-			feature: NovelFeature{Command: "portfolio perf"},
-			want:    true,
-		},
-		{
-			name:    "exact full path: auth login-chrome",
-			feature: NovelFeature{Command: "auth login-chrome"},
-			want:    true,
-		},
-		{
-			name:    "hyphen-prefix under same parent: auth login → auth login-chrome",
-			feature: NovelFeature{Command: "auth login --chrome"},
-			want:    true,
-		},
-		{
-			name:    "hyphen-prefix under root: options → options-chain",
-			feature: NovelFeature{Command: "options --moneyness otm"},
-			want:    true,
-		},
-		{
-			name:    "exact digest",
-			feature: NovelFeature{Command: "digest"},
-			want:    true,
-		},
-		{
-			name:    "no match on unbuilt feature",
-			feature: NovelFeature{Command: "insiders --recent 30d"},
-			want:    false,
-		},
-		{
-			name:    "alias rescues a missing primary",
-			feature: NovelFeature{Command: "portfolio dividends", Aliases: []string{"portfolio gains"}},
-			want:    true,
-		},
-		{
-			name:    "case insensitive full path",
-			feature: NovelFeature{Command: "Portfolio Perf"},
-			want:    true,
-		},
-		{
-			name:    "no match when planned path has wrong parent",
-			feature: NovelFeature{Command: "nonexistent perf"},
-			want:    false,
-		},
-	}
+		{"exact full path", NovelFeature{Command: "portfolio perf"}, true},
+		{"exact hyphenated leaf", NovelFeature{Command: "auth login-chrome"}, true},
+		{"sibling hyphen-prefix under parent", NovelFeature{Command: "auth login --chrome"}, true},
+		{"sibling hyphen-prefix at root", NovelFeature{Command: "options --moneyness otm"}, true},
+		{"alias rescues missing primary", NovelFeature{Command: "portfolio dividends", Aliases: []string{"portfolio gains"}}, true},
+		{"case insensitive path", NovelFeature{Command: "Portfolio Perf"}, true},
+		{"wrong parent does not match", NovelFeature{Command: "nonexistent perf"}, false},
+	}, matcherCommonCases...)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, reason := matchNovelFeature(tc.feature, paths, nil)
-			if got != tc.want {
-				t.Errorf("matchNovelFeature(%q) = %v, want %v (reason: %s)",
-					tc.feature.Command, got, tc.want, reason)
+			if got := matchNovelFeature(tc.feature, paths, nil); got != tc.want {
+				t.Errorf("matchNovelFeature(%q) = %v, want %v", tc.feature.Command, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestMatchNovelFeature_NoFalsePositive_CrossParent is the critical
-// accuracy guarantee: a leaf match under one parent must NOT match a
-// sibling leaf under a different parent. Without path awareness, the
-// old flat-map matcher would match any "perf" anywhere. With path
-// awareness, "portfolio perf" must not be satisfied by a hypothetical
-// "analytics perf" living under a different root.
+// A planned leaf must not match a registered leaf under a different parent.
+// This is the accuracy guarantee that path-awareness buys over the old
+// flat-map matcher.
 func TestMatchNovelFeature_NoFalsePositive_CrossParent(t *testing.T) {
 	paths := map[string]bool{
 		"analytics":      true,
 		"analytics perf": true,
-		// deliberately NOT "portfolio perf"
 	}
 	nf := NovelFeature{Command: "portfolio perf"}
-	got, reason := matchNovelFeature(nf, paths, nil)
-	if got {
-		t.Errorf("planned 'portfolio perf' should not match 'analytics perf' across parents; got matched with reason: %s", reason)
+	if matchNovelFeature(nf, paths, nil) {
+		t.Error("planned 'portfolio perf' should not match 'analytics perf' across parents")
 	}
 }
 
-// TestMatchNovelFeature_NoFalsePositive_BareLeaf is the guard against the
-// old matcher's worst failure mode: "op" shouldn't match "options"
-// because the hyphen-boundary rule rejects substring prefixes.
+// "op" must not prefix-match "options" — hyphen boundary required.
 func TestMatchNovelFeature_NoFalsePositive_BareLeaf(t *testing.T) {
 	paths := map[string]bool{"options": true}
 	nf := NovelFeature{Command: "op"}
-	got, _ := matchNovelFeature(nf, paths, nil)
-	if got {
-		t.Error("planned 'op' should not prefix-match 'options' (no hyphen boundary)")
+	if matchNovelFeature(nf, paths, nil) {
+		t.Error("planned 'op' should not prefix-match 'options'")
 	}
 }
 
-// TestCommandPath covers the flag-stripping path extractor.
 func TestCommandPath(t *testing.T) {
 	cases := map[string]string{
 		"portfolio perf":                       "portfolio perf",
@@ -191,31 +119,9 @@ func TestCommandPath(t *testing.T) {
 	}
 }
 
-// TestCommandLeaf preserves backward compatibility — commandLeaf remains
-// a thin wrapper around commandPath + lastPathSegment.
-func TestCommandLeaf(t *testing.T) {
-	cases := map[string]string{
-		"portfolio perf":                       "perf",
-		"auth login --chrome":                  "login",
-		"options --moneyness otm --max-dte 45": "options",
-		"digest":                               "digest",
-		"earnings-calendar --watchlist":        "earnings-calendar",
-		"":                                     "",
-		"--json":                               "",
-	}
-	for in, want := range cases {
-		if got := commandLeaf(in); got != want {
-			t.Errorf("commandLeaf(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-// TestCollectRegisteredCommandPaths exercises the tree walker end-to-end:
-// it writes a synthetic CLI fixture mirroring the yahoo-finance layout,
-// invokes the regex-based command-tree resolver, and asserts the emitted
-// paths cover nested subcommands (portfolio perf) and hyphenated
-// transcendence commands (auth login-chrome).
-func TestCollectRegisteredCommandPaths(t *testing.T) {
+// End-to-end: synthetic CLI fixture + tree walker should emit every
+// nested path the matcher needs.
+func TestCollectRegisteredCommands_Tree(t *testing.T) {
 	dir := t.TempDir()
 	cli := filepath.Join(dir, "internal", "cli")
 	if err := os.MkdirAll(cli, 0o755); err != nil {
@@ -264,24 +170,23 @@ func newOptionsCmd() *cobra.Command { return &cobra.Command{Use: "options <symbo
 func newOptionsChainCmd() *cobra.Command { return &cobra.Command{Use: "options-chain <symbol>"} }
 `)
 
-	paths := collectRegisteredCommandPaths(dir)
+	paths, leaves := collectRegisteredCommands(dir)
 
-	// Every nested + transcendence path the matcher needs.
-	want := []string{
-		"auth",
-		"auth login",
-		"auth login-chrome",
-		"auth logout",
-		"portfolio",
-		"portfolio perf",
-		"portfolio gains",
-		"digest",
-		"options",
-		"options-chain",
+	wantPaths := []string{
+		"auth", "auth login", "auth login-chrome", "auth logout",
+		"portfolio", "portfolio perf", "portfolio gains",
+		"digest", "options", "options-chain",
 	}
-	for _, w := range want {
+	for _, w := range wantPaths {
 		if !paths[w] {
-			t.Errorf("expected path %q in tree, got paths: %v", w, paths)
+			t.Errorf("expected path %q, got paths: %v", w, paths)
+		}
+	}
+
+	wantLeaves := []string{"auth", "login", "login-chrome", "logout", "portfolio", "perf", "gains", "digest", "options", "options-chain"}
+	for _, w := range wantLeaves {
+		if !leaves[w] {
+			t.Errorf("expected leaf %q, got leaves: %v", w, leaves)
 		}
 	}
 }

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -1,112 +1,207 @@
 package pipeline
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-// TestMatchNovelFeature covers the three-pass matcher — exact, prefix, alias —
-// exercising the yahoo-finance retro scenarios where the previous literal
-// matcher false-negatived features that were actually built.
-func TestMatchNovelFeature(t *testing.T) {
-	registered := map[string]bool{
-		"perf":          true, // under `portfolio perf`
+// TestMatchNovelFeature_LeafFallback covers the leaf-only fallback path
+// (empty registeredPaths). This exercises the same scenarios the previous
+// flat-map matcher handled: exact leaf, hyphen-prefix, aliases, case
+// folding. Preserves backward compatibility for CLI layouts where the
+// path-aware command-tree walker produces nothing.
+func TestMatchNovelFeature_LeafFallback(t *testing.T) {
+	leaves := map[string]bool{
+		"perf":          true,
 		"gains":         true,
 		"digest":        true,
-		"login-chrome":  true, // under `auth login-chrome`
+		"login-chrome":  true,
 		"options":       true,
 		"options-chain": true,
 		"sparkline":     true,
-		"earnings":      true, // registered but planned was "earnings-calendar"
+		"earnings":      true,
+	}
+	var emptyPaths map[string]bool
+
+	cases := []struct {
+		name    string
+		feature NovelFeature
+		want    bool
+	}{
+		{"exact leaf (portfolio perf → perf)", NovelFeature{Command: "portfolio perf"}, true},
+		{"exact after flag strip (digest --watchlist tech → digest)", NovelFeature{Command: "digest --watchlist tech"}, true},
+		{"hyphen-prefix (auth login --chrome → login-chrome)", NovelFeature{Command: "auth login --chrome"}, true},
+		{"exact when bare command is registered (options)", NovelFeature{Command: "options --moneyness otm"}, true},
+		{"no match when truly absent", NovelFeature{Command: "insiders --recent 30d"}, false},
+		{"alias rescues a rename", NovelFeature{Command: "portfolio dividends", Aliases: []string{"portfolio gains"}}, true},
+		{"alias exact (login-chrome registered)", NovelFeature{Command: "portfolio dividends", Aliases: []string{"auth login-chrome"}}, true},
+		{"empty command returns false", NovelFeature{Command: ""}, false},
+		{"flag-only command returns false", NovelFeature{Command: "--json"}, false},
+		{"case insensitive", NovelFeature{Command: "PORTFOLIO PERF"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := matchNovelFeature(tc.feature, emptyPaths, leaves)
+			if got != tc.want {
+				t.Errorf("matchNovelFeature(%q) = %v, want %v (reason: %s)",
+					tc.feature.Command, got, tc.want, reason)
+			}
+		})
+	}
+}
+
+// TestMatchNovelFeature_PathAware covers the core new behavior:
+// path-aware matching against a real command tree, with hyphen-prefix
+// restricted to sibling commands (same parent path).
+func TestMatchNovelFeature_PathAware(t *testing.T) {
+	// Full command tree with parent context. `perf` lives under
+	// `portfolio`. `sparkline` and `login-chrome` are at similar depths
+	// but in different subtrees.
+	paths := map[string]bool{
+		"portfolio":         true,
+		"portfolio perf":    true,
+		"portfolio gains":   true,
+		"portfolio add":     true,
+		"auth":              true,
+		"auth login":        true,
+		"auth login-chrome": true,
+		"auth logout":       true,
+		"options":           true,
+		"options-chain":     true, // top-level sibling of `options`
+		"digest":            true,
+		"watchlist":         true,
+		"watchlist create":  true,
+		"watchlist add":     true,
 	}
 
 	cases := []struct {
 		name    string
 		feature NovelFeature
 		want    bool
-		pass    string
 	}{
 		{
-			name:    "exact match on leaf (portfolio perf → perf)",
+			name:    "exact full path",
 			feature: NovelFeature{Command: "portfolio perf"},
 			want:    true,
-			pass:    "exact",
 		},
 		{
-			name:    "exact match after flag strip (digest --watchlist tech → digest)",
-			feature: NovelFeature{Command: "digest --watchlist tech"},
+			name:    "exact full path: auth login-chrome",
+			feature: NovelFeature{Command: "auth login-chrome"},
 			want:    true,
-			pass:    "exact",
 		},
 		{
-			name:    "prefix match: planned auth login --chrome → built login-chrome",
+			name:    "hyphen-prefix under same parent: auth login → auth login-chrome",
 			feature: NovelFeature{Command: "auth login --chrome"},
 			want:    true,
-			pass:    "prefix",
 		},
 		{
-			name:    "prefix match: planned options --moneyness → built options or options-chain",
-			feature: NovelFeature{Command: "options --moneyness otm --max-dte 45"},
+			name:    "hyphen-prefix under root: options → options-chain",
+			feature: NovelFeature{Command: "options --moneyness otm"},
 			want:    true,
-			pass:    "exact (options registered) or prefix (options-chain)",
 		},
 		{
-			name:    "no match when truly absent",
-			feature: NovelFeature{Command: "insiders --recent 30d --net-buying"},
+			name:    "exact digest",
+			feature: NovelFeature{Command: "digest"},
+			want:    true,
+		},
+		{
+			name:    "no match on unbuilt feature",
+			feature: NovelFeature{Command: "insiders --recent 30d"},
 			want:    false,
 		},
 		{
-			name:    "alias rescues a rename",
+			name:    "alias rescues a missing primary",
 			feature: NovelFeature{Command: "portfolio dividends", Aliases: []string{"portfolio gains"}},
 			want:    true,
-			pass:    "alias (gains built as renamed feature)",
 		},
 		{
-			name:    "alias prefix match",
-			feature: NovelFeature{Command: "portfolio dividends", Aliases: []string{"auth login-chrome"}},
+			name:    "case insensitive full path",
+			feature: NovelFeature{Command: "Portfolio Perf"},
 			want:    true,
-			pass:    "alias exact (login-chrome registered)",
 		},
 		{
-			name:    "empty command returns false",
-			feature: NovelFeature{Command: ""},
+			name:    "no match when planned path has wrong parent",
+			feature: NovelFeature{Command: "nonexistent perf"},
 			want:    false,
-		},
-		{
-			name:    "flag-only command returns false (nothing to match)",
-			feature: NovelFeature{Command: "--json"},
-			want:    false,
-		},
-		{
-			name:    "case insensitive",
-			feature: NovelFeature{Command: "PORTFOLIO PERF"},
-			want:    true,
-			pass:    "exact (case folded)",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := matchNovelFeature(tc.feature, registered)
+			got, reason := matchNovelFeature(tc.feature, paths, nil)
 			if got != tc.want {
-				t.Errorf("matchNovelFeature(%q, aliases=%v) = %v, want %v (pass: %s)",
-					tc.feature.Command, tc.feature.Aliases, got, tc.want, tc.pass)
+				t.Errorf("matchNovelFeature(%q) = %v, want %v (reason: %s)",
+					tc.feature.Command, got, tc.want, reason)
 			}
 		})
 	}
 }
 
-// TestCommandLeaf covers the flag-stripping helper.
-func TestCommandLeaf(t *testing.T) {
+// TestMatchNovelFeature_NoFalsePositive_CrossParent is the critical
+// accuracy guarantee: a leaf match under one parent must NOT match a
+// sibling leaf under a different parent. Without path awareness, the
+// old flat-map matcher would match any "perf" anywhere. With path
+// awareness, "portfolio perf" must not be satisfied by a hypothetical
+// "analytics perf" living under a different root.
+func TestMatchNovelFeature_NoFalsePositive_CrossParent(t *testing.T) {
+	paths := map[string]bool{
+		"analytics":      true,
+		"analytics perf": true,
+		// deliberately NOT "portfolio perf"
+	}
+	nf := NovelFeature{Command: "portfolio perf"}
+	got, reason := matchNovelFeature(nf, paths, nil)
+	if got {
+		t.Errorf("planned 'portfolio perf' should not match 'analytics perf' across parents; got matched with reason: %s", reason)
+	}
+}
+
+// TestMatchNovelFeature_NoFalsePositive_BareLeaf is the guard against the
+// old matcher's worst failure mode: "op" shouldn't match "options"
+// because the hyphen-boundary rule rejects substring prefixes.
+func TestMatchNovelFeature_NoFalsePositive_BareLeaf(t *testing.T) {
+	paths := map[string]bool{"options": true}
+	nf := NovelFeature{Command: "op"}
+	got, _ := matchNovelFeature(nf, paths, nil)
+	if got {
+		t.Error("planned 'op' should not prefix-match 'options' (no hyphen boundary)")
+	}
+}
+
+// TestCommandPath covers the flag-stripping path extractor.
+func TestCommandPath(t *testing.T) {
 	cases := map[string]string{
-		"portfolio perf":                       "perf",
-		"auth login --chrome":                  "login",
+		"portfolio perf":                       "portfolio perf",
+		"auth login --chrome":                  "auth login",
 		"options --moneyness otm --max-dte 45": "options",
 		"digest":                               "digest",
 		"digest --watchlist tech":              "digest",
 		"earnings-calendar --watchlist":        "earnings-calendar",
 		"":                                     "",
 		"--json":                               "",
-		"   padded   perf  ":                   "perf",
+		"   padded   perf  ":                   "padded perf",
+		"PORTFOLIO PERF":                       "portfolio perf",
+	}
+	for in, want := range cases {
+		if got := commandPath(in); got != want {
+			t.Errorf("commandPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCommandLeaf preserves backward compatibility — commandLeaf remains
+// a thin wrapper around commandPath + lastPathSegment.
+func TestCommandLeaf(t *testing.T) {
+	cases := map[string]string{
+		"portfolio perf":                       "perf",
+		"auth login --chrome":                  "login",
+		"options --moneyness otm --max-dte 45": "options",
+		"digest":                               "digest",
+		"earnings-calendar --watchlist":        "earnings-calendar",
+		"":                                     "",
+		"--json":                               "",
 	}
 	for in, want := range cases {
 		if got := commandLeaf(in); got != want {
@@ -115,15 +210,78 @@ func TestCommandLeaf(t *testing.T) {
 	}
 }
 
-// TestMatchNovelFeature_PrefixDoesNotFalsePositive guards against over-eager
-// prefix matching. "op" should NOT match "options" — only hyphen-bounded
-// prefixes count.
-func TestMatchNovelFeature_PrefixDoesNotFalsePositive(t *testing.T) {
-	registered := map[string]bool{
-		"options": true,
+// TestCollectRegisteredCommandPaths exercises the tree walker end-to-end:
+// it writes a synthetic CLI fixture mirroring the yahoo-finance layout,
+// invokes the regex-based command-tree resolver, and asserts the emitted
+// paths cover nested subcommands (portfolio perf) and hyphenated
+// transcendence commands (auth login-chrome).
+func TestCollectRegisteredCommandPaths(t *testing.T) {
+	dir := t.TempDir()
+	cli := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cli, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	nf := NovelFeature{Command: "op"}
-	if matchNovelFeature(nf, registered) {
-		t.Error("commandLeaf 'op' should not prefix-match 'options' (no hyphen boundary)")
+
+	writeTestFile(t, filepath.Join(cli, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func Execute() {
+	rootCmd := &cobra.Command{Use: "tool"}
+	rootCmd.AddCommand(newAuthCmd())
+	rootCmd.AddCommand(newPortfolioCmd())
+	rootCmd.AddCommand(newDigestCmd())
+	rootCmd.AddCommand(newOptionsCmd())
+	rootCmd.AddCommand(newOptionsChainCmd())
+}
+`)
+	writeTestFile(t, filepath.Join(cli, "auth.go"), `package cli
+import "github.com/spf13/cobra"
+func newAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "auth"}
+	cmd.AddCommand(newAuthLoginCmd())
+	cmd.AddCommand(newAuthLoginChromeCmd())
+	cmd.AddCommand(newAuthLogoutCmd())
+	return cmd
+}
+func newAuthLoginCmd() *cobra.Command { return &cobra.Command{Use: "login"} }
+func newAuthLoginChromeCmd() *cobra.Command { return &cobra.Command{Use: "login-chrome"} }
+func newAuthLogoutCmd() *cobra.Command { return &cobra.Command{Use: "logout"} }
+`)
+	writeTestFile(t, filepath.Join(cli, "portfolio.go"), `package cli
+import "github.com/spf13/cobra"
+func newPortfolioCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "portfolio"}
+	cmd.AddCommand(newPortfolioPerfCmd())
+	cmd.AddCommand(newPortfolioGainsCmd())
+	return cmd
+}
+func newPortfolioPerfCmd() *cobra.Command { return &cobra.Command{Use: "perf"} }
+func newPortfolioGainsCmd() *cobra.Command { return &cobra.Command{Use: "gains"} }
+`)
+	writeTestFile(t, filepath.Join(cli, "misc.go"), `package cli
+import "github.com/spf13/cobra"
+func newDigestCmd() *cobra.Command { return &cobra.Command{Use: "digest"} }
+func newOptionsCmd() *cobra.Command { return &cobra.Command{Use: "options <symbol>"} }
+func newOptionsChainCmd() *cobra.Command { return &cobra.Command{Use: "options-chain <symbol>"} }
+`)
+
+	paths := collectRegisteredCommandPaths(dir)
+
+	// Every nested + transcendence path the matcher needs.
+	want := []string{
+		"auth",
+		"auth login",
+		"auth login-chrome",
+		"auth logout",
+		"portfolio",
+		"portfolio perf",
+		"portfolio gains",
+		"digest",
+		"options",
+		"options-chain",
+	}
+	for _, w := range want {
+		if !paths[w] {
+			t.Errorf("expected path %q in tree, got paths: %v", w, paths)
+		}
 	}
 }


### PR DESCRIPTION
Closes #191.

## Summary

Dogfood's novel-feature matcher no longer false-negatives legitimately-built commands. The previous leaf-only flat-map matcher dropped parent context (planned `portfolio perf` matched any `perf` anywhere in the tree) and missed hyphen specializations that a planner had described loosely (`auth login --chrome` → built `login-chrome`). Both failure modes suppressed entries from \`novel_features_built\`, which the README and publish steps consume — so shipped CLIs under-reported their own transcendence features.

The new matcher walks the Cobra command tree from source and matches planned commands by full path, with a leaf-only fallback that kicks in when tree reconstruction is partial.

## Approach

\`collectRegisteredCommands\` now reads every \`internal/cli/*.go\` once and returns two views in a single pass:

- **paths** — full space-separated paths (\`portfolio perf\`, \`auth login-chrome\`), reconstructed by regex-scanning \`func new*Cmd\` bodies for \`Use:\` + \`AddCommand\` edges and BFS-ing from \`rootCmd.AddCommand(...)\` call sites across full source.
- **leaves** — every \`Use:\` name regardless of nesting, pulled from the same regex pass.

\`matchNovelFeature\` tries in order:

1. **Exact full-path match.** `portfolio perf` matches `portfolio perf`.
2. **Sibling hyphen-prefix** on the last segment, restricted to the same parent. `auth login` matches `auth login-chrome` because both live under `auth`.
3. **Leaf fallback.** Every planned command runs through \`matchLeaf\` as a backstop.

The final leaf fallback exists because tree reconstruction only sees direct \`parent.AddCommand(newFooCmd())\` literals. CLIs using variable indirection — \`sub := newFooCmd(); parent.AddCommand(sub)\` — produce a partial paths map (e.g., yahoo-finance's \`auth login-chrome\` wiring, hackernews's \`show\`/\`ask\` commands). Treating a non-empty paths map as complete would false-negative legitimate built commands; the leaves map, populated from a pure \`Use:\` regex scan, is the safety net.

Aliases run the same two-tier dispatch. Commands are case-folded before matching.

## Tradeoff

Leaf fallback can re-introduce cross-parent leaf collisions when two built commands share a leaf under different parents AND only one is captured in paths. That's a rare corner case; the much more common case is paths is incomplete for a legitimately built command. Leaf-fallback is the pragmatically correct default.

## Tests

| Test | What it locks in |
|---|---|
| \`TestMatchNovelFeature_PathAware\` | Exact + sibling hyphen-prefix matching against a full tree |
| \`TestMatchNovelFeature_LeafFallback\` | Legacy leaf-only behavior when paths is empty |
| \`TestMatchNovelFeature_NoFalsePositive_CrossParent\` | Accuracy guarantee: \`portfolio perf\` does not match \`analytics perf\` |
| \`TestMatchNovelFeature_NoFalsePositive_BareLeaf\` | \`op\` does not prefix-match \`options\` (hyphen boundary required) |
| \`TestMatchNovelFeature_FallsBackToLeavesWhenPathsPartial\` | Regression guard for the Codex-review fix: commands captured only in leaves still match when paths is partial |
| \`TestCollectRegisteredCommands_Tree\` | End-to-end walker against a synthetic fixture mirroring the yahoo-finance layout (nested \`portfolio perf\`, transcendence \`auth login-chrome\`, sibling \`options\` vs \`options-chain\`) |
| \`TestCommandPath\` | Flag-stripping path extractor |

1642 tests pass across 22 packages. golangci-lint clean.

## Reviewers

After the initial path-aware commit, the \`/simplify\` pass pruned ~190 lines: merged two file-scanning functions into one, dropped a write-only \`(bool, string)\` reason return, removed a dead \`commandLeaf\` wrapper, switched the BFS seen-map to a struct key, and consolidated overlapping test cases into a shared table. A Codex review then caught the all-or-nothing paths-vs-leaves dispatch bug and the leaf-fallback fix landed with a regression test.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)