### PR TITLE
fix(cli): dogfood agent-context discovery reads stdout only

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1557,11 +1558,30 @@ func checkExamples(dir string) ExampleCheckResult {
 }
 
 func discoverExampleCheckCommands(binaryPath string) ([][]string, error) {
-	out, err := runDogfoodCmd(binaryPath, 15*time.Second, "agent-context")
-	if err != nil {
-		return nil, err
+	// Use Output() rather than the shared runDogfoodCmd which calls
+	// CombinedOutput. agent-context emits JSON to stdout; any stderr
+	// leak (deprecation warnings, config-load notices, panics that
+	// race with the JSON write) ends up prefixed to stdout in
+	// CombinedOutput and breaks json.Unmarshal with "invalid character
+	// 'E' looking for beginning of value" or similar.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "agent-context")
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("agent-context timed out after 15s")
 	}
-	paths, err := dogfoodExampleCommandPathsFromAgentContext([]byte(out))
+	if err != nil {
+		// Surface stderr in the error so the dogfood "Examples" check's
+		// skip-detail line tells the user what actually broke rather
+		// than just "exit status 1".
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, fmt.Errorf("agent-context failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("agent-context failed: %w", err)
+	}
+	paths, err := dogfoodExampleCommandPathsFromAgentContext(out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1558,27 +1558,8 @@ func checkExamples(dir string) ExampleCheckResult {
 }
 
 func discoverExampleCheckCommands(binaryPath string) ([][]string, error) {
-	// Use Output() rather than the shared runDogfoodCmd which calls
-	// CombinedOutput. agent-context emits JSON to stdout; any stderr
-	// leak (deprecation warnings, config-load notices, panics that
-	// race with the JSON write) ends up prefixed to stdout in
-	// CombinedOutput and breaks json.Unmarshal with "invalid character
-	// 'E' looking for beginning of value" or similar.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, binaryPath, "agent-context")
-	out, err := cmd.Output()
-	if ctx.Err() == context.DeadlineExceeded {
-		return nil, fmt.Errorf("agent-context timed out after 15s")
-	}
+	out, err := runStdoutOnly(binaryPath, 15*time.Second, "agent-context")
 	if err != nil {
-		// Surface stderr in the error so the dogfood "Examples" check's
-		// skip-detail line tells the user what actually broke rather
-		// than just "exit status 1".
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return nil, fmt.Errorf("agent-context failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
-		}
 		return nil, fmt.Errorf("agent-context failed: %w", err)
 	}
 	paths, err := dogfoodExampleCommandPathsFromAgentContext(out)
@@ -1589,6 +1570,31 @@ func discoverExampleCheckCommands(binaryPath string) ([][]string, error) {
 		paths = sampleEvenlyCommandPaths(paths, 10)
 	}
 	return paths, nil
+}
+
+// runStdoutOnly runs binaryPath with args and returns stdout. Unlike
+// runDogfoodCmd, stderr is captured separately so a leaky printed CLI
+// (deprecation warnings, config-load notices, panics that race with
+// stdout writes) doesn't prefix the JSON consumers expect to parse.
+// On non-zero exit, the trimmed stderr surfaces in the error so
+// callers can surface a meaningful "what broke" instead of "exit
+// status 1".
+func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("timed out after %s", timeout)
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, fmt.Errorf("%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, err
+	}
+	return out, nil
 }
 
 func dogfoodExampleCommandPathsFromAgentContext(data []byte) ([][]string, error) {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1616,4 +1617,65 @@ func TestCollectDogfoodIssues_ThinTestsNotHardIssue(t *testing.T) {
 		assert.NotContains(t, i, "recipes")
 		assert.NotContains(t, i, "thin")
 	}
+}
+
+// TestDiscoverExampleCheckCommandsIgnoresStderrNoise — printed CLIs
+// commonly write to stderr before agent-context succeeds (deprecation
+// warnings, config-load notices, panics that race with the JSON
+// write). Previously runDogfoodCmd merged stderr into stdout via
+// CombinedOutput, prefixing the JSON with text and breaking
+// json.Unmarshal with "invalid character 'E' looking for beginning of
+// value". discoverExampleCheckCommands must read stdout only so the
+// dogfood "Examples" check survives stderr leaks.
+func TestDiscoverExampleCheckCommandsIgnoresStderrNoise(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	t.Parallel()
+
+	script := `#!/bin/sh
+# Deliberately write to stderr before the JSON write — simulates a
+# printed CLI emitting a deprecation warning or config-load notice.
+echo "WARN: legacy config path detected" >&2
+cat <<EOF
+{
+  "commands": [
+    {"name": "posts", "subcommands": [{"name": "list"}]},
+    {"name": "auth", "subcommands": [{"name": "login"}]}
+  ]
+}
+EOF
+`
+	binPath := filepath.Join(t.TempDir(), "fakebin")
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+
+	paths, err := discoverExampleCheckCommands(binPath)
+	require.NoError(t, err, "stderr noise must not break JSON parsing")
+	// auth/login is filtered out because "auth" is in the framework
+	// skip set; only the posts subtree should survive.
+	assert.Equal(t, [][]string{{"posts", "list"}}, paths)
+}
+
+// TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure — when the
+// binary actually fails (non-zero exit), stderr carries the reason
+// and the caller deserves to see it. Previously a CombinedOutput
+// failure left the user with "exit status 1"; the new path uses
+// exec.ExitError.Stderr to surface the underlying message.
+func TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+	t.Parallel()
+
+	script := `#!/bin/sh
+echo "config file ~/.fakebin/config.toml: permission denied" >&2
+exit 1
+`
+	binPath := filepath.Join(t.TempDir(), "fakebin")
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+
+	_, err := discoverExampleCheckCommands(binPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied",
+		"stderr from the failed agent-context call must surface in the error")
 }

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -267,11 +267,11 @@ func pickFeatures(r *ResearchResult) []NovelFeature {
 }
 
 func pickGeneratedCommandFeatures(binaryPath string) ([]NovelFeature, error) {
-	out, err := runDogfoodCmd(binaryPath, 15*time.Second, "agent-context")
+	out, err := runStdoutOnly(binaryPath, 15*time.Second, "agent-context")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("agent-context failed: %w", err)
 	}
-	paths, err := dogfoodExampleCommandPathsFromAgentContext([]byte(out))
+	paths, err := dogfoodExampleCommandPathsFromAgentContext(out)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The dogfood "Examples" check runs \`<cli> agent-context\` and parses the output as JSON. The call went through \`runDogfoodCmd\` which uses \`cmd.CombinedOutput()\` — fine for \`--help\`, broken for \`agent-context\`. Any stderr emission before \`agent-context\`'s JSON write (deprecation warnings, config-load notices, panics that race with the JSON) prefixes the JSON with text and breaks \`json.Unmarshal\` with \`invalid character 'E' looking for beginning of value\` or similar.

Surfaced during weather-goat polish: the Examples check went from informative to skipped on every run because agent-context introspection failed at the JSON parse.

## Fix

Replace the \`runDogfoodCmd\` call inside \`discoverExampleCheckCommands\` with a direct \`exec.CommandContext\` using \`cmd.Output()\`. Stdout-only. Shared \`runDogfoodCmd\` continues to use \`CombinedOutput\` because \`--help\` and similar callers genuinely want both streams.

When \`agent-context\` actually fails (non-zero exit), surface stderr in the returned error via \`*exec.ExitError.Stderr\` so the dogfood "Examples" row tells the user *why* it skipped (\`agent-context failed: config file …: permission denied\`) instead of \`exit status 1\`.

## Tests

- \`TestDiscoverExampleCheckCommandsIgnoresStderrNoise\` — fake binary writes \`WARN: legacy config path detected\` to stderr before the JSON; the JSON parse must still succeed.
- \`TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure\` — fake binary fails with stderr; assert the returned error carries the stderr message.

Both skip on Windows (use a sh script as the fake binary). \`go test ./...\`, \`go vet\`, \`go fmt\`, \`scripts/golden.sh verify\` (9/9) all green.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)