### PR TITLE
feat(cli): README template links to release page for binary + MCPB

### DIFF
--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -17,15 +17,15 @@ Learn more at [{{.ProseName}}]({{.WebsiteURL}}).
 
 ## Install
 
+### Binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/{{.Name}}-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
 ### Go
 
 ```
 go install github.com/mvanhorn/printing-press-library/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest
 ```
-
-### Binary
-
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
 {{- if and .Narrative .Narrative.AuthNarrative}}
 
 {{if .Auth.Optional}}## Optional: API Key{{else}}## Authentication{{end}}
@@ -375,13 +375,13 @@ Store your token first if you haven't:
 
 To install:
 
-1. Download [`{{.Name}}-pp-mcp-darwin-arm64.mcpb`](https://github.com/mvanhorn/printing-press-library/blob/main/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/build/{{.Name}}-pp-mcp-darwin-arm64.mcpb) from the public library.
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/{{.Name}}-current).
 2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
 {{- if and .Auth.EnvVars (ne .Auth.Type "none") (ne .Auth.Type "cookie") (ne .Auth.Type "composed")}}
 3. Fill in `{{index .Auth.EnvVars 0}}` when Claude Desktop prompts you.
 {{- end}}
 
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`); for other platforms, build a bundle with `printing-press bundle <cli-dir> --platform <os>/<arch>` or use the manual config below.
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
 
 <details>
 <summary>Manual JSON config (advanced)</summary>

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -4,15 +4,15 @@ Purpose-built fixture for golden generation coverage.
 
 ## Install
 
+### Binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-golden-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
+
 ### Go
 
 ```
 go install github.com/mvanhorn/printing-press-library/library/other/printing-press-golden/cmd/printing-press-golden-pp-cli@latest
 ```
-
-### Binary
-
-Download from [Releases](https://github.com/mvanhorn/printing-press-library/releases).
 
 ## Quick Start
 
@@ -144,11 +144,11 @@ This CLI ships an [MCPB](https://github.com/modelcontextprotocol/mcpb) bundle â€
 
 To install:
 
-1. Download [`printing-press-golden-pp-mcp-darwin-arm64.mcpb`](https://github.com/mvanhorn/printing-press-library/blob/main/library/other/printing-press-golden/build/printing-press-golden-pp-mcp-darwin-arm64.mcpb) from the public library.
+1. Download the `.mcpb` for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-golden-current).
 2. Double-click the `.mcpb` file. Claude Desktop opens and walks you through the install.
 3. Fill in `PRINTING_PRESS_GOLDEN_API_KEY_AUTH` when Claude Desktop prompts you.
 
-Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`); for other platforms, build a bundle with `printing-press bundle <cli-dir> --platform <os>/<arch>` or use the manual config below.
+Requires Claude Desktop 1.0.0 or later. Pre-built bundles ship for macOS Apple Silicon (`darwin-arm64`) and Windows (`amd64`, `arm64`); for other platforms, use the manual config below.
 
 <details>
 <summary>Manual JSON config (advanced)</summary>


### PR DESCRIPTION
## Summary

After the public library migrated to release-asset distribution, the template's URLs became stale:

- \`## Install\` → \`### Binary\` pointed at the global \`releases/\` listing — useless because the listing has every CLI's release intermixed.
- \`## Use with Claude Desktop\` → step 1 pointed at \`blob/main/library/<cat>/<slug>/build/<binary>-pp-mcp-darwin-arm64.mcpb\`, which no longer exists since \`build/\` is no longer committed.

Both now link to the per-CLI release tag page: \`releases/tag/<slug>-current\`. That page lists all platform artifacts (3 \`.mcpb\` for Claude Desktop, 6 CLI binaries for terminal use) so users can pick the right one.

## Other changes

- Reorders \`## Install\` to put \`### Binary\` before \`### Go\` (download is the easier path for non-Go users); adds macOS Gatekeeper quarantine + \`chmod +x\` hints inline.
- Updates the \"platforms shipped\" line to reflect the actual matrix (`darwin-arm64`, `windows-{amd64,arm64}` for MCPB).

## Test plan

- [x] \`go build -o ./printing-press ./cmd/printing-press\`
- [x] \`go test ./...\` — 2758 pass
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] \`scripts/golden.sh verify\` — passes after fixture update

## Follow-up

Existing CLIs in the public library still have READMEs from the old template. Phase 3 PR (#194) handled the 5 with previously-committed \`build/\` dirs. The remaining post-3.0.0 CLIs (ahrefs, klaviyo, plus pre-existing pokeapi/shopify/food52 if they need README structure cleanup) need similar updates — those will land as separate PRs in the public library repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)