### PR TITLE
fix(cli): mcp-sync bumps mcp-go pin when migrating to cobratree surface

### DIFF
--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v2/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v2/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v2/internal/spec"
+	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/semver"
 )
 
@@ -673,46 +674,60 @@ func writeFileAtomic(path string, data []byte) error {
 	return nil
 }
 
+// mcpGoModulePath identifies the mcp-go module across regex/lookup
+// sites. Single source so the import path stays in lockstep with the
+// constant it pairs with.
+const mcpGoModulePath = "github.com/mark3labs/mcp-go"
+
 // minMCPGoVersionForCobratree is the floor mark3labs/mcp-go version
 // the cobratree-era templates compile against. Pinned to whatever the
 // generator's go.mod template currently emits — bump both together.
+// TestMinMCPGoVersionMatchesGoModTemplate keeps them in lockstep.
 const minMCPGoVersionForCobratree = "v0.47.0"
 
-// mcpGoRequireLine matches a `github.com/mark3labs/mcp-go vX.Y.Z`
-// require directive. The version capture allows pre-release and
-// build-metadata suffixes (v0.47.0-rc1, v0.47.0+meta) — Go's semver
-// package treats them correctly.
-var mcpGoRequireLine = regexp.MustCompile(`github\.com/mark3labs/mcp-go\s+(v[0-9][^\s]*)`)
-
-// ensureMCPGoMinVersion bumps the mark3labs/mcp-go pin in go.mod to
-// minMCPGoVersionForCobratree when the existing pin is older. Returns
-// the prior version when a bump happened, the empty string when no
-// change was needed (already current, or dep absent from go.mod).
+// ensureMCPGoMinVersion bumps the mark3labs/mcp-go require directive
+// in go.mod to minMCPGoVersionForCobratree when the existing pin is
+// older. Returns the prior version when a bump happened, the empty
+// string when no change was needed (already current, or dep absent).
 //
 // Older library CLIs predating cobratree pin v0.26.0 or similar; the
-// migration block below regenerates MCP source against the cobratree
+// migration block above regenerates MCP source against the cobratree
 // templates which call APIs (WithReadOnlyHintAnnotation, GetArguments)
 // added in v0.47.0. Without the bump the regenerated CLI fails to
 // compile and the sync silently leaves a broken state.
+//
+// Uses modfile.Parse so a `replace` directive pointing the module at
+// a fork or local path is left alone — only the require entry moves.
 func ensureMCPGoMinVersion(cliDir string) (priorVersion string, err error) {
 	gomodPath := filepath.Join(cliDir, "go.mod")
 	data, err := os.ReadFile(gomodPath)
 	if err != nil {
 		return "", fmt.Errorf("reading go.mod: %w", err)
 	}
-	matches := mcpGoRequireLine.FindSubmatch(data)
-	if matches == nil {
+	mf, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return "", fmt.Errorf("parsing go.mod: %w", err)
+	}
+	var current string
+	for _, r := range mf.Require {
+		if r.Mod.Path == mcpGoModulePath {
+			current = r.Mod.Version
+			break
+		}
+	}
+	if current == "" {
 		return "", nil
 	}
-	current := string(matches[1])
-	if !semver.IsValid(current) {
+	if !semver.IsValid(current) || semver.Compare(current, minMCPGoVersionForCobratree) >= 0 {
 		return "", nil
 	}
-	if semver.Compare(current, minMCPGoVersionForCobratree) >= 0 {
-		return "", nil
+	if err := mf.AddRequire(mcpGoModulePath, minMCPGoVersionForCobratree); err != nil {
+		return "", fmt.Errorf("updating mcp-go require: %w", err)
 	}
-	rewritten := mcpGoRequireLine.ReplaceAll(data,
-		[]byte("github.com/mark3labs/mcp-go "+minMCPGoVersionForCobratree))
+	rewritten, err := mf.Format()
+	if err != nil {
+		return "", fmt.Errorf("formatting go.mod: %w", err)
+	}
 	if err := writeFileAtomic(gomodPath, rewritten); err != nil {
 		return "", fmt.Errorf("rewriting go.mod: %w", err)
 	}

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v2/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v2/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v2/internal/spec"
+	"golang.org/x/mod/semver"
 )
 
 var (
@@ -133,6 +134,18 @@ func Sync(cliDir string, opts Options) (Result, error) {
 		}
 		if err := ensureEndpointAnnotations(cliDir, parsed, features); err != nil {
 			return Result{}, err
+		}
+		// Cobratree templates (mcp_tools.go.tmpl, main_mcp.go.tmpl, etc.)
+		// use APIs added in mcp-go v0.47.0 (WithReadOnlyHintAnnotation,
+		// req.GetArguments). Older generated CLIs pin a lower version
+		// and won't compile after the surface regen below. Bump the
+		// pin in go.mod before generation so the resulting CLI builds.
+		bumpedFrom, err := ensureMCPGoMinVersion(cliDir)
+		if err != nil {
+			return Result{}, err
+		}
+		if bumpedFrom != "" {
+			fmt.Fprintf(os.Stderr, "mcp-sync: bumped mark3labs/mcp-go in go.mod from %s to %s for cobratree compatibility\n", bumpedFrom, minMCPGoVersionForCobratree)
 		}
 		// Older generator templates split MCP handlers into a separate
 		// internal/mcp/handlers.go file. The current template emits all
@@ -658,4 +671,50 @@ func writeFileAtomic(path string, data []byte) error {
 		return fmt.Errorf("replacing %s: %w", path, err)
 	}
 	return nil
+}
+
+// minMCPGoVersionForCobratree is the floor mark3labs/mcp-go version
+// the cobratree-era templates compile against. Pinned to whatever the
+// generator's go.mod template currently emits — bump both together.
+const minMCPGoVersionForCobratree = "v0.47.0"
+
+// mcpGoRequireLine matches a `github.com/mark3labs/mcp-go vX.Y.Z`
+// require directive. The version capture allows pre-release and
+// build-metadata suffixes (v0.47.0-rc1, v0.47.0+meta) — Go's semver
+// package treats them correctly.
+var mcpGoRequireLine = regexp.MustCompile(`github\.com/mark3labs/mcp-go\s+(v[0-9][^\s]*)`)
+
+// ensureMCPGoMinVersion bumps the mark3labs/mcp-go pin in go.mod to
+// minMCPGoVersionForCobratree when the existing pin is older. Returns
+// the prior version when a bump happened, the empty string when no
+// change was needed (already current, or dep absent from go.mod).
+//
+// Older library CLIs predating cobratree pin v0.26.0 or similar; the
+// migration block below regenerates MCP source against the cobratree
+// templates which call APIs (WithReadOnlyHintAnnotation, GetArguments)
+// added in v0.47.0. Without the bump the regenerated CLI fails to
+// compile and the sync silently leaves a broken state.
+func ensureMCPGoMinVersion(cliDir string) (priorVersion string, err error) {
+	gomodPath := filepath.Join(cliDir, "go.mod")
+	data, err := os.ReadFile(gomodPath)
+	if err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	matches := mcpGoRequireLine.FindSubmatch(data)
+	if matches == nil {
+		return "", nil
+	}
+	current := string(matches[1])
+	if !semver.IsValid(current) {
+		return "", nil
+	}
+	if semver.Compare(current, minMCPGoVersionForCobratree) >= 0 {
+		return "", nil
+	}
+	rewritten := mcpGoRequireLine.ReplaceAll(data,
+		[]byte("github.com/mark3labs/mcp-go "+minMCPGoVersionForCobratree))
+	if err := writeFileAtomic(gomodPath, rewritten); err != nil {
+		return "", fmt.Errorf("rewriting go.mod: %w", err)
+	}
+	return current, nil
 }

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -405,6 +405,76 @@ func TestReconcileSpecNameWithDirNoYAMLFallsThroughToValidator(t *testing.T) {
 	assert.Contains(t, err.Error(), "--force")
 }
 
+// TestEnsureMCPGoMinVersionBumpsOldPin — older library CLIs predating
+// the cobratree templates pin a v0.x version that lacks
+// WithReadOnlyHintAnnotation/GetArguments. mcp-sync bumps to the floor
+// before regenerating MCP source so the generated CLI compiles.
+func TestEnsureMCPGoMinVersionBumpsOldPin(t *testing.T) {
+	t.Parallel()
+	cliDir := t.TempDir()
+	gomod := `module example.com/foo
+
+go 1.23.0
+
+require github.com/mark3labs/mcp-go v0.26.0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte(gomod), 0o644))
+
+	prior, err := ensureMCPGoMinVersion(cliDir)
+	require.NoError(t, err)
+	assert.Equal(t, "v0.26.0", prior, "must report the prior pin so callers can log it")
+
+	updated, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.47.0")
+	assert.NotContains(t, string(updated), "github.com/mark3labs/mcp-go v0.26.0")
+	// Surrounding directives must be preserved.
+	assert.Contains(t, string(updated), "module example.com/foo")
+	assert.Contains(t, string(updated), "go 1.23.0")
+}
+
+// TestEnsureMCPGoMinVersionNoOpAtOrAboveFloor — at or above the floor,
+// no-op even if exactly equal. Avoids spurious go.mod rewrites on
+// already-current CLIs.
+func TestEnsureMCPGoMinVersionNoOpAtOrAboveFloor(t *testing.T) {
+	t.Parallel()
+	for _, version := range []string{"v0.47.0", "v0.48.0", "v1.0.0"} {
+		t.Run(version, func(t *testing.T) {
+			t.Parallel()
+			cliDir := t.TempDir()
+			gomod := "module example.com/foo\nrequire github.com/mark3labs/mcp-go " + version + "\n"
+			require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte(gomod), 0o644))
+
+			prior, err := ensureMCPGoMinVersion(cliDir)
+			require.NoError(t, err)
+			assert.Equal(t, "", prior, "must report no-rename when already at or above floor")
+
+			after, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
+			require.NoError(t, err)
+			assert.Equal(t, gomod, string(after), "go.mod must be byte-identical when no bump needed")
+		})
+	}
+}
+
+// TestEnsureMCPGoMinVersionNoOpWhenDepAbsent — a CLI without mcp-go
+// in go.mod (e.g., a CLI generated before MCP support was added)
+// must not have the dep injected. Other migration steps (or a future
+// `go mod tidy`) handle that.
+func TestEnsureMCPGoMinVersionNoOpWhenDepAbsent(t *testing.T) {
+	t.Parallel()
+	cliDir := t.TempDir()
+	gomod := "module example.com/foo\n\ngo 1.23.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte(gomod), 0o644))
+
+	prior, err := ensureMCPGoMinVersion(cliDir)
+	require.NoError(t, err)
+	assert.Equal(t, "", prior)
+
+	after, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
+	require.NoError(t, err)
+	assert.Equal(t, gomod, string(after))
+}
+
 // TestRemoveStaleMCPHandlersFile locks behavior for the food52 case:
 // older generator templates emitted MCP handlers in a separate
 // internal/mcp/handlers.go; the current template emits everything in

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v2/internal/generator"
@@ -473,6 +474,60 @@ func TestEnsureMCPGoMinVersionNoOpWhenDepAbsent(t *testing.T) {
 	after, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
 	require.NoError(t, err)
 	assert.Equal(t, gomod, string(after))
+}
+
+// TestEnsureMCPGoMinVersionLeavesReplaceDirectiveAlone — a `replace`
+// directive that pins mcp-go to a fork or local checkout must survive
+// the bump. Only the require entry moves; the replace target is
+// independent and may legitimately point at any version.
+func TestEnsureMCPGoMinVersionLeavesReplaceDirectiveAlone(t *testing.T) {
+	t.Parallel()
+	cliDir := t.TempDir()
+	gomod := `module example.com/foo
+
+go 1.23.0
+
+require github.com/mark3labs/mcp-go v0.26.0
+
+replace github.com/mark3labs/mcp-go => github.com/myfork/mcp-go v0.30.0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte(gomod), 0o644))
+
+	prior, err := ensureMCPGoMinVersion(cliDir)
+	require.NoError(t, err)
+	assert.Equal(t, "v0.26.0", prior)
+
+	updated, err := os.ReadFile(filepath.Join(cliDir, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "github.com/mark3labs/mcp-go v0.47.0",
+		"require entry must be bumped to the floor")
+	assert.Contains(t, string(updated), "github.com/myfork/mcp-go v0.30.0",
+		"replace directive's target must be untouched")
+}
+
+// TestMinMCPGoVersionMatchesGoModTemplate is the drift-detection
+// gate: minMCPGoVersionForCobratree (used by ensureMCPGoMinVersion to
+// decide whether an existing pin is too old) must match the version
+// the generator's go.mod.tmpl actually emits. If they drift, freshly
+// generated CLIs and freshly migrated CLIs end up on different mcp-go
+// versions — silent inconsistency.
+func TestMinMCPGoVersionMatchesGoModTemplate(t *testing.T) {
+	t.Parallel()
+	// The template lives at internal/generator/templates/go.mod.tmpl;
+	// this test runs from internal/pipeline/mcpsync/.
+	tmplPath := filepath.Join("..", "..", "..", "internal", "generator", "templates", "go.mod.tmpl")
+	data, err := os.ReadFile(tmplPath)
+	require.NoError(t, err, "go.mod.tmpl must be readable from the test cwd")
+
+	// Match the bare require directive: `require github.com/mark3labs/mcp-go vX.Y.Z`.
+	// The template emits the directive literally (no Go template
+	// interpolation in the version), so a regex over the raw source
+	// is sufficient.
+	re := regexp.MustCompile(`(?m)^require[ \t]+github\.com/mark3labs/mcp-go[ \t]+(v[0-9][^\s]+)`)
+	m := re.FindSubmatch(data)
+	require.NotNil(t, m, "go.mod.tmpl must contain a `require github.com/mark3labs/mcp-go vX.Y.Z` line")
+	assert.Equal(t, minMCPGoVersionForCobratree, string(m[1]),
+		"minMCPGoVersionForCobratree drifted from the version pinned in go.mod.tmpl — bump both together")
 }
 
 // TestRemoveStaleMCPHandlersFile locks behavior for the food52 case:


### PR DESCRIPTION
## Summary

Older library CLIs predating the cobratree runtime walker pin \`mark3labs/mcp-go v0.26.0\` (or similar). mcp-sync's migration step regenerates the MCP surface from cobratree templates which call \`WithReadOnlyHintAnnotation\` and \`req.GetArguments\` — APIs added in v0.47.0. Without a matching dep bump, the regenerated CLI fails to compile and the sync silently leaves a broken state.

Polish on weather-goat hit this case and had to bump the dep manually as a separate step. With 13 more CLIs in the upcoming sweep, that hand-step compounds. Fold it into mcp-sync.

## How it works

A new \`ensureMCPGoMinVersion\` runs in the migration block (\`!alreadyMigrated\`) before \`generator.GenerateMCPSurface\`:

1. Read go.mod, find the \`github.com/mark3labs/mcp-go vX.Y.Z\` require line.
2. Compare against \`minMCPGoVersionForCobratree\` (\`v0.47.0\`, pinned to match \`go.mod.tmpl\`) using \`golang.org/x/mod/semver\`.
3. If older, rewrite the line and log \`mcp-sync: bumped mark3labs/mcp-go in go.mod from v0.26.0 to v0.47.0 for cobratree compatibility\`.

Already-cobratree CLIs skip the migration block entirely — their go.mod doesn't churn on every sync.

## Tests

- \`TestEnsureMCPGoMinVersionBumpsOldPin\` — v0.26.0 → v0.47.0, surrounding directives preserved
- \`TestEnsureMCPGoMinVersionNoOpAtOrAboveFloor\` — three sub-cases (v0.47.0 exact, v0.48.0, v1.0.0), all byte-identical after
- \`TestEnsureMCPGoMinVersionNoOpWhenDepAbsent\` — a go.mod without mcp-go is left untouched (no injection); future \`go mod tidy\` adds it if needed
- \`go test ./...\`, \`go vet\`, \`go fmt\`, \`scripts/golden.sh verify\` (9/9) all green

## When the floor moves

The constant \`minMCPGoVersionForCobratree\` and the version pinned in \`internal/generator/templates/go.mod.tmpl\` must move together. A doc comment on the constant calls this out.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)