### PR TITLE
fix(cli): backfill parent_id on store upgrade (#272)

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2957,6 +2957,72 @@ func TestGenerateDependentSyncCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/store")
 }
 
+func TestGenerateDependentSyncReservedWordCompiles(t *testing.T) {
+	t.Parallel()
+
+	// A spec whose dependent-resource table name is a SQL reserved word
+	// (e.g. references, trigger, view, order) must still produce a CLI
+	// that builds and whose store tests pass. The store template's
+	// backfillColumns slice and the upgrade-path test's t.Fatalf format
+	// string both interpolate the table name into Go double-quoted
+	// strings; safeSQLName quote-wraps reserved words for SQL contexts,
+	// so applying it in a Go-string context would emit invalid Go for
+	// any reserved-word resource. Regression for issue #272 follow-up.
+	apiSpec := &spec.APISpec{
+		Name:    "docstore",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"DOCSTORE_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/docstore-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"documents": {
+				Description: "Manage documents",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/documents",
+						Description: "List documents",
+						Response:    spec.ResponseDef{Type: "array"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+			// "references" snake_cases to "references" — a SQL reserved
+			// word per internal/generator/schema_builder.go:322.
+			"references": {
+				Description: "Manage references attached to a document",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/documents/{documentId}/references",
+						Description: "List references for a document",
+						Response:    spec.ResponseDef{Type: "array"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	// The generated store.go must compile (no embedded "" from safeName
+	// quote-wrapping) and the per-table upgrade test must run cleanly.
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+	runGoCommand(t, outputDir, "test", "./internal/store")
+}
+
 func TestGenerateGraphQLCompiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -146,6 +146,13 @@ func (s *Store) ensureColumn(table, column, decl string) error {
 	}
 
 	if _, err := s.db.Exec(fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {
+		// A concurrent Open() may have added the column between our
+		// PRAGMA check and this ALTER. SQLite returns SQLITE_ERROR with
+		// "duplicate column name", which busy_timeout does not retry.
+		// The DB is now in the desired state regardless of who won.
+		if strings.Contains(err.Error(), "duplicate column name") {
+			return nil
+		}
 		return fmt.Errorf("add column %s.%s: %w", table, column, err)
 	}
 	return nil
@@ -157,12 +164,20 @@ func (s *Store) ensureColumn(table, column, decl string) error {
 // statements referencing the column can succeed against the upgraded
 // table. Idempotent: safe to call on fresh DBs (table-not-found short-
 // circuit) and on already-current DBs (column-exists short-circuit).
+//
+// Table names are emitted bare (no safeName) — ensureColumn double-quotes
+// them at SQL emit time and uses parameter binding for the sqlite_master
+// lookup, so the values flow as Go string literals first and SQL
+// identifiers second. Wrapping with safeName here would embed literal
+// double-quote characters into the Go string and break compilation for
+// any spec whose dependent-resource snake_cased name is a SQL reserved
+// word.
 func (s *Store) backfillColumns() error {
 	for _, c := range []struct{ table, column, decl string }{
 {{- range $table := .Tables}}
 {{- range $col := $table.Columns}}
 {{- if eq $col.Name "parent_id"}}
-		{table: "{{safeName $table.Name}}", column: "parent_id", decl: "TEXT"},
+		{table: "{{$table.Name}}", column: "parent_id", decl: "TEXT"},
 {{- end}}
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -102,6 +102,78 @@ func (s *Store) setSchemaVersion(version int) error {
 	return nil
 }
 
+// ensureColumn adds a column to an existing table if it isn't already
+// present. It is the upgrade-path safety valve for schema additions:
+// CREATE TABLE IF NOT EXISTS is a no-op when the table already exists, so
+// columns added by newer binaries (e.g. parent_id from the dependent-
+// resources work) never land on databases created by older binaries —
+// which then trip "no such column" when a follow-on CREATE INDEX runs.
+//
+// Skips silently if the table doesn't yet exist (fresh install — the
+// CREATE TABLE migration will create it with the column already declared)
+// or if the column already exists.
+func (s *Store) ensureColumn(table, column, decl string) error {
+	var name string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table,
+	).Scan(&name)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking table %s: %w", table, err)
+	}
+
+	rows, err := s.db.Query(fmt.Sprintf(`PRAGMA table_info("%s")`, table))
+	if err != nil {
+		return fmt.Errorf("table_info %s: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var n, typ string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &n, &typ, &notnull, &dflt, &pk); err != nil {
+			return fmt.Errorf("scan table_info %s: %w", table, err)
+		}
+		if n == column {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating table_info %s: %w", table, err)
+	}
+
+	if _, err := s.db.Exec(fmt.Sprintf(`ALTER TABLE "%s" ADD COLUMN "%s" %s`, table, column, decl)); err != nil {
+		return fmt.Errorf("add column %s.%s: %w", table, column, err)
+	}
+	return nil
+}
+
+// backfillColumns adds columns that newer binaries declare but that
+// pre-existing databases (created before those columns were added) lack.
+// Must run before the migrations slice so that subsequent CREATE INDEX
+// statements referencing the column can succeed against the upgraded
+// table. Idempotent: safe to call on fresh DBs (table-not-found short-
+// circuit) and on already-current DBs (column-exists short-circuit).
+func (s *Store) backfillColumns() error {
+	for _, c := range []struct{ table, column, decl string }{
+{{- range $table := .Tables}}
+{{- range $col := $table.Columns}}
+{{- if eq $col.Name "parent_id"}}
+		{table: "{{safeName $table.Name}}", column: "parent_id", decl: "TEXT"},
+{{- end}}
+{{- end}}
+{{- end}}
+	} {
+		if err := s.ensureColumn(c.table, c.column, c.decl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Store) migrate() error {
 	current, err := s.SchemaVersion()
 	if err != nil {
@@ -109,6 +181,10 @@ func (s *Store) migrate() error {
 	}
 	if current > StoreSchemaVersion {
 		return fmt.Errorf("database schema version %d is newer than supported version %d; upgrade the CLI binary or open an older database", current, StoreSchemaVersion)
+	}
+
+	if err := s.backfillColumns(); err != nil {
+		return fmt.Errorf("backfilling columns: %w", err)
 	}
 
 	migrations := []string{

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -176,7 +176,7 @@ func TestMigrate_AddsParentIDOnUpgrade_{{pascal $table.Name}}(t *testing.T) {
 		t.Fatalf("rows: %v", err)
 	}
 	if !hasParentID {
-		t.Fatalf("parent_id column missing from {{safeName $table.Name}} after migrate")
+		t.Fatalf("parent_id column missing from {{$table.Name}} after migrate")
 	}
 }
 {{- end}}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -114,3 +114,70 @@ func TestSchemaVersion_ReopenIsIdempotent(t *testing.T) {
 		t.Fatalf("reopened version = %d, want %d", v, StoreSchemaVersion)
 	}
 }
+{{- range $table := .Tables}}
+{{- $hasParentID := false}}
+{{- range $col := $table.Columns}}{{if eq $col.Name "parent_id"}}{{$hasParentID = true}}{{end}}{{end}}
+{{- if $hasParentID}}
+
+// TestMigrate_AddsParentIDOnUpgrade_{{pascal $table.Name}} verifies that opening a
+// database created by an older binary — before the dependent-resources work
+// added the parent_id column — succeeds and adds the column rather than
+// failing with "no such column: parent_id" when CREATE INDEX runs against a
+// pre-existing table. Regression for issue #272.
+func TestMigrate_AddsParentIDOnUpgrade_{{pascal $table.Name}}(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	// Pre-create the DB with the older table shape: id, data, synced_at and
+	// no parent_id column. This mirrors what a pre-dependent-resources binary
+	// would have written. user_version stays 0 (pre-gate).
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE {{safeName $table.Name}} (
+		id TEXT PRIMARY KEY,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create old table: %v", err)
+	}
+	raw.Close()
+
+	// Opening with the new binary must run the CREATE INDEX on parent_id
+	// without erroring on the missing column.
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open upgraded db: %v", err)
+	}
+	defer s.Close()
+
+	// The migration must have added the parent_id column.
+	rows, err := s.DB().Query(`PRAGMA table_info({{safeName $table.Name}})`)
+	if err != nil {
+		t.Fatalf("table_info: %v", err)
+	}
+	defer rows.Close()
+
+	hasParentID := false
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if name == "parent_id" {
+			hasParentID = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if !hasParentID {
+		t.Fatalf("parent_id column missing from {{safeName $table.Name}} after migrate")
+	}
+}
+{{- end}}
+{{- end}}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -56,7 +56,7 @@ func TestUpsertBatch_Populates{{pascal .Name}}Table(t *testing.T) {
 	}
 
 	var typed int
-	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s`, "{{safeName .Name}}")
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "{{.Name}}")
 	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
 		t.Fatalf("count {{.Name}}: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestUpsertBatch_Sets{{pascal .Name}}ParentID(t *testing.T) {
 	db := s.DB()
 
 	var matchedA int
-	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE parent_id = ?`, "{{safeName .Name}}")
+	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE parent_id = ?`, "{{.Name}}")
 	if err := db.QueryRow(parentQuery, "parent-A").Scan(&matchedA); err != nil {
 		t.Fatalf("count by parent_id: %v", err)
 	}


### PR DESCRIPTION
## Summary

Every printed CLI with a parent-child resource (Discord, GitHub, Asana, Square, Pipedrive, meta-ads, etc.) was locked out of its local `data.db` on upgrade. The first command to call `store.Open` errored with `migration failed: SQL logic error: no such column: parent_id (1)` because `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables, so the `parent_id` column added by the dependent-resources work never landed and the follow-on `CREATE INDEX … ON <table>(parent_id)` failed.

This is a machine-side fix in `internal/generator/templates/store.go.tmpl`: every CLI regenerated from this point onward gets an upgrade-safe `migrate()`. Closes mvanhorn/cli-printing-press#272.

## What changed

`store.go.tmpl` gains two helpers:

- `ensureColumn(table, column, decl)` — checks `sqlite_master` and `PRAGMA table_info`. Returns silently if the table doesn't yet exist (fresh install — `CREATE TABLE` will create it with the column declared) or if the column is already present. Otherwise runs `ALTER TABLE … ADD COLUMN`. Treats SQLite's `duplicate column name` error as success so concurrent `Open()` races don't surface a fatal-looking error from the losing process.
- `backfillColumns()` — iterates a template-emitted list of `(table, "parent_id", "TEXT")` tuples, one per dependent-resource table.

`migrate()` calls `backfillColumns()` *before* the migrations slice runs. Subsequent `CREATE INDEX` statements then see a column-correct table on every code path:

| State | `backfillColumns` | `CREATE TABLE` | `CREATE INDEX` |
|-------|-------------------|----------------|----------------|
| Fresh install (table doesn't exist) | no-op | creates with `parent_id` | succeeds |
| Upgrade (table exists, no `parent_id`) | `ALTER TABLE ADD COLUMN` | no-op | succeeds |
| Already current | no-op | no-op | no-op |
| Concurrent `Open()` race | one process ALTERs; the other gets `duplicate column name` (treated as success) | no-op | succeeds |

## Identifier quoting belongs in the SQL format string, not the Go literal

`safeSQLName` quote-wraps SQL reserved words (~50 entries: `order`, `view`, `references`, `key`, `index`, `column`, `match`, `trigger`, `replace`, `set`, `default`, `values`, etc.) so they parse correctly as table or column names in DDL. Several sites in the store templates were interpolating that output into Go double-quoted string literals — where the embedded quotes break compilation for any spec whose dependent-resource snake_cased table name is a reserved word. The very fix this PR ships would not have compiled for those CLIs.

The principle: pass the bare table name as the Go string and let the SQL format string own the identifier quoting (`PRAGMA table_info("%s")`, `ALTER TABLE "%s" …`, `SELECT COUNT(*) FROM "%s"`). `ensureColumn` already does this for its own DDL and parameter-binds the `sqlite_master` probe. Three sites updated:

- `store.go.tmpl:165` — `backfillColumns` struct slice (this PR's own regression).
- `store_schema_version_test.go.tmpl:179` — `t.Fatalf` format string (this PR's own regression).
- `store_upsert_batch_test.go.tmpl:59,92` — `fmt.Sprintf` SQL builders (latent since #268; the existing `TestGenerateDependentSyncCompiles` only ever exercised non-reserved resource names like `messages`/`channels`, so the defect shipped silently).

## Why not a versioned migration system

The issue suggested `PRAGMA user_version`-driven discrete migration steps as an alternative. That solves the upgrade problem more generally for future column additions, but it's a meaningfully larger change and isn't required to fix #272. The existing `StoreSchemaVersion` constant + gate is still in place and ready to host a real migration table when the next column-addition warrants it; `ensureColumn` is generic enough that the next case becomes one more entry in the `backfillColumns` enumeration.

## Tests

`store_schema_version_test.go.tmpl` now emits `TestMigrate_AddsParentIDOnUpgrade_<Table>` for each parent_id-bearing table. Each test pre-creates a raw SQLite DB with the older shape (`id`, `data`, `synced_at` only) and `user_version = 0`, calls `Open`, and asserts (a) no error and (b) `parent_id` is present after migration.

`generator_test.go` adds `TestGenerateDependentSyncReservedWordCompiles`, a synthetic spec with a `references` child resource (snake-cases to a SQL reserved word). Builds the generated CLI and runs `go test ./internal/store`. Locks in the identifier-quoting regression at the generator-unit-test layer rather than waiting for dogfood time.

Confirmed both new tests reproduce their respective failures before the fix and pass after. Full `go test ./...` (2024 tests) and `golangci-lint run ./...` are clean.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)