### PR TITLE
fix(regenmerge): semantic dedup for AddCommand calls

### DIFF
--- a/internal/pipeline/regenmerge/registrations.go
+++ b/internal/pipeline/regenmerge/registrations.go
@@ -174,20 +174,46 @@ func formatCallExpr(fset *token.FileSet, ce *ast.CallExpr) (addCommandCall, erro
 	}
 	src := buf.String()
 
-	// Normalize: collapse internal whitespace into single spaces. This
-	// makes `rootCmd.AddCommand(newX(flags))` and the same call across
-	// formatting differences match for set-comparison.
-	normalized := strings.Join(strings.Fields(src), " ")
-
-	// Infer constructor name from the first argument: usually
-	// `newX(args...)` — extract `newX`.
+	// Infer the constructor name from the first argument. Two shapes:
+	//  - `newX(args...)` — extract `newX` from the *ast.CallExpr.
+	//  - `someCmd` — bare ident, treat the ident as the constructor.
 	var ctor string
 	if len(ce.Args) > 0 {
-		if argCall, ok := ce.Args[0].(*ast.CallExpr); ok {
-			if id, ok := argCall.Fun.(*ast.Ident); ok {
+		switch arg := ce.Args[0].(type) {
+		case *ast.CallExpr:
+			if id, ok := arg.Fun.(*ast.Ident); ok {
 				ctor = id.Name
 			}
+		case *ast.Ident:
+			ctor = arg.Name
 		}
+	}
+
+	// Extract the parent receiver: `rootCmd.AddCommand(...)` -> `rootCmd`.
+	// Only handles bare-ident receivers; chained calls fall through to the
+	// text-based fallback below.
+	var parent string
+	if sel, ok := ce.Fun.(*ast.SelectorExpr); ok {
+		if id, ok := sel.X.(*ast.Ident); ok {
+			parent = id.Name
+		}
+	}
+
+	// Semantic dedup key: <parent>.AddCommand(<ctor>). Treats
+	// `rootCmd.AddCommand(newX(flags))` and `rootCmd.AddCommand(newX(&flags))`
+	// as the same call — template generations regularly tweak the
+	// argument shape (pointer vs value, added context arg, etc.) without
+	// changing the registration's identity. A pure text comparison would
+	// flag the older form as "lost" and re-inject it on top of the newer
+	// form, producing duplicate cobra registrations at runtime.
+	//
+	// When parent or ctor can't be cleanly extracted (chained calls,
+	// inline command literals), fall back to whitespace-collapsed source.
+	var normalized string
+	if parent != "" && ctor != "" {
+		normalized = parent + ".AddCommand(" + ctor + ")"
+	} else {
+		normalized = strings.Join(strings.Fields(src), " ")
 	}
 
 	return addCommandCall{source: src, normalized: normalized, constructorName: ctor}, nil

--- a/internal/pipeline/regenmerge/registrations.go
+++ b/internal/pipeline/regenmerge/registrations.go
@@ -207,6 +207,13 @@ func formatCallExpr(fset *token.FileSet, ce *ast.CallExpr) (addCommandCall, erro
 	// flag the older form as "lost" and re-inject it on top of the newer
 	// form, producing duplicate cobra registrations at runtime.
 	//
+	// Limitation: AddCommand is variadic. A multi-arg call like
+	// `rootCmd.AddCommand(newA(), newB(), newC())` fingerprints by the
+	// first ctor only, so additional args don't participate in the
+	// lost-set comparison. Cobra projects almost universally use one
+	// AddCommand call per command, so this hasn't bitten in practice;
+	// revisit if a template starts emitting multi-arg form.
+	//
 	// When parent or ctor can't be cleanly extracted (chained calls,
 	// inline command literals), fall back to whitespace-collapsed source.
 	var normalized string

--- a/internal/pipeline/regenmerge/registrations_test.go
+++ b/internal/pipeline/regenmerge/registrations_test.go
@@ -149,6 +149,35 @@ func newRssCmd(rootFlags) *cobra.Command  { return nil }
 	assert.Empty(t, regs, "arg-shape variation alone should not produce lost registrations")
 }
 
+// TestExtractLostRegistrationsChainedCallFallback pins the fallback contract:
+// when a parent receiver isn't a bare ident (e.g., `getRoot().AddCommand(...)`
+// where the AST root is *ast.CallExpr, not *ast.Ident), the semantic key
+// extraction can't apply, so the call falls back to whitespace-collapsed
+// source comparison. Identical chained calls in pub+fresh must still match
+// under that fallback.
+func TestExtractLostRegistrationsChainedCallFallback(t *testing.T) {
+	t.Parallel()
+
+	chainedCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func getRoot() *cobra.Command { return &cobra.Command{Use: "x"} }
+
+func Execute() {
+	getRoot().AddCommand(newSubCmd())
+}
+
+func newSubCmd() *cobra.Command { return nil }
+`
+	pubDir, freshDir := buildSyntheticFixture(t,
+		map[string]string{"internal/cli/root.go": chainedCLI},
+		map[string]string{"internal/cli/root.go": chainedCLI})
+	regs, err := extractLostRegistrations(pubDir, freshDir)
+	require.NoError(t, err)
+	assert.Empty(t, regs, "identical chained-call AddCommand should match via text fallback")
+}
+
 // TestExtractLostRegistrationsDistinguishesParents pins the other half of the
 // semantic dedup contract: two calls with the same constructor but different
 // parent receivers are distinct registrations and must not be deduped.

--- a/internal/pipeline/regenmerge/registrations_test.go
+++ b/internal/pipeline/regenmerge/registrations_test.go
@@ -99,3 +99,98 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+// TestExtractLostRegistrationsArgShapeNoFalsePositives is the regression test
+// for the pypi dogfood finding: a templated AddCommand call where the new
+// template tweaked the argument shape (e.g., `flags` -> `&flags`, or `c`
+// -> `cmd.Context(), c`) must NOT flag the published form as "lost". Pure
+// text comparison would, and the call would be re-injected on top of fresh's
+// existing call producing duplicate cobra registrations at runtime.
+func TestExtractLostRegistrationsArgShapeNoFalsePositives(t *testing.T) {
+	t.Parallel()
+
+	pubCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	flags := &rootFlags{}
+	rootCmd.AddCommand(newPypiCmd(&flags))
+	rootCmd.AddCommand(newRssCmd(&flags))
+	_ = rootCmd.Execute()
+}
+
+type rootFlags struct{}
+func newPypiCmd(*rootFlags) *cobra.Command { return nil }
+func newRssCmd(*rootFlags) *cobra.Command  { return nil }
+`
+	freshCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	flags := rootFlags{}
+	rootCmd.AddCommand(newPypiCmd(flags))
+	rootCmd.AddCommand(newRssCmd(flags))
+	_ = rootCmd.Execute()
+}
+
+type rootFlags struct{}
+func newPypiCmd(rootFlags) *cobra.Command { return nil }
+func newRssCmd(rootFlags) *cobra.Command  { return nil }
+`
+	pubDir, freshDir := buildSyntheticFixture(t,
+		map[string]string{"internal/cli/root.go": pubCLI},
+		map[string]string{"internal/cli/root.go": freshCLI})
+	regs, err := extractLostRegistrations(pubDir, freshDir)
+	require.NoError(t, err)
+	assert.Empty(t, regs, "arg-shape variation alone should not produce lost registrations")
+}
+
+// TestExtractLostRegistrationsDistinguishesParents pins the other half of the
+// semantic dedup contract: two calls with the same constructor but different
+// parent receivers are distinct registrations and must not be deduped.
+func TestExtractLostRegistrationsDistinguishesParents(t *testing.T) {
+	t.Parallel()
+
+	pubCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	parentCmd := &cobra.Command{Use: "p"}
+	rootCmd.AddCommand(parentCmd)
+	parentCmd.AddCommand(newSubCmd())
+	_ = rootCmd.Execute()
+}
+
+func newSubCmd() *cobra.Command { return nil }
+`
+	freshCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newSubCmd())
+	_ = rootCmd.Execute()
+}
+
+func newSubCmd() *cobra.Command { return nil }
+`
+	pubDir, freshDir := buildSyntheticFixture(t,
+		map[string]string{"internal/cli/root.go": pubCLI},
+		map[string]string{"internal/cli/root.go": freshCLI})
+	regs, err := extractLostRegistrations(pubDir, freshDir)
+	require.NoError(t, err)
+
+	// pub registers newSubCmd under parentCmd; fresh registers it under
+	// rootCmd. These are distinct registrations — pub's parentCmd-attached
+	// call should be flagged as lost.
+	require.Len(t, regs, 1, "parentCmd's distinct registration of newSubCmd must be flagged")
+	assert.Contains(t, regs[0].Calls, "parentCmd.AddCommand(newSubCmd())",
+		"lost call should preserve the parentCmd parent (not deduped against rootCmd's call)")
+}


### PR DESCRIPTION
## Summary

Fixes a false-positive class in regen-merge's lost-AddCommand detection. The previous text-based normalizer treated `rootCmd.AddCommand(newPypiCmd(&flags))` and `rootCmd.AddCommand(newPypiCmd(flags))` as different calls, even though they register the same constructor under the same parent. Across template generations the argument shape regularly drifts (pointer vs value, added \`context.Context\` arg, etc.) without changing the registration's identity.

The bug surfaced during the first dogfood of regen-merge against `library/developer-tools/pypi`: 10 calls in `root.go` were flagged as "lost" when in fact fresh's `root.go` had every one of them — just with the new `flags` shape. Apply would have re-injected all 10 on top of fresh's existing calls, producing duplicate cobra registrations and a runtime panic on first command invocation.

## Fix

Replace the whitespace-collapse normalizer with a `<parent>.AddCommand(<ctor>)` semantic fingerprint extracted from the AST:

- Parent receiver: bare ident left of `.AddCommand` (e.g., \`rootCmd\`, \`parentCmd\`)
- Constructor: ident from `arg[0]` — supports both `newFooCmd(args)` (call expression) and `someCmd` (bare variable)
- Falls back to whitespace-collapsed source when either part can't be cleanly extracted (chained calls, inline command literals)

## Tests

- `TestExtractLostRegistrationsArgShapeNoFalsePositives` — pypi dogfood regression: arg-shape variation across pub/fresh produces zero lost registrations
- `TestExtractLostRegistrationsDistinguishesParents` — same constructor under different parent receivers stays distinct (no over-dedup)

## Test plan

- [x] `go test ./...` (2618 pass)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/pipeline/regenmerge/...` clean
- [x] Existing 18 regenmerge tests still pass
- [ ] Re-run the pypi dogfood after merge and verify the 10 false-positive lost registrations are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)