### PR TITLE
fix(ci): include refactors in release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,8 @@ Every commit and PR title must include one of these scopes. The `PR Title` actio
 - `fix(scope):` → patch (0.4.0 → 0.4.1)
 - `feat(scope):` → minor (0.4.0 → 0.5.0)
 - `feat(scope)!:` or `BREAKING CHANGE:` footer → major (0.4.0 → 1.0.0)
-- `docs:`, `chore:`, `refactor:`, `test:` → included in next release but don't trigger a bump alone
+- `refactor(scope):` → included in the next release PR but doesn't trigger a bump alone
+- `docs:`, `chore:`, `test:` → don't trigger a bump alone and stay out of release notes by default
 
 **PR titles must follow the same format.** GitHub's "Squash and merge" uses the PR title as the squash commit message, so release-please reads PR titles on main. The `PR Title` GitHub Action (`.github/workflows/pr-title.yml`) enforces this — PRs with invalid titles cannot merge.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,23 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": false
+        }
+      ],
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- show refactor commits in release-please changelog sections
- keep docs, test, and chore commits out of release notes by default
- align AGENTS.md version-bump guidance with the release-please config

## Verification
- jq empty release-please-config.json
- go test ./internal/cli