### PR TITLE
fix(cli): hydrate promote state across scopes

### DIFF
--- a/internal/pipeline/minimal_state_test.go
+++ b/internal/pipeline/minimal_state_test.go
@@ -3,6 +3,7 @@
 package pipeline
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,4 +104,22 @@ func TestNewMinimalState_PreservesScopeFromRecoveredState(t *testing.T) {
 
 	state := NewMinimalState("scope-test-pp-cli", "/tmp/different")
 	assert.Equal(t, "test-scope", state.Scope, "Scope must be borrowed from the recovered state")
+}
+
+func TestFindStateByWorkingDirFindsRunFromDifferentCurrentScope(t *testing.T) {
+	home := setPressTestEnv(t)
+	workingDir := filepath.Join(home, "work", "cross-scope-pp-cli")
+	prior := NewState("cross-scope", workingDir)
+	require.NoError(t, prior.Save())
+
+	t.Setenv("PRINTING_PRESS_SCOPE", "fresh-publish-scope")
+
+	state, err := FindStateByWorkingDir(workingDir)
+	require.NoError(t, err)
+	assert.Equal(t, prior.RunID, state.RunID)
+	assert.Equal(t, "test-scope", state.Scope)
+	assert.Equal(t,
+		filepath.Join(home, ".runstate", "test-scope", "runs", prior.RunID, "pipeline"),
+		state.PipelineDir(),
+		"state path helpers should honor the recovered state's scope, not the current shell scope")
 }

--- a/internal/pipeline/paths.go
+++ b/internal/pipeline/paths.go
@@ -46,19 +46,38 @@ func RunstateRoot() string {
 }
 
 func ScopedRunstateRoot() string {
-	return filepath.Join(RunstateRoot(), WorkspaceScope())
+	return scopedRunstateRoot(WorkspaceScope())
+}
+
+func scopedRunstateRoot(scope string) string {
+	if scope == "" {
+		scope = WorkspaceScope()
+	}
+	return filepath.Join(RunstateRoot(), scope)
+}
+
+func currentRunDirForScope(scope string) string {
+	return filepath.Join(scopedRunstateRoot(scope), "current")
+}
+
+func currentRunPointerPathForScope(scope, apiName string) string {
+	return filepath.Join(currentRunDirForScope(scope), apiName+".json")
+}
+
+func runRootForScope(scope, runID string) string {
+	return filepath.Join(scopedRunstateRoot(scope), "runs", runID)
 }
 
 func CurrentRunDir() string {
-	return filepath.Join(ScopedRunstateRoot(), "current")
+	return currentRunDirForScope(WorkspaceScope())
 }
 
 func CurrentRunPointerPath(apiName string) string {
-	return filepath.Join(CurrentRunDir(), apiName+".json")
+	return currentRunPointerPathForScope(WorkspaceScope(), apiName)
 }
 
 func RunRoot(runID string) string {
-	return filepath.Join(ScopedRunstateRoot(), "runs", runID)
+	return runRootForScope(WorkspaceScope(), runID)
 }
 
 func RunStatePath(runID string) string {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -211,6 +211,28 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	if existingData, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename)); err == nil {
 		var existing CLIManifest
 		if json.Unmarshal(existingData, &existing) == nil {
+			if state.RunID == "" && existing.RunID != "" {
+				state.RunID = existing.RunID
+				m.RunID = existing.RunID
+			}
+			if existing.DisplayName != "" {
+				m.DisplayName = existing.DisplayName
+			}
+			if existing.Owner != "" {
+				m.Owner = existing.Owner
+			}
+			if existing.CatalogEntry != "" {
+				m.CatalogEntry = existing.CatalogEntry
+			}
+			if existing.Category != "" {
+				m.Category = existing.Category
+			}
+			if existing.Description != "" {
+				m.Description = existing.Description
+			}
+			if existing.APIVersion != "" {
+				m.APIVersion = existing.APIVersion
+			}
 			m.MCPBinary = existing.MCPBinary
 			m.MCPToolCount = existing.MCPToolCount
 			m.MCPPublicToolCount = existing.MCPPublicToolCount
@@ -218,6 +240,11 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 			m.AuthType = existing.AuthType
 			m.AuthEnvVars = existing.AuthEnvVars
 			m.AuthEnvVarSpecs = existing.AuthEnvVarSpecs
+			m.EndpointTemplateVars = existing.EndpointTemplateVars
+			m.AuthKeyURL = existing.AuthKeyURL
+			m.AuthTitle = existing.AuthTitle
+			m.AuthDescription = existing.AuthDescription
+			m.AuthOptional = existing.AuthOptional
 			m.NovelFeatures = existing.NovelFeatures
 		}
 	}
@@ -304,7 +331,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		if len(nfs) > 0 {
 			m.NovelFeatures = novelFeaturesToManifest(nfs)
 		}
-		if len(m.NovelFeatures) > 0 && source != "" && source != state.PipelineDir() && source != RunRoot(state.RunID) {
+		if len(m.NovelFeatures) > 0 && source != "" && source != state.PipelineDir() && source != state.RunRoot() {
 			// Visibility for non-canonical sources — a one-line stderr
 			// note keeps promote silent on the happy path but tells the
 			// user when novel_features came from the glob fallback.
@@ -320,7 +347,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		fmt.Fprintf(os.Stderr,
 			"debug: research.json not found at %s or %s; skipping novel_features enrichment "+
 				"(state.RunID=%q)\n",
-			filepath.Join(RunRoot(state.RunID), "research.json"),
+			filepath.Join(state.RunRoot(), "research.json"),
 			filepath.Join(state.PipelineDir(), "research.json"),
 			state.RunID)
 	}
@@ -349,8 +376,8 @@ func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
 		// caller's "is this a non-canonical source?" check compares
 		// against state.PipelineDir() and RunRoot(state.RunID).
 		if state.RunID != "" {
-			if _, statErr := os.Stat(filepath.Join(RunRoot(state.RunID), "research.json")); statErr == nil {
-				return r, RunRoot(state.RunID)
+			if _, statErr := os.Stat(filepath.Join(state.RunRoot(), "research.json")); statErr == nil {
+				return r, state.RunRoot()
 			}
 			return r, state.PipelineDir()
 		}
@@ -358,9 +385,7 @@ func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
 	}
 
 	if state.RunID != "" {
-		// loadResearchForState already covered both canonical paths
-		// for a populated state — no further fallback to try.
-		return nil, ""
+		return loadMatchingResearch(globResearchCandidatesForRunID(state.RunID), state.APIName)
 	}
 
 	// Minimal-state fallback: empty RunID and the canonical loader
@@ -373,17 +398,60 @@ func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return candidates[i].mtime.After(candidates[j].mtime)
 	})
+	return loadMatchingResearch(candidates, state.APIName)
+}
+
+func loadMatchingResearch(candidates []researchCandidate, apiName string) (*ResearchResult, string) {
 	for _, c := range candidates {
 		r, err := LoadResearch(filepath.Dir(c.path))
 		if err != nil {
 			continue
 		}
-		if state.APIName != "" && r.APIName != "" && r.APIName != state.APIName {
+		if apiName != "" && r.APIName != "" && r.APIName != apiName {
 			continue
 		}
 		return r, c.path
 	}
 	return nil, ""
+}
+
+func globResearchCandidatesForRunID(runID string) []researchCandidate {
+	if runID == "" {
+		return nil
+	}
+	var out []researchCandidate
+	seen := make(map[string]bool)
+	add := func(path string) {
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		info, err := os.Stat(path)
+		if err != nil {
+			return
+		}
+		out = append(out, researchCandidate{path: path, mtime: info.ModTime()})
+	}
+
+	add(filepath.Join(RunRoot(runID), "research.json"))
+	add(filepath.Join(RunRoot(runID), "pipeline", "research.json"))
+
+	scopeEntries, err := os.ReadDir(RunstateRoot())
+	if err != nil {
+		return out
+	}
+	for _, entry := range scopeEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		runRoot := runRootForScope(entry.Name(), runID)
+		add(filepath.Join(runRoot, "research.json"))
+		add(filepath.Join(runRoot, "pipeline", "research.json"))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].mtime.After(out[j].mtime)
+	})
+	return out
 }
 
 // researchCandidate is a path + mtime for sorting glob results.

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -219,6 +219,46 @@ func TestWriteCLIManifestForPublish_NovelFeaturesFromPrintFlowResearch(t *testin
 	assert.Equal(t, "conflicts", m.NovelFeatures[0].Command)
 }
 
+// TestWriteCLIManifestForPublish_HydratesFromManifestRunIDAcrossScopes covers
+// the deferred-publish flow: generate wrote a manifest with run_id under one
+// PRESS_SCOPE, then promote runs from a different shell/cwd with a different
+// scope. The source manifest's run_id must still let promote find research.json.
+func TestWriteCLIManifestForPublish_HydratesFromManifestRunIDAcrossScopes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "publish-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	runID := "20260508-070627"
+	workingDir := filepath.Join(tmp, "working", "test-api-pp-cli")
+	require.NoError(t, os.MkdirAll(workingDir, 0o755))
+	require.NoError(t, WriteCLIManifest(workingDir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "test-api",
+		CLIName:       "test-api-pp-cli",
+		RunID:         runID,
+	}))
+
+	built := []NovelFeature{
+		{Name: "Cross-scope feature", Command: "feature", Description: "Loaded from the original run scope."},
+	}
+	originalRunRoot := filepath.Join(RunstateRoot(), "generate-scope", "runs", runID)
+	writeResearchAt(t, originalRunRoot, &ResearchResult{
+		APIName:            "test-api",
+		NovelFeaturesBuilt: &built,
+	})
+
+	state := NewMinimalState("test-api-pp-cli", workingDir)
+	require.Empty(t, state.RunID, "current scope has no registry entry")
+
+	require.NoError(t, writeCLIManifestForPublish(state, workingDir))
+
+	m := readPublishedManifest(t, workingDir)
+	assert.Equal(t, runID, m.RunID)
+	require.Len(t, m.NovelFeatures, 1)
+	assert.Equal(t, "feature", m.NovelFeatures[0].Command)
+}
+
 // TestWriteCLIManifestForPublish_NovelFeaturesPreservedFromCarryForward covers
 // the defense-in-depth path: research.json missing (deleted, not yet written),
 // but the existing manifest in the staging dir already has novel_features from

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -279,7 +279,7 @@ func LoadResearch(pipelineDir string) (*ResearchResult, error) {
 // Without this fallback the publish-time read silently misses skill-flow runs
 // and ships manifests with empty novel_features (cal-com retro #334 F2).
 func loadResearchForState(state *PipelineState) (*ResearchResult, error) {
-	if r, err := LoadResearch(RunRoot(state.RunID)); err == nil {
+	if r, err := LoadResearch(state.RunRoot()); err == nil {
 		return r, nil
 	}
 	return LoadResearch(state.PipelineDir())

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -179,7 +179,7 @@ func writeCurrentRunPointer(state *PipelineState) error {
 		UpdatedAt:  time.Now(),
 	}
 
-	if err := os.MkdirAll(CurrentRunDir(), 0o755); err != nil {
+	if err := os.MkdirAll(currentRunDirForScope(state.Scope), 0o755); err != nil {
 		return fmt.Errorf("creating current run dir: %w", err)
 	}
 
@@ -188,7 +188,7 @@ func writeCurrentRunPointer(state *PipelineState) error {
 		return fmt.Errorf("marshaling current run pointer: %w", err)
 	}
 
-	return os.WriteFile(CurrentRunPointerPath(state.APIName), data, 0o644)
+	return os.WriteFile(currentRunPointerPathForScope(state.Scope, state.APIName), data, 0o644)
 }
 
 func findRunstateStatePath(apiName string) (string, bool) {
@@ -272,13 +272,7 @@ func FindStateByWorkingDir(dir string) (*PipelineState, error) {
 		return nil, fmt.Errorf("resolving working dir: %w", err)
 	}
 
-	pattern := filepath.Join(ScopedRunstateRoot(), "runs", "*", "state.json")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, fmt.Errorf("scanning runstate: %w", err)
-	}
-
-	for _, candidate := range matches {
+	for _, candidate := range runstateStatePathCandidates() {
 		data, err := os.ReadFile(candidate)
 		if err != nil {
 			continue
@@ -293,13 +287,46 @@ func FindStateByWorkingDir(dir string) (*PipelineState, error) {
 				state.RunID = filepath.Base(filepath.Dir(candidate))
 			}
 			if state.Scope == "" {
-				state.Scope = WorkspaceScope()
+				state.Scope = scopeFromStatePath(candidate)
 			}
 			return &state, nil
 		}
 	}
 
 	return nil, fmt.Errorf("no runstate entry for working dir %s", absDir)
+}
+
+func runstateStatePathCandidates() []string {
+	seen := make(map[string]bool)
+	var out []string
+	addMatches := func(pattern string) {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return
+		}
+		for _, match := range matches {
+			if !seen[match] {
+				seen[match] = true
+				out = append(out, match)
+			}
+		}
+	}
+	addMatches(filepath.Join(ScopedRunstateRoot(), "runs", "*", "state.json"))
+	addMatches(filepath.Join(RunstateRoot(), "*", "runs", "*", "state.json"))
+	return out
+}
+
+func scopeFromStatePath(path string) string {
+	runsDir := filepath.Dir(filepath.Dir(path))
+	scopeDir := filepath.Dir(runsDir)
+	if filepath.Base(runsDir) != "runs" {
+		return WorkspaceScope()
+	}
+	scope := filepath.Base(scopeDir)
+	if scope == "." || scope == string(filepath.Separator) || scope == "" {
+		return WorkspaceScope()
+	}
+	return scope
 }
 
 // NewMinimalState creates a lightweight state for CLIs that skipped the
@@ -597,27 +624,31 @@ func (s *PipelineState) EffectiveWorkingDir() string {
 }
 
 func (s *PipelineState) StatePath() string {
-	return RunStatePath(s.RunID)
+	return filepath.Join(s.RunRoot(), "state.json")
 }
 
 func (s *PipelineState) PipelineDir() string {
-	return RunPipelineDir(s.RunID)
+	return filepath.Join(s.RunRoot(), "pipeline")
 }
 
 func (s *PipelineState) ResearchDir() string {
-	return RunResearchDir(s.RunID)
+	return filepath.Join(s.RunRoot(), "research")
 }
 
 func (s *PipelineState) ProofsDir() string {
-	return RunProofsDir(s.RunID)
+	return filepath.Join(s.RunRoot(), "proofs")
 }
 
 func (s *PipelineState) DiscoveryDir() string {
-	return RunDiscoveryDir(s.RunID)
+	return filepath.Join(s.RunRoot(), "discovery")
 }
 
 func (s *PipelineState) ManifestPath() string {
-	return RunManifestPath(s.RunID)
+	return filepath.Join(s.RunRoot(), "manifest.json")
+}
+
+func (s *PipelineState) RunRoot() string {
+	return runRootForScope(s.Scope, s.RunID)
 }
 
 // NextPhase returns the name of the next incomplete phase, or "".


### PR DESCRIPTION
## Summary

`lock promote` can now finish deferred publish flows even when `generate` and `promote` run under different `PRESS_SCOPE` values. Explicit `--dir` state recovery scans all runstate scopes, recovered states keep using their original scope for runstate paths, and the source manifest's `run_id` can hydrate publish metadata when the current scope has no state entry.

This keeps published manifests from losing `run_id`, provenance metadata, and `novel_features` after a fresh conversation or cwd change.

Fixes #724.

## Tests

- `go test ./internal/pipeline -run 'TestWriteCLIManifestForPublish_HydratesFromManifestRunIDAcrossScopes|TestFindStateByWorkingDirFindsRunFromDifferentCurrentScope'`
- `go test ./internal/pipeline`
- `go test ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `golangci-lint run ./...`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
