### PR TITLE
fix(skills): drop context: fork from output-review

### DIFF
--- a/skills/printing-press-output-review/SKILL.md
+++ b/skills/printing-press-output-review/SKILL.md
@@ -7,7 +7,6 @@ description: >
   Skill tool by main printing-press SKILL.md (Phase 4.85) and printing-press-polish
   SKILL.md during the diagnostic loop. Not for direct user invocation — its
   actionable wrappers are /printing-press and /printing-press-polish.
-context: fork
 user-invocable: false
 allowed-tools:
   - Bash

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1971,7 +1971,7 @@ Skill(
 )
 ```
 
-The sub-skill carries `context: fork` so the reviewer agent's diagnostic chatter stays isolated from this generation flow. It returns a `---OUTPUT-REVIEW-RESULT---` block with `status: PASS|WARN|SKIP` and a list of findings.
+The sub-skill returns a `---OUTPUT-REVIEW-RESULT---` block with `status: PASS|WARN|SKIP` and a list of findings.
 
 **Wave B rollout policy:** all findings surface as **warnings**, not blockers. Shipcheck does not fail on Phase 4.85 findings. Log the findings to `manuscripts/<api>/<run>/proofs/phase-4.85-findings.md` and surface them to the user. The user decides case by case whether to fix before shipping. Wave B calibrates false-positive rates before Wave C flips errors to blocking.
 


### PR DESCRIPTION
## Summary

Same migration as #410, applied to the output-review sub-skill.

- `skills/printing-press-output-review/SKILL.md` — remove `context: fork` from frontmatter so the sub-skill runs in the parent context
- `skills/printing-press/SKILL.md` — drop the parent prose that was explaining *why* output-review carried `context: fork`

## Why

#410 already laid out the rationale for the polish skill. Same problem here: output-review prompts the user via `AskUserQuestion`, which is a deferred tool. In a fork, its schema isn't in the starting tool list, and prompt sites inconsistently fall back to plain text — the user's reply lands in the parent session and the fork stalls.

Trade-off: reviewer-agent diagnostic chatter now lands in the parent flow. Acceptable cost for reliable user prompting at the WARN/SKIP decision point.

## Test plan

- [x] Frontmatter still parses (no other fields affected)
- [x] Parent prose at `skills/printing-press/SKILL.md:1971` reads cleanly without the dropped clause
- [ ] Next output-review run during shipcheck exercises `AskUserQuestion` natively

🤖 Generated with [Claude Code](https://claude.com/claude-code)