### PR TITLE
fix(cli): authenticate mega MCP library fetches with GITHUB_TOKEN

### DIFF
--- a/internal/megamcp/manifest.go
+++ b/internal/megamcp/manifest.go
@@ -279,8 +279,18 @@ func tryCache(cachePath, expectedChecksum string) (*ToolsManifest, error) {
 }
 
 // fetchManifestData downloads manifest data from a URL.
+// When GITHUB_TOKEN is set, an Authorization header is attached so private-repo
+// reads via raw.githubusercontent.com succeed.
 func fetchManifestData(manifestURL string) ([]byte, error) {
-	resp, err := http.Get(manifestURL)
+	req, err := http.NewRequest(http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request: %w", err)
 	}

--- a/internal/megamcp/registry.go
+++ b/internal/megamcp/registry.go
@@ -5,17 +5,28 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 )
 
-// DefaultBaseURL is the default GitHub raw content URL for the public library repo.
+// DefaultBaseURL is the default GitHub raw content URL for the library repo.
 const DefaultBaseURL = "https://raw.githubusercontent.com/mvanhorn/printing-press-library/main"
 
 // FetchRegistry fetches registry.json from baseURL and parses it into a Registry.
 // baseURL is injectable for testing (use httptest.NewServer).
+// When GITHUB_TOKEN is set, an Authorization header is attached so private-repo
+// reads via raw.githubusercontent.com succeed.
 func FetchRegistry(baseURL string) (*Registry, error) {
 	registryURL := baseURL + "/registry.json"
 
-	resp, err := http.Get(registryURL)
+	req, err := http.NewRequest(http.MethodGet, registryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building registry request: %w", err)
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching registry: %w", err)
 	}

--- a/internal/megamcp/registry_test.go
+++ b/internal/megamcp/registry_test.go
@@ -96,3 +96,29 @@ func TestFetchRegistryInvalidJSON(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "parsing registry JSON")
 }
+
+func TestFetchRegistryAttachesGitHubToken(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Registry{SchemaVersion: 1})
+	}))
+	defer server.Close()
+
+	t.Run("with token set", func(t *testing.T) {
+		gotAuth = ""
+		t.Setenv("GITHUB_TOKEN", "ghp_testtoken123")
+		_, err := FetchRegistry(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "token ghp_testtoken123", gotAuth)
+	})
+
+	t.Run("with token unset", func(t *testing.T) {
+		gotAuth = ""
+		t.Setenv("GITHUB_TOKEN", "")
+		_, err := FetchRegistry(server.URL)
+		require.NoError(t, err)
+		assert.Empty(t, gotAuth)
+	})
+}


### PR DESCRIPTION
## Summary

The `printing-press-mcp` binary fetches `registry.json` and per-API `tools-manifest.json` from `raw.githubusercontent.com/mvanhorn/printing-press-library`. That repo is private, so unauthenticated reads return 404 and the mega MCP ships with an empty tool catalog (0 APIs, 0 tools in `library_info`).

When `GITHUB_TOKEN` is set, attach `Authorization: token <value>` to the outbound GET. Same URL, same response shape, just with auth. Matches the existing convention in `internal/crowdsniff/github.go`.

## Changes

- `internal/megamcp/registry.go` - `FetchRegistry` builds a request, sets the Authorization header when `GITHUB_TOKEN` is set, calls `http.DefaultClient.Do`
- `internal/megamcp/manifest.go` - `fetchManifestData` same treatment
- `internal/megamcp/registry_test.go` - new `TestFetchRegistryAttachesGitHubToken` with two subtests (token set, token unset)

Plan: `docs/plans/2026-04-17-002-fix-private-library-registry-auth-plan.md`

## Testing

- `go test ./internal/megamcp/...` passes (new auth-header cases included)
- `go vet ./...` clean
- Existing registry/manifest tests unchanged

## Post-Deploy Monitoring & Validation

- **Validation:** after merge + `go install ./cmd/printing-press-mcp` + Claude Code restart, `library_info` returns a non-empty API list when `GITHUB_TOKEN` is set
- **Failure signal:** still 404 with token set -> token lacks `contents:read` on `mvanhorn/printing-press-library`, not a code issue
- **Window:** immediate, maintainer-only tooling

---

[![Compound Engineering v2.56.1](https://img.shields.io/badge/Compound_Engineering-v2.56.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)