### PR TITLE
ci(cli): skip title lint for merge queue batches

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Skip Mergify merge queue batches
+        if: startsWith(github.event.pull_request.title, 'merge queue:')
+        run: echo "Skipping semantic title check for Mergify merge queue batch."
+
       - uses: amannn/action-semantic-pull-request@v6
+        if: ${{ !startsWith(github.event.pull_request.title, 'merge queue:') }}
         with:
           types: |
             feat


### PR DESCRIPTION
## Summary
- skip semantic PR title lint for Mergify's synthetic merge queue batch PRs
- keep conventional title enforcement for normal pull requests

## Verification
- actionlint .github/workflows/pr-title.yml
- git diff --check