### PR TITLE
chore(ci): clean up release workflow warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           # Fall back to GITHUB_TOKEN when RELEASE_PLEASE_TOKEN is unset.
@@ -50,9 +50,11 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - uses: sigstore/cosign-installer@v4.1.0
+
       - uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
 
 archives:
   - id: printing-press
-    builds:
+    ids:
       - printing-press
     formats:
       - tar.gz


### PR DESCRIPTION
## Summary

Release CI now avoids the warning set surfaced by the v4.0.1 GoReleaser run.

This bumps release-please to v5 for the Node 24 action runtime, installs cosign before GoReleaser so the action can verify the downloaded GoReleaser signature, pins GoReleaser to the documented `~> v2` range instead of `latest`, and replaces the deprecated `archives.builds` key with `archives.ids`.

## Verification

- `goreleaser check`
- `go test ./internal/cli -run 'Test(GoreleaserLdflagsTargetMatchesVersionVar|ReleasePleaseAnnotationExists|VersionConsistencyAcrossFiles|ModulePathMatchesMajorVersion|PRTitleWorkflowAllowsReleasePleaseScope)'`
- `actionlint .github/workflows/release.yml`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
