### PR TITLE
chore(cli): drop dead manifest_url + manifest_checksum from registry guidance

### DIFF
--- a/cmd/manifest-gen/main.go
+++ b/cmd/manifest-gen/main.go
@@ -11,7 +11,6 @@
 //	manifest-gen -spec ./espn-spec.yaml -format internal -output ./out
 //
 // The tool writes tools-manifest.json to the output directory.
-// It also prints a SHA-256 checksum for use in registry.json.
 package main
 
 import (
@@ -103,15 +102,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	checksum := pipeline.ComputeToolsManifestChecksum(manifestData)
 	fmt.Fprintf(os.Stderr, "\nWrote %s (%d bytes)\n", manifestPath, len(manifestData))
-	fmt.Fprintf(os.Stderr, "Checksum: %s\n", checksum)
-	fmt.Fprintf(os.Stderr, "\nFor registry.json:\n")
-	fmt.Fprintf(os.Stderr, "  \"manifest_checksum\": %q,\n", checksum)
-	fmt.Fprintf(os.Stderr, "  \"spec_format\": %q\n", format)
-
-	// Also print the checksum to stdout for scripting.
-	fmt.Println(checksum)
+	fmt.Fprintf(os.Stderr, "Spec format: %s\n", format)
 }
 
 func loadSpec(source string) ([]byte, error) {

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -619,10 +619,8 @@ The registry file has this structure:
         "public_tool_count": 7,
         "auth_type": "<api_key|none|bearer_token|cookie|composed>",
         "env_vars": ["<ENV_VAR_NAME>"],
-        "mcp_ready": "<full|partial|cli-only>",
-        "manifest_checksum": "<sha256:hex of tools-manifest.json>",
-        "spec_format": "<openapi3|graphql|internal>",
-        "manifest_url": "library/<category>/<api-slug>/tools-manifest.json"
+        "mcp_ready": "<full|partial>",
+        "spec_format": "<openapi3|graphql|internal>"
       }
     }
   ]
@@ -639,9 +637,7 @@ Read `$PUBLISH_REPO_DIR/registry.json`, parse the `entries` array (not the top-l
 - `auth_type`: from manifest `auth_type`
 - `env_vars`: from manifest `auth_env_vars`
 - `mcp_ready`: from manifest `mcp_ready`
-- `manifest_checksum`: SHA-256 hash of the `tools-manifest.json` file in the CLI directory (format: `sha256:<hex>`). Compute with: `sha256sum tools-manifest.json | awk '{print "sha256:" $1}'`. If `tools-manifest.json` does not exist, omit this field.
 - `spec_format`: from manifest `spec_format` (e.g., `openapi3`, `graphql`, `internal`). Omit if empty.
-- `manifest_url`: derived from the entry's `path` field: `<path>/tools-manifest.json`. Omit if `tools-manifest.json` does not exist.
 
 If the manifest has no MCP fields (empty `mcp_binary`), omit the `mcp` block entirely.
 


### PR DESCRIPTION
## Summary

Megamcp was the only consumer of these registry.json fields. With megamcp removed in #363, both are dead weight. This drops them from the publish skill's instructions and from manifest-gen's stdout guidance.

## Changes

- \`skills/printing-press-publish/SKILL.md\` — example schema and per-field guidance no longer instruct agents to compute or write \`manifest_url\` / \`manifest_checksum\`. Also drops \`cli-only\` from the \`mcp_ready\` enum example since \`computeMCPReady\` stopped emitting it after #359.
- \`cmd/manifest-gen/main.go\` — drops the \"For registry.json:\" trailer that printed \`manifest_checksum\` guidance. \`spec_format\` now prints as a plain \"Spec format:\" line. The trailing stdout-checksum print is removed.

## Library follow-up

The library repo's existing \`registry.json\` entries still carry these fields. A follow-up PR over there strips them. Field readers in \`tools/generate-skills/main.go\` ignore both, so no consumer breaks during the transition.

## Verification

- \`go build ./cmd/printing-press\` ✓
- \`go build ./cmd/manifest-gen\` ✓
- \`go vet ./...\` ✓
- \`go test ./...\` — 2,171 / 2,171
- \`scripts/golden.sh verify\` — 8 / 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)