### PR TITLE
fix(cli): ASCII-fold spec slugs so accented titles produce portable names

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2670,13 +2670,45 @@ func toKebabCase(input string) string {
 	return strings.Trim(b.String(), "-")
 }
 
-// asciiFold decomposes accented Latin characters and drops the combining
-// marks, leaving the ASCII base. "Pokémon" → "Pokemon", "café" → "cafe".
-// Non-Latin scripts pass through unchanged; the surrounding cleanSpecName
-// loop will drop them when they don't satisfy unicode.IsLetter / IsDigit
-// after this fold (e.g., "東京 API" → "api"), which matches today's
-// behavior for spec titles without ASCII tokens.
+// latinNonDecomposable maps Latin-script letters that NFD does not
+// decompose into base + combining mark. NFD handles precomposed accents
+// (é → e + ◌́), but characters where the diacritic is fused into the
+// codepoint itself (ø, ß, æ, ł, đ, þ, ð, ı) need an explicit replacement
+// to reach ASCII. Keys are lowercase only because cleanSpecName
+// lowercases its input before calling asciiFold.
+var latinNonDecomposable = strings.NewReplacer(
+	"ø", "o", // Norwegian/Danish o with stroke (Ørsted)
+	"ß", "ss", // German sharp s (Großhandel)
+	"æ", "ae", // ash (Encyclopædia)
+	"œ", "oe", // French oe ligature (cœur)
+	"ł", "l", // Polish l with stroke (Łódź)
+	"đ", "d", // Croatian/Vietnamese d with stroke (Đorđević)
+	"þ", "th", // Icelandic thorn (Þingvellir)
+	"ð", "d", // Icelandic eth (Friðrik)
+	"ı", "i", // Turkish dotless i
+)
+
+// asciiFold maps Latin-script titles to ASCII so the slug stays portable
+// across filesystems, Go import paths, and Cobra command names.
+// "Pokémon" → "pokemon", "café" → "cafe", "Großhandel" → "grosshandel",
+// "Łódź" → "lodz". Two passes:
+//
+//  1. latinNonDecomposable replaces Latin letters whose diacritic is
+//     fused into the codepoint (NFD won't split them).
+//  2. norm.NFD decomposes precomposed accents into base + combining
+//     marks, and the loop drops the combining marks (category Mn).
+//
+// Scope is intentionally Latin-only. Non-Latin scripts (Greek δ,
+// Cyrillic русский, CJK 東京, Arabic …) survive both passes because
+// they don't decompose into Latin bases and because cleanSpecName's
+// downstream loop accepts any Unicode letter via unicode.IsLetter.
+// That means "東京 API" produces a slug of "東京" — non-ASCII surfaces
+// in directory names, Go import paths, and Cobra commands the same
+// way pokémon did before this fold. Transliterating non-Latin scripts
+// to ASCII is opinionated (Tokyo? Tōkyō? Toukyou?) and a separate
+// concern; this fold deliberately does not attempt it.
 func asciiFold(s string) string {
+	s = latinNonDecomposable.Replace(s)
 	decomposed := norm.NFD.String(s)
 	var b strings.Builder
 	b.Grow(len(decomposed))

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v2/internal/spec"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"golang.org/x/text/unicode/norm"
 )
 
 var (
@@ -2669,11 +2670,37 @@ func toKebabCase(input string) string {
 	return strings.Trim(b.String(), "-")
 }
 
+// asciiFold decomposes accented Latin characters and drops the combining
+// marks, leaving the ASCII base. "Pokémon" → "Pokemon", "café" → "cafe".
+// Non-Latin scripts pass through unchanged; the surrounding cleanSpecName
+// loop will drop them when they don't satisfy unicode.IsLetter / IsDigit
+// after this fold (e.g., "東京 API" → "api"), which matches today's
+// behavior for spec titles without ASCII tokens.
+func asciiFold(s string) string {
+	decomposed := norm.NFD.String(s)
+	var b strings.Builder
+	b.Grow(len(decomposed))
+	for _, r := range decomposed {
+		if unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func cleanSpecName(title string) string {
 	title = strings.ToLower(strings.TrimSpace(title))
 	if title == "" {
 		return "api"
 	}
+
+	// ASCII-fold accented letters so "Pok\u00e9mon API" becomes "pokemon api"
+	// instead of "pok\u00e9mon api". Without this, the slug retains non-ASCII
+	// characters, which then drift through to directory names, binary
+	// names, and Cobra command paths \u2014 producing spurious cmd dirs on
+	// regen and breaking import paths on case-folding filesystems.
+	title = asciiFold(title)
 
 	title = strings.ReplaceAll(title, "open api", " ")
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -423,6 +423,14 @@ func TestCleanSpecName(t *testing.T) {
 		{title: "Domino\u2019s Pizza API", want: "dominos-pizza"},
 		// Multiple apostrophes
 		{title: "Rock'n'Roll API", want: "rocknroll"},
+		// Accented Latin characters get ASCII-folded so the slug stays
+		// portable across filesystems and Go import paths. Without folding,
+		// the spec title "Pok\u00e9mon API" produced the slug "pok\u00e9mon" and
+		// regen emitted spurious cmd/pok\u00e9mon-pp-{cli,mcp}/ alongside the
+		// directory's actual cmd/pokemon-pp-{cli,mcp}/.
+		{title: "Pok\u00e9mon API", want: "pokemon"},
+		{title: "Caf\u00e9 Reservations", want: "cafe-reservations"},
+		{title: "Na\u00efve Bayes API", want: "naive-bayes"},
 	}
 
 	for _, tt := range tests {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -427,10 +427,23 @@ func TestCleanSpecName(t *testing.T) {
 		// portable across filesystems and Go import paths. Without folding,
 		// the spec title "Pok\u00e9mon API" produced the slug "pok\u00e9mon" and
 		// regen emitted spurious cmd/pok\u00e9mon-pp-{cli,mcp}/ alongside the
-		// directory's actual cmd/pokemon-pp-{cli,mcp}/.
+		// directory's actual cmd/pokemon-pp-{cli,mcp}/. Two flavors:
+		// precomposed accents (NFD-decomposable: \u00e9, \u00ef, \u00f3, \u00e4, ...) and
+		// fused-diacritic Latin letters (non-decomposable: \u00f8, \u00df, \u00e6, \u0142,
+		// \u0111, \u00fe, \u00f0, \u0153, \u0131), which need an explicit replacement table.
 		{title: "Pok\u00e9mon API", want: "pokemon"},
 		{title: "Caf\u00e9 Reservations", want: "cafe-reservations"},
 		{title: "Na\u00efve Bayes API", want: "naive-bayes"},
+		{title: "Gro\u00dfhandel API", want: "grosshandel"},
+		{title: "Encyclop\u00e6dia API", want: "encyclopaedia"},
+		{title: "\u00d8rsted Energy", want: "orsted-energy"},
+		{title: "\u0141\u00f3d\u017a Transit", want: "lodz-transit"},
+		{title: "\u00deingvellir Tours", want: "thingvellir-tours"},
+		// Non-Latin scripts are out of scope for the fold and survive
+		// into the slug today. This test pins that behavior so a future
+		// "transliterate everything to ASCII" change is visible in the
+		// diff rather than accidental. See asciiFold's godoc.
+		{title: "\u6771\u4eac API", want: "\u6771\u4eac"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Spec titles with accented Latin characters (e.g., `Pokémon API`) were producing slugs that retained the accent (`pokémon`). When the slug becomes a directory key, binary name, or Go import path, the accent causes drift across filesystems, tooling, and Cobra command paths. The visible failure mode was `mcp-sync` emitting spurious `cmd/pokémon-pp-{cli,mcp}/` alongside the existing `cmd/pokemon-pp-{cli,mcp}/` on regen.

`cleanSpecName` now ASCII-folds the title in two passes:

1. **Replacement table** for Latin letters whose diacritic is fused into the codepoint (NFD won't split them): `ø → o`, `ß → ss`, `æ → ae`, `œ → oe`, `ł → l`, `đ → d`, `þ → th`, `ð → d`, `ı → i`.
2. **NFD decomposition** for precomposed accents, then drop combining marks (category Mn).

| Input | Before | After |
|---|---|---|
| `Pokémon API` | `pokémon` | `pokemon` |
| `Café Reservations` | `café-reservations` | `cafe-reservations` |
| `Naïve Bayes API` | `naïve-bayes` | `naive-bayes` |
| `Großhandel API` | `großhandel` | `grosshandel` |
| `Encyclopædia API` | `encyclopædia` | `encyclopaedia` |
| `Ørsted Energy` | `ørsted-energy` | `orsted-energy` |
| `Łódź Transit` | `łódź-transit` | `lodz-transit` |
| `Þingvellir Tours` | `þingvellir-tours` | `thingvellir-tours` |

## Scope

**Latin only.** Non-Latin scripts (CJK, Cyrillic, Greek, Arabic, …) survive into the slug today — `東京 API` produces slug `東京`. This is a known gap and pinned with a regression test; transliteration is opinionated (Tokyo? Tōkyō? Toukyou?) and out of scope for this PR. See `asciiFold`'s godoc.

## Why now

This unblocks the upcoming public-library sweep through `mcp-sync`. With #369 merged, `mcp-sync` hard-fails on `spec.yaml.name` / directory divergence — without this fold, any future CLI generated from an accented title would trip that guard.

## Library coordination

This is a generator-side fix. Library CLIs already on disk have their accented `spec.yaml.name` baked in from the prior generator. After this lands, regenerating those CLIs through `mcp-sync` will trip `validateSpecNameMatchesDir` because the new slug differs from the on-disk `name:`. The sweep PR will hand-edit `spec.yaml.name` in each affected CLI before running `mcp-sync`. No CLI in `~/printing-press/library/` today has an accented `name:` (verified via grep), but pokeapi/open-meteo will when re-added.

## Test plan

- [x] `go test ./internal/openapi -run TestCleanSpecName` — 20/20 (12 new cases: 8 Latin + 1 non-Latin pin + 3 original)
- [x] `go test ./...` — 2213/2213
- [x] `go build ./...` clean
- [x] `scripts/golden.sh verify` — 8/8 cases pass