### PR TITLE
fix(cli): handle sentry openapi generation

### DIFF
--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -583,7 +583,7 @@ func ftsRowID(id string) int64 {
 // way — a divergence here produces silent drops on heterogeneous payloads.
 func LookupFieldValue(obj map[string]any, snakeKey string) any {
 	if v, ok := obj[snakeKey]; ok {
-		return v
+		return sqliteFieldValue(v)
 	}
 	parts := strings.Split(snakeKey, "_")
 	for i := 1; i < len(parts); i++ {
@@ -593,9 +593,22 @@ func LookupFieldValue(obj map[string]any, snakeKey string) any {
 		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
 	}
 	if v, ok := obj[strings.Join(parts, "")]; ok {
-		return v
+		return sqliteFieldValue(v)
 	}
 	return nil
+}
+
+func sqliteFieldValue(v any) any {
+	switch v.(type) {
+	case nil, string, bool, int, int64, float64, []byte:
+		return v
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v)
+		}
+		return string(data)
+	}
 }
 
 // lookupFieldValue is kept as an unexported alias for in-package callers so

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -428,7 +428,13 @@ func mapAuth(doc *openapi3.T, name string) spec.AuthConfig {
 			auth.EnvVars = []string{envPrefix + "_API_KEY"}
 		}
 	case "bearer_token":
-		auth.EnvVars = []string{envPrefix + "_TOKEN"}
+		schemeEnvSuffix := toSnakeCase(schemeName)
+		switch schemeEnvSuffix {
+		case "", "bearer", "bearer_token", "token":
+			auth.EnvVars = []string{envPrefix + "_TOKEN"}
+		default:
+			auth.EnvVars = []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
+		}
 	}
 
 	return auth
@@ -2671,10 +2677,14 @@ func isGenericAPIPrefix(segment string) bool {
 }
 
 func isVersionSegment(segment string) bool {
-	if len(segment) < 2 || segment[0] != 'v' {
+	if segment == "" {
 		return false
 	}
-	_, err := strconv.Atoi(segment[1:])
+	if segment[0] == 'v' && len(segment) >= 2 {
+		_, err := strconv.Atoi(segment[1:])
+		return err == nil
+	}
+	_, err := strconv.Atoi(segment)
 	return err == nil
 }
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -160,6 +160,37 @@ func TestParseGmailOAuth2(t *testing.T) {
 	assert.NotEmpty(t, parsed.Auth.Scopes)
 }
 
+func TestBearerSchemeNameCanSpecializeEnvVar(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: "3.0.3"
+info:
+  title: Sentry
+  version: "1.0"
+servers:
+  - url: https://example.com
+components:
+  securitySchemes:
+    auth_token:
+      type: http
+      scheme: bearer
+paths:
+  /api/0/organizations/:
+    get:
+      operationId: List Your Organizations
+      security:
+        - auth_token: []
+      responses:
+        "200":
+          description: ok
+`)
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, []string{"SENTRY_AUTH_TOKEN"}, parsed.Auth.EnvVars)
+}
+
 func TestSkipUnderscoreFields(t *testing.T) {
 	spec := []byte(`
 openapi: "3.0.0"
@@ -413,6 +444,7 @@ func TestPathSegmentsStripsGenericAPIPrefix(t *testing.T) {
 		{"strips version then api", "/v1/api/networkentity", "", "networkentity"},
 		{"strips api then version", "/api/v2/pokemon", "", "pokemon"},
 		{"strips version then api then version", "/v2/api/v1/pokemon", "", "pokemon"},
+		{"strips api then numeric version", "/api/0/organizations", "", "organizations"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat numeric OpenAPI prefixes such as `/api/0/...` as version segments when deriving resources
- derive bearer-token env vars from specific security scheme names when they carry useful names, e.g. `auth_token` -> `SENTRY_AUTH_TOKEN`
- serialize nested map/slice values before SQLite insertion in generated store sync code

## Validation
- `go fmt ./...`
- `go test ./internal/openapi ./internal/generator`
- `go build -o ./printing-press ./cmd/printing-press`
- `scripts/golden.sh verify`