### PR TITLE
ci(workflows): drop PR-title scope allow-list

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,11 +30,6 @@ jobs:
             build
             style
             revert
-          scopes: |
-            cli
-            skills
-            ci
-            main
           requireScope: true
           subjectPattern: ^.+$
           subjectPatternError: "PR title must have a description after the colon"


### PR DESCRIPTION
## Summary

The PR-title check rejects scopes that aren't in a 4-item allow-list (\`cli\`, \`skills\`, \`ci\`, \`main\`), even when they're real internal packages — \`regenmerge\`, \`generator\`, \`pipeline\`, \`mcpsync\`, etc. That forces PR authors to either retitle or coarsen scopes, which flattens information that's actually useful in \`git log --grep\` filtering.

\`release-please-config.json\` keys changelog sections off the conventional-commit \`type\` only — scope is unused by the release pipeline, so loosening it here has zero effect on versioning, changelog generation, or binary releases.

## Change

Drop the \`scopes:\` allow-list. Keep \`requireScope: true\` so every PR title still has to name something it touches; just don't dictate which somethings count.

## Test plan

- [ ] CI runs the updated pr-title check on this PR — verify a non-allowlisted scope (\`workflows\`) passes
- [ ] Future PRs using package-level scopes (\`regenmerge\`, \`generator\`, etc.) no longer trip the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)