### PR TITLE
fix(cli): promoted-command presence check uses promoted type

### DIFF
--- a/internal/generator/promoted_presence_check_test.go
+++ b/internal/generator/promoted_presence_check_test.go
@@ -3,36 +3,19 @@ package generator
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/internal/spec"
 	"github.com/stretchr/testify/require"
 )
 
-// TestPromotedPresenceCheckUsesPromotedType guards against a class of
-// generator bugs where a flag declared with one Go type was compared
-// against the zero value of a different type.
-//
-// Background: ID-like int parameters (steamid, appid, etc.) are promoted
-// to string at declaration by goTypeForParam / cobraFlagFuncForParam to
-// avoid overflow and empty-vs-unset confusion. Before this fix, the
-// promoted command template used zeroVal(p.Type) for the presence check —
-// which returned "0" for the original int type, producing
-//
-//	if flagSteamid != 0 { ... }   // flagSteamid is string!
-//
-// go vet rejected the generated code with "mismatched types string and
-// untyped int". This test asserts both that the emitted check uses the
-// string zero and that go vet passes end-to-end on a spec shaped like
-// steam-web's failing case.
+// Ensures promoted commands emit presence checks against the flag's
+// declared type — which is string for ID-promoted ints — not the
+// spec's original type. Regression guard for #189.
 func TestPromotedPresenceCheckUsesPromotedType(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("steam-like")
-	// Replace the default items/list endpoint with one that carries an
-	// ID-like int query parameter. The promoted-command codepath emits
-	// the buggy presence check when such a flag is present.
 	apiSpec.Resources["items"] = spec.Resource{
 		Description: "Items",
 		Endpoints: map[string]spec.Endpoint{
@@ -50,27 +33,11 @@ func TestPromotedPresenceCheckUsesPromotedType(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "steam-like-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
-	// 1. Inspect the rendered promoted-command source directly — pinpoints
-	//    the template emission even if go vet is unavailable.
-	promotedFiles, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "promoted_*.go"))
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "promoted_items.go"))
 	require.NoError(t, err)
-	require.NotEmpty(t, promotedFiles, "expected at least one promoted command file")
 
-	var combined strings.Builder
-	for _, f := range promotedFiles {
-		data, err := os.ReadFile(f)
-		require.NoError(t, err)
-		combined.Write(data)
-	}
-	src := combined.String()
-
-	require.Contains(t, src, `flagSteamid != ""`,
+	require.Contains(t, string(src), `flagSteamid != ""`,
 		"flag declared as string (ID promotion) must be compared against string zero")
-	require.NotContains(t, src, "flagSteamid != 0",
+	require.NotContains(t, string(src), "flagSteamid != 0",
 		"flag declared as string must not be compared against int zero — this is the #189 bug")
-
-	// 2. go vet catches the type mismatch at the Go toolchain level. This
-	//    is the acceptance bar — if it passes, the generated code compiles.
-	require.NoError(t, runGoVet(t, outputDir),
-		"generated promoted command with ID-like int param must pass go vet")
 }

--- a/internal/generator/promoted_presence_check_test.go
+++ b/internal/generator/promoted_presence_check_test.go
@@ -1,0 +1,76 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromotedPresenceCheckUsesPromotedType guards against a class of
+// generator bugs where a flag declared with one Go type was compared
+// against the zero value of a different type.
+//
+// Background: ID-like int parameters (steamid, appid, etc.) are promoted
+// to string at declaration by goTypeForParam / cobraFlagFuncForParam to
+// avoid overflow and empty-vs-unset confusion. Before this fix, the
+// promoted command template used zeroVal(p.Type) for the presence check —
+// which returned "0" for the original int type, producing
+//
+//	if flagSteamid != 0 { ... }   // flagSteamid is string!
+//
+// go vet rejected the generated code with "mismatched types string and
+// untyped int". This test asserts both that the emitted check uses the
+// string zero and that go vet passes end-to-end on a spec shaped like
+// steam-web's failing case.
+func TestPromotedPresenceCheckUsesPromotedType(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("steam-like")
+	// Replace the default items/list endpoint with one that carries an
+	// ID-like int query parameter. The promoted-command codepath emits
+	// the buggy presence check when such a flag is present.
+	apiSpec.Resources["items"] = spec.Resource{
+		Description: "Items",
+		Endpoints: map[string]spec.Endpoint{
+			"get": {
+				Method:      "GET",
+				Path:        "/items/get",
+				Description: "Get items for a Steam account",
+				Params: []spec.Param{
+					{Name: "steamid", Type: "int", Required: false, Description: "Steam ID (64-bit)"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "steam-like-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	// 1. Inspect the rendered promoted-command source directly — pinpoints
+	//    the template emission even if go vet is unavailable.
+	promotedFiles, err := filepath.Glob(filepath.Join(outputDir, "internal", "cli", "promoted_*.go"))
+	require.NoError(t, err)
+	require.NotEmpty(t, promotedFiles, "expected at least one promoted command file")
+
+	var combined strings.Builder
+	for _, f := range promotedFiles {
+		data, err := os.ReadFile(f)
+		require.NoError(t, err)
+		combined.Write(data)
+	}
+	src := combined.String()
+
+	require.Contains(t, src, `flagSteamid != ""`,
+		"flag declared as string (ID promotion) must be compared against string zero")
+	require.NotContains(t, src, "flagSteamid != 0",
+		"flag declared as string must not be compared against int zero — this is the #189 bug")
+
+	// 2. go vet catches the type mismatch at the Go toolchain level. This
+	//    is the acceptance bar — if it passes, the generated code compiles.
+	require.NoError(t, runGoVet(t, outputDir),
+		"generated promoted command with ID-like int param must pass go vet")
+}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -82,7 +82,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			params["{{.Name}}"] = args[{{$i}}]
 {{- end}}
 {{- if not .Positional}}
-			if flag{{camel .Name}} != {{zeroVal .Type}} {
+			if flag{{camel .Name}} != {{zeroValForParam .Name .Type}} {
 				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel .Name}})
 			}
 {{- end}}


### PR DESCRIPTION
Closes #189.

## Summary

Generator emitted a type-mismatched comparison in promoted commands when a parameter's declared Go type was promoted. \`steamid\` (spec type \`int\`) is rewritten to \`string\` at declaration by \`goTypeForParam\` / \`cobraFlagFuncForParam\` to avoid 64-bit overflow, but the promoted-command template still used \`zeroVal(originalType)\` for the presence check:

\`\`\`go
var flagSteamid string                 // promoted type
if flagSteamid != 0 { ... }            // zeroVal("int") — go vet: mismatched types
\`\`\`

steam-web couldn't regenerate; any future spec with an ID-like int parameter on a promoted command would hit the same failure.

## Fix

One template callsite. \`command_promoted.go.tmpl\` line 85 now routes through \`zeroValForParam(name, type)\` — the helper that already exists in the template FuncMap and mirrors the same ID-promotion logic \`goTypeForParam\` uses. Emitted comparison now matches the declared variable type:

\`\`\`go
var flagSteamid string
if flagSteamid != "" { ... }           // compiles
\`\`\`

## Scope

Only the promoted-command presence check. The three \`zeroVal .Type\` callsites in \`command_endpoint.go.tmpl\` (body-field presence checks) are correct as-is: body fields are declared via \`goType\` directly (no ID promotion), so the original type is authoritative there.

## Regression test

\`promoted_presence_check_test.go\` generates a CLI with a \`steamid\`-shaped int parameter on a GET endpoint, reads the rendered \`promoted_items.go\`, and asserts the emitted code contains \`flagSteamid != ""\` and not \`flagSteamid != 0\`. Positive + negative assertions catch both the bug's original form and regressions to any other wrong-type comparison.

The existing \`TestEndToEndGenerateWithFullNarrativeBuildsAndParses\` already runs \`go vet\` on generated output at integration level, so this regression test stays at the template-emission layer — fast and deterministic.

## Test plan

- [x] \`go test ./...\` — all tests pass
- [x] \`golangci-lint run ./internal/generator/...\` — clean
- [ ] After merge: regenerate steam-web from its manuscript spec, confirm \`go vet\` passes on the output (currently the known-failing CLI from the issue)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)