### PR TITLE
test(cli): speed up generator test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .gotmp/
 .claude/worktrees/
 /refactor/artifacts/
+/tests/artifacts/perf/
 /printing-press
 library/
 dist/

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -523,6 +523,15 @@ func countFiles(t *testing.T, root string) int {
 func runGoCommand(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
+	// Generated-project compile tests exercise module resolution via -mod=mod;
+	// production Validate still owns the go mod tidy quality gate.
+	if len(args) >= 2 && args[0] == "mod" && args[1] == "tidy" {
+		return
+	}
+	if len(args) > 0 && (args[0] == "build" || args[0] == "test") {
+		args = append([]string{args[0], "-mod=mod"}, args[1:]...)
+	}
+
 	cmd := exec.Command("go", args...)
 	cmd.Dir = dir
 	cacheDir, err := goBuildCacheDir(dir)
@@ -614,9 +623,8 @@ func TestGenerateBrowserChromeTransport(t *testing.T) {
 	readme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(readme), "Chrome-compatible HTTP transport")
-
-	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "build", "./...")
+	// The H3 sibling below compiles the same surf-backed client path; this
+	// test stays focused on the non-H3 rendering branch.
 }
 
 func TestGenerateBrowserChromeH3Transport(t *testing.T) {
@@ -656,7 +664,7 @@ func TestGenerateBrowserChromeH3Transport(t *testing.T) {
 	assert.Contains(t, string(clientGo), "ForceHTTP3()")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "build", "./...")
+	runGoCommand(t, outputDir, "test", "./internal/client")
 }
 
 func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
@@ -2656,7 +2664,9 @@ func TestGenerateGraphQLBFFUsesSemanticCommandSurface(t *testing.T) {
 	}
 	apiSpec, err := browsersniff.AnalyzeCapture(capture)
 	require.NoError(t, err)
-	apiSpec.HTTPTransport = spec.HTTPTransportBrowserChromeH3
+	// Browser/H3 transport has focused coverage above; this test is about
+	// GraphQL BFF command shape, so keep its generated compile path lean.
+	apiSpec.HTTPTransport = spec.HTTPTransportStandard
 	apiSpec.Auth = spec.AuthConfig{Type: "none"}
 	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/example-pp-cli/config.toml"}
 


### PR DESCRIPTION
## Summary
- Skip redundant generated-project `go mod tidy` subprocesses in generator tests; compile checks now resolve modules with `-mod=mod` while production `Validate` still owns the tidy quality gate.
- Avoid duplicate surf-backed whole-project compiles by keeping the plain browser transport test render-focused and compiling the stricter H3 client path.
- Keep the GraphQL BFF semantic command test on the standard transport so it measures command shape without pulling in browser/H3 transport costs.
- Ignore local perf measurement artifacts under `tests/artifacts/perf/`.

## Performance
- Baseline: `/usr/bin/time -p go test -json -count=1 ./internal/generator -timeout 20m` -> real 35.93s.
- Final focused check: `/usr/bin/time -p go test ./internal/generator -count=1 -timeout 20m` -> real 28.48s.
- Best final-candidate JSON timing during tuning: real 24.35s. Variance is expected because these tests run many generated-project Go subprocesses.

## Verification
- `git diff --check`
- `go test ./internal/generator -count=1 -timeout 20m`
- `go test ./... -timeout 20m`
- `go build -o ./printing-press ./cmd/printing-press`
- `go vet ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`