### PR TITLE
fix: use path.Join not filepath.Join for embed.FS reads on Windows

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -2703,7 +2704,7 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -90,7 +91,7 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}


### PR DESCRIPTION
## Problem

`printing-press generate` fails on Windows on the very first template read:

```
Error: generating project: rendering NOTICE.tmpl: reading template NOTICE.tmpl: open templates\NOTICE.tmpl: file does not exist
```

Zero files are written. Every subsequent call surfaces a different missing template (NOTICE → golangci.yml → cobratree/walker.go → LICENSE → …) because the templates the call site reaches before crashing depend on render order.

## Root cause

Two call sites read templates from `templateFS embed.FS` using `filepath.Join`:

- `internal/generator/generator.go:2706`
- `internal/generator/plan_generate.go:93`

`embed.FS` paths are forward-slash regardless of OS (per [`embed` docs](https://pkg.go.dev/embed#hdr-Patterns)). On Windows, `filepath.Join("templates", name)` yields `templates\name`, which `embed.FS.ReadFile` cannot resolve.

## Fix

Swap `filepath.Join` → `path.Join` in both call sites. `path.Join` is forward-slash-only and matches the `embed.FS` contract on every OS.

## Verification

After the patch, `printing-press generate --spec <front-spec> --spec-source official --name front` against the Front Core API OpenAPI spec (244 endpoints / 111 resources) completes successfully on Windows 10:

```
PASS go mod tidy
PASS govulncheck ./...
PASS go vet ./...
PASS go build ./...
PASS build runnable binary
```

Generated CLI then scores **86/100 — Grade A** on `printing-press scorecard`. Re-running with an `x-mcp.orchestration: code` enrichment in the spec drops the MCP surface from 248 tools to 6 and the scorecard rises to **91/100**.

## Notes / out of scope

- The generated CLI's `--help` quality gate also fails on Windows because the validation harness spawns `<name>-pp-cli-validation` without an `.exe` suffix:
  ```
  exec: "...\\library\\front\\front-pp-cli-validation": executable file not found in %PATH%
  ```
  That looks like a separate bug and is left for a follow-up.
- One template read at `workflows/comm_health.go.tmpl` still emits a soft warning (`reading template workflows/comm_health.go.tmpl: open templates/workflows/comm_health.go.tmpl: file does not exist`) — different code path, doesn't block generation, also left for follow-up.
