### PR TITLE
fix(skills): polish syncs novel_features; publish detects squash-zombie branches

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -101,7 +101,7 @@ echo "Polishing: $CLI_NAME"
 echo "Location: $CLI_DIR"
 ```
 
-### Find spec
+### Find spec and research dir
 
 ```bash
 API_SLUG="${CLI_NAME%-pp-cli}"
@@ -118,6 +118,25 @@ done
 SPEC_FLAG=""
 if [ -n "$SPEC_PATH" ]; then
   SPEC_FLAG="--spec $SPEC_PATH"
+fi
+
+# Locate the research dir (parent of the spec's research/ folder, i.e.
+# manuscripts/<api>/<run-id>/). dogfood's --research-dir triggers
+# checkNovelFeatures, which writes novel_features_built back into
+# research.json AND syncs the verified list into .printing-press.json.
+# Without this flag, legacy CLIs whose manifest predates the
+# novel_features schema fail publish-validate's transcendence gate.
+RESEARCH_DIR=""
+for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json; do
+  if [ -f "$d" ]; then
+    RESEARCH_DIR="$(dirname "$d")"
+    break
+  fi
+done
+
+RESEARCH_FLAG=""
+if [ -n "$RESEARCH_DIR" ]; then
+  RESEARCH_FLAG="--research-dir $RESEARCH_DIR"
 fi
 ```
 
@@ -162,8 +181,11 @@ cd "$CLI_DIR"
 # Build
 go build -o "$CLI_NAME" ./cmd/"$CLI_NAME" 2>&1
 
-# Diagnostics. SPEC_FLAG is set in the "Find spec" step above.
-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG 2>&1
+# Diagnostics. SPEC_FLAG and RESEARCH_FLAG are set in the "Find spec
+# and research dir" step above. RESEARCH_FLAG enables dogfood to
+# verify novel features and sync them into .printing-press.json
+# (required for publish-validate's transcendence gate).
+printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG $RESEARCH_FLAG 2>&1
 printing-press verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
 printing-press workflow-verify --dir "$CLI_DIR" --json > /tmp/polish-workflow-verify.json 2>&1 || true
 printing-press verify-skill --dir "$CLI_DIR" --json > /tmp/polish-verify-skill.json 2>&1 || true

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -407,13 +407,15 @@ gh pr list --repo mvanhorn/printing-press-library --head "$HEAD_REF" --state ope
 
 If found, record `OWN_PR=true`, store `EXISTING_PR_NUMBER` and `EXISTING_PR_URL`.
 
-**If no open PR was found**, also check for a previously merged PR on the same branch:
+**If no open PR was found**, also check for a previously merged PR on the same branch — by ANY author, not just yours:
 
 ```bash
-MERGED_PR=$(gh pr list --repo mvanhorn/printing-press-library --head "$HEAD_REF" --state merged --author @me --json number --jq '.[0].number' 2>/dev/null)
+MERGED_PR=$(gh pr list --repo mvanhorn/printing-press-library --head "$HEAD_REF" --state merged --json number --jq '.[0].number' 2>/dev/null)
 ```
 
 If `MERGED_PR` is non-empty, the branch name was already used and merged. Set `BRANCH_MERGED=true` so Step 8 creates a new branch name (e.g., `feat/<api-slug>-YYYYMMDD`) instead of reusing the merged branch. Do NOT force-push onto a merged branch — `gh pr edit` would silently update a closed PR nobody is watching.
+
+The author-agnostic lookup also catches **squash-zombie branches**: GitHub squash-merge leaves the source branch behind on the remote, with pre-squash commit refs that look "ahead of main" but are content-equivalent to the squash commit. Without this check, the skill misclassifies the zombie as fresh-publish, then `git push -u` fails because the remote branch already exists. Timestamping sidesteps the issue entirely.
 
 ### No collision
 


### PR DESCRIPTION
## Summary

Two related skill bugs surfaced during a scrape-creators publish run today (printing-press-library #156). Both fixes are minimal SKILL.md edits — no Go code changes.

### #412 — polish skill omits `--research-dir` from dogfood

`SyncCLIManifestNovelFeatures` only fires when `dogfood --research-dir` runs and finds verified novel features. The polish skill passed `--spec` but not `--research-dir`, so legacy CLIs whose `.printing-press.json` predates the `novel_features` schema couldn't pass publish-validate's transcendence gate even after a clean polish.

Fix: resolve `RESEARCH_DIR` next to where `SPEC_PATH` is resolved, then pass `--research-dir "$RESEARCH_DIR"` to dogfood.

### #413 — publish skill misses cross-author merged PRs and squash zombies

`gh pr list --state merged --author @me` only catches PRs *you* merged on the head branch. Adrian's merged PR #113 on `feat/scrape-creators` was invisible to the check, and the post-squash zombie commits on the remote branch looked like real unmerged work. Result: `BRANCH_MERGED` stayed false, the skill thought it was a fresh publish, and `git push -u` collided with the existing remote branch.

Fix: drop `--author @me` from the merged-PR lookup. The timestamped-branch fallback already handles both cross-author merges and squash zombies safely — they just weren't being detected.

## Test plan

- [x] `go build -o ./printing-press ./cmd/printing-press` passes
- [x] `go test ./internal/cli/...` (34 passed)
- [x] `go vet ./...` clean
- [x] `scripts/golden.sh verify` (9 cases passed)
- [x] Verified `RESEARCH_DIR` resolution logic finds the correct manuscript dir for scrape-creators
- [ ] Reviewer to confirm the SKILL.md edits read sensibly

## Companion

Library-side issue #157 ([mvanhorn/printing-press-library](https://github.com/mvanhorn/printing-press-library/issues/157)) requests enabling "automatically delete head branches" on the library repo, which would eliminate the zombie-branch class entirely. That's a settings change, not code.

Closes #412
Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)