### PR TITLE
fix(cli): preserve Unicode in OpenAPI display_name

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -183,15 +183,21 @@ func parse(data []byte, lenient bool) (*spec.APISpec, error) {
 
 	// Extract x-display-name extension. Carries the human-readable
 	// brand name when it differs from the slug-derived form ("Cal.com"
-	// vs "Cal Com"). Without this, the OpenAPI parser leaves
-	// DisplayName empty and downstream consumers fall back to
-	// naming.HumanName(slug), which deforms multi-word brands.
+	// vs "Cal Com"). When absent, derive a Unicode-preserving form from
+	// info.title so accented brands like "Café Bistro" or "PokéAPI"
+	// don't get flattened by EffectiveDisplayName's HumanName(slug)
+	// fallback (the slug is ASCII-folded for filesystem safety).
 	var displayName string
 	if doc.Info != nil && doc.Info.Extensions != nil {
 		if raw, ok := doc.Info.Extensions["x-display-name"]; ok {
 			if s, ok := raw.(string); ok {
 				displayName = strings.TrimSpace(s)
 			}
+		}
+	}
+	if displayName == "" && doc.Info != nil {
+		if derived := cleanSpecNameUnicode(doc.Info.Title); derived != "" && derived != "api" {
+			displayName = naming.HumanName(derived)
 		}
 	}
 
@@ -2852,7 +2858,13 @@ func toCamelCase(s string) string {
 }
 
 func toKebabCase(input string) string {
-	input = naming.ASCIIFold(input)
+	return toKebabCaseInternal(input, true)
+}
+
+func toKebabCaseInternal(input string, foldASCII bool) string {
+	if foldASCII {
+		input = naming.ASCIIFold(input)
+	}
 	var b strings.Builder
 	lastHyphen := true
 
@@ -2872,8 +2884,50 @@ func toKebabCase(input string) string {
 	return strings.Trim(b.String(), "-")
 }
 
+// specNameNoiseWords names tokens stripped during slug derivation. Shared by
+// the ASCII slug path (cleanSpecName) and the Unicode-preserving display-name
+// path (cleanSpecNameUnicode) so adding a new noise word affects both.
+var specNameNoiseWords = map[string]struct{}{
+	"swagger":       {},
+	"openapi":       {},
+	"rest":          {},
+	"api":           {},
+	"spec":          {},
+	"specification": {},
+	"preview":       {},
+	"http":          {},
+	"with":          {},
+	"and":           {},
+	"from":          {},
+	"for":           {},
+	"the":           {},
+	"by":            {},
+	"of":            {},
+	"in":            {},
+	"on":            {},
+	"to":            {},
+	"fixes":         {},
+	"improvements":  {},
+}
+
 func cleanSpecName(title string) string {
-	title = naming.ASCIIFold(title)
+	return cleanSpecNameInternal(title, true)
+}
+
+// cleanSpecNameUnicode mirrors cleanSpecName's noise-word and version-token
+// stripping but skips the Unicode-to-ASCII fold. Used to derive display_name
+// from info.title when the spec has no x-display-name extension — the slug
+// path still folds ("Café Bistro API" → "cafe-bistro" for filesystem and
+// shell safety), while this path keeps accents intact ("café-bistro") so
+// HumanName produces "Café Bistro" rather than "Cafe Bistro".
+func cleanSpecNameUnicode(title string) string {
+	return cleanSpecNameInternal(title, false)
+}
+
+func cleanSpecNameInternal(title string, foldASCII bool) string {
+	if foldASCII {
+		title = naming.ASCIIFold(title)
+	}
 	title = strings.ToLower(strings.TrimSpace(title))
 	if title == "" {
 		return "api"
@@ -2882,8 +2936,10 @@ func cleanSpecName(title string) string {
 	title = strings.ReplaceAll(title, "open api", " ")
 
 	// Strip apostrophes so brand names like "Domino's" become "dominos" not
-	// "domino-s". Smart-quote U+2019 already folds to ASCII via ASCIIFold above.
+	// "domino-s". When foldASCII is false, smart-quote U+2019 hasn't been
+	// folded to ASCII '\'' yet, so strip both forms.
 	title = strings.ReplaceAll(title, "'", "")
+	title = strings.ReplaceAll(title, "’", "")
 
 	var normalized strings.Builder
 	lastSpace := true
@@ -2904,35 +2960,19 @@ func cleanSpecName(title string) string {
 		return "api"
 	}
 
-	noiseWords := map[string]struct{}{
-		"swagger":       {},
-		"openapi":       {},
-		"rest":          {},
-		"api":           {},
-		"spec":          {},
-		"specification": {},
-		"preview":       {},
-		"http":          {},
-		"with":          {},
-		"and":           {},
-		"from":          {},
-		"for":           {},
-		"the":           {},
-		"by":            {},
-		"of":            {},
-		"in":            {},
-		"on":            {},
-		"to":            {},
-		"fixes":         {},
-		"improvements":  {},
-	}
-
 	filtered := make([]string, 0, len(tokens))
 	for _, token := range tokens {
-		if _, ok := noiseWords[token]; ok {
+		// Compare against an ASCII-folded form so accented variants like
+		// "ApÍ" still match the noise-word filter even when foldASCII is
+		// false; the original token text is what gets kept.
+		compare := token
+		if !foldASCII {
+			compare = naming.ASCIIFold(token)
+		}
+		if _, ok := specNameNoiseWords[compare]; ok {
 			continue
 		}
-		if isVersionToken(token) {
+		if isVersionToken(compare) {
 			continue
 		}
 		filtered = append(filtered, token)
@@ -2941,7 +2981,7 @@ func cleanSpecName(title string) string {
 		filtered = filtered[:3]
 	}
 
-	name := toKebabCase(strings.Join(filtered, " "))
+	name := toKebabCaseInternal(strings.Join(filtered, " "), foldASCII)
 	if name == "" {
 		return "api"
 	}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2884,9 +2884,8 @@ func toKebabCaseInternal(input string, foldASCII bool) string {
 	return strings.Trim(b.String(), "-")
 }
 
-// specNameNoiseWords names tokens stripped during slug derivation. Shared by
-// the ASCII slug path (cleanSpecName) and the Unicode-preserving display-name
-// path (cleanSpecNameUnicode) so adding a new noise word affects both.
+// specNameNoiseWords are tokens stripped during slug derivation. Shared
+// across both fold variants so adding a word affects slug and display_name.
 var specNameNoiseWords = map[string]struct{}{
 	"swagger":       {},
 	"openapi":       {},
@@ -2914,12 +2913,8 @@ func cleanSpecName(title string) string {
 	return cleanSpecNameInternal(title, true)
 }
 
-// cleanSpecNameUnicode mirrors cleanSpecName's noise-word and version-token
-// stripping but skips the Unicode-to-ASCII fold. Used to derive display_name
-// from info.title when the spec has no x-display-name extension — the slug
-// path still folds ("Café Bistro API" → "cafe-bistro" for filesystem and
-// shell safety), while this path keeps accents intact ("café-bistro") so
-// HumanName produces "Café Bistro" rather than "Cafe Bistro".
+// cleanSpecNameUnicode is cleanSpecName without the ASCII fold, so display_name
+// keeps accents the slug must drop for filesystem and shell safety.
 func cleanSpecNameUnicode(title string) string {
 	return cleanSpecNameInternal(title, false)
 }
@@ -2962,9 +2957,8 @@ func cleanSpecNameInternal(title string, foldASCII bool) string {
 
 	filtered := make([]string, 0, len(tokens))
 	for _, token := range tokens {
-		// Compare against an ASCII-folded form so accented variants like
-		// "ApÍ" still match the noise-word filter even when foldASCII is
-		// false; the original token text is what gets kept.
+		// The noise list is ASCII; fold for the membership check so accented
+		// variants still match, but keep the original token in the output.
 		compare := token
 		if !foldASCII {
 			compare = naming.ASCIIFold(token)

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -180,11 +180,29 @@ paths:
 	assert.Equal(t, "Brand Name", parsed.DisplayName)
 }
 
-func TestParseDerivesDisplayNameFromTitleWhenExtensionAbsent(t *testing.T) {
-	spec := []byte(`
+// TestParseDerivesDisplayNameFromTitle locks the dual contract when no
+// x-display-name extension is set: slug is ASCII-folded for filesystem and
+// shell safety, display_name keeps Unicode for the human-facing surfaces
+// (manifest.json, .printing-press.json, MCP server identity).
+func TestParseDerivesDisplayNameFromTitle(t *testing.T) {
+	cases := []struct {
+		name        string
+		title       string
+		wantSlug    string
+		wantDisplay string
+	}{
+		{name: "ascii", title: "Test API", wantSlug: "test", wantDisplay: "Test"},
+		{name: "precomposed_accent", title: "Café Bistro API", wantSlug: "cafe-bistro", wantDisplay: "Café Bistro"},
+		{name: "fused_diacritics", title: "Strüdel Service API", wantSlug: "strudel-service", wantDisplay: "Strüdel Service"},
+		{name: "non_latin_script", title: "東京 API", wantSlug: "dong-jing", wantDisplay: "東京"},
+		{name: "single_token_accent", title: "PokéAPI", wantSlug: "pokeapi", wantDisplay: "Pokéapi"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := fmt.Appendf(nil, `
 openapi: "3.0.0"
 info:
-  title: Test API
+  title: %s
   version: "1.0"
 servers:
   - url: https://api.example.com
@@ -195,105 +213,13 @@ paths:
       responses:
         "200":
           description: OK
-`)
-	parsed, err := Parse(spec)
-	require.NoError(t, err)
-	assert.Equal(t, "Test", parsed.DisplayName)
-}
-
-// TestParseDisplayNamePreservesPrecomposedAccent locks the Unicode-aware
-// derivation contract: the slug is ASCII-folded for portability ("cafe-bistro"),
-// but display_name keeps the original codepoints. Without this guarantee,
-// EffectiveDisplayName falls through to HumanName(slug) and produces
-// "Cafe Bistro" — visible in manifest.json, .printing-press.json, and the
-// MCP server's identity string.
-func TestParseDisplayNamePreservesPrecomposedAccent(t *testing.T) {
-	spec := []byte(`
-openapi: "3.0.0"
-info:
-  title: Café Bistro API
-  version: "1.0"
-servers:
-  - url: https://api.example.com
-paths:
-  /items:
-    get:
-      operationId: listItems
-      responses:
-        "200":
-          description: OK
-`)
-	parsed, err := Parse(spec)
-	require.NoError(t, err)
-	assert.Equal(t, "cafe-bistro", parsed.Name, "slug stays ASCII-folded for filesystem safety")
-	assert.Equal(t, "Café Bistro", parsed.DisplayName, "display_name preserves accent")
-}
-
-func TestParseDisplayNamePreservesFusedDiacritics(t *testing.T) {
-	spec := []byte(`
-openapi: "3.0.0"
-info:
-  title: Strüdel Service API
-  version: "1.0"
-servers:
-  - url: https://api.example.com
-paths:
-  /items:
-    get:
-      operationId: listItems
-      responses:
-        "200":
-          description: OK
-`)
-	parsed, err := Parse(spec)
-	require.NoError(t, err)
-	assert.Equal(t, "Strüdel Service", parsed.DisplayName)
-}
-
-func TestParseDisplayNamePreservesNonLatinScript(t *testing.T) {
-	spec := []byte(`
-openapi: "3.0.0"
-info:
-  title: 東京 API
-  version: "1.0"
-servers:
-  - url: https://api.example.com
-paths:
-  /items:
-    get:
-      operationId: listItems
-      responses:
-        "200":
-          description: OK
-`)
-	parsed, err := Parse(spec)
-	require.NoError(t, err)
-	assert.Equal(t, "東京", parsed.DisplayName)
-}
-
-// TestParseDisplayNameSingleTokenAccent locks the contract for the canonical
-// motivating case in EffectiveDisplayName's docstring — "PokéAPI" must
-// produce a Unicode-preserving display name even though the title has no
-// internal whitespace.
-func TestParseDisplayNameSingleTokenAccent(t *testing.T) {
-	spec := []byte(`
-openapi: "3.0.0"
-info:
-  title: PokéAPI
-  version: "1.0"
-servers:
-  - url: https://api.example.com
-paths:
-  /items:
-    get:
-      operationId: listItems
-      responses:
-        "200":
-          description: OK
-`)
-	parsed, err := Parse(spec)
-	require.NoError(t, err)
-	assert.Equal(t, "Pokéapi", parsed.DisplayName)
+`, tc.title)
+			parsed, err := Parse(spec)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantSlug, parsed.Name)
+			assert.Equal(t, tc.wantDisplay, parsed.DisplayName)
+		})
+	}
 }
 
 func TestIsOpenAPI(t *testing.T) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -180,7 +180,7 @@ paths:
 	assert.Equal(t, "Brand Name", parsed.DisplayName)
 }
 
-func TestParseLeavesDisplayNameEmptyWhenAbsent(t *testing.T) {
+func TestParseDerivesDisplayNameFromTitleWhenExtensionAbsent(t *testing.T) {
 	spec := []byte(`
 openapi: "3.0.0"
 info:
@@ -198,7 +198,102 @@ paths:
 `)
 	parsed, err := Parse(spec)
 	require.NoError(t, err)
-	assert.Equal(t, "", parsed.DisplayName)
+	assert.Equal(t, "Test", parsed.DisplayName)
+}
+
+// TestParseDisplayNamePreservesPrecomposedAccent locks the Unicode-aware
+// derivation contract: the slug is ASCII-folded for portability ("cafe-bistro"),
+// but display_name keeps the original codepoints. Without this guarantee,
+// EffectiveDisplayName falls through to HumanName(slug) and produces
+// "Cafe Bistro" — visible in manifest.json, .printing-press.json, and the
+// MCP server's identity string.
+func TestParseDisplayNamePreservesPrecomposedAccent(t *testing.T) {
+	spec := []byte(`
+openapi: "3.0.0"
+info:
+  title: Café Bistro API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+	assert.Equal(t, "cafe-bistro", parsed.Name, "slug stays ASCII-folded for filesystem safety")
+	assert.Equal(t, "Café Bistro", parsed.DisplayName, "display_name preserves accent")
+}
+
+func TestParseDisplayNamePreservesFusedDiacritics(t *testing.T) {
+	spec := []byte(`
+openapi: "3.0.0"
+info:
+  title: Strüdel Service API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+	assert.Equal(t, "Strüdel Service", parsed.DisplayName)
+}
+
+func TestParseDisplayNamePreservesNonLatinScript(t *testing.T) {
+	spec := []byte(`
+openapi: "3.0.0"
+info:
+  title: 東京 API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+	assert.Equal(t, "東京", parsed.DisplayName)
+}
+
+// TestParseDisplayNameSingleTokenAccent locks the contract for the canonical
+// motivating case in EffectiveDisplayName's docstring — "PokéAPI" must
+// produce a Unicode-preserving display name even though the title has no
+// internal whitespace.
+func TestParseDisplayNameSingleTokenAccent(t *testing.T) {
+	spec := []byte(`
+openapi: "3.0.0"
+info:
+  title: PokéAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+	assert.Equal(t, "Pokéapi", parsed.DisplayName)
 }
 
 func TestIsOpenAPI(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -6,7 +6,7 @@
   ],
   "auth_type": "api_key",
   "cli_name": "cafe-bistro-pp-cli",
-  "display_name": "Cafe Bistro",
+  "display_name": "Café Bistro",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "cafe-bistro-pp-mcp",
   "mcp_ready": "full",

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	s := server.NewMCPServer(
-		"Cafe Bistro",
+		"Café Bistro",
 		"1.0.0",
 		server.WithToolCapabilities(false),
 	)

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
@@ -10,8 +10,8 @@
       "win32"
     ]
   },
-  "description": "Cafe Bistro API surface as MCP tools.",
-  "display_name": "Cafe Bistro",
+  "description": "Café Bistro API surface as MCP tools.",
+  "display_name": "Café Bistro",
   "license": "Apache-2.0",
   "manifest_version": "0.3",
   "name": "cafe-bistro-pp-mcp",
@@ -28,7 +28,7 @@
   },
   "user_config": {
     "cafe_bistro_api_key_auth": {
-      "description": "Sets CAFE_BISTRO_API_KEY_AUTH for the Cafe Bistro MCP server.",
+      "description": "Sets CAFE_BISTRO_API_KEY_AUTH for the Café Bistro MCP server.",
       "required": true,
       "sensitive": true,
       "title": "CAFE_BISTRO_API_KEY_AUTH",


### PR DESCRIPTION
## Summary

Fixes mvanhorn/cli-printing-press#372. PR #371 added `naming.ASCIIFold` to every spec-string → identifier chokepoint, including `cleanSpecName`. That correctly hardened slug, binary name, env var, and Go identifier portability. But OpenAPI specs without an `x-display-name` extension regressed: `DisplayName` stayed empty, `EffectiveDisplayName` fell through to `naming.HumanName(slug)`, and the slug was now ASCII-folded — so `Café Bistro API` surfaced as `Cafe Bistro` and `PokéAPI` as `Pokeapi` in `manifest.json`, `.printing-press.json`, and the MCP server's identity string.

`Parse` now derives `DisplayName` from a Unicode-preserving form of `info.title` whenever no `x-display-name` is set. Explicit extensions still win, matching `EffectiveDisplayName`'s contract.

## Implementation

`cleanSpecName` and `toKebabCase` are refactored to share their bodies via internal helpers parameterized by `foldASCII`. A new `cleanSpecNameUnicode` passes `false` and produces `café-bistro`; `naming.HumanName` then title-cases it to `Café Bistro`. The noise-word map is hoisted to a package-level `specNameNoiseWords` so both paths stay aligned when noise words are added.

The two-surface contract holds:

| Surface | Before fix | After fix |
|---|---|---|
| Slug / directory | `cafe-bistro` | `cafe-bistro` |
| Binary name | `cafe-bistro-pp-cli` | `cafe-bistro-pp-cli` |
| Env var | `CAFE_BISTRO_API_KEY_AUTH` | `CAFE_BISTRO_API_KEY_AUTH` |
| Generated Go types | ASCII | ASCII |
| `display_name` | `Cafe Bistro` | `Café Bistro` |
| MCP server identity | `Cafe Bistro` | `Café Bistro` |

Identifiers stay ASCII-folded for filesystem and shell safety; only display surfaces gain the accent back.

## Tests

`internal/openapi/parser_test.go` replaces `TestParseLeavesDisplayNameEmptyWhenAbsent` (which locked in the buggy behavior) with `TestParseDerivesDisplayNameFromTitleWhenExtensionAbsent`. Four new cases cover the Unicode contract: precomposed accent (`Café Bistro`), fused diacritic (`Strüdel Service`), non-Latin script (`東京`), and the docstring-canonical single-token case (`PokéAPI` → `Pokéapi`). `TestParseReadsXDisplayName` continues to verify explicit-extension precedence.

The `generate-golden-api-unicode` golden case picks up four `Cafe Bistro → Café Bistro` swaps end-to-end (display_name, MCP description, MCP server identity, `user_config` blurb). The slug, binary name, env var, and `internal/types/types.go` (ASCII Go identifiers) remain unchanged — the golden continues to enforce the PR #371 ASCII-fold contract for identifiers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)