### PR TITLE
fix(generator): wrapWithProvenance handles non-JSON response bodies

### DIFF
--- a/internal/cli/release_test.go
+++ b/internal/cli/release_test.go
@@ -146,8 +146,11 @@ func majorVersion(t *testing.T, v string) int {
 func TestPRTitleWorkflowAllowsReleasePleaseScope(t *testing.T) {
 	// release-please uses the target branch as the conventional-commit scope
 	// for generated release PR titles, e.g. chore(main): release 2.2.0.
-	// The PR title workflow must allow that generated title or release PRs
-	// cannot merge.
+	// The PR title workflow must accept that scope. Two valid configurations:
+	//   - explicit scopes allow-list containing "main"
+	//   - no allow-list at all (any scope passes), with requireScope: true
+	// PR #463 removed the allow-list to stop friction with package-name
+	// scopes like `regenmerge`; this test pins both shapes as acceptable.
 	data, err := os.ReadFile("../../.github/workflows/pr-title.yml")
 	require.NoError(t, err)
 
@@ -169,15 +172,16 @@ func TestPRTitleWorkflowAllowsReleasePleaseScope(t *testing.T) {
 			continue
 		}
 
-		scopes, ok := step.With["scopes"].(string)
-		require.True(t, ok, "semantic pull request action should declare scopes")
-
-		allowed := map[string]bool{}
-		for scope := range strings.FieldsSeq(scopes) {
-			allowed[scope] = true
+		if scopes, ok := step.With["scopes"].(string); ok {
+			allowed := map[string]bool{}
+			for scope := range strings.FieldsSeq(scopes) {
+				allowed[scope] = true
+			}
+			assert.True(t, allowed["main"], "scope allow-list must include 'main' for release-please PR titles")
+			return
 		}
 
-		assert.True(t, allowed["main"], "release-please PR titles use main as the scope")
+		// No allow-list — any scope is accepted, including release-please's "main".
 		return
 	}
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1250,7 +1250,12 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
-// wrapWithProvenance wraps JSON data in a provenance envelope: {"results": ..., "meta": {...}}.
+// wrapWithProvenance wraps response data in a provenance envelope:
+// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
+// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
+// text), it embeds as a JSON string so json.Marshal doesn't choke on
+// "invalid character '<'" while still passing the raw payload through to
+// the consumer.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -1265,8 +1270,12 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if prov.Freshness != nil {
 		meta["freshness"] = prov.Freshness
 	}
+	var results any = json.RawMessage(data)
+	if !json.Valid(data) {
+		results = string(data)
+	}
 	envelope := map[string]any{
-		"results": json.RawMessage(data),
+		"results": results,
 		"meta":    meta,
 	}
 	return json.Marshal(envelope)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1137,7 +1137,12 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
-// wrapWithProvenance wraps JSON data in a provenance envelope: {"results": ..., "meta": {...}}.
+// wrapWithProvenance wraps response data in a provenance envelope:
+// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
+// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
+// text), it embeds as a JSON string so json.Marshal doesn't choke on
+// "invalid character '<'" while still passing the raw payload through to
+// the consumer.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -1152,8 +1157,12 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if prov.Freshness != nil {
 		meta["freshness"] = prov.Freshness
 	}
+	var results any = json.RawMessage(data)
+	if !json.Valid(data) {
+		results = string(data)
+	}
 	envelope := map[string]any{
-		"results": json.RawMessage(data),
+		"results": results,
 		"meta":    meta,
 	}
 	return json.Marshal(envelope)


### PR DESCRIPTION
## Summary

Generator templates emit a `wrapWithProvenance` helper that JSON-marshals every response body inside a `{results, meta}` envelope. For endpoints that return XML, RSS, plain text, or any other non-JSON content type, that marshal validates the embedded `json.RawMessage` and errors with \`invalid character '<' looking for beginning of value\` — every \`--agent\` invocation against such an endpoint crashed.

Surfaced by dogfooding the pypi sweep ([library #166](https://github.com/mvanhorn/printing-press-library/pull/166)): \`rss recent-updates --agent\` failed on pypi.org's RSS feed despite the spec correctly declaring \`application/xml\` as the response content type.

## Fix

When `data` isn't valid JSON, embed it as a JSON string so the envelope marshals cleanly while still passing the raw payload through to the consumer. Valid JSON keeps its previous shape (embedded as parsed structure).

## Bonus

Also fixed `TestPRTitleWorkflowAllowsReleasePleaseScope` — left stale by [#463](https://github.com/mvanhorn/cli-printing-press/pull/463) which removed the scope allow-list the test was checking for. Updated to accept either shape (allow-list with \"main\" OR no allow-list).

## Verification

- \`go test ./...\` — 2619 pass
- \`go vet\` clean
- \`golangci-lint\` clean
- Golden fixtures updated
- End-to-end: regenerated pypi, built binary, ran \`pypi-pp-cli rss recent-updates --agent\` — now returns the full RSS XML wrapped as a JSON string under \`results\` instead of crashing

## Test plan

- [x] Existing test suite passes
- [x] Golden tests updated
- [ ] Library sweep follow-up: regenerate the affected CLIs (pypi at minimum) so they pick up the helper fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)