### PR TITLE
fix(skill): Add write-time PII redaction guidance to Phase 5 acceptance reports

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2574,6 +2574,18 @@ Acceptance Report: <api>
   Gate: PASS / FAIL
 ```
 
+**Redact PII while authoring the report.** When live API responses include an
+organization or workspace name, user email, assignee/collaborator name, or any
+other human-identifying string, describe the result generically instead of
+quoting the literal value:
+- organization or workspace name -> "the test workspace"
+- authenticated user email/name -> "the authenticated viewer"
+- assignees or collaborators -> "the highest-loaded assignee" / "the project lead"
+- team identifiers such as `ENG` or `T2` are OK when they are structural keys
+
+The Phase 5.6 manuscript scan and publish-skill PII scan are defense in depth;
+keep PII out of the acceptance report from the moment you write it.
+
 **Acceptance threshold:**
 - Quick Check: 5/6 core tests must pass. Auth (`doctor`) or sync failure is automatic FAIL.
 - Full Dogfood: every mandatory test in the matrix must pass. A single broken flagship feature is automatic FAIL. Auth/sync failures are automatic FAIL.


### PR DESCRIPTION
## Summary
- Update the Printing Press Phase 5 acceptance report instructions to require redacting PII as the report is written.
- Use generic descriptors for workspace names, authenticated users, and collaborators while preserving structural team identifiers.
- Keep the existing Phase 5.6 manuscript scan and publish-skill PII scan as defense in depth.

closes #667 

## Testing
- Not run (not requested)