### PR TITLE
fix(cli): mcp-sync auto-fixes spec.yaml name drift for internal YAML specs

### DIFF
--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -74,11 +74,17 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// faithfully creates spurious cmd/<spec.name>-pp-cli/ and
 	// cmd/<spec.name>-pp-mcp/ directories alongside the canonical ones,
 	// and emits server.NewMCPServer(<spec.name>) with the wrong identity.
-	// The fix per CLI is to update spec.yaml's name field to match the
-	// directory; mcp-sync surfaces the divergence rather than silently
-	// generating wrong artifacts.
-	if err := validateSpecNameMatchesDir(cliDir, parsed); err != nil && !opts.Force {
+	//
+	// reconcileSpecNameWithDir auto-fixes the common case (internal YAML
+	// spec with a stale top-level `name:` field) by rewriting the line in
+	// place. For OpenAPI/GraphQL specs the fix is too invasive, so it
+	// falls through to the validator's --force-required error.
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	if err != nil && !opts.Force {
 		return Result{}, err
+	}
+	if renamedFrom != "" {
+		fmt.Fprintf(os.Stderr, "mcp-sync: rewrote spec.yaml name from %q to %q to match directory basename\n", renamedFrom, parsed.Name)
 	}
 	// Preserve the existing manifest.json's display_name onto the parsed
 	// spec when the spec itself doesn't carry one. Library CLIs printed
@@ -544,6 +550,61 @@ func validateSpecNameMatchesDir(cliDir string, parsed *spec.APISpec) error {
 			"Fix spec.yaml's `name:` field to match the directory, or pass --force to bypass",
 		parsed.Name, dirName, parsed.Name,
 	)
+}
+
+// internalSpecNameLine matches the top-level `name:` key in an internal
+// YAML spec. Anchored to start of line so it never matches nested keys.
+var internalSpecNameLine = regexp.MustCompile(`(?m)^name:[ \t]*.*$`)
+
+// reconcileSpecNameWithDir wraps validateSpecNameMatchesDir with a safe
+// auto-fix for the common drift case: an internal YAML spec whose
+// top-level `name:` field doesn't match the directory basename. The
+// fix rewrites the line in place and updates parsed.Name in memory so
+// downstream generation uses the corrected name.
+//
+// Auto-fix only applies to internal YAML specs because rewriting an
+// OpenAPI `info.title` or a GraphQL schema is invasive and ambiguous —
+// the existing behavior (refuse with --force) remains correct there.
+// Internal JSON specs are also left to the validator; they're rare
+// enough that a manual fix is fine.
+//
+// Returns the prior name when a rename happened so the caller can log
+// it; returns the empty string when no change was needed; returns the
+// validator's error when auto-fix is not applicable.
+func reconcileSpecNameWithDir(cliDir string, parsed *spec.APISpec) (renamedFrom string, err error) {
+	if parsed == nil || parsed.Name == "" {
+		return "", nil
+	}
+	dirName := filepath.Base(cliDir)
+	if dirName == parsed.Name {
+		return "", nil
+	}
+	// Drift detected. Try internal YAML auto-fix.
+	for _, candidate := range []string{"spec.yaml", "spec.yml"} {
+		path := filepath.Join(cliDir, candidate)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if errors.Is(readErr, fs.ErrNotExist) {
+				continue
+			}
+			return "", fmt.Errorf("reading %s: %w", path, readErr)
+		}
+		if openapi.IsOpenAPI(data) {
+			// OpenAPI YAML — name derives from info.title; not safe to rewrite.
+			break
+		}
+		if !internalSpecNameLine.Match(data) {
+			break
+		}
+		rewritten := internalSpecNameLine.ReplaceAll(data, []byte("name: "+dirName))
+		if err := os.WriteFile(path, rewritten, 0o644); err != nil {
+			return "", fmt.Errorf("rewriting %s: %w", path, err)
+		}
+		oldName := parsed.Name
+		parsed.Name = dirName
+		return oldName, nil
+	}
+	return "", validateSpecNameMatchesDir(cliDir, parsed)
 }
 
 // removeStaleMCPHandlersFile deletes internal/mcp/handlers.go when it

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -556,21 +556,13 @@ func validateSpecNameMatchesDir(cliDir string, parsed *spec.APISpec) error {
 // YAML spec. Anchored to start of line so it never matches nested keys.
 var internalSpecNameLine = regexp.MustCompile(`(?m)^name:[ \t]*.*$`)
 
-// reconcileSpecNameWithDir wraps validateSpecNameMatchesDir with a safe
-// auto-fix for the common drift case: an internal YAML spec whose
-// top-level `name:` field doesn't match the directory basename. The
-// fix rewrites the line in place and updates parsed.Name in memory so
-// downstream generation uses the corrected name.
-//
-// Auto-fix only applies to internal YAML specs because rewriting an
-// OpenAPI `info.title` or a GraphQL schema is invasive and ambiguous —
-// the existing behavior (refuse with --force) remains correct there.
-// Internal JSON specs are also left to the validator; they're rare
-// enough that a manual fix is fine.
-//
-// Returns the prior name when a rename happened so the caller can log
-// it; returns the empty string when no change was needed; returns the
-// validator's error when auto-fix is not applicable.
+// reconcileSpecNameWithDir auto-fixes the common drift case (internal
+// YAML spec whose top-level `name:` doesn't match the directory) by
+// rewriting the line in place and updating parsed.Name. Falls back to
+// validateSpecNameMatchesDir's --force-required error for OpenAPI and
+// GraphQL specs, where rewriting info.title or schema metadata is too
+// invasive to do silently. The non-empty renamedFrom return signals
+// the caller to log the rename.
 func reconcileSpecNameWithDir(cliDir string, parsed *spec.APISpec) (renamedFrom string, err error) {
 	if parsed == nil || parsed.Name == "" {
 		return "", nil
@@ -579,32 +571,38 @@ func reconcileSpecNameWithDir(cliDir string, parsed *spec.APISpec) (renamedFrom 
 	if dirName == parsed.Name {
 		return "", nil
 	}
-	// Drift detected. Try internal YAML auto-fix.
+	specPath, data, ok := findInternalYAMLSpec(cliDir)
+	if !ok || !internalSpecNameLine.Match(data) {
+		return "", validateSpecNameMatchesDir(cliDir, parsed)
+	}
+	rewritten := internalSpecNameLine.ReplaceAll(data, []byte("name: "+dirName))
+	if err := writeFileAtomic(specPath, rewritten); err != nil {
+		return "", fmt.Errorf("rewriting %s: %w", specPath, err)
+	}
+	oldName := parsed.Name
+	parsed.Name = dirName
+	return oldName, nil
+}
+
+// findInternalYAMLSpec returns the first existing internal YAML spec
+// in cliDir. OpenAPI YAML files are skipped because their identity
+// derives from info.title rather than a top-level name field.
+func findInternalYAMLSpec(cliDir string) (path string, data []byte, ok bool) {
 	for _, candidate := range []string{"spec.yaml", "spec.yml"} {
-		path := filepath.Join(cliDir, candidate)
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			if errors.Is(readErr, fs.ErrNotExist) {
+		p := filepath.Join(cliDir, candidate)
+		d, err := os.ReadFile(p)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
-			return "", fmt.Errorf("reading %s: %w", path, readErr)
+			return "", nil, false
 		}
-		if openapi.IsOpenAPI(data) {
-			// OpenAPI YAML — name derives from info.title; not safe to rewrite.
-			break
+		if openapi.IsOpenAPI(d) {
+			continue
 		}
-		if !internalSpecNameLine.Match(data) {
-			break
-		}
-		rewritten := internalSpecNameLine.ReplaceAll(data, []byte("name: "+dirName))
-		if err := os.WriteFile(path, rewritten, 0o644); err != nil {
-			return "", fmt.Errorf("rewriting %s: %w", path, err)
-		}
-		oldName := parsed.Name
-		parsed.Name = dirName
-		return oldName, nil
+		return p, d, true
 	}
-	return "", validateSpecNameMatchesDir(cliDir, parsed)
+	return "", nil, false
 }
 
 // removeStaleMCPHandlersFile deletes internal/mcp/handlers.go when it

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -321,6 +321,90 @@ func TestValidateSpecNameMatchesDirNoOpOnEmptySpec(t *testing.T) {
 	}
 }
 
+// TestReconcileSpecNameWithDirAutoFixesInternalYAML — the weather-goat
+// case. Internal YAML spec with `name: weather` in a `weather-goat/`
+// directory gets auto-corrected: spec.yaml is rewritten and the parsed
+// struct's Name is updated in-place so downstream generation uses the
+// corrected name.
+func TestReconcileSpecNameWithDirAutoFixesInternalYAML(t *testing.T) {
+	t.Parallel()
+	cliDir := filepath.Join(t.TempDir(), "weather-goat")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	specPath := filepath.Join(cliDir, "spec.yaml")
+	original := "name: weather\ndescription: \"Weather GOAT\"\nversion: \"1.0.0\"\nbase_url: \"https://api.example.com\"\n"
+	require.NoError(t, os.WriteFile(specPath, []byte(original), 0o644))
+
+	parsed := &spec.APISpec{Name: "weather"}
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "weather", renamedFrom, "should report the prior name")
+	assert.Equal(t, "weather-goat", parsed.Name, "parsed.Name should be corrected in place")
+
+	// File on disk should have the corrected name; the rest of the
+	// content (description, version, base_url) should be untouched.
+	updated, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "name: weather-goat\n")
+	assert.NotContains(t, string(updated), "name: weather\n",
+		"the unanchored 'name: weather' line should be gone")
+	assert.Contains(t, string(updated), `description: "Weather GOAT"`)
+	assert.Contains(t, string(updated), `base_url: "https://api.example.com"`)
+}
+
+// TestReconcileSpecNameWithDirSkipsOpenAPI — for OpenAPI specs the name
+// derives from info.title and rewriting it is invasive. Auto-fix should
+// not touch the file; the validator's --force-required error should
+// surface unchanged.
+func TestReconcileSpecNameWithDirSkipsOpenAPI(t *testing.T) {
+	t.Parallel()
+	cliDir := filepath.Join(t.TempDir(), "newname")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	specPath := filepath.Join(cliDir, "spec.yaml")
+	original := "openapi: 3.0.0\ninfo:\n  title: Old Name\n  version: 1.0.0\npaths: {}\n"
+	require.NoError(t, os.WriteFile(specPath, []byte(original), 0o644))
+
+	parsed := &spec.APISpec{Name: "old-name"}
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	require.Error(t, err, "OpenAPI spec must surface the validator error rather than be auto-fixed")
+	assert.Equal(t, "", renamedFrom)
+	assert.Equal(t, "old-name", parsed.Name, "parsed.Name must not change for OpenAPI specs")
+	assert.Contains(t, err.Error(), "--force")
+
+	// File on disk must be untouched.
+	after, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(after), "OpenAPI spec must not be rewritten")
+}
+
+// TestReconcileSpecNameWithDirNoOpWhenAligned — no drift, no work.
+func TestReconcileSpecNameWithDirNoOpWhenAligned(t *testing.T) {
+	t.Parallel()
+	cliDir := filepath.Join(t.TempDir(), "weather-goat")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	parsed := &spec.APISpec{Name: "weather-goat"}
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "", renamedFrom, "no rename should be reported when names already match")
+}
+
+// TestReconcileSpecNameWithDirNoYAMLFallsThroughToValidator — when no
+// internal YAML spec exists (e.g., spec.json or schema.graphql), the
+// auto-fix path is skipped and the validator's error surfaces.
+func TestReconcileSpecNameWithDirNoYAMLFallsThroughToValidator(t *testing.T) {
+	t.Parallel()
+	cliDir := filepath.Join(t.TempDir(), "weather-goat")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	// Only a non-YAML spec exists.
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.json"), []byte(`{"name":"weather"}`), 0o644))
+
+	parsed := &spec.APISpec{Name: "weather"}
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	require.Error(t, err)
+	assert.Equal(t, "", renamedFrom)
+	assert.Equal(t, "weather", parsed.Name, "parsed.Name unchanged when auto-fix declines")
+	assert.Contains(t, err.Error(), "--force")
+}
+
 // TestRemoveStaleMCPHandlersFile locks behavior for the food52 case:
 // older generator templates emitted MCP handlers in a separate
 // internal/mcp/handlers.go; the current template emits everything in


### PR DESCRIPTION
## Summary

Polishing weather-goat surfaced that mcp-sync refused with \`--force\` required when spec.yaml's \`name:\` field had drifted from the directory basename. The fix per CLI was hand-rewriting one line and re-running mcp-sync. With 13 more CLIs to sweep, that hand-step compounds.

For internal YAML specs the rewrite is deterministic: the top-level \`name:\` field is the single source of truth and aligning it with the directory is always what the user wants (the alternative — keeping a stale name — produces spurious \`cmd/<spec.name>-pp-{cli,mcp}/\` directories on regen and an incorrect MCP server identity). Auto-fix the drift in place: rewrite spec.yaml, update \`parsed.Name\` in memory, log the rename, continue the sync.

OpenAPI and GraphQL specs are explicitly left to the validator's existing \`--force\`-required error. Their identity comes from \`info.title\` or schema metadata; rewriting is invasive and ambiguous.

## How it works

Before:
\`\`\`
$ printing-press mcp-sync ~/printing-press/library/weather-goat
Error: spec.yaml name "weather" does not match directory basename "weather-goat".
This produces spurious cmd/weather-pp-{cli,mcp}/ directories on regen and an incorrect MCP server identity.
Fix spec.yaml's \`name:\` field to match the directory, or pass --force to bypass
\`\`\`

After:
\`\`\`
$ printing-press mcp-sync ~/printing-press/library/weather-goat
mcp-sync: rewrote spec.yaml name from "weather" to "weather-goat" to match directory basename
migrated MCP surface in /Users/.../weather-goat
\`\`\`

## Test plan

- New: \`TestReconcileSpecNameWithDirAutoFixesInternalYAML\` — drift on YAML, expect rewrite + parsed.Name updated, surrounding spec content preserved
- New: \`TestReconcileSpecNameWithDirSkipsOpenAPI\` — drift on OpenAPI YAML, expect validator error and file untouched
- New: \`TestReconcileSpecNameWithDirNoOpWhenAligned\` — no drift, no work
- New: \`TestReconcileSpecNameWithDirNoYAMLFallsThroughToValidator\` — non-YAML spec (spec.json), validator error surfaces
- Existing \`TestValidateSpecNameMatchesDir*\` tests preserved
- \`go test ./...\`, \`go vet\`, \`go fmt\`, \`scripts/golden.sh verify\` (9/9) all green

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)