### PR TITLE
fix(cli): preserve query params in generated MCP handlers

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5950,6 +5950,83 @@ func assertNewMCPClientSkipsCache(t *testing.T, specSource string) {
 		"newMCPClient must disable the response cache so MCP-driven reads see fresh state across mutations")
 }
 
+// TestGenerateMCPHandlerPreservesQueryPositionals proves the makeAPIHandler
+// body in generated MCP tools.go distinguishes real URL path placeholders
+// (e.g. /movie/{movieId}) from CLI positional args that map to query
+// params (e.g. `search <query>` -> ?query=). The bug was that the handler
+// dropped every positionalParams entry from the query map, so a query-style
+// positional like `query` silently disappeared from the request — TMDb
+// returned an empty page for movies_search even with a non-empty query.
+func TestGenerateMCPHandlerPreservesQueryPositionals(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcphandler")
+	apiSpec.Resources = map[string]spec.Resource{
+		"movies": {
+			Description: "Movies",
+			Endpoints: map[string]spec.Endpoint{
+				// Query-style positional: `query` is a CLI positional but
+				// must be sent as ?query=… because the path has no {query}.
+				"search": {
+					Method:      "GET",
+					Path:        "/search/movie",
+					Description: "Search movies",
+					Params: []spec.Param{
+						{Name: "query", Type: "string", Required: true, Positional: true, Description: "Search query"},
+						{Name: "year", Type: "string", Description: "Release year"},
+					},
+				},
+				// Real path param: `movieId` is substituted into the URL.
+				"get": {
+					Method:      "GET",
+					Path:        "/movie/{movieId}",
+					Description: "Get a movie",
+					Params: []spec.Param{
+						{Name: "movieId", Type: "string", Required: true, PathParam: true, Description: "Movie ID"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	toolsData, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	tools := string(toolsData)
+
+	// Call sites still pass both names — the upstream emit is unchanged;
+	// the fix lives entirely inside the handler body.
+	assert.Regexp(t,
+		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/search/movie",\s*\[]string\{[^}]*"query"`),
+		tools,
+		"search call site must still pass `query` in positionalParams (handler decides path vs query at runtime)")
+	assert.Regexp(t,
+		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/movie/\{movieId\}",\s*\[]string\{[^}]*"movieId"`),
+		tools,
+		"get-by-id call site must pass `movieId` in positionalParams")
+
+	// Handler body: only entries whose placeholder appears in the path
+	// template are treated as path params. Everything else stays in the
+	// query map.
+	assert.Contains(t, tools,
+		`if !strings.Contains(pathTemplate, placeholder) {`,
+		"makeAPIHandler must skip positionalParams entries that have no matching path placeholder")
+	assert.Contains(t, tools,
+		`pathParams := make(map[string]bool, len(positionalParams))`,
+		"makeAPIHandler must build a pathParams set so the query-collection loop can reuse the path-vs-query decision")
+
+	// Old buggy shape must be gone: a flat positional-skip in the query
+	// loop dropped query-style positionals from the request.
+	assert.NotContains(t, tools, "isPositional := false",
+		"old handler shape skipped every positionalParams entry from query — must not regress")
+
+	// Generated CLI must still compile.
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 // TestGenerateMCPCodeOrchKeywordsHasStopwordFilter proves the keyword
 // extractor in the code-orchestration thin surface filters short tokens
 // and a stopword set. Without this, two-letter substrings like "is"/"in"

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6007,18 +6007,10 @@ func TestGenerateMCPHandlerPreservesQueryPositionals(t *testing.T) {
 		tools,
 		"get-by-id call site must pass `movieId` in positionalParams")
 
-	// Handler body: only entries whose placeholder appears in the path
-	// template are treated as path params. Everything else stays in the
-	// query map.
-	assert.Contains(t, tools,
-		`if !strings.Contains(pathTemplate, placeholder) {`,
-		"makeAPIHandler must skip positionalParams entries that have no matching path placeholder")
-	assert.Contains(t, tools,
-		`pathParams := make(map[string]bool, len(positionalParams))`,
-		"makeAPIHandler must build a pathParams set so the query-collection loop can reuse the path-vs-query decision")
-
-	// Old buggy shape must be gone: a flat positional-skip in the query
-	// loop dropped query-style positionals from the request.
+	assert.Regexp(t,
+		regexp.MustCompile(`strings\.Contains\(pathTemplate,`),
+		tools,
+		"makeAPIHandler must guard the path-substitution loop with a placeholder-presence check so query-style positionals stay in the query map")
 	assert.NotContains(t, tools, "isPositional := false",
 		"old handler shape skipped every positionalParams entry from query — must not regress")
 

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -177,9 +177,8 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 		args := req.GetArguments()
 
 		// positionalParams mixes real URL path params with CLI positional
-		// args that map to query params (e.g. `search <query>` -> ?query=).
-		// Only treat an entry as a path param when the path template
-		// actually contains {name}; everything else stays in the query map.
+		// args that map to query params (e.g. `search <query>` -> ?query=);
+		// the placeholder check below disambiguates them at runtime.
 		path := pathTemplate
 		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -176,27 +176,29 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 		// we rely on here (or an empty map when the payload is something else).
 		args := req.GetArguments()
 
-		// Build path by substituting positional params
+		// positionalParams mixes real URL path params with CLI positional
+		// args that map to query params (e.g. `search <query>` -> ?query=).
+		// Only treat an entry as a path param when the path template
+		// actually contains {name}; everything else stays in the query map.
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
 		params := make(map[string]string)
 		for k, v := range args {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
+			if pathParams[k] {
+				continue
 			}
-			if !isPositional {
-				params[k] = fmt.Sprintf("%v", v)
-			}
+			params[k] = fmt.Sprintf("%v", v)
 		}
 
 		var data json.RawMessage

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -155,27 +155,29 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 		// we rely on here (or an empty map when the payload is something else).
 		args := req.GetArguments()
 
-		// Build path by substituting positional params
+		// positionalParams mixes real URL path params with CLI positional
+		// args that map to query params (e.g. `search <query>` -> ?query=).
+		// Only treat an entry as a path param when the path template
+		// actually contains {name}; everything else stays in the query map.
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
 		params := make(map[string]string)
 		for k, v := range args {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
+			if pathParams[k] {
+				continue
 			}
-			if !isPositional {
-				params[k] = fmt.Sprintf("%v", v)
-			}
+			params[k] = fmt.Sprintf("%v", v)
 		}
 
 		var data json.RawMessage

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -156,9 +156,8 @@ func makeAPIHandler(method, pathTemplate string, positionalParams []string) serv
 		args := req.GetArguments()
 
 		// positionalParams mixes real URL path params with CLI positional
-		// args that map to query params (e.g. `search <query>` -> ?query=).
-		// Only treat an entry as a path param when the path template
-		// actually contains {name}; everything else stays in the query map.
+		// args that map to query params (e.g. `search <query>` -> ?query=);
+		// the placeholder check below disambiguates them at runtime.
 		path := pathTemplate
 		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -92,27 +92,29 @@ func makeAPIHandler(method, pathTemplate, tier string, positionalParams []string
 		// we rely on here (or an empty map when the payload is something else).
 		args := req.GetArguments()
 
-		// Build path by substituting positional params
+		// positionalParams mixes real URL path params with CLI positional
+		// args that map to query params (e.g. `search <query>` -> ?query=).
+		// Only treat an entry as a path param when the path template
+		// actually contains {name}; everything else stays in the query map.
 		path := pathTemplate
+		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {
+			placeholder := "{" + p + "}"
+			if !strings.Contains(pathTemplate, placeholder) {
+				continue
+			}
+			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, "{"+p+"}", fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
 			}
 		}
 
-		// Collect non-positional params as query params
 		params := make(map[string]string)
 		for k, v := range args {
-			isPositional := false
-			for _, p := range positionalParams {
-				if k == p {
-					isPositional = true
-					break
-				}
+			if pathParams[k] {
+				continue
 			}
-			if !isPositional {
-				params[k] = fmt.Sprintf("%v", v)
-			}
+			params[k] = fmt.Sprintf("%v", v)
 		}
 
 		var data json.RawMessage

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -93,9 +93,8 @@ func makeAPIHandler(method, pathTemplate, tier string, positionalParams []string
 		args := req.GetArguments()
 
 		// positionalParams mixes real URL path params with CLI positional
-		// args that map to query params (e.g. `search <query>` -> ?query=).
-		// Only treat an entry as a path param when the path template
-		// actually contains {name}; everything else stays in the query map.
+		// args that map to query params (e.g. `search <query>` -> ?query=);
+		// the placeholder check below disambiguates them at runtime.
 		path := pathTemplate
 		pathParams := make(map[string]bool, len(positionalParams))
 		for _, p := range positionalParams {


### PR DESCRIPTION
## Summary

- Fixes #578: typed MCP endpoint tools silently dropped query-style positional args (e.g. `movies_search` called with `query=The Martian` was sent to TMDb without `query`).
- Updates `makeAPIHandler` in `internal/generator/templates/mcp_tools.go.tmpl` to only treat a `positionalParams` entry as a path param when the path template actually contains `{name}`. Everything else stays in the query map.
- Adds `TestGenerateMCPHandlerPreservesQueryPositionals` in `internal/generator/generator_test.go` covering both shapes (`/search/movie` with `query` positional + `/movie/{movieId}` with real path param) and asserting the generated CLI compiles.
- Regenerates the two affected MCP goldens (`generate-golden-api`, `generate-tier-routing-api`); call-site emit is unchanged, only the shared handler body changes.

## Test plan

- [x] `go test ./...` — 2891 pass
- [x] `go vet ./...` — clean
- [x] `scripts/golden.sh verify` — 11/11 pass
- [x] New unit test fails on the prior template (verified locally before edit) and passes on the new one
- [ ] Library backports (`mvanhorn/printing-press-library#232`, `#233`) handled separately per the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)