### PR TITLE
feat(cli): support static config headers

### DIFF
--- a/internal/generator/config_headers_test.go
+++ b/internal/generator/config_headers_test.go
@@ -1,0 +1,70 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientAppliesConfigHeadersBeforeRequestOverrides(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("static-headers")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const behaviorTest = `package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"static-headers-pp-cli/internal/config"
+)
+
+func TestConfigHeadersAreAppliedBeforeRequestOverrides(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		if got := r.Header.Get("Authorization"); got != "Bearer config-token" {
+			t.Fatalf("Authorization header = %q, want %q", got, "Bearer config-token")
+		}
+		if got := r.Header.Get("apikey"); got != "config-key" {
+			t.Fatalf("apikey header = %q, want %q", got, "config-key")
+		}
+		if got := r.Header.Get("x-api-version"); got != "override-version" {
+			t.Fatalf("x-api-version header = %q, want request override to win", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:       server.URL,
+		AuthHeaderVal: "Bearer config-token",
+		Headers: map[string]string{
+			"apikey":        "config-key",
+			"x-api-version": "config-version",
+		},
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+
+	if _, err := c.GetWithHeaders("/items", nil, map[string]string{"x-api-version": "override-version"}); err != nil {
+		t.Fatalf("GetWithHeaders returned error: %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("server saw %d requests, want 1", seen)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "config_headers_test.go"), []byte(behaviorTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -670,6 +670,11 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 {{- range .RequiredHeaders}}
 		req.Header.Set("{{.Name}}", "{{.Value}}")
 {{- end}}
+		if c.Config != nil {
+			for k, v := range c.Config.Headers {
+				req.Header.Set(k, v)
+			}
+		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
 			req.Header.Set(k, v)

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -23,6 +23,7 @@ import (
 type Config struct {
 	BaseURL        string `{{configTag .Config.Format}}:"base_url"`
 	AuthHeaderVal  string `{{configTag .Config.Format}}:"auth_header"`
+	Headers        map[string]string `{{configTag .Config.Format}}:"headers,omitempty"`
 	AuthSource     string `{{configTag .Config.Format}}:"-"`
 {{- if .HasAuthCommand}}
 	AccessToken    string `{{configTag .Config.Format}}:"access_token"`

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -490,6 +490,8 @@ Verifies configuration{{if and (ne .Auth.Type "") (ne .Auth.Type "none")}}, cred
 ## Configuration
 
 Config file: `{{.Config.Path}}`
+
+Static request headers can be configured under `headers`; per-command header overrides take precedence.
 {{- if or .Auth.EnvVarSpecs .Auth.EnvVars}}
 
 Environment variables:

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -227,6 +227,11 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		if authHeader != "" {
 			req.Header.Set("Authorization", authHeader)
 		}
+		if c.Config != nil {
+			for k, v := range c.Config.Headers {
+				req.Header.Set(k, v)
+			}
+		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
 			req.Header.Set(k, v)

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	BaseURL        string `toml:"base_url"`
 	AuthHeaderVal  string `toml:"auth_header"`
+	Headers        map[string]string `toml:"headers,omitempty"`
 	AuthSource     string `toml:"-"`
 	AccessToken    string `toml:"access_token"`
 	RefreshToken   string `toml:"refresh_token"`

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -201,6 +201,8 @@ Verifies configuration, credentials, and connectivity to the API.
 
 Config file: `~/.config/printing-press-rich-pp-cli/config.toml`
 
+Static request headers can be configured under `headers`; per-command header overrides take precedence.
+
 Environment variables:
 
 | Name | Kind | Required | Description |

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	BaseURL        string `toml:"base_url"`
 	AuthHeaderVal  string `toml:"auth_header"`
+	Headers        map[string]string `toml:"headers,omitempty"`
 	AuthSource     string `toml:"-"`
 	AccessToken    string `toml:"access_token"`
 	RefreshToken   string `toml:"refresh_token"`

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -222,6 +222,8 @@ Verifies configuration, credentials, and connectivity to the API.
 
 Config file: `~/.config/printing-press-golden-pp-cli/config.toml`
 
+Static request headers can be configured under `headers`; per-command header overrides take precedence.
+
 Environment variables:
 
 | Name | Kind | Required | Description |

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -222,6 +222,11 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 			req.Header.Set("X-API-Key", authHeader)
 		}
 		req.Header.Set("X-Api-Version", "2026-04-01")
+		if c.Config != nil {
+			for k, v := range c.Config.Headers {
+				req.Header.Set(k, v)
+			}
+		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
 			req.Header.Set(k, v)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	BaseURL        string `toml:"base_url"`
 	AuthHeaderVal  string `toml:"auth_header"`
+	Headers        map[string]string `toml:"headers,omitempty"`
 	AuthSource     string `toml:"-"`
 	AccessToken    string `toml:"access_token"`
 	RefreshToken   string `toml:"refresh_token"`

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -189,6 +189,8 @@ Verifies configuration and connectivity to the API.
 
 Config file: ``
 
+Static request headers can be configured under `headers`; per-command header overrides take precedence.
+
 ## Troubleshooting
 **Not found errors (exit code 3)**
 - Check the resource ID is correct

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -325,6 +325,11 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 				req.Header.Set(authInfo.Name, authHeader)
 			}
 		}
+		if c.Config != nil {
+			for k, v := range c.Config.Headers {
+				req.Header.Set(k, v)
+			}
+		}
 		// Per-endpoint header overrides (e.g., different API version per resource)
 		for k, v := range headerOverrides {
 			req.Header.Set(k, v)


### PR DESCRIPTION
## Summary

The Printing Press can now generate usable CLIs for Supabase-style APIs that require more than one always-on request header. A printed CLI can keep the existing `auth_header` for `Authorization` while configuring additional static headers such as `apikey`, without forking the generated client or wrapping every command in a script.

The request pipeline keeps the intended precedence: generated auth and spec-required headers are applied first, config headers provide operator-owned static defaults, and per-endpoint header overrides still win for cases like resource-specific API version headers.

## Why This Matters

Supabase REST is a strong target for agent-native CLIs: it exposes an OpenAPI document directly from each project, maps cleanly to CRUD resources, and backs real app state. Before this PR, generation could succeed but live commands still failed with 401s because Supabase requires both `Authorization: Bearer <key>` and `apikey: <key>`.

This also covers the broader multi-header API shape: tenant IDs, gateway keys, fixed client headers, and other static request headers that are not the primary auth header but still need to ride on every request.

## Config Shape

Existing configs keep working:

```toml
base_url = "https://<project>.supabase.co/rest/v1"
auth_header = "Bearer <SERVICE_KEY>"
```

Generated CLIs now also accept static request headers:

```toml
[headers]
apikey = "<SERVICE_KEY>"
x-tenant-id = "tenant_123"
```

Per-command header overrides continue to take final precedence, so generated endpoint-specific headers such as API-version overrides are not shadowed by config defaults.

Closes mvanhorn/cli-printing-press#768.

## Test Plan

- `go test ./internal/generator -run TestGeneratedClientAppliesConfigHeadersBeforeRequestOverrides -count=1`
- `go test ./internal/generator -count=1`
- `go build -o ./printing-press ./cmd/printing-press`
- `scripts/golden.sh verify`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
