### PR TITLE
fix(cli): prepend T to type names that match Go reserved words

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2328,7 +2328,29 @@ func safeTypeName(name string) string {
 	if len(result) > 0 && !unicode.IsLetter(rune(result[0])) {
 		result = "T" + result
 	}
+	if isGoKeyword(result) {
+		result = "T" + result
+	}
 	return result
+}
+
+// goKeywords is the set of reserved words from the Go language spec
+// (https://go.dev/ref/spec#Keywords). Type names that match these refuse to
+// parse as `type X struct { ... }`. Predeclared identifiers (bool, int,
+// string, error, etc.) shadow rather than fail and are intentionally
+// excluded; OpenAPI specs that use them as type names compile, just with
+// shadowed builtins inside that file.
+var goKeywords = map[string]bool{
+	"break": true, "case": true, "chan": true, "const": true, "continue": true,
+	"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
+	"func": true, "go": true, "goto": true, "if": true, "import": true,
+	"interface": true, "map": true, "package": true, "range": true, "return": true,
+	"select": true, "struct": true, "switch": true, "type": true, "var": true,
+}
+
+// isGoKeyword reports whether s is a reserved word in the Go language spec.
+func isGoKeyword(s string) bool {
+	return goKeywords[s]
 }
 
 // toKebab converts PascalCase, camelCase, or mixed names to kebab-case.

--- a/internal/generator/types_keyword_test.go
+++ b/internal/generator/types_keyword_test.go
@@ -1,0 +1,44 @@
+package generator
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateTypesAvoidsGoKeywordCollision covers issue #275 F-3. GitHub's
+// OpenAPI spec has hundreds of type definitions; at least one is named `import`,
+// which the generator emits verbatim as `type import struct {`, a parse error
+// because `import` is a Go reserved word. Other reserved words (`package`,
+// `func`, `type`, `var`, `range`, `select`, etc.) hit the same trap.
+//
+// `safeTypeName` (and the OpenAPI parser's `sanitizeTypeName`) strip
+// non-alphanumeric characters but never check for keywords. Both should
+// produce identifiers that are guaranteed-safe for `type X struct { ... }`.
+func TestGenerateTypesAvoidsGoKeywordCollision(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("keyword-types")
+	apiSpec.Types = map[string]spec.TypeDef{
+		"import":  {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+		"package": {Fields: []spec.TypeField{{Name: "name", Type: "string"}}},
+		"func":    {Fields: []spec.TypeField{{Name: "name", Type: "string"}}},
+		"User":    {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "keyword-types-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	typesPath := filepath.Join(outputDir, "internal", "types", "types.go")
+	src, err := os.ReadFile(typesPath)
+	require.NoError(t, err, "generated types.go must exist")
+
+	_, err = parser.ParseFile(token.NewFileSet(), typesPath, src, 0)
+	require.NoError(t, err,
+		"generated types.go must parse as Go even when source schemas use Go reserved words for names")
+}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2572,7 +2572,28 @@ func sanitizeTypeName(name string) string {
 	if len(result) > 0 && !unicode.IsLetter(rune(result[0])) {
 		result = "T" + result
 	}
+	if isGoReservedWord(result) {
+		result = "T" + result
+	}
 	return result
+}
+
+// goReservedWords is the set of reserved keywords from the Go language spec
+// (https://go.dev/ref/spec#Keywords). When a sanitized type name matches one
+// of these, the generated `type X struct { ... }` will fail to parse;
+// sanitize prepends "T" to dodge the collision. Predeclared identifiers
+// (bool, int, string, error, etc.) shadow rather than fail and are
+// intentionally excluded.
+var goReservedWords = map[string]bool{
+	"break": true, "case": true, "chan": true, "const": true, "continue": true,
+	"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
+	"func": true, "go": true, "goto": true, "if": true, "import": true,
+	"interface": true, "map": true, "package": true, "range": true, "return": true,
+	"select": true, "struct": true, "switch": true, "type": true, "var": true,
+}
+
+func isGoReservedWord(s string) bool {
+	return goReservedWords[s]
 }
 
 func toCamelCase(s string) string {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2572,19 +2572,19 @@ func sanitizeTypeName(name string) string {
 	if len(result) > 0 && !unicode.IsLetter(rune(result[0])) {
 		result = "T" + result
 	}
-	if isGoReservedWord(result) {
+	if isGoKeyword(result) {
 		result = "T" + result
 	}
 	return result
 }
 
-// goReservedWords is the set of reserved keywords from the Go language spec
+// goKeywords is the set of reserved words from the Go language spec
 // (https://go.dev/ref/spec#Keywords). When a sanitized type name matches one
 // of these, the generated `type X struct { ... }` will fail to parse;
 // sanitize prepends "T" to dodge the collision. Predeclared identifiers
 // (bool, int, string, error, etc.) shadow rather than fail and are
 // intentionally excluded.
-var goReservedWords = map[string]bool{
+var goKeywords = map[string]bool{
 	"break": true, "case": true, "chan": true, "const": true, "continue": true,
 	"default": true, "defer": true, "else": true, "fallthrough": true, "for": true,
 	"func": true, "go": true, "goto": true, "if": true, "import": true,
@@ -2592,8 +2592,9 @@ var goReservedWords = map[string]bool{
 	"select": true, "struct": true, "switch": true, "type": true, "var": true,
 }
 
-func isGoReservedWord(s string) bool {
-	return goReservedWords[s]
+// isGoKeyword reports whether s is a reserved word in the Go language spec.
+func isGoKeyword(s string) bool {
+	return goKeywords[s]
 }
 
 func toCamelCase(s string) string {


### PR DESCRIPTION
GitHub's OpenAPI spec contains schemas literally named `import` (Source Imports API) and `package` (GitHub Packages); both happen to be Go reserved words. `safeTypeName` (generator) and `sanitizeTypeName` (parser) each stripped non-alphanumeric characters without checking for keywords, so the names passed through into `type import struct { ... }` and `type package struct { ... }` and refused to parse at column 6.

Both sanitizers now check whether the cleaned name matches a Go reserved word and prepend `T` when it does, mirroring the existing non-letter-prefix guard. The fix is symmetric across the parser and generator because each has its own near-identical sanitizer; covering both keeps the spec consistent at the parser boundary and the generator defended-in-depth. Predeclared identifiers (`bool`, `int`, `string`, `error`) are intentionally excluded; they shadow rather than fail to parse, and F-3 is specifically about parse-time errors.

Combined with #283 (F-2), GitHub's full CLI now regenerates and builds from the upstream 9MB spec for the first time. `internal/generator/types_keyword_test.go` adds a regression test that builds a spec with types named after Go keywords and asserts the generated `types.go` parses as Go via `go/parser`.

Addresses #275 (F-3 only). Findings F-4 and F-5 remain open.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)