### PR TITLE
fix(cli): use strconv.Atoi for major-version parsing in guard test

### DIFF
--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -137,8 +138,7 @@ func majorVersion(t *testing.T, v string) int {
 	t.Helper()
 	parts := strings.SplitN(v, ".", 2)
 	require.NotEmpty(t, parts[0], "Version must have a major component")
-	var major int
-	_, err := fmt.Sscanf(parts[0], "%d", &major)
+	major, err := strconv.Atoi(parts[0])
 	require.NoError(t, err, "Version major %q must be an integer", parts[0])
 	return major
 }


### PR DESCRIPTION
## Summary

Tightens the `majorVersion` helper in `TestModulePathMatchesMajorVersion` (added in #298) to use `strconv.Atoi` instead of `fmt.Sscanf`. `Sscanf` with `%d` happily accepts input like `"2abc"` — it stops at the first non-digit and returns `2`, which would mask a malformed `version.Version` constant. `strconv.Atoi` rejects trailing junk and is the idiomatic choice when the entire string must be exactly an integer.

This is defense in depth, not a live bug fix: `TestVersionIsValidSemver` already enforces `^\d+\.\d+\.\d+$` on `Version`, so the guard helper would never see malformed input in practice. But the cheaper, more correct API is the right one when both are available.

Identified during the post-merge review of #298.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)