### PR TITLE
fix(cli): quote paths in emboss stderr output to prevent shell injection

### DIFF
--- a/internal/cli/emboss.go
+++ b/internal/cli/emboss.go
@@ -157,9 +157,9 @@ The improvement steps (2-4) are driven by the /printing-press emboss skill.`,
 			}
 
 			fmt.Fprintln(os.Stderr, "\nBaseline saved. Now run the skill for improvements:")
-			fmt.Fprintf(os.Stderr, "  /printing-press emboss %s\n\n", workingDir)
+			fmt.Fprintf(os.Stderr, "  /printing-press emboss %q\n\n", workingDir)
 			fmt.Fprintln(os.Stderr, "When done, re-run this command to compute the delta:")
-			fmt.Fprintf(os.Stderr, "  printing-press emboss --dir %s --spec %s\n", workingDir, specPath)
+			fmt.Fprintf(os.Stderr, "  printing-press emboss --dir %q --spec %q\n", workingDir, specPath)
 			return nil
 		},
 	}

--- a/internal/megamcp/auth.go
+++ b/internal/megamcp/auth.go
@@ -38,6 +38,9 @@ func ApplyAuthFormat(format string, envVars map[string]string) (string, error) {
 
 	// Perform substitutions.
 	for key, value := range replacements {
+		if strings.Contains(value, "}") {
+			return "", fmt.Errorf("env var value for %s contains invalid character }", key)
+		}
 		result = strings.ReplaceAll(result, "{"+key+"}", value)
 	}
 

--- a/internal/megamcp/auth_test.go
+++ b/internal/megamcp/auth_test.go
@@ -63,6 +63,12 @@ func TestApplyAuthFormat(t *testing.T) {
 			envVars: map[string]string{},
 			want:    "",
 		},
+		{
+			name:    "value with closing brace rejected",
+			format:  "Bearer {token}",
+			envVars: map[string]string{"token": "abc}123"},
+			wantErr: "invalid character }",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #253