### PR TITLE
fix(cli): manifest emission no longer gated by stale mcp_ready label

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -158,17 +158,28 @@ func specChecksum(path string) (string, error) {
 	return "sha256:" + hex.EncodeToString(h[:]), nil
 }
 
-// computeMCPReady determines the MCP readiness level based on the auth type
-// and the public/total tool split.
-func computeMCPReady(authType string, publicTools int) string {
+// computeMCPReady determines the MCP readiness label for scorecard /
+// SKILL prose. It does NOT gate manifest emission — that decision lives
+// in WriteMCPBManifestFromStruct and is purely "do we have an MCP binary
+// to ship?". The label exists to set user expectations: full = every
+// tool works without per-tool auth setup; partial = some tools work
+// without credentials, others need auth provided through the companion
+// CLI's flow (composed, cookie). cli-only is reserved for the
+// degenerate case of no MCP tools at all and is rarely set in practice.
+//
+// Why no `publicTools > 0` gate for composed/cookie any more: the count
+// relies on spec authors tagging endpoints `no_auth: true`, which most
+// generated specs don't audit carefully. A composed-auth CLI with zero
+// no_auth tags was previously labeled cli-only even when many endpoints
+// (registration, login, public discovery) actually work without auth.
+// Defaulting to "partial" matches the typical reality and avoids
+// suppressing manifest emission downstream.
+func computeMCPReady(authType string) string {
 	switch authType {
 	case "none", "api_key", "bearer_token":
 		return "full"
 	case "cookie", "composed":
-		if publicTools > 0 {
-			return "partial"
-		}
-		return "cli-only"
+		return "partial"
 	default:
 		return "full"
 	}
@@ -182,7 +193,7 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	m.MCPBinary = naming.MCP(parsed.Name)
 	m.MCPToolCount = total
 	m.MCPPublicToolCount = public
-	m.MCPReady = computeMCPReady(parsed.Auth.Type, public)
+	m.MCPReady = computeMCPReady(parsed.Auth.Type)
 	m.AuthType = parsed.Auth.Type
 	m.AuthEnvVars = parsed.Auth.EnvVars
 	m.AuthKeyURL = parsed.Auth.KeyURL

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -542,25 +542,30 @@ func TestArchiveRunArtifactsSkipsMissingDiscovery(t *testing.T) {
 }
 
 func TestComputeMCPReady(t *testing.T) {
+	// composed/cookie auth always reports "partial" — the older `if
+	// publicTools > 0` gate produced false-negative "cli-only" labels for
+	// CLIs whose spec authors hadn't yet tagged endpoints with `no_auth:
+	// true`. Pagliacci-pizza is the canonical case: composed auth, 67
+	// registered tools (account_register, account_login, store/menu
+	// lookups all unauthenticated), but mcp_public_tool_count was 0 so
+	// the readiness label was wrong and downstream manifest emission
+	// was suppressed.
 	tests := []struct {
-		name        string
-		authType    string
-		publicTools int
-		want        string
+		name     string
+		authType string
+		want     string
 	}{
-		{"none", "none", 0, "full"},
-		{"api_key", "api_key", 0, "full"},
-		{"bearer_token", "bearer_token", 0, "full"},
-		{"oauth2 defaults to full", "oauth2", 0, "full"},
-		{"cookie with public tools", "cookie", 3, "partial"},
-		{"cookie no public tools", "cookie", 0, "cli-only"},
-		{"composed with public tools", "composed", 5, "partial"},
-		{"composed no public tools", "composed", 0, "cli-only"},
-		{"empty auth type", "", 0, "full"},
+		{"none", "none", "full"},
+		{"api_key", "api_key", "full"},
+		{"bearer_token", "bearer_token", "full"},
+		{"oauth2 defaults to full", "oauth2", "full"},
+		{"cookie always partial", "cookie", "partial"},
+		{"composed always partial", "composed", "partial"},
+		{"empty auth type", "", "full"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := computeMCPReady(tt.authType, tt.publicTools)
+			got := computeMCPReady(tt.authType)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -575,14 +580,23 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr))
 	})
 
-	t.Run("cli-only readiness → skipped (host can't use bundle alone)", func(t *testing.T) {
+	t.Run("cli-only readiness still emits manifest", func(t *testing.T) {
+		// Earlier behavior: cli-only readiness skipped manifest emission
+		// entirely, on the theory that "the bundle won't work standalone."
+		// In practice that suppressed bundles for composed/cookie-auth CLIs
+		// with unauthenticated tools (registration, login, public lookups).
+		// The manifest now ships regardless; user_config's required flag
+		// communicates auth-required-or-optional. See Pagliacci-pizza.
 		dir := t.TempDir()
-		m := CLIManifest{MCPBinary: "test-pp-mcp", MCPReady: "cli-only"}
-		writeManifest(t, dir, m)
+		writeManifest(t, dir, CLIManifest{
+			APIName:   "test",
+			MCPBinary: "test-pp-mcp",
+			MCPReady:  "cli-only",
+		})
 
 		require.NoError(t, WriteMCPBManifest(dir))
 		_, statErr := os.Stat(filepath.Join(dir, MCPBManifestFilename))
-		assert.True(t, os.IsNotExist(statErr))
+		require.NoError(t, statErr, "cli-only readiness should NOT skip manifest emission")
 	})
 
 	t.Run("missing MCP binary → skipped", func(t *testing.T) {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -127,10 +127,16 @@ type MCPBCompat struct {
 }
 
 // WriteMCPBManifest emits manifest.json for a published CLI directory by
-// reading .printing-press.json. Skips silently when the CLI dir has no
-// manifest, no MCP binary, or cli-only readiness — none of those should
-// produce a draggable .mcpb. Callers that already have the CLIManifest
-// in memory should use WriteMCPBManifestFromStruct to avoid the re-read.
+// reading .printing-press.json. Skips silently only when the CLI dir has
+// no .printing-press.json or no MCP binary — every other CLI ships a
+// manifest, including composed/cookie-auth ones whose MCPReady label
+// says "partial" or "cli-only". The user_config block already conveys
+// auth-required-or-optional (per authRequiresCredential), so withholding
+// the manifest from cli-only readiness CLIs only hurt users who could
+// otherwise install the bundle and use any unauthenticated tools.
+//
+// Callers that already have the CLIManifest in memory should use
+// WriteMCPBManifestFromStruct to avoid the re-read.
 func WriteMCPBManifest(dir string) error {
 	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
 	if err != nil {
@@ -147,7 +153,7 @@ func WriteMCPBManifest(dir string) error {
 // Use it when the CLIManifest was just built and writing it back to disk
 // only to re-read it would be wasted work.
 func WriteMCPBManifestFromStruct(dir string, m CLIManifest) error {
-	if m.MCPBinary == "" || m.MCPReady == "cli-only" {
+	if m.MCPBinary == "" {
 		return nil
 	}
 	// SetEscapeHTML(false) so `>=1.0.0` stays readable instead of `>=1.0.0`.

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -85,7 +85,7 @@ func WriteToolsManifest(dir string, parsed *spec.APISpec) error {
 	}
 
 	total, public := parsed.CountMCPTools()
-	mcpReady := computeMCPReady(parsed.Auth.Type, public)
+	mcpReady := computeMCPReady(parsed.Auth.Type)
 
 	// For cookie/composed auth, only include NoAuth endpoints.
 	cookieOrComposed := parsed.Auth.Type == "cookie" || parsed.Auth.Type == "composed"

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1409,6 +1409,66 @@ template produces correct auth from the start.
 APIs, public data feeds), don't invent auth. The signal must come from research — not
 from guessing. No research mention of auth = no enrichment.
 
+#### Tagging endpoints `no_auth: true` (composed/cookie auth APIs)
+
+For APIs whose `auth.type` is `cookie`, `composed`, or `session_handshake` — i.e.,
+auth that requires interactive setup (browser cookie capture, multi-step token
+exchange) — audit each endpoint individually for whether it actually needs
+authentication. The default of `no_auth: false` means "auth required"; flip it to
+`no_auth: true` for endpoints that work without credentials.
+
+Typical unauthenticated endpoints worth tagging:
+
+- **Auth-flow primitives:** login, registration, password-reset, email-confirm,
+  refresh-token, OAuth callback. The user isn't authenticated when calling these —
+  they ARE the auth flow.
+- **Public discovery:** store/location finder, menu browse, public catalog,
+  category listing, public search, public product detail.
+- **Health/metadata:** health checks, version probes, capability flags, sitemap.
+
+Why this matters: the `no_auth` count drives downstream decisions. Specifically,
+a composed-auth API with zero `no_auth: true` tags previously got labeled
+`mcp_ready: cli-only` and was suppressed from MCPB manifest emission, which
+broke the Claude Desktop install path entirely. The current generator
+(post-2.5) ships a manifest regardless, but the readiness label, scorecard
+breadth dimension, and SKILL.md prose all read better when the count
+reflects reality.
+
+If unsure whether an endpoint requires auth, the safe default is `no_auth: false`
+(auth required) — over-tagging can mislead users to expect tools that won't work.
+
+**Example for a composed-auth pizza-ordering API:**
+
+```yaml
+resources:
+  account:
+    endpoints:
+      register:
+        method: POST
+        path: /account/register
+        no_auth: true   # registering means you're not yet authenticated
+      login:
+        method: POST
+        path: /account/login
+        no_auth: true   # the auth flow itself
+      profile:
+        method: GET
+        path: /account/profile
+        # no_auth defaults to false — needs auth to view your own profile
+  stores:
+    endpoints:
+      find:
+        method: GET
+        path: /stores/near
+        no_auth: true   # public store finder
+  cart:
+    endpoints:
+      checkout:
+        method: POST
+        path: /cart/checkout
+        # no_auth defaults to false — placing an order needs auth
+```
+
 ### Lock and Generate
 
 Before running any generate command, acquire the build lock:


### PR DESCRIPTION
## Summary

Generated CLIs now ship `manifest.json` regardless of `mcp_ready`, fixing the Pagliacci-pizza class of bug where composed/cookie-auth CLIs with unauthenticated tools (registration, login, public discovery) were silently denied an MCPB install path.

End-user impact: a Claude Desktop user dragging `<api>-pp-mcp.mcpb` from a composed-auth CLI now gets the install dialog, optionally fills in credentials, and can call the unauthenticated surface immediately. Previously, the bundle simply didn't exist for such CLIs.

## Root cause

Three-step chain:

1. **Spec authors rarely tag endpoints `no_auth: true` granularly.** The field defaults to `false` (auth required), and most generated specs don't audit each endpoint individually.
2. **`computeMCPReady` saw `publicTools == 0`** for composed/cookie auth and returned `"cli-only"`.
3. **`WriteMCPBManifestFromStruct` skipped emission** whenever `MCPReady == "cli-only"`, suppressing the entire install path — even for CLIs whose MCPs registered 67+ tools (Pagliacci-pizza shipped `account_register`, `account_login`, `store_*`, `menu_*` tools that work without creds).

The labels were over-conservative because the heuristic upstream of them (the `no_auth` tag count) was undertagged.

## Fix — defense in depth

### Machine (safety net)

**`internal/pipeline/mcpb_manifest.go`** — drop the `cli-only` skip entirely. New gate is just `m.MCPBinary == ""`:

```go
// before
if m.MCPBinary == "" || m.MCPReady == "cli-only" {
    return nil
}

// after
if m.MCPBinary == "" {
    return nil
}
```

The `user_config.required` flag already correctly carries auth-required-or-optional per `authRequiresCredential()`. Claude Desktop honors `required: false`. There is no scenario where withholding the manifest makes the user better off.

**`internal/pipeline/climanifest.go`** — `computeMCPReady` drops the `publicTools > 0` gate. composed/cookie always return `"partial"`. `cli-only` is no longer produced by this function:

```go
// before
case "cookie", "composed":
    if publicTools > 0 {
        return "partial"
    }
    return "cli-only"

// after
case "cookie", "composed":
    return "partial"
```

Function signature dropped the now-unused `publicTools` int parameter; one caller in `toolsmanifest.go` updated.

### Skill (quality lever)

**`skills/printing-press/SKILL.md`** — new "Tagging endpoints `no_auth: true`" subsection in Pre-Generation Auth Enrichment. Prompts the agent during research to audit each endpoint when auth is composed/cookie/session_handshake, with a worked example for a pizza-ordering API and explicit guidance on which categories typically don't need auth (auth-flow primitives, public discovery, health checks).

The skill change is defense-in-depth — better-tagged specs improve scorecard accuracy and SKILL prose, but they're no longer load-bearing for the install path.

## Why both layers

| Future scenario | Machine fix? | Skill fix? |
|---|---|---|
| Agent forgets to tag any endpoint as `no_auth: true` | ✅ Manifest still ships, MCPB install still works | Reduces likelihood agent forgets |
| Spec genuinely has zero unauthenticated tools | ✅ Manifest ships with `required: true` user_config; user gets a clear "fill creds" prompt rather than no install path | N/A — ground truth |
| Composed-auth CLI with mixed public/auth-required surface | ✅ Works regardless of tagging | ✅ Better readiness label, scorecard breadth |
| Reviewer audits a published manifest later | N/A — readiness label is now informational | Audit checklist surfaces drift |

The machine fix is the **safety net**: even when the skill fix fails, users still get a working install. The skill fix is the **quality lever**: better-tagged specs improve every downstream signal that reads `mcp_public_tool_count` or `mcp_ready`.

## Tests

- `TestComputeMCPReady` simplified: composed/cookie always partial, no more `publicTools` axis. Comment block captures Pagliacci-pizza as the canonical regression case.
- `TestWriteMCPBManifest`'s "cli-only readiness → skipped" case **inverted** to "cli-only readiness still emits manifest" — the test now asserts the new behavior and prevents regression.

## No golden update

`testdata/golden/fixtures/golden-api.yaml` uses `api_key` auth, which is unaffected by the composed/cookie path changes. Golden suite still passes 8 of 8 cases.

## Already exercised in production

PR mvanhorn/printing-press-library#145 ran the equivalent codemod against 25 published CLIs and produced a manifest for Pagliacci-pizza specifically (its `mcp_ready` was `cli-only`). All 25 manifests pass the new `verify_manifest.py` validation script and all 25 CLIs build clean. This PR makes the same outcome the default for fresh `printing-press generate` runs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)