### PR TITLE
fix(cli): skip destructive-at-auth endpoints in live dogfood

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -22,6 +22,7 @@ func newDogfoodCmd() *cobra.Command {
 	var timeout time.Duration
 	var writeAcceptance string
 	var authEnv string
+	var allowDestructive bool
 
 	cmd := &cobra.Command{
 		Use:   "dogfood",
@@ -40,6 +41,7 @@ func newDogfoodCmd() *cobra.Command {
 					Timeout:             timeout,
 					WriteAcceptancePath: writeAcceptance,
 					AuthEnv:             authEnv,
+					AllowDestructive:    allowDestructive,
 				})
 				if err != nil {
 					return &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("running live dogfood: %w", err)}
@@ -88,6 +90,7 @@ func newDogfoodCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Second, "Timeout for each live dogfood test")
 	cmd.Flags().StringVar(&writeAcceptance, "write-acceptance", "", "Write phase5-acceptance.json to this path when live dogfood passes")
 	cmd.Flags().StringVar(&authEnv, "auth-env", "", "Environment variable that proves an API credential was available for the acceptance marker")
+	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "Re-enable testing of endpoints classified as destructive-at-auth (path/annotation matches refresh/rotate/revoke). Default skips them to prevent runner-credential rotation.")
 	_ = cmd.MarkFlagRequired("dir")
 	return cmd
 }

--- a/internal/generator/templates/agent_context.go.tmpl
+++ b/internal/generator/templates/agent_context.go.tmpl
@@ -60,6 +60,7 @@ type agentContextCommand struct {
 	Name        string                `json:"name"`
 	Use         string                `json:"use,omitempty"`
 	Short       string                `json:"short,omitempty"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Flags       []agentContextFlag    `json:"flags,omitempty"`
 	Subcommands []agentContextCommand `json:"subcommands,omitempty"`
 }
@@ -187,6 +188,16 @@ func collectAgentCommands(c *cobra.Command) []agentContextCommand {
 			Name:  sub.Name(),
 			Use:   sub.Use,
 			Short: sub.Short,
+		}
+		// Surface Cobra annotations (e.g., pp:endpoint, mcp:read-only) so
+		// agents and the live-dogfood classifier can detect destructive-at-auth
+		// endpoints without parsing source. Empty maps are stripped via
+		// omitempty in the struct tag.
+		if len(sub.Annotations) > 0 {
+			entry.Annotations = make(map[string]string, len(sub.Annotations))
+			for k, v := range sub.Annotations {
+				entry.Annotations[k] = v
+			}
 		}
 		sub.Flags().VisitAll(func(f *pflag.Flag) {
 			entry.Flags = append(entry.Flags, agentContextFlag{

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -143,6 +143,7 @@ type dogfoodAgentContext struct {
 
 type dogfoodAgentCommand struct {
 	Name        string                `json:"name"`
+	Annotations map[string]string     `json:"annotations,omitempty"`
 	Subcommands []dogfoodAgentCommand `json:"subcommands,omitempty"`
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -32,6 +32,11 @@ const (
 	LiveDogfoodTestError LiveDogfoodTestKind = "error_path"
 )
 
+// reasonDestructiveAtAuth is the Skip reason emitted for endpoints whose
+// path or pp:endpoint annotation matches refresh/rotate/revoke. Reused
+// across the matrix builder, the flag help text, and the test fixtures.
+const reasonDestructiveAtAuth = "destructive-at-auth"
+
 type LiveDogfoodOptions struct {
 	CLIDir              string
 	BinaryName          string
@@ -40,8 +45,8 @@ type LiveDogfoodOptions struct {
 	WriteAcceptancePath string
 	AuthEnv             string
 	// AllowDestructive re-enables testing of endpoints classified as
-	// destructive-at-auth (refresh/rotate/revoke/etc.). Default skips them
-	// to prevent runner-credential rotation. See #602.
+	// destructive-at-auth. Default skips them to prevent runner-credential
+	// rotation.
 	AllowDestructive bool
 }
 
@@ -586,16 +591,15 @@ func collectLiveDogfoodCommands(prefix []string, command dogfoodAgentCommand, cm
 func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDogfoodTestResult {
 	commandName := strings.Join(command.Path, " ")
 
-	// Destructive-at-auth short-circuit (#602): commands that rotate or
-	// revoke the runner's bearer would 401-cascade every subsequent test.
-	// finalizeLiveDogfoodReport excludes Skip from MatrixSize, so this is
-	// neutral on the verdict gate. Source of truth: see #602.
+	// Destructive-at-auth short-circuit: commands that rotate or revoke
+	// the runner's bearer would 401-cascade every subsequent test. Skips
+	// don't count toward MatrixSize (see finalizeLiveDogfoodReport).
 	if !ctx.allowDestructive && isDestructiveAtAuth(command.Annotations, command.Path) {
 		return []LiveDogfoodTestResult{
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHelp, "destructive-at-auth"),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, "destructive-at-auth"),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, "destructive-at-auth"),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, "destructive-at-auth"),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHelp, reasonDestructiveAtAuth),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonDestructiveAtAuth),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonDestructiveAtAuth),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonDestructiveAtAuth),
 		}
 	}
 
@@ -845,45 +849,25 @@ func skippedLiveDogfoodResult(command string, kind LiveDogfoodTestKind, reason s
 	}
 }
 
-// destructiveAuthTerms are case-insensitive substrings that classify a
-// command as destructive-at-auth. Limited to the three terms #602's body
-// names; extension-by-discovery is the deferred-question hook for new
-// patterns surfaced during live runs.
+// destructiveAuthTerms are case-insensitive substrings classifying a
+// command as destructive-at-auth.
 var destructiveAuthTerms = []string{"refresh", "rotate", "revoke"}
 
 // isDestructiveAtAuth reports whether a command rotates or revokes the
-// bearer the live-dogfood runner is using. Annotation-primary: read
-// pp:endpoint (set by the generator on every endpoint mirror per
-// AGENTS.md "Endpoint mirrors") and substring-match against the
-// destructiveAuthTerms set. Cobra-leaf-segment fallback handles novel
-// hand-built commands that lack the annotation. Read-only commands
-// (mcp:read-only=true) are exempt regardless of name — read-only commands
-// cannot rotate auth. See #602.
+// bearer the live-dogfood runner is using. Reads pp:endpoint
+// (authoritative for endpoint-mirror commands) and falls back to
+// Cobra-leaf-segment matching for novel commands. Read-only commands
+// are exempt regardless of name.
 func isDestructiveAtAuth(annotations map[string]string, commandPath []string) bool {
 	if annotations["mcp:read-only"] == "true" {
 		return false
 	}
 	if endpoint := annotations["pp:endpoint"]; endpoint != "" {
-		lower := strings.ToLower(endpoint)
-		for _, term := range destructiveAuthTerms {
-			if strings.Contains(lower, term) {
-				return true
-			}
-		}
-		// pp:endpoint annotation is present and authoritative — no
-		// leaf-fallback for endpoint-mirror commands. Their pp:endpoint
-		// captures the destructive signal completely.
-		return false
+		return containsAnyOf(strings.ToLower(endpoint), destructiveAuthTerms)
 	}
-	// Annotation absent: novel hand-built command. Substring-match on
-	// each leaf-path segment, lowercase. Catches compound names like
-	// `oauth-client-force-refresh`.
 	for _, seg := range commandPath {
-		lower := strings.ToLower(seg)
-		for _, term := range destructiveAuthTerms {
-			if strings.Contains(lower, term) {
-				return true
-			}
+		if containsAnyOf(strings.ToLower(seg), destructiveAuthTerms) {
+			return true
 		}
 	}
 	return false

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -856,8 +856,8 @@ var destructiveAuthTerms = []string{"refresh", "rotate", "revoke"}
 // isDestructiveAtAuth reports whether a command rotates or revokes the
 // bearer the live-dogfood runner is using. Reads pp:endpoint
 // (authoritative for endpoint-mirror commands) and falls back to
-// Cobra-leaf-segment matching for novel commands. Read-only commands
-// are exempt regardless of name.
+// path-segment matching across the command path for novel commands.
+// Read-only commands are exempt regardless of name.
 func isDestructiveAtAuth(annotations map[string]string, commandPath []string) bool {
 	if annotations["mcp:read-only"] == "true" {
 		return false

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -39,6 +39,10 @@ type LiveDogfoodOptions struct {
 	Timeout             time.Duration
 	WriteAcceptancePath string
 	AuthEnv             string
+	// AllowDestructive re-enables testing of endpoints classified as
+	// destructive-at-auth (refresh/rotate/revoke/etc.). Default skips them
+	// to prevent runner-credential rotation. See #602.
+	AllowDestructive bool
 }
 
 type LiveDogfoodReport struct {
@@ -66,8 +70,9 @@ type LiveDogfoodTestResult struct {
 }
 
 type liveDogfoodCommand struct {
-	Path []string
-	Help string
+	Path        []string
+	Help        string
+	Annotations map[string]string
 }
 
 type liveDogfoodRun struct {
@@ -116,11 +121,12 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	}
 
 	ctx := resolveCtx{
-		binaryPath: binaryPath,
-		cliDir:     opts.CLIDir,
-		siblings:   buildSiblingMap(commands),
-		cache:      newCompanionCache(),
-		timeout:    timeout,
+		binaryPath:       binaryPath,
+		cliDir:           opts.CLIDir,
+		siblings:         buildSiblingMap(commands),
+		cache:            newCompanionCache(),
+		timeout:          timeout,
+		allowDestructive: opts.AllowDestructive,
 	}
 
 	for _, command := range commands {
@@ -163,18 +169,13 @@ func discoverLiveDogfoodCommands(binaryPath string) ([]liveDogfoodCommand, error
 		return nil, fmt.Errorf("parsing agent-context: %w", err)
 	}
 
-	var paths [][]string
+	var commands []liveDogfoodCommand
 	for _, command := range ctx.Commands {
-		collectLiveDogfoodCommandPaths(nil, command, &paths)
+		collectLiveDogfoodCommands(nil, command, &commands)
 	}
-	sort.Slice(paths, func(i, j int) bool {
-		return strings.Join(paths[i], " ") < strings.Join(paths[j], " ")
+	sort.Slice(commands, func(i, j int) bool {
+		return strings.Join(commands[i].Path, " ") < strings.Join(commands[j].Path, " ")
 	})
-
-	commands := make([]liveDogfoodCommand, 0, len(paths))
-	for _, path := range paths {
-		commands = append(commands, liveDogfoodCommand{Path: path})
-	}
 	return commands, nil
 }
 
@@ -235,11 +236,12 @@ type companionCache struct {
 // resolveCtx threads run-scoped state into the chained companion walk so
 // individual helpers don't need to take the same five parameters.
 type resolveCtx struct {
-	binaryPath string
-	cliDir     string
-	siblings   map[string][]liveDogfoodCommand
-	cache      *companionCache
-	timeout    time.Duration
+	binaryPath       string
+	cliDir           string
+	siblings         map[string][]liveDogfoodCommand
+	cache            *companionCache
+	timeout          time.Duration
+	allowDestructive bool
 }
 
 func newCompanionCache() *companionCache {
@@ -566,23 +568,36 @@ func idValueAsString(v any) (string, bool) {
 	}
 }
 
-func collectLiveDogfoodCommandPaths(prefix []string, command dogfoodAgentCommand, paths *[][]string) {
+func collectLiveDogfoodCommands(prefix []string, command dogfoodAgentCommand, cmds *[]liveDogfoodCommand) {
 	if command.Name == "" || liveDogfoodFrameworkSkip[command.Name] {
 		return
 	}
 
 	next := append(append([]string{}, prefix...), command.Name)
 	if len(command.Subcommands) == 0 {
-		*paths = append(*paths, next)
+		*cmds = append(*cmds, liveDogfoodCommand{Path: next, Annotations: command.Annotations})
 		return
 	}
 	for _, sub := range command.Subcommands {
-		collectLiveDogfoodCommandPaths(next, sub, paths)
+		collectLiveDogfoodCommands(next, sub, cmds)
 	}
 }
 
 func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDogfoodTestResult {
 	commandName := strings.Join(command.Path, " ")
+
+	// Destructive-at-auth short-circuit (#602): commands that rotate or
+	// revoke the runner's bearer would 401-cascade every subsequent test.
+	// finalizeLiveDogfoodReport excludes Skip from MatrixSize, so this is
+	// neutral on the verdict gate. Source of truth: see #602.
+	if !ctx.allowDestructive && isDestructiveAtAuth(command.Annotations, command.Path) {
+		return []LiveDogfoodTestResult{
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHelp, "destructive-at-auth"),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, "destructive-at-auth"),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, "destructive-at-auth"),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, "destructive-at-auth"),
+		}
+	}
 
 	helpArgs := append(append([]string{}, command.Path...), "--help")
 	helpRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, helpArgs, ctx.timeout)
@@ -828,6 +843,50 @@ func skippedLiveDogfoodResult(command string, kind LiveDogfoodTestKind, reason s
 		Status:  LiveDogfoodStatusSkip,
 		Reason:  reason,
 	}
+}
+
+// destructiveAuthTerms are case-insensitive substrings that classify a
+// command as destructive-at-auth. Limited to the three terms #602's body
+// names; extension-by-discovery is the deferred-question hook for new
+// patterns surfaced during live runs.
+var destructiveAuthTerms = []string{"refresh", "rotate", "revoke"}
+
+// isDestructiveAtAuth reports whether a command rotates or revokes the
+// bearer the live-dogfood runner is using. Annotation-primary: read
+// pp:endpoint (set by the generator on every endpoint mirror per
+// AGENTS.md "Endpoint mirrors") and substring-match against the
+// destructiveAuthTerms set. Cobra-leaf-segment fallback handles novel
+// hand-built commands that lack the annotation. Read-only commands
+// (mcp:read-only=true) are exempt regardless of name — read-only commands
+// cannot rotate auth. See #602.
+func isDestructiveAtAuth(annotations map[string]string, commandPath []string) bool {
+	if annotations["mcp:read-only"] == "true" {
+		return false
+	}
+	if endpoint := annotations["pp:endpoint"]; endpoint != "" {
+		lower := strings.ToLower(endpoint)
+		for _, term := range destructiveAuthTerms {
+			if strings.Contains(lower, term) {
+				return true
+			}
+		}
+		// pp:endpoint annotation is present and authoritative — no
+		// leaf-fallback for endpoint-mirror commands. Their pp:endpoint
+		// captures the destructive signal completely.
+		return false
+	}
+	// Annotation absent: novel hand-built command. Substring-match on
+	// each leaf-path segment, lowercase. Catches compound names like
+	// `oauth-client-force-refresh`.
+	for _, seg := range commandPath {
+		lower := strings.ToLower(seg)
+		for _, term := range destructiveAuthTerms {
+			if strings.Contains(lower, term) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {

--- a/internal/pipeline/live_dogfood_destructive_test.go
+++ b/internal/pipeline/live_dogfood_destructive_test.go
@@ -6,119 +6,84 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestIsDestructiveAtAuthAnnotationPrimary covers the cal-com case from
-// #602: a promoted command with Use="api-keys" but pp:endpoint annotation
-// "api-keys.keys-refresh". Leaf-path matching alone misses this; the
-// classifier MUST read the annotation.
-func TestIsDestructiveAtAuthAnnotationPrimary(t *testing.T) {
+// TestIsDestructiveAtAuth covers the classifier's annotation-primary path,
+// Cobra-leaf-segment fallback, read-only exemption, and negative cases.
+// Cal.com's promoted command (Use="api-keys" with pp:endpoint=
+// "api-keys.keys-refresh") is the motivating example: leaf-only matching
+// misses it; the annotation lookup catches it.
+func TestIsDestructiveAtAuth(t *testing.T) {
 	t.Parallel()
 
-	got := isDestructiveAtAuth(
-		map[string]string{"pp:endpoint": "api-keys.keys-refresh"},
-		[]string{"cal-com-pp-cli", "api-keys"},
-	)
-	assert.True(t, got, "annotation pp:endpoint=api-keys.keys-refresh must classify as destructive-at-auth")
-}
-
-func TestIsDestructiveAtAuthAnnotationRotate(t *testing.T) {
-	t.Parallel()
-
-	got := isDestructiveAtAuth(
-		map[string]string{"pp:endpoint": "tokens.token-rotate"},
-		[]string{"my-cli", "tokens"},
-	)
-	assert.True(t, got)
-}
-
-func TestIsDestructiveAtAuthLeafFallbackNovelCommand(t *testing.T) {
-	t.Parallel()
-
-	// No annotation (novel hand-built command); leaf segment is `refresh`.
-	got := isDestructiveAtAuth(nil, []string{"my-cli", "auth", "refresh"})
-	assert.True(t, got, "annotation absent — leaf-segment match should fire")
-}
-
-func TestIsDestructiveAtAuthLeafFallbackCompoundName(t *testing.T) {
-	t.Parallel()
-
-	// Compound leaf name like cal-com's `oauth-client-force-refresh`. Substring
-	// match (not exact) catches it.
-	got := isDestructiveAtAuth(
-		nil,
-		[]string{"my-cli", "oauth-clients", "users", "oauth-client-force-refresh"},
-	)
-	assert.True(t, got)
-}
-
-func TestIsDestructiveAtAuthReadOnlyExempt(t *testing.T) {
-	t.Parallel()
-
-	// craigslist `catalog refresh` is annotated mcp:read-only=true. It cannot
-	// rotate auth regardless of name.
-	got := isDestructiveAtAuth(
-		map[string]string{
-			"mcp:read-only": "true",
-			"pp:endpoint":   "catalog.catalog-refresh",
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		path        []string
+		want        bool
+	}{
+		{
+			name:        "annotation primary cal-com api-keys-refresh",
+			annotations: map[string]string{"pp:endpoint": "api-keys.keys-refresh"},
+			path:        []string{"cal-com-pp-cli", "api-keys"},
+			want:        true,
 		},
-		[]string{"craigslist-pp-cli", "catalog", "refresh"},
-	)
-	assert.False(t, got, "mcp:read-only=true must exempt regardless of name")
-}
+		{
+			name:        "annotation primary token rotate",
+			annotations: map[string]string{"pp:endpoint": "tokens.token-rotate"},
+			path:        []string{"my-cli", "tokens"},
+			want:        true,
+		},
+		{
+			name:        "annotation case-insensitive",
+			annotations: map[string]string{"pp:endpoint": "API-Keys.Refresh-Key"},
+			path:        []string{"my-cli", "API-Keys"},
+			want:        true,
+		},
+		{
+			name:        "annotation present without destructive term",
+			annotations: map[string]string{"pp:endpoint": "users.list-users"},
+			path:        []string{"my-cli", "users", "refresh-cache"},
+			want:        false,
+		},
+		{
+			name: "leaf fallback novel command",
+			path: []string{"my-cli", "auth", "refresh"},
+			want: true,
+		},
+		{
+			name: "leaf fallback compound name",
+			path: []string{"my-cli", "oauth-clients", "users", "oauth-client-force-refresh"},
+			want: true,
+		},
+		{
+			name: "leaf fallback no match",
+			path: []string{"my-cli", "users", "list"},
+			want: false,
+		},
+		{
+			name: "read-only exempt with pp:endpoint",
+			annotations: map[string]string{
+				"mcp:read-only": "true",
+				"pp:endpoint":   "catalog.catalog-refresh",
+			},
+			path: []string{"craigslist-pp-cli", "catalog", "refresh"},
+			want: false,
+		},
+		{
+			name:        "read-only exempt leaf only",
+			annotations: map[string]string{"mcp:read-only": "true"},
+			path:        []string{"my-cli", "store", "refresh"},
+			want:        false,
+		},
+		{
+			name: "empty inputs",
+			want: false,
+		},
+	}
 
-func TestIsDestructiveAtAuthReadOnlyExemptLeafOnly(t *testing.T) {
-	t.Parallel()
-
-	// Read-only annotation must also short-circuit the leaf-fallback path.
-	got := isDestructiveAtAuth(
-		map[string]string{"mcp:read-only": "true"},
-		[]string{"my-cli", "store", "refresh"},
-	)
-	assert.False(t, got)
-}
-
-func TestIsDestructiveAtAuthCaseInsensitive(t *testing.T) {
-	t.Parallel()
-
-	got := isDestructiveAtAuth(
-		map[string]string{"pp:endpoint": "API-Keys.Refresh-Key"},
-		[]string{"my-cli", "API-Keys"},
-	)
-	assert.True(t, got)
-}
-
-func TestIsDestructiveAtAuthAnnotationPresentNoSignal(t *testing.T) {
-	t.Parallel()
-
-	// Annotation present but doesn't contain destructive terms — and the
-	// leaf-fallback is intentionally suppressed when pp:endpoint is set
-	// (the annotation is authoritative for endpoint-mirror commands).
-	got := isDestructiveAtAuth(
-		map[string]string{"pp:endpoint": "users.list-users"},
-		[]string{"my-cli", "users", "refresh-cache"},
-	)
-	assert.False(t, got, "pp:endpoint without destructive term should not fall back to leaf — annotation is authoritative")
-}
-
-func TestIsDestructiveAtAuthNegativeNoSignal(t *testing.T) {
-	t.Parallel()
-
-	got := isDestructiveAtAuth(
-		map[string]string{"pp:endpoint": "users.list-users"},
-		[]string{"my-cli", "users"},
-	)
-	assert.False(t, got)
-}
-
-func TestIsDestructiveAtAuthNegativeNoAnnotationNoMatch(t *testing.T) {
-	t.Parallel()
-
-	got := isDestructiveAtAuth(nil, []string{"my-cli", "users", "list"})
-	assert.False(t, got)
-}
-
-func TestIsDestructiveAtAuthEmptyInputs(t *testing.T) {
-	t.Parallel()
-
-	assert.False(t, isDestructiveAtAuth(nil, nil))
-	assert.False(t, isDestructiveAtAuth(map[string]string{}, []string{}))
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDestructiveAtAuth(tt.annotations, tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/pipeline/live_dogfood_destructive_test.go
+++ b/internal/pipeline/live_dogfood_destructive_test.go
@@ -78,6 +78,19 @@ func TestIsDestructiveAtAuth(t *testing.T) {
 			name: "empty inputs",
 			want: false,
 		},
+		{
+			// Adversarial reviewer caught: a non-pp:endpoint annotation
+			// containing a destructive term must not trigger the classifier.
+			// Annotation-primary path reads pp:endpoint exclusively; other
+			// keys (description, etc.) are not part of the contract.
+			name: "destructive term in non-pp:endpoint key is ignored",
+			annotations: map[string]string{
+				"pp:endpoint": "users.list-users",
+				"description": "list users (refresh the cache)",
+			},
+			path: []string{"my-cli", "users"},
+			want: false,
+		},
 	}
 
 	for _, tt := range cases {

--- a/internal/pipeline/live_dogfood_destructive_test.go
+++ b/internal/pipeline/live_dogfood_destructive_test.go
@@ -1,0 +1,124 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsDestructiveAtAuthAnnotationPrimary covers the cal-com case from
+// #602: a promoted command with Use="api-keys" but pp:endpoint annotation
+// "api-keys.keys-refresh". Leaf-path matching alone misses this; the
+// classifier MUST read the annotation.
+func TestIsDestructiveAtAuthAnnotationPrimary(t *testing.T) {
+	t.Parallel()
+
+	got := isDestructiveAtAuth(
+		map[string]string{"pp:endpoint": "api-keys.keys-refresh"},
+		[]string{"cal-com-pp-cli", "api-keys"},
+	)
+	assert.True(t, got, "annotation pp:endpoint=api-keys.keys-refresh must classify as destructive-at-auth")
+}
+
+func TestIsDestructiveAtAuthAnnotationRotate(t *testing.T) {
+	t.Parallel()
+
+	got := isDestructiveAtAuth(
+		map[string]string{"pp:endpoint": "tokens.token-rotate"},
+		[]string{"my-cli", "tokens"},
+	)
+	assert.True(t, got)
+}
+
+func TestIsDestructiveAtAuthLeafFallbackNovelCommand(t *testing.T) {
+	t.Parallel()
+
+	// No annotation (novel hand-built command); leaf segment is `refresh`.
+	got := isDestructiveAtAuth(nil, []string{"my-cli", "auth", "refresh"})
+	assert.True(t, got, "annotation absent — leaf-segment match should fire")
+}
+
+func TestIsDestructiveAtAuthLeafFallbackCompoundName(t *testing.T) {
+	t.Parallel()
+
+	// Compound leaf name like cal-com's `oauth-client-force-refresh`. Substring
+	// match (not exact) catches it.
+	got := isDestructiveAtAuth(
+		nil,
+		[]string{"my-cli", "oauth-clients", "users", "oauth-client-force-refresh"},
+	)
+	assert.True(t, got)
+}
+
+func TestIsDestructiveAtAuthReadOnlyExempt(t *testing.T) {
+	t.Parallel()
+
+	// craigslist `catalog refresh` is annotated mcp:read-only=true. It cannot
+	// rotate auth regardless of name.
+	got := isDestructiveAtAuth(
+		map[string]string{
+			"mcp:read-only": "true",
+			"pp:endpoint":   "catalog.catalog-refresh",
+		},
+		[]string{"craigslist-pp-cli", "catalog", "refresh"},
+	)
+	assert.False(t, got, "mcp:read-only=true must exempt regardless of name")
+}
+
+func TestIsDestructiveAtAuthReadOnlyExemptLeafOnly(t *testing.T) {
+	t.Parallel()
+
+	// Read-only annotation must also short-circuit the leaf-fallback path.
+	got := isDestructiveAtAuth(
+		map[string]string{"mcp:read-only": "true"},
+		[]string{"my-cli", "store", "refresh"},
+	)
+	assert.False(t, got)
+}
+
+func TestIsDestructiveAtAuthCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	got := isDestructiveAtAuth(
+		map[string]string{"pp:endpoint": "API-Keys.Refresh-Key"},
+		[]string{"my-cli", "API-Keys"},
+	)
+	assert.True(t, got)
+}
+
+func TestIsDestructiveAtAuthAnnotationPresentNoSignal(t *testing.T) {
+	t.Parallel()
+
+	// Annotation present but doesn't contain destructive terms — and the
+	// leaf-fallback is intentionally suppressed when pp:endpoint is set
+	// (the annotation is authoritative for endpoint-mirror commands).
+	got := isDestructiveAtAuth(
+		map[string]string{"pp:endpoint": "users.list-users"},
+		[]string{"my-cli", "users", "refresh-cache"},
+	)
+	assert.False(t, got, "pp:endpoint without destructive term should not fall back to leaf — annotation is authoritative")
+}
+
+func TestIsDestructiveAtAuthNegativeNoSignal(t *testing.T) {
+	t.Parallel()
+
+	got := isDestructiveAtAuth(
+		map[string]string{"pp:endpoint": "users.list-users"},
+		[]string{"my-cli", "users"},
+	)
+	assert.False(t, got)
+}
+
+func TestIsDestructiveAtAuthNegativeNoAnnotationNoMatch(t *testing.T) {
+	t.Parallel()
+
+	got := isDestructiveAtAuth(nil, []string{"my-cli", "users", "list"})
+	assert.False(t, got)
+}
+
+func TestIsDestructiveAtAuthEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isDestructiveAtAuth(nil, nil))
+	assert.False(t, isDestructiveAtAuth(map[string]string{}, []string{}))
+}


### PR DESCRIPTION
## Summary

- `printing-press dogfood --live` no longer invokes endpoints that rotate or revoke the runner's bearer (default-skip; `--allow-destructive` opts back in).
- Annotation-primary classifier reads `pp:endpoint` from agent-context; falls back to Cobra-leaf-segment matching for novel commands. `mcp:read-only` commands are exempt.
- Closes #602. Cal.com's documented 595/723 cascade (after `POST /api-keys/refresh` rotated the bearer as test #1) won't recur.

## Background

`printing-press dogfood --live --level full` invoked `POST /api-keys/refresh` against cal-com as test #1. Documented behavior: delete current key, return a new one. The runner didn't capture rotation. All 723 subsequent tests 401'd in cascade. The same pattern hits Linear (`tokenRotate`), Stripe (`/v1/keys`), and any API with token-rotation endpoints.

## Why annotation-primary

The Cobra leaf path alone misses promoted commands. Cal.com ships `POST /api-keys/refresh` as `Use: "api-keys"` (a promoted leaf); the path is `["cal-com-pp-cli", "api-keys"]` with no `refresh` segment. The destructive signal lives in `cmd.Annotations["pp:endpoint"] = "api-keys.keys-refresh"`, which the generator already populates on every endpoint mirror per AGENTS.md.

This PR plumbs annotations through agent-context's JSON output → `dogfoodAgentCommand` → `liveDogfoodCommand` → classifier. The agent-context JSON now includes an `annotations` field on each command (omitempty). Existing CLIs without re-generation still get leaf-fallback classification; freshly-printed CLIs get annotation-primary.

## Plumbing

| File | Change |
|---|---|
| `internal/generator/templates/agent_context.go.tmpl` | `agentContextCommand` gains `Annotations map[string]string`; `collectAgentCommands` populates from `sub.Annotations` |
| `internal/pipeline/dogfood.go` | `dogfoodAgentCommand` gains `Annotations map[string]string` |
| `internal/pipeline/live_dogfood.go` | `liveDogfoodCommand` gains `Annotations`; `LiveDogfoodOptions` gains `AllowDestructive`; `resolveCtx` gains `allowDestructive`; `collectLiveDogfoodCommandPaths` → `collectLiveDogfoodCommands` (now produces `[]liveDogfoodCommand` directly with annotations) |
| `internal/cli/dogfood.go` | `--allow-destructive` flag, plumbed through `LiveDogfoodOptions` |

## Classifier (`isDestructiveAtAuth`)

Three checks in order:

1. **Read-only exemption:** `mcp:read-only=true` short-circuits to false. Read-only commands cannot rotate auth regardless of name.
2. **Annotation-primary:** if `pp:endpoint` is set, substring-match (case-insensitive) against `{refresh, rotate, revoke}`. Annotation is authoritative for endpoint-mirror commands — no leaf fallback.
3. **Leaf-segment fallback:** when `pp:endpoint` is absent, substring-match on each leaf path segment.

Match list intentionally limited to `{refresh, rotate, revoke}` per #602's stated scope. Extension by discovery is the deferred-question hook for new patterns surfaced during live runs.

## Note on existing library CLIs

Until library CLIs are re-generated, their agent-context output won't carry annotations and the classifier falls back to leaf-path matching. Cal-com today ships `Use: "api-keys"` with no refresh segment, so leaf fallback misses it — re-printing cal-com (or `printing-press regen-merge`) picks up the new agent-context emit and the classifier catches the endpoint correctly. False negatives are recoverable (operator gets a 401 cascade); false positives are bounded by the read-only exemption.

## Test plan

- [x] `go test ./... -count=1` — 3030 tests pass
- [x] `go vet ./...` clean
- [x] 11 new classifier tests cover: annotation primary (cal-com case + rotate variant), leaf fallback (novel + compound name like `oauth-client-force-refresh`), read-only exempt (annotation + leaf-only paths), case-insensitive, annotation-without-signal, negative paths, empty inputs
- [x] `scripts/golden.sh verify` passes 11/11 (no goldens snapshot agent_context.go)

Closes #602.

Plan: `docs/plans/2026-05-05-006-fix-wave-2-retro-blockers-plan.md` (U4 + U5 of Wave 2; companion PR-A #612 ships the invalidateCache template fix; library backfill PR-B forthcoming on printing-press-library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)