### PR TITLE
feat(cli): generator emits mcp:read-only on read-only novel commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ The generator emits annotations automatically:
 - **Built-in tools:** `context`, `sql`, `search` are read-only (no open-world; they read local data).
 - **Shell-out tools (runtime walker):** no annotations by default — the walker can't infer from a Cobra command alone. Opt into read-only with `cmd.Annotations["mcp:read-only"] = "true"` for novel commands that don't mutate external state (read-only API queries, cache lookups, derivations).
 
+When adding a generator template that emits a novel command whose only effect is reading from the API, the local store, or the CLI tree itself, set `Annotations: map[string]string{"mcp:read-only": "true"}` in the rendered Cobra literal. Skip the annotation when the command can mutate external state (writes via API, store updates, git pushes) or write to user-visible files outside the local cache (e.g., commands accepting `--output <file>` or `--repo <dir>`). The polish skill catches misses heuristically per CLI, but template-time emission is the single-source path.
+
 Wrong annotations are worse than missing ones: the host trusts the claim and stops asking. A `readOnlyHint: true` on a mutating tool is a real bug; a missing annotation is just a permission prompt.
 
 ## Build, Test & Lint

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -397,12 +397,20 @@ func TestGenerateAgentContextCommand(t *testing.T) {
 		"func newAgentContextCmd",
 		"agentContextSchemaVersion",
 		`"schema_version"`,
-		`Use:   "agent-context"`,
 		"collectAgentCommands",
 		`"pretty"`,
 	} {
 		assert.Contains(t, src, snippet, "agent_context.go missing %q", snippet)
 	}
+	// Field/value pair matched as a regex so column alignment from gofmt
+	// (which shifts when the longest field name in the literal grows)
+	// doesn't break the assertion.
+	assert.Regexp(t, `Use:\s+"agent-context"`, src, `agent_context.go missing Use: "agent-context"`)
+	// agent-context only reads CLI tree state and emits JSON to stdout.
+	// The runtime walker uses this annotation to set readOnlyHint on
+	// the resulting MCP tool so hosts skip the per-call permission prompt.
+	assert.Regexp(t, `Annotations:\s+map\[string\]string\{"mcp:read-only":\s*"true"\}`, src,
+		"agent_context.go must carry mcp:read-only annotation")
 
 	// The subcommand must be registered in root.go so the CLI picks it up.
 	rootSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -4107,6 +4108,51 @@ func TestToKebab_SnakeCaseInput(t *testing.T) {
 			t.Parallel()
 			got := toKebab(tt.input)
 			require.Equal(t, tt.expected, got, tt.why)
+		})
+	}
+}
+
+// TestTemplatesEmitReadOnlyAnnotation locks in the contract that
+// novel-command templates whose only effect is reading from the API,
+// the local store, or the CLI tree itself emit the mcp:read-only Cobra
+// annotation. The runtime walker uses this annotation to set
+// readOnlyHint on the resulting MCP tool so hosts skip the per-call
+// permission prompt. See AGENTS.md "Tool safety annotations".
+//
+// Templates intentionally NOT in this list because they mutate state
+// or write user-visible files outside the local cache:
+// export.go.tmpl (--output writes user files), share_commands.go.tmpl
+// (snapshot dirs, git pushes), import/sync/feedback/graphql_sync (writes).
+func TestTemplatesEmitReadOnlyAnnotation(t *testing.T) {
+	t.Parallel()
+	annotationRE := regexp.MustCompile(`Annotations:\s+map\[string\]string\{"mcp:read-only":\s*"true"\}`)
+
+	cases := []struct {
+		template string
+		// minMatches is the number of distinct cobra.Command literals
+		// inside the template that should carry the annotation. Templates
+		// emitting one command have minMatches=1; multi-command templates
+		// list the read-only subcommands' count.
+		minMatches int
+		why        string
+	}{
+		{"analytics.go.tmpl", 1, "analytics queries on the local store"},
+		{"agent_context.go.tmpl", 1, "walks cobra tree, emits introspection JSON"},
+		{"api_discovery.go.tmpl", 1, "walks cobra tree, prints help"},
+		{"tail.go.tmpl", 1, "polls API GETs, NDJSON to stdout"},
+		{"jobs.go.tmpl", 2, "list and get; prune is omitted (mutates ledger)"},
+		{"channel_workflow.go.tmpl", 1, "status only; workflow parent and archive omitted"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.template, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(filepath.Join("templates", tc.template))
+			require.NoError(t, err)
+			matches := annotationRE.FindAllString(string(data), -1)
+			assert.Len(t, matches, tc.minMatches,
+				"%s should carry exactly %d mcp:read-only annotation(s) — %s",
+				tc.template, tc.minMatches, tc.why)
 		})
 	}
 }

--- a/internal/generator/templates/agent_context.go.tmpl
+++ b/internal/generator/templates/agent_context.go.tmpl
@@ -74,8 +74,9 @@ type agentContextFlag struct {
 func newAgentContextCmd(rootCmd *cobra.Command) *cobra.Command {
 	var pretty bool
 	cmd := &cobra.Command{
-		Use:   "agent-context",
-		Short: "Emit structured JSON describing this CLI for agents",
+		Use:         "agent-context",
+		Short:       "Emit structured JSON describing this CLI for agents",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Long: `Outputs a machine-readable description of commands, flags, and auth so
 agents can introspect this CLI at runtime without parsing --help or
 reading source. Schema is versioned via schema_version.`,

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -20,8 +20,9 @@ func newAnalyticsCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 
 	cmd := &cobra.Command{
-		Use:   "analytics",
-		Short: "Run analytics queries on locally synced data",
+		Use:         "analytics",
+		Short:       "Run analytics queries on locally synced data",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Long: `Analyze locally synced data with count, group-by, and summary operations.
 Data must be synced first with the sync command.`,
 		Example: `  # Count records by type

--- a/internal/generator/templates/api_discovery.go.tmpl
+++ b/internal/generator/templates/api_discovery.go.tmpl
@@ -13,8 +13,9 @@ import (
 
 func newAPICmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "api [interface]",
-		Short: "Browse all API endpoints by interface name",
+		Use:         "api [interface]",
+		Short:       "Browse all API endpoints by interface name",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Long: `Browse and call any API endpoint using the raw interface names.
 
 The friendly top-level commands cover the most common operations.

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -145,8 +145,9 @@ func newWorkflowStatusCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: "Show local archive status and sync state for all resources",
+		Use:         "status",
+		Short:       "Show local archive status and sync state for all resources",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Example: `  # Show archive status
   {{.Name}}-pp-cli workflow status
 

--- a/internal/generator/templates/jobs.go.tmpl
+++ b/internal/generator/templates/jobs.go.tmpl
@@ -228,8 +228,9 @@ func newJobsListCmd(flags *rootFlags) *cobra.Command {
 	var limit int
 	var all bool
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List recent async jobs",
+		Use:         "list",
+		Short:       "List recent async jobs",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rows, err := readJobRows()
 			if err != nil {
@@ -265,9 +266,10 @@ func newJobsListCmd(flags *rootFlags) *cobra.Command {
 
 func newJobsGetCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <job-id>",
-		Short: "Show the latest state row for a job",
-		Args:  cobra.ExactArgs(1),
+		Use:         "get <job-id>",
+		Short:       "Show the latest state row for a job",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rows, err := readJobRows()
 			if err != nil {

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -20,8 +20,9 @@ func newTailCmd(flags *rootFlags) *cobra.Command {
 	var follow bool
 
 	cmd := &cobra.Command{
-		Use:   "tail [resource]",
-		Short: "Stream live changes by polling the API at regular intervals",
+		Use:         "tail [resource]",
+		Short:       "Stream live changes by polling the API at regular intervals",
+		Annotations: map[string]string{"mcp:read-only": "true"},
 		Long: `Tail streams live data changes by polling the API at configurable intervals.
 Events are emitted as NDJSON to stdout for piping to other tools.
 Gracefully shuts down on SIGTERM/SIGINT.


### PR DESCRIPTION
## Summary

When the generator emits a novel command whose only effect is reading from the API, the local store, or the CLI tree itself, mark it \`mcp:read-only\` so the runtime walker sets \`readOnlyHint\` on the resulting MCP tool. Hosts like Claude Desktop skip per-call permission prompts for these tools, which is the difference between an agent flow that interrupts every few steps and one that doesn't.

Polishing weather-goat surfaced this gap: the audit's name heuristic catches a handful (\`analytics\`, \`tail\`, \`show\`), but the long tail of read-shaped commands needs polish to hand-edit DO-NOT-EDIT generated files. Single-source it at the template level and the polish step shrinks proportionally.

## What gets the annotation

| Template | Why |
|---|---|
| \`analytics.go.tmpl\` | Aggregation queries on the local store; stdout output |
| \`agent_context.go.tmpl\` | Walks cobra tree, emits CLI introspection JSON to stdout |
| \`api_discovery.go.tmpl\` | Walks cobra tree and prints help; no API calls |
| \`tail.go.tmpl\` | Polls API read endpoints; NDJSON to stdout |
| \`jobs.go.tmpl\` (list, get only) | Reads local jobs.jsonl ledger; \`prune\` skipped — mutates ledger |
| \`channel_workflow.go.tmpl\` (status only) | Reads local store status; \`archive\` skipped — mutates store |

## What does NOT get the annotation

Per the polish-skill convention ("skip for commands that mutate external state OR write to user-visible files outside the local cache"):

- \`export.go.tmpl\` — \`--output\` flag writes user files
- \`share_commands.go.tmpl\` (export to dir, import/publish/subscribe touch git or cache)
- \`import.go.tmpl\`, \`sync.go.tmpl\`, \`graphql_sync.go.tmpl\` — write to API or store
- \`feedback.go.tmpl\` — sends data upstream
- Endpoint mirrors (\`command_endpoint\`, \`command_promoted\`) — already classified by HTTP method via \`pp:endpoint\`

## Test plan

- New regex assertion in \`TestGenerateAgentContextCommand\` verifying the annotation lands on the rendered \`agent_context.go\` (alignment-agnostic so future field additions don't break it).
- Existing alignment-sensitive assertion (\`Use:   "agent-context"\` with 3 spaces) replaced with a regex — gofmt now shifts to wider alignment because \`Annotations:\` is the longest field name.
- \`go test ./...\`, \`go vet\`, \`go fmt\`, \`scripts/golden.sh verify\` (9/9) all green.
- Goldens unchanged because the generate-golden-api fixture doesn't render any of the affected templates.

## Sweep impact

For each CLI in the upcoming library sweep, a re-generation (or future polish run on a freshly-generated copy) will pick up the annotations automatically. Existing library CLIs predating this change still need polish to add annotations manually, but \`mcp-sync\` doesn't rewrite \`internal/cli/*.go\` files — only the templates affect new output.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)