### PR TITLE
docs(cli): prefer npx-based installer over raw go install in README

### DIFF
--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -18,15 +18,31 @@ Learn more at [{{.ProseName}}]({{.WebsiteURL}}).
 
 ## Install
 
-### Binary
+The recommended path installs both the `{{.Name}}-pp-cli` binary and the `pp-{{.Name}}` agent skill in one shot:
 
-Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/{{.Name}}-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
-
-### Go
-
+```bash
+npx -y @mvanhorn/printing-press install {{.Name}}
 ```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press install {{.Name}} --cli-only
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires {{if .UsesBrowserHTTPTransport}}Go 1.25+{{else}}Go 1.23+{{end}}):
+
+```bash
 go install github.com/mvanhorn/printing-press-library/library/{{if .Category}}{{.Category}}{{else}}other{{end}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/{{.Name}}-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 {{- if and .Narrative .Narrative.AuthNarrative}}
 
 {{if .Auth.Optional}}## Optional: API Key{{else}}## Authentication{{end}}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -4,15 +4,31 @@ Purpose-built fixture for rich auth env-var model coverage.
 
 ## Install
 
-### Binary
+The recommended path installs both the `printing-press-rich-pp-cli` binary and the `pp-printing-press-rich` agent skill in one shot:
 
-Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-rich-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
-
-### Go
-
+```bash
+npx -y @mvanhorn/printing-press install printing-press-rich
 ```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press install printing-press-rich --cli-only
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.23+):
+
+```bash
 go install github.com/mvanhorn/printing-press-library/library/other/printing-press-rich/cmd/printing-press-rich-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-rich-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 ## Quick Start
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -4,15 +4,31 @@ Purpose-built fixture for golden generation coverage.
 
 ## Install
 
-### Binary
+The recommended path installs both the `printing-press-golden-pp-cli` binary and the `pp-printing-press-golden` agent skill in one shot:
 
-Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-golden-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
-
-### Go
-
+```bash
+npx -y @mvanhorn/printing-press install printing-press-golden
 ```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press install printing-press-golden --cli-only
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.23+):
+
+```bash
 go install github.com/mvanhorn/printing-press-library/library/other/printing-press-golden/cmd/printing-press-golden-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/printing-press-golden-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 ## Quick Start
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -4,15 +4,31 @@ Public parameter name golden fixture
 
 ## Install
 
-### Binary
+The recommended path installs both the `public-param-golden-pp-cli` binary and the `pp-public-param-golden` agent skill in one shot:
 
-Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/public-param-golden-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
-
-### Go
-
+```bash
+npx -y @mvanhorn/printing-press install public-param-golden
 ```
+
+For CLI only (no skill):
+
+```bash
+npx -y @mvanhorn/printing-press install public-param-golden --cli-only
+```
+
+### Without Node (Go fallback)
+
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.23+):
+
+```bash
 go install github.com/mvanhorn/printing-press-library/library/other/public-param-golden/cmd/public-param-golden-pp-cli@latest
 ```
+
+This installs the CLI only — no skill.
+
+### Pre-built binary
+
+Download a pre-built binary for your platform from the [latest release](https://github.com/mvanhorn/printing-press-library/releases/tag/public-param-golden-current). On macOS, clear the Gatekeeper quarantine: `xattr -d com.apple.quarantine <binary>`. On Unix, mark it executable: `chmod +x <binary>`.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Switches the generated README's `## Install` section to lead with `npx -y @mvanhorn/printing-press install <api>` (installs CLI + `pp-<api>` agent skill), with `--cli-only` and a Go fallback below.

Mirrors the SKILL.md change in #655 (commit 8bade0d9), but with the important difference that the README defaults to **CLI + skill** (modal entry-point user) while SKILL.md still uses `--cli-only` (skill is already installed by the time SKILL.md is read).

The skill is called an "agent skill", not "Claude Code skill" — `pp-<api>` works across Claude Code, Hermes, OpenClaw, etc.

## Generated `## Install` shape

````markdown
## Install

The recommended path installs both the `<cli>-pp-cli` binary and the `pp-<api>` agent skill in one shot:

```bash
npx -y @mvanhorn/printing-press install <api>
```

For CLI only (no skill):

```bash
npx -y @mvanhorn/printing-press install <api> --cli-only
```

### Without Node (Go fallback)

If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.23+):

```bash
go install github.com/mvanhorn/printing-press-library/library/<cat>/<api>/cmd/<cli>-pp-cli@latest
```

This installs the CLI only — no skill.

### Pre-built binary

Download a pre-built binary for your platform from the [latest release]…
````

## Paired sweep

A library-wide sweep in [mvanhorn/printing-press-library](https://github.com/mvanhorn/printing-press-library) applies the same shape across the existing 47 published library/<cat>/<api>/README.md files alongside this template change.

## Test plan

- [x] `scripts/golden.sh verify` — 13/13 cases pass after golden update
- [x] `go test ./internal/generator/...` — 592 tests pass
- [x] Goldens updated for `generate-golden-api`, `generate-golden-api-rich-auth`, `generate-public-param-names` — diffs are exactly the install-section rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)