### PR TITLE
fix(cli): score sync_correctness on usage, not dead helper presence

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2161,7 +2161,7 @@ func scoreSyncCorrectness(dir string) int {
 	if strings.Contains(content, "SaveSyncState") {
 		score++
 	}
-	if strings.Contains(content, "paginatedGet") || strings.Contains(content, "hasNextPage") || strings.Contains(content, "endCursor") || strings.Contains(content, "cursor") {
+	if funcIsCalled(content, "paginatedGet") || strings.Contains(content, "hasNextPage") || strings.Contains(content, "endCursor") || strings.Contains(content, "cursor") {
 		score += 2
 	}
 	// URL path parameters only count when other sync signals are present,
@@ -2543,6 +2543,22 @@ func readFileContent(path string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// funcIsCalled reports whether content references a Go function name in a
+// way that's not just its own definition. The bare-token check (used by
+// some scorers as a behavior signal) rewards a CLI that *defines* a helper
+// regardless of whether anything calls it — so polish removing a genuinely
+// dead helper would regress the score even though the CLI's pagination
+// behavior didn't change. Counting non-definition occurrences ties the
+// signal to actual use. See cli-printing-press#717.
+func funcIsCalled(content, name string) bool {
+	total := strings.Count(content, name)
+	if total == 0 {
+		return false
+	}
+	defs := strings.Count(content, "func "+name+"(")
+	return total > defs
 }
 
 func computeGrade(percentage int) string {


### PR DESCRIPTION
## Summary

`scoreSyncCorrectness` was awarding +2 whenever `paginatedGet` appeared in `internal/cli/*.go` — including when it was a dead helper with no callers. So when polish removed the dead helper (rightly, dogfood rewards `dead_code` removal), the scorer regressed by 2 even though pagination behavior didn't change. The pre-polish 5 was inflated; post-polish 0 was the correct value, just delivered as an apparent regression.

This is the dead-code-rewards-points half of #717.

## Change

Adds `funcIsCalled(content, name string) bool` in `internal/pipeline/scorecard.go`:

```go
func funcIsCalled(content, name string) bool {
    total := strings.Count(content, name)
    if total == 0 {
        return false
    }
    defs := strings.Count(content, "func "+name+"(")
    return total > defs
}
```

Applies it to the `paginatedGet` branch of the `scoreSyncCorrectness` OR. The other three tokens in the same OR (`hasNextPage`, `endCursor`, `cursor`) are GraphQL field names / variable names, not functions, so bare `strings.Contains` stays correct for those.

## Test plan

- [x] `TestScoreSyncCorrectness` fixtures use `paginatedGet(path, cursor)` as a call with no definition in scope. With the change: `total=1, defs=0 → true → still scores +2`. Existing assertion `assert.Equal(t, 10, scoreSyncCorrectness(dir))` should still pass.
- [x] `TestScoreSyncCorrectness_NonSyncFilename` same pattern, same outcome.
- [ ] Could not run `go test ./internal/pipeline/...` locally (no Go on the dev box). Relying on CI.
- [ ] Could not run `scripts/golden.sh verify`. Goldens *should* be unaffected because their fixtures presumably exercise pagination via real call sites, but a reviewer with Go available should confirm.

## What this PR does **not** fix

`scoreOutputModes` (line 311) checks the string literal `"page_fetch"`. That's not a function name, so `funcIsCalled` doesn't apply. Tightening that to "appears inside an `Fprintln`/`Fprintf` call site, not just any string occurrence" is regex/AST work and merits a separate, more carefully-tested PR.

Refs #717 (closes the sync_correctness half; output_modes half remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)