### PR TITLE
fix(cli): scorecard APIName drops binary suffix

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v3/internal/naming"
 	apispec "github.com/mvanhorn/cli-printing-press/v3/internal/spec"
 	"gopkg.in/yaml.v3"
 )
@@ -108,7 +109,11 @@ type CompScore struct {
 // RunScorecard evaluates generated CLI files and produces a scorecard.
 // If verifyReport is non-nil, verify results calibrate the final score.
 func RunScorecard(outputDir, pipelineDir, specPath string, verifyReport *VerifyReport) (*Scorecard, error) {
-	sc := &Scorecard{APIName: filepath.Base(outputDir)}
+	// Strip the CLI suffix because outputDir from fullrun (paths.WorkingCLIDir)
+	// and library checkouts both end in -pp-cli; APIName is the API slug,
+	// not the binary name, and lands in user-visible output (Markdown
+	// scorecard header, "Quality Scorecard:" CLI line).
+	sc := &Scorecard{APIName: naming.TrimCLISuffix(filepath.Base(outputDir))}
 
 	if err := scoreScorecardDimensions(sc, outputDir, specPath, verifyReport); err != nil {
 		return nil, err

--- a/internal/pipeline/scorecard_artifacts_test.go
+++ b/internal/pipeline/scorecard_artifacts_test.go
@@ -34,3 +34,25 @@ func TestRunScorecardLoadsResearchFromSiblingResearchDir(t *testing.T) {
 	assert.Len(t, scorecard.CompetitorScores, 1)
 	assert.FileExists(t, filepath.Join(proofsDir, "scorecard.md"))
 }
+
+// TestRunScorecardStripsCLISuffixFromAPIName — APIName lands in the
+// Markdown scorecard header and the "Quality Scorecard:" CLI line.
+// fullrun passes paths.WorkingCLIDir (always -pp-cli suffixed), and
+// library checkouts share that shape; APIName must be the bare slug,
+// not the binary name.
+func TestRunScorecardStripsCLISuffixFromAPIName(t *testing.T) {
+	parent := t.TempDir()
+	suffixedDir := filepath.Join(parent, "producthunt-pp-cli")
+	require.NoError(t, os.MkdirAll(suffixedDir, 0o755))
+
+	sc, err := RunScorecard(suffixedDir, t.TempDir(), "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "producthunt", sc.APIName, "APIName must drop the -pp-cli binary suffix")
+
+	// Bare-slug dirs (local library convention) must pass through unchanged.
+	bareDir := filepath.Join(parent, "notion")
+	require.NoError(t, os.MkdirAll(bareDir, 0o755))
+	scBare, err := RunScorecard(bareDir, t.TempDir(), "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "notion", scBare.APIName, "bare-slug dirs must pass through unchanged")
+}


### PR DESCRIPTION
## Summary

`RunScorecard` set `sc.APIName = filepath.Base(outputDir)`. The full pipeline calls it with `paths.WorkingCLIDir` (always `-pp-cli` suffixed), and library checkouts share that shape, so `APIName` carried the binary suffix into two user-visible spots: the Markdown scorecard header (`# Scorecard: producthunt-pp-cli`) and the CLI's `Quality Scorecard:` output line. Same conflation class as #487 (mcp-sync slug derivation), in a different module.

## Root cause

`internal/pipeline/scorecard.go:111` — `Scorecard{APIName: filepath.Base(outputDir)}`. `outputDir` from `internal/pipeline/fullrun.go:256` is `paths.WorkingCLIDir(apiName, runID)` → `<run>/working/<api>-pp-cli/`. `APIName` then flowed to:

- `scorecard.go:2540` — `# Scorecard: %s\n\n` Markdown header
- `internal/cli/scorecard.go:148` — `Quality Scorecard: %s\n\n` CLI output

## Fix

Use `naming.TrimCLISuffix(filepath.Base(outputDir))`, matching the established idiom at `runtime.go:116`, `emboss.go:245`, and the mcp-sync fix in #487. The helper handles `-pp-cli`, legacy `-cli`, and numeric rerun suffixes; bare-slug `outputDir` (local library convention) passes through unchanged.

## Tests

`TestRunScorecardStripsCLISuffixFromAPIName` in `scorecard_artifacts_test.go`:
- `outputDir = producthunt-pp-cli` → `sc.APIName == "producthunt"`
- `outputDir = notion` (bare slug) → `sc.APIName == "notion"` (regression guard for the local-library case)

## Verification

- `go test ./...` — 2670 passed
- `go vet ./...` — clean
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 9 cases passed

Surfaced as a follow-up in the review of #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)