### PR TITLE
fix(ci): CI slowdown in generated compile tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,6 @@ jobs:
           exit "$status"
 
   generated-test:
-    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -114,7 +113,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check whether full generated tests are needed
+      - name: Check whether generated compile tests are needed
         id: changes
         shell: bash
         run: |
@@ -138,10 +137,10 @@ jobs:
 
           echo "needs_full=$needs_full" >> "$GITHUB_OUTPUT"
 
-      - name: Skip full generated tests
+      - name: Skip generated compile tests
         if: steps.changes.outputs.needs_full != 'true'
         run: |
-          echo "Skipping full generated tests: no generator, parser, pipeline, CLI, module, workflow, catalog, or testdata changes."
+          echo "Skipping generated compile tests: no generator, parser, pipeline, CLI, module, workflow, catalog, or testdata changes."
 
       - uses: actions/setup-go@v6
         if: steps.changes.outputs.needs_full == 'true'
@@ -150,16 +149,18 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Run full Go tests
+      - name: Run generated compile tests
         if: steps.changes.outputs.needs_full == 'true'
         shell: bash
         run: |
           set -o pipefail
 
-          go test -json -timeout 12m ./... 2>&1 | tee /tmp/go-test-full.json
+          generated_compile_tests='^(TestGenerateProjectsCompile|TestGenerateCliutilPackage|TestGenerateFreshnessHelperEmitted|TestGenerateShareEmittedWhenEnabled|TestGenerateAgentContextCommand|TestGenerateBrowserChromeH3Transport|TestGenerateHTMLExtractionEndpoint|TestGenerateHTMLExtractionEmbeddedJSONMode|TestGenerateHTMLExtractionPerModeGating|TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch|TestGenerateStoreUpsertBatchDispatchesToTypedTable|TestGenerateStoreBackfillsIndexedColumnsOnUpgrade|TestGenerateStoreQuotesNumericTableAndDerivedIdentifiers|TestGeneratedOutput_PromotedCommandCompiles|TestGeneratedHelpers_AuthWithKeyURL_Compiles|TestGenerate_CookieAuthUsesBrowserTemplate|TestGenerate_ComposedAuthUsesBrowserTemplate|TestJSONStringParamRejectsInvalidValueBeforeClient|TestGenerateGraphQLBFFUsesSemanticCommandSurface|TestGenerateWhichFallsBackToCommandTree|TestGenerateDependentSyncCompiles|TestGenerateDependentSyncReservedWordCompiles|TestGeneratedSyncTreatsAccessDeniedAsWarning|TestGenerateGraphQLCompiles|TestGenerateMCPCodeOrchestrationEmitsSearchExecute|TestGenerateMCPIntentsEmittedWhenDeclared|TestGenerateMCPEndpointToolsHiddenSuppressesEndpointTools|TestGenerateMCPMainRemoteRuntime|TestGenerateMCPMainRemoteCompiles|TestSessionHandshakeBrowserTransportSharesJar|TestGenerateFromOpenAPICompiles)$'
+
+          go test -json -timeout 12m -run "$generated_compile_tests" ./internal/generator ./internal/openapi 2>&1 | tee /tmp/go-test-generated.json
           status=${PIPESTATUS[0]}
 
-          python3 - /tmp/go-test-full.json <<'PY'
+          python3 - /tmp/go-test-generated.json <<'PY'
           import json
           import sys
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -116,8 +116,7 @@ func TestGenerateProjectsCompile(t *testing.T) {
 func TestGenerateCliutilPackage(t *testing.T) {
 	t.Parallel()
 
-	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "stytch.yaml"))
-	require.NoError(t, err)
+	apiSpec := minimalSpec("cliutil")
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	gen := New(apiSpec, outputDir)
@@ -162,14 +161,12 @@ func TestGenerateCliutilPackage(t *testing.T) {
 func TestGenerateFreshnessHelperEmitted(t *testing.T) {
 	t.Parallel()
 
-	// Start from stytch (has resources -> has store) and flip cache on.
-	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "stytch.yaml"))
-	require.NoError(t, err)
+	apiSpec := minimalSpec("freshness")
 	apiSpec.Cache = spec.CacheConfig{
 		Enabled:    true,
 		StaleAfter: "6h",
 		Commands: []spec.CacheCommand{
-			{Name: "dashboard", Resources: []string{"users"}},
+			{Name: "dashboard", Resources: []string{"items"}},
 		},
 	}
 
@@ -195,9 +192,9 @@ func TestGenerateFreshnessHelperEmitted(t *testing.T) {
 		"func ensureFreshForResources(",
 		"func ensureFreshForCommand(",
 		"func runAutoRefresh(",
-		`"stytch-pp-cli dashboard": {`,
-		`"users",`,
-		`envOptOut := "STYTCH_NO_AUTO_REFRESH"`,
+		`"freshness-pp-cli dashboard": {`,
+		`"items",`,
+		`envOptOut := "FRESHNESS_NO_AUTO_REFRESH"`,
 	} {
 		assert.Contains(t, src, snippet, "auto_refresh.go missing %q", snippet)
 	}
@@ -222,18 +219,17 @@ func TestGenerateFreshnessHelperEmitted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(readme), "## Freshness")
 	assert.Contains(t, string(readme), "meta.freshness")
-	assert.Contains(t, string(readme), "`stytch-pp-cli dashboard`")
+	assert.Contains(t, string(readme), "`freshness-pp-cli dashboard`")
 
 	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
 	require.NoError(t, err)
 	assert.Contains(t, string(skill), "## Freshness Contract")
 	assert.Contains(t, string(skill), "Covered paths:")
 
-	// Generated helper must compile and its tests must pass end-to-end,
-	// exercising the sync_state contract against a real SQLite DB.
+	// Generated helper and hook packages must compile, and cliutil tests
+	// exercise the sync_state contract against a real SQLite DB.
 	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "build", "./...")
-	runGoCommand(t, outputDir, "test", "./internal/cliutil/...")
+	runGoCommand(t, outputDir, "test", "./internal/cli/...", "./internal/cliutil/...")
 }
 
 func TestGenerateFreshnessOptOutUsesASCIIPrefix(t *testing.T) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -212,7 +212,7 @@ func runGo(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("go", args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(dir, ".cache", "go-build"))
+	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 }


### PR DESCRIPTION
## Summary
- Remove the serial `generated-test` dependency and run only the generated compile tests that were skipped in short mode.
- Replace oversized fixture usage in generator helper tests with minimal specs where the behavior under test is generic.
- Let OpenAPI generated CLI compile tests use the shared Go build cache instead of a per-temp-dir cache.

## Testing
- `go fmt ./...`
- `actionlint .github/workflows/lint.yml`
- `go test -short ./...`
- Targeted generator and OpenAPI compile-test runs passed locally.