### PR TITLE
fix(cli): tools-manifest.json classifies reclassified path params as path, not query

### DIFF
--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -198,10 +198,18 @@ func buildManifestTool(name, description string, ep spec.Endpoint) ManifestTool 
 		Params:      make([]ManifestParam, 0, len(ep.Params)+len(ep.Body)),
 	}
 
-	// Regular params: positional → path, others → query.
+	// Regular params. A param ends up at "path" when the runtime
+	// substitutes it into the URL — that's true for both positional
+	// path args (Positional=true) AND path params reclassified into
+	// CLI flags by reclassifyPathParamModifiers (PathParam=true, e.g.,
+	// enum-typed path params like /v2/calendars/{calendar} that the CLI
+	// renders as --calendar). Without this OR, reclassified path params
+	// land in the manifest as location: "query", which misleads
+	// description-override agents reading the manifest to understand
+	// the API contract.
 	for _, p := range ep.Params {
 		loc := "query"
-		if p.Positional {
+		if p.Positional || p.PathParam {
 			loc = "path"
 		}
 		tool.Params = append(tool.Params, ManifestParam{

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -234,6 +234,58 @@ func TestWriteToolsManifest_ParamLocationClassification(t *testing.T) {
 	assert.False(t, tool.Params[3].Required)
 }
 
+// TestWriteToolsManifest_ReclassifiedPathParamKeepsPathLocation pins
+// the path location for path params that reclassifyPathParamModifiers
+// converted from positional args to flags (e.g., enum-typed path
+// params like /v2/calendars/{calendar} where calendar has
+// enum: [apple, google, office365]). Without checking PathParam
+// alongside Positional, these end up location: "query" and the
+// description-override agent can't tell they're URL-substituted.
+func TestWriteToolsManifest_ReclassifiedPathParamKeepsPathLocation(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "test-api",
+		BaseURL: "https://api.test.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"Calendars": {
+				Endpoints: map[string]spec.Endpoint{
+					"Disconnect": {
+						Method: "POST",
+						Path:   "/calendars/{calendar}/disconnect",
+						Params: []spec.Param{
+							{
+								Name:        "calendar",
+								Type:        "string",
+								Description: "Calendar provider",
+								Enum:        []string{"apple", "google", "office365"},
+								Default:     "apple",
+								Positional:  false, // reclassified: enum + default → flag
+								PathParam:   true,  // ...but still substituted into URL
+								Required:    false, // CLI default fills in if omitted
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+
+	data, err := os.ReadFile(filepath.Join(dir, ToolsManifestFilename))
+	require.NoError(t, err)
+	var got ToolsManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	require.Len(t, got.Tools, 1)
+	require.Len(t, got.Tools[0].Params, 1)
+	calendar := got.Tools[0].Params[0]
+	assert.Equal(t, "calendar", calendar.Name)
+	assert.Equal(t, "path", calendar.Location, "reclassified path param must still be location: path")
+	assert.False(t, calendar.Required, "default fills in if omitted; agent may skip the param")
+}
+
 func TestWriteToolsManifest_AuthConfigRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	parsed := &spec.APISpec{


### PR DESCRIPTION
## Summary

\`reclassifyPathParamModifiers\` (parser.go) converts certain path params (enum-typed, date-named, paginated, default-bearing) from positional CLI args into flags for ergonomics — \`/v2/calendars/{calendar}/disconnect\` becomes \`disconnect --calendar=google\` instead of \`disconnect google\`. It sets \`Positional=false\` but keeps \`PathParam=true\` because the value still gets substituted into the URL at runtime.

\`buildManifestTool\` only inspected \`Positional\` when classifying \`location\`, so reclassified path params landed in \`tools-manifest.json\` as \`"location": "query"\`. That's a lie about the API contract — the param does end up in the URL path, not the query string.

## How this surfaced

cal-com's polish session generated 250 description overrides via the \`mcp-descriptions.json\` route. Validating the work against the spec showed 19 tools (~8% of the manifest) with **inverted required/optional claims** on path params:

| Tool | Override claim | Spec reality |
|---|---|---|
| \`calendars_disconnect_calendars-delete-calendar-credentials\` | \`Required: id. Optional: calendar.\` | \`calendar\` is required path param; \`id\` is body |
| \`calendars_events_cal-unified-calendars-create-calendar\` | \`Required: start, end, title. Optional: calendar.\` | \`calendar\` is required path; rest are body |
| \`calendars_connect_calendars-redirect\` | \`Required: isDryRun. Optional: calendar, redir.\` | \`calendar\` is required path; \`isDryRun\` is optional |

All 19 errors clustered on calendar-scoped endpoints with \`/v2/calendars/{calendar}/...\` paths, where \`calendar\` has \`enum: [apple, google, office365]\` — the enum triggered reclassification. The agent reading the manifest correctly inferred from \`location: "query"\` and missing \`required\` that calendar was optional. Manifest told it the wrong story.

## Fix

Classify `location: "path"` when either `Positional` OR `PathParam` is true. One-line change.

```go
loc := "query"
if p.Positional || p.PathParam {
    loc = "path"
}
```

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`
- [x] \`go test ./...\` 2318 pass (was 2317; new \`TestWriteToolsManifest_ReclassifiedPathParamKeepsPathLocation\`)
- [x] \`scripts/golden.sh verify\` 9/9 pass

## Related

- Surfaced during validation of #383 polish on cal-com (commit 8d1ae61e merged via #391).
- Adjacent: golden harness doesn't currently include \`tools-manifest.json\` in the \`generate-golden-api\` artifacts because \`generate\` doesn't write it (only \`publish\` and \`mcp-sync\` do). A follow-up could add a separate golden case that runs \`mcp-sync\` end-to-end so manifest writer regressions are caught at the golden level — for now the unit test pins the contract.