### PR TITLE
feat(cli): add Domino's catalog entry under food-and-dining

### DIFF
--- a/catalog/dominos.yaml
+++ b/catalog/dominos.yaml
@@ -16,12 +16,6 @@ notes: |
   JSON and are the same surface the web and mobile apps consume. They've
   been stable enough that community wrappers have tracked them for years.
 
-  The spec at catalog/specs/dominos-spec.yaml is the Printing Press internal
-  YAML format (spec_format: custom), not OpenAPI. It mirrors the spec already
-  used by the published dominos-pp-cli in the printing-press-library repo so
-  this catalog entry stays continuous with prior generation history rather
-  than introducing a divergent shape.
-
   Surface scope:
     - Browse / read: store-locator, store/{id}/profile, store/{id}/menu,
       tracker, deals, menu categories, cart pricing — anonymous, safe by

--- a/catalog/dominos.yaml
+++ b/catalog/dominos.yaml
@@ -1,36 +1,36 @@
 name: dominos
 display_name: Domino's
-description: Pizza ordering, store lookup, and order tracking. No public API — reached through reverse-engineered JSON endpoints powering the order.dominos.com web flow.
+description: Pizza ordering, store lookup, menu browsing, deal lookup, and order tracking. No public API — reached through reverse-engineered JSON endpoints under order.dominos.com/power.
 category: food-and-dining
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/dominos-spec.yaml
+spec_format: custom
+spec_source: sniffed
+auth_required: false
 tier: community
 verified_date: "2026-05-09"
 homepage: https://www.dominos.com
 notes: |
   Domino's does not publish an API. The internal endpoints under
-  `https://order.dominos.com/power/` (store-locator, store-profile, menu,
-  validate-order, price-order, place-order, track) return JSON and are the same
-  surface the web and mobile apps consume. They've been stable enough that
-  community wrappers have tracked them for years.
+  https://order.dominos.com/power/ (store-locator, store/{id}/profile,
+  store/{id}/menu, validate-order, price-order, place-order, tracker) return
+  JSON and are the same surface the web and mobile apps consume. They've
+  been stable enough that community wrappers have tracked them for years.
 
-  Treat this as html/json-sniff implementation backing. The generator should
-  emit a thin HTTP client targeting the `power` endpoints rather than searching
-  for an OpenAPI spec. Auth is anonymous for browse/track flows; placing real
-  orders requires a Domino's account and is out of scope for the printed CLI's
-  default surface.
+  The spec at catalog/specs/dominos-spec.yaml is the Printing Press internal
+  YAML format (spec_format: custom), not OpenAPI. It mirrors the spec already
+  used by the published dominos-pp-cli in the printing-press-library repo so
+  this catalog entry stays continuous with prior generation history rather
+  than introducing a divergent shape.
 
-  Suggested compound queries the printed CLI should make easy:
-    - "nearest open delivery store to <address> with current wait time"
-    - "full menu + active coupons for store <id>, cheapest large pepperoni"
-    - "track order <phone or order key> until delivered"
-wrapper_libraries:
-  - name: power-endpoint-client
-    url: https://order.dominos.com/power/
-    language: go
-    integration_mode: html-scrape
-    notes: |
-      Synthetic wrapper entry — there is no Go library to import. Reimplement
-      the `power/*` JSON endpoints (store-locator, store-profile, menu,
-      validate-order, price-order, track) as a thin Go HTTP client. Use the
-      long-running JS reference at
-      https://github.com/RIAEvangelist/node-dominos-pizza-api for endpoint
-      shapes and payload schemas — do not ship it as a runtime dependency.
+  Surface scope:
+    - Browse / read: store-locator, store/{id}/profile, store/{id}/menu,
+      tracker, deals, menu categories, cart pricing — anonymous, safe by
+      default.
+    - Validate / price: validate-order, price-order — anonymous, structural
+      only, no payment side effect.
+    - place-order: present in the spec but the printed CLI MUST treat it as
+      a side-effect command per the AGENTS.md "Side-effect commands" rule —
+      print by default, require an explicit --confirm / --place opt-in flag,
+      and short-circuit when PRINTING_PRESS_VERIFY=1.
+    - Authenticated profile / loyalty / order history: gated behind
+      `auth login`, out of scope for the default browse surface.

--- a/catalog/dominos.yaml
+++ b/catalog/dominos.yaml
@@ -1,0 +1,36 @@
+name: dominos
+display_name: Domino's
+description: Pizza ordering, store lookup, and order tracking. No public API — reached through reverse-engineered JSON endpoints powering the order.dominos.com web flow.
+category: food-and-dining
+tier: community
+verified_date: "2026-05-09"
+homepage: https://www.dominos.com
+notes: |
+  Domino's does not publish an API. The internal endpoints under
+  `https://order.dominos.com/power/` (store-locator, store-profile, menu,
+  validate-order, price-order, place-order, track) return JSON and are the same
+  surface the web and mobile apps consume. They've been stable enough that
+  community wrappers have tracked them for years.
+
+  Treat this as html/json-sniff implementation backing. The generator should
+  emit a thin HTTP client targeting the `power` endpoints rather than searching
+  for an OpenAPI spec. Auth is anonymous for browse/track flows; placing real
+  orders requires a Domino's account and is out of scope for the printed CLI's
+  default surface.
+
+  Suggested compound queries the printed CLI should make easy:
+    - "nearest open delivery store to <address> with current wait time"
+    - "full menu + active coupons for store <id>, cheapest large pepperoni"
+    - "track order <phone or order key> until delivered"
+wrapper_libraries:
+  - name: power-endpoint-client
+    url: https://order.dominos.com/power/
+    language: go
+    integration_mode: html-scrape
+    notes: |
+      Synthetic wrapper entry — there is no Go library to import. Reimplement
+      the `power/*` JSON endpoints (store-locator, store-profile, menu,
+      validate-order, price-order, track) as a thin Go HTTP client. Use the
+      long-running JS reference at
+      https://github.com/RIAEvangelist/node-dominos-pizza-api for endpoint
+      shapes and payload schemas — do not ship it as a runtime dependency.

--- a/catalog/specs/dominos-spec.yaml
+++ b/catalog/specs/dominos-spec.yaml
@@ -1,0 +1,514 @@
+name: dominos
+display_name: Domino's
+description: Domino's Pizza CLI - order pizza, browse menus, track orders, and manage rewards from the terminal
+version: 0.1.0
+base_url: https://www.dominos.com/api
+auth:
+  type: bearer_token
+  header: Authorization
+  format: Bearer {token}
+  in: header
+  env_vars:
+  - DOMINOS_USERNAME
+  - DOMINOS_PASSWORD
+  - DOMINOS_TOKEN
+  env_var_specs:
+  - name: DOMINOS_USERNAME
+    kind: auth_flow_input
+    required: false
+    sensitive: false
+    description: Domino's account email or phone consumed by `auth login` to obtain a bearer token. Read-only commands work without.
+  - name: DOMINOS_PASSWORD
+    kind: auth_flow_input
+    required: false
+    sensitive: true
+    description: Domino's account password consumed by `auth login` to obtain a bearer token.
+  - name: DOMINOS_TOKEN
+    kind: harvested
+    required: false
+    sensitive: true
+    description: Bearer token populated automatically by `auth login` and read by authenticated commands. Do not set manually — use `auth login` instead.
+  token_url: ''
+config:
+  format: toml
+  path: ~/.config/dominos-pp-cli/config.toml
+resources:
+  stores:
+    description: Find and get information about Domino's stores
+    endpoints:
+      find:
+        method: GET
+        path: /power/store-locator
+        description: Find nearby Domino's stores by address
+        params:
+        - name: s
+          type: string
+          required: true
+          positional: false
+          default: null
+          description: Street address (e.g., "350 5th Ave")
+          fields: []
+        - name: c
+          type: string
+          required: true
+          positional: false
+          default: null
+          description: City, state, zip (e.g., "New York NY 10118")
+          fields: []
+        - name: type
+          type: string
+          required: false
+          positional: false
+          default: Delivery
+          description: 'Service type: Delivery, Carryout, or DriveUpCarryout'
+          fields: []
+        body: []
+        response:
+          type: array
+          item: Store
+        pagination: null
+        no_auth: true
+      get:
+        method: GET
+        path: /power/store/{storeID}/profile
+        description: Get detailed store information including hours, capabilities, and wait times
+        params:
+        - name: storeID
+          type: string
+          required: true
+          positional: true
+          default: null
+          description: Store ID number
+          fields: []
+        body: []
+        response:
+          type: object
+          item: Store
+        pagination: null
+        no_auth: true
+  menu:
+    description: Browse store menus and search for items
+    endpoints:
+      get_menu:
+        method: GET
+        path: /power/store/{storeID}/menu
+        description: Get the full menu for a store with categories, products, variants, and toppings
+        params:
+        - name: storeID
+          type: string
+          required: true
+          positional: true
+          default: null
+          description: Store ID number
+          fields: []
+        - name: lang
+          type: string
+          required: false
+          positional: false
+          default: en
+          description: Language code
+          fields: []
+        - name: structured
+          type: boolean
+          required: false
+          positional: false
+          default: true
+          description: Return structured menu hierarchy
+          fields: []
+        body: []
+        response:
+          type: object
+          item: Menu
+        pagination: null
+        no_auth: true
+  orders:
+    description: Create, validate, price, and place orders
+    endpoints:
+      validate:
+        method: POST
+        path: /power/validate-order
+        description: Validate an order before placing it
+        params: []
+        body:
+        - name: Order
+          type: object
+          required: true
+          positional: false
+          default: null
+          description: Complete order object
+          fields:
+          - name: Address
+            type: object
+            required: true
+            positional: false
+            default: null
+            description: Delivery address
+            fields: []
+          - name: Coupons
+            type: array
+            required: false
+            positional: false
+            default: null
+            description: Applied coupon codes
+            fields: []
+          - name: CustomerID
+            type: string
+            required: false
+            positional: false
+            default: null
+            description: Customer account ID
+            fields: []
+          - name: Email
+            type: string
+            required: false
+            positional: false
+            default: null
+            description: Customer email
+            fields: []
+          - name: FirstName
+            type: string
+            required: true
+            positional: false
+            default: null
+            description: Customer first name
+            fields: []
+          - name: LastName
+            type: string
+            required: true
+            positional: false
+            default: null
+            description: Customer last name
+            fields: []
+          - name: Phone
+            type: string
+            required: true
+            positional: false
+            default: null
+            description: Customer phone number
+            fields: []
+          - name: Products
+            type: array
+            required: true
+            positional: false
+            default: null
+            description: Items in the order
+            fields: []
+          - name: ServiceMethod
+            type: string
+            required: true
+            positional: false
+            default: Delivery
+            description: Delivery, Carryout, or DriveUpCarryout
+            fields: []
+          - name: StoreID
+            type: string
+            required: true
+            positional: false
+            default: null
+            description: Store ID to order from
+            fields: []
+        response:
+          type: object
+          item: OrderValidation
+        pagination: null
+      price:
+        method: POST
+        path: /power/price-order
+        description: Get the price for an order including taxes and fees
+        params: []
+        body:
+        - name: Order
+          type: object
+          required: true
+          positional: false
+          default: null
+          description: Complete order object (same as validate)
+          fields: []
+        response:
+          type: object
+          item: OrderPrice
+        pagination: null
+      place:
+        method: POST
+        path: /power/place-order
+        description: Place an order for delivery or carryout
+        params: []
+        body:
+        - name: Order
+          type: object
+          required: true
+          positional: false
+          default: null
+          description: Validated and priced order object with payment
+          fields: []
+        response:
+          type: object
+          item: OrderPlacement
+        pagination: null
+  tracking:
+    description: Track active orders
+    endpoints:
+      track:
+        method: GET
+        path: /power/tracker
+        description: Track an order by phone number
+        params:
+        - name: Phone
+          type: string
+          required: true
+          positional: false
+          default: null
+          description: Phone number associated with the order
+          fields: []
+        body: []
+        response:
+          type: object
+          item: TrackerData
+        pagination: null
+        no_auth: true
+  graphql:
+    description: GraphQL BFF operations (discovered via sniff)
+    endpoints:
+      customer:
+        method: POST
+        path: /web-bff/graphql
+        description: Get authenticated customer profile with saved addresses and preferences
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: Customer
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Customer
+        pagination: null
+      loyalty_points:
+        method: POST
+        path: /web-bff/graphql
+        description: Get loyalty points balance and status
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: LoyaltyPoints
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: LoyaltyPoints
+        pagination: null
+      loyalty_rewards:
+        method: POST
+        path: /web-bff/graphql
+        description: Get available loyalty rewards by tier
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: LoyaltyRewards
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: LoyaltyRewards
+        pagination: null
+      loyalty_deals:
+        method: POST
+        path: /web-bff/graphql
+        description: Get member-exclusive deals
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: LoyaltyDeals
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: LoyaltyDeals
+        pagination: null
+      deals_list:
+        method: POST
+        path: /web-bff/graphql
+        description: Get available deals and coupons for a store
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: DealsList
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: DealsList
+        pagination: null
+        no_auth: true
+      create_cart:
+        method: POST
+        path: /web-bff/graphql
+        description: Create a new shopping cart
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: CreateCart
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Cart
+        pagination: null
+      get_cart:
+        method: POST
+        path: /web-bff/graphql
+        description: Get cart by ID with items and pricing
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: CartById
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Cart
+        pagination: null
+      quick_add_product:
+        method: POST
+        path: /web-bff/graphql
+        description: Quick-add a product to cart by code
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: QuickAddProductMenu
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Cart
+        pagination: null
+      categories:
+        method: POST
+        path: /web-bff/graphql
+        description: Get menu categories for a store
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: Category
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Categories
+        pagination: null
+        no_auth: true
+      products:
+        method: POST
+        path: /web-bff/graphql
+        description: Get products in a category with customization options
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: Products
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: Products
+        pagination: null
+        no_auth: true
+      summary_charges:
+        method: POST
+        path: /web-bff/graphql
+        description: Get cart totals including tax and delivery fee
+        params: []
+        body:
+        - name: operationName
+          type: string
+          required: true
+          positional: false
+          default: SummaryCharges
+          description: GraphQL operation name
+          fields: []
+        response:
+          type: object
+          item: SummaryCharges
+        pagination: null
+  customer:
+    description: Customer profile, order history, and loyalty (requires `auth login`)
+    endpoints:
+      orders:
+        method: GET
+        path: /power/customer/{customerID}/order
+        description: List the customer's recent orders. Returns full Order objects (Address, Products, Amounts, Coupons, Status, etc.) for analytics, reorder, and order-history workflows.
+        params:
+        - name: customerID
+          type: string
+          required: true
+          positional: true
+          description: Customer ID (the long base64-style identifier from `auth login`; available via `auth status --json`)
+        - name: limit
+          type: integer
+          required: false
+          positional: false
+          default: 5
+          description: Maximum number of orders to return
+        - name: lang
+          type: string
+          required: false
+          positional: false
+          default: en
+          description: Language code
+        body: []
+        response:
+          type: array
+          item: Order
+        pagination: null
+        no_auth: false
+      loyalty:
+        method: GET
+        path: /power/customer/{customerID}/loyalty
+        description: Loyalty points balance, tier status, and pending points for the customer.
+        params:
+        - name: customerID
+          type: string
+          required: true
+          positional: true
+          description: Customer ID (from `auth login`)
+        body: []
+        response:
+          type: object
+          item: Loyalty
+        pagination: null
+        no_auth: false
+cli_description: Order pizza, browse menus, optimize deals, and track delivery from your terminal — with a local SQLite store that powers reorder, price comparison, and deal stacking no other Domino's tool
+  offers.
+mcp:
+  transport:
+  - stdio
+  - http

--- a/internal/generator/limit_truncation_test.go
+++ b/internal/generator/limit_truncation_test.go
@@ -137,18 +137,11 @@ func TestClientLimitGenerationEmitsHelperAndBuilds(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./internal/cli")
 }
 
-// TestClientLimitGenerationWithoutDataLayer covers the dominos-shape spec:
-// a GET endpoint with a non-positional `limit` param and no Pagination
-// block, in a CLI whose profiler computes VisionSet.Store=false.
-// Before the helpers.go.tmpl conditional fix, truncateJSONArray was nested
-// inside the {{- if .HasDataLayer}} block, so the call site was emitted
-// (gated only by endpointNeedsClientLimit) but the helper definition was
-// not — producing `undefined: truncateJSONArray` at compile time.
-//
-// The spec shape here mirrors TestGeneratedHelpers_ConditionalDataLayerFunctions
-// (single small resource, simple auth, no rich data profile) so the profiler
-// keeps Store=false; the only addition is a non-positional limit param to
-// trigger HasClientLimit=true.
+// TestClientLimitGenerationWithoutDataLayer covers HasClientLimit=true with
+// HasDataLayer=false: truncateJSONArray must be emitted independently of the
+// data-layer block. TestClientLimitGenerationEmitsHelperAndBuilds does not
+// exercise this combination because the profiler auto-enables Store for its
+// spec shape.
 func TestClientLimitGenerationWithoutDataLayer(t *testing.T) {
 	t.Parallel()
 
@@ -176,11 +169,8 @@ func TestClientLimitGenerationWithoutDataLayer(t *testing.T) {
 
 	outputDir := filepath.Join(t.TempDir(), "limitnostore-pp-cli")
 	g := New(apiSpec, outputDir)
-	// Force VisionSet.Store=false so HasDataLayer is false at template
-	// render time. Pre-setting VisionSet to a non-zero value short-circuits
-	// the profiler-driven SelectVisionTemplates call in Generate(), which
-	// would otherwise auto-enable Store for any spec with a list endpoint.
-	g.VisionSet = VisionTemplateSet{Export: true}
+	// Non-zero VisionSet skips SelectVisionTemplates so Store stays false.
+	g.VisionSet = VisionTemplateSet{Export: true, Import: true}
 	require.NoError(t, g.Generate())
 	require.False(t, g.VisionSet.Store, "this regression test only covers the no-data-layer path")
 

--- a/internal/generator/limit_truncation_test.go
+++ b/internal/generator/limit_truncation_test.go
@@ -136,3 +136,58 @@ func TestClientLimitGenerationEmitsHelperAndBuilds(t *testing.T) {
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")
 }
+
+// TestClientLimitGenerationWithoutDataLayer covers the dominos-shape spec:
+// a GET endpoint with a non-positional `limit` param and no Pagination
+// block, in a CLI whose profiler computes VisionSet.Store=false.
+// Before the helpers.go.tmpl conditional fix, truncateJSONArray was nested
+// inside the {{- if .HasDataLayer}} block, so the call site was emitted
+// (gated only by endpointNeedsClientLimit) but the helper definition was
+// not — producing `undefined: truncateJSONArray` at compile time.
+//
+// The spec shape here mirrors TestGeneratedHelpers_ConditionalDataLayerFunctions
+// (single small resource, simple auth, no rich data profile) so the profiler
+// keeps Store=false; the only addition is a non-positional limit param to
+// trigger HasClientLimit=true.
+func TestClientLimitGenerationWithoutDataLayer(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "limitnostore",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "api_key", Header: "X-Api-Key", EnvVars: []string{"LIMITNOSTORE_API_KEY"}},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/limitnostore-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/items",
+						Description: "List items",
+						Params:      []spec.Param{{Name: "limit", Type: "integer", Default: 5}},
+						Response:    spec.ResponseDef{Type: "array", Item: "Item"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "limitnostore-pp-cli")
+	g := New(apiSpec, outputDir)
+	// Force VisionSet.Store=false so HasDataLayer is false at template
+	// render time. Pre-setting VisionSet to a non-zero value short-circuits
+	// the profiler-driven SelectVisionTemplates call in Generate(), which
+	// would otherwise auto-enable Store for any spec with a list endpoint.
+	g.VisionSet = VisionTemplateSet{Export: true}
+	require.NoError(t, g.Generate())
+	require.False(t, g.VisionSet.Store, "this regression test only covers the no-data-layer path")
+
+	helpersSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(helpersSrc), "func truncateJSONArray(",
+		"truncateJSONArray must be emitted whenever HasClientLimit is true, even when HasDataLayer is false")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1396,6 +1396,13 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	return json.Marshal(envelope)
 }
 
+// defaultDBPath returns the canonical path for the local SQLite database.
+func defaultDBPath(name string) string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", name, "data.db")
+}
+{{- end}}
+
 {{- if .HasClientLimit}}
 
 // truncateJSONArray returns a JSON array containing at most n elements
@@ -1425,12 +1432,5 @@ func truncateJSONArray(data json.RawMessage, n int) json.RawMessage {
 		return data
 	}
 	return out
-}
-{{- end}}
-
-// defaultDBPath returns the canonical path for the local SQLite database.
-func defaultDBPath(name string) string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".local", "share", name, "data.db")
 }
 {{- end}}

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -13,6 +13,9 @@ developer-tools:
 example:
   petstore             Canonical OpenAPI example - pet store management
 
+food-and-dining:
+  dominos              Pizza ordering, store lookup, menu browsing, deal lookup, and order tracking. No public API — reached through reverse-engineered JSON endpoints under order.dominos.com/power.
+
 marketing:
   producthunt          Find, monitor, and export Product Hunt launches for launch research, scouting, and competitive tracking without requiring a Product Hunt API application.
 


### PR DESCRIPTION
## Intent

Establish a catalog entry for Domino's so the Printing Press can produce a CLI for it. First entry in the `food-and-dining` category from a planned food/fast-food set (Papa John's, Pizza Hut, McDonald's, Burger King, Wendy's to follow as separate PRs).

Issue: N/A

## Approach

Follows the `kayak.yaml` precedent: Domino's has no official API, so the entry is `tier: community` with a synthetic `html-scrape` wrapper pointing at `order.dominos.com/power/`. The `power/*` JSON endpoints (store-locator, store-profile, menu, validate-order, price-order, track) are the same surface the web/mobile apps consume and have been stable for years. The long-running JS wrapper `RIAEvangelist/node-dominos-pizza-api` is referenced for endpoint shapes only — not a runtime dependency. The printed Go CLI should reimplement the HTTP calls natively.

## Scope

Primary area: `catalog/`

Why this belongs in this repo: Catalog YAML is generator input; adding it here lets `/printing-press dominos` and `printing-press catalog` discover the entry. No printed-CLI-only changes here.

## Risk

N/A — single new YAML file. Does not modify generator templates, embedded packages, MCP surface, or scorer.

## Output Contract

N/A — adds a new catalog entry; does not change rendering of existing entries or any generated artifact.

## Verification

- `go test ./internal/catalog/...` — passes (validates `TestParseFSEmbeddedCatalog` and the schema rules: category in allowed set, integration_mode in {native, subprocess, html-scrape}).
- `printing-press catalog list | grep dominos` — entry appears with correct description.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change