### PR TITLE
fix(ci): allow release-please PR title scope

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -29,6 +29,7 @@ jobs:
             cli
             skills
             ci
+            main
           requireScope: true
           subjectPattern: ^.+$
           subjectPatternError: "PR title must have a description after the colon"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,9 @@ Key terms used throughout this repo. Several have overloaded meanings — the gl
 | `cli` | Go binary, commands, flags, embedded catalog, docs | `feat(cli): add catalog subcommands` |
 | `skills` | Skill definitions (SKILL.md), references, setup contract | `fix(skills): remove repo checkout requirement` |
 | `ci` | Workflows, release config, goreleaser | `feat(ci): add release-please` |
+| `main` | release-please generated release PRs targeting `main` | `chore(main): release 2.2.0` |
+
+`main` is reserved for release-please PR titles. Human-authored changes should use `cli`, `skills`, or `ci`.
 
 Every commit and PR title must include one of these scopes. The `PR Title` action enforces this.
 

--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -93,3 +93,44 @@ func TestMarketplaceJSONHasNoPluginVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestPRTitleWorkflowAllowsReleasePleaseScope(t *testing.T) {
+	// release-please uses the target branch as the conventional-commit scope
+	// for generated release PR titles, e.g. chore(main): release 2.2.0.
+	// The PR title workflow must allow that generated title or release PRs
+	// cannot merge.
+	data, err := os.ReadFile("../../.github/workflows/pr-title.yml")
+	require.NoError(t, err)
+
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Uses string         `yaml:"uses"`
+				With map[string]any `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &workflow))
+
+	lintJob, ok := workflow.Jobs["lint"]
+	require.True(t, ok, "PR title workflow should have a lint job")
+
+	for _, step := range lintJob.Steps {
+		if !strings.HasPrefix(step.Uses, "amannn/action-semantic-pull-request@") {
+			continue
+		}
+
+		scopes, ok := step.With["scopes"].(string)
+		require.True(t, ok, "semantic pull request action should declare scopes")
+
+		allowed := map[string]bool{}
+		for _, scope := range strings.Fields(scopes) {
+			allowed[scope] = true
+		}
+
+		assert.True(t, allowed["main"], "release-please PR titles use main as the scope")
+		return
+	}
+
+	t.Fatal("PR title workflow should use amannn/action-semantic-pull-request")
+}


### PR DESCRIPTION
## Summary

Release-please PRs targeting `main` now pass the PR title gate instead of failing on the generated `chore(main): release ...` title. The workflow allows `main` as a reserved release-please scope, documents that exception, and adds a regression test so future title-scope edits do not block generated release PRs.

## Testing

- `go test ./internal/cli`
- `go test ./...`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000?logoColor=white)