### PR TITLE
feat(cli): split BaseURL from GraphQLEndpointPath

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3775,6 +3775,121 @@ func TestGenerateGraphQLCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// TestGenerateGraphQLEndpointPathRendersTemplatedURL guards PR-1's contract:
+// when a GraphQL spec sets BaseURL to a templated host and GraphQLEndpointPath
+// to a templated path (the Shopify shape), the generated client must build
+// the request URL by concatenating BaseURL + GraphQLEndpointPath without
+// stripping or normalizing the {var} placeholders. PR-2 will substitute the
+// placeholders against env vars at request time; this test simulates that
+// substitution to prove the URL the runtime sees would resolve correctly.
+//
+// The test deliberately builds the spec by hand (instead of going through
+// graphql.ParseSDL) because no real-world API in the parser's
+// knownGraphQLDefaults table uses a templated host today — Shopify is the
+// motivating case but ships outside this repo. Constructing the spec inline
+// keeps the test focused on the template plumbing.
+func TestGenerateGraphQLEndpointPathRendersTemplatedURL(t *testing.T) {
+	t.Parallel()
+
+	const (
+		baseURL          = "https://{shop}"
+		endpointPath     = "/admin/api/{version}/graphql.json"
+		shopValue        = "foo.myshopify.com"
+		versionValue     = "2026-04"
+		expectedFinalURL = "https://foo.myshopify.com/admin/api/2026-04/graphql.json"
+	)
+
+	apiSpec := &spec.APISpec{
+		Name:                 "shopify",
+		Description:          "Shopify Admin GraphQL (test fixture)",
+		Version:              "2026-04",
+		BaseURL:              baseURL,
+		GraphQLEndpointPath:  endpointPath,
+		EndpointTemplateVars: []string{"shop", "version"},
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "X-Shopify-Access-Token",
+			EnvVars: []string{"SHOPIFY_ACCESS_TOKEN"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/shopify-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			// isGraphQLSpec gates emission of graphql.go on every list endpoint
+			// having Path == "/graphql". The path field is a sentinel for
+			// "this resource flows through the GraphQL transport"; it is
+			// distinct from GraphQLEndpointPath, which is the URL path the
+			// client posts to at runtime.
+			"orders": {
+				Description: "Orders",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "List orders",
+						ResponsePath: "data.orders.nodes",
+						Pagination: &spec.Pagination{
+							Type:           "cursor",
+							LimitParam:     "first",
+							CursorParam:    "after",
+							NextCursorPath: "data.orders.pageInfo.endCursor",
+							HasMoreField:   "data.orders.pageInfo.hasNextPage",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "Order"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Order": {Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			}},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	graphqlGoPath := filepath.Join(outputDir, "internal", "client", "graphql.go")
+	graphqlGoBytes, err := os.ReadFile(graphqlGoPath)
+	require.NoError(t, err, "graphql.go should be generated for a GraphQL spec")
+	graphqlGo := string(graphqlGoBytes)
+
+	// The endpoint path constant must render the templated value verbatim.
+	// Anything that strips or pre-resolves the {var} placeholders here would
+	// break PR-2's runtime substitution and quietly send requests to the
+	// wrong host once a real shop is configured.
+	assert.Contains(t, graphqlGo, `const graphqlEndpointPath = "`+endpointPath+`"`,
+		"graphql.go must render GraphQLEndpointPath into a const")
+	assert.NotContains(t, graphqlGo, `c.Post("/graphql"`,
+		"graphql.go must not retain the hardcoded /graphql path after PR-1")
+	assert.Contains(t, graphqlGo, "c.Post(graphqlEndpointPath",
+		"Query/Mutate must post against the rendered constant, not a literal")
+
+	// The config struct must carry the templated BaseURL through unchanged so
+	// PR-2 can resolve {shop} against SHOPIFY_SHOP at Load() time without
+	// re-deriving the URL shape.
+	configGoBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configGoBytes), `BaseURL: "`+baseURL+`"`,
+		"config.go must carry the templated BaseURL into Load()'s defaults")
+
+	// Simulate the runtime URL build: client.do() concatenates BaseURL+path.
+	// PR-1 must produce a URL that — once env vars are substituted — points
+	// at the real Shopify endpoint. The substitution itself ships in PR-2;
+	// here we mimic it inline to prove the structure is right.
+	rawURL := baseURL + endpointPath
+	resolved := strings.NewReplacer(
+		"{shop}", shopValue,
+		"{version}", versionValue,
+	).Replace(rawURL)
+	assert.Equal(t, expectedFinalURL, resolved,
+		"BaseURL + GraphQLEndpointPath must resolve to the Shopify Admin endpoint after env substitution")
+}
+
 // TestGenerateMCPMainStdioDefault confirms that a spec with no mcp: block
 // produces the same stdio-only MCP entry point we've always emitted. Remote
 // transport is opt-in; the default stays on the current behavior so existing

--- a/internal/generator/templates/graphql_client.go.tmpl
+++ b/internal/generator/templates/graphql_client.go.tmpl
@@ -53,10 +53,17 @@ func isGraphQLAccessDenialCode(code string) bool {
 	return false
 }
 
-// Query executes a GraphQL query via POST /graphql and returns the raw data payload.
+// graphqlEndpointPath is the request path appended to BaseURL for every
+// GraphQL POST. It is rendered from APISpec.GraphQLEndpointPath at generate
+// time so per-tenant or versioned endpoints (e.g.,
+// "/admin/api/{version}/graphql.json") work without editing the client.
+const graphqlEndpointPath = "{{.GraphQLEndpointPath}}"
+
+// Query executes a GraphQL query via POST against graphqlEndpointPath and
+// returns the raw data payload.
 func (c *Client) Query(query string, variables map[string]any) (json.RawMessage, error) {
 	req := GraphQLRequest{Query: query, Variables: variables}
-	raw, _, err := c.Post("/graphql", req)
+	raw, _, err := c.Post(graphqlEndpointPath, req)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +93,9 @@ func (c *Client) Query(query string, variables map[string]any) (json.RawMessage,
 	return resp.Data, nil
 }
 
-// Mutate executes a GraphQL mutation via POST /graphql and returns the raw data payload.
-// Identical transport to Query; separate method for clarity.
+// Mutate executes a GraphQL mutation via POST against graphqlEndpointPath and
+// returns the raw data payload. Identical transport to Query; separate method
+// for clarity.
 func (c *Client) Mutate(query string, variables map[string]any) (json.RawMessage, error) {
 	return c.Query(query, variables)
 }

--- a/internal/graphql/parser.go
+++ b/internal/graphql/parser.go
@@ -70,9 +70,16 @@ func parseSDLContent(source, raw string) (*spec.APISpec, error) {
 	}
 
 	name := deriveAPIName(source)
-	baseURL, auth := knownGraphQLDefaults(name, source)
+	baseURL, endpointPath, auth := knownGraphQLDefaults(name, source)
 	if baseURL == "" {
-		baseURL = "https://api.example.com/graphql"
+		baseURL = "https://api.example.com"
+	}
+	if endpointPath == "" {
+		// Default to the canonical "/graphql" path so existing GraphQL specs
+		// regenerate to a working client without spec-author intervention.
+		// Specs that need a different path (Shopify's
+		// "/admin/api/{version}/graphql.json") populate the field directly.
+		endpointPath = "/graphql"
 	}
 	if auth.Type == "" {
 		auth = spec.AuthConfig{
@@ -83,10 +90,11 @@ func parseSDLContent(source, raw string) (*spec.APISpec, error) {
 	}
 
 	apiSpec := &spec.APISpec{
-		Name:        name,
-		Description: "Generated from GraphQL schema",
-		BaseURL:     baseURL,
-		Auth:        auth,
+		Name:                name,
+		Description:         "Generated from GraphQL schema",
+		BaseURL:             baseURL,
+		GraphQLEndpointPath: endpointPath,
+		Auth:                auth,
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
@@ -772,28 +780,33 @@ func deriveAPIName(source string) string {
 	return base
 }
 
-func knownGraphQLDefaults(name, source string) (string, spec.AuthConfig) {
+// knownGraphQLDefaults returns the (baseURL, graphqlEndpointPath, auth) tuple
+// for APIs the parser recognizes by name or source URL. The split between
+// baseURL and endpointPath lets the generated client build per-tenant or
+// versioned URLs at request time (PR-2 substitutes {var} placeholders) rather
+// than baking the path into the BaseURL string.
+func knownGraphQLDefaults(name, source string) (string, string, spec.AuthConfig) {
 	match := strings.ToLower(name + " " + source)
 	switch {
 	case strings.Contains(match, "linear"):
-		return "https://api.linear.app/graphql", spec.AuthConfig{
+		return "https://api.linear.app", "/graphql", spec.AuthConfig{
 			Type:    "api_key",
 			Header:  "Authorization",
 			EnvVars: []string{"LINEAR_API_KEY"},
 		}
 	case strings.Contains(match, "github"):
-		return "https://api.github.com/graphql", spec.AuthConfig{
+		return "https://api.github.com", "/graphql", spec.AuthConfig{
 			Type:    "bearer_token",
 			Header:  "Authorization",
 			EnvVars: []string{"GITHUB_TOKEN"},
 		}
 	case strings.Contains(match, "shopify"):
-		return "https://shopify.dev/graphql", spec.AuthConfig{
+		return "https://shopify.dev", "/graphql", spec.AuthConfig{
 			Type:    "api_key",
 			Header:  "X-Shopify-Access-Token",
 			EnvVars: []string{"SHOPIFY_ACCESS_TOKEN"},
 		}
 	default:
-		return "", spec.AuthConfig{}
+		return "", "", spec.AuthConfig{}
 	}
 }

--- a/internal/graphql/parser_test.go
+++ b/internal/graphql/parser_test.go
@@ -100,7 +100,9 @@ func TestParseSDLContent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "linear", parsed.Name)
-	assert.Equal(t, "https://api.linear.app/graphql", parsed.BaseURL)
+	assert.Equal(t, "https://api.linear.app", parsed.BaseURL)
+	assert.Equal(t, "/graphql", parsed.GraphQLEndpointPath)
+	assert.Empty(t, parsed.EndpointTemplateVars)
 	assert.Equal(t, "api_key", parsed.Auth.Type)
 	assert.Equal(t, []string{"LINEAR_API_KEY"}, parsed.Auth.EnvVars)
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -29,6 +29,11 @@ func TestParsePetstore(t *testing.T) {
 	assert.Equal(t, "petstore", parsed.Name)
 	assert.Equal(t, "", parsed.BaseURL)
 	assert.Equal(t, "/api/v3", parsed.BasePath)
+	// REST specs must leave the GraphQL-only fields unset; the generated
+	// graphql_client template is gated on isGraphQLSpec so a stray value here
+	// would silently leak into REST clients that never call POST /graphql.
+	assert.Empty(t, parsed.GraphQLEndpointPath)
+	assert.Empty(t, parsed.EndpointTemplateVars)
 	assert.NotEmpty(t, parsed.Resources)
 
 	hasEndpoint := false

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -74,6 +74,20 @@ type APISpec struct {
 	Version         string              `yaml:"version" json:"version"`
 	BaseURL         string              `yaml:"base_url" json:"base_url"`
 	BasePath        string              `yaml:"base_path,omitempty" json:"base_path,omitempty"`
+	// GraphQLEndpointPath is the path appended to BaseURL for GraphQL POSTs.
+	// REST specs leave it empty; GraphQL specs default it to "/graphql" but
+	// can override (e.g., Shopify's "/admin/api/{version}/graphql.json").
+	// The split exists because some GraphQL APIs put the endpoint behind a
+	// per-tenant subdomain or version segment, and the old single-BaseURL
+	// model couldn't represent that without hardcoding "/graphql" in the
+	// generated client.
+	GraphQLEndpointPath string `yaml:"graphql_endpoint_path,omitempty" json:"graphql_endpoint_path,omitempty"`
+	// EndpointTemplateVars lists placeholder names embedded in BaseURL or
+	// GraphQLEndpointPath as {var} (e.g., ["shop", "version"]). The
+	// generator emits per-variable env-var lookups in the printed CLI's
+	// config so users can resolve them at runtime. PR-1 carries this field
+	// as plumbing only; PR-2 wires the runtime substitution.
+	EndpointTemplateVars []string `yaml:"endpoint_template_vars,omitempty" json:"endpoint_template_vars,omitempty"`
 	Owner           string              `yaml:"owner,omitempty" json:"owner,omitempty"`                   // GitHub owner for import paths and Homebrew tap
 	Kind            string              `yaml:"kind,omitempty" json:"kind,omitempty"`                     // "rest" (default) or "synthetic" — synthetic CLIs aggregate multiple sources beyond the spec; dogfood's path-validity check is relaxed accordingly
 	SpecSource      string              `yaml:"spec_source,omitempty" json:"spec_source,omitempty"`       // official, community, sniffed, docs — affects generated client defaults

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -70,10 +70,10 @@ type APISpec struct {
 	// then to a generic "Manage <api> resources via the <api> API". Adding
 	// this field eliminates a recurring manual rewrite step that the main
 	// skill used to instruct Claude to perform after every generation.
-	CLIDescription  string              `yaml:"cli_description,omitempty" json:"cli_description,omitempty"`
-	Version         string              `yaml:"version" json:"version"`
-	BaseURL         string              `yaml:"base_url" json:"base_url"`
-	BasePath        string              `yaml:"base_path,omitempty" json:"base_path,omitempty"`
+	CLIDescription string `yaml:"cli_description,omitempty" json:"cli_description,omitempty"`
+	Version        string `yaml:"version" json:"version"`
+	BaseURL        string `yaml:"base_url" json:"base_url"`
+	BasePath       string `yaml:"base_path,omitempty" json:"base_path,omitempty"`
 	// GraphQLEndpointPath is the path appended to BaseURL for GraphQL POSTs.
 	// REST specs leave it empty; GraphQL specs default it to "/graphql" but
 	// can override (e.g., Shopify's "/admin/api/{version}/graphql.json").
@@ -87,24 +87,24 @@ type APISpec struct {
 	// generator emits per-variable env-var lookups in the printed CLI's
 	// config so users can resolve them at runtime. PR-1 carries this field
 	// as plumbing only; PR-2 wires the runtime substitution.
-	EndpointTemplateVars []string `yaml:"endpoint_template_vars,omitempty" json:"endpoint_template_vars,omitempty"`
-	Owner           string              `yaml:"owner,omitempty" json:"owner,omitempty"`                   // GitHub owner for import paths and Homebrew tap
-	Kind            string              `yaml:"kind,omitempty" json:"kind,omitempty"`                     // "rest" (default) or "synthetic" — synthetic CLIs aggregate multiple sources beyond the spec; dogfood's path-validity check is relaxed accordingly
-	SpecSource      string              `yaml:"spec_source,omitempty" json:"spec_source,omitempty"`       // official, community, sniffed, docs — affects generated client defaults
-	ClientPattern   string              `yaml:"client_pattern,omitempty" json:"client_pattern,omitempty"` // rest (default), proxy-envelope — affects generated HTTP client
-	HTTPTransport   string              `yaml:"http_transport,omitempty" json:"http_transport,omitempty"` // standard (default for official APIs), browser-chrome, or browser-chrome-h3
-	ProxyRoutes     map[string]string   `yaml:"proxy_routes,omitempty" json:"proxy_routes,omitempty"`     // path prefix → service name for proxy-envelope routing
-	WebsiteURL      string              `yaml:"website_url,omitempty" json:"website_url,omitempty"`       // product/company website (not the API base URL)
-	Category        string              `yaml:"category,omitempty" json:"category,omitempty"`             // catalog category (e.g., productivity, developer-tools) — used for library install path
-	Auth            AuthConfig          `yaml:"auth" json:"auth"`
-	RequiredHeaders []RequiredHeader    `yaml:"required_headers,omitempty" json:"required_headers,omitempty"`
-	Config          ConfigSpec          `yaml:"config" json:"config"`
-	Resources       map[string]Resource `yaml:"resources" json:"resources"`
-	Types           map[string]TypeDef  `yaml:"types" json:"types"`
-	ExtraCommands   []ExtraCommand      `yaml:"extra_commands,omitempty" json:"extra_commands,omitempty"` // hand-written cobra commands declared so SKILL.md can document them; spec-only metadata, no code generated
-	Cache           CacheConfig         `yaml:"cache,omitempty" json:"cache"`                             // cache freshness + auto-refresh config; when enabled, generated read commands auto-refresh stale local data before serving
-	Share           ShareConfig         `yaml:"share,omitempty" json:"share"`                             // git-backed snapshot sharing config; when enabled, emits a `share` subcommand that publishes/subscribes to a git repo
-	MCP             MCPConfig           `yaml:"mcp,omitempty" json:"mcp"`                                 // MCP server generation config; when unset, the emitted MCP binary is stdio-only (today's default). Opting into http adds a --transport/--addr flag surface so the same binary can serve cloud-hosted agents.
+	EndpointTemplateVars []string            `yaml:"endpoint_template_vars,omitempty" json:"endpoint_template_vars,omitempty"`
+	Owner                string              `yaml:"owner,omitempty" json:"owner,omitempty"`                   // GitHub owner for import paths and Homebrew tap
+	Kind                 string              `yaml:"kind,omitempty" json:"kind,omitempty"`                     // "rest" (default) or "synthetic" — synthetic CLIs aggregate multiple sources beyond the spec; dogfood's path-validity check is relaxed accordingly
+	SpecSource           string              `yaml:"spec_source,omitempty" json:"spec_source,omitempty"`       // official, community, sniffed, docs — affects generated client defaults
+	ClientPattern        string              `yaml:"client_pattern,omitempty" json:"client_pattern,omitempty"` // rest (default), proxy-envelope — affects generated HTTP client
+	HTTPTransport        string              `yaml:"http_transport,omitempty" json:"http_transport,omitempty"` // standard (default for official APIs), browser-chrome, or browser-chrome-h3
+	ProxyRoutes          map[string]string   `yaml:"proxy_routes,omitempty" json:"proxy_routes,omitempty"`     // path prefix → service name for proxy-envelope routing
+	WebsiteURL           string              `yaml:"website_url,omitempty" json:"website_url,omitempty"`       // product/company website (not the API base URL)
+	Category             string              `yaml:"category,omitempty" json:"category,omitempty"`             // catalog category (e.g., productivity, developer-tools) — used for library install path
+	Auth                 AuthConfig          `yaml:"auth" json:"auth"`
+	RequiredHeaders      []RequiredHeader    `yaml:"required_headers,omitempty" json:"required_headers,omitempty"`
+	Config               ConfigSpec          `yaml:"config" json:"config"`
+	Resources            map[string]Resource `yaml:"resources" json:"resources"`
+	Types                map[string]TypeDef  `yaml:"types" json:"types"`
+	ExtraCommands        []ExtraCommand      `yaml:"extra_commands,omitempty" json:"extra_commands,omitempty"` // hand-written cobra commands declared so SKILL.md can document them; spec-only metadata, no code generated
+	Cache                CacheConfig         `yaml:"cache,omitempty" json:"cache"`                             // cache freshness + auto-refresh config; when enabled, generated read commands auto-refresh stale local data before serving
+	Share                ShareConfig         `yaml:"share,omitempty" json:"share"`                             // git-backed snapshot sharing config; when enabled, emits a `share` subcommand that publishes/subscribes to a git repo
+	MCP                  MCPConfig           `yaml:"mcp,omitempty" json:"mcp"`                                 // MCP server generation config; when unset, the emitted MCP binary is stdio-only (today's default). Opting into http adds a --transport/--addr flag surface so the same binary can serve cloud-hosted agents.
 }
 
 // ExtraCommand declares a hand-written cobra command so the SKILL.md


### PR DESCRIPTION
## Summary

Splits the GraphQL endpoint path off the `BaseURL` field on `APISpec` so the generator can target per-tenant or versioned URLs without hardcoding `/graphql` in the client template.

The motivating case is Shopify, whose Admin GraphQL endpoint is `https://{shop}/admin/api/{version}/graphql.json` — both the host and the path carry runtime-resolved variables. Today the GraphQL parser stores the full URL (e.g., `https://api.linear.app/graphql`) in `BaseURL` and `graphql_client.go.tmpl` hardcodes `/graphql` as the request path inside `c.Post`. That model can't represent APIs whose endpoint sits behind a per-tenant subdomain or a version segment, and it doubles the path for any caller that wires `BaseURL` through unchanged.

After this PR, runtime URL building is a clean concatenation of `BaseURL + GraphQLEndpointPath`. Existing GraphQL specs default `GraphQLEndpointPath` to `/graphql`, so the printed-CLI output is byte-compatible for the standard case (Linear, GitHub).

## What changed

- **`internal/spec/spec.go`** — adds two fields to `APISpec`:
  - `GraphQLEndpointPath` (string) — the path appended to `BaseURL` for GraphQL POSTs. REST specs leave it empty; GraphQL specs default it to `/graphql`.
  - `EndpointTemplateVars` ([]string) — placeholder names embedded in `BaseURL` or `GraphQLEndpointPath` as `{var}`. Carried as plumbing for a follow-up that wires runtime env-var substitution; this PR reads the field but does not resolve it.
- **`internal/openapi/parser.go`** — unchanged. REST specs continue to populate `BaseURL` only and leave the GraphQL-only fields empty. New assertion in `TestParsePetstore` locks that in.
- **`internal/graphql/parser.go`** — `knownGraphQLDefaults` now returns `(baseURL, endpointPath, auth)` and writes both fields onto the spec. Linear, GitHub, and Shopify defaults are split accordingly (e.g., Linear becomes `BaseURL=https://api.linear.app`, `GraphQLEndpointPath=/graphql`).
- **`internal/generator/templates/graphql_client.go.tmpl`** — renders `{{.GraphQLEndpointPath}}` into a `const graphqlEndpointPath` and posts against that constant from `Query`/`Mutate`, instead of the literal `/graphql` it carried before.

## PR title scope

`.github/workflows/pr-title.yml` restricts conventional-commit scopes to `cli`, `skills`, `ci`, and `main` per AGENTS.md, so the title uses `feat(cli):`.

## Test plan

- [x] `go test ./...` passes — including `TestGenerateGraphQLCompiles`, which regenerates a GraphQL CLI from the test SDL fixture and compiles it.
- [x] New `TestGenerateGraphQLEndpointPathRendersTemplatedURL` in `internal/generator/generator_test.go` covers a spec with `BaseURL=https://{shop}` and `GraphQLEndpointPath=/admin/api/{version}/graphql.json`. It asserts the generated `graphql.go` carries the templated path verbatim into the `graphqlEndpointPath` constant, that `config.go` carries the templated `BaseURL` through unchanged, and that the resulting `BaseURL + GraphQLEndpointPath` resolves to the expected URL after placeholder substitution.
- [x] Existing `TestParseSDLContent` updated to assert the split: `parsed.BaseURL == "https://api.linear.app"` and `parsed.GraphQLEndpointPath == "/graphql"`.
- [x] `go vet ./...` and `go fmt ./...` clean.
- [x] Rebased onto current `main` (d1b9cd2). One conflict resolved in `internal/spec/spec.go` where the new fields landed alongside the recently-added `DisplayName` and `CLIDescription` fields.