### PR TITLE
fix(catalog): update stale spec URLs + add download content-validity check

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -814,6 +815,17 @@ func fetchOrCacheSpec(specURL string, refresh bool, skipCache bool) ([]byte, err
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
 
+	// Content-validity check: reject responses that look like error pages
+	// instead of feeding them to the parser (which emits confusing errors).
+	if len(data) < 256 {
+		trimmed := strings.TrimSpace(string(data))
+		if strings.HasPrefix(trimmed, "<") ||
+			regexp.MustCompile(`^\d{3}:\s`).MatchString(trimmed) {
+			return nil, fmt.Errorf("spec_url %s returned a small response that does not look like an OpenAPI spec (%d bytes): %q",
+				specURL, len(data), trunc50(trimmed))
+		}
+	}
+
 	if !skipCache {
 		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 			return nil, fmt.Errorf("creating cache directory: %w", err)
@@ -824,6 +836,13 @@ func fetchOrCacheSpec(specURL string, refresh bool, skipCache bool) ([]byte, err
 	}
 
 	return data, nil
+}
+
+func trunc50(s string) string {
+	if len(s) > 50 {
+		return s[:50] + "..."
+	}
+	return s
 }
 
 func newVersionCmd() *cobra.Command {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchOrCacheSpec_ContentValidityCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		wantErr    string
+	}{
+		{
+			name:       "small HTML error page",
+			body:       "<html><body>404 Not Found</body></html>",
+			statusCode: 200,
+			wantErr:    "does not look like an OpenAPI spec",
+		},
+		{
+			name:       "small status-text error",
+			body:       "404: Not Found",
+			statusCode: 200,
+			wantErr:    "does not look like an OpenAPI spec",
+		},
+		{
+			name:       "valid large spec passes",
+			body:       "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Test\",\"version\":\"1.0\"},\"paths\":{}}" + string(make([]byte, 300)),
+			statusCode: 200,
+			wantErr:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := fetchOrCacheSpec(srv.URL, true, true)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || searchString(s, sub))
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Fixes two stale catalog spec URLs and adds a content-validity guard that catches broken downloads early.

### URL fixes
- **asana**: `Asana/openapi` uses `master` branch, not `main` (HTTP 404 on the old URL)
- **square**: repo renamed from `square-openapi` to `connect-api-specification`, file moved from `openapi.json` to `api.json`

### Content-validity check (F-5c from #275)

When `fetchOrCacheSpec` downloads a response that is:
- Less than 256 bytes AND
- Starts with `<` (HTML error page) or matches `^\d{3}:\s` (status-text like `404: Not Found`)

...it fails with a clear error instead of forwarding the garbage to the parser. Example:

```
Error: spec_url https://... returned a small response that does not look like an OpenAPI spec (14 bytes): "404: Not Found"
```

Previously the parser would emit confusing errors like `validation: name is required` on the error page body.

### What's still broken

These catalog entries still have stale/broken spec_urls and need maintainer decisions:
- **sendgrid**: consolidated spec removed upstream; split into ~30 `tsg_*.json` files that can't be used as a single spec
- **postman-explore, producthunt**: spec_url points to the private `cli-printing-press` repo; end users without auth can't fetch them
- **digitalocean**: spec parses but `Tag.description` is an object, not a string (F-4 from #275, separate parser fix needed)

## Testing

```
go test ./internal/cli/ -run TestFetchOrCacheSpec -v
--- PASS: TestFetchOrCacheSpec_ContentValidityCheck (0.00s)
```

Full `./internal/cli/` test suite passes.

Refs #275