### PR TITLE
refactor(cli): reuse generated operation id params

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -948,7 +948,9 @@ func (s *APISpec) expandOperations() {
 		if r.Endpoints == nil {
 			r.Endpoints = make(map[string]Endpoint)
 		}
-		idParam := singularize(name) + "Id"
+		singularName := singularize(name)
+		idParam := singularName + "Id"
+		idPath := r.Path + "/{" + idParam + "}"
 		for _, op := range r.Operations {
 			// Skip if an explicit endpoint already exists with this name
 			if _, exists := r.Endpoints[op]; exists {
@@ -965,47 +967,29 @@ func (s *APISpec) expandOperations() {
 			case "get":
 				r.Endpoints["get"] = Endpoint{
 					Method:      "GET",
-					Path:        r.Path + "/{" + idParam + "}",
-					Description: "Get a " + singularize(name) + " by ID",
-					Params: []Param{{
-						Name:        idParam,
-						Type:        "string",
-						Required:    true,
-						Positional:  true,
-						Description: singularize(name) + " ID",
-					}},
+					Path:        idPath,
+					Description: "Get a " + singularName + " by ID",
+					Params:      operationIDParams(idParam, singularName),
 				}
 			case "create":
 				r.Endpoints["create"] = Endpoint{
 					Method:      "POST",
 					Path:        r.Path,
-					Description: "Create a new " + singularize(name),
+					Description: "Create a new " + singularName,
 				}
 			case "update":
 				r.Endpoints["update"] = Endpoint{
 					Method:      "PATCH",
-					Path:        r.Path + "/{" + idParam + "}",
-					Description: "Update a " + singularize(name),
-					Params: []Param{{
-						Name:        idParam,
-						Type:        "string",
-						Required:    true,
-						Positional:  true,
-						Description: singularize(name) + " ID",
-					}},
+					Path:        idPath,
+					Description: "Update a " + singularName,
+					Params:      operationIDParams(idParam, singularName),
 				}
 			case "delete":
 				r.Endpoints["delete"] = Endpoint{
 					Method:      "DELETE",
-					Path:        r.Path + "/{" + idParam + "}",
-					Description: "Delete a " + singularize(name),
-					Params: []Param{{
-						Name:        idParam,
-						Type:        "string",
-						Required:    true,
-						Positional:  true,
-						Description: singularize(name) + " ID",
-					}},
+					Path:        idPath,
+					Description: "Delete a " + singularName,
+					Params:      operationIDParams(idParam, singularName),
 				}
 			case "search":
 				r.Endpoints["search"] = Endpoint{
@@ -1023,6 +1007,16 @@ func (s *APISpec) expandOperations() {
 		}
 		s.Resources[name] = r
 	}
+}
+
+func operationIDParams(idParam, singularName string) []Param {
+	return []Param{{
+		Name:        idParam,
+		Type:        "string",
+		Required:    true,
+		Positional:  true,
+		Description: singularName + " ID",
+	}}
 }
 
 // singularize returns a simple singular form of a plural noun.


### PR DESCRIPTION
## Summary

Operations shorthand now builds generated ID parameters through one shared helper instead of repeating the same `Param` literal across `get`, `update`, and `delete`. This keeps behavior identical while removing a production-code duplication group from `internal/spec`.

## Verification

- `go fmt ./...`
- `go test ./internal/spec`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)