### PR TITLE
fix(skills): tighten publish and polish workflows

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -267,6 +267,16 @@ Fix in priority order. After each priority level, update the lock heartbeat:
 printing-press lock update --cli "$CLI_NAME" --phase polish 2>/dev/null
 ```
 
+### Runtime variant default checklist
+
+If a polish fix adds or changes a runtime mode, data-source option, auth tier, transport, or other user-visible default, document this short checklist before selecting the default:
+
+- **User-visible default:** which behavior users get without extra flags or config.
+- **Compatibility risk:** whether existing commands, scripts, MCP tools, or stored config change behavior.
+- **Verification command:** the exact command that proves the default and the non-default escape hatch both work.
+
+Keep the checklist in the polish notes or result block. Skip it for ordinary bug fixes that do not change runtime variants or defaults.
+
 ### Priority 0: MCP surface migration (legacy CLIs)
 
 If Phase 1's `dogfood` reported `MCP Surface: FAIL` with a parity mismatch, the CLI was generated before the runtime cobratree walker existed and is still on the static `internal/mcp/tools.go` surface. The fix is mechanical:

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -680,7 +680,7 @@ Read `access` and `gh_user` from `$PUBLISH_CONFIG`. These determine how `gh pr c
 
 **For fork-based PRs** (`access` is `fork`): use `--head <gh_user>:feat/<api-slug>` so GitHub creates a cross-repo PR from the fork to the upstream. Without `--head`, `gh pr create` would try to find the branch on the upstream repo (where the user can't push) and fail.
 
-**For push-access PRs** (`access` is `push`): no `--head` needed — the branch is on the same repo.
+**For push-access PRs** (`access` is `push`): use `--head feat/<api-slug>` so GitHub creates the PR from the branch this flow just pushed, even when the managed clone or shell session has other branches checked out.
 
 Build the PR description from:
 - The manifest (`description`, `api_name`, `category`, `printing_press_version`, `spec_url`)
@@ -764,19 +764,17 @@ ACCESS=$(jq -r .access "$PUBLISH_CONFIG")
 GH_USER=$(jq -r .gh_user "$PUBLISH_CONFIG")
 
 if [ "$ACCESS" = "fork" ]; then
-  gh pr create \
-    --repo mvanhorn/printing-press-library \
-    --head "$GH_USER:feat/<api-slug>" \
-    --base main \
-    --title "feat(<api-slug>): add <api-slug>" \
-    --body "<constructed PR body>"
+  PR_HEAD_REF="$GH_USER:feat/<api-slug>"
 else
-  gh pr create \
-    --repo mvanhorn/printing-press-library \
-    --base main \
-    --title "feat(<api-slug>): add <api-slug>" \
-    --body "<constructed PR body>"
+  PR_HEAD_REF="feat/<api-slug>"
 fi
+
+gh pr create \
+  --repo mvanhorn/printing-press-library \
+  --head "$PR_HEAD_REF" \
+  --base main \
+  --title "feat(<api-slug>): add <api-slug>" \
+  --body "<constructed PR body>"
 ```
 
 Display the full PR URL (e.g., `https://github.com/mvanhorn/printing-press-library/pull/10`), not the shorthand `org/repo#N` format. The full URL is clickable in all terminals and contexts.


### PR DESCRIPTION
## Summary

Publish and polish workflows now document the deterministic choices agents need for recently observed edge cases. Push-access publish PRs pass an explicit head ref, and polish runs that change runtime defaults now require a short default-selection checklist before choosing behavior.

This keeps both fixes in one skills-only PR because they update adjacent agent workflow guidance without touching generator behavior.

## Testing

- `rtk git diff --check`
- `rtk go test ./...`
- `rtk golangci-lint run ./...`

Fixes #545
Fixes #546

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)