### PR TITLE
fix(ci): disable golangci-lint remote schema verify

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,7 @@ jobs:
         if: steps.changes.outputs.needs_lint == 'true'
         with:
           version: v2.11.4
+          verify: false
 
   test-shard:
     name: test (${{ matrix.shard }})


### PR DESCRIPTION
## Summary

- The lint job intermittently fails when `golangci-lint config verify` times out fetching `https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json` (`context deadline exceeded`).
- Set `verify: false` on `golangci-lint-action@v9` to skip the remote schema fetch; the actual `golangci-lint run` step is unaffected, and local invocations still validate the config.

## Test plan

- [ ] Confirm the `lint` job passes on this PR without the JSON schema fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)