### PR TITLE
fix(megamcp): reject env var values containing '}' in ApplyAuthFormat

### DIFF
--- a/internal/megamcp/auth.go
+++ b/internal/megamcp/auth.go
@@ -38,6 +38,9 @@ func ApplyAuthFormat(format string, envVars map[string]string) (string, error) {
 
 	// Perform substitutions.
 	for key, value := range replacements {
+		if strings.Contains(value, "}") {
+			return "", fmt.Errorf("env var value for %s contains invalid character }", key)
+		}
 		result = strings.ReplaceAll(result, "{"+key+"}", value)
 	}
 

--- a/internal/megamcp/auth_test.go
+++ b/internal/megamcp/auth_test.go
@@ -63,6 +63,12 @@ func TestApplyAuthFormat(t *testing.T) {
 			envVars: map[string]string{},
 			want:    "",
 		},
+		{
+			name:    "value with closing brace rejected",
+			format:  "Bearer {token}",
+			envVars: map[string]string{"token": "abc}123"},
+			wantErr: "invalid character }",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #251