### PR TITLE
fix(cli,skills): manifest display_name preservation + divergence-check exemptions

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -245,9 +245,10 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	m.AuthEnvVars = parsed.Auth.EnvVars
 	m.AuthKeyURL = parsed.Auth.KeyURL
 	m.AuthOptional = parsed.Auth.Optional
-	if m.DisplayName == "" {
-		m.DisplayName = parsed.EffectiveDisplayName()
-	}
+	// Always refresh from parsed; an empty-check here would let a
+	// stale .printing-press.json overwrite the spec on the next
+	// mcp-sync cycle.
+	m.DisplayName = parsed.EffectiveDisplayName()
 }
 
 // GenerateManifestParams holds the information available at generate time

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -808,6 +808,31 @@ func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 	})
 }
 
+func TestRefreshCLIManifestFromSpecRefreshesDisplayName(t *testing.T) {
+	// RefreshCLIManifestFromSpec must overwrite an existing
+	// DisplayName, not preserve it — otherwise stale slug-derived
+	// values survive across mcp-sync cycles.
+	dir := t.TempDir()
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "cal-com",
+		DisplayName: "Cal Com", // stale slug-derived value
+		MCPBinary:   "cal-com-pp-mcp",
+		MCPReady:    "full",
+	})
+	parsed := &spec.APISpec{
+		Name:        "cal-com",
+		DisplayName: "Cal.com", // authoritative value from upstream preservation
+	}
+
+	require.NoError(t, RefreshCLIManifestFromSpec(dir, parsed))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "Cal.com", got.DisplayName)
+}
+
 func writeManifest(t *testing.T, dir string, m CLIManifest) {
 	t.Helper()
 	data, err := json.Marshal(m)

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -124,7 +124,14 @@ The internal copy at `$CLI_DIR` can drift from the public library (`mvanhorn/pri
 
 1. **Locate the public library clone.** Honor `$PRINTING_PRESS_LIBRARY_PUBLIC` if set; otherwise scan the user's filesystem however fits this platform. Validate every candidate by checking the git remote points at `mvanhorn/printing-press-library` — other directories may share the name (forks, accidental name collisions). If multiple valid clones exist, prefer the most recently modified; ask the user to disambiguate only if still unclear.
 2. **Locate this CLI inside the clone.** `find <clone>/library -type d -name "<api>-pp-cli"` or equivalent.
-3. **Run `diff -r <public-cli-dir> $CLI_DIR`** (excluding build artifacts, the `.printing-press-tools-polish.json` ledger, and the binary).
+3. **Run `diff -r <public-cli-dir> $CLI_DIR`** with these exclusions, all of which are expected to diverge after publish:
+   - `.printing-press-tools-polish.json` (local ledger, not published)
+   - `go.mod` and `go.sum` — publish rewrites the module path from `<api>-pp-cli` to `github.com/mvanhorn/printing-press-library/library/<category>/<api>`
+   - All `.go` files where the only difference is the rewritten import path (the publish step propagates the new module path through every internal import). When inspecting `.go` diffs, scan for substantive changes — anything beyond the module-path prefix swap is real divergence.
+
+   Concretely: `diff -r --exclude=go.mod --exclude=go.sum --exclude=.printing-press-tools-polish.json <public-cli-dir> $CLI_DIR`.
+
+   Don't pass `--exclude='<api>-pp-cli'` or `--exclude='<api>-pp-mcp'` — those names match both the root-level binary files **and** the `cmd/<api>-pp-cli/` and `cmd/<api>-pp-mcp/` source directories. Excluding by binary name silently skips the entire `cmd/` subtree, hiding real divergence in `main.go`. The "Only in $CLI_DIR: <api>-pp-cli" line for the built binary is one row of expected output, not noise worth filtering at the cost of completeness.
 4. **Surface the result** before continuing.
 
 Outcomes:


### PR DESCRIPTION
## Summary

Two focused bug fixes both surfaced by the cal-com polish session:

- **#385** (`fix(cli)`): \`populateMCPMetadata\` refused to update \`m.DisplayName\` when it was already set, so once \`.printing-press.json\` carried a slug-derived value (e.g., "Cal Com" instead of "Cal.com"), every subsequent \`mcp-sync\` run clobbered a hand-fixed \`manifest.json\` by reading the stale value back. Drop the empty-check; always refresh from \`parsed.EffectiveDisplayName()\`. The upstream chain in \`mcpsync/sync.go\` already preserves \`manifest.json\`'s value into \`parsed.DisplayName\` before this runs.
- **#387** (\`fix(skills)\`): The polish divergence check's previous exclusion list (build artifacts, ledger, binary) flagged \`go.mod\` / \`go.sum\` / all \`.go\` files as drift on every run because publish rewrites the module path from \`<api>-pp-cli\` to \`github.com/mvanhorn/printing-press-library/library/<category>/<api>\`. Add \`go.mod\` / \`go.sum\` / the binary names to the exclusion list and document that \`.go\` file diffs will show the module-path prefix swap by design.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`
- [x] \`go test ./...\` 2301 pass (was 2300; new \`TestRefreshCLIManifestFromSpecRefreshesDisplayName\` pins the #385 fix)
- [x] \`scripts/golden.sh verify\` 9 cases pass

Closes #385
Closes #387