### PR TITLE
fix(cli): reclaim locks from dead owners

### DIFF
--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -351,10 +351,20 @@ func validatePhase5GateForPromote(workingDir string, state *PipelineState) error
 	return fmt.Errorf("phase5 gate failed: %s", result.Detail)
 }
 
-// IsStale returns true if the lock's UpdatedAt is older than StaleLockThreshold.
+// IsStale returns true if the lock's heartbeat is too old or its owner
+// process is known to have exited.
 func IsStale(lock *LockState) bool {
-	return time.Since(lock.UpdatedAt) > StaleLockThreshold
+	if time.Since(lock.UpdatedAt) > StaleLockThreshold {
+		return true
+	}
+	return lockOwnerDead(lock)
 }
+
+func lockOwnerDead(lock *LockState) bool {
+	return lock.PID > 0 && !lockOwnerAliveFunc(lock.PID)
+}
+
+var lockOwnerAliveFunc = lockOwnerAlive
 
 func readLock(path string) (*LockState, error) {
 	data, err := os.ReadFile(path)

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -81,6 +81,25 @@ func TestAcquireLock_StaleLockAutoReclaim(t *testing.T) {
 	assert.Equal(t, "new-scope", lock.Scope)
 }
 
+func TestAcquireLock_FreshLockDeadPIDAutoReclaim(t *testing.T) {
+	setupLockTest(t)
+	setLockOwnerAliveForTest(t, false)
+
+	require.NoError(t, os.MkdirAll(LocksDir(), 0o755))
+	deadLock := &LockState{
+		Scope:      "old-scope",
+		Phase:      "build",
+		PID:        12345,
+		AcquiredAt: time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	require.NoError(t, writeLock(LockFilePath("test-pp-cli"), deadLock))
+
+	lock, err := AcquireLock("test-pp-cli", "new-scope", false)
+	require.NoError(t, err)
+	assert.Equal(t, "new-scope", lock.Scope)
+}
+
 func TestAcquireLock_FreshLockDifferentScope_Blocked(t *testing.T) {
 	setupLockTest(t)
 
@@ -143,6 +162,27 @@ func TestLockStatus_ActiveLock(t *testing.T) {
 	assert.Equal(t, "acquire", status.Phase)
 	assert.Equal(t, "scope-1", status.Scope)
 	assert.NotNil(t, status.Lock)
+}
+
+func TestLockStatus_FreshLockDeadPIDIsStale(t *testing.T) {
+	setupLockTest(t)
+	setLockOwnerAliveForTest(t, false)
+
+	require.NoError(t, os.MkdirAll(LocksDir(), 0o755))
+	deadLock := &LockState{
+		Scope:      "old-scope",
+		Phase:      "build",
+		PID:        12345,
+		AcquiredAt: time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	require.NoError(t, writeLock(LockFilePath("test-pp-cli"), deadLock))
+
+	status := LockStatus("test-pp-cli")
+	assert.True(t, status.Held)
+	assert.True(t, status.Stale)
+	assert.Equal(t, "build", status.Phase)
+	assert.Equal(t, "old-scope", status.Scope)
 }
 
 func TestLockStatus_NoLock(t *testing.T) {
@@ -606,4 +646,12 @@ func TestConcurrentAcquire(t *testing.T) {
 		winners++
 	}
 	assert.GreaterOrEqual(t, winners, 1, "at least one goroutine should acquire the lock")
+}
+
+func setLockOwnerAliveForTest(t *testing.T, alive bool) {
+	t.Helper()
+
+	original := lockOwnerAliveFunc
+	lockOwnerAliveFunc = func(pid int) bool { return alive }
+	t.Cleanup(func() { lockOwnerAliveFunc = original })
 }

--- a/internal/pipeline/process_liveness_other.go
+++ b/internal/pipeline/process_liveness_other.go
@@ -1,0 +1,7 @@
+//go:build !unix && !windows
+
+package pipeline
+
+func lockOwnerAlive(pid int) bool {
+	return pid > 0
+}

--- a/internal/pipeline/process_liveness_unix.go
+++ b/internal/pipeline/process_liveness_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package pipeline
+
+import "syscall"
+
+func lockOwnerAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/pipeline/process_liveness_windows.go
+++ b/internal/pipeline/process_liveness_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package pipeline
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsStillActive = 259
+
+func lockOwnerAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false
+		}
+		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return true
+	}
+	return exitCode == windowsStillActive
+}


### PR DESCRIPTION
## Summary

Fresh lock files whose owner process has exited are now treated as stale, so `lock status` reports them as stale and `lock acquire` can reclaim them without `--force`.

The stale predicate still preserves heartbeat-age behavior, but now adds OS-specific PID liveness checks. Unix checks signal 0 and treats permission-denied as “process exists”; Windows checks process exit status when a handle can be opened and otherwise stays conservative for access errors. Unsupported platforms keep the prior conservative behavior.

## Testing

- `rtk go test ./internal/pipeline -run 'Test(AcquireLock_FreshLockDeadPIDAutoReclaim|LockStatus_FreshLockDeadPIDIsStale)'`
- `rtk env GOOS=windows GOARCH=amd64 go test -c ./internal/pipeline -o ./.gotmp/cross/pipeline-windows.test`
- `rtk env GOOS=linux GOARCH=amd64 go test -c ./internal/pipeline -o ./.gotmp/cross/pipeline-linux.test`
- `rtk go test ./internal/cli -run Lock`
- `rtk go test ./internal/pipeline`
- `rtk go test ./...`
- `rtk golangci-lint run ./...`
- `rtk scripts/golden.sh verify`
- `rtk go build -o ./printing-press ./cmd/printing-press`

Fixes #547.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
