### PR TITLE
fix(cli): README template recommends MCPB drag-and-drop and skill install

### DIFF
--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -284,11 +284,26 @@ GraphQL path: `{{.GraphQLEndpointPath}}`
 {{- end}}
 {{- end}}
 
-## Use as MCP Server
+## Use with Claude Code
 
-This CLI ships a companion MCP server for use with Claude Desktop, Cursor, and other MCP-compatible tools.
+Install the focused skill — it auto-installs the CLI on first invocation:
 
-### Claude Code
+```bash
+npx skills add mvanhorn/printing-press-library/cli-skills/pp-{{.Name}} -g
+```
+
+Then invoke `/pp-{{.Name}} <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
+
+<details>
+<summary>Use as an MCP server in Claude Code (advanced)</summary>
+
+If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/cmd/{{.Name}}-pp-mcp@latest
+```
+
+Then register it:
 {{- if and (eq .Auth.Type "api_key") .Auth.EnvVars}}
 
 ```bash
@@ -330,7 +345,52 @@ claude mcp add {{.Name}} {{.Name}}-pp-mcp
 ```
 {{- end}}
 
-### Claude Desktop
+</details>
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+
+The bundle reuses your local browser session — set it up first if you haven't:
+
+```bash
+{{.Name}}-pp-cli auth login --chrome
+```
+{{- else if eq .Auth.Type "oauth2"}}
+
+The bundle reuses your local OAuth tokens — authenticate first if you haven't:
+
+```bash
+{{.Name}}-pp-cli auth login
+```
+{{- else if and (eq .Auth.Type "bearer_token") (not .Auth.EnvVars)}}
+
+Store your token first if you haven't:
+
+```bash
+{{.Name}}-pp-cli auth set-token YOUR_TOKEN_HERE
+```
+{{- end}}
+
+To install:
+
+1. Download [`{{.Name}}-pp-mcp-darwin-arm64.mcpb`](https://github.com/mvanhorn/printing-press-library/blob/main/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/build/{{.Name}}-pp-mcp-darwin-arm64.mcpb) from the public library.
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+{{- if and .Auth.EnvVars (ne .Auth.Type "none") (ne .Auth.Type "cookie") (ne .Auth.Type "composed")}}
+3. Fill in `{{index .Auth.EnvVars 0}}` when Claude Desktop prompts you.
+{{- end}}
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`); for other platforms, build a bundle with `printing-press bundle <cli-dir> --platform <os>/<arch>` or use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/cmd/{{.Name}}-pp-mcp@latest
+```
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -349,6 +409,8 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   }
 }
 ```
+
+</details>
 
 ## Health Check
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -111,17 +111,53 @@ This CLI is designed for AI agent consumption:
 
 Exit codes: `0` success, `2` usage error, `3` not found, `4` auth error, `5` API error, `7` rate limited, `10` config error.
 
-## Use as MCP Server
+## Use with Claude Code
 
-This CLI ships a companion MCP server for use with Claude Desktop, Cursor, and other MCP-compatible tools.
+Install the focused skill — it auto-installs the CLI on first invocation:
 
-### Claude Code
+```bash
+npx skills add mvanhorn/printing-press-library/cli-skills/pp-printing-press-golden -g
+```
+
+Then invoke `/pp-printing-press-golden <query>` in Claude Code. The skill is the most efficient path — Claude Code drives the CLI directly without an MCP server in the middle.
+
+<details>
+<summary>Use as an MCP server in Claude Code (advanced)</summary>
+
+If you'd rather register this CLI as an MCP server in Claude Code, install the MCP binary first:
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/printing-press-golden/cmd/printing-press-golden-pp-mcp@latest
+```
+
+Then register it:
 
 ```bash
 claude mcp add printing-press-golden printing-press-golden-pp-mcp -e PRINTING_PRESS_GOLDEN_API_KEY_AUTH=<your-key>
 ```
 
-### Claude Desktop
+</details>
+
+## Use with Claude Desktop
+
+This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle — Claude Desktop's standard format for one-click MCP extension installs (no JSON config required).
+
+To install:
+
+1. Download [`printing-press-golden-pp-mcp-darwin-arm64.mcpb`](https://github.com/mvanhorn/printing-press-library/blob/main/library/other/printing-press-golden/build/printing-press-golden-pp-mcp-darwin-arm64.mcpb) from the public library.
+2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
+3. Fill in `PRINTING_PRESS_GOLDEN_API_KEY_AUTH` when Claude Desktop prompts you.
+
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`); for other platforms, build a bundle with `printing-press bundle <cli-dir> --platform <os>/<arch>` or use the manual config below.
+
+<details>
+<summary>Manual JSON config (advanced)</summary>
+
+If you can't use the MCPB bundle (older Claude Desktop, unsupported platform), install the MCP binary and configure it manually.
+
+```bash
+go install github.com/mvanhorn/printing-press-library/library/other/printing-press-golden/cmd/printing-press-golden-pp-mcp@latest
+```
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -137,6 +173,8 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   }
 }
 ```
+
+</details>
 
 ## Health Check
 


### PR DESCRIPTION
## Summary

The README template's MCP-server section was stale and incomplete:

- It advertised the legacy `claude_desktop_config.json` edit path as the only Claude Desktop option, missing the MCPB bundle that `printing-press generate` has been emitting since v3.0.0 (Apr 27).
- That JSON config path doesn't actually work for users who follow the documented install instructions — the `## Install` section only puts `<name>-pp-cli` on PATH, but the JSON config and `claude mcp add` examples both reference `<name>-pp-mcp`.
- For Claude Code, the recommended path is the focused skill (`npx skills add ...`), which auto-installs the CLI. The README never mentioned it.

Restructured into host-oriented sections so users see the right path for where they want to use the CLI:

- `## Use with Claude Code` — focused skill via `npx skills add` is the visible primary. `claude mcp add` collapsed under `<details>` with the missing `go install ...cmd/<name>-pp-mcp@latest` prerequisite added so it actually works.
- `## Use with Claude Desktop` — MCPB double-click install is the visible primary, with a brief link to the MCPB spec. Manual JSON config collapsed under `<details>`, also with the `go install ...-pp-mcp` prerequisite.

The bare-CLI use case stays as the README's default content (Install / Quick Start / Commands sections above the integration sections).

Existing per-CLI READMEs in the public library will be updated in a follow-up PR against `printing-press-library` for the five CLIs that already have `build/.mcpb` committed (ebay, company-goat, postman-explore, scrape-creators, producthunt).

## Test plan

- [x] `go build -o ./printing-press ./cmd/printing-press`
- [x] `go test ./...` — 2732 passed
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `scripts/golden.sh verify` after fixture update — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)