### PR TITLE
fix(cli): parse epoch Retry-After headers

### DIFF
--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -121,25 +121,26 @@ func (e *RateLimitError) Error() string {
 // or hostile upstream cannot pin a CLI for hours.
 const MaxRetryWait = 60 * time.Second
 
+const (
+	defaultRetryWait               = 5 * time.Second
+	unixEpochSecondsThreshold      = 1_000_000_000
+	unixEpochMillisecondsThreshold = 1_000_000_000_000
+)
+
 // RetryAfter parses an HTTP Retry-After header (RFC 7231: delta-seconds or
-// HTTP-date), capped at MaxRetryWait. Returns 5s when missing or unparseable.
+// HTTP-date), plus common Unix epoch seconds/milliseconds variants emitted by
+// some APIs. Waits are capped at MaxRetryWait. Returns 5s when missing or
+// unparseable.
 func RetryAfter(resp *http.Response) time.Duration {
 	if resp == nil {
-		return 5 * time.Second
+		return defaultRetryWait
 	}
 	header := strings.TrimSpace(resp.Header.Get("Retry-After"))
 	if header == "" {
-		return 5 * time.Second
+		return defaultRetryWait
 	}
-	if seconds, err := strconv.Atoi(header); err == nil {
-		d := time.Duration(seconds) * time.Second
-		if d > MaxRetryWait {
-			return MaxRetryWait
-		}
-		if d <= 0 {
-			return 5 * time.Second
-		}
-		return d
+	if value, err := strconv.ParseInt(header, 10, 64); err == nil {
+		return retryAfterFromNumber(value)
 	}
 	if t, err := http.ParseTime(header); err == nil {
 		wait := time.Until(t)
@@ -150,7 +151,34 @@ func RetryAfter(resp *http.Response) time.Duration {
 			return wait
 		}
 	}
-	return 5 * time.Second
+	return defaultRetryWait
+}
+
+func retryAfterFromNumber(value int64) time.Duration {
+	if value <= 0 {
+		return defaultRetryWait
+	}
+	if value > int64(MaxRetryWait/time.Second) {
+		if wait := retryAfterEpochWait(value); wait > 0 {
+			if wait > MaxRetryWait {
+				return MaxRetryWait
+			}
+			return wait
+		}
+		return MaxRetryWait
+	}
+	return time.Duration(value) * time.Second
+}
+
+func retryAfterEpochWait(value int64) time.Duration {
+	switch {
+	case value >= unixEpochMillisecondsThreshold:
+		return time.Until(time.UnixMilli(value))
+	case value >= unixEpochSecondsThreshold:
+		return time.Until(time.Unix(value, 0))
+	default:
+		return 0
+	}
 }
 
 // MaxBackoff caps Backoff so tests stay bounded. Callers needing jitter

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -755,6 +755,26 @@ func TestRetryAfter_HTTPDate(t *testing.T) {
 	}
 }
 
+func TestRetryAfter_EpochSeconds(t *testing.T) {
+	future := time.Now().Add(7 * time.Second)
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", fmt.Sprint(future.Unix()))
+	got := RetryAfter(resp)
+	if got < 5*time.Second || got > 8*time.Second {
+		t.Errorf("RetryAfter(epoch seconds 7s ahead) = %v, want ~7s", got)
+	}
+}
+
+func TestRetryAfter_EpochMilliseconds(t *testing.T) {
+	future := time.Now().Add(7 * time.Second)
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", fmt.Sprint(future.UnixMilli()))
+	got := RetryAfter(resp)
+	if got < 5*time.Second || got > 8*time.Second {
+		t.Errorf("RetryAfter(epoch milliseconds 7s ahead) = %v, want ~7s", got)
+	}
+}
+
 func TestRetryAfter_Cap(t *testing.T) {
 	resp := &http.Response{Header: http.Header{}}
 	resp.Header.Set("Retry-After", "600")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -121,25 +121,26 @@ func (e *RateLimitError) Error() string {
 // or hostile upstream cannot pin a CLI for hours.
 const MaxRetryWait = 60 * time.Second
 
+const (
+	defaultRetryWait               = 5 * time.Second
+	unixEpochSecondsThreshold      = 1_000_000_000
+	unixEpochMillisecondsThreshold = 1_000_000_000_000
+)
+
 // RetryAfter parses an HTTP Retry-After header (RFC 7231: delta-seconds or
-// HTTP-date), capped at MaxRetryWait. Returns 5s when missing or unparseable.
+// HTTP-date), plus common Unix epoch seconds/milliseconds variants emitted by
+// some APIs. Waits are capped at MaxRetryWait. Returns 5s when missing or
+// unparseable.
 func RetryAfter(resp *http.Response) time.Duration {
 	if resp == nil {
-		return 5 * time.Second
+		return defaultRetryWait
 	}
 	header := strings.TrimSpace(resp.Header.Get("Retry-After"))
 	if header == "" {
-		return 5 * time.Second
+		return defaultRetryWait
 	}
-	if seconds, err := strconv.Atoi(header); err == nil {
-		d := time.Duration(seconds) * time.Second
-		if d > MaxRetryWait {
-			return MaxRetryWait
-		}
-		if d <= 0 {
-			return 5 * time.Second
-		}
-		return d
+	if value, err := strconv.ParseInt(header, 10, 64); err == nil {
+		return retryAfterFromNumber(value)
 	}
 	if t, err := http.ParseTime(header); err == nil {
 		wait := time.Until(t)
@@ -150,7 +151,34 @@ func RetryAfter(resp *http.Response) time.Duration {
 			return wait
 		}
 	}
-	return 5 * time.Second
+	return defaultRetryWait
+}
+
+func retryAfterFromNumber(value int64) time.Duration {
+	if value <= 0 {
+		return defaultRetryWait
+	}
+	if value > int64(MaxRetryWait/time.Second) {
+		if wait := retryAfterEpochWait(value); wait > 0 {
+			if wait > MaxRetryWait {
+				return MaxRetryWait
+			}
+			return wait
+		}
+		return MaxRetryWait
+	}
+	return time.Duration(value) * time.Second
+}
+
+func retryAfterEpochWait(value int64) time.Duration {
+	switch {
+	case value >= unixEpochMillisecondsThreshold:
+		return time.Until(time.UnixMilli(value))
+	case value >= unixEpochSecondsThreshold:
+		return time.Until(time.Unix(value, 0))
+	default:
+		return 0
+	}
 }
 
 // MaxBackoff caps Backoff so tests stay bounded. Callers needing jitter


### PR DESCRIPTION
## Summary

Generated CLIs now interpret plausible Unix epoch `Retry-After` numbers before applying the delta-seconds cap, so near-future epoch seconds or milliseconds wait for the intended duration instead of always rounding up to `MaxRetryWait`.

Small numeric delta-seconds keep the existing behavior, non-positive values still use the 5s default, and large non-epoch numeric values remain capped. The generated cliutil tests now cover epoch seconds and epoch milliseconds, and the golden fixture records the emitted helper change.

## Testing

- `rtk go test ./internal/generator -run TestGenerateCliutilPackage`
- `rtk go test ./internal/generator -run 'TestGenerate(CliutilPackage|ProjectsCompile)'`
- `rtk go test ./internal/generator`
- `rtk scripts/golden.sh verify`
- `rtk go test ./...`
- `rtk golangci-lint run ./...`
- `rtk go build -o ./printing-press ./cmd/printing-press`

Fixes #542.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
