### PR TITLE
fix(cli): avoid duplicate token auth map keys

### DIFF
--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -187,7 +187,9 @@ func (c *Config) AuthHeader() string {
 		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
 		})
 		{{- else}}
 		return c.{{resolveEnvVarField .Name}}
@@ -287,7 +289,9 @@ func (c *Config) AuthHeader() string {
 		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
 		})
 		{{- else}}
 		return "Bearer " + c.{{resolveEnvVarField .Name}}
@@ -302,7 +306,9 @@ func (c *Config) AuthHeader() string {
 		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
 		})
 		{{- else}}
 		return "Bearer " + c.{{resolveEnvVarField .Name}}

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -194,3 +194,58 @@ func TestAuthHeaderBearerORCaseFallsThroughToAccessToken(t *testing.T) {
 	assert.Less(t, fanOutIdx, accessTokenIdx, "AccessToken fallback should remain reachable after OR fan-out")
 	require.NotContains(t, content[fanOutIdx:accessTokenIdx], `return ""`)
 }
+
+func TestAuthHeaderTokenEnvVarsDoNotEmitDuplicateMapKeys(t *testing.T) {
+	t.Parallel()
+
+	orTokenEnvVars := []spec.AuthEnvVar{
+		{Name: "PRIMARY_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true, Description: "Set this OR SECONDARY_TOKEN."},
+		{Name: "SECONDARY_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true, Description: "Set this OR PRIMARY_TOKEN."},
+	}
+
+	tests := []struct {
+		name string
+		auth spec.AuthConfig
+	}{
+		{
+			name: "bearer-canonical-token",
+			auth: spec.AuthConfig{
+				Type:    "bearer_token",
+				Header:  "Authorization",
+				Format:  "Bearer {token}",
+				EnvVars: []string{"CANONICAL_TOKEN"},
+			},
+		},
+		{
+			name: "bearer-or-token",
+			auth: spec.AuthConfig{
+				Type:        "bearer_token",
+				Header:      "Authorization",
+				Format:      "Bearer {token}",
+				EnvVarSpecs: orTokenEnvVars,
+			},
+		},
+		{
+			name: "api-key-or-token",
+			auth: spec.AuthConfig{
+				Type:        "api_key",
+				Header:      "Authorization",
+				Format:      "Bearer {token}",
+				EnvVarSpecs: orTokenEnvVars,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec(tt.name)
+			apiSpec.Auth = tt.auth
+
+			outputDir := filepath.Join(t.TempDir(), tt.name+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+			runGoCommand(t, outputDir, "test", "./internal/config")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- avoid duplicate generated auth replacement map keys when `envVarPlaceholder` resolves `*_TOKEN` to `token`
- cover canonical bearer, bearer OR-case, and API-key OR-case generated config branches with compile-level regression coverage

## Testing
- `go test ./internal/generator -run TestAuthHeaderTokenEnvVarsDoNotEmitDuplicateMapKeys -count=1` (failed before fix with duplicate `"token"` map keys; passes after fix)
- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./printing-press ./cmd/printing-press`
- `golangci-lint run ./...`
- `git diff --check`

Fixes #773
