### PR TITLE
fix(cli): unscore large code-orch token catalogs

### DIFF
--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -462,9 +462,17 @@ func normalizedStringMapLiteral(expr ast.Expr) map[string]string {
 //   - per-tool <= 320 tokens: partial (4)
 //   - per-tool > 320 tokens: 0
 //
+// Large code-orchestrated catalogs are unscored instead. Their catalog
+// payload intentionally scales with endpoint count while the exposed tool
+// count stays fixed at search+execute, so a per-tool average is not a
+// meaningful efficiency signal.
+//
 // Empty or missing MCP surface returns (0, false) so the dimension is
 // added to UnscoredDimensions.
 func scoreMCPTokenEfficiency(dir string) (int, bool) {
+	if canonicalMCPSurfacePath(dir) == mcpCodeOrchPath(dir) && codeOrchEndpointCount(dir) > surfaceStrategyLargeThreshold {
+		return 0, false
+	}
 	est := estimateMCPTokens(dir)
 	if est.ToolCount == 0 {
 		return 0, false
@@ -480,4 +488,34 @@ func scoreMCPTokenEfficiency(dir string) (int, bool) {
 	default:
 		return 0, true
 	}
+}
+
+func codeOrchEndpointCount(dir string) int {
+	file, err := parser.ParseFile(token.NewFileSet(), mcpCodeOrchPath(dir), nil, 0)
+	if err != nil {
+		return 0
+	}
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if name.Name != "codeOrchEndpoints" || i >= len(valueSpec.Values) {
+					continue
+				}
+				lit, ok := valueSpec.Values[i].(*ast.CompositeLit)
+				if !ok {
+					return 0
+				}
+				return len(lit.Elts)
+			}
+		}
+	}
+	return 0
 }

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -35,6 +36,52 @@ func writeMCPCLISource(t *testing.T, dir, name, content string) {
 	cliDir := filepath.Join(dir, "internal", "cli")
 	require.NoError(t, os.MkdirAll(cliDir, 0o755))
 	writeFile(t, filepath.Join(cliDir, name), content)
+}
+
+func writeCodeOrchSurface(t *testing.T, endpointCount int) string {
+	t.Helper()
+	dir := t.TempDir()
+	mcpDir := filepath.Join(dir, "internal", "mcp")
+	require.NoError(t, os.MkdirAll(mcpDir, 0o755))
+
+	toolsBody := `package mcp
+
+func RegisterTools(s *server.MCPServer) {
+	RegisterCodeOrchestrationTools(s)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(mcpDir, "tools.go"), []byte(toolsBody), 0o644))
+
+	var endpoints strings.Builder
+	for i := range endpointCount {
+		endpoints.WriteString(`
+	{ID: "items.endpoint_`)
+		endpoints.WriteString(strconv.Itoa(i))
+		endpoints.WriteString(`", Method: "GET", Path: "/items", Summary: "`)
+		endpoints.WriteString(strings.Repeat("x", 40))
+		endpoints.WriteString(`"},
+`)
+	}
+	codeOrchBody := `package mcp
+
+import mcplib "github.com/mark3labs/mcp-go/mcp"
+
+type codeOrchEndpoint struct {
+	ID      string
+	Method  string
+	Path    string
+	Summary string
+}
+
+var codeOrchEndpoints = []codeOrchEndpoint{` + endpoints.String() + `}
+
+func RegisterCodeOrchestrationTools(s *server.MCPServer) {
+	s.AddTool(mcplib.NewTool("demo_search", mcplib.WithDescription("Search the API.")), nil)
+	s.AddTool(mcplib.NewTool("demo_execute", mcplib.WithDescription("Execute one endpoint.")), nil)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(mcpDir, "code_orch.go"), []byte(codeOrchBody), 0o644))
+	return dir
 }
 
 func TestEstimateMCPTokens_NoMCPSurface(t *testing.T) {
@@ -197,6 +244,36 @@ func TestScoreMCPTokenEfficiency_PartialCreditMedium(t *testing.T) {
 	score, scored := scoreMCPTokenEfficiency(dir)
 	assert.True(t, scored)
 	assert.Equal(t, 7, score)
+}
+
+func TestScoreMCPTokenEfficiency_UnscoredForLargeCodeOrchCatalog(t *testing.T) {
+	dir := writeCodeOrchSurface(t, 200)
+
+	score, scored := scoreMCPTokenEfficiency(dir)
+	assert.False(t, scored, "large code-orchestrated catalogs should be unscored instead of zero-scored")
+	assert.Equal(t, 0, score)
+
+	sc := &Scorecard{}
+	scoreInfrastructureDimensions(sc, dir)
+	assert.Contains(t, sc.UnscoredDimensions, DimMCPTokenEfficiency)
+}
+
+func TestScoreMCPTokenEfficiency_ScoresSmallCodeOrchCatalog(t *testing.T) {
+	dir := writeCodeOrchSurface(t, 20)
+
+	score, scored := scoreMCPTokenEfficiency(dir)
+	assert.True(t, scored, "small code-orchestrated catalogs should still use the scoring bands")
+	assert.Greater(t, score, 0)
+}
+
+func TestScoreMCPTokenEfficiency_EndpointMirrorBehaviorUnchanged(t *testing.T) {
+	dir := writeMCPTools(t, `
+	s.AddTool(mcplib.NewTool("bloated", mcplib.WithDescription("`+strings.Repeat("x", 1600)+`")), nil)
+`)
+
+	score, scored := scoreMCPTokenEfficiency(dir)
+	assert.True(t, scored)
+	assert.Equal(t, 0, score)
 }
 
 // TestEstimateMCPTokens_RuntimeSurfaceSelection captures WU-A4 from


### PR DESCRIPTION
## Summary

- Mark large code-orchestrated MCP catalogs as unscored for `mcp_token_efficiency` instead of forcing a 0/10 per-tool average.
- Count generated `codeOrchEndpoints` entries to apply that exception only when the canonical runtime surface is `code_orch.go` and the catalog is past the large-surface threshold.
- Add regression coverage for a 200-endpoint code-orch catalog, a small code-orch catalog, and unchanged endpoint-mirror scoring.

Fixes #740

## Verification

- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `go build -o ./printing-press ./cmd/printing-press`
