### PR TITLE
fix(skills): inherit Codex model from ~/.codex/config.toml

### DIFF
--- a/internal/cli/codex_model_invariant_test.go
+++ b/internal/cli/codex_model_invariant_test.go
@@ -1,0 +1,137 @@
+package cli_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkillsInheritCodexModelFromConfig is the regression guard for the
+// 2026-04-26 codex-model auto-default fix.
+//
+// Codex CLI delegations in printing-press skill files must inherit the
+// user's ~/.codex/config.toml default model and reasoning effort.
+// Pinning -m "gpt-...", --model "gpt-...", model_reasoning_effort=...,
+// or invoking the non-existent `codex config get model` subcommand
+// causes every codex run to drift from the user's actual configured
+// model and freezes the skill at whatever literal string is hardcoded.
+//
+// The test walks every markdown file under skills/ and fails on any of
+// those patterns. Vendored content under */vendor/* is excluded.
+func TestSkillsInheritCodexModelFromConfig(t *testing.T) {
+	skillsRoot := "../../skills"
+	info, err := os.Stat(skillsRoot)
+	require.NoError(t, err, "skills/ directory must exist")
+	require.True(t, info.IsDir(), "skills/ must be a directory")
+
+	// Forbidden patterns. Any match in a skill markdown file is a
+	// violation.
+	forbidden := []struct {
+		pattern *regexp.Regexp
+		reason  string
+	}{
+		{
+			regexp.MustCompile(`-m\s+"gpt-`),
+			`hardcoded -m "gpt-..." (use codex's config.toml default instead)`,
+		},
+		{
+			regexp.MustCompile(`--model\s+"gpt-`),
+			`hardcoded --model "gpt-..." (use codex's config.toml default instead)`,
+		},
+		{
+			regexp.MustCompile(`model_reasoning_effort\s*=\s*`),
+			`hardcoded model_reasoning_effort= (inherits from config.toml)`,
+		},
+		{
+			regexp.MustCompile(`codex\s+config\s+get\s+model`),
+			"calls non-existent `codex config get model` subcommand " +
+				"(grep ~/.codex/config.toml directly instead)",
+		},
+	}
+
+	// Files allowed to mention forbidden patterns. The test file itself
+	// quotes the patterns; release notes and changelogs may reference
+	// the historical hardcoded values.
+	allowlist := map[string]bool{
+		filepath.Clean("../../internal/cli/codex_model_invariant_test.go"): true,
+	}
+
+	var violations []string
+
+	walkErr := filepath.WalkDir(skillsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Skip vendored content.
+			if strings.Contains(path, "/vendor/") || strings.HasSuffix(path, "/vendor") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		if allowlist[filepath.Clean(path)] {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		for lineNum, line := range strings.Split(string(data), "\n") {
+			for _, f := range forbidden {
+				if f.pattern.MatchString(line) {
+					rel := strings.TrimPrefix(path, "../../")
+					violations = append(violations,
+						"  "+rel+":"+itoa(lineNum+1)+": "+f.reason+
+							"\n    > "+strings.TrimSpace(line))
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, walkErr)
+
+	if len(violations) > 0 {
+		t.Fatalf("Skill files must inherit Codex model from "+
+			"~/.codex/config.toml. Found pinned models or invalid "+
+			"config calls:\n%s\n\n"+
+			"Fix: remove `-m \"gpt-...\"` and "+
+			"`-c 'model_reasoning_effort=...'` from `codex exec` calls. "+
+			"For display, replace `codex config get model` with a "+
+			"`grep ^model ~/.codex/config.toml` pattern.",
+			strings.Join(violations, "\n"))
+	}
+}
+
+// itoa is a small wrapper to avoid pulling strconv into this file's
+// import list when the tests already use require/strings/regexp.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -294,7 +294,9 @@ fi
 # Health check: verify codex binary exists
 if [ "$CODEX_MODE" = "true" ]; then
   if command -v codex >/dev/null 2>&1; then
-    CODEX_MODEL=$(codex config get model 2>/dev/null || echo "gpt-5.4")
+    # Model and reasoning effort inherit from ~/.codex/config.toml. Do not pin -m / -c here.
+    CODEX_MODEL=$(grep -E '^model[[:space:]]*=' ~/.codex/config.toml 2>/dev/null | head -1 | sed -E 's/^model[[:space:]]*=[[:space:]]*"?([^"]+)"?.*$/\1/')
+    [ -z "$CODEX_MODEL" ] && CODEX_MODEL="codex default"
     echo "Codex mode enabled (model: $CODEX_MODEL). Code-writing tasks will be delegated to Codex."
   else
     echo "Codex CLI not found - running in standard mode."

--- a/skills/printing-press/references/codex-delegation.md
+++ b/skills/printing-press/references/codex-delegation.md
@@ -26,10 +26,9 @@ When `CODEX_MODE` is true, delegate code-writing tasks to Codex CLI. Claude stil
 
    d. **Delegate** — Pipe to Codex:
    ```bash
+   # Model and reasoning effort inherit from ~/.codex/config.toml. Do not pin -m / -c here.
    cd "$PRESS_LIBRARY/<api>-pp-cli" && echo "$CODEX_PROMPT" | codex exec \
      --yolo \
-     -c 'model_reasoning_effort="medium"' \
-     -m "gpt-5.4" \
      -
    ```
 
@@ -212,10 +211,9 @@ When `CODEX_MODE` is true, delegate each bug fix to Codex. The shipcheck tools t
    ```
 
    ```bash
+   # Model and reasoning effort inherit from ~/.codex/config.toml. Do not pin -m / -c here.
    cd "$PRESS_LIBRARY/<api>-pp-cli" && echo "$CODEX_PROMPT" | codex exec \
      --yolo \
-     -c 'model_reasoning_effort="medium"' \
-     -m "gpt-5.4" \
      -
    ```
 


### PR DESCRIPTION
## What's wrong today

The `printing-press` skill delegates code-writing to Codex CLI when `CODEX_MODE=true`. Two compounding bugs:

1. **Hardcoded `-m "gpt-5.4" -c 'model_reasoning_effort="medium"'`** on both `codex exec` blocks in `skills/printing-press/references/codex-delegation.md` (Phase 3 delegation, Phase 4 second-pass). This overrode whatever the user has set as their codex CLI default. When OpenAI ships gpt-5.6, every skill needs a coordinated PR to update.
2. **`CODEX_MODEL=$(codex config get model 2>/dev/null || echo "gpt-5.4")`** for the display banner in `skills/printing-press/SKILL.md`. `codex config get model` is not a real Codex 0.124.0 subcommand — it has always errored, the fallback has always fired, and the announced model has always been the literal string `"gpt-5.4"` regardless of what the skill actually invoked.

The Go binary's existing `internal/llm/llm.go:52` already calls codex without `-m`, so it inherits the user default correctly. This PR brings the skill-side delegation in line with that pattern.

## What changes

- **Omit `-m` and `-c`** from both `codex exec` blocks in `references/codex-delegation.md`. Codex inherits from `~/.codex/config.toml` automatically when the flags are absent.
- **Replace the broken display logic** with `grep ^model ~/.codex/config.toml | head -1 | sed ...`. The `head -1` filter ensures `[projects.*]` block model overrides do not leak into the display.
- **Add `internal/cli/codex_model_invariant_test.go`** — a Go test that walks every `skills/**/*.md` file and fails on hardcoded `-m "gpt-..."`, `--model "gpt-..."`, `model_reasoning_effort=`, or `codex config get model`. Runs as part of `go test ./...`. Self-tested by simulating a regression and confirming the test catches it with a clear error message.

## Result

When the user updates `~/.codex/config.toml` (e.g., `model = "gpt-5.6"`), no skill PR or version bump is required — every codex delegation picks up the new model on the next invocation. The display banner now reflects the model that will actually be used.

## Test plan

- `go test ./internal/cli/ -run TestSkillsInheritCodexModelFromConfig` passes on the cleaned-up tree.
- `go test ./internal/cli/` full package run passes.
- `scripts/golden.sh verify` passes (skill changes don't affect golden output).
- `gofmt -l ./internal/ ./cmd/` clean.
- Manual: simulated a regression by appending `-m "gpt-9.9"` to `skills/printing-press/SKILL.md`; the invariant test failed with a readable message naming the file and line. Reverted, test passes again.