### PR TITLE
fix(skills): polish loads AskUserQuestion via ToolSearch in forked context

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -48,6 +48,8 @@ PRESS_HOME="$HOME/printing-press"
 PRESS_LIBRARY="$PRESS_HOME/library"
 ```
 
+**`AskUserQuestion` is a deferred tool.** Before the first use in this session, load its schema with `ToolSearch select:AskUserQuestion`. Without that load step the tool's schema isn't visible in the tool list and it appears unavailable — do not fall back to plain-text "reply 1 or 2" prompts when running in a forked context. Plain-text replies land in the parent session, never reach this fork, and the workflow stalls. Load AskUserQuestion eagerly during Setup so every later prompt site (resolve CLI, divergence check, publish offer) just works.
+
 ### Public-library hint
 
 If the user's request includes phrasing like "polish notion **in the


### PR DESCRIPTION
## Summary

Polish stalled at the divergence-check prompt on weather-goat last session: the forked agent claimed \`AskUserQuestion\` was unavailable, fell back to a plain-text \"reply 1 or 2\" prompt, the user's reply landed in the parent session instead of the fork, and the workflow timed out without doing the sync.

\`AskUserQuestion\` is a deferred tool — its schema isn't visible until \`ToolSearch select:AskUserQuestion\` loads it. The agent didn't know that and assumed unavailability. The other forked skill in the repo (\`/printing-press\`) uses \`AskUserQuestion\` 32 times without issue, which confirms forks aren't actually restricted from it.

## Fix

Document the load step explicitly in polish's Setup section. Eager-load during Setup so every later prompt site (resolve CLI, divergence check, publish offer) finds the schema already loaded.

## Test plan

- Re-ran \`/printing-press-polish weather-goat\` in the same divergence-needed scenario after the change.
- Divergence prompt fired interactively, sync proceeded (PR #218 features pulled in, version bumped, mcp:read-only annotations added on 9 files), and the polish run completed end-to-end with a \`ship\` verdict.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)