### PR TITLE
fix(cli): mcp-sync preserves manifest brand-casing and hand-edited descriptions

### DIFF
--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -701,6 +701,116 @@ func TestWriteMCPBManifest(t *testing.T) {
 	})
 }
 
+// TestWriteMCPBManifestPreservesExistingDisplayName covers the regen path
+// (mcp-sync against an existing CLI with manifest.json on disk). Single-
+// word brand names — "Wikipedia", "Stripe", "Discord" — must round-trip
+// unchanged. Earlier logic rejected them as derived defaults because the
+// title-cased slug happened to match the brand, regressing display_name
+// to the lowercase slug.
+func TestWriteMCPBManifestPreservesExistingDisplayName(t *testing.T) {
+	cases := []struct {
+		name     string
+		apiSlug  string
+		existing string
+		want     string
+	}{
+		{"single-word title-case brand (Wikipedia)", "wikipedia", "Wikipedia", "Wikipedia"},
+		{"single-word title-case brand (Stripe)", "stripe", "Stripe", "Stripe"},
+		{"all-caps brand (ESPN)", "espn", "ESPN", "ESPN"},
+		{"branded with punctuation (Cal.com)", "cal-com", "Cal.com", "Cal.com"},
+		{"multi-word brand (Company GOAT)", "company-goat", "Company GOAT", "Company GOAT"},
+		{"lowercase slug treated as derived fallback", "espn", "espn", "espn"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// Seed an existing manifest.json with the brand-cased display_name
+			// the way a published library CLI would carry it.
+			seed := MCPBManifest{
+				ManifestVersion: MCPBManifestVersion,
+				Name:            tc.apiSlug + "-pp-mcp",
+				DisplayName:     tc.existing,
+				Description:     "stale description",
+			}
+			seedData, err := json.Marshal(seed)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
+
+			// Write a CLIManifest WITHOUT a DisplayName — forces the chain
+			// to fall through to readExistingManifestDisplayName.
+			writeManifest(t, dir, CLIManifest{
+				APIName:   tc.apiSlug,
+				MCPBinary: tc.apiSlug + "-pp-mcp",
+				MCPReady:  "full",
+			})
+
+			require.NoError(t, WriteMCPBManifest(dir))
+			got := readMCPBManifest(t, dir)
+			assert.Equal(t, tc.want, got.DisplayName)
+		})
+	}
+}
+
+// TestWriteMCPBManifestPreservesExistingDescription covers the regen
+// path: a hand-curated manifest.json description must survive mcp-sync
+// even when .printing-press.json carries a different "canonical"
+// description. Pre-fix, m.Description (from .printing-press.json)
+// silently overwrote hand-edits to manifest.json's description.
+func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
+	t.Run("hand-edited description preserved over canonical", func(t *testing.T) {
+		dir := t.TempDir()
+		handEdit := "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal."
+		seed := MCPBManifest{
+			ManifestVersion: MCPBManifestVersion,
+			Name:            "recipe-goat-pp-mcp",
+			DisplayName:     "Recipe Goat",
+			Description:     handEdit,
+		}
+		seedData, err := json.Marshal(seed)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
+
+		writeManifest(t, dir, CLIManifest{
+			APIName:     "recipe-goat",
+			DisplayName: "Recipe Goat",
+			MCPBinary:   "recipe-goat-pp-mcp",
+			MCPReady:    "full",
+			Description: "Recipe GOAT aggregates recipes from canonical-description-source.json",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+		assert.Equal(t, handEdit, got.Description, "hand-edited manifest description must survive regen")
+	})
+
+	t.Run("derived-default existing description refreshed from canonical", func(t *testing.T) {
+		dir := t.TempDir()
+		// Existing description IS the derived default. We expect canonical
+		// to win because there's nothing meaningful to preserve.
+		seed := MCPBManifest{
+			ManifestVersion: MCPBManifestVersion,
+			Name:            "wikipedia-pp-mcp",
+			DisplayName:     "Wikipedia",
+			Description:     "Wikipedia API surface as MCP tools.",
+		}
+		seedData, err := json.Marshal(seed)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
+
+		writeManifest(t, dir, CLIManifest{
+			APIName:     "wikipedia",
+			DisplayName: "Wikipedia",
+			MCPBinary:   "wikipedia-pp-mcp",
+			MCPReady:    "full",
+			Description: "Wikipedia REST API. Article summaries, search, related topics.",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+		assert.Equal(t, "Wikipedia REST API. Article summaries, search, related topics.", got.Description)
+	})
+}
+
 func writeManifest(t *testing.T, dir string, m CLIManifest) {
 	t.Helper()
 	data, err := json.Marshal(m)

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -701,12 +701,6 @@ func TestWriteMCPBManifest(t *testing.T) {
 	})
 }
 
-// TestWriteMCPBManifestPreservesExistingDisplayName covers the regen path
-// (mcp-sync against an existing CLI with manifest.json on disk). Single-
-// word brand names — "Wikipedia", "Stripe", "Discord" — must round-trip
-// unchanged. Earlier logic rejected them as derived defaults because the
-// title-cased slug happened to match the brand, regressing display_name
-// to the lowercase slug.
 func TestWriteMCPBManifestPreservesExistingDisplayName(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -724,20 +718,14 @@ func TestWriteMCPBManifestPreservesExistingDisplayName(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			// Seed an existing manifest.json with the brand-cased display_name
-			// the way a published library CLI would carry it.
-			seed := MCPBManifest{
+			writeMCPBManifest(t, dir, MCPBManifest{
 				ManifestVersion: MCPBManifestVersion,
 				Name:            tc.apiSlug + "-pp-mcp",
 				DisplayName:     tc.existing,
 				Description:     "stale description",
-			}
-			seedData, err := json.Marshal(seed)
-			require.NoError(t, err)
-			require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
-
-			// Write a CLIManifest WITHOUT a DisplayName — forces the chain
-			// to fall through to readExistingManifestDisplayName.
+			})
+			// CLIManifest WITHOUT DisplayName forces the chain to fall
+			// through to the existing manifest.
 			writeManifest(t, dir, CLIManifest{
 				APIName:   tc.apiSlug,
 				MCPBinary: tc.apiSlug + "-pp-mcp",
@@ -745,31 +733,21 @@ func TestWriteMCPBManifestPreservesExistingDisplayName(t *testing.T) {
 			})
 
 			require.NoError(t, WriteMCPBManifest(dir))
-			got := readMCPBManifest(t, dir)
-			assert.Equal(t, tc.want, got.DisplayName)
+			assert.Equal(t, tc.want, readMCPBManifest(t, dir).DisplayName)
 		})
 	}
 }
 
-// TestWriteMCPBManifestPreservesExistingDescription covers the regen
-// path: a hand-curated manifest.json description must survive mcp-sync
-// even when .printing-press.json carries a different "canonical"
-// description. Pre-fix, m.Description (from .printing-press.json)
-// silently overwrote hand-edits to manifest.json's description.
 func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 	t.Run("hand-edited description preserved over canonical", func(t *testing.T) {
 		dir := t.TempDir()
 		handEdit := "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal."
-		seed := MCPBManifest{
+		writeMCPBManifest(t, dir, MCPBManifest{
 			ManifestVersion: MCPBManifestVersion,
 			Name:            "recipe-goat-pp-mcp",
 			DisplayName:     "Recipe Goat",
 			Description:     handEdit,
-		}
-		seedData, err := json.Marshal(seed)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
-
+		})
 		writeManifest(t, dir, CLIManifest{
 			APIName:     "recipe-goat",
 			DisplayName: "Recipe Goat",
@@ -779,24 +757,17 @@ func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 		})
 
 		require.NoError(t, WriteMCPBManifest(dir))
-		got := readMCPBManifest(t, dir)
-		assert.Equal(t, handEdit, got.Description, "hand-edited manifest description must survive regen")
+		assert.Equal(t, handEdit, readMCPBManifest(t, dir).Description)
 	})
 
 	t.Run("derived-default existing description refreshed from canonical", func(t *testing.T) {
 		dir := t.TempDir()
-		// Existing description IS the derived default. We expect canonical
-		// to win because there's nothing meaningful to preserve.
-		seed := MCPBManifest{
+		writeMCPBManifest(t, dir, MCPBManifest{
 			ManifestVersion: MCPBManifestVersion,
 			Name:            "wikipedia-pp-mcp",
 			DisplayName:     "Wikipedia",
 			Description:     "Wikipedia API surface as MCP tools.",
-		}
-		seedData, err := json.Marshal(seed)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), seedData, 0o644))
-
+		})
 		writeManifest(t, dir, CLIManifest{
 			APIName:     "wikipedia",
 			DisplayName: "Wikipedia",
@@ -806,8 +777,7 @@ func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 		})
 
 		require.NoError(t, WriteMCPBManifest(dir))
-		got := readMCPBManifest(t, dir)
-		assert.Equal(t, "Wikipedia REST API. Article summaries, search, related topics.", got.Description)
+		assert.Equal(t, "Wikipedia REST API. Article summaries, search, related topics.", readMCPBManifest(t, dir).Description)
 	})
 }
 
@@ -816,6 +786,13 @@ func writeManifest(t *testing.T, dir string, m CLIManifest) {
 	data, err := json.Marshal(m)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), data, 0o644))
+}
+
+func writeMCPBManifest(t *testing.T, dir string, m MCPBManifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), data, 0o644))
 }
 
 func readMCPBManifest(t *testing.T, dir string) MCPBManifest {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -161,20 +161,15 @@ func WriteMCPBManifestFromStruct(dir string, m CLIManifest) error {
 }
 
 func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
-	// display_name resolution: canonical source first (.printing-press.json
-	// populated by spec.display_name on modern prints), then existing
-	// manifest.json for older library CLIs whose codemod-baked display_name
-	// carries the right brand casing, then derived from the API slug.
-	// Without the existing-manifest fallback, mcp-sync regressed library
-	// CLIs from "ESPN" → "espn".
-	//
-	// Description resolution (in manifestDescription) is *deliberately
-	// reversed* — existing manifest first. Hand-curated descriptions are
-	// the dominant ground truth for mature library CLIs and must survive
-	// regen even when .printing-press.json carries a different value.
+	// display_name and description use opposite preservation rules:
+	// canonical wins for display_name (so spec updates flow through),
+	// existing wins for description (so hand-edits survive regen). Both
+	// consult the existing manifest.json — load once, share the snapshot.
+	existing := loadExistingMCPBManifest(dir)
+
 	displayName := m.DisplayName
-	if displayName == "" {
-		displayName = readExistingManifestDisplayName(dir, m.APIName)
+	if displayName == "" && existing != nil && existing.DisplayName != "" && existing.DisplayName != m.APIName {
+		displayName = existing.DisplayName
 	}
 	if displayName == "" {
 		displayName = m.APIName
@@ -189,7 +184,7 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 		// regeneration. A hardcoded "1.0.0" would defeat the host's
 		// "newer bundle available" prompt.
 		Version:     bundleVersion(m),
-		Description: manifestDescription(dir, m, displayName),
+		Description: manifestDescription(existing, m, displayName),
 		Author:      MCPBAuthor{Name: "CLI Printing Press"},
 		License:     "Apache-2.0",
 		Server: MCPBServer{
@@ -223,88 +218,44 @@ func bundleVersion(m CLIManifest) string {
 	return "0.0.0"
 }
 
-// manifestDescription prefers the catalog/spec description verbatim and
-// only falls back to a derived sentence when nothing better is available.
-// We deliberately keep this single-line — long_description is reserved for
-// multi-paragraph context, which we don't synthesize from spec data today.
-//
-// Resolution order: the .printing-press.json description (canonical source
-// when the printing-press version that produced the CLI populates it) →
-// the existing manifest.json's description (preserves rich descriptions
-// baked by older codemods or hand-edits when .printing-press.json lacks
-// the field — e.g., library CLIs printed under v1.x predate the field) →
-// derived from displayName.
-func manifestDescription(dir string, m CLIManifest, displayName string) string {
-	// Preserve hand-edits to manifest.json before falling back to the
-	// canonical description from .printing-press.json. mcp-sync's job
-	// is to migrate the MCP surface, not to clobber user-curated
-	// manifest content. readExistingManifestDescription only returns
-	// content that's neither empty nor the derived "<displayName> API
-	// surface as MCP tools." default, so canonical still wins when the
-	// existing description was itself derived. For initial generation
-	// (no prior manifest) the read fails and canonical takes over.
-	if existing := readExistingManifestDescription(dir, displayName); existing != "" {
-		return existing
+// manifestDescription returns the existing hand-edited description over
+// the canonical one from .printing-press.json. The existing snapshot's
+// description is only treated as "hand-edited" when it differs from the
+// derived default — so a prior derived default still loses to canonical.
+func manifestDescription(existing *existingMCPBManifest, m CLIManifest, displayName string) string {
+	derivedDefault := displayName + " API surface as MCP tools."
+	if existing != nil && existing.Description != "" && existing.Description != derivedDefault {
+		return existing.Description
 	}
 	if m.Description != "" {
 		return m.Description
 	}
-	return displayName + " API surface as MCP tools."
+	return derivedDefault
 }
 
-// readExistingManifestDescription returns the description from an existing
-// manifest.json on disk, but only if it's a real description rather than
-// the derived "<displayName> API surface as MCP tools." default we'd
-// otherwise re-emit. Returning the derived form would defeat the
-// fallback chain by treating an old derived-default as "preserved
-// content" and never advancing past it.
-func readExistingManifestDescription(dir, displayName string) string {
-	data, err := os.ReadFile(filepath.Join(dir, MCPBManifestFilename))
-	if err != nil {
-		return ""
-	}
-	var existing struct {
-		Description string `json:"description"`
-	}
-	if err := json.Unmarshal(data, &existing); err != nil {
-		return ""
-	}
-	derivedDefault := displayName + " API surface as MCP tools."
-	if existing.Description == "" || existing.Description == derivedDefault {
-		return ""
-	}
-	return existing.Description
+// existingMCPBManifest is the subset of manifest.json the manifest writer
+// reads when refreshing a published CLI's bundle. Single load site so the
+// display_name and description preservation rules don't each re-read the
+// file on every WriteMCPBManifest call.
+type existingMCPBManifest struct {
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
 }
 
-// readExistingManifestDisplayName returns the display_name from an
-// existing manifest.json if it's a real brand name. The only form we
-// explicitly reject is the bare API slug (lowercase, e.g. "espn") that
-// buildMCPBManifest emits as the last-resort fallback. Anything else —
-// "ESPN", "Wikipedia", "Cal.com", "Company GOAT", "PokéAPI" — is real
-// brand content from a hand-edit or codemod and worth preserving across
-// regen. The previous version of this function also rejected
-// title-cased slugs ("Wikipedia" matching titleCaseFirstRune("wikipedia"))
-// on the theory they were derived defaults; that misfired on every
-// single-word brand whose correct casing happens to be Title Case
-// (Wikipedia, Stripe, Discord, Pinterest, …) and dropped the brand back
-// to the lowercase slug. Without an oracle for "is this hand-edited?"
-// the safest rule is "preserve unless it's the lowercase slug we'd
-// otherwise emit as last resort."
-func readExistingManifestDisplayName(dir, apiSlug string) string {
+// loadExistingMCPBManifest returns nil when the file is missing or
+// unparseable. Callers branch on nil; non-nil means the snapshot is
+// usable but each field still needs its own "is this a derived default?"
+// check (see buildMCPBManifest and manifestDescription).
+func loadExistingMCPBManifest(dir string) *existingMCPBManifest {
 	data, err := os.ReadFile(filepath.Join(dir, MCPBManifestFilename))
 	if err != nil {
-		return ""
+		return nil
 	}
-	var existing struct {
-		DisplayName string `json:"display_name"`
-	}
+	var existing existingMCPBManifest
 	if err := json.Unmarshal(data, &existing); err != nil {
-		return ""
+		return nil
 	}
-	if existing.DisplayName == "" || existing.DisplayName == apiSlug {
-		return ""
-	}
-	return existing.DisplayName
+	return &existing
 }
 
 // buildMCPBEnv maps each declared auth env var into the launch spec's env

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -161,12 +161,17 @@ func WriteMCPBManifestFromStruct(dir string, m CLIManifest) error {
 }
 
 func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
-	// Resolution order mirrors manifestDescription: canonical source first
-	// (.printing-press.json populated by spec.display_name on modern
-	// prints), then existing manifest.json for older library CLIs whose
-	// codemod-baked display_name carries the right brand casing, then
-	// derived from the API slug. Without the existing-manifest fallback,
-	// mcp-sync regressed library CLIs from "ESPN" → "espn".
+	// display_name resolution: canonical source first (.printing-press.json
+	// populated by spec.display_name on modern prints), then existing
+	// manifest.json for older library CLIs whose codemod-baked display_name
+	// carries the right brand casing, then derived from the API slug.
+	// Without the existing-manifest fallback, mcp-sync regressed library
+	// CLIs from "ESPN" → "espn".
+	//
+	// Description resolution (in manifestDescription) is *deliberately
+	// reversed* — existing manifest first. Hand-curated descriptions are
+	// the dominant ground truth for mature library CLIs and must survive
+	// regen even when .printing-press.json carries a different value.
 	displayName := m.DisplayName
 	if displayName == "" {
 		displayName = readExistingManifestDisplayName(dir, m.APIName)
@@ -230,11 +235,19 @@ func bundleVersion(m CLIManifest) string {
 // the field — e.g., library CLIs printed under v1.x predate the field) →
 // derived from displayName.
 func manifestDescription(dir string, m CLIManifest, displayName string) string {
-	if m.Description != "" {
-		return m.Description
-	}
+	// Preserve hand-edits to manifest.json before falling back to the
+	// canonical description from .printing-press.json. mcp-sync's job
+	// is to migrate the MCP surface, not to clobber user-curated
+	// manifest content. readExistingManifestDescription only returns
+	// content that's neither empty nor the derived "<displayName> API
+	// surface as MCP tools." default, so canonical still wins when the
+	// existing description was itself derived. For initial generation
+	// (no prior manifest) the read fails and canonical takes over.
 	if existing := readExistingManifestDescription(dir, displayName); existing != "" {
 		return existing
+	}
+	if m.Description != "" {
+		return m.Description
 	}
 	return displayName + " API surface as MCP tools."
 }
@@ -264,13 +277,19 @@ func readExistingManifestDescription(dir, displayName string) string {
 }
 
 // readExistingManifestDisplayName returns the display_name from an
-// existing manifest.json if it's a real brand name rather than a derived
-// fallback. The two derived forms we explicitly reject: the bare API slug
-// (lowercase, e.g. "espn") that buildMCPBManifest emits when nothing
-// better is known, and the title-cased slug ("Espn") that the older
-// spec.EffectiveDisplayName fallback used to produce. Anything else —
-// "ESPN", "Cal.com", "Company GOAT", "PokéAPI" — is real brand content
-// from a hand-edit or a codemod and worth preserving across regen.
+// existing manifest.json if it's a real brand name. The only form we
+// explicitly reject is the bare API slug (lowercase, e.g. "espn") that
+// buildMCPBManifest emits as the last-resort fallback. Anything else —
+// "ESPN", "Wikipedia", "Cal.com", "Company GOAT", "PokéAPI" — is real
+// brand content from a hand-edit or codemod and worth preserving across
+// regen. The previous version of this function also rejected
+// title-cased slugs ("Wikipedia" matching titleCaseFirstRune("wikipedia"))
+// on the theory they were derived defaults; that misfired on every
+// single-word brand whose correct casing happens to be Title Case
+// (Wikipedia, Stripe, Discord, Pinterest, …) and dropped the brand back
+// to the lowercase slug. Without an oracle for "is this hand-edited?"
+// the safest rule is "preserve unless it's the lowercase slug we'd
+// otherwise emit as last resort."
 func readExistingManifestDisplayName(dir, apiSlug string) string {
 	data, err := os.ReadFile(filepath.Join(dir, MCPBManifestFilename))
 	if err != nil {
@@ -285,25 +304,7 @@ func readExistingManifestDisplayName(dir, apiSlug string) string {
 	if existing.DisplayName == "" || existing.DisplayName == apiSlug {
 		return ""
 	}
-	titleCased := titleCaseFirstRune(apiSlug)
-	if existing.DisplayName == titleCased {
-		return ""
-	}
 	return existing.DisplayName
-}
-
-// titleCaseFirstRune capitalizes the first ASCII letter of slug. Mirrors
-// the older spec.EffectiveDisplayName fallback so we can detect and
-// reject preserved title-cased slugs that masquerade as real brand names.
-func titleCaseFirstRune(slug string) string {
-	if slug == "" {
-		return ""
-	}
-	runes := []rune(slug)
-	if runes[0] >= 'a' && runes[0] <= 'z' {
-		runes[0] -= 'a' - 'A'
-	}
-	return string(runes)
 }
 
 // buildMCPBEnv maps each declared auth env var into the launch spec's env

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -348,17 +348,12 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
 }
 
 // readExistingManifestDisplayName returns the display_name from an
-// existing manifest.json on disk if it's a real brand name. The only
-// form rejected is the bare lowercase slug ("espn") that mcp-sync would
-// otherwise re-emit as the last-resort fallback; anything else is
-// preserved. The previous version also rejected title-cased slugs
-// (treating "Wikipedia" matching titleCaseFromSlug("wikipedia") as a
-// derived default), but that misfires on every single-word brand whose
-// correct casing is Title Case (Wikipedia, Stripe, Discord, Pinterest…)
-// and silently regressed the manifest's display_name back to the
-// lowercase slug.
+// existing manifest.json if it's a real brand name. The only form
+// rejected is the bare lowercase slug we'd otherwise emit as last
+// resort; everything else (ESPN, Wikipedia, Cal.com, Company GOAT,
+// PokéAPI) is preserved.
 func readExistingManifestDisplayName(cliDir string) string {
-	manifestData, err := os.ReadFile(filepath.Join(cliDir, "manifest.json"))
+	manifestData, err := os.ReadFile(filepath.Join(cliDir, pipeline.MCPBManifestFilename))
 	if err != nil {
 		return ""
 	}

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -347,10 +347,16 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
 	return writeFileAtomic(path, []byte(src))
 }
 
-// readExistingManifestDisplayName returns the display_name from an existing
-// manifest.json on disk if it's a real brand name rather than the
-// title-cased slug fallback. Used by Sync to preserve PR #145 codemod
-// brand-casing for library CLIs printed before spec.display_name existed.
+// readExistingManifestDisplayName returns the display_name from an
+// existing manifest.json on disk if it's a real brand name. The only
+// form rejected is the bare lowercase slug ("espn") that mcp-sync would
+// otherwise re-emit as the last-resort fallback; anything else is
+// preserved. The previous version also rejected title-cased slugs
+// (treating "Wikipedia" matching titleCaseFromSlug("wikipedia") as a
+// derived default), but that misfires on every single-word brand whose
+// correct casing is Title Case (Wikipedia, Stripe, Discord, Pinterest…)
+// and silently regressed the manifest's display_name back to the
+// lowercase slug.
 func readExistingManifestDisplayName(cliDir string) string {
 	manifestData, err := os.ReadFile(filepath.Join(cliDir, "manifest.json"))
 	if err != nil {
@@ -363,34 +369,11 @@ func readExistingManifestDisplayName(cliDir string) string {
 	if err := json.Unmarshal(manifestData, &existing); err != nil {
 		return ""
 	}
-	if existing.DisplayName == "" {
-		return ""
-	}
-	// The derived form for old prints is the title-cased mcp-binary slug
-	// minus the "-pp-mcp" suffix (e.g., "espn-pp-mcp" → "Espn"). If the
-	// existing display_name matches that derived shape, treat it as no
-	// brand info and fall through.
-	derived := titleCaseFromSlug(strings.TrimSuffix(existing.Name, "-pp-mcp"))
-	if existing.DisplayName == derived {
+	apiSlug := strings.TrimSuffix(existing.Name, "-pp-mcp")
+	if existing.DisplayName == "" || existing.DisplayName == apiSlug {
 		return ""
 	}
 	return existing.DisplayName
-}
-
-// titleCaseFromSlug capitalizes the first rune of a slug. Approximates
-// the spec.EffectiveDisplayName fallback for slugs without an explicit
-// display_name (e.g., "espn" → "Espn"). Mirrors the case-detection logic
-// readExistingManifestDisplayName uses to decide whether the existing
-// manifest carries real brand information.
-func titleCaseFromSlug(slug string) string {
-	if slug == "" {
-		return ""
-	}
-	runes := []rune(slug)
-	if runes[0] >= 'a' && runes[0] <= 'z' {
-		runes[0] -= 'a' - 'A'
-	}
-	return string(runes)
 }
 
 // validateSpecNameMatchesDir refuses to migrate when spec.yaml.name


### PR DESCRIPTION
## Summary

Pilot sweep on the public library surfaced two regen-only regressions in mcp-sync's manifest preservation chain. Both ship now in v2.4.0 mcp-sync but only manifest during regen against an existing manifest.json — the golden harness covers fresh generation, so neither bug shows up there.

## Bug 1 — `display_name` regression for single-word brands

Pre-fix, mcp-sync regressed library CLIs whose brand name happens to be Title Case:

| CLI | Existing manifest.json | After mcp-sync (pre-fix) | After mcp-sync (post-fix) |
|---|---|---|---|
| Wikipedia | `"Wikipedia"` | `"wikipedia"` ❌ | `"Wikipedia"` ✓ |
| Stripe | `"Stripe"` | `"stripe"` ❌ | `"Stripe"` ✓ |
| Discord | `"Discord"` | `"discord"` ❌ | `"Discord"` ✓ |

`readExistingManifestDisplayName` rejected any existing `display_name` that matched `titleCaseFirstRune(slug)` on the theory it was a derived default. But for single-word brands, the title-cased slug **is** the correct brand name. Drop the `titleCased` check; preserve any non-slug `display_name`. The only form rejected now is the bare lowercase slug (which we'd otherwise emit as last resort).

## Bug 2 — hand-curated descriptions overwritten

Pre-fix, mcp-sync silently replaced hand-edited manifest descriptions with whatever `.printing-press.json` carried. recipe-goat lost a 60-word hand-curated description ("Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal at 80%…") and got replaced with a different description from research.json.

Reorder `manifestDescription`'s resolution chain so existing-manifest hand-edits win over canonical. `readExistingManifestDescription` already filters out the derived `"<displayName> API surface as MCP tools."` default, so canonical still wins when the existing manifest description was itself a default.

**Trade-off documented:** `spec.description` updates won't auto-propagate after first generation. Users who want to push a new description must clear it from manifest.json first to re-derive. The mcp-sync use case (preserve through regen) is the dominant one; one-off spec updates are rare.

## Cleanup

`titleCaseFirstRune` and the duplicate `titleCaseFromSlug` in `mcpsync/sync.go` were dead-code-removed after the fix.

## Test plan

- [x] `TestWriteMCPBManifestPreservesExistingDisplayName` — 6 cases: single-word title-case (Wikipedia, Stripe), all-caps (ESPN), branded with punctuation (Cal.com), multi-word (Company GOAT), and the lowercase-slug rejection
- [x] `TestWriteMCPBManifestPreservesExistingDescription` — hand-edit-wins and derived-default-refreshes paths
- [x] `go test ./...` — 2227/2227
- [x] `scripts/golden.sh verify` — 9/9 (no behavior change for fresh generation)
- [x] `golangci-lint run ./...` clean
- [x] **End-to-end:** re-ran mcp-sync against `~/Code/printing-press-library/library/{wikipedia,recipe-goat}` — both manifests preserved correctly

## Why not in #369?

#369 added the `alreadyMigrated` metadata-only refresh path that exposed these bugs, but the underlying preservation logic in `mcpb_manifest.go` predates it. The pilot sweep was the first time we ran mcp-sync's manifest refresh against published library CLIs with hand-curated content, so the regressions only became visible now.