### PR TITLE
fix(cli): strip build/ from publish staging

### DIFF
--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -119,6 +119,11 @@ from another build pipeline.`,
 }
 
 // autoBundleForHost packages a host-platform .mcpb after generate.
+// The output lives at <cliDir>/build/ as local-dev scratch — useful for
+// trying the bundle in Claude Desktop on the generating machine before
+// publishing. The canonical multi-platform .mcpb artifacts are produced by
+// the public library's CI on merge to main and attached as release assets;
+// `printing-press publish package` strips build/ from the staged tree.
 // Best-effort: skips silently for expected non-bundle states (no manifest,
 // no go.sum) and warns on real failures (malformed manifest, build/zip
 // errors). Users can always re-run via `printing-press bundle <dir>`.

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -337,6 +337,16 @@ func newPublishPackageCmd() *cobra.Command {
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("copying CLI: %w", err)}
 			}
 
+			// Strip build/ from the staged tree. autoBundleForHost writes
+			// host-platform .mcpb bundles + staged binaries there as a
+			// local-dev convenience; the public library treats CI release
+			// artifacts as canonical, so build/ should never reach the
+			// public library through the publish path.
+			if err := os.RemoveAll(filepath.Join(outCLIDir, "build")); err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping build dir: %w", err)}
+			}
+
 			// Rewrite go.mod module path if --module-path is set
 			if modulePath != "" {
 				oldModPath := cliName // generated CLIs use bare CLI name as module path

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -377,6 +377,37 @@ func TestPublishPackageDoesNotStageCompiledBinary(t *testing.T) {
 	assert.ErrorIs(t, stagedErr, os.ErrNotExist, "packaged source should not include a compiled binary")
 }
 
+func TestPublishPackageStripsBuildDir(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	// Simulate autoBundleForHost output: build/ exists in the source
+	// dir with a host-platform .mcpb and a staged binary copy.
+	buildDir := filepath.Join(cliDir, "build")
+	require.NoError(t, os.MkdirAll(filepath.Join(buildDir, "stage", "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "test-pp-mcp-darwin-arm64.mcpb"), []byte("zip-bytes"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "stage", "bin", "test-pp-mcp"), []byte("staged-binary"), 0o755))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	// Source build/ stays intact — we don't touch the user's working tree.
+	_, sourceErr := os.Stat(buildDir)
+	assert.NoError(t, sourceErr, "package must not delete the source build/ dir")
+
+	// Staged tree must have no build/ — CI is canonical for distribution.
+	_, stagedErr := os.Stat(filepath.Join(result.StagedDir, "build"))
+	assert.ErrorIs(t, stagedErr, os.ErrNotExist, "staged dir must not include build/")
+}
+
 func TestPublishPackageFailsWhenManuscriptsCopyFails(t *testing.T) {
 	skipIfRootCannotSimulateUnreadable(t)
 	home := setLibraryTestEnv(t)


### PR DESCRIPTION
## Summary

\`autoBundleForHost\` writes a host-platform \`.mcpb\` plus the staged binary into \`<cliDir>/build/\` after generate. That output is intended as local-dev scratch — useful for testing the bundle in Claude Desktop on the generating machine — but \`printing-press publish package\`'s \`pipeline.CopyDir\` was unconditional, so \`build/\` also reached the public library through the publish path.

The result was that 5 of 37 published CLIs had a \`build/\` directory committed (host-platform-only), 32 didn't, and the public library couldn't reliably tell users where to get the \`.mcpb\` for their platform.

Going forward, the canonical multi-platform \`.mcpb\` artifacts are produced by the public library's CI on merge to \`main\` and attached as GitHub release assets, keyed by a moving \`<slug>-current\` tag the README links to. \`build/\` is local-dev only.

## Changes
- \`internal/cli/publish.go\`: \`os.RemoveAll(outCLIDir/build)\` after \`CopyDir\` in \`publish package\`.
- \`internal/cli/bundle.go\`: docstring update on \`autoBundleForHost\` explaining the local-vs-CI split.
- \`internal/cli/publish_test.go\`: new \`TestPublishPackageStripsBuildDir\` — sets up a build/ tree with a fake \`.mcpb\` and staged binary, runs publish package, asserts source dir keeps build/ but staging strips it.

## Test plan
- [x] \`go build -o ./printing-press ./cmd/printing-press\`
- [x] \`go test ./...\` — 2734 passed (was 2733; +1 new test)
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — clean
- [x] \`scripts/golden.sh verify\` — passes (no fixture changes; this is a publish-flow change, not a generation-output change)

## Follow-ups
This is part of a multi-PR migration to ship \`.mcpb\` files via release assets instead of git-committed \`build/\` dirs. Subsequent work happens in the \`mvanhorn/printing-press-library\` repo: a \`build-mcpb.yml\` workflow for cross-platform bundle builds + release publishing, a \`bundle-audit.yml\` discovery workflow, and per-CLI README URL updates pointing at \`releases/download/<slug>-current/...\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)