### PR TITLE
fix(cli): pagination cursor lookup recurses into well-known wrapper objects (#157 F3)

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1499,6 +1499,148 @@ func TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch(t *testing.T)
 // generates a spec with a typed table, then runs the generated store
 // tests — the emitted TestUpsertBatch_Populates*Table tests fail if the
 // dispatch ever regresses.
+// TestSyncExtractPaginationNestedCursor verifies that the emitted
+// extractPaginationFromEnvelope helper finds cursors hidden inside
+// well-known wrapper objects like Slack's response_metadata. Without
+// this, paginated syncs against APIs with envelope-style cursors
+// terminate after the first page even though more data is available.
+//
+// Two-tier check: the generator-level grep asserts the wrapper-key
+// recursion code shipped, and the in-CLI test (written into the
+// emitted tree at internal/cli/sync_pagination_test.go and run via
+// `go test ./internal/cli`) exercises it against real Slack-shaped
+// JSON. Either tier alone is weaker — the grep can't catch a typo
+// inside the recursion, the runtime test can't catch a refactor that
+// keeps the same code shape but breaks the cursor extraction.
+func TestSyncExtractPaginationNestedCursor(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "slacky",
+		Version: "0.1.0",
+		BaseURL: "https://slacky.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/slacky-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"messages": {
+				Description: "Messages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/messages",
+						Description: "List messages",
+						Response:    spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{
+							{Name: "channel", Type: "string"},
+							{Name: "cursor", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	src := string(syncSrc)
+
+	// Tier 1: emission canary. The wrapper-key recursion must ship.
+	assert.Contains(t, src, "paginationWrapperKeys",
+		"sync.go must declare paginationWrapperKeys for nested-cursor support")
+	assert.Contains(t, src, `"response_metadata"`,
+		"paginationWrapperKeys must include response_metadata (Slack's envelope)")
+	assert.Contains(t, src, `"pagination"`,
+		"paginationWrapperKeys must include pagination (MongoDB Atlas-style)")
+
+	// Tier 2: behavioral test, written into the generated tree as a
+	// same-package _test.go so it can call the unexported helper.
+	const inlineTest = `package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractPageItemsSlackEnvelope(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"ok": true,
+		"messages": [{"text":"hello"},{"text":"world"}],
+		"response_metadata": {"next_cursor": "abc123"}
+	}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if cursor != "abc123" {
+		t.Fatalf("want cursor abc123, got %q", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("want hasMore=true when cursor is present")
+	}
+}
+
+func TestExtractPageItemsMongoPaginationEnvelope(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"results": [{"_id":"a"},{"_id":"b"}],
+		"pagination": {"next_page_token": "tok-2"}
+	}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if cursor != "tok-2" {
+		t.Fatalf("want cursor tok-2, got %q", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("want hasMore=true when nested cursor is present")
+	}
+}
+
+// Negative case: top-level cursor should still win even when a
+// non-cursor field happens to live in a wrapper-named key.
+func TestExtractPageItemsTopLevelCursorWinsOverWrapper(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"items": [{"id":1}],
+		"next_cursor": "top-level-wins",
+		"meta": {"next_cursor": "should-not-be-used"}
+	}` + "`" + `)
+	_, cursor, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if cursor != "top-level-wins" {
+		t.Fatalf("want top-level cursor, got %q", cursor)
+	}
+}
+
+// Negative case: no cursor anywhere returns empty without spurious
+// nested matches on unrelated wrapper-named objects.
+func TestExtractPageItemsNoCursor(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"items": [{"id":1}],
+		"meta": {"count": 1, "page": 1}
+	}` + "`" + `)
+	_, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if cursor != "" {
+		t.Fatalf("want empty cursor, got %q", cursor)
+	}
+	if hasMore {
+		t.Fatalf("want hasMore=false when no cursor present")
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "sync_pagination_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "-run", "TestExtractPageItems", "./internal/cli")
+}
+
 func TestGenerateStoreUpsertBatchDispatchesToTypedTable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1499,19 +1499,11 @@ func TestGenerateStoreWithBatchResourceDoesNotDuplicateUpsertBatch(t *testing.T)
 // generates a spec with a typed table, then runs the generated store
 // tests — the emitted TestUpsertBatch_Populates*Table tests fail if the
 // dispatch ever regresses.
-// TestSyncExtractPaginationNestedCursor verifies that the emitted
-// extractPaginationFromEnvelope helper finds cursors hidden inside
-// well-known wrapper objects like Slack's response_metadata. Without
-// this, paginated syncs against APIs with envelope-style cursors
-// terminate after the first page even though more data is available.
-//
-// Two-tier check: the generator-level grep asserts the wrapper-key
-// recursion code shipped, and the in-CLI test (written into the
-// emitted tree at internal/cli/sync_pagination_test.go and run via
-// `go test ./internal/cli`) exercises it against real Slack-shaped
-// JSON. Either tier alone is weaker — the grep can't catch a typo
-// inside the recursion, the runtime test can't catch a refactor that
-// keeps the same code shape but breaks the cursor extraction.
+// TestSyncExtractPaginationNestedCursor verifies the emitted
+// extractPaginationFromEnvelope finds cursors inside well-known wrapper
+// objects (Slack response_metadata, etc.). Combines a generator-level
+// emission canary with a behavioral test written into the generated
+// tree, since either tier alone misses real regressions.
 func TestSyncExtractPaginationNestedCursor(t *testing.T) {
 	t.Parallel()
 
@@ -1604,6 +1596,27 @@ func TestExtractPageItemsMongoPaginationEnvelope(t *testing.T) {
 	}
 }
 
+// Fast path: top-level cursor with no wrapper present at all. Proves
+// the common case (Stripe, GitHub, Linear, Notion) doesn't enter the
+// wrapper recursion. Pairs with TopLevelCursorWinsOverWrapper which
+// pairs both forms; this isolates the no-wrapper shape.
+func TestExtractPageItemsTopLevelCursorOnly(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"items": [{"id":1},{"id":2}],
+		"next_cursor": "page-2"
+	}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if cursor != "page-2" {
+		t.Fatalf("want top-level cursor page-2, got %q", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("want hasMore=true when cursor is present")
+	}
+}
+
 // Negative case: top-level cursor should still win even when a
 // non-cursor field happens to live in a wrapper-named key.
 func TestExtractPageItemsTopLevelCursorWinsOverWrapper(t *testing.T) {
@@ -1637,8 +1650,8 @@ func TestExtractPageItemsNoCursor(t *testing.T) {
 	testPath := filepath.Join(outputDir, "internal", "cli", "sync_pagination_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
-	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "test", "-run", "TestExtractPageItems", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestExtractPageItems", "./internal/cli")
 }
 
 func TestGenerateStoreUpsertBatchDispatchesToTypedTable(t *testing.T) {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -616,7 +616,6 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
 func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
-	var nextCursor string
 	var hasMore bool
 
 	// Try common cursor field names
@@ -624,15 +623,7 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 		"next_cursor", "nextCursor", "cursor", "next_page_token",
 		"nextPageToken", "page_token", "after", "end_cursor", "endCursor",
 	}
-	for _, key := range cursorKeys {
-		if raw, ok := envelope[key]; ok {
-			var s string
-			if err := json.Unmarshal(raw, &s); err == nil && s != "" {
-				nextCursor = s
-				break
-			}
-		}
-	}
+	nextCursor := findCursorInMap(envelope, cursorKeys)
 
 	// If no top-level cursor was found, look one level deeper into well-known
 	// pagination wrapper objects. Slack returns {"messages":[...],
@@ -651,16 +642,8 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 			if json.Unmarshal(rawWrapper, &inner) != nil {
 				continue
 			}
-			for _, key := range cursorKeys {
-				if rawCursor, ok := inner[key]; ok {
-					var s string
-					if err := json.Unmarshal(rawCursor, &s); err == nil && s != "" {
-						nextCursor = s
-						break
-					}
-				}
-			}
-			if nextCursor != "" {
+			if c := findCursorInMap(inner, cursorKeys); c != "" {
+				nextCursor = c
 				break
 			}
 		}
@@ -682,6 +665,24 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	}
 
 	return nextCursor, hasMore
+}
+
+// findCursorInMap returns the first non-empty string-typed value in m
+// whose key matches one of cursorKeys. Used by extractPaginationFromEnvelope
+// to scan both the top-level envelope and well-known wrapper objects with
+// the same name-match rules — extracted so the two scans can't drift.
+func findCursorInMap(m map[string]json.RawMessage, cursorKeys []string) string {
+	for _, key := range cursorKeys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // upsertSingleObject stores a non-array API response as a single record.

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -634,6 +634,38 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 		}
 	}
 
+	// If no top-level cursor was found, look one level deeper into well-known
+	// pagination wrapper objects. Slack returns {"messages":[...],
+	// "response_metadata":{"next_cursor":"..."}}; MongoDB Atlas uses
+	// "pagination"; many APIs use "meta" or "paging". Purely additive — only
+	// runs when the top-level scan returned empty — and uses the same
+	// cursorKeys set so wrapper contents go through the same name match.
+	if nextCursor == "" {
+		paginationWrapperKeys := []string{"response_metadata", "pagination", "meta", "paging"}
+		for _, wrapperKey := range paginationWrapperKeys {
+			rawWrapper, ok := envelope[wrapperKey]
+			if !ok {
+				continue
+			}
+			var inner map[string]json.RawMessage
+			if json.Unmarshal(rawWrapper, &inner) != nil {
+				continue
+			}
+			for _, key := range cursorKeys {
+				if rawCursor, ok := inner[key]; ok {
+					var s string
+					if err := json.Unmarshal(rawCursor, &s); err == nil && s != "" {
+						nextCursor = s
+						break
+					}
+				}
+			}
+			if nextCursor != "" {
+				break
+			}
+		}
+	}
+
 	// Try common has_more field names
 	hasMoreKeys := []string{"has_more", "hasMore", "has_next", "hasNext", "next_page"}
 	for _, key := range hasMoreKeys {


### PR DESCRIPTION
## Summary

Closes the last open finding from [#157](https://github.com/mvanhorn/cli-printing-press/issues/157) (Slack retro — F3, nested cursor objects not handled in pagination).

## Background

Slack-style pagination puts the cursor inside a `response_metadata` envelope:

```json
{
  "ok": true,
  "messages": [...],
  "response_metadata": {"next_cursor": "abc123"}
}
```

`extractPaginationFromEnvelope` only checked top-level keys, so paginated syncs against Slack / MongoDB Atlas / similar APIs terminated after the first page even though more data was available. The old path didn't fail loudly — `nextCursor` stayed empty, `hasMore` stayed false, sync silently stopped.

## What changed

When no top-level cursor is found, look one level deeper into well-known wrapper objects (`response_metadata`, `pagination`, `meta`, `paging`) using the same `cursorKeys` set the top-level scan uses. Purely additive — only runs when the existing path returned empty, so APIs with top-level cursors (Stripe, GitHub, Linear, Notion) hit the fast path and short-circuit.

## Cross-API confidence

This is an industry-standard envelope pattern:

- Slack: `response_metadata.next_cursor`
- MongoDB Atlas: `pagination.next_page_token`
- Several REST APIs: `meta.next_cursor` or `paging.cursor`

The fix actively widens compatibility without changing behavior for APIs that already worked.

## Test plan

- [x] **TestSyncExtractPaginationNestedCursor** combines two tiers:
  - **Tier 1 (emission canary):** generator-level grep asserts the wrapper-key recursion code shipped (`paginationWrapperKeys`, `response_metadata`, `pagination`).
  - **Tier 2 (behavioral test):** writes a same-package `_test.go` into the generated `internal/cli/` and runs `go test -run TestExtractPageItems`. Four cases:
    - Slack envelope (positive — `response_metadata.next_cursor` extracted)
    - MongoDB envelope (positive — `pagination.next_page_token` extracted)
    - Top-level cursor wins over wrapper (negative — proves the existing path still short-circuits)
    - No cursor anywhere (negative — proves no spurious match on `meta: {count: 1}`)
- [x] `go test ./...` — 2549 tests across 28 packages, all green
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `scripts/golden.sh verify` — 9 cases pass (no fixture changes; the standard golden fixture doesn't exercise sync)

## Status of retro #157 after this PR

| WU | Title | Status |
|---|---|---|
| WU-1 F2 | Smart wrapper-key extraction | done by intervening work |
| WU-1 F3 | Nested cursor objects | **done HERE** |
| WU-2 | Parent-child dependent sync | done by intervening work |
| WU-3 | SQLite nested-query safety | done by intervening work |
| WU-4 | Resource priority for large specs | effectively done — cap raised 50→500 |
| WU-5 | Swagger 2.0 auth scoring | done by intervening work |

All 5 work units now resolved. Issue #157 will be closed when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)