### PR TITLE
fix(skills): align publish with library-backed skill mirror

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -137,19 +137,22 @@ func TestPublishSkillTracksCanonicalUpstreamAndOverwriteFlow(t *testing.T) {
 	assert.Contains(t, skill, "git push --force-with-lease")
 }
 
-func TestPublishSkillSeedsRegistryBeforeCliSkillsMirror(t *testing.T) {
+func TestPublishSkillUsesLibraryTreeForCliSkillsMirror(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 
-	assert.Contains(t, skill, `REGISTRY_HAS_ENTRY=$(jq -r --arg name "<api-slug>" 'any(.entries[]?; .name == $name)'`)
-	assert.Contains(t, skill, `--slurpfile press "$PUBLISHED_CLI_DIR/.printing-press.json"`)
-	assert.Contains(t, skill, `| .entries = ((.entries | map(select(.name != $name))) + [$entry] | sort_by(.name))`)
-	assert.Contains(t, skill, "git add library/ cli-skills/ registry.json")
+	assert.Contains(t, skill, "Do not\nedit `registry.json`")
+	assert.Contains(t, skill, "fix the\nlibrary mirror generator to discover from `library/`")
+	assert.Contains(t, skill, "# Regenerate the flat cli-skills mirror from the library tree")
+	assert.Contains(t, skill, "git add library/ cli-skills/")
+	assert.NotContains(t, skill, "git add library/ cli-skills/ registry.json")
+	assert.NotContains(t, skill, "REGISTRY_HAS_ENTRY")
+	assert.NotContains(t, skill, "seed one registry")
 
-	registrySeed := strings.Index(skill, "missing entry before mirror generation")
+	copyIntoLibrary := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<cli-name>"`)
 	mirrorRun := strings.Index(skill, "go run ./tools/generate-skills/main.go")
-	require.NotEqual(t, -1, registrySeed)
+	require.NotEqual(t, -1, copyIntoLibrary)
 	require.NotEqual(t, -1, mirrorRun)
-	assert.Less(t, registrySeed, mirrorRun)
+	assert.Less(t, copyIntoLibrary, mirrorRun)
 }
 
 func TestREADMEOutputContract(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -137,6 +137,21 @@ func TestPublishSkillTracksCanonicalUpstreamAndOverwriteFlow(t *testing.T) {
 	assert.Contains(t, skill, "git push --force-with-lease")
 }
 
+func TestPublishSkillSeedsRegistryBeforeCliSkillsMirror(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+
+	assert.Contains(t, skill, `REGISTRY_HAS_ENTRY=$(jq -r --arg name "<api-slug>" 'any(.entries[]?; .name == $name)'`)
+	assert.Contains(t, skill, `--slurpfile press "$PUBLISHED_CLI_DIR/.printing-press.json"`)
+	assert.Contains(t, skill, `| .entries = ((.entries | map(select(.name != $name))) + [$entry] | sort_by(.name))`)
+	assert.Contains(t, skill, "git add library/ cli-skills/ registry.json")
+
+	registrySeed := strings.Index(skill, "missing entry before mirror generation")
+	mirrorRun := strings.Index(skill, "go run ./tools/generate-skills/main.go")
+	require.NotEqual(t, -1, registrySeed)
+	require.NotEqual(t, -1, mirrorRun)
+	assert.Less(t, registrySeed, mirrorRun)
+}
+
 func TestREADMEOutputContract(t *testing.T) {
 	readme := readContractFile(t, filepath.Join("..", "..", "README.md"))
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -25,13 +25,13 @@ Publish a generated CLI from your local library to the [printing-press-library](
 
 The public library treats `library/<category>/<api-slug>/.printing-press.json`
 and `manifest.json` as the source of truth for registry-display fields. Do not
-hand-edit existing `registry.json` entries or README catalog cells in publish
-PRs; the library's post-merge workflow refreshes them from the CLI tree. For a
-brand-new CLI whose slug is missing from `registry.json`, seed one registry
-entry from the packaged CLI manifest before regenerating `cli-skills/` so PR CI
-does not prune the new mirror as an orphan. Do regenerate and commit the
-`cli-skills/pp-<api-slug>/SKILL.md` mirror because PR CI verifies it against
-`library/<category>/<api-slug>/SKILL.md`.
+edit `registry.json` or README catalog cells in publish PRs; the library's
+post-merge workflow refreshes them from the CLI tree. Do regenerate and commit
+the `cli-skills/pp-<api-slug>/SKILL.md` mirror from
+`library/<category>/<api-slug>/SKILL.md` because PR CI verifies mirror parity.
+If a brand-new CLI's mirror is pruned because `registry.json` is behind, fix the
+library mirror generator to discover from `library/`; do not add a registry
+entry solely to satisfy mirror parity.
 
 ## Setup
 
@@ -384,11 +384,6 @@ Parse the JSON result. Note the `staged_dir`, `module_path`, `manuscripts_includ
 Then copy the staged CLI into the publish repo, replacing any existing version:
 
 ```bash
-REGISTRY_HAS_ENTRY=false
-if [ -f "$PUBLISH_REPO_DIR/registry.json" ]; then
-  REGISTRY_HAS_ENTRY=$(jq -r --arg name "<api-slug>" 'any(.entries[]?; .name == $name)' "$PUBLISH_REPO_DIR/registry.json")
-fi
-
 # Remove existing version (handles category changes)
 rm -rf "$PUBLISH_REPO_DIR/library"/*/"<api-slug>"
 
@@ -398,49 +393,7 @@ cp -r "$STAGING_DIR/library/<category>/<cli-name>" "$PUBLISH_REPO_DIR/library/<c
 # Remove binaries (should not be committed)
 rm -f "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<cli-name>"
 
-# The library mirror generator reads registry.json to decide which cli-skills
-# entries are real. Brand-new CLIs are not in registry.json yet, so seed the
-# missing entry before mirror generation or CI will show:
-# " D cli-skills/pp-<api-slug>/SKILL.md".
-if [ "$REGISTRY_HAS_ENTRY" != "true" ]; then
-  PUBLISHED_CLI_DIR="$PUBLISH_REPO_DIR/library/<category>/<api-slug>"
-  REGISTRY_TMP="$(mktemp)"
-  jq \
-    --arg name "<api-slug>" \
-    --arg category "<category>" \
-    --arg path "library/<category>/<api-slug>" \
-    --slurpfile press "$PUBLISHED_CLI_DIR/.printing-press.json" \
-    --slurpfile plugin "$PUBLISHED_CLI_DIR/manifest.json" '
-      def present($v): $v != null and $v != "";
-      def fallback($primary; $secondary): if present($primary) then $primary else $secondary end;
-
-      (.schema_version //= 1)
-      | (.entries //= [])
-      | ($press[0] // {}) as $p
-      | ($plugin[0] // {}) as $plugin
-      | {
-          name: $name,
-          category: $category,
-          api: fallback($p.display_name; fallback($plugin.display_name; $p.api_name)),
-          description: fallback($p.description; fallback($plugin.description; "")),
-          path: $path,
-          mcp: {
-            binary: fallback($p.mcp_binary; ($name + "-pp-mcp")),
-            transports: ["stdio", "http"],
-            tool_count: ($p.mcp_tool_count // 0),
-            public_tool_count: ($p.mcp_public_tool_count // 0),
-            auth_type: fallback($p.auth_type; "none"),
-            env_vars: ($p.auth_env_vars // []),
-            mcp_ready: fallback($p.mcp_ready; "unknown"),
-            spec_format: fallback($p.spec_format; "unknown")
-          }
-        } as $entry
-      | .entries = ((.entries | map(select(.name != $name))) + [$entry] | sort_by(.name))
-    ' "$PUBLISH_REPO_DIR/registry.json" > "$REGISTRY_TMP"
-  mv "$REGISTRY_TMP" "$PUBLISH_REPO_DIR/registry.json"
-fi
-
-# Regenerate the flat cli-skills mirror so library PR CI passes mirror parity.
+# Regenerate the flat cli-skills mirror from the library tree so library PR CI passes mirror parity.
 if [ -f "$PUBLISH_REPO_DIR/tools/generate-skills/main.go" ]; then
   (cd "$PUBLISH_REPO_DIR" && go run ./tools/generate-skills/main.go)
 fi
@@ -700,7 +653,7 @@ git checkout -B feat/<api-slug>
 
 ```bash
 cd "$PUBLISH_REPO_DIR"
-git add library/ cli-skills/ registry.json
+git add library/ cli-skills/
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -25,8 +25,11 @@ Publish a generated CLI from your local library to the [printing-press-library](
 
 The public library treats `library/<category>/<api-slug>/.printing-press.json`
 and `manifest.json` as the source of truth for registry-display fields. Do not
-edit `registry.json` or README catalog cells in publish PRs; the library's
-post-merge workflow regenerates them. Do regenerate and commit the
+hand-edit existing `registry.json` entries or README catalog cells in publish
+PRs; the library's post-merge workflow refreshes them from the CLI tree. For a
+brand-new CLI whose slug is missing from `registry.json`, seed one registry
+entry from the packaged CLI manifest before regenerating `cli-skills/` so PR CI
+does not prune the new mirror as an orphan. Do regenerate and commit the
 `cli-skills/pp-<api-slug>/SKILL.md` mirror because PR CI verifies it against
 `library/<category>/<api-slug>/SKILL.md`.
 
@@ -381,6 +384,11 @@ Parse the JSON result. Note the `staged_dir`, `module_path`, `manuscripts_includ
 Then copy the staged CLI into the publish repo, replacing any existing version:
 
 ```bash
+REGISTRY_HAS_ENTRY=false
+if [ -f "$PUBLISH_REPO_DIR/registry.json" ]; then
+  REGISTRY_HAS_ENTRY=$(jq -r --arg name "<api-slug>" 'any(.entries[]?; .name == $name)' "$PUBLISH_REPO_DIR/registry.json")
+fi
+
 # Remove existing version (handles category changes)
 rm -rf "$PUBLISH_REPO_DIR/library"/*/"<api-slug>"
 
@@ -389,6 +397,48 @@ cp -r "$STAGING_DIR/library/<category>/<cli-name>" "$PUBLISH_REPO_DIR/library/<c
 
 # Remove binaries (should not be committed)
 rm -f "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<cli-name>"
+
+# The library mirror generator reads registry.json to decide which cli-skills
+# entries are real. Brand-new CLIs are not in registry.json yet, so seed the
+# missing entry before mirror generation or CI will show:
+# " D cli-skills/pp-<api-slug>/SKILL.md".
+if [ "$REGISTRY_HAS_ENTRY" != "true" ]; then
+  PUBLISHED_CLI_DIR="$PUBLISH_REPO_DIR/library/<category>/<api-slug>"
+  REGISTRY_TMP="$(mktemp)"
+  jq \
+    --arg name "<api-slug>" \
+    --arg category "<category>" \
+    --arg path "library/<category>/<api-slug>" \
+    --slurpfile press "$PUBLISHED_CLI_DIR/.printing-press.json" \
+    --slurpfile plugin "$PUBLISHED_CLI_DIR/manifest.json" '
+      def present($v): $v != null and $v != "";
+      def fallback($primary; $secondary): if present($primary) then $primary else $secondary end;
+
+      (.schema_version //= 1)
+      | (.entries //= [])
+      | ($press[0] // {}) as $p
+      | ($plugin[0] // {}) as $plugin
+      | {
+          name: $name,
+          category: $category,
+          api: fallback($p.display_name; fallback($plugin.display_name; $p.api_name)),
+          description: fallback($p.description; fallback($plugin.description; "")),
+          path: $path,
+          mcp: {
+            binary: fallback($p.mcp_binary; ($name + "-pp-mcp")),
+            transports: ["stdio", "http"],
+            tool_count: ($p.mcp_tool_count // 0),
+            public_tool_count: ($p.mcp_public_tool_count // 0),
+            auth_type: fallback($p.auth_type; "none"),
+            env_vars: ($p.auth_env_vars // []),
+            mcp_ready: fallback($p.mcp_ready; "unknown"),
+            spec_format: fallback($p.spec_format; "unknown")
+          }
+        } as $entry
+      | .entries = ((.entries | map(select(.name != $name))) + [$entry] | sort_by(.name))
+    ' "$PUBLISH_REPO_DIR/registry.json" > "$REGISTRY_TMP"
+  mv "$REGISTRY_TMP" "$PUBLISH_REPO_DIR/registry.json"
+fi
 
 # Regenerate the flat cli-skills mirror so library PR CI passes mirror parity.
 if [ -f "$PUBLISH_REPO_DIR/tools/generate-skills/main.go" ]; then
@@ -650,7 +700,7 @@ git checkout -B feat/<api-slug>
 
 ```bash
 cd "$PUBLISH_REPO_DIR"
-git add library/ cli-skills/
+git add library/ cli-skills/ registry.json
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 


### PR DESCRIPTION
## Summary
- Update the publish skill to treat `library/<category>/<api-slug>/SKILL.md` as the source for the flat `cli-skills/pp-<api-slug>/SKILL.md` mirror.
- Keep `registry.json` out of the publish PR path; if a brand-new CLI mirror is pruned because the registry is behind, the fix belongs in the library mirror generator discovering from `library/`.
- Add a contract test that guards the publish skill against reintroducing registry-seeding workarounds and verifies mirror generation happens after the CLI is copied into `library/`.

Refs #682.

## Testing
- `go test ./internal/pipeline -run TestPublishSkillUsesLibraryTreeForCliSkillsMirror -count=1`
- `go test ./...`
- `git diff --check`