### PR TITLE
feat(skills): add divergence check to polish skill setup

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -114,6 +114,23 @@ if [ -n "$SPEC_PATH" ]; then
 fi
 ```
 
+### Divergence check
+
+The internal copy at `$CLI_DIR` can drift from the public library (`mvanhorn/printing-press-library`) copy if anyone edited the public repo directly after this CLI was last published. Polishing a stale internal copy and re-publishing later would overwrite those public-only fixes.
+
+Find the public library clone on the user's machine. Honor `$PRINTING_PRESS_LIBRARY_PUBLIC` if set, otherwise locate a clone however fits this platform. Validate by checking the git remote points at `mvanhorn/printing-press-library` — other directories may share the name (forks, accidental name collisions). If multiple valid clones exist, prefer the most recently modified; ask the user to disambiguate only if still unclear.
+
+Outcomes:
+
+- **No clone found** → user doesn't have public locally; proceed silently on internal.
+- **Clone found but doesn't contain this CLI** → never published or under a different name; proceed silently on internal.
+- **Found and `diff -r` is empty** → in sync; proceed silently on internal.
+- **Found and divergent** → don't compute "which side is newer" (file mtimes lie, internal isn't a git repo). Show the user the divergent files and ask via AskUserQuestion: **sync public→internal**, or **proceed without syncing**. If the user picks sync, copy public's version of the divergent files into internal, then continue polish.
+
+Before showing the sync prompt, check whether internal has files modified after its `.printing-press.json` timestamp (the user has been polishing locally without publishing). If yes, hedge the prompt explicitly: syncing will overwrite their pending local work. Let them decide whether to keep their local edits or pull public's.
+
+After sync (or skip), the rest of polish operates on `$CLI_DIR` as canonical. The eventual `/printing-press-publish` step pushes internal back to public; no second divergence check is needed there.
+
 ## Phase 1: Baseline diagnostics
 
 ```bash


### PR DESCRIPTION
## Summary

Polish previously assumed the internal copy at `~/printing-press/library/<api>/` was canonical, but that breaks once the CLI has been published. Anyone editing the public library repo (`mvanhorn/printing-press-library`) directly creates drift the internal copy can't see. Re-publishing a stale internal copy would silently overwrite public-only fixes — the gotcha that motivated this PR.

Adds a divergence-check step to `/printing-press-polish` setup, after CLI resolution and before Phase 1 diagnostics. Pure skill prose, no Go code: the agent scans for a clone of the public library on whatever platform the user is on, validates by git remote, falls back gracefully when no clone is present (the dominant case for users who didn't generate the CLI originally).

## Design

**Telling the agent what to look for, not how.** The prose names the goal (find `mvanhorn/printing-press-library` on this machine, validate by remote) and lets the agent pick tools — `mdfind`, `locate`, `find`, whatever fits. Earlier drafts of this prose enumerated specific commands; that turned into a recipe that goes stale when tools change and signals distrust of the agent's judgment.

**One-way resolution.** When divergence is detected, the user is offered a single direction: sync public→internal, or proceed without syncing. After the choice, internal is canonical for the rest of polish. Less branching than a four-option flow, simpler mental model, and publish naturally pushes internal back to public.

**No publish-side check.** Polish is the entry point that does the gating. Publishing without polishing is the user opting out of the safety net — accept that risk in exchange for one canonical detection point.

**Honest hedge for local polish work.** If internal has files modified after its `.printing-press.json` timestamp, the user has been polishing locally without publishing. The prompt calls this out explicitly so they know syncing will overwrite that pending work — they can pick which side to keep.

## What this doesn't try to do

- **Compute "which side is newer."** File mtimes lie and the internal library isn't a git repo. The user judges from context and picks.
- **Auto-sync.** Always opt-in, always visible.
- **Path-guess from a hardcoded list of common clone locations.** There's no canonical place users clone repos (`~/Code`, `~/src`, `~/dev`, `~/work`, flat `~/`, nested by org). Enumerating a few would catch some users and miss most, giving false confidence. Either an env var (`PRINTING_PRESS_LIBRARY_PUBLIC`) or platform-appropriate scan.

## Out of scope

The longer-term answer is "public library is canonical for any published CLI" (Option C from the design discussion) — once published, polish operates on the public clone directly, internal becomes a generation-only working dir, and drift is impossible because there's only one place to edit. Worth the lift if divergence-rate data shows this is a real day-to-day problem; deferred for now.

## Verified

`go test ./...` (2233 passed), `golangci-lint run ./...` (0 issues), `scripts/golden.sh verify` (9/9 PASS). No code changes — entirely skill prose.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)