### PR TITLE
fix(generator): use path.Join for embed.FS template lookups (Windows)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -2703,7 +2704,7 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -90,7 +91,7 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}


### PR DESCRIPTION
## Symptom

On Windows, a fresh `/printing-press <api>` run fails during generate with:

```
Error: generating project: rendering which_test.go.tmpl: reading template which_test.go.tmpl: open templates\which_test.go.tmpl: file does not exist
```

(Or `LICENSE.tmpl`, or any other template — depending on Go map iteration order.) The CLI never gets generated.

## Root cause

`embed.FS.ReadFile` goes through `fs.ValidPath`, which only accepts forward-slash separators. On Windows `filepath.Join` produces backslashes, so:

```go
templateFS.ReadFile(filepath.Join("templates", tmplName))
// Windows: ReadFile("templates\which_test.go.tmpl") -> error
// Linux:   ReadFile("templates/which_test.go.tmpl")  -> ok
```

The bug fires on every uncached template lookup. The cache check at the top of `(*Generator).template` short-circuits already-rendered templates, so the first `renderTemplate` call after a cold cache is the one that surfaces the failure. Which template that is depends on Go map iteration order, hence the variable failure name.

## Fix

Two production call sites in `internal/generator/`:

- `generator.go:2706` — `(*Generator).template()`
- `plan_generate.go:94` — the render closure inside `GenerateFromPlan()`

Both switch from `filepath.Join` to `path.Join` (forward slashes always). Verified manually on Windows 11: with the patch, `printing-press generate --spec ./openapi.yaml` completes through generation, build, and shipcheck.

## Behavior on other platforms

No change on macOS or Linux — `filepath.Join` already uses forward slashes there.

## Tests

The existing `generator_test.go` calls at lines 7553 and 7595 use `os.ReadFile(filepath.Join("templates", ...))` which IS correct (those are real-filesystem reads, not embed.FS). Left alone.

## Repro before the fix

```pwsh
go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest
printing-press generate --spec ./any-spec.yaml --output ./test-cli --force
# fails with 'open templates\<name>.tmpl: file does not exist'
```

## Repro after the fix

```pwsh
git clone -b fix/windows-template-embed-paths https://github.com/ctrlBizz/cli-printing-press
cd cli-printing-press
go build -o printing-press.exe ./cmd/printing-press
.\printing-press.exe generate --spec ./any-spec.yaml --output ./test-cli --force
# succeeds
```

Discovered while generating an internal-API CLI under `/printing-press twinorg --spec docs/twinorg-pp-priority-openapi.yaml` on Windows 11 / Go 1.26.3 / printing-press v4.2.0.