### PR TITLE
fix(cli): avoid duplicate batch store upsert generation

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -241,6 +241,9 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		},
 		"envName":  func(s string) string { return strings.ToUpper(strings.ReplaceAll(s, "-", "_")) },
 		"safeName": safeSQLName,
+		"hasDomainUpsert": func(name string) bool {
+			return domainUpsertMethodName(name) != "UpsertBatch"
+		},
 		"pathContainsParam": func(path, name string) bool {
 			return strings.Contains(path, "{"+name+"}")
 		},
@@ -1313,6 +1316,10 @@ func toPascal(s string) string {
 		parts[i] = strings.ToUpper(lower[:1]) + lower[1:]
 	}
 	return strings.Join(parts, "")
+}
+
+func domainUpsertMethodName(tableName string) string {
+	return "Upsert" + toPascal(tableName)
 }
 
 // isIDParam returns true if the parameter name suggests it's an identifier

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -395,6 +395,60 @@ func TestGenerateWithEmptyOwner(t *testing.T) {
 	assert.NotContains(t, string(gomod), "module github.com/")
 }
 
+func TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "batch",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/batch-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"batch": {
+				Description: "Manage batch jobs",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/batch",
+						Description: "List batch jobs",
+						Params: []spec.Param{
+							{Name: "id", Type: "string"},
+							{Name: "name", Type: "string"},
+							{Name: "status", Type: "string"},
+							{Name: "created_at", Type: "string", Format: "date-time"},
+						},
+					},
+					"create": {
+						Method:      "POST",
+						Path:        "/batch",
+						Description: "Create a batch job",
+						Body: []spec.Param{
+							{Name: "name", Type: "string"},
+							{Name: "description", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(storeSrc), "func (s *Store) UpsertBatch("))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/store")
+}
+
 // --- Unit 7: Feature Verification Tests ---
 
 func generatePetstore(t *testing.T) string {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -285,7 +285,7 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 }
 
 {{- range .Tables}}
-{{- if and (gt (len .Columns) 3) (ne .Name "sync_state")}}
+{{- if and (gt (len .Columns) 3) (ne .Name "sync_state") (hasDomainUpsert .Name)}}
 // Upsert{{pascal .Name}} inserts or updates a {{.Name}} record with domain-specific columns.
 func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	var obj map[string]any

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -471,7 +471,7 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 
 	switch resource {
 {{- range .Tables}}
-{{- if and (gt (len .Columns) 3) (ne .Name "sync_state")}}
+{{- if and (gt (len .Columns) 3) (ne .Name "sync_state") (hasDomainUpsert .Name)}}
 	case "{{.Name}}":
 		return db.Upsert{{pascal .Name}}(data)
 {{- end}}


### PR DESCRIPTION
Fixes #188

## Problem

HubSpot regeneration can flatten many sub-specs into a single generated CLI. In that path, one store-backed resource can normalize to the table name `batch`.

The store template always emits the generic bulk helper:

```go
func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) error
```

For high-gravity tables, the same template also emits a domain-specific upsert method named from the table:

```go
func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error
```

When `.Name == "batch"`, that second method also renders as `Store.UpsertBatch`, so the generated CLI fails during validation with a duplicate method declaration in `internal/store/store.go`.

## Fix

This keeps the generic bulk helper as the canonical `UpsertBatch` implementation and prevents table-specific upsert generation from claiming that reserved method name.

Concretely:
- Add a generator template predicate for domain-specific upsert emission.
- Skip domain-specific `UpsertBatch` when a generated table name is `batch`.
- Apply the same predicate in `sync.go.tmpl` so sync code only calls domain-specific upsert methods that were actually emitted.
- Let `batch` resources use the existing generic upsert fallback instead of generating a colliding method.

This is intentionally scoped to the collision path instead of renaming generic `UpsertBatch`, which is already used by generated sync code.

## Regression Coverage

Added `TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch`, which builds a minimal store-backed API spec with a `batch` resource. The test verifies:
- generated `internal/store/store.go` contains exactly one `Store.UpsertBatch` method,
- the generated `internal/store` package compiles,
- the sync/store templates stay consistent for this reserved method name.

I verified this test failed before the implementation with the same duplicate method shape reported in #188, then passed after the template guard.

## Verification

- `go test ./internal/generator -run TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch -count=1`
- `go test ./...`
- `go vet ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `/Users/pejman/go/bin/golangci-lint run ./...`