### PR TITLE
feat(ci): add verify-skill drift check

### DIFF
--- a/.github/workflows/verify-skill-drift-check.yml
+++ b/.github/workflows/verify-skill-drift-check.yml
@@ -1,0 +1,90 @@
+name: Verify Skill Drift
+
+on:
+  schedule:
+    - cron: '23 12 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/verify-skill/verify_skill.py'
+      - '.github/workflows/verify-skill-drift-check.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  compare-library-copy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      LIBRARY_VERIFY_SKILL_URL: https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/.github/scripts/verify-skill/verify_skill.py
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare verify-skill scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          local_script="scripts/verify-skill/verify_skill.py"
+          library_script="${RUNNER_TEMP:-/tmp}/library-verify_skill.py"
+
+          curl -fsSL --retry 3 --retry-delay 2 "$LIBRARY_VERIFY_SKILL_URL" -o "$library_script"
+
+          local_hash="$(sha256sum "$local_script" | awk '{print $1}')"
+          library_hash="$(sha256sum "$library_script" | awk '{print $1}')"
+
+          {
+            echo "### verify-skill drift check"
+            echo
+            echo "- Printing Press canonical: \`$local_hash\`"
+            echo "- printing-press-library copy: \`$library_hash\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if ! cmp -s "$local_script" "$library_script"; then
+            cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+
+          The canonical verify-skill script and the printing-press-library CI copy have drifted.
+
+          From a workspace containing sibling checkouts of both repositories, update the library copy with:
+
+          ```bash
+          cp scripts/verify-skill/verify_skill.py ../printing-press-library/.github/scripts/verify-skill/verify_skill.py
+          ```
+          EOF
+
+            issue_title="verify-skill drift detected with printing-press-library"
+            existing_issue="$(gh issue list --state open --search "$issue_title in:title" --json number --jq '.[0].number // empty')"
+            if [[ -z "$existing_issue" ]]; then
+              issue_body="${RUNNER_TEMP:-/tmp}/verify-skill-drift-issue.md"
+              cat > "$issue_body" <<EOF
+          The canonical verify-skill script in cli-printing-press no longer matches the printing-press-library CI copy.
+
+          - Printing Press canonical: \`$local_hash\`
+          - printing-press-library copy: \`$library_hash\`
+          - Library source: $LIBRARY_VERIFY_SKILL_URL
+
+          From a workspace containing sibling checkouts of both repositories, update the library copy with:
+
+          \`\`\`bash
+          cp scripts/verify-skill/verify_skill.py ../printing-press-library/.github/scripts/verify-skill/verify_skill.py
+          \`\`\`
+          EOF
+
+              gh issue create --title "$issue_title" --body-file "$issue_body"
+            else
+              echo "Existing open drift issue: #$existing_issue" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            echo "::error::verify-skill drift detected between cli-printing-press and printing-press-library"
+            exit 1
+          fi
+
+          echo "verify-skill scripts are in sync."

--- a/internal/cli/verify_skill_sync_test.go
+++ b/internal/cli/verify_skill_sync_test.go
@@ -8,7 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestVerifySkillScriptInSync ensures the script embedded into the binary
@@ -61,6 +64,47 @@ func TestVerifySkillScriptInSync(t *testing.T) {
 			hex.EncodeToString(canonicalHash[:]), len(canonicalBytes),
 			hex.EncodeToString(bundledHash[:]), len(bundledBytes),
 		)
+	}
+}
+
+func TestVerifySkillDriftWorkflowGuardsLibraryCopy(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := findRepoRoot(t)
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "verify-skill-drift-check.yml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read verify-skill drift workflow %s: %v", workflowPath, err)
+	}
+
+	var workflow map[string]any
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse verify-skill drift workflow YAML: %v", err)
+	}
+
+	content := string(data)
+	required := []string{
+		"name: Verify Skill Drift",
+		"schedule:",
+		"cron:",
+		"push:",
+		"branches: [main]",
+		"scripts/verify-skill/verify_skill.py",
+		".github/workflows/verify-skill-drift-check.yml",
+		"issues: write",
+		"https://raw.githubusercontent.com/mvanhorn/printing-press-library/main/.github/scripts/verify-skill/verify_skill.py",
+		"GH_TOKEN: ${{ github.token }}",
+		"sha256sum",
+		"cmp -s",
+		"gh issue list",
+		"gh issue create",
+		"exit 1",
+		"cp scripts/verify-skill/verify_skill.py ../printing-press-library/.github/scripts/verify-skill/verify_skill.py",
+	}
+	for _, want := range required {
+		if !strings.Contains(content, want) {
+			t.Fatalf("verify-skill drift workflow should contain %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
Verify-skill drift between the Printing Press canonical script and the printing-press-library CI copy now creates a durable remediation task instead of waiting for a library PR to discover it. The new scheduled workflow compares the current canonical script against the public library copy, reports both SHA256 hashes, opens a same-repo tracking issue when no open drift issue exists, and fails red with the exact copy recipe needed to resync them.

The workflow also runs on main pushes that change the canonical script or the workflow itself, so in-repo changes get checked immediately while out-of-band library edits are caught by the daily schedule.

Closes #726

Tests:
- `go test ./internal/cli -run 'TestVerifySkill(ScriptInSync|DriftWorkflowGuardsLibraryCopy)' -count=1`
- `go test ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
- `actionlint .github/workflows/verify-skill-drift-check.yml`
- live hash comparison against `mvanhorn/printing-press-library/main`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
