### PR TITLE
feat(cli): add Quo (formerly OpenPhone) catalog entry and OpenAPI spec

### DIFF
--- a/catalog/quo.yaml
+++ b/catalog/quo.yaml
@@ -1,0 +1,19 @@
+name: quo
+display_name: Quo
+description: Business phone system API for contacts, SMS messaging, call transcripts, and inbox management (formerly OpenPhone)
+category: social-and-messaging
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/quo-spec.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: official
+spec_source: docs
+auth_required: true
+client_pattern: rest
+http_transport: standard
+verified_date: "2026-05-09"
+homepage: https://www.quo.com/docs/mdx/api-reference/introduction
+notes: >
+  Quo (formerly OpenPhone) business phone system. API lives at api.openphone.com/v1
+  (legacy domain). Auth via plain API key in Authorization header (not Bearer).
+  Spec built from official docs + MCP tool schemas. Transcripts require Business plan.
+  No MMS support via API. Credit-based pricing for API messaging.

--- a/catalog/specs/quo-spec.yaml
+++ b/catalog/specs/quo-spec.yaml
@@ -1,0 +1,852 @@
+openapi: "3.0.3"
+info:
+  title: Quo API
+  description: |
+    Quo (formerly OpenPhone) REST API for business phone system management.
+    Supports contacts, phone numbers (inboxes), users, SMS messaging, and
+    call transcripts. Auth via API key in the Authorization header.
+  version: "1.0.0"
+  contact:
+    name: Quo
+  x-display-name: Quo
+  x-website: https://www.quo.com
+
+servers:
+  - url: https://api.openphone.com/v1
+    description: Quo production API (legacy OpenPhone domain)
+
+tags:
+  - name: contacts
+    description: Contact management (CRUD)
+  - name: phone-numbers
+    description: Phone number / inbox listing
+  - name: users
+    description: Workspace user management
+  - name: conversations
+    description: Conversation threads (list and manage)
+  - name: messages
+    description: SMS messaging (send and retrieve)
+  - name: calls
+    description: Call history and transcripts
+
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      x-auth-env-vars:
+        - QUO_API_KEY
+      x-auth-key-url: https://www.quo.com/docs/mdx/api-reference/authentication
+      x-auth-title: Quo API Key
+      x-auth-description: API key from Quo workspace settings (owner/admin only)
+
+  schemas:
+    Contact:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique contact ID
+        firstName:
+          type: string
+        lastName:
+          type: string
+        company:
+          type: string
+        role:
+          type: string
+        emails:
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+                format: email
+              type:
+                type: string
+        phoneNumbers:
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+              type:
+                type: string
+        customFields:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+        source:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    PhoneNumber:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Phone number ID (PN... format)
+        number:
+          type: string
+          description: E.164 formatted number
+        formattedNumber:
+          type: string
+        name:
+          type: string
+          description: Display name for this inbox
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              firstName:
+                type: string
+              lastName:
+                type: string
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          description: User ID (US... format)
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [owner, admin, member]
+
+    Message:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum: [message]
+        from:
+          type: string
+          description: Sender phone number (E.164)
+        to:
+          type: string
+          description: Recipient phone number (E.164)
+        body:
+          type: string
+        direction:
+          type: string
+          enum: [incoming, outgoing]
+        status:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        userId:
+          type: string
+        phoneNumberId:
+          type: string
+        conversationId:
+          type: string
+
+    Call:
+      type: object
+      properties:
+        id:
+          type: string
+        object:
+          type: string
+          enum: [call]
+        from:
+          type: string
+        to:
+          type: string
+        direction:
+          type: string
+          enum: [incoming, outgoing]
+        duration:
+          type: integer
+          description: Call duration in seconds
+        status:
+          type: string
+        userId:
+          type: string
+        phoneNumberId:
+          type: string
+        conversationId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    Transcript:
+      type: object
+      properties:
+        id:
+          type: string
+        callId:
+          type: string
+        text:
+          type: string
+        segments:
+          type: array
+          items:
+            type: object
+            properties:
+              speaker:
+                type: string
+              text:
+                type: string
+              startTime:
+                type: number
+              endTime:
+                type: number
+
+    Conversation:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Conversation ID (CN... format)
+        phoneNumberId:
+          type: string
+          description: Phone number ID this conversation belongs to
+        participants:
+          type: array
+          items:
+            type: string
+          description: Participant phone numbers (E.164)
+        name:
+          type: string
+          nullable: true
+        assignedTo:
+          type: string
+          nullable: true
+        lastActivityAt:
+          type: string
+          format: date-time
+        lastActivityId:
+          type: string
+        snoozedUntil:
+          type: string
+          format: date-time
+          nullable: true
+        mutedUntil:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    PaginatedResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items: {}
+        nextPageToken:
+          type: string
+          description: Token for next page of results
+        totalCount:
+          type: integer
+
+security:
+  - apiKey: []
+
+paths:
+  /contacts:
+    get:
+      operationId: listContacts
+      summary: List contacts
+      description: List contacts in the workspace with optional filtering by external IDs or sources. Supports pagination.
+      tags: [contacts]
+      parameters:
+        - name: pageToken
+          in: query
+          description: Pagination token from previous response
+          schema:
+            type: string
+        - name: maxResults
+          in: query
+          description: Maximum contacts per page (1-50)
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 50
+        - name: externalIds
+          in: query
+          description: Filter by external identifiers (comma-separated)
+          schema:
+            type: string
+        - name: sources
+          in: query
+          description: Filter by contact source (comma-separated)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated list of contacts
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Contact"
+    post:
+      operationId: createContact
+      summary: Create a contact
+      description: Create a new contact in the workspace. Only firstName is required.
+      tags: [contacts]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - firstName
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                company:
+                  type: string
+                role:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                phoneNumber:
+                  type: string
+                  description: E.164 format
+      responses:
+        "201":
+          description: Created contact
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
+
+  /contacts/{contactId}:
+    get:
+      operationId: getContact
+      summary: Get a contact
+      description: Retrieve a single contact by ID, including custom fields.
+      tags: [contacts]
+      parameters:
+        - name: contactId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Contact details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
+    patch:
+      operationId: updateContact
+      summary: Update a contact
+      description: Update fields on an existing contact. Omit fields to leave unchanged; set to null to clear.
+      tags: [contacts]
+      parameters:
+        - name: contactId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                company:
+                  type: string
+                role:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                phoneNumber:
+                  type: string
+      responses:
+        "200":
+          description: Updated contact
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
+    delete:
+      operationId: deleteContact
+      summary: Delete a contact
+      description: Permanently delete a contact by ID.
+      tags: [contacts]
+      parameters:
+        - name: contactId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Contact deleted
+
+  /phone-numbers:
+    get:
+      operationId: listPhoneNumbers
+      summary: List phone numbers (inboxes)
+      description: List phone numbers in the workspace with assigned users. Use to discover inbox IDs for messaging and call transcript queries.
+      tags: [phone-numbers]
+      parameters:
+        - name: userId
+          in: query
+          description: Filter by user ID (US... format)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of phone numbers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PhoneNumber"
+
+  /phone-numbers/{phoneNumberId}:
+    get:
+      operationId: getPhoneNumber
+      summary: Get a phone number
+      description: Retrieve details for a specific phone number.
+      tags: [phone-numbers]
+      parameters:
+        - name: phoneNumberId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Phone number details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhoneNumber"
+
+  /users:
+    get:
+      operationId: listUsers
+      summary: List workspace users
+      description: List users (members) in the workspace. Returns ID, name, email, and role. Supports pagination.
+      tags: [users]
+      parameters:
+        - name: maxResults
+          in: query
+          description: Maximum users per page (1-50)
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 50
+        - name: pageToken
+          in: query
+          description: Pagination token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated list of users
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/User"
+
+  /users/{userId}:
+    get:
+      operationId: getUser
+      summary: Get a user
+      description: Retrieve details for a specific workspace user.
+      tags: [users]
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+
+  /conversations:
+    get:
+      operationId: listConversations
+      summary: List conversations
+      description: |
+        List conversation threads for one or more phone numbers. Each conversation
+        has participants (external phone numbers) and tracks last activity. Use this
+        to discover conversations before fetching messages or calls per conversation.
+      tags: [conversations]
+      parameters:
+        - name: phoneNumbers[]
+          in: query
+          required: true
+          description: Phone number IDs to list conversations for (array)
+          schema:
+            type: array
+            items:
+              type: string
+        - name: updatedAfter
+          in: query
+          description: ISO 8601 datetime — only conversations updated after this time
+          schema:
+            type: string
+            format: date-time
+        - name: maxResults
+          in: query
+          description: Maximum conversations per page (default 50, max 100)
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: pageToken
+          in: query
+          description: Pagination token from previous response
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated list of conversations
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Conversation"
+
+  /messages:
+    get:
+      operationId: listMessages
+      summary: List messages
+      description: |
+        Fetch message history for an inbox conversation. Requires both phoneNumberId
+        and participants[] (array of external phone numbers from the conversation).
+        Use /conversations first to discover participant phone numbers.
+      tags: [messages]
+      parameters:
+        - name: phoneNumberId
+          in: query
+          required: true
+          description: Inbox phone number ID (PN... format)
+          schema:
+            type: string
+        - name: participants[]
+          in: query
+          required: true
+          description: Participant phone numbers (E.164 array). Required — get from /conversations.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: maxResults
+          in: query
+          description: Maximum messages (default 50, max 100)
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: createdAfter
+          in: query
+          description: ISO 8601 datetime filter
+          schema:
+            type: string
+            format: date-time
+        - name: createdBefore
+          in: query
+          description: ISO 8601 datetime filter
+          schema:
+            type: string
+            format: date-time
+        - name: pageToken
+          in: query
+          description: Pagination token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Message history
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Message"
+    post:
+      operationId: sendMessage
+      summary: Send an SMS message
+      description: |
+        Send an SMS from a Quo inbox to a recipient. The from number must belong
+        to the workspace. Recipient must be in E.164 format.
+      tags: [messages]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - from
+                - to
+                - content
+              properties:
+                from:
+                  type: string
+                  description: Quo inbox number (E.164 or phone number ID)
+                to:
+                  type: string
+                  description: Recipient phone number (E.164)
+                content:
+                  type: string
+                  description: Message body
+      responses:
+        "201":
+          description: Message sent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Message"
+
+  /messages/{messageId}:
+    get:
+      operationId: getMessage
+      summary: Get a message
+      description: Retrieve a single message by ID.
+      tags: [messages]
+      parameters:
+        - name: messageId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Message details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Message"
+
+  /calls:
+    get:
+      operationId: listCalls
+      summary: List calls
+      description: |
+        Fetch call history for an inbox conversation. Requires both phoneNumberId
+        and participants[] (array of external phone numbers). Use /conversations
+        first to discover participant phone numbers.
+      tags: [calls]
+      parameters:
+        - name: phoneNumberId
+          in: query
+          required: true
+          description: Inbox phone number ID (PN... format)
+          schema:
+            type: string
+        - name: participants[]
+          in: query
+          required: true
+          description: Participant phone numbers (E.164 array). Required — get from /conversations.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: maxResults
+          in: query
+          description: Maximum results (default 50, max 100)
+          schema:
+            type: integer
+            default: 50
+            maximum: 100
+        - name: createdAfter
+          in: query
+          description: ISO 8601 datetime filter
+          schema:
+            type: string
+            format: date-time
+        - name: createdBefore
+          in: query
+          description: ISO 8601 datetime filter
+          schema:
+            type: string
+            format: date-time
+        - name: pageToken
+          in: query
+          description: Pagination token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Call history
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/PaginatedResponse"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Call"
+
+  /calls/{callId}:
+    get:
+      operationId: getCall
+      summary: Get a call
+      description: Retrieve details for a specific call.
+      tags: [calls]
+      parameters:
+        - name: callId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Call details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Call"
+
+  /calls/{callId}/transcription:
+    get:
+      operationId: getCallTranscript
+      summary: Get call transcript
+      description: Retrieve the transcript for a call (requires Quo Business plan).
+      tags: [calls]
+      parameters:
+        - name: callId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Call transcript
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Transcript"
+
+  /calls/{callId}/voicemail:
+    get:
+      operationId: getCallVoicemail
+      summary: Get call voicemail
+      description: Retrieve voicemail audio URL for a call.
+      tags: [calls]
+      parameters:
+        - name: callId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Voicemail data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                  duration:
+                    type: integer
+
+  /calls/{callId}/recordings:
+    get:
+      operationId: getCallRecording
+      summary: Get call recording
+      description: Retrieve recording URL for a call.
+      tags: [calls]
+      parameters:
+        - name: callId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Recording data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                  duration:
+                    type: integer

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -38,6 +38,7 @@ sales-and-crm:
 social-and-messaging:
   discord              Chat and community platform API
   front                Customer communication platform API
+  quo                  Business phone system API for contacts, SMS messaging, call transcripts, and inbox management (formerly OpenPhone)
   telegram             Telegram Bot API for building bots - send messages, manage chats, webhooks, stickers
   twilio               Communication APIs for SMS, voice, and messaging
 


### PR DESCRIPTION
## What

Add Quo (formerly OpenPhone) to the catalog with a docs-derived OpenAPI spec.

## Catalog Entry

- `catalog/quo.yaml` — category: social-and-messaging, tier: official, spec_source: docs
- `catalog/specs/quo-spec.yaml` — 20 endpoints across 6 resource groups

## Resources

| Group | Endpoints |
|-------|-----------|
| contacts | list, get, create, update, delete |
| conversations | list |
| phone-numbers | list, get |
| users | list, get |
| messages | list, send, get |
| calls | list, get, transcript, voicemail, recording |

## Auth

Plain API key in `Authorization` header (not Bearer). Env var: `QUO_API_KEY`.

## Key Discovery

`/messages` and `/calls` require `participants[]` array param alongside `phoneNumberId`. The `/conversations` endpoint is needed first to discover participant phone numbers per inbox.

## Verification

- All 8 generator quality gates pass
- Live-tested against production Quo API (contacts, conversations, messages, calls, phone-numbers, users)
- Golden fixtures updated (catalog-list +1 line)
- `go test ./...` clean
- `scripts/golden.sh verify` 16/16 pass