### PR TITLE
fix(cli): normalize lock name so slug and binary form share lock file

### DIFF
--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -42,9 +42,21 @@ func LocksDir() string {
 	return filepath.Join(PressHome(), locksDir)
 }
 
-// LockFilePath returns the lock file path for a given CLI name.
+// LockFilePath returns the lock file path for a given CLI name. The name
+// is normalized to the binary-name form (-pp-cli suffix) so the slug and
+// binary name resolve to the same lock file. The build acquires the lock
+// as "<api>-pp-cli" while the polish skill derives the name from a library
+// directory's basename (the slug); without normalization the polish-mid-
+// pipeline safety check silently misses an active lock.
 func LockFilePath(cliName string) string {
-	return filepath.Join(LocksDir(), cliName+".lock")
+	return filepath.Join(LocksDir(), normalizeLockName(cliName)+".lock")
+}
+
+func normalizeLockName(cliName string) string {
+	if naming.IsCLIDirName(cliName) {
+		return cliName
+	}
+	return naming.CLI(cliName)
 }
 
 // AcquireLock attempts to acquire a build lock for the given CLI.

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -42,12 +42,10 @@ func LocksDir() string {
 	return filepath.Join(PressHome(), locksDir)
 }
 
-// LockFilePath returns the lock file path for a given CLI name. The name
-// is normalized to the binary-name form (-pp-cli suffix) so the slug and
-// binary name resolve to the same lock file. The build acquires the lock
-// as "<api>-pp-cli" while the polish skill derives the name from a library
-// directory's basename (the slug); without normalization the polish-mid-
-// pipeline safety check silently misses an active lock.
+// LockFilePath returns the lock file path for a given CLI name. Callers may
+// pass either the slug or the binary name; both forms resolve to the same
+// file. Caller is responsible for validating the name first via
+// validateCLIName — LockFilePath itself does not check.
 func LockFilePath(cliName string) string {
 	return filepath.Join(LocksDir(), normalizeLockName(cliName)+".lock")
 }
@@ -59,10 +57,25 @@ func normalizeLockName(cliName string) string {
 	return naming.CLI(cliName)
 }
 
+// validateCLIName rejects names that would escape LocksDir() once joined as
+// a filename. naming.IsValidLibraryDirName covers path separators, "..",
+// NUL, dotfile prefixes, and non-slug shapes. The lock helpers below call
+// this at entry so a malicious or buggy --cli value can never reach
+// filepath.Join with traversal characters intact.
+func validateCLIName(cliName string) error {
+	if !naming.IsValidLibraryDirName(cliName) {
+		return fmt.Errorf("invalid cli name %q", cliName)
+	}
+	return nil
+}
+
 // AcquireLock attempts to acquire a build lock for the given CLI.
 // It auto-reclaims stale locks. If force is true, it overrides even fresh
 // locks held by a different scope.
 func AcquireLock(cliName, scope string, force bool) (*LockState, error) {
+	if err := validateCLIName(cliName); err != nil {
+		return nil, err
+	}
 	lockPath := LockFilePath(cliName)
 
 	if err := os.MkdirAll(LocksDir(), 0o755); err != nil {
@@ -124,6 +137,9 @@ func AcquireLock(cliName, scope string, force bool) (*LockState, error) {
 
 // UpdateLock refreshes the heartbeat and phase of an existing lock.
 func UpdateLock(cliName, phase string) error {
+	if err := validateCLIName(cliName); err != nil {
+		return err
+	}
 	lockPath := LockFilePath(cliName)
 
 	existing, err := readLock(lockPath)
@@ -139,9 +155,15 @@ func UpdateLock(cliName, phase string) error {
 }
 
 // LockStatus returns the current lock state for a CLI, including whether
-// a completed CLI exists in the library.
+// a completed CLI exists in the library. An invalid cliName returns the
+// zero result (no lock held, no library CLI) — safe behavior at this
+// boundary since the function has no error channel.
 func LockStatus(cliName string) LockStatusResult {
 	result := LockStatusResult{}
+
+	if err := validateCLIName(cliName); err != nil {
+		return result
+	}
 
 	// Check library for completed CLI (slug-keyed directory).
 	slug := naming.TrimCLISuffix(cliName)
@@ -173,6 +195,9 @@ func LockStatus(cliName string) LockStatusResult {
 
 // ReleaseLock removes the lock file for a CLI. It is idempotent.
 func ReleaseLock(cliName string) error {
+	if err := validateCLIName(cliName); err != nil {
+		return err
+	}
 	lockPath := LockFilePath(cliName)
 	err := os.Remove(lockPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -186,6 +211,9 @@ func ReleaseLock(cliName string) error {
 // Uses a staging directory with atomic swap so the previous library copy
 // survives if any step fails.
 func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
+	if err := validateCLIName(cliName); err != nil {
+		return err
+	}
 	if workingDir == "" {
 		return fmt.Errorf("working directory is empty")
 	}

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -211,6 +211,43 @@ func TestReleaseLock_Idempotent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// LockFilePath must produce the same path regardless of whether the caller
+// passes the slug ("notion") or the binary name ("notion-pp-cli"). Issue #483:
+// the build acquires the lock as "<api>-pp-cli" while the polish skill derives
+// the name from a library directory's basename (the slug), and a mixed-form
+// caller would silently miss an active lock and stomp on a build in progress.
+func TestLockFilePath_NormalizesSlugAndBinaryName(t *testing.T) {
+	setupLockTest(t)
+
+	assert.Equal(t, LockFilePath("notion-pp-cli"), LockFilePath("notion"))
+}
+
+// AcquireLock with the binary name and LockStatus with the slug (or vice
+// versa) must observe the same lock. This is the polish-skill safety net:
+// when polish is invoked mid-pipeline, its lock check needs to detect the
+// build's lock regardless of which name form polish derives.
+func TestLockStatus_SeesLockAcquiredByOtherNameForm(t *testing.T) {
+	setupLockTest(t)
+
+	// Build acquires under the binary name.
+	_, err := AcquireLock("notion-pp-cli", "build-scope", false)
+	require.NoError(t, err)
+
+	// Polish queries with the slug (basename of $PRESS_LIBRARY/notion).
+	status := LockStatus("notion")
+	assert.True(t, status.Held, "lock acquired as binary name must be visible by slug")
+	assert.Equal(t, "build-scope", status.Scope)
+
+	// And the reverse: lock acquired by slug must be visible by binary name.
+	require.NoError(t, ReleaseLock("notion-pp-cli"))
+	_, err = AcquireLock("notion", "polish-scope", false)
+	require.NoError(t, err)
+
+	status = LockStatus("notion-pp-cli")
+	assert.True(t, status.Held, "lock acquired by slug must be visible by binary name")
+	assert.Equal(t, "polish-scope", status.Scope)
+}
+
 func TestPromoteWorkingCLI(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmp)

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -222,6 +222,69 @@ func TestLockFilePath_NormalizesSlugAndBinaryName(t *testing.T) {
 	assert.Equal(t, LockFilePath("notion-pp-cli"), LockFilePath("notion"))
 }
 
+// Pin LockFilePath's normalization output across the name-form edge cases
+// callers actually produce: bare slugs, binary names, legacy -cli suffix,
+// rerun forms (numeric suffix on either side of -pp-cli), and the empty
+// degenerate. These pin current behavior so a future refactor of the
+// underlying naming helpers can't quietly drift the lock-file naming.
+func TestLockFilePath_NormalizationEdgeCases(t *testing.T) {
+	setupLockTest(t)
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"bare slug appends -pp-cli", "foo", "foo-pp-cli.lock"},
+		{"binary name kept verbatim", "foo-pp-cli", "foo-pp-cli.lock"},
+		{"legacy -cli suffix kept verbatim", "foo-cli", "foo-cli.lock"},
+		{"rerun binary form (suffix-then-number) kept", "foo-pp-cli-2", "foo-pp-cli-2.lock"},
+		{"rerun library form gets -pp-cli appended", "foo-2", "foo-2-pp-cli.lock"},
+		{"empty string degenerates to bare suffix", "", "-pp-cli.lock"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, filepath.Base(LockFilePath(tc.input)))
+		})
+	}
+}
+
+// Lock helpers must reject cliName values that would escape LocksDir() or
+// otherwise behave as filesystem-traversal payloads. Without this guard a
+// caller passing "../foo" via `printing-press lock --cli ...` would write
+// the lock file outside LocksDir() once filepath.Join resolved the "..".
+func TestLockHelpers_RejectInvalidCLIName(t *testing.T) {
+	setupLockTest(t)
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"path traversal with dotdot", "../foo"},
+		{"forward slash", "foo/bar"},
+		{"dotfile prefix", ".hidden"},
+		{"embedded dotdot", "foo..bar"},
+		{"empty string", ""},
+		{"uppercase rejected by slug grammar", "FooBar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := AcquireLock(tc.input, "scope-1", false)
+			assert.Error(t, err, "AcquireLock must reject %q", tc.input)
+
+			err = UpdateLock(tc.input, "build")
+			assert.Error(t, err, "UpdateLock must reject %q", tc.input)
+
+			err = ReleaseLock(tc.input)
+			assert.Error(t, err, "ReleaseLock must reject %q", tc.input)
+
+			status := LockStatus(tc.input)
+			assert.False(t, status.Held, "LockStatus must return zero result for %q", tc.input)
+			assert.False(t, status.HasCLI, "LockStatus must return zero result for %q", tc.input)
+		})
+	}
+}
+
 // AcquireLock with the binary name and LockStatus with the slug (or vice
 // versa) must observe the same lock. This is the polish-skill safety net:
 // when polish is invoked mid-pipeline, its lock check needs to detect the

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -212,10 +212,9 @@ func TestReleaseLock_Idempotent(t *testing.T) {
 }
 
 // LockFilePath must produce the same path regardless of whether the caller
-// passes the slug ("notion") or the binary name ("notion-pp-cli"). Issue #483:
-// the build acquires the lock as "<api>-pp-cli" while the polish skill derives
-// the name from a library directory's basename (the slug), and a mixed-form
-// caller would silently miss an active lock and stomp on a build in progress.
+// passes the slug ("notion") or the binary name ("notion-pp-cli"). A mixed-
+// form caller would otherwise silently miss an active lock acquired under
+// the other form.
 func TestLockFilePath_NormalizesSlugAndBinaryName(t *testing.T) {
 	setupLockTest(t)
 

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -77,6 +77,13 @@ Resolution order:
 3. If arg has `-pp-cli` suffix, strip it and try `$PRESS_LIBRARY/<slug>` (e.g., `redfin-pp-cli` → `redfin`)
 4. Fuzzy search: `ls $PRESS_LIBRARY/ | grep -i <arg>` for close matches
 
+**Caller scenarios.** Polish has two callers and they pass different argument forms:
+
+- **Standalone (user-invoked, `/printing-press-polish redfin`).** The arg is a slug or binary name; resolution lands on `$PRESS_LIBRARY/<slug>/`. This is the published copy and the right target.
+- **Mid-pipeline (main printing-press skill Phase 5.5).** The arg is `$CLI_WORK_DIR` — an absolute path to `~/printing-press/.runstate/.../runs/.../working/<api>-pp-cli/`. Resolution must hit rule 1. **Do not paraphrase this to the slug** — Phase 5.5 fires before the working CLI is promoted, so `$PRESS_LIBRARY/<slug>/` either doesn't exist or holds the *prior* run's stale CLI.
+
+The lock-status check in the next code block is the safety net for the mid-pipeline scenario: if a build lock is held for this CLI (under either name form), polish refuses to run. `printing-press lock` normalizes slug ↔ binary-name internally, so the check works regardless of which form the basename produces.
+
 If no match or multiple matches, present via `AskUserQuestion`. Show at most 4
 matches sorted by modification time (most recent first) with human-friendly
 relative timestamps (e.g., "generated 2 hours ago").

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2327,6 +2327,8 @@ Skill(
 )
 ```
 
+**Pass `$CLI_WORK_DIR` (the absolute working-dir path), not the API slug.** Phase 5.5 fires before Phase 5.6 promotes the working CLI to the library, so `$PRESS_LIBRARY/<slug>/` either doesn't exist yet or contains the *prior* run's CLI. If you paraphrase the args to the slug (e.g., `args: "producthunt"`), polish silently operates on the stale library copy.
+
 The polish skill runs the full diagnostic-fix-rediagnose loop including MCP tool quality polish (via `printing-press tools-audit` plus the playbook at `references/tools-polish.md`) and ends its response with a `---POLISH-RESULT---` block containing scorecard/verify/tools-audit before/after, fixes applied, and a ship recommendation.
 
 Parse the result block. Display the delta to the user:


### PR DESCRIPTION
## Summary

When `/printing-press-polish` was invoked from the main pipeline at Phase 5.5 and an agent paraphrased the args from `$CLI_WORK_DIR` to the API slug, polish silently operated on the prior run's stale library copy. The lock-status safety net that should have caught this silently missed the build's active lock too: the build acquires the lock under the binary name (`<api>-pp-cli`) while polish derived the name from a library directory's basename (the slug). `LockFilePath` joined the caller's name verbatim, so `notion.lock` and `notion-pp-cli.lock` were different files.

## Fix

Two layers on the same root cause:

- **`internal/pipeline/lock.go`** — added `normalizeLockName` (uses `naming.IsCLIDirName` / `naming.CLI`); `LockFilePath` now produces the same file for `notion` and `notion-pp-cli`. Every other lock helper routes through `LockFilePath`, so `AcquireLock`, `LockStatus`, `UpdateLock`, and `ReleaseLock` inherit the normalization. Two new tests pin both directions: a lock acquired by binary name is visible by slug, and vice versa.
- **`skills/printing-press/SKILL.md` Phase 5.5 and `skills/printing-press-polish/SKILL.md` resolver section** — explain *why* the mid-pipeline caller must pass `$CLI_WORK_DIR` (not the slug). Phase 5.5 fires before promotion, so `$PRESS_LIBRARY/<slug>/` either doesn't exist or holds the prior run.

The Go fix is the load-bearing safety net; the docs reduce the likelihood it ever has to fire.

Fixes #483

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)