### PR TITLE
fix(cli): emit mcp:read-only + plumb body fields in promoted commands (#426, #427)

### DIFF
--- a/internal/generator/endpoint_is_write_test.go
+++ b/internal/generator/endpoint_is_write_test.go
@@ -369,3 +369,165 @@ func TestHasWriteCommands_GenuineMutationsStayTrue(t *testing.T) {
 	assert.True(t, hasWriteCommands(resources),
 		"a POST endpoint with a write-shape operationId and body should classify as write")
 }
+
+// TestMCPReadOnlyAnnotationEmission verifies the cobratree readOnlyHint
+// cascade. When endpointIsWriteCommand returns false (POST search,
+// POST GraphQL, etc.), the generated cobra command must carry
+// Annotations["mcp:read-only"] = "true" so the runtime cobratree
+// walker marks the MCP tool with readOnlyHint and hosts skip the
+// per-call permission prompt. When the endpoint genuinely mutates
+// state, the annotation must be absent.
+func TestMCPReadOnlyAnnotationEmission(t *testing.T) {
+	cases := []struct {
+		name         string
+		apiName      string
+		resourceName string
+		endpointName string
+		endpoint     spec.Endpoint
+		wantReadOnly bool
+	}{
+		{
+			name:         "POST search endpoint emits mcp:read-only annotation",
+			apiName:      "search-readonly",
+			resourceName: "queries",
+			endpointName: "searchAll",
+			endpoint: spec.Endpoint{
+				Method:      "POST",
+				Path:        "/search-all",
+				Description: "Search collections by free text",
+				Body:        []spec.Param{{Name: "queryText", Type: "string"}},
+			},
+			wantReadOnly: true,
+		},
+		{
+			name:         "GET list endpoint emits mcp:read-only annotation",
+			apiName:      "get-readonly",
+			resourceName: "items",
+			endpointName: "listItems",
+			endpoint: spec.Endpoint{
+				Method:      "GET",
+				Path:        "/items",
+				Description: "List items",
+			},
+			wantReadOnly: true,
+		},
+		{
+			name:         "POST create endpoint omits mcp:read-only annotation",
+			apiName:      "post-mutation",
+			resourceName: "users",
+			endpointName: "createUser",
+			endpoint: spec.Endpoint{
+				Method:      "POST",
+				Path:        "/users",
+				Description: "Create a new user",
+				Body: []spec.Param{
+					{Name: "name", Type: "string"},
+					{Name: "email", Type: "string"},
+				},
+			},
+			wantReadOnly: false,
+		},
+		{
+			name:         "DELETE endpoint omits mcp:read-only annotation",
+			apiName:      "delete-mutation",
+			resourceName: "users",
+			endpointName: "deleteUser",
+			endpoint: spec.Endpoint{
+				Method:      "DELETE",
+				Path:        "/users/{id}",
+				Description: "Delete a user",
+			},
+			wantReadOnly: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec(tc.apiName)
+			apiSpec.Resources = map[string]spec.Resource{
+				tc.resourceName: {
+					Description: tc.resourceName,
+					Endpoints:   map[string]spec.Endpoint{tc.endpointName: tc.endpoint},
+				},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), tc.apiName+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			src := readPromotedCommandFile(t, outputDir)
+			marker := `"mcp:read-only": "true"`
+			if tc.wantReadOnly {
+				require.Contains(t, src, marker,
+					"%s endpoint should emit mcp:read-only annotation so the cobratree walker marks the MCP tool readOnlyHint", tc.endpointName)
+			} else {
+				require.NotContains(t, src, marker,
+					"%s endpoint must NOT emit mcp:read-only annotation — false positive would tell hosts to skip permission prompts on a real mutation", tc.endpointName)
+			}
+		})
+	}
+}
+
+// TestPromotedCommandPlumbsBodyFields verifies that promoted commands
+// emit a per-body-field flag, build a JSON body map from those flags,
+// and pass the body (not URL params) to the client's Post/Put/Patch
+// method. Before this change the promoted template forwarded `params`
+// (built from query/path Params) as the request body for non-GET
+// verbs, which silently dropped every spec-declared body field.
+func TestPromotedCommandPlumbsBodyFields(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("body-plumb")
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"createWidget": {
+					Method:      "POST",
+					Path:        "/widgets",
+					Description: "Create a widget",
+					Body: []spec.Param{
+						{Name: "name", Type: "string", Required: true},
+						{Name: "color", Type: "string"},
+						{Name: "tags", Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "body-plumb-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src := readPromotedCommandFile(t, outputDir)
+
+	// 1. Each body field declares a body* var.
+	require.Contains(t, src, "var bodyName string",
+		"promoted command must declare a body var for each body param")
+	require.Contains(t, src, "var bodyColor string")
+	require.Contains(t, src, "var bodyTags string")
+
+	// 2. Each body field registers a --flag.
+	require.Contains(t, src, `cmd.Flags().StringVar(&bodyName, "name"`,
+		"promoted command must register a flag per body param")
+	require.Contains(t, src, `cmd.Flags().StringVar(&bodyColor, "color"`)
+	require.Contains(t, src, `cmd.Flags().StringVar(&bodyTags, "tags"`)
+
+	// 3. Required body field is enforced (not via cobra's MarkFlagRequired,
+	// which breaks --dry-run probes — the verify-friendly RunE pattern
+	// uses an in-RunE check instead).
+	require.Contains(t, src, `cmd.Flags().Changed("name")`,
+		"required body field must be checked in RunE, not via MarkFlagRequired")
+
+	// 4. The RunE builds a body map from the body* vars and passes it
+	// to c.Post — not `params`, which is what the OLD template did.
+	require.Contains(t, src, `body := map[string]any{}`,
+		"promoted command must build a body map from body flags")
+	require.Contains(t, src, `body["name"] = bodyName`,
+		"body map must use the spec-declared field name, not the camelCased flag var")
+	require.Contains(t, src, `c.Post(path, body)`,
+		"promoted command must pass the body map to c.Post, not the params map")
+	require.NotContains(t, src, `c.Post(path, params)`,
+		"promoted command must NOT pass params (URL/path params) as the request body — that was the bug")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -606,6 +606,11 @@ type endpointTemplateData struct {
 	HasStore        bool
 	IsAsync         bool
 	Async           AsyncJobInfo
+	// IsReadOnly mirrors !endpointIsWriteCommand(endpoint, name). The
+	// emitted command sets Annotations["mcp:read-only"] = "true" when
+	// it's true so the cobratree MCP walker marks the tool with
+	// readOnlyHint and hosts skip the per-call permission prompt.
+	IsReadOnly bool
 	*spec.APISpec
 }
 
@@ -1467,6 +1472,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				HasStore:        g.VisionSet.Store,
 				IsAsync:         isAsync,
 				Async:           asyncInfo,
+				IsReadOnly:      !endpointIsWriteCommand(endpoint, eName),
 				APISpec:         g.Spec,
 			}
 			epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+eName)+".go")
@@ -1527,6 +1533,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 					HasStore:        g.VisionSet.Store,
 					IsAsync:         isAsync,
 					Async:           asyncInfo,
+					IsReadOnly:      !endpointIsWriteCommand(endpoint, eName),
 					APISpec:         g.Spec,
 				}
 				epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+subName+"_"+eName)+".go")
@@ -1917,6 +1924,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			HasStore     bool
 			Resource     spec.Resource
 			FuncPrefix   string
+			IsReadOnly   bool
 			*spec.APISpec
 		}{
 			PromotedName: pc.PromotedName,
@@ -1926,6 +1934,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			HasStore:     g.VisionSet.Store,
 			Resource:     resource,
 			FuncPrefix:   pc.ResourceName,
+			IsReadOnly:   !endpointIsWriteCommand(pc.Endpoint, pc.EndpointName),
 			APISpec:      g.Spec,
 		}
 		promotedPath := filepath.Join("internal", "cli", "promoted_"+pc.PromotedName+".go")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -868,6 +868,17 @@ func endpointIsWriteCommand(endpoint spec.Endpoint, opName string) bool {
 	return !bodyIsAllFilterShape(endpoint.Body)
 }
 
+// endpointIsReadCommand is the inverse of endpointIsWriteCommand.
+// Templates use this through the IsReadOnly field on their data
+// structs to decide whether to emit Annotations["mcp:read-only"].
+// Centralizing the negation keeps "read-only command = not a write
+// command" declared in one place; a future definition shift (e.g. a
+// new annotation that forces read-only regardless of verb) only needs
+// one update site.
+func endpointIsReadCommand(endpoint spec.Endpoint, opName string) bool {
+	return !endpointIsWriteCommand(endpoint, opName)
+}
+
 // camelCaseTokens splits "getOrCreate" → ["get", "Or", "Create"] and
 // "searchAll" → ["search", "All"]. Non-letter runes (digits, separators)
 // stay attached to the preceding token.
@@ -1472,7 +1483,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				HasStore:        g.VisionSet.Store,
 				IsAsync:         isAsync,
 				Async:           asyncInfo,
-				IsReadOnly:      !endpointIsWriteCommand(endpoint, eName),
+				IsReadOnly:      endpointIsReadCommand(endpoint, eName),
 				APISpec:         g.Spec,
 			}
 			epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+eName)+".go")
@@ -1533,7 +1544,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 					HasStore:        g.VisionSet.Store,
 					IsAsync:         isAsync,
 					Async:           asyncInfo,
-					IsReadOnly:      !endpointIsWriteCommand(endpoint, eName),
+					IsReadOnly:      endpointIsReadCommand(endpoint, eName),
 					APISpec:         g.Spec,
 				}
 				epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+subName+"_"+eName)+".go")
@@ -1934,7 +1945,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			HasStore:     g.VisionSet.Store,
 			Resource:     resource,
 			FuncPrefix:   pc.ResourceName,
-			IsReadOnly:   !endpointIsWriteCommand(pc.Endpoint, pc.EndpointName),
+			IsReadOnly:   endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
 			APISpec:      g.Spec,
 		}
 		promotedPath := filepath.Join("internal", "cli", "promoted_"+pc.PromotedName+".go")

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -48,7 +48,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 		Short: "{{oneline .Endpoint.Description}}",
 		Example: "{{exampleLine .CommandPath .EndpointName .Endpoint}}",
-		Annotations: map[string]string{"pp:endpoint": "{{.ResourceName}}.{{.EndpointName}}"},
+		Annotations: map[string]string{"pp:endpoint": "{{.ResourceName}}.{{.EndpointName}}"{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if positionalArgs .Endpoint}}
 			if len(args) == 0 {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -17,6 +17,9 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 	var flag{{camel (paramIdent .)}} {{goTypeForParam .Name .Type}}
 {{- end}}
 {{- end}}
+{{- range .Endpoint.Body}}
+	var body{{camel (paramIdent .)}} {{goType .Type}}
+{{- end}}
 {{- if .Endpoint.Pagination}}
 	var flagAll bool
 {{- end}}
@@ -26,10 +29,17 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Short: "{{oneline .Endpoint.Description}}",
 		Long:  "Shortcut for '{{.ResourceName}} {{.EndpointName}}'. {{oneline .Endpoint.Description}}",
 		Example: "  {{modulePath}} {{.PromotedName}}",
-		Annotations: map[string]string{"pp:endpoint": "{{.ResourceName}}.{{.EndpointName}}"},
+		Annotations: map[string]string{"pp:endpoint": "{{.ResourceName}}.{{.EndpointName}}"{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
+			if !cmd.Flags().Changed("{{flagName (paramIdent .)}}") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "{{flagName (paramIdent .)}}")
+			}
+{{- end}}
+{{- end}}
+{{- range .Endpoint.Body}}
+{{- if and .Required (not .Default)}}
 			if !cmd.Flags().Changed("{{flagName (paramIdent .)}}") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "{{flagName (paramIdent .)}}")
 			}
@@ -126,6 +136,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			}, nil, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
+{{- if or .HasStore (eq (upper .Endpoint.Method) "GET") (eq (upper .Endpoint.Method) "HEAD") (eq (upper .Endpoint.Method) "OPTIONS")}}
 			params := map[string]string{}
 {{- range $i, $p := .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
@@ -135,6 +146,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
 				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
+{{- end}}
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
@@ -147,10 +159,36 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- else if eq (upper .Endpoint.Method) "DELETE"}}
 			data, _, err := c.Delete(path)
 {{- else if or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")}}
-			// params (built from query/path Params) is sent as the request body.
-			// Rich body shapes should use the typed `<resource> <endpoint>`
-			// command, which declares each body field as a flag.
-			data, _, err := c.{{pascal (lower .Endpoint.Method)}}(path, params)
+			// Build the JSON body from --field flags. Query/path params
+			// are intentionally not folded into the body here — the typed
+			// `<resource> <endpoint>` command is the place to combine
+			// query params with body for non-GET verbs. Promoted commands
+			// cover the common case: body-only POST/PUT/PATCH.
+			body := map[string]any{}
+{{- range .Endpoint.Body}}
+{{- if or (eq .Type "object") (eq .Type "array")}}
+			if body{{camel (paramIdent .)}} != "" {
+				var parsed{{camel (paramIdent .)}} any
+				if err := json.Unmarshal([]byte(body{{camel (paramIdent .)}}), &parsed{{camel (paramIdent .)}}); err != nil {
+					return fmt.Errorf("parsing --{{flagName (paramIdent .)}} JSON: %w", err)
+				}
+				body["{{.Name}}"] = parsed{{camel (paramIdent .)}}
+			}
+{{- else if jsonStringParam .}}
+			if body{{camel (paramIdent .)}} != "" {
+				var parsed{{camel (paramIdent .)}} any
+				if err := json.Unmarshal([]byte(body{{camel (paramIdent .)}}), &parsed{{camel (paramIdent .)}}); err != nil {
+					return fmt.Errorf("parsing --{{flagName (paramIdent .)}} JSON: %w", err)
+				}
+				body["{{.Name}}"] = body{{camel (paramIdent .)}}
+			}
+{{- else}}
+			if body{{camel (paramIdent .)}} != {{zeroVal .Type}} {
+				body["{{.Name}}"] = body{{camel (paramIdent .)}}
+			}
+{{- end}}
+{{- end}}
+			data, _, err := c.{{pascal (lower .Endpoint.Method)}}(path, body)
 {{- else}}
 			// HEAD/OPTIONS and unknown verbs fall back to GET so generation
 			// stays compileable. Spec authors who genuinely need these verbs
@@ -239,6 +277,9 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if not .Positional}}
 	cmd.Flags().{{cobraFlagFuncForParam .Name .Type}}(&flag{{camel (paramIdent .)}}, "{{flagName (paramIdent .)}}", {{defaultValForParam .}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
 {{- end}}
+{{- end}}
+{{- range .Endpoint.Body}}
+	cmd.Flags().{{cobraFlagFunc .Type}}(&body{{camel (paramIdent .)}}, "{{flagName (paramIdent .)}}", {{defaultVal .}}, "{{oneline .Description}}")
 {{- end}}
 {{- if .Endpoint.Pagination}}
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -31,7 +31,7 @@ var (
 	errAnnotationSoftFail = errors.New("endpoint annotation skipped")
 )
 
-var endpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+"\},\s*$`)
+var endpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+"(?:, "mcp:read-only": "true")?\},\s*$`)
 
 type Result struct {
 	Changed bool

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -71,7 +71,7 @@ func RegisterNovelFeatureTools() { shellOutToCLI("projects list") }
 
 	updatedEndpoint, err := os.ReadFile(endpointPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(updatedEndpoint), `Annotations: map[string]string{"pp:endpoint": "projects.list"}`)
+	assert.Contains(t, string(updatedEndpoint), `Annotations: map[string]string{"pp:endpoint": "projects.list", "mcp:read-only": "true"}`)
 
 	updatedTools, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -21,7 +21,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 		Use:   "list",
 		Short: "List projects",
 		Example: "  printing-press-golden-pp-cli projects list",
-		Annotations: map[string]string{"pp:endpoint": "projects.list"},
+		Annotations: map[string]string{"pp:endpoint": "projects.list", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("status") {
 				allowedStatus := []string{ "draft", "active", "archived" }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -22,7 +22,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 		Aliases: []string{"get"},
 		Short: "List project tasks",
 		Example: "  printing-press-golden-pp-cli projects tasks list-project example-value",
-		Annotations: map[string]string{"pp:endpoint": "tasks.list-project"},
+		Annotations: map[string]string{"pp:endpoint": "tasks.list-project", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -18,7 +18,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 		Short: "Get public service status",
 		Long:  "Shortcut for 'public get-status'. Get public service status",
 		Example: "  printing-press-golden-pp-cli public",
-		Annotations: map[string]string{"pp:endpoint": "public.get-status"},
+		Annotations: map[string]string{"pp:endpoint": "public.get-status", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := flags.newClient()
 			if err != nil {


### PR DESCRIPTION
## Summary

Closes [#426](https://github.com/mvanhorn/cli-printing-press/issues/426) and [#427](https://github.com/mvanhorn/cli-printing-press/issues/427). Both close out the POST-as-query story from retro #423 WU-1 (POST-as-query detection) and modify the same generator/template surface, so they land together.

| Issue | Problem | Fix |
|------|---------|-----|
| #426 | The `endpointIsWriteCommand` classifier (added in retro #423 WU-1) drove README copy and the promoted-command verb branch but not MCP `readOnlyHint`. POST-search endpoints still presented to MCP hosts with no `readOnlyHint`, causing per-call permission prompts on every read. | Plumb `IsReadOnly = !endpointIsWriteCommand(...)` through both template data structs. Templates emit `Annotations["mcp:read-only"] = "true"` on read endpoints. The cobratree runtime walker already keys on this annotation via `isMCPReadOnly`. |
| #427 | Promoted commands forwarded `params` (built from query/path Params) as the request body for non-GET verbs, silently dropping every spec-declared body field. Mutations couldn't actually be invoked correctly through promoted commands. | Mirror the typed-endpoint template's body-flag pattern in promoted commands: declare `body* var` per body field, register `--field` flag, build a JSON body map, pass it to `c.Post/Put/Patch`. |

## Implementation notes

- **`IsReadOnly` plumbing.** Added to `endpointTemplateData` and the promoted-command anonymous struct in `generator.go`. Computed at three call sites (top-level endpoints, sub-resource endpoints, promoted commands) using the same `!endpointIsWriteCommand(endpoint, name)` predicate.
- **Annotation emission.** Inline conditional in the existing `Annotations:` line so the diff stays surgical: `Annotations: map[string]string{"pp:endpoint": "...", "mcp:read-only": "true"}` when read; existing single-key map when write.
- **Body-flag plumbing.** Mirrors `command_endpoint.go.tmpl`'s structure: per-field `body*` vars, per-field `--field` flags via `cobraFlagFunc`, in-RunE required checks (no `MarkFlagRequired` — that breaks `--dry-run` probes per the verify-friendly RunE rule), JSON body map built before the client call.
- **`params` declaration gating.** Pre-PR the template unconditionally declared `params := map[string]string{}` at the top of the no-store branch, then only the GET/DELETE/POST/PUT/PATCH branches used it (DELETE didn't, but `params` was still empty). Post-PR the body-only POST/PUT/PATCH path doesn't use `params`, so the unconditional declaration would trip "declared and not used". The fix gates the declaration to branches that actually consume it (`HasStore` resolveRead, GET, HEAD/OPTIONS fallback). Caught and fixed during test runs.
- **mcpsync compatibility.** `endpointAnnotationLine` regex updated to optionally match `, "mcp:read-only": "true"` suffix. The mcp-sync migration logic continues to backfill any unannotated endpoint command; the expected line shape just got slightly wider. One test assertion follows the same widening.

## Test plan

- [x] **New: TestMCPReadOnlyAnnotationEmission** — table-driven across POST-search (read), GET (read), POST-create (write), DELETE (write). Asserts the `"mcp:read-only": "true"` marker is present iff `endpointIsWriteCommand` returns false.
- [x] **New: TestPromotedCommandPlumbsBodyFields** — asserts four contracts in the emitted code: per-field `body*` var declarations, per-field `--field` flag registrations, in-RunE required check, body-map (not `params`) passed to `c.Post`.
- [x] Existing `TestEndpointIsWriteCommand` (24 cases), `TestPromotedCommandVerbBranching`, `TestSyncBackfillsEndpointAnnotations` all still pass with the new annotation shape.
- [x] `go test ./...` — 2548 tests across 28 packages, all green.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] `go fmt ./...` clean.
- [x] **Golden fixtures refreshed** for the 3 new `mcp:read-only` annotation sites in `generate-golden-api` (projects_list.go, projects_tasks_list-project.go, promoted_public.go — all GET endpoints, all now correctly annotated).
- [x] Smoke: regenerated a sample CLI with a POST-search endpoint; emitted command carries `Annotations: map[string]string{"pp:endpoint": "...", "mcp:read-only": "true"}`. Regenerated a sample CLI with a POST-create endpoint with a body field; emitted promoted command declares `--name` flag, builds a body map, and passes it to `c.Post(path, body)`.

## Acknowledged limitations

- **Existing library CLIs** (recipe-goat, dub, espn, yahoo-finance, postman-explore, etc.) regenerate with the new annotation + body-flag plumbing on next polish/regen pass. The mcpsync migration also picks up the new annotation form for already-published CLIs that re-run `printing-press mcp-sync`. Per-CLI re-publish to the public library is the trailing operational step — not in scope here.
- **HasStore + non-GET still routes through `resolveRead`** which is GET-only internally (existing carve-out, not changed here). #425 tracks the POST-aware store-cached path; this PR's body-flag plumbing applies only to the no-store branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)