### PR TITLE
fix(cli): stamp run_id into manifest at generate time

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -158,11 +158,16 @@ func newGenerateCmd() *cobra.Command {
 					return err
 				}
 
+				runID := pipeline.DeriveRunIDFromResearchDir(researchDir)
+				if runID == "" {
+					fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
+				}
 				if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
 					APIName:       parsed.Name,
 					DocsURL:       docsURL,
 					OutputDir:     absOut,
 					Owner:         parsed.Owner,
+					RunID:         runID,
 					Spec:          parsed,
 					NovelFeatures: novelFeatures,
 				}); err != nil {
@@ -318,12 +323,17 @@ func newGenerateCmd() *cobra.Command {
 				}
 			}
 
+			runID := pipeline.DeriveRunIDFromResearchDir(researchDir)
+			if runID == "" {
+				fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
+			}
 			if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
 				APIName:       apiSpec.Name,
 				SpecSrcs:      specFiles,
 				SpecURL:       specURL,
 				OutputDir:     absOut,
 				Owner:         apiSpec.Owner,
+				RunID:         runID,
 				Spec:          apiSpec,
 				NovelFeatures: novelFeatures,
 			}); err != nil {

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -330,8 +331,30 @@ type GenerateManifestParams struct {
 	DocsURL       string   // --docs URL, if used
 	OutputDir     string
 	Owner         string                 // resolved owner attribution (manifest preserve > copyright parse > git config)
+	RunID         string                 // YYYYMMDD-HHMMSS, derived from --research-dir basename when empty
 	Spec          *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
 	NovelFeatures []NovelFeatureManifest // transcendence features from research (nil if unavailable)
+}
+
+// runIDPattern matches the canonical pipeline run_id shape: YYYYMMDD-HHMMSS.
+// When an arbitrary path basename happens to match this pattern, treat it as
+// a real run_id; otherwise fall back to empty (and warn at the call site).
+var runIDPattern = regexp.MustCompile(`^\d{8}-\d{6}$`)
+
+// DeriveRunIDFromResearchDir extracts a canonical run_id from a research-dir
+// path, or returns "" when no valid run_id can be derived. The standalone
+// generate command does not load a PipelineState, so it cannot reach
+// state.RunID directly; the basename of --research-dir is the only structured
+// signal available without a state-loading refactor.
+func DeriveRunIDFromResearchDir(researchDir string) string {
+	if researchDir == "" {
+		return ""
+	}
+	base := filepath.Base(researchDir)
+	if runIDPattern.MatchString(base) {
+		return base
+	}
+	return ""
 }
 
 // WriteManifestForGenerate writes a .printing-press.json manifest into the
@@ -344,6 +367,7 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		PrintingPressVersion: version.Version,
 		APIName:              p.APIName,
 		CLIName:              naming.CLI(p.APIName),
+		RunID:                p.RunID,
 		Owner:                p.Owner,
 	}
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -474,6 +474,61 @@ func TestWriteManifestForGenerateNoSpec(t *testing.T) {
 	assert.Empty(t, got.SpecChecksum)
 }
 
+func TestWriteManifestForGenerateStampsRunID(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "runid-test",
+		RunID:     "20260504-190931",
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "20260504-190931", got.RunID)
+}
+
+func TestWriteManifestForGenerateOmitsEmptyRunID(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "norunid-test",
+		OutputDir: dir,
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	// run_id has the omitempty tag; empty value must not appear in serialized JSON.
+	assert.NotContains(t, string(data), `"run_id"`)
+}
+
+func TestDeriveRunIDFromResearchDir(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"canonical run_id basename", "/tmp/runs/20260504-190931", "20260504-190931"},
+		{"trailing slash", "/tmp/runs/20260504-190931/", "20260504-190931"},
+		{"basename only", "20260101-000000", "20260101-000000"},
+		{"empty input", "", ""},
+		{"non-matching basename", "/tmp/runs/research", ""},
+		{"partial match (date only)", "/tmp/runs/20260504", ""},
+		{"longer suffix", "/tmp/runs/20260504-190931-x", ""},
+		{"wrong shape (T separator)", "/tmp/runs/20260504T190931", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, DeriveRunIDFromResearchDir(tc.input))
+		})
+	}
+}
+
 func TestArchiveRunArtifactsCopiesDiscovery(t *testing.T) {
 	home := setPressTestEnv(t)
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -406,11 +406,14 @@ Maintain a lightweight state file at `$STATE_FILE` so `/printing-press-score` ca
 ```json
 {
   "api_name": "<api>",
+  "run_id": "$RUN_ID",
   "working_dir": "$CLI_WORK_DIR",
   "output_dir": "$CLI_WORK_DIR",
   "spec_path": "<absolute spec path if known>"
 }
 ```
+
+`run_id` is the same `YYYYMMDD-HHMMSS` value computed earlier as `RUN_ID="$(date +%Y%m%d-%H%M%S)"`. The generator's manifest writer derives the same value from the `--research-dir` basename when generate is invoked through the canonical `$API_RUN_DIR` (whose basename equals `$RUN_ID`); persisting it in `state.json` here keeps `/printing-press-score` and any future state-loading consumer in sync. Without `run_id` in either path, `printing-press dogfood --live --write-acceptance` refuses to write the gate marker.
 
 Do not create a `go.work` file in `$CLI_WORK_DIR`. Generated modules must build and test as standalone modules; a mismatched workspace `go` directive can break Go 1.25+ toolchains and lefthook checks. Editor/gopls workspace noise is cosmetic and must not be traded for broken `go build` or `go test`.
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/stderr.txt
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/stderr.txt
@@ -1,1 +1,2 @@
+warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it
 Generated printing-press-oauth2 at <ARTIFACT_DIR>/generate-golden-api-oauth2-cc/printing-press-oauth2-cc

--- a/testdata/golden/expected/generate-golden-api-unicode/stderr.txt
+++ b/testdata/golden/expected/generate-golden-api-unicode/stderr.txt
@@ -1,1 +1,2 @@
+warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it
 Generated cafe-bistro at <ARTIFACT_DIR>/generate-golden-api-unicode/cafe-bistro

--- a/testdata/golden/expected/generate-golden-api/stderr.txt
+++ b/testdata/golden/expected/generate-golden-api/stderr.txt
@@ -1,1 +1,2 @@
+warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it
 Generated printing-press-golden at <ARTIFACT_DIR>/generate-golden-api/printing-press-golden

--- a/testdata/golden/expected/generate-tier-routing-api/stderr.txt
+++ b/testdata/golden/expected/generate-tier-routing-api/stderr.txt
@@ -1,1 +1,2 @@
+warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it
 Generated tier-routing-golden at <ARTIFACT_DIR>/generate-tier-routing-api/tier-routing-golden


### PR DESCRIPTION
## Summary

- `printing-press generate --research-dir <YYYYMMDD-HHMMSS-dir>` now stamps `run_id` into `.printing-press.json`. Without it, `dogfood --live --write-acceptance` refuses to write the gate marker and `lock promote` refuses to promote.
- Belt-and-suspenders: the SKILL.md state.json schema also gains `run_id`, so `/printing-press-score` and any future state-loading consumer stay in sync.
- Reverses the now-obsolete boundary set in `docs/plans/2026-03-28-002-feat-cli-manifest-plan.md` ("standalone generate does not write a manifest"); `WriteManifestForGenerate` exists today, this PR finishes the contract that the post-3-28 reversal left incomplete.

## Background

Library audit at the time of the Trigger.dev retro (#587) showed 3 of 26 v3.x CLIs (allrecipes, yahoo-finance, trigger-dev) ship with `run_id` MISSING — the discriminator was whether `state.json` happened to be loaded by the time `WriteManifestForGenerate` was called. The HN reprint hit the same gap (#586). #591 consolidated #588 to address both observations from one PR.

The marker writer at `internal/pipeline/publish.go:203` already stamps `RunID: state.RunID` correctly at publish; the asymmetry was that `internal/pipeline/climanifest.go:340` (`WriteManifestForGenerate`) had no `RunID` field on its params struct and never set it. This PR adds the field, threads it through both `internal/cli/root.go` call sites (:161, :321), and derives the value via `DeriveRunIDFromResearchDir` — basename of `--research-dir` when it matches `^\d{8}-\d{6}$`, else empty + a one-line stderr warning that phase5 acceptance will refuse to write without it.

The `generate` command does not load a `PipelineState` today, so the basename derivation is the only structured signal available without a state-loading refactor. The SKILL.md state.json schema fix is the upstream side: it ensures the canonical state file is well-formed for any future state-loading consumer (and for `/printing-press-score`, which already reads state.json).

## Goldens

The new stderr warning surfaces on every `generate` invocation that doesn't pass `--research-dir`. The four `generate-*` golden cases run that way (deliberately deterministic), so each picks up exactly one new prefix line. The diff is a separate commit so reviewers see the source change and the golden re-baseline as two independent surfaces.

## Test plan

- [x] `go test ./... -count=1` — all packages pass (incl. 1033 in `internal/pipeline/`)
- [x] `go vet ./...` clean
- [x] `scripts/golden.sh verify` passes after update — 11/11 cases
- [x] New tests: `TestWriteManifestForGenerateStampsRunID`, `TestWriteManifestForGenerateOmitsEmptyRunID`, `TestDeriveRunIDFromResearchDir` (8 sub-cases covering canonical, edge, and non-matching shapes)
- [x] Manual smoke: `printing-press generate --research-dir /tmp/runs/20260504-190931 ...` produces a manifest where `jq .run_id .printing-press.json` returns `"20260504-190931"`

Closes #591 (which consolidated #588).

Plan: `docs/plans/2026-05-04-005-fix-wave-1-retro-blockers-plan.md` (U2 + U3 of three Wave 1 retro blockers; U1 shipped in #605, U4 to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)