### PR TITLE
fix(cli): normalize routing prefixes in OpenAPI paths

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2302,17 +2302,24 @@ func pathSegmentsAfterBase(path, basePath string) []string {
 		}
 	}
 
-	if len(segments) > 0 && isVersionSegment(segments[0]) {
-		segments = segments[1:]
-	}
+	for len(segments) > 0 {
+		if isVersionSegment(segments[0]) {
+			segments = segments[1:]
+			continue
+		}
 
-	// Strip generic API routing prefixes when followed by a concrete resource
-	// segment. "api", "apis", "rest" as the first segment after version are
-	// routing infrastructure, not resource names. /v1/api/users → "users".
-	// Do NOT strip when the next segment is a path param ({id}), because
-	// /api/{id} means "api" IS the resource.
-	if len(segments) >= 2 && isGenericAPIPrefix(segments[0]) && !isPathParamSegment(segments[1]) {
-		segments = segments[1:]
+		// Strip generic API routing prefixes when followed by a concrete
+		// resource or another routing segment. "api", "apis", "rest" are
+		// infrastructure, not resource names. /v1/api/users and
+		// /api/v2/users both normalize to "users".
+		// Do NOT strip when the next segment is a path param ({id}), because
+		// /api/{id} means "api" IS the resource.
+		if len(segments) >= 2 && isGenericAPIPrefix(segments[0]) && !isPathParamSegment(segments[1]) {
+			segments = segments[1:]
+			continue
+		}
+
+		break
 	}
 
 	return segments

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -252,6 +252,8 @@ func TestPathSegmentsStripsGenericAPIPrefix(t *testing.T) {
 		{"keeps api when followed by path param", "/api/{id}", "", "api"},
 		{"keeps rest when followed by path param", "/rest/{job_id}/runs", "", "rest"},
 		{"strips version then api", "/v1/api/networkentity", "", "networkentity"},
+		{"strips api then version", "/api/v2/pokemon", "", "pokemon"},
+		{"strips version then api then version", "/v2/api/v1/pokemon", "", "pokemon"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes OpenAPI path resource extraction so routing-only prefixes and version segments are stripped regardless of order. This prevents specs with paths like `/api/v2/pokemon` from generating an awkward top-level `v2` resource.

## Root Cause

`pathSegmentsAfterBase` stripped at most one leading version segment and then at most one generic API prefix. For PokeAPI-style paths, `/api/v2/pokemon` became `v2/pokemon`, so resource extraction treated `v2` as the resource.

## Fix

- Repeatedly strip leading version segments and generic routing prefixes until the first domain-specific segment.
- Preserve the existing guard for `/api/{id}` and similar paths where `api` or `rest` is the actual resource.
- Add regression coverage for `/api/v2/pokemon` and `/v2/api/v1/pokemon`.

## Review

Ran a focused review pass on the diff. No findings: the loop terminates on domain segments, keeps the path-param guard intact, and is covered by the existing and new prefix-order cases.

## Verification

- `go test ./internal/openapi -run TestPathSegmentsStripsGenericAPIPrefix -count=1`
- `go test ./...`
- `git diff --check`
- `go build -o ./printing-press ./cmd/printing-press`
- `golangci-lint run ./...`
