### PR TITLE
chore(ci): add post-merge Main CI workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,0 +1,51 @@
+name: Main CI
+
+# Runs the full unit-test + golden-verify suite against main and against PRs
+# targeting main. The push trigger is the post-merge alarm; the pull_request
+# trigger lets a branch protection rule require this exact check, so the
+# Release PR (and any other PR) cannot merge with a stale view of main.
+#
+# The existing CI in lint.yml runs sharded, change-gated tests to keep PR
+# turnaround fast. This workflow is intentionally redundant: it reruns the
+# whole suite from scratch as a single load-bearing signal a branch protection
+# rule can pin against.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# cancel-in-progress so a batch of rapid merges only burns CI for the final
+# state. The question this workflow answers is "is main green right now?" —
+# only the latest run matters. Per-merge attribution can be recovered with
+# git bisect if a regression slips through.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -timeout 15m ./...
+
+      - name: Verify golden fixtures
+        run: bash scripts/golden.sh verify


### PR DESCRIPTION
## Summary

Adds a `Main CI` workflow that runs `go build`, `go test ./...`, and `scripts/golden.sh verify` on every push to `main` and every PR targeting `main`. Once branch protection on `main` requires the new `build-and-test` check with "Require branches to be up to date before merging" enabled, no PR can merge against a stale view of `main`, and the Release PR can never auto-merge while `main` is broken.

## Why now

A test added in #704 was silently violated by code in #706 because the two PRs landed 17 seconds apart, and GitHub's squash-merge does not re-run CI on the post-merge state. Auth-less specs failed to compile through `main` until #707 carried the follow-up fix in. The same merge-skew shape also let template changes in #708 and #709 land without refreshing the `mcp-cloudflare` golden.

## Manual follow-ups (not in this PR)

1. After this lands, the workflow's first push run on `main` registers `Main CI / build-and-test` as a known check name in repo settings.
2. Repo Settings → Branches → branch protection on `main`: require `Main CI / build-and-test` and tick "Require branches to be up to date before merging."

Until step 2, the workflow is informational only. The branch protection rule is what makes it a gate.

## Design choices

- `cancel-in-progress: true` so a batch of rapid merges only burns CI for the final state. Per-merge attribution is recoverable with `git bisect` if a regression slips through.
- Single job (no shards, no change-gate) so the required-check name is stable and immune to "skipped because no relevant files changed" outcomes that would falsely satisfy a branch protection rule.
- The existing sharded `lint.yml` stays as-is for fast PR feedback. This workflow is intentionally redundant as the single load-bearing signal branch protection can pin against.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
