### PR TITLE
docs(cli): codify lookup-priority discipline in layout contract

### DIFF
--- a/docs/solutions/best-practices/checkout-scoped-printing-press-output-layout-2026-03-28.md
+++ b/docs/solutions/best-practices/checkout-scoped-printing-press-output-layout-2026-03-28.md
@@ -1,6 +1,7 @@
 ---
 title: "Printing-press runstate and publish/archive layout contract"
 date: 2026-03-28
+last_updated: 2026-05-05
 category: best-practices
 module: printing-press output layout
 problem_type: best_practice
@@ -10,6 +11,7 @@ symptoms:
   - "Mutable run state collides across parallel workspaces or repeated runs"
   - "Runtime tooling breaks when a claimed output directory uses a suffix like -pp-cli-2"
   - "Research and proof artifacts leak into repo-local docs/plans or other source directories"
+  - "publish package returns a stale run_id when both API-slug and CLI-name manuscripts dirs exist"
 root_cause: config_error
 resolution_type: workflow_improvement
 severity: high
@@ -21,6 +23,7 @@ tags:
   - manuscripts
   - runstate
   - workspace-scope
+  - lookup-priority
 ---
 
 # Printing-press runstate and publish/archive layout contract
@@ -132,6 +135,8 @@ That removes the class of bugs where docs say one thing, skills do another, and 
 - Add tests whenever code infers API names or command directories from filesystem paths.
 - Treat published library CLIs as immutable outputs. Workflows like `emboss` should copy them into a new runstate working dir instead of mutating them in place.
 - Update README and onboarding docs whenever default output locations change. Path migrations that only touch code are incomplete by definition.
+- **Read-side lookup priority must match the write-side convention.** When a binary helper resolves a manuscripts directory (or any other archive path the SKILL writes), check the canonical SKILL key (`<api-slug>`) before any legacy or compatibility key (`<cli-name>`, `<api>-cli`). Label the branches with the convention owner (`SKILL convention` / `legacy binary convention`) — never with temporal adjectives like `new convention` / `old convention`, which invert silently when the convention shifts. Enforcement point in code: `resolveManuscripts` in `internal/cli/publish.go`.
+- **Test ordered lookups with a both-keys-present fixture.** Independent per-branch subtests cannot detect priority inversions — both branches resolve fine in isolation, and only the both-keys case exercises which one wins. For any helper that walks an ordered key list, add a fixture that populates every key simultaneously and asserts the canonical key wins. Reprints inevitably create both keys, so an inverted priority will silently publish stale artifacts until a both-keys test catches it. (See `TestManuscriptLookupPriority` in `internal/cli/publish_resolve_test.go` for the pattern.)
 
 Recommended verification for future changes:
 
@@ -142,3 +147,5 @@ Recommended verification for future changes:
 ## Related Issues
 
 - `docs/solutions/best-practices/steinberger-scorecard-scoring-architecture-2026-03-27.md` is related only in that both docs codify “shared rules that must stay in sync.” It does not cover path layout or output scoping.
+- [#597](https://github.com/mvanhorn/cli-printing-press/issues/597) — Cal.com retro that surfaced F2: `resolveManuscripts` lookup priority lagged the SKILL's API-slug archive convention.
+- [#598](https://github.com/mvanhorn/cli-printing-press/issues/598) / [PR #615](https://github.com/mvanhorn/cli-printing-press/pull/615) — fix that swapped the lookup order in `resolveManuscripts` (API-slug first, CLI-name as legacy fallback) and added the both-keys-present regression test that the prevention rule now requires.


### PR DESCRIPTION
## Summary

Follow-up to #615 (resolveManuscripts API-slug priority fix). Folds the durable lessons from that fix into the existing layout-contract doc rather than creating a duplicate learning. The Related Docs Finder during the compound pass scored HIGH overlap (4/5 dimensions) with the existing doc, so this updates instead of creating a new file.

Two new prevention rules:

- **Read-side lookup priority must match the SKILL's write-side convention.** Label branches by convention owner (`SKILL convention` / `legacy binary convention`), never by temporal adjective (`new convention` / `old convention`) — temporal labels invert silently when the canonical convention shifts.
- **Test ordered lookups with a both-keys-present fixture.** Per-branch subtests can't detect priority inversions; only a fixture with every key populated proves which one wins.

## Why a follow-up PR

The doc commit was authored after #615 merged. Rather than reopen the merged branch, this lands the doc update as a focused follow-up.

## Changes

- `docs/solutions/best-practices/checkout-scoped-printing-press-output-layout-2026-03-28.md`
  - frontmatter: add `last_updated: 2026-05-05`, add stale-`run_id` symptom, add `lookup-priority` tag
  - Prevention: two new bullets (read-side lookup priority + both-keys-present test fixture)
  - Related Issues: link #597, #598, PR #615

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — frontmatter parses cleanly
- [x] No code changes; doc-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)