### PR TITLE
docs(cli): add MIT LICENSE matching README declaration

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Van Horn and Trevin Chow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -1,5 +1,3 @@
-// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
-
 package cli
 
 import (


### PR DESCRIPTION
## Summary

- Adds a root `LICENSE` (MIT, "Matt Van Horn and Trevin Chow", 2026) so the project's stated license is legally backed and not just a `README.md:486` claim.
- Removes a stray `// Licensed under Apache-2.0` header from `internal/cli/verify_skill.go` — it's machine code, not a printed-CLI file, and the convention documented at `internal/patch/dropins.go:84-86` reserves that header for emitted printed-CLI files.
- Printed CLIs are unchanged: generator templates still emit Apache-2.0, and `NOTICE.tmpl`'s "CLI Printing Press is licensed separately under the MIT License" claim now points at a real file.

## Test plan
- [x] `go build -o ./printing-press ./cmd/printing-press` passes
- [x] `go fmt ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)