### PR TITLE
fix(ci): shard test lanes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,9 +60,17 @@ jobs:
         with:
           version: v2.11.4
 
-  test:
+  test-shard:
+    name: test (${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: generator
+          - shard: pipeline-cli
+          - shard: rest
     steps:
       - uses: actions/checkout@v6
 
@@ -77,7 +85,26 @@ jobs:
         run: |
           set -o pipefail
 
-          go test -short -json -timeout 12m ./... 2>&1 | tee /tmp/go-test.json
+          case "${{ matrix.shard }}" in
+            generator)
+              packages=(./internal/generator)
+              ;;
+            pipeline-cli)
+              packages=(./internal/pipeline ./internal/cli)
+              ;;
+            rest)
+              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)$')
+              ;;
+            *)
+              echo "unknown test shard: ${{ matrix.shard }}" >&2
+              exit 1
+              ;;
+          esac
+
+          printf 'Testing packages:\n'
+          printf '  %s\n' "${packages[@]}"
+
+          go test -short -json -timeout 12m "${packages[@]}" 2>&1 | tee /tmp/go-test.json
           status=${PIPESTATUS[0]}
 
           python3 - /tmp/go-test.json <<'PY'
@@ -105,9 +132,27 @@ jobs:
 
           exit "$status"
 
-  generated-test:
+  test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    needs: test-shard
+    if: ${{ always() }}
+    timeout-minutes: 5
+    steps:
+      - name: Check test shards
+        shell: bash
+        run: |
+          if [[ "${{ needs.test-shard.result }}" != "success" ]]; then
+            echo "A test shard failed or was cancelled."
+            exit 1
+          fi
+
+          echo "All test shards passed."
+
+  generated-test-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      needs_full: ${{ steps.changes.outputs.needs_full }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -137,27 +182,48 @@ jobs:
 
           echo "needs_full=$needs_full" >> "$GITHUB_OUTPUT"
 
-      - name: Skip generated compile tests
-        if: steps.changes.outputs.needs_full != 'true'
-        run: |
-          echo "Skipping generated compile tests: no generator, parser, pipeline, CLI, module, workflow, catalog, or testdata changes."
+  generated-test-shard:
+    name: generated-test (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: generated-test-changes
+    if: needs.generated-test-changes.outputs.needs_full == 'true'
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: h3
+            packages: ./internal/generator
+            pattern: ^(TestGenerateBrowserChromeH3Transport)$
+          - shard: generator
+            packages: ./internal/generator
+            pattern: ^(TestGenerateProjectsCompile|TestGenerateCliutilPackage|TestGenerateFreshnessHelperEmitted|TestGenerateShareEmittedWhenEnabled|TestGenerateAgentContextCommand|TestGenerateHTMLExtractionEndpoint|TestGenerateHTMLExtractionEmbeddedJSONMode|TestGenerateHTMLExtractionPerModeGating|TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch|TestGenerateStoreUpsertBatchDispatchesToTypedTable|TestGenerateStoreBackfillsIndexedColumnsOnUpgrade|TestGenerateStoreQuotesNumericTableAndDerivedIdentifiers|TestGeneratedOutput_PromotedCommandCompiles|TestGeneratedHelpers_AuthWithKeyURL_Compiles|TestGenerate_CookieAuthUsesBrowserTemplate|TestGenerate_ComposedAuthUsesBrowserTemplate|TestJSONStringParamRejectsInvalidValueBeforeClient|TestGenerateGraphQLBFFUsesSemanticCommandSurface|TestGenerateWhichFallsBackToCommandTree|TestGenerateDependentSyncCompiles|TestGenerateDependentSyncReservedWordCompiles|TestGeneratedSyncTreatsAccessDeniedAsWarning|TestGenerateGraphQLCompiles|TestGenerateMCPCodeOrchestrationEmitsSearchExecute|TestGenerateMCPIntentsEmittedWhenDeclared|TestGenerateMCPEndpointToolsHiddenSuppressesEndpointTools|TestGenerateMCPMainRemoteRuntime|TestGenerateMCPMainRemoteCompiles)$
+          - shard: openapi
+            packages: ./internal/openapi
+            pattern: ^(TestGenerateFromOpenAPICompiles)$
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
-        if: steps.changes.outputs.needs_full == 'true'
         with:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
       - name: Run generated compile tests
-        if: steps.changes.outputs.needs_full == 'true'
         shell: bash
         run: |
           set -o pipefail
 
-          generated_compile_tests='^(TestGenerateProjectsCompile|TestGenerateCliutilPackage|TestGenerateFreshnessHelperEmitted|TestGenerateShareEmittedWhenEnabled|TestGenerateAgentContextCommand|TestGenerateBrowserChromeH3Transport|TestGenerateHTMLExtractionEndpoint|TestGenerateHTMLExtractionEmbeddedJSONMode|TestGenerateHTMLExtractionPerModeGating|TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch|TestGenerateStoreUpsertBatchDispatchesToTypedTable|TestGenerateStoreBackfillsIndexedColumnsOnUpgrade|TestGenerateStoreQuotesNumericTableAndDerivedIdentifiers|TestGeneratedOutput_PromotedCommandCompiles|TestGeneratedHelpers_AuthWithKeyURL_Compiles|TestGenerate_CookieAuthUsesBrowserTemplate|TestGenerate_ComposedAuthUsesBrowserTemplate|TestJSONStringParamRejectsInvalidValueBeforeClient|TestGenerateGraphQLBFFUsesSemanticCommandSurface|TestGenerateWhichFallsBackToCommandTree|TestGenerateDependentSyncCompiles|TestGenerateDependentSyncReservedWordCompiles|TestGeneratedSyncTreatsAccessDeniedAsWarning|TestGenerateGraphQLCompiles|TestGenerateMCPCodeOrchestrationEmitsSearchExecute|TestGenerateMCPIntentsEmittedWhenDeclared|TestGenerateMCPEndpointToolsHiddenSuppressesEndpointTools|TestGenerateMCPMainRemoteRuntime|TestGenerateMCPMainRemoteCompiles|TestGenerateFromOpenAPICompiles)$'
+          read -r -a packages <<< "${{ matrix.packages }}"
 
-          go test -json -timeout 12m -run "$generated_compile_tests" ./internal/generator ./internal/openapi 2>&1 | tee /tmp/go-test-generated.json
+          printf 'Testing packages:\n'
+          printf '  %s\n' "${packages[@]}"
+          echo 'Test pattern: ${{ matrix.pattern }}'
+
+          go test -json -timeout 12m -run '${{ matrix.pattern }}' "${packages[@]}" 2>&1 | tee /tmp/go-test-generated.json
           status=${PIPESTATUS[0]}
 
           python3 - /tmp/go-test-generated.json <<'PY'
@@ -184,3 +250,27 @@ jobs:
           PY
 
           exit "$status"
+
+  generated-test:
+    runs-on: ubuntu-latest
+    needs:
+      - generated-test-changes
+      - generated-test-shard
+    if: ${{ always() }}
+    timeout-minutes: 5
+    steps:
+      - name: Skip generated compile tests
+        if: needs.generated-test-changes.outputs.needs_full != 'true'
+        run: |
+          echo "Skipping generated compile tests: no generator, parser, pipeline, CLI, module, workflow, catalog, or testdata changes."
+
+      - name: Check generated compile shards
+        if: needs.generated-test-changes.outputs.needs_full == 'true'
+        shell: bash
+        run: |
+          if [[ "${{ needs.generated-test-shard.result }}" != "success" ]]; then
+            echo "A generated compile shard failed or was cancelled."
+            exit 1
+          fi
+
+          echo "All generated compile shards passed."


### PR DESCRIPTION
## Summary
- shard the regular Go test lane into generator, pipeline/cli, and remaining package groups
- shard generated compile tests so the H3 compile sentinel, other generator compile tests, and OpenAPI compile tests run in parallel
- keep aggregate `test` and `generated-test` jobs so existing required check names remain stable

## Validation
- actionlint .github/workflows/lint.yml
- go test -short -timeout 12m ./internal/generator
- go test -short -timeout 12m ./internal/pipeline ./internal/cli
- bash -lc 'mapfile -t packages < <(go list ./... | grep -Ev "/internal/(generator|pipeline|cli)$"); go test -short -timeout 12m "${packages[@]}"'
- go test -timeout 12m -run '^(TestGenerateBrowserChromeH3Transport)$' ./internal/generator
- go test -timeout 12m -run '^(TestGenerateProjectsCompile|TestGenerateCliutilPackage|TestGenerateFreshnessHelperEmitted|TestGenerateShareEmittedWhenEnabled|TestGenerateAgentContextCommand|TestGenerateHTMLExtractionEndpoint|TestGenerateHTMLExtractionEmbeddedJSONMode|TestGenerateHTMLExtractionPerModeGating|TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch|TestGenerateStoreUpsertBatchDispatchesToTypedTable|TestGenerateStoreBackfillsIndexedColumnsOnUpgrade|TestGenerateStoreQuotesNumericTableAndDerivedIdentifiers|TestGeneratedOutput_PromotedCommandCompiles|TestGeneratedHelpers_AuthWithKeyURL_Compiles|TestGenerate_CookieAuthUsesBrowserTemplate|TestGenerate_ComposedAuthUsesBrowserTemplate|TestJSONStringParamRejectsInvalidValueBeforeClient|TestGenerateGraphQLBFFUsesSemanticCommandSurface|TestGenerateWhichFallsBackToCommandTree|TestGenerateDependentSyncCompiles|TestGenerateDependentSyncReservedWordCompiles|TestGeneratedSyncTreatsAccessDeniedAsWarning|TestGenerateGraphQLCompiles|TestGenerateMCPCodeOrchestrationEmitsSearchExecute|TestGenerateMCPIntentsEmittedWhenDeclared|TestGenerateMCPEndpointToolsHiddenSuppressesEndpointTools|TestGenerateMCPMainRemoteRuntime|TestGenerateMCPMainRemoteCompiles)$' ./internal/generator
- go test -timeout 12m -run '^(TestGenerateFromOpenAPICompiles)$' ./internal/openapi
- go test ./...
- git diff --check