### PR TITLE
fix(cli): unbreak HasStore + non-GET promoted commands (#425)

### DIFF
--- a/internal/generator/promoted_poststore_test.go
+++ b/internal/generator/promoted_poststore_test.go
@@ -11,18 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPromotedHasStorePostRoutesThroughVerbBranch guards #425's interim
-// fix: a HasStore + POST endpoint emitted as a promoted command must
-// route through c.Post (live API call) instead of resolveRead, which is
-// GET-only internally. Pre-fix the template called resolveRead unconditionally
-// for HasStore and produced broken code (params built but no body, calling
-// a POST endpoint as if it were GET-with-params).
-//
-// The cached-read path for POST searches needs a body-aware helper
-// (resolvePostRead) that doesn't exist yet. Until a second store-backed
-// POST-search consumer ships, the promoted command makes a live call —
-// no worse than the typed `<resource> <endpoint>` form, which has the
-// same behavior for the same shape.
+// TestPromotedHasStorePostRoutesThroughVerbBranch is #425's interim-fix
+// guard: HasStore + POST must route through c.Post (live API call) rather
+// than resolveRead, which is GET-only internally. Pre-fix the template
+// emitted resolveRead unconditionally for HasStore and produced
+// uncompilable code for non-GET endpoints.
 func TestPromotedHasStorePostRoutesThroughVerbBranch(t *testing.T) {
 	t.Parallel()
 
@@ -57,16 +50,16 @@ func TestPromotedHasStorePostRoutesThroughVerbBranch(t *testing.T) {
 	got := string(src)
 
 	assert.NotContains(t, got, "resolveRead(",
-		"HasStore + POST must NOT route through resolveRead (GET-only internally; was the broken pre-fix behavior)")
+		"HasStore + POST must NOT route through resolveRead (GET-only internally)")
 	assert.Contains(t, got, "c.Post(path, body)",
-		"HasStore + POST must route through the verb branch with a built body, mirroring command_endpoint.go.tmpl")
+		"HasStore + POST must route through the verb branch with a built body")
+	assert.Contains(t, got, `attachFreshness(DataProvenance{Source: "live"}, flags)`,
+		"non-GET HasStore commands must synthesize a live-call prov so the downstream HasStore block compiles")
 }
 
-// TestPromotedHasStoreGetStillUsesResolveRead is the byte-compat guard:
-// the fix narrows the resolveRead branch to GET only, and we want to
-// confirm GET endpoints (the existing happy path) keep routing through
-// resolveRead. The golden harness also covers this; the test is a
-// faster, more explicit signal when the template gate gets touched.
+// TestPromotedHasStoreGetStillUsesResolveRead is the byte-compat guard for
+// the GET happy path. The golden harness also covers this; the assertion
+// is faster and more explicit when the template gate gets touched.
 func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
 	t.Parallel()
 
@@ -98,4 +91,45 @@ func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
 		"HasStore + GET must keep routing through resolveRead (the cached fast-path)")
 	assert.NotContains(t, got, "c.Get(path, params)",
 		"HasStore + GET must not also emit a direct c.Get call (would mean both branches fired)")
+}
+
+// TestPromotedHasStoreDeleteSynthesizesProv covers the DELETE branch the
+// other tests don't reach. The provenance synthesis lives in a single
+// post-chain block, so a regression that drops it from one verb shape
+// drops it from all of them — but DELETE has its own pre-existing
+// `data, _, err := c.Delete(path)` call site, so an explicit assertion
+// guards against template refactors that re-introduce the dup.
+func TestPromotedHasStoreDeleteSynthesizesProv(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("delstore")
+	apiSpec.Resources = map[string]spec.Resource{
+		"sessions": {
+			Description: "Session management",
+			Endpoints: map[string]spec.Endpoint{
+				"revokeAll": {
+					Method:      "DELETE",
+					Path:        "/sessions",
+					Description: "Revoke all active sessions",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	promotedPath := filepath.Join(outputDir, "internal", "cli", "promoted_sessions.go")
+	src, err := os.ReadFile(promotedPath)
+	require.NoError(t, err)
+	got := string(src)
+
+	assert.NotContains(t, got, "resolveRead(",
+		"HasStore + DELETE must NOT route through resolveRead")
+	assert.Contains(t, got, "c.Delete(path)",
+		"HasStore + DELETE must route through c.Delete")
+	assert.Contains(t, got, `attachFreshness(DataProvenance{Source: "live"}, flags)`,
+		"HasStore + DELETE must synthesize a live-call prov for the downstream provenance block")
 }

--- a/internal/generator/promoted_poststore_test.go
+++ b/internal/generator/promoted_poststore_test.go
@@ -1,0 +1,101 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v3/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v3/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromotedHasStorePostRoutesThroughVerbBranch guards #425's interim
+// fix: a HasStore + POST endpoint emitted as a promoted command must
+// route through c.Post (live API call) instead of resolveRead, which is
+// GET-only internally. Pre-fix the template called resolveRead unconditionally
+// for HasStore and produced broken code (params built but no body, calling
+// a POST endpoint as if it were GET-with-params).
+//
+// The cached-read path for POST searches needs a body-aware helper
+// (resolvePostRead) that doesn't exist yet. Until a second store-backed
+// POST-search consumer ships, the promoted command makes a live call —
+// no worse than the typed `<resource> <endpoint>` form, which has the
+// same behavior for the same shape.
+func TestPromotedHasStorePostRoutesThroughVerbBranch(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("poststore")
+	apiSpec.Resources = map[string]spec.Resource{
+		"searches": {
+			Description: "Search across resources by free-text query",
+			Endpoints: map[string]spec.Endpoint{
+				"searchAll": {
+					Method:      "POST",
+					Path:        "/search-all",
+					Description: "Search by free-text query across all entities",
+					Body: []spec.Param{
+						{Name: "query", Type: "string", Description: "Free-text query"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	promotedPath := filepath.Join(outputDir, "internal", "cli", "promoted_searches.go")
+	require.FileExists(t, promotedPath,
+		"single-endpoint POST resource with read-shaped operationId 'searchAll' must produce a promoted command")
+
+	src, err := os.ReadFile(promotedPath)
+	require.NoError(t, err)
+	got := string(src)
+
+	assert.NotContains(t, got, "resolveRead(",
+		"HasStore + POST must NOT route through resolveRead (GET-only internally; was the broken pre-fix behavior)")
+	assert.Contains(t, got, "c.Post(path, body)",
+		"HasStore + POST must route through the verb branch with a built body, mirroring command_endpoint.go.tmpl")
+}
+
+// TestPromotedHasStoreGetStillUsesResolveRead is the byte-compat guard:
+// the fix narrows the resolveRead branch to GET only, and we want to
+// confirm GET endpoints (the existing happy path) keep routing through
+// resolveRead. The golden harness also covers this; the test is a
+// faster, more explicit signal when the template gate gets touched.
+func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("getstore")
+	apiSpec.Resources = map[string]spec.Resource{
+		"status": {
+			Description: "Public status",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/status",
+					Description: "Get current status",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	promotedPath := filepath.Join(outputDir, "internal", "cli", "promoted_status.go")
+	src, err := os.ReadFile(promotedPath)
+	require.NoError(t, err)
+	got := string(src)
+
+	assert.Contains(t, got, "resolveRead(",
+		"HasStore + GET must keep routing through resolveRead (the cached fast-path)")
+	assert.NotContains(t, got, "c.Get(path, params)",
+		"HasStore + GET must not also emit a direct c.Get call (would mean both branches fired)")
+}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -136,7 +136,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			}, nil, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- end}}
 {{- else}}
-{{- if or .HasStore (eq (upper .Endpoint.Method) "GET") (eq (upper .Endpoint.Method) "HEAD") (eq (upper .Endpoint.Method) "OPTIONS")}}
+{{- if or (eq (upper .Endpoint.Method) "GET") (eq (upper .Endpoint.Method) "HEAD") (eq (upper .Endpoint.Method) "OPTIONS")}}
 			params := map[string]string{}
 {{- range $i, $p := .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
@@ -149,23 +149,34 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- end}}
-{{- if .HasStore}}
-			// resolveRead is GET-only internally, so HasStore + non-GET should
-			// be marked Hidden in the printed CLI and reached via the typed
-			// `<resource> <endpoint>` form instead.
+{{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{if .Endpoint.Pagination}}true{{else}}false{{end}}, path, params, nil)
 {{- else if eq (upper .Endpoint.Method) "GET"}}
 			data, err := c.Get(path, params)
 {{- else if eq (upper .Endpoint.Method) "DELETE"}}
 			data, _, err := c.Delete(path)
+{{- if .HasStore}}
+			// Synthesize a live-call provenance so the downstream HasStore
+			// block has a `prov` to pass into printProvenance and
+			// wrapWithProvenance — non-GET verbs never round-trip through
+			// resolveRead (GET-only) yet still need the same output shape.
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
+{{- end}}
 {{- else if or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")}}
 			// Build the JSON body from --field flags. Query/path params
 			// are intentionally not folded into the body here — the typed
 			// `<resource> <endpoint>` command is the place to combine
 			// query params with body for non-GET verbs. Promoted commands
-			// cover the common case: body-only POST/PUT/PATCH.
+			// cover the common case: body-only POST/PUT/PATCH. HasStore +
+			// non-GET falls through here (live API call) rather than
+			// resolveRead, which is GET-only internally; a body-aware
+			// cached read helper is filed as #425 for when a second
+			// store-backed POST-search consumer ships.
 			body := map[string]any{}
 {{bodyMap .Endpoint.Body "\t\t\t"}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}(path, body)
+{{- if .HasStore}}
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
+{{- end}}
 {{- else}}
 			// HEAD/OPTIONS and unknown verbs fall back to GET so generation
 			// stays compileable. Spec authors who genuinely need these verbs

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -155,33 +155,21 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, err := c.Get(path, params)
 {{- else if eq (upper .Endpoint.Method) "DELETE"}}
 			data, _, err := c.Delete(path)
-{{- if .HasStore}}
-			// Synthesize a live-call provenance so the downstream HasStore
-			// block has a `prov` to pass into printProvenance and
-			// wrapWithProvenance — non-GET verbs never round-trip through
-			// resolveRead (GET-only) yet still need the same output shape.
-			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
-{{- end}}
 {{- else if or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")}}
-			// Build the JSON body from --field flags. Query/path params
-			// are intentionally not folded into the body here — the typed
-			// `<resource> <endpoint>` command is the place to combine
-			// query params with body for non-GET verbs. Promoted commands
-			// cover the common case: body-only POST/PUT/PATCH. HasStore +
-			// non-GET falls through here (live API call) rather than
-			// resolveRead, which is GET-only internally; a body-aware
-			// cached read helper is filed as #425 for when a second
-			// store-backed POST-search consumer ships.
+			// HasStore + non-GET falls through to a live API call here
+			// rather than through resolveRead (GET-only internally); a
+			// body-aware cached read helper is filed as #425 for when a
+			// second store-backed POST-search consumer ships.
 			body := map[string]any{}
 {{bodyMap .Endpoint.Body "\t\t\t"}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}(path, body)
-{{- if .HasStore}}
-			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
-{{- end}}
 {{- else}}
 			// HEAD/OPTIONS and unknown verbs fall back to GET so generation
 			// stays compileable. Spec authors who genuinely need these verbs
 			// should add a typed client method and a dedicated template branch.
 			data, err := c.Get(path, params)
+{{- end}}
+{{- if and .HasStore (ne (upper .Endpoint.Method) "GET")}}
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 {{- end}}
 {{- end}}
 			if err != nil {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -27,9 +27,6 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/public/status"
 			params := map[string]string{}
-			// resolveRead is GET-only internally, so HasStore + non-GET should
-			// be marked Hidden in the printed CLI and reached via the typed
-			// `<resource> <endpoint>` form instead.
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "public", false, path, params, nil)
 			if err != nil {
 				return classifyAPIError(err)


### PR DESCRIPTION
## Summary

`postman-explore-pp-cli`'s `search-all` command was shipping uncompilable code: HasStore + POST endpoints in the promoted-command template called `resolveRead` (GET-only), which produced `params := ...` with no body and tried to GET a POST-only endpoint. The `loops` golden fixture also failed to compile (`undefined: prov` in `promoted_emails.go`).

Fix narrows the `resolveRead` branch to GET only, mirroring the typed-form pattern in `command_endpoint.go.tmpl`. HasStore + non-GET now falls through to the verb branch (`c.Post` / `c.Put` / `c.Patch` / `c.Delete`) with a synthesized `prov := attachFreshness(DataProvenance{Source: "live"}, flags)` so the downstream HasStore provenance UI keeps compiling and producing consistent JSON output.

## Scope: interim, not the full #425 fix

This is the smaller of two viable fixes for #425. The full fix — a body-aware `resolvePostRead` helper that hashes the canonical JSON body into a cache key — is left for the follow-on work, when a second store-backed POST-search consumer materializes to inform the cache-key design.

Today only `postman-explore-pp-cli` exercises HasStore + POST, and a live API call is no worse than the typed `<resource> <endpoint>` form, which has the same behavior for the same shape. Building the cached path now would mean designing canonical-body hashing, TTL semantics, and "different body but same logical query" behavior in a vacuum.

## Test plan

3 new unit tests in `internal/generator/promoted_poststore_test.go` cover the verb-method matrix:

- `TestPromotedHasStorePostRoutesThroughVerbBranch` — POST + HasStore emits `c.Post(path, body)` and a synthesized prov, never `resolveRead`.
- `TestPromotedHasStoreGetStillUsesResolveRead` — byte-compat guard for the GET happy path.
- `TestPromotedHasStoreDeleteSynthesizesProv` — DELETE branch coverage (the existing `TestGenerateProjectsCompile` fixtures all run with `VisionSet.Store = false`, so DELETE+HasStore had no compile coverage).

Goldens lose 3 lines from `printing-press-golden/internal/cli/promoted_public.go` — a stale comment that no longer describes template behavior. Generated code itself is byte-identical for HasStore + GET.

Closes #425

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)