### PR TITLE
fix(cli): honor explicit --output flag in generate

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -584,3 +584,46 @@ func TestGenerateCmdRejectsTrafficAnalysisWithPlan(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--traffic-analysis cannot be used with --plan")
 }
+
+func TestGenerateCmdHonorsExplicitOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "user-chosen-path")
+	derivedDir := filepath.Join(dir, "explicitoutput")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: explicitoutput
+description: Explicit output API
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/explicitoutput-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+`), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.FileExists(t, filepath.Join(outputDir, "go.mod"),
+		"generated files should land at the user-supplied --output path")
+	assert.NoDirExists(t, derivedDir,
+		"the spec-derived directory must not be created when --output is explicit")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -421,18 +421,20 @@ func newGenerateCmd() *cobra.Command {
 				}
 			}
 
-			// Rename output directory to match the derived CLI name if they differ.
-			// This prevents mismatches when the caller passes a directory name
-			// that doesn't match what the generator derives from the spec title
-			// (e.g., --output .../calcom-pp-cli but spec title "Cal.com" derives "cal-com-pp-cli").
-			derivedDir := apiSpec.Name
-			currentBase := filepath.Base(absOut)
-			if currentBase != derivedDir {
-				finalPath := filepath.Join(filepath.Dir(absOut), derivedDir)
-				if err := os.Rename(absOut, finalPath); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: could not rename output dir from %s to %s: %v\n", currentBase, derivedDir, err)
-				} else {
-					absOut = finalPath
+			// When --output was not explicitly supplied, normalize the output
+			// directory to the spec-derived name so default-path runs land in the
+			// expected slot (e.g., spec title "Cal.com" derives "cal-com-pp-cli").
+			// When --output is explicit, the caller's chosen path is authoritative.
+			if !explicitOutput {
+				derivedDir := apiSpec.Name
+				currentBase := filepath.Base(absOut)
+				if currentBase != derivedDir {
+					finalPath := filepath.Join(filepath.Dir(absOut), derivedDir)
+					if err := os.Rename(absOut, finalPath); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: could not rename output dir from %s to %s: %v\n", currentBase, derivedDir, err)
+					} else {
+						absOut = finalPath
+					}
 				}
 			}
 


### PR DESCRIPTION
`printing-press generate --output /path/A` previously moved generated files to `/path/<spec.name>` after writing them, silently overriding the caller's chosen path. The post-generate rename block at `internal/cli/root.go:424` compared the output directory's basename against the spec-derived name and forced them to match, never consulting the `explicitOutput` flag computed 9 lines earlier.

When `--output` is supplied, the caller's path is now authoritative. Default-path runs (no `--output`) still normalize to the spec-derived slot for `pipeline.DefaultOutputDir` callers, since `currentBase` already equals `derivedDir` in that flow.

`TestGenerateCmdHonorsExplicitOutput` asserts the new contract: a `--output` whose basename differs from the spec's `name` lands at the user's path, and the spec-derived sibling directory is not created.

Addresses #275 (F-1 only). Findings F-2 through F-5 remain open for separate fixes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)