### PR TITLE
fix(skills): add Phase 3 starter templates for novel feature commands

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1931,6 +1931,110 @@ Before moving to shipcheck, verify the build log against the absorb manifest:
 
 The generator handles Priority 0 (data layer) and most of Priority 1 (absorbed API endpoints). Priority 2 (transcendence) is always hand-built — the generator does not produce these. If you skip Priority 2, the CLI ships without the features that differentiate it from every other tool.
 
+**Starter templates for novel commands.** Cobra wiring is mechanical and consistent across novel features; the actual feature work lives in the RunE body. Copy the wrapper below and one of the RunE skeletons that follows, fill in the placeholders from the absorb manifest's transcendence row (`Name`, `Command`, `Description`, `Example`, `WhyItMatters`), and replace the body comments with your implementation. Dogfood, verify, and scorecard still apply to the result — the templates raise the floor without changing what shipcheck checks.
+
+```go
+// internal/cli/<command>.go — replace <command> with the kebab leaf
+// of NovelFeature.Command (e.g., "issues stale" → "issues_stale.go").
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	// add: "encoding/json", "fmt", "<module>/internal/store", etc. as needed
+)
+
+func newXxxCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "<leaf-of-Command>",                    // e.g. "stale" for "issues stale"
+		Short:   "<NovelFeature.Description, one line>", // truncate to ~70 chars
+		Long:    "<optional: Description + WhyItMatters>", // omit if Short is enough
+		Example: "  <cli>-pp-cli <Command> --json",       // from NovelFeature.Example
+		Annotations: map[string]string{
+			// Set "mcp:read-only": "true" only when the command does NOT mutate
+			// external state (lookups, comparisons, aggregations, render views).
+			// Omit the whole map for commands that mutate (post, delete, write file).
+			"mcp:read-only": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Pick the matching RunE skeleton below (API-call or store-query),
+			// then implement the feature-specific path/query/parsing/formatting.
+			return nil
+		},
+	}
+	// cmd.Flags().StringVar(...) — add flags from the planned --flag list, if any
+	return cmd
+}
+
+// Multi-word Commands like "issues stale": this constructor is registered as
+// a child of the matching spec-resource parent (newIssuesCmd) — wire the
+// AddCommand call inside root.go via local-variable capture:
+//   issuesCmd := newIssuesCmd(flags)
+//   issuesCmd.AddCommand(newIssuesStaleCmd(flags))
+//   rootCmd.AddCommand(issuesCmd)
+// Single-word Commands register directly: rootCmd.AddCommand(newXxxCmd(flags)).
+```
+
+**RunE skeleton — API-call shape** (live data via the generated client):
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+	c, err := flags.newClient()
+	if err != nil {
+		return err
+	}
+	// Replace path with the absorbed endpoint or hand-rolled URL. Use
+	// cliutil.FanoutRun for any --site/--source/--region CSV fan-out;
+	// re-implementing fanout inline is the recipe-goat silent-drop bug.
+	data, err := c.Get("/api/v1/path", nil)
+	if err != nil {
+		return fmt.Errorf("fetching <resource>: %w", err)
+	}
+	// Parse data into your feature's view. Use cliutil.CleanText for any
+	// text extracted from HTML or schema.org JSON-LD; re-implementing
+	// HTML-entity unescape inline is the &#39; bug class.
+	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		wrapped, err := wrapWithProvenance(data, DataProvenance{Source: "live"})
+		if err != nil {
+			return err
+		}
+		return printOutput(cmd.OutOrStdout(), wrapped, true)
+	}
+	// Human/terminal output. printTable / printRows helpers in cliutil.
+	return nil
+},
+```
+
+**RunE skeleton — store-query shape** (offline data via the local SQLite):
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+	db, err := store.OpenWithContext(cmd.Context(), dbPath())
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer db.Close()
+	// Replace the query with your aggregation. The store schema mirrors
+	// the synced resources; `printing-press dogfood --json` shows the
+	// table list. SQL must be SELECT-only; the search/sql gates reject
+	// mutating statements.
+	rows, err := db.DB().QueryContext(cmd.Context(), `SELECT id, data FROM <table> WHERE ...`)
+	if err != nil {
+		return fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+	// Scan rows into your feature's view.
+	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+		// Marshal results (non-nil empty slice → "[]", not "null").
+		// Match the search/sql convention: always emit a valid envelope.
+		return nil
+	}
+	// Human/terminal output.
+	return nil
+},
+```
+
+For features that combine both (cache an API response in the store, or fall through to live when the local store is stale), nest one skeleton inside the other and use the `--data-source auto/local/live` flag pattern from the generated `sync` command.
+
 **Shared helpers available to novel code:** The generator emits `internal/cliutil/` in every CLI. When authoring novel commands, prefer `cliutil.FanoutRun` for any aggregation command (any `--site`/`--source`/`--region` CSV fan-out) and `cliutil.CleanText` for any text extracted from HTML or schema.org JSON-LD. Re-implementing these inline is how recipe-goat's trending silent-drop and `&#39;` entity bugs shipped.
 
 **MCP exposure:** The generator emits `internal/mcp/cobratree/`, and the MCP binary mirrors the Cobra tree at startup. When you add, rename, or remove a user-facing Cobra command, the MCP surface follows automatically. Two annotations control how each command appears as an MCP tool:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1992,14 +1992,13 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	// Parse data into your feature's view. Use cliutil.CleanText for any
 	// text extracted from HTML or schema.org JSON-LD; re-implementing
 	// HTML-entity unescape inline is the &#39; bug class.
-	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
-		wrapped, err := wrapWithProvenance(data, DataProvenance{Source: "live"})
-		if err != nil {
-			return err
-		}
-		return printOutput(cmd.OutOrStdout(), wrapped, true)
+	var view yourViewType // = parse(data)
+	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(view)
 	}
-	// Human/terminal output. printTable / printRows helpers in cliutil.
+	// Human/terminal output (table or pretty print).
 	return nil
 },
 ```
@@ -2007,8 +2006,15 @@ RunE: func(cmd *cobra.Command, args []string) error {
 **RunE skeleton — store-query shape** (offline data via the local SQLite):
 
 ```go
+// Declare these alongside the cmd literal, before return cmd:
+//   var dbPath string
+//   cmd.Flags().StringVar(&dbPath, "db", "", "Database path")
+
 RunE: func(cmd *cobra.Command, args []string) error {
-	db, err := store.OpenWithContext(cmd.Context(), dbPath())
+	if dbPath == "" {
+		dbPath = defaultDBPath("<cli>-pp-cli") // replace <cli> with the API slug
+	}
+	db, err := store.OpenWithContext(cmd.Context(), dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
@@ -2022,11 +2028,11 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("query: %w", err)
 	}
 	defer rows.Close()
-	// Scan rows into your feature's view.
-	if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
-		// Marshal results (non-nil empty slice → "[]", not "null").
-		// Match the search/sql convention: always emit a valid envelope.
-		return nil
+	var results []yourRowType // scan rows into the slice
+	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
 	}
 	// Human/terminal output.
 	return nil


### PR DESCRIPTION
## Summary

Adds copy-pasteable starter templates to `skills/printing-press/SKILL.md` Phase 3 for novel-feature command wiring. The cobra literal portion is mechanical and consistent across the espn / allrecipes / hackernews / kalshi / yahoo-finance / dub novel features I sampled; this gives agents a known-good shape to copy from instead of typing from scratch.

Three blocks added, ~70 LOC of skill content:

1. **Cobra-wrapper template** — function signature, cobra.Command literal in canonical field order, comments mapping `NovelFeature` fields to cobra fields, registration guidance for single-word vs multi-word commands.
2. **RunE skeleton — API-call shape** — `flags.newClient()` + `c.Get(path)` + dual-mode output dispatch.
3. **RunE skeleton — store-query shape** — `store.OpenWithContext` + `db.QueryContext` + dual-mode output dispatch.

Plus a brief note on combining the two for hybrid features.

## What this is NOT

This is not a generator change. The generator continues to NOT produce these files. SKILL.md remains correct that "Priority 2 (transcendence) is always hand-built." The agent's Phase 3 workflow is just: copy the wrapper, copy the matching RunE skeleton, fill in path/query/parsing.

## What this replaces

Considered (and rejected) a full WU-5 in-generator stub-emission plan. Document review surfaced critical concerns:
- Real LOC saving was overstated (~25-30 LOC mechanical wiring per feature, not the 80-100 the retro framing implied)
- The skip-if-exists emission contract would break the codebase's regenerate-from-scratch invariant for the first time
- The new dogfood gate had a half-implementation hole (sentinel removed but body still trivial)
- The MCP cobra-tree-mirror plan recently moved AWAY from generated lists; WU-5 would re-introduce one
- Phase 3 cognitive load increased on net (1 simple rule → 7 edge cases)

This change captures the actual value (consistent cobra-literal shape, no Use-vs-Command drift, faster Phase 3 start) at near-zero cost — pure SKILL.md prose, no new code, no architectural commitment.

## Validation continues unchanged

All existing gates apply to the result:
- `checkNovelFeatures` (planned-vs-built)
- `reimplementation_check` (hand-rolled response detection)
- `verify` runtime tests
- Build / lint / scorecard

The templates are a floor-raiser, not a gate.

## Test plan

- [x] `go test ./...` — 2548 passing (pure-prose change, no behavioral surface)
- [x] `golangci-lint run ./...` — clean (no Go change)
- [x] Sample real novel features (espn scores/today/streak/recap/search, allrecipes search/cookbook, hackernews top, kalshi typed endpoints, yahoo-finance fundamentals/trending, dub per-domain reports) all match the wrapper shape — templates verified against shipped reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)