### PR TITLE
fix(cli): exempt generated-client source helpers

### DIFF
--- a/internal/pipeline/internal_packages.go
+++ b/internal/pipeline/internal_packages.go
@@ -20,11 +20,22 @@ var reservedInternalPackages = map[string]bool{
 	"graphql":  true,
 }
 
+const (
+	rawOutboundHTTPCallPattern = `\bhttp\.(?:Get|Post|NewRequest(?:WithContext)?|Do)\s*\(|` +
+		`\b\w+\.HTTPClient\.Do\s*\(|` +
+		`\b\w+\.HTTP\.Do\s*\(`
+	generatedClientReceiverCallPattern = `\bc\.(?:Do|Get|Post)\s*\(`
+)
+
+// rawOutboundHTTPCallRe matches outbound HTTP request shapes that bypass the
+// generated client. Files with these calls need local limiter and typed 429
+// handling when they live in hand-written sibling internal packages.
+var rawOutboundHTTPCallRe = regexp.MustCompile(rawOutboundHTTPCallPattern)
+
+var generatedClientParamRe = regexp.MustCompile(`\bc\s+\*client\.Client\b`)
+var generatedClientReceiverCallRe = regexp.MustCompile(generatedClientReceiverCallPattern)
+
 // outboundHTTPCallRe matches every outbound HTTP request shape that appears in
 // generated and agent-authored Go code. Centralized so reimplementation_check
 // (per-command) and source_client_check (per-sibling-package) cannot diverge.
-var outboundHTTPCallRe = regexp.MustCompile(
-	`\bhttp\.(?:Get|Post|NewRequest(?:WithContext)?|Do)\s*\(|` +
-		`\b\w+\.HTTPClient\.Do\s*\(|` +
-		`\b\w+\.HTTP\.Do\s*\(|` +
-		`\bc\.(?:Do|Get|Post)\s*\(`)
+var outboundHTTPCallRe = regexp.MustCompile(rawOutboundHTTPCallPattern + `|` + generatedClientReceiverCallPattern)

--- a/internal/pipeline/source_client_check.go
+++ b/internal/pipeline/source_client_check.go
@@ -104,6 +104,9 @@ func walkSourcePackage(cliDir, pkgDir string, result *SourceClientCheckResult) {
 		if !outboundHTTPCallRe.MatchString(content) {
 			return nil
 		}
+		if hasGeneratedClientMediatedCall(content) && !rawOutboundHTTPCallRe.MatchString(content) {
+			return nil
+		}
 
 		hasLimiter := limiterUseRe.MatchString(content)
 		hasTypedError := rateLimitErrorRe.MatchString(content)
@@ -128,4 +131,10 @@ func walkSourcePackage(cliDir, pkgDir string, result *SourceClientCheckResult) {
 		result.Findings = append(result.Findings, finding)
 		return nil
 	})
+}
+
+func hasGeneratedClientMediatedCall(content string) bool {
+	return clientImportRe.MatchString(content) &&
+		generatedClientParamRe.MatchString(content) &&
+		generatedClientReceiverCallRe.MatchString(content)
 }

--- a/internal/pipeline/source_client_check_test.go
+++ b/internal/pipeline/source_client_check_test.go
@@ -82,6 +82,51 @@ func (c *Client) Fetch(url string) error {
 	return nil
 }
 `
+	const generatedClientHelper = `package sec
+
+import (
+	"context"
+
+	"example.com/foo/internal/client"
+)
+
+func Fetch(ctx context.Context, c *client.Client, path string) ([]byte, error) {
+	return c.Get(ctx, path, nil, nil)
+}
+`
+	const rawHTTPWithGeneratedClientImport = `package sec
+
+import (
+	"net/http"
+
+	"example.com/foo/internal/client"
+)
+
+var _ *client.Client
+
+func Fetch(url string) error {
+	resp, err := http.Get(url)
+	if err != nil { return err }
+	_ = resp
+	return nil
+}
+`
+	const generatedClientImportWithUnrelatedCGet = `package sec
+
+import "example.com/foo/internal/client"
+
+var _ *client.Client
+
+type Cache struct{}
+
+func (c *Cache) Get(key string) ([]byte, error) {
+	return nil, nil
+}
+
+func Fetch(c *Cache, key string) ([]byte, error) {
+	return c.Get(key)
+}
+`
 	const limiterButNo429 = `package sec
 
 import (
@@ -231,6 +276,23 @@ func (c *Client) Fetch(url string) error {
 			wantFindings:  1,
 			wantReasonHas: "rate limiter",
 			wantPackage:   "source/sec",
+		},
+		{
+			name:           "generated client helper passes without local limiter",
+			files:          map[string]string{"source/sec/sec.go": generatedClientHelper},
+			wantCheckedPos: true,
+		},
+		{
+			name:          "generated client import does not exempt raw HTTP",
+			files:         map[string]string{"source/sec/sec.go": rawHTTPWithGeneratedClientImport},
+			wantFindings:  1,
+			wantReasonHas: "without rate limiter or typed 429",
+		},
+		{
+			name:          "generated client import does not exempt unrelated c Get",
+			files:         map[string]string{"source/sec/sec.go": generatedClientImportWithUnrelatedCGet},
+			wantFindings:  1,
+			wantReasonHas: "without rate limiter or typed 429",
 		},
 		{
 			name:          "flags swallowed 429",


### PR DESCRIPTION
## Summary

`source_client_check` now treats sibling helper packages that delegate through the generated `internal/client` as already covered by the generated client limiter and retry behavior. This removes the false positive where `*client.Client` helper methods like `c.Get(...)` were classified as raw outbound HTTP and required a second local limiter.

The exemption is intentionally narrow: files that import `internal/client` but also make raw `net/http` or embedded HTTP-client calls still require local limiter and typed 429 handling.

## Testing

- `go test ./internal/pipeline`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./printing-press ./cmd/printing-press`

Fixes #538

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)