### PR TITLE
fix(cli): publish manifest must read spec.yaml alongside spec.json

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -76,6 +76,25 @@ func WriteCLIManifest(dir string, m CLIManifest) error {
 	return nil
 }
 
+// findArchivedSpec looks for a spec file archived alongside a generated CLI.
+// generate archives the source spec as spec.json (for JSON inputs) or
+// spec.yaml (for YAML inputs); older runs occasionally used spec.yml. Returns
+// the first match's path and contents, or an empty path with nil error when
+// no archive is present.
+func findArchivedSpec(dir string) (string, []byte, error) {
+	for _, name := range []string{"spec.json", "spec.yaml", "spec.yml"} {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return path, data, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+	}
+	return "", nil, nil
+}
+
 // specChecksum computes a SHA-256 checksum of the file at path.
 // Returns "sha256:<hex>" on success, or an empty string if the file
 // does not exist.
@@ -173,22 +192,15 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 
 	// Fallback: detect format and checksum from any spec file cached in the output dir.
 	if m.SpecFormat == "" || m.SpecChecksum == "" {
-		for _, name := range []string{"spec.json", "spec.yaml", "spec.yml"} {
-			specFile := filepath.Join(p.OutputDir, name)
-			data, err := os.ReadFile(specFile)
-			if err != nil {
-				continue
-			}
+		if specFile, data, err := findArchivedSpec(p.OutputDir); err == nil && specFile != "" {
 			if m.SpecFormat == "" {
 				m.SpecFormat = detectSpecFormat(data)
 			}
 			if m.SpecChecksum == "" {
-				cs, err := specChecksum(specFile)
-				if err == nil {
+				if cs, err := specChecksum(specFile); err == nil {
 					m.SpecChecksum = cs
 				}
 			}
-			break
 		}
 	}
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -259,6 +259,45 @@ func TestPublishManifestNormalizesURLDuplicatedInBothFields(t *testing.T) {
 	assert.Empty(t, got.SpecPath, "URL should not be duplicated in spec_path")
 }
 
+func TestPublishWorkingCLIWritesManifestForYAMLSpec(t *testing.T) {
+	home := setPressTestEnv(t)
+
+	workingDir := filepath.Join(home, "working", "yaml-spec-pp-cli")
+	require.NoError(t, os.MkdirAll(workingDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workingDir, "main.go"),
+		[]byte("package main\nfunc main() {}"),
+		0o644,
+	))
+
+	specContent := []byte("openapi: 3.0.0\ninfo:\n  title: YAML Test\n  version: 1.0.0\npaths: {}\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workingDir, "spec.yaml"),
+		specContent,
+		0o644,
+	))
+
+	state := NewState("yaml-api", workingDir)
+	require.NoError(t, os.MkdirAll(filepath.Dir(state.StatePath()), 0o755))
+	require.NoError(t, state.Save())
+
+	publishDir := filepath.Join(home, "library", "yaml-spec-pp-cli")
+	finalDir, err := PublishWorkingCLI(state, publishDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(finalDir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "openapi3", got.SpecFormat, "publish must detect format of YAML-archived specs")
+
+	h := sha256.Sum256(specContent)
+	expectedChecksum := "sha256:" + hex.EncodeToString(h[:])
+	assert.Equal(t, expectedChecksum, got.SpecChecksum, "publish must checksum YAML-archived specs")
+}
+
 func TestPublishWorkingCLIManifestWithoutSpec(t *testing.T) {
 	home := setPressTestEnv(t)
 

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -217,14 +217,13 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		}
 	}
 
-	// Detect spec format and compute checksum from the spec file in the
-	// working directory. spec.json only exists when specFlag is --spec;
-	// for --docs runs it won't be present and these fields stay empty.
-	specFile := filepath.Join(state.EffectiveWorkingDir(), "spec.json")
-	if data, err := os.ReadFile(specFile); err == nil {
+	// Detect spec format and compute checksum from the spec file archived
+	// alongside the CLI. generate writes spec.json for JSON inputs and
+	// spec.yaml for YAML inputs; --docs / --plan runs leave no archive and
+	// these fields stay empty.
+	if specFile, data, err := findArchivedSpec(state.EffectiveWorkingDir()); err == nil && specFile != "" {
 		m.SpecFormat = detectSpecFormat(data)
-		checksum, err := specChecksum(specFile)
-		if err == nil {
+		if checksum, err := specChecksum(specFile); err == nil {
 			m.SpecChecksum = checksum
 		}
 


### PR DESCRIPTION
## Summary

- `writeCLIManifestForPublish` only looked for `spec.json` in the working directory, so YAML-archived CLIs silently lost `spec_format`, `spec_checksum`, MCP metadata refresh, and `tools-manifest.json` regeneration at publish time.
- The generate-time manifest path (`climanifest.go` line 174-193) already handled the multi-extension case (`spec.json` → `spec.yaml` → `spec.yml`); the publish-time path drifted.
- Extracted `findArchivedSpec(dir)` so both call sites share the lookup.

## Why

Audit of `~/Code/printing-press-library/library/`:

| CLI | spec file on disk | manifest `spec_format` | manifest `spec_checksum` |
|-----|-------------------|------------------------|--------------------------|
| espn | spec.yaml | NULL | NULL |
| hackernews | spec.yaml | NULL | NULL |
| recipe-goat | spec.yaml | NULL | NULL |
| yahoo-finance | spec.yaml | NULL | NULL |

Generate-time manifest correctly set `spec_format` from the YAML; publish-time overwrote it back to empty because the `spec.json` lookup missed.

## Scope boundaries

- Fix applies only to **future** publishes. Existing manifests stay NULL until each CLI is republished — no backfill in this PR.
- The 10 library CLIs that have **no** archived spec at all (plan-driven, sniff-driven, docs-driven, internal-yaml passed via different paths) are a separate gap. Worth a follow-up that archives the source spec for those generation paths too.

## Test plan

- [x] New test `TestPublishWorkingCLIWritesManifestForYAMLSpec` in `internal/pipeline/climanifest_test.go` covers the YAML case
- [x] Existing `TestPublishWorkingCLIWritesManifest` (JSON), `TestPublishWorkingCLIManifestWithoutSpec`, `TestPublishWorkingCLIWritesMCPMetadataForInternalSpec` still pass
- [x] `go test ./...` — 1738 pass
- [x] `go build ./...` clean
- [x] `gofmt -w` applied

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)