### PR TITLE
fix(cli): manifest description no longer doubles 'API' when display_name ends in 'API'

### DIFF
--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -808,6 +808,88 @@ func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 	})
 }
 
+func TestWriteMCPBManifest_DerivedDescriptionTrimsAPIFromDisplayName(t *testing.T) {
+	// Spec authors commonly suffix " API" on info.title and
+	// x-display-name. Without trimming, the derived description
+	// concatenates "Stripe API" + " API surface as MCP tools." into
+	// "Stripe API API surface as MCP tools." Single-source the trim
+	// at concat sites; the manifest's display_name field still keeps
+	// the unmodified spec value.
+	tests := []struct {
+		name        string
+		displayName string
+		want        string
+	}{
+		{"trailing API trimmed", "Stripe API", "Stripe API surface as MCP tools."},
+		{"branded with punctuation+API trimmed", "Cal.com API", "Cal.com API surface as MCP tools."},
+		{"no trailing API unchanged", "Stripe", "Stripe API surface as MCP tools."},
+		{"embedded API not trimmed", "API Gateway", "API Gateway API surface as MCP tools."},
+		{"trailing APIs (plural) not trimmed", "Stripe APIs", "Stripe APIs API surface as MCP tools."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeManifest(t, dir, CLIManifest{
+				APIName:     "test",
+				DisplayName: tc.displayName,
+				MCPBinary:   "test-pp-mcp",
+				MCPReady:    "full",
+			})
+			require.NoError(t, WriteMCPBManifest(dir))
+			assert.Equal(t, tc.want, readMCPBManifest(t, dir).Description)
+			// display_name field itself stays unmodified — only concat
+			// sites trim the redundant " API" suffix.
+			assert.Equal(t, tc.displayName, readMCPBManifest(t, dir).DisplayName)
+		})
+	}
+}
+
+func TestWriteMCPBManifest_MigratesPriorDoubledAPIDescription(t *testing.T) {
+	// Manifests written before this fix carry the doubled form
+	// "Stripe API API surface as MCP tools." On the next mcp-sync,
+	// the new derived default ("Stripe API surface as MCP tools.")
+	// no longer matches; a naive "preserve when not matching"
+	// preserves the doubled form forever. Recognize the prior form
+	// too so the regen refreshes to the trimmed default.
+	dir := t.TempDir()
+	writeMCPBManifest(t, dir, MCPBManifest{
+		ManifestVersion: MCPBManifestVersion,
+		Name:            "stripe-pp-mcp",
+		DisplayName:     "Stripe API",
+		Description:     "Stripe API API surface as MCP tools.",
+	})
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "stripe",
+		DisplayName: "Stripe API",
+		MCPBinary:   "stripe-pp-mcp",
+		MCPReady:    "full",
+	})
+	require.NoError(t, WriteMCPBManifest(dir))
+	assert.Equal(t, "Stripe API surface as MCP tools.", readMCPBManifest(t, dir).Description)
+}
+
+func TestWriteMCPBManifest_EnvVarDescriptionTrimsAPIFromDisplayName(t *testing.T) {
+	// The user_config env var description's "<displayName> MCP server"
+	// substring uses the same trim so "Stripe API MCP server" reads
+	// as "Stripe MCP server" — slightly more natural English and
+	// keeps the surfaces consistent.
+	dir := t.TempDir()
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "stripe",
+		DisplayName: "Stripe API",
+		MCPBinary:   "stripe-pp-mcp",
+		MCPReady:    "full",
+		AuthType:    "bearer_token",
+		AuthEnvVars: []string{"STRIPE_TOKEN"},
+	})
+	require.NoError(t, WriteMCPBManifest(dir))
+	got := readMCPBManifest(t, dir)
+	require.NotNil(t, got.UserConfig)
+	stripe, ok := got.UserConfig["stripe_token"]
+	require.True(t, ok, "stripe_token user_config entry must exist")
+	assert.Equal(t, "Sets STRIPE_TOKEN for the Stripe MCP server.", stripe.Description)
+}
+
 func TestRefreshCLIManifestFromSpecRefreshesDisplayName(t *testing.T) {
 	// RefreshCLIManifestFromSpec must overwrite an existing
 	// DisplayName, not preserve it — otherwise stale slug-derived

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -220,17 +220,32 @@ func bundleVersion(m CLIManifest) string {
 
 // manifestDescription returns the existing hand-edited description over
 // the canonical one from .printing-press.json. The existing snapshot's
-// description is only treated as "hand-edited" when it differs from the
-// derived default — so a prior derived default still loses to canonical.
+// description is only treated as "hand-edited" when it differs from
+// every form the generator would have emitted — current and prior — so
+// a manifest written before the displayNameForConcat trim still gets
+// recognized as derived and refreshed from canonical.
 func manifestDescription(existing *existingMCPBManifest, m CLIManifest, displayName string) string {
-	derivedDefault := displayName + " API surface as MCP tools."
-	if existing != nil && existing.Description != "" && existing.Description != derivedDefault {
+	derivedDefault := displayNameForConcat(displayName) + " API surface as MCP tools."
+	priorDerivedDefault := displayName + " API surface as MCP tools."
+	if existing != nil && existing.Description != "" &&
+		existing.Description != derivedDefault &&
+		existing.Description != priorDerivedDefault {
 		return existing.Description
 	}
 	if m.Description != "" {
 		return m.Description
 	}
 	return derivedDefault
+}
+
+// displayNameForConcat strips a trailing " API" from displayName so
+// concatenating with text that already names the API doesn't read
+// "Stripe API API surface as MCP tools." or "Stripe API MCP server."
+// Spec authors commonly include " API" as a suffix in info.title and
+// x-display-name; we let them keep that form for the manifest's
+// display_name field while removing the redundancy at concat sites.
+func displayNameForConcat(displayName string) string {
+	return strings.TrimSuffix(displayName, " API")
 }
 
 // existingMCPBManifest is the subset of manifest.json the manifest writer
@@ -319,7 +334,7 @@ func envVarDescription(m CLIManifest, envVar string, required bool) string {
 	b.WriteString(envVar)
 	b.WriteString(" for the ")
 	if m.DisplayName != "" {
-		b.WriteString(m.DisplayName)
+		b.WriteString(displayNameForConcat(m.DisplayName))
 	} else {
 		b.WriteString(m.APIName)
 	}


### PR DESCRIPTION
## Summary

Spec authors commonly suffix \`" API"\` on \`info.title\` (and now on \`x-display-name\` from #391). The derived description concatenated `"Stripe API"` + `" API surface as MCP tools."` into `"Stripe API API surface as MCP tools."` — and the env var help text concatenated `"Stripe API"` + `" MCP server."` into `"Stripe API MCP server."` The first reads as a typo; the second reads as describing a category ("API MCP server") instead of the brand's MCP server.

Closes #393.

## Fix

Single helper `displayNameForConcat` strips a trailing `" API"` (with the leading space, so embedded "API" in names like `"API Gateway"` stays untouched, and plural `"Stripe APIs"` isn't accidentally consumed). Used at the two concat sites: `manifestDescription` and `envVarDescription`. The manifest's \`display_name\` field itself keeps the unmodified spec value — only the concat sites trim.

## Migration handling

Manifests written before this fix carry the doubled form (\`"Stripe API API surface as MCP tools."\`). On the next \`mcp-sync\`, the new derived default no longer matches and a naive "preserve when not matching" would lock that doubled form in forever as a fake hand-edit. \`manifestDescription\` now recognizes both the new and prior forms as "derived, refresh from canonical" — so existing CLIs migrate cleanly to the trimmed default on their next sync.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`
- [x] \`go test ./...\` 2346 pass (was 2338; +8 new test cases)
- [x] \`scripts/golden.sh verify\` 9/9 pass

## Test cases

- \`Stripe API\` → \`Stripe API surface as MCP tools.\` (trim fires)
- \`Cal.com API\` → \`Cal.com API surface as MCP tools.\` (punctuation+API trim)
- \`Stripe\` → \`Stripe API surface as MCP tools.\` (no change)
- \`API Gateway\` → \`API Gateway API surface as MCP tools.\` (embedded API not trimmed)
- \`Stripe APIs\` → \`Stripe APIs API surface as MCP tools.\` (plural not trimmed)
- env var description for \`"Stripe API"\` → \`"Sets STRIPE_TOKEN for the Stripe MCP server."\` (trim applied)
- Migration: existing manifest with \`"Stripe API API surface as MCP tools."\` regenerates to \`"Stripe API surface as MCP tools."\`

## Known limitation

Versioned suffixes like \`"Stripe API v2"\` still produce a doubled form because the trim only matches a literal trailing \`" API"\`. If the library sweep surfaces a real CLI hitting this, the heuristic can be extended then. Not blocking.

## Library sweep impact

Every existing CLI with \`display_name\` ending in \`" API"\` will see its \`description\` field regenerate from the doubled form to the trimmed form on next \`mcp-sync\`. This is the intended behavior; the migration check handles it.