### PR TITLE
ci(ci): split fast and full test lanes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   pull_request:
@@ -62,7 +62,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -73,4 +73,113 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Run Go tests
-        run: go test ./...
+        shell: bash
+        run: |
+          set -o pipefail
+
+          go test -short -json -timeout 12m ./... 2>&1 | tee /tmp/go-test.json
+          status=${PIPESTATUS[0]}
+
+          python3 - /tmp/go-test.json <<'PY'
+          import json
+          import sys
+
+          packages = {}
+          tests = 0
+          with open(sys.argv[1]) as events:
+            for line in events:
+              try:
+                  event = json.loads(line)
+              except Exception:
+                  continue
+              if event.get("Action") == "pass" and event.get("Test"):
+                  tests += 1
+              if event.get("Action") in {"pass", "fail"} and event.get("Test") is None:
+                  packages[event["Package"]] = event.get("Elapsed", 0)
+
+          print("Slowest Go packages:")
+          for pkg, elapsed in sorted(packages.items(), key=lambda item: -item[1])[:15]:
+              print(f"{elapsed:6.1f}s {pkg}")
+          print(f"test_pass_events {tests}")
+          PY
+
+          exit "$status"
+
+  generated-test:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether full generated tests are needed
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
+
+          echo "Changed files:"
+          printf '  %s\n' "${changed[@]}"
+
+          needs_full=false
+          for file in "${changed[@]}"; do
+            case "$file" in
+              .github/workflows/lint.yml|go.mod|go.sum|cmd/*|catalog/*|internal/cli/*|internal/generator/*|internal/openapi/*|internal/pipeline/*|internal/spec/*|testdata/*)
+                needs_full=true
+                break
+                ;;
+            esac
+          done
+
+          echo "needs_full=$needs_full" >> "$GITHUB_OUTPUT"
+
+      - name: Skip full generated tests
+        if: steps.changes.outputs.needs_full != 'true'
+        run: |
+          echo "Skipping full generated tests: no generator, parser, pipeline, CLI, module, workflow, catalog, or testdata changes."
+
+      - uses: actions/setup-go@v6
+        if: steps.changes.outputs.needs_full == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Run full Go tests
+        if: steps.changes.outputs.needs_full == 'true'
+        shell: bash
+        run: |
+          set -o pipefail
+
+          go test -json -timeout 12m ./... 2>&1 | tee /tmp/go-test-full.json
+          status=${PIPESTATUS[0]}
+
+          python3 - /tmp/go-test-full.json <<'PY'
+          import json
+          import sys
+
+          packages = {}
+          tests = 0
+          with open(sys.argv[1]) as events:
+            for line in events:
+              try:
+                  event = json.loads(line)
+              except Exception:
+                  continue
+              if event.get("Action") == "pass" and event.get("Test"):
+                  tests += 1
+              if event.get("Action") in {"pass", "fail"} and event.get("Test") is None:
+                  packages[event["Package"]] = event.get("Elapsed", 0)
+
+          print("Slowest Go packages:")
+          for pkg, elapsed in sorted(packages.items(), key=lambda item: -item[1])[:15]:
+              print(f"{elapsed:6.1f}s {pkg}")
+          print(f"test_pass_events {tests}")
+          PY
+
+          exit "$status"

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 type EndpointGroup struct {
@@ -18,6 +19,7 @@ var (
 	uuidSegmentPattern  = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 	hashSegmentPattern  = regexp.MustCompile(`(?i)^[0-9a-f]{32,}$`)
 	numericPattern      = regexp.MustCompile(`^\d+$`)
+	blocklistMu         sync.RWMutex
 	additionalBlocklist []string
 )
 
@@ -25,7 +27,11 @@ func ClassifyEntries(entries []EnrichedEntry) (api []EnrichedEntry, noise []Enri
 	api = make([]EnrichedEntry, 0, len(entries))
 	noise = make([]EnrichedEntry, 0, len(entries))
 
-	blocklist := append(DefaultBlocklist(), additionalBlocklist...)
+	blocklistMu.RLock()
+	extraBlocklist := append([]string(nil), additionalBlocklist...)
+	blocklistMu.RUnlock()
+
+	blocklist := append(DefaultBlocklist(), extraBlocklist...)
 	for _, entry := range entries {
 		score := scoreEntry(entry, blocklist)
 		classified := entry
@@ -45,6 +51,9 @@ func ClassifyEntries(entries []EnrichedEntry) (api []EnrichedEntry, noise []Enri
 }
 
 func SetAdditionalBlocklist(domains []string) {
+	blocklistMu.Lock()
+	defer blocklistMu.Unlock()
+
 	additionalBlocklist = append([]string(nil), domains...)
 }
 

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -17,6 +17,8 @@ import (
 // `printing-press verify-skill` catches it at generation time instead of
 // letting it ship to the library.
 func TestVerifySkill_DetectsWrongFlagOnCommand(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 
@@ -82,6 +84,8 @@ fixture-pp-cli search "chicken" --max-time 30m
 // the verifier does NOT report a false-positive flag-commands finding
 // when the SKILL example uses a flag declared on the top-level command.
 func TestVerifySkill_NoFalsePositiveOnSharedLeafName(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
@@ -146,6 +150,8 @@ func newProfileSaveCmd() *cobra.Command {
 // TestVerifySkill_PassesWhenSkillMatches confirms the verifier doesn't
 // false-positive on a well-formed CLI.
 func TestVerifySkill_PassesWhenSkillMatches(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
@@ -169,6 +175,8 @@ func newSearchCmd() *cobra.Command {
 
 // TestVerifySkill_RejectsMissingInputs confirms usage errors (code 2).
 func TestVerifySkill_RejectsMissingInputs(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 
 	// Missing --dir

--- a/internal/cli/verify_skill_unknown_command_test.go
+++ b/internal/cli/verify_skill_unknown_command_test.go
@@ -16,6 +16,8 @@ import (
 // path (`<cli> qr get-qrcode`) for a resource the cobra source actually
 // registers as a leaf (`<cli> qr`) is rejected.
 func TestVerifySkill_DetectsUnknownCommand(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 
@@ -68,6 +70,8 @@ description: "fixture"
 // negative case: a SKILL whose command-reference paths all map to real
 // cobra Use: declarations passes the unknown-command check.
 func TestVerifySkill_UnknownCommandPassesWhenAllPathsResolve(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 
@@ -112,6 +116,8 @@ description: "fixture"
 // built-in commands (help, completion, version) are whitelisted — references
 // to `<cli> help` in SKILL.md must NOT fire unknown-command.
 func TestVerifySkill_UnknownCommandSkipsBuiltins(t *testing.T) {
+	t.Parallel()
+
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -71,7 +71,10 @@ func TestGenerateProjectsCompile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt //nolint:modernize // keep the parallel subtest capture explicit
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			apiSpec, err := spec.Parse(tt.specPath)
 			require.NoError(t, err)
 
@@ -522,6 +525,14 @@ func countFiles(t *testing.T, root string) int {
 }
 
 func runGoCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if testing.Short() && len(args) > 0 && (args[0] == "build" || args[0] == "test") {
+		t.Skip("generated CLI compile tests run in the full generated-test CI lane")
+	}
+	runGoCommandRequired(t, dir, args...)
+}
+
+func runGoCommandRequired(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
 	// Generated-project compile tests exercise module resolution via -mod=mod;
@@ -1039,6 +1050,8 @@ func TestGenerateHTMLExtractionPerModeGating(t *testing.T) {
 	}
 
 	t.Run("embedded-json-only omits page+links helpers", func(t *testing.T) {
+		t.Parallel()
+
 		dir := filepath.Join(t.TempDir(), "ejonly-pp-cli")
 		require.NoError(t, New(specWithMode("ejonly", spec.HTMLExtractModeEmbeddedJSON), dir).Generate())
 		body := read(t, dir)
@@ -1064,6 +1077,8 @@ func TestGenerateHTMLExtractionPerModeGating(t *testing.T) {
 	})
 
 	t.Run("page-only omits embedded-json helpers", func(t *testing.T) {
+		t.Parallel()
+
 		dir := filepath.Join(t.TempDir(), "pageonly-pp-cli")
 		require.NoError(t, New(specWithMode("pageonly", spec.HTMLExtractModePage), dir).Generate())
 		body := read(t, dir)
@@ -1082,6 +1097,8 @@ func TestGenerateHTMLExtractionPerModeGating(t *testing.T) {
 	})
 
 	t.Run("mixed modes emit both branches", func(t *testing.T) {
+		t.Parallel()
+
 		// One endpoint per mode in the same spec.
 		mixedSpec := &spec.APISpec{
 			Name:    "mixed",

--- a/internal/generator/session_handshake_test.go
+++ b/internal/generator/session_handshake_test.go
@@ -13,6 +13,8 @@ import (
 // session.go helper and wires it into the client when auth.type is
 // "session_handshake". This is the WU-2 acceptance test (retro issue #174).
 func TestSessionHandshakeGeneration(t *testing.T) {
+	t.Parallel()
+
 	sp := &spec.APISpec{
 		Name:        "demo",
 		Version:     "1.0.0",
@@ -104,6 +106,8 @@ func TestSessionHandshakeGeneration(t *testing.T) {
 }
 
 func TestSessionHandshakeBrowserTransportSharesJar(t *testing.T) {
+	t.Parallel()
+
 	sp := &spec.APISpec{
 		Name:          "demo",
 		Version:       "1.0.0",
@@ -171,6 +175,8 @@ func TestSessionHandshakeBrowserTransportSharesJar(t *testing.T) {
 // TestSessionHandshakeNotEmittedForOtherAuth verifies the session helper is
 // NOT emitted for non-session auth types — no file bloat for bearer_token CLIs.
 func TestSessionHandshakeNotEmittedForOtherAuth(t *testing.T) {
+	t.Parallel()
+
 	sp := &spec.APISpec{
 		Name:        "demo",
 		Version:     "1.0.0",

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -168,6 +168,9 @@ resources:
 
 func TestGenerateFromOpenAPICompiles(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("OpenAPI generated CLI compile coverage runs in the generated-test CI lane")
+	}
 
 	tests := []struct {
 		name     string
@@ -178,6 +181,7 @@ func TestGenerateFromOpenAPICompiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt //nolint:modernize // keep the parallel subtest capture explicit
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary

- Rename the mixed lint/test workflow display name from `Lint` to `CI`, so checks display as `CI / lint`, `CI / test`, and `CI / generated-test` instead of `Lint / test`.
- Make the regular `test` job run `go test -short -json -timeout 12m ./...` with a 10-minute workflow timeout and printed slow-package timing summary.
- Add a conditional `generated-test` job, sequenced after `test`, that runs full `go test -json -timeout 12m ./...` when generator, parser, pipeline, CLI, module, workflow, catalog, or testdata paths change.
- Move generated CLI compile/integration checks out of the fast lane and into `generated-test`; source-level assertions still run in `test`.
- Preserve the browser-sniff blocklist race fix and targeted safe `t.Parallel()` additions.

## Test job duration

| Run | Test job duration |
| --- | --- |
| Pre-change baseline (run 25022521456) | 14m |
| First attempt, `go test -p 4` (run 25033768327) | 15m58s |
| Split lane, compile smoke still in fast lane (run 25035408106) | 9m17s |
| This version, generated compile moved to full lane (run 25035827978) | 8m51s |

This hits the under-9m target for the regular `test` job: about 37% faster than the 14m baseline.

## Full generated lane status

`generated-test` did not start on run 25035827978 because GitHub Actions returned an account billing/spending-limit failure before assigning a runner:

> The job was not started because recent account payments have failed or your spending limit needs to be increased.

So the workflow/test configuration still needs a rerun once Actions billing is healthy. The job is intentionally present because it preserves the expensive generated compile/integration coverage outside the fast lane.

## Local verification

- `go fmt ./...`
- `go vet ./...`
- `go test -short ./...`
- `go test ./internal/generator ./internal/openapi`
- `go test -count=3 -race ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `actionlint .github/workflows/lint.yml`

Local `go test -short -json -timeout 12m ./...` timing in the dirty workspace after moving generated compiles out of short mode: about 25s wall-clock, 2319 pass events, 41 skip events.