### PR TITLE
feat(openapi): honor x-mcp extension

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -18,6 +18,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-origin` | `info` | Google Discovery resource fallback | No |
 | `x-providerName` | `info` | Google Discovery resource fallback | No |
 | `x-tier-routing` | root or `info` | `APISpec.TierRouting` | No |
+| `x-mcp` | root or `info` | `APISpec.MCP` | No |
 | `x-auth-type` | `components.securitySchemes.<name>` | `APISpec.Auth.Type` | No |
 | `x-auth-format` | `components.securitySchemes.<name>` | `APISpec.Auth.Format` | No |
 | `x-prefix` | `components.securitySchemes.<name>` | `APISpec.Auth.Format` | No |
@@ -184,6 +185,34 @@ x-tier-routing:
         in: query
         header: api_key
         env_vars: [EXAMPLE_PAID_KEY]
+```
+
+### `x-mcp`
+
+Declares MCP server shape directly in an OpenAPI document. This mirrors the
+Printing Press spec-level `mcp:` block so OpenAPI-only sources can opt into
+agent-native surfaces without a separate hand-authored spec file.
+
+Parsed field: `APISpec.MCP`
+
+Rules:
+- Optional.
+- May be declared at the OpenAPI root or under `info`.
+- Uses the same fields and validation as `mcp:` in Printing Press specs:
+  `transport`, `addr`, `intents`, `endpoint_tools`, `orchestration`, and
+  `orchestration_threshold`.
+- Unknown or invalid MCP values fail parse during normal `APISpec` validation.
+- Root-level `x-mcp` wins when both root and `info` declarations are present.
+
+Example:
+
+```yaml
+x-mcp:
+  transport: [stdio, http]
+  addr: :8787
+  endpoint_tools: hidden
+  orchestration: code
+  orchestration_threshold: 25
 ```
 
 ## Security Scheme Extensions

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -37,6 +37,7 @@ const (
 	extensionAuthDescription  = "x-auth-description"
 	extensionSpeakeasyExample = "x-speakeasy-example"
 	extensionTierRouting      = "x-tier-routing"
+	extensionMCP              = "x-mcp"
 	extensionTier             = "x-tier"
 	extensionAPIName          = "x-api-name"
 	extensionDisplayName      = "x-display-name"
@@ -282,6 +283,10 @@ func parse(data []byte, lenient bool) (*spec.APISpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	mcp, err := parseMCPExtension(doc)
+	if err != nil {
+		return nil, err
+	}
 
 	result := &spec.APISpec{
 		Name:                        name,
@@ -295,6 +300,7 @@ func parse(data []byte, lenient bool) (*spec.APISpec, error) {
 		ProxyRoutes:                 proxyRoutes,
 		Auth:                        auth,
 		TierRouting:                 tierRouting,
+		MCP:                         mcp,
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
@@ -327,6 +333,22 @@ func parse(data []byte, lenient bool) (*spec.APISpec, error) {
 	}
 
 	return result, nil
+}
+
+func parseMCPExtension(doc *openapi3.T) (spec.MCPConfig, error) {
+	raw, ok := lookupOpenAPIExtension(doc, extensionMCP)
+	if !ok {
+		return spec.MCPConfig{}, nil
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return spec.MCPConfig{}, fmt.Errorf("marshaling %s: %w", extensionMCP, err)
+	}
+	var cfg spec.MCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return spec.MCPConfig{}, fmt.Errorf("parsing %s: %w", extensionMCP, err)
+	}
+	return cfg, nil
 }
 
 func parseTierRoutingExtension(doc *openapi3.T) (spec.TierRoutingConfig, error) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -18,6 +18,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseHonorsRootXMCPConfig(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Agent Native API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+x-mcp:
+  transport: [stdio, http]
+  addr: :8787
+  endpoint_tools: hidden
+  orchestration: code
+  orchestration_threshold: 25
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"stdio", "http"}, parsed.MCP.Transport)
+	assert.Equal(t, ":8787", parsed.MCP.Addr)
+	assert.Equal(t, "hidden", parsed.MCP.EndpointTools)
+	assert.Equal(t, "code", parsed.MCP.Orchestration)
+	assert.Equal(t, 25, parsed.MCP.OrchestrationThreshold)
+}
+
 func TestParsePetstore(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Wire OpenAPI x-mcp metadata into the existing MCP config model
- Enable OpenAPI-only specs to opt into existing MCP generation behavior without YAML conversion