### PR TITLE
fix(ci): build from local checkout instead of proxying private module

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-gomod:
-  proxy: true
-
 builds:
   - id: printing-press
     main: ./cmd/printing-press


### PR DESCRIPTION
## Summary
- Drop `gomod.proxy: true` from `.goreleaser.yaml` so goreleaser builds from the local checkout instead of trying to round-trip the module through Go's proxy
- Unblocks the goreleaser job in `Release` for private repos

## Why
The repo is private, so when goreleaser runs `go mod download <module>@<tag>` (which `proxy: true` triggers), the Go proxy can't see it and falls through to `git ls-remote` direct. The runner's `git` has credentials wired up only for `actions/checkout` — `go`'s child invocation gets none, and dies with `fatal: could not read Username for 'https://github.com': terminal prompts disabled`.

Concretely, [run #24922456911](https://github.com/mvanhorn/cli-printing-press/actions/runs/24922456911) failed with:
```
failed to proxy module: exit status 1: go: github.com/mvanhorn/cli-printing-press@v2.3.2:
  invalid version: git ls-remote -q ... https://github.com/mvanhorn/cli-printing-press
  fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Same error on v2.3.1's run. Every release since at least v2.3.1 has **zero binary assets attached** — release-please created the tags + GitHub Releases, but goreleaser never produced binaries.

Building from the local checkout works because `release.yml` already does `actions/checkout@v6` with `fetch-depth: 0`. We lose the "always build from a proxy-published immutable version" guarantee, but for a private auto-release project that benefit is marginal.

## Recovering v2.3.2
After this merges, the next release-please-cut release will have binaries. To backfill v2.3.2 itself: build locally from the v2.3.2 tag and `gh release upload`, or delete the v2.3.2 release/tag and re-cut.

## Test plan
- [ ] After merge, the next `Release` workflow run completes both jobs and the resulting GitHub Release has tar.gz/zip + checksums attached for `printing-press` and `printing-press-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)