### PR TITLE
fix(cli): dedupe regen-merge registrations by command use

### DIFF
--- a/internal/pipeline/regenmerge/registrations.go
+++ b/internal/pipeline/regenmerge/registrations.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -45,6 +46,14 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 	freshCalls, _, err := collectAddCommandCalls(freshCLIDir)
 	if err != nil {
 		return nil, fmt.Errorf("scanning fresh internal/cli: %w", err)
+	}
+	pubCommandUses, err := collectCommandUses(pubCLIDir)
+	if err != nil {
+		return nil, fmt.Errorf("collecting published command uses: %w", err)
+	}
+	freshCommandUses, err := collectCommandUses(freshCLIDir)
+	if err != nil {
+		return nil, fmt.Errorf("collecting fresh command uses: %w", err)
 	}
 
 	// Apply only overwrites host files that exist in fresh (TEMPLATED-CLEAN +
@@ -81,6 +90,9 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 	for _, calls := range freshCalls {
 		for _, c := range calls {
 			freshCallSet[c.normalized] = struct{}{}
+			if key := commandUseRegistrationKey(c, freshCommandUses); key != "" {
+				freshCallSet[key] = struct{}{}
+			}
 		}
 	}
 
@@ -102,6 +114,11 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 		for _, call := range pubCalls[host] {
 			if _, present := freshCallSet[call.normalized]; present {
 				continue
+			}
+			if key := commandUseRegistrationKey(call, pubCommandUses); key != "" {
+				if _, present := freshCallSet[key]; present {
+					continue
+				}
 			}
 			// Referent check.
 			if call.constructorName != "" {
@@ -130,6 +147,7 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 type addCommandCall struct {
 	source          string // pretty-printed call expression
 	normalized      string // identical-ish form for diffing across files
+	parentName      string // e.g. "rootCmd"; empty when receiver shape is unrecognized
 	constructorName string // e.g. "newCanonicalCmd"; empty when arg shape is unrecognized
 }
 
@@ -255,7 +273,114 @@ func formatCallExpr(fset *token.FileSet, ce *ast.CallExpr) (addCommandCall, erro
 		normalized = strings.Join(strings.Fields(src), " ")
 	}
 
-	return addCommandCall{source: src, normalized: normalized, constructorName: ctor}, nil
+	return addCommandCall{source: src, normalized: normalized, parentName: parent, constructorName: ctor}, nil
+}
+
+func commandUseRegistrationKey(call addCommandCall, commandUses map[string]string) string {
+	if call.parentName == "" || call.constructorName == "" {
+		return ""
+	}
+	use := commandUses[call.constructorName]
+	if use == "" {
+		return ""
+	}
+	return call.parentName + ".AddCommand(use:" + use + ")"
+}
+
+func collectCommandUses(dir string) (map[string]string, error) {
+	uses := map[string]string{}
+	entries, err := readDirAllowMissing(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "regen-merge: warning: skipping unparseable file %s while collecting command uses: %v\n", path, err)
+			continue
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Body == nil {
+				continue
+			}
+			if use := firstCobraUse(fn.Body); use != "" {
+				uses[fn.Name.Name] = use
+			}
+		}
+	}
+	return uses, nil
+}
+
+func firstCobraUse(body *ast.BlockStmt) string {
+	var out string
+	ast.Inspect(body, func(n ast.Node) bool {
+		if out != "" {
+			return false
+		}
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || !isCobraCommandComposite(lit) {
+			return true
+		}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Use" {
+				continue
+			}
+			if value, ok := stringLiteralValue(kv.Value); ok {
+				out = commandUseToken(value)
+				return false
+			}
+		}
+		return true
+	})
+	return out
+}
+
+func isCobraCommandComposite(lit *ast.CompositeLit) bool {
+	star, ok := lit.Type.(*ast.StarExpr)
+	if ok {
+		return isCobraCommandType(star.X)
+	}
+	return isCobraCommandType(lit.Type)
+}
+
+func isCobraCommandType(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Command" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "cobra"
+}
+
+func stringLiteralValue(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func commandUseToken(use string) string {
+	fields := strings.Fields(use)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 // collectDeclsFromDir walks dir's .go files (non-recursive) and returns the

--- a/internal/pipeline/regenmerge/registrations_test.go
+++ b/internal/pipeline/regenmerge/registrations_test.go
@@ -84,6 +84,42 @@ func TestExtractLostRegistrationsReferentCheck(t *testing.T) {
 	t.Skip("after the fresh-or-novels referent-check fix")
 }
 
+func TestExtractLostRegistrationsCommandUseNoFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	pubCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newListingsCmd())
+	_ = rootCmd.Execute()
+}
+
+func newListingsCmd() *cobra.Command { return &cobra.Command{Use: "listings"} }
+`
+	freshCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newHomesCmd())
+	_ = rootCmd.Execute()
+}
+
+func newHomesCmd() *cobra.Command { return &cobra.Command{Use: "listings"} }
+`
+	pubDir, freshDir := buildSyntheticFixture(t,
+		map[string]string{"internal/cli/root.go": pubCLI},
+		map[string]string{"internal/cli/root.go": freshCLI})
+
+	regs, err := extractLostRegistrations(pubDir, freshDir, nil)
+	require.NoError(t, err)
+	assert.Empty(t, regs, "same parent + same Cobra Use should not produce a lost registration even when constructor names differ")
+}
+
 func containsConstructor(callSrc, ctorName string) bool {
 	// Hacky but adequate for tests — calls look like
 	// "rootCmd.AddCommand(newCanonicalCmd(flags))"; check the constructor


### PR DESCRIPTION
## Summary

This fixes a regen-merge lost-registration false positive when a regenerated command keeps the same Cobra `Use:` token under the same parent but the constructor name changes.

Previously, lost-registration dedupe compared semantic `AddCommand` keys by parent + constructor name. That handled argument-shape drift, but still treated this as lost:

```go
// published
rootCmd.AddCommand(newListingsCmd()) // Use: "listings"

// fresh
rootCmd.AddCommand(newHomesCmd())    // Use: "listings"
```

The apply step could then re-inject the old registration, producing duplicate Cobra registrations for the same command surface.

The fix adds a second dedupe key based on parent + extracted Cobra `Use` token, while keeping the existing constructor-based key and text fallback.

## Validation

- `go test ./internal/pipeline/regenmerge -run TestExtractLostRegistrationsCommandUseNoFalsePositive -count=1`
- `go test ./internal/pipeline/regenmerge -count=20`
- `go test ./internal/pipeline/regenmerge ./internal/pipeline -run 'Regen|Lost|Registration|Apply' -count=1`
- `go test ./internal/pipeline/regenmerge -count=1`
- `go test ./...`
