### PR TITLE
chore(skills): drop compound-engineering plugin and retro hand-off

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "enabledPlugins": {
-    "compound-engineering@every-marketplace": true
-  },
   "permissions": {
     "deny": [
       "Bash(git commit --no-verify:*)",

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -731,8 +731,7 @@ template gap that would help every future CLI *is* worth filing.
 
 If filing is skipped, still save the retro locally (manuscript proofs +
 `/tmp/printing-press/retro/`), present the findings to the user, then jump
-directly to Phase 6 Step 6 (present results — adjusted to show local-only paths)
-and Step 8 (offer next steps).
+directly to Phase 6 Step 6 (present results — adjusted to show local-only paths).
 
 ## Phase 6: Package, upload, and present
 
@@ -912,28 +911,6 @@ the issue-template fallback path.
 ### Step 7: Clean up staging folder
 
 Run artifact-packaging.md Step 7 to delete `$STAGING_DIR`.
-
-### Step 8: Offer next steps
-
-Use `AskUserQuestion`:
-
-**If `IN_REPO=true`:**
-
-> 1. **Plan work units** — invoke `/compound-engineering:ce-plan` to plan top-priority WUs
-> 2. **Plan a specific work unit** — pick one WU to plan
-> 3. **Done for now**
-
-If the user picks option 1 or 2, try to invoke `compound-engineering:ce-plan`. If
-it's not available, fall back to printing the prompt the user would run manually.
-
-**If `IN_REPO=false`:**
-
-> The Printing Press maintainers will review your findings.
->
-> 1. **Done**
-
-Do not offer to plan work units when `IN_REPO=false` — the user is not in the
-Printing Press repo and cannot act on the findings directly.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Remove the `compound-engineering@every-marketplace` entry from `.claude/settings.json` so the plugin no longer auto-loads in this repo.
- Drop Step 8 of the `printing-press-retro` skill, which offered to invoke `/compound-engineering:ce-plan` or pitch per-WU planning after a retro — retro-runners rarely act on a follow-up planning prompt, so the prompt added ceremony without value. Retros now end after Phase 6 Step 7 (cleanup), and the Phase 5.6 skip-filing fallback no longer points to the deleted Step 8.

## Test plan
- [ ] No remaining `compound-engineering` / `ce-plan` references in `skills/`
- [ ] Retro skill still reads cleanly end-to-end after the trim

🤖 Generated with [Claude Code](https://claude.com/claude-code)