### PR TITLE
ci(ci): improve workflow coverage and guards

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
 
       - name: Verify golden outputs
         run: scripts/golden.sh verify

--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -3,12 +3,17 @@ name: Golden
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   golden:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,17 @@ name: Lint
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -19,4 +24,18 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.4
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Go tests
+        run: go test ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
 
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -36,6 +37,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
 
       - name: Run Go tests
         run: go test ./...

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -13,6 +17,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -24,6 +29,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
 
       - uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
 
       - name: Build printing-press
         run: go build -o ./printing-press ./cmd/printing-press

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -5,9 +5,17 @@ on:
     paths:
       - 'catalog/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,7 +43,7 @@ jobs:
 
           mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- 'catalog/*.yaml')
 
-          if [ ${#CHANGED[@]} -eq 0 ]; then
+          if [ "${#CHANGED[@]}" -eq 0 ]; then
             echo "FAIL: workflow triggered on catalog/** changes but git diff found no changed catalog/*.yaml files."
             echo "This usually means the base ref was not fetched. Check actions/checkout fetch-depth."
             exit 1
@@ -63,7 +71,7 @@ jobs:
               exit 1
             fi
 
-            SPEC_FILE=/tmp/spec-validate.yaml
+            SPEC_FILE="$(mktemp "${RUNNER_TEMP:-/tmp}/spec-validate.XXXXXX.yaml")"
             RAW_PREFIX="https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/"
             if [[ "$SPEC_URL" == "$RAW_PREFIX"* ]]; then
               LOCAL_SPEC="${SPEC_URL#"$RAW_PREFIX"}"
@@ -87,12 +95,13 @@ jobs:
 
             # Generate from the resolved spec.
             NAME=$(grep '^name:' "$file" | head -1 | sed 's/name: *//')
+            OUT_DIR="${RUNNER_TEMP:-/tmp}/${NAME}-cli"
 
             ./printing-press generate \
               --spec "$SPEC_FILE" \
-              --output /tmp/${NAME}-cli \
+              --output "$OUT_DIR" \
               --validate
 
             echo "PASS: Generated CLI compiles"
-            rm -rf /tmp/${NAME}-cli "$SPEC_FILE"
+            rm -rf "$OUT_DIR" "$SPEC_FILE"
           done


### PR DESCRIPTION
## Summary

PR checks now run the missing Go test suite and waste fewer CI minutes on stale pushes. This keeps lint, tests, and golden verification parallel while adding cancellation, explicit timeouts, and repeatable tool versions.

The catalog workflow also passes `actionlint` cleanly now: shell expansions are quoted, temporary files live under `$RUNNER_TEMP`, and the job has explicit read-only permissions.

## Testing

- `actionlint .github/workflows/*.yml`
- `go test ./...`
- `go build -o ./printing-press ./cmd/printing-press`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
