### PR TITLE
fix(generator): use simple backticks in auth_client_credentials.go.tmpl

### DIFF
--- a/internal/generator/templates/auth_client_credentials.go.tmpl
+++ b/internal/generator/templates/auth_client_credentials.go.tmpl
@@ -45,20 +45,20 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Mint an OAuth2 bearer token via the client_credentials grant",
-		Long: strings.TrimSpace(` + "`" + `
+		Long: strings.TrimSpace(`
 Mint an OAuth2 bearer token via POST {{.Auth.TokenURL}} with
 grant_type=client_credentials and cache it on disk. Subsequent commands
 auto-refresh the token before expiry.
 
 Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID){{if gt (len .Auth.EnvVars) 1}} and {{index .Auth.EnvVars 1}} (Client Secret){{end}}{{else}}your project's Client ID and Client Secret{{end}} environment variables.
-` + "`" + `),
-		Example: strings.Trim(` + "`" + `
+`),
+		Example: strings.Trim(`
   # Use env vars
   {{.Name}}-pp-cli auth login
 
   # Explicit credentials
   {{.Name}}-pp-cli auth login --client-id <id> --client-secret <secret>
-` + "`" + `, "\n"),
+`, "\n"),
 		Annotations: map[string]string{"mcp:hidden": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cliutil.IsVerifyEnv() {
@@ -121,8 +121,8 @@ Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID)
 }
 
 type tokenResponse struct {
-	AccessToken string ` + "`" + `json:"access_token"` + "`" + `
-	ExpiresIn   int    ` + "`" + `json:"expires_in"` + "`" + `
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
 }
 
 // mintClientCredentialsToken POSTs grant_type=client_credentials to the

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/cli/auth.go
@@ -45,20 +45,20 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Mint an OAuth2 bearer token via the client_credentials grant",
-		Long: strings.TrimSpace(` + "`" + `
+		Long: strings.TrimSpace(`
 Mint an OAuth2 bearer token via POST https://api.cc.example/oauth/token with
 grant_type=client_credentials and cache it on disk. Subsequent commands
 auto-refresh the token before expiry.
 
 Credentials default to PRINTING_PRESS_OAUTH2_CLIENT_ID (Client ID) and PRINTING_PRESS_OAUTH2_CLIENT_SECRET (Client Secret) environment variables.
-` + "`" + `),
-		Example: strings.Trim(` + "`" + `
+`),
+		Example: strings.Trim(`
   # Use env vars
   printing-press-oauth2-pp-cli auth login
 
   # Explicit credentials
   printing-press-oauth2-pp-cli auth login --client-id <id> --client-secret <secret>
-` + "`" + `, "\n"),
+`, "\n"),
 		Annotations: map[string]string{"mcp:hidden": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cliutil.IsVerifyEnv() {
@@ -103,8 +103,8 @@ Credentials default to PRINTING_PRESS_OAUTH2_CLIENT_ID (Client ID) and PRINTING_
 }
 
 type tokenResponse struct {
-	AccessToken string ` + "`" + `json:"access_token"` + "`" + `
-	ExpiresIn   int    ` + "`" + `json:"expires_in"` + "`" + `
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
 }
 
 // mintClientCredentialsToken POSTs grant_type=client_credentials to the


### PR DESCRIPTION
## Summary
Closes #733.

The OAuth2 `client_credentials` auth template emitted literal `` `+ "`" + ` `` template-syntax into the generated `internal/cli/auth.go`, producing uncompilable Go for any spec triggering this auth path (Discord is the clear case — see linked issue for repro).

The over-escaped pattern appears to have been intended to embed a literal backtick inside an enclosing raw string, but there was no enclosing raw string — the docstrings and struct tags here don't contain internal backticks. Replacing each `` `+ "`" + ` `` sequence with a plain backtick produces clean Go.

## Diff scope

**`internal/generator/templates/auth_client_credentials.go.tmpl`:**
- Lines 48 / 54 — `Long: strings.TrimSpace(...)` raw string delimiters
- Lines 55 / 61 — `Example: strings.Trim(...)` raw string delimiters
- Lines 124 / 125 — struct tag delimiters on `tokenResponse.AccessToken` / `ExpiresIn`

8 occurrences total, all the same broken pattern, all replaced.

**`testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/cli/auth.go`** (added in commit 2 per @tmchow's review):
- Same 8 corrections propagated from the template into the rendered golden output
- 6 insertions / 6 deletions in the expected fixture
- `scripts/golden.sh verify` previously failed on this case ("FAIL generate-golden-api-oauth2-cc"); now passes 14/14

## Verification

**Generator-level:** Rebuilt the binary from this branch and regenerated `pp-discord` from the official Discord OpenAPI spec:

```
PASS govulncheck ./...
PASS go vet ./...
PASS go build ./...
PASS build runnable binary
PASS discord-pp-cli --help
PASS discord-pp-cli version
PASS discord-pp-cli doctor
Generated discord at ~/printing-press/library/discord
Bundled ~/printing-press/library/discord/build/discord-pp-mcp-darwin-arm64.mcpb
```

`auth.go` now has clean Go raw strings with the rendered template values inline (Discord token URL embedded directly, no concat dance).

**Golden:** `scripts/golden.sh verify` passes 14/14 cases. Only `generate-golden-api-oauth2-cc/.../auth.go` had a content diff after `scripts/golden.sh update`; the other 13 cases are byte-identical pre/post update. The golden diff is exactly what the template fix produces — no surprises.

## Commits

1. `fix(generator): use simple backticks in auth_client_credentials.go.tmpl` — the template fix itself
2. `test(golden): update oauth2-cc auth.go to match template fix` — the existing oauth2-cc golden fixture brought in line with the new template output, per @tmchow's review feedback. This is the contract-update accompanying the intentional template behavior change.