### PR TITLE
fix(cli): promote write-endpoint params to body when body is empty

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1323,6 +1323,7 @@ func ParseBytes(data []byte) (*APISpec, error) {
 	}
 	s.expandOperations()
 	s.enrichPathParams()
+	s.promoteParamsToBodyForWriteEndpoints()
 	if err := s.validateReservedNames(); err != nil {
 		return nil, err
 	}
@@ -1566,6 +1567,60 @@ func enrichEndpointPathParams(e *Endpoint) {
 			Description: name,
 		})
 	}
+}
+
+// promoteParamsToBodyForWriteEndpoints fills Endpoint.Body for POST/PUT/PATCH
+// endpoints whose Body is empty by relocating non-path, non-positional Params
+// there. Internal YAML specs commonly list write-endpoint payload fields under
+// `params:` instead of `body:`. Without this promotion, the generator declares
+// flags and required-flag validation for those params, but the body-assembly
+// branch in command_endpoint.go.tmpl iterates only Endpoint.Body — so the
+// values never reach the request body and the API rejects the call with
+// "missing required field". An explicit `body:` block on the endpoint is
+// preserved verbatim; this function only fills in the gap.
+func (s *APISpec) promoteParamsToBodyForWriteEndpoints() {
+	for resourceName, r := range s.Resources {
+		s.promoteResourceParamsToBody(&r)
+		s.Resources[resourceName] = r
+	}
+}
+
+func (s *APISpec) promoteResourceParamsToBody(r *Resource) {
+	if r.Endpoints != nil {
+		for endpointName, e := range r.Endpoints {
+			promoteEndpointParamsToBody(&e)
+			r.Endpoints[endpointName] = e
+		}
+	}
+	for subName, sub := range r.SubResources {
+		s.promoteResourceParamsToBody(&sub)
+		r.SubResources[subName] = sub
+	}
+}
+
+func promoteEndpointParamsToBody(e *Endpoint) {
+	switch strings.ToUpper(e.Method) {
+	case "POST", "PUT", "PATCH":
+	default:
+		return
+	}
+	if len(e.Body) > 0 || len(e.Params) == 0 {
+		return
+	}
+	keep := make([]Param, 0, len(e.Params))
+	promote := make([]Param, 0, len(e.Params))
+	for _, p := range e.Params {
+		if p.PathParam || p.Positional {
+			keep = append(keep, p)
+			continue
+		}
+		promote = append(promote, p)
+	}
+	if len(promote) == 0 {
+		return
+	}
+	e.Params = keep
+	e.Body = promote
 }
 
 // expandOperations converts operations shorthand (e.g., [list, get, create])

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1073,6 +1073,12 @@ type Endpoint struct {
 	// docs/SPEC-EXTENSIONS.md for the canonical schema.
 	Walker *WalkerConfig `yaml:"walker,omitempty" json:"walker,omitempty"`
 	Alias  string        `yaml:"-" json:"-"` // computed, not from YAML
+	// BodySet reports whether the source spec declared a `body:` key on this
+	// endpoint, distinct from an absent key. Populated by the custom
+	// UnmarshalYAML / UnmarshalJSON below. The params→body promotion pass
+	// reads this to honor an explicit empty `body: []` as an opt-out signal
+	// for write endpoints that genuinely take query params and no JSON body.
+	BodySet bool `yaml:"-" json:"-"`
 }
 
 // WalkerConfig declares a hierarchical-walk dependency for a child endpoint.
@@ -1093,6 +1099,31 @@ type WalkerConfig struct {
 	// multiple placeholders or when the placeholder name does not match the
 	// auto-detection convention.
 	KeyParam string `yaml:"key_param,omitempty" json:"key_param,omitempty"`
+}
+
+func (e *Endpoint) UnmarshalYAML(value *yaml.Node) error {
+	type endpointAlias Endpoint
+	var out endpointAlias
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	*e = Endpoint(out)
+	e.BodySet = yamlMappingHasKey(value, "body")
+	return nil
+}
+
+func (e *Endpoint) UnmarshalJSON(data []byte) error {
+	type endpointAlias Endpoint
+	var out endpointAlias
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+	*e = Endpoint(out)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err == nil {
+		_, e.BodySet = raw["body"]
+	}
+	return nil
 }
 
 func (e Endpoint) EffectiveResponseFormat() string {
@@ -1570,14 +1601,23 @@ func enrichEndpointPathParams(e *Endpoint) {
 }
 
 // promoteParamsToBodyForWriteEndpoints fills Endpoint.Body for POST/PUT/PATCH
-// endpoints whose Body is empty by relocating non-path, non-positional Params
-// there. Internal YAML specs commonly list write-endpoint payload fields under
-// `params:` instead of `body:`. Without this promotion, the generator declares
-// flags and required-flag validation for those params, but the body-assembly
-// branch in command_endpoint.go.tmpl iterates only Endpoint.Body — so the
-// values never reach the request body and the API rejects the call with
-// "missing required field". An explicit `body:` block on the endpoint is
-// preserved verbatim; this function only fills in the gap.
+// endpoints whose source spec did not declare a `body:` key by relocating
+// non-path, non-positional Params there. Internal YAML specs commonly list
+// write-endpoint payload fields under `params:` instead of `body:`. Without
+// this promotion, the generator declares flags and required-flag validation
+// for those params, but the body-assembly branch in command_endpoint.go.tmpl
+// iterates only Endpoint.Body — so the values never reach the request body
+// and the API rejects the call with "missing required field".
+//
+// Author intent wins when `body:` is present in the source, even if empty:
+//   - `body: [...]` (non-empty) preserves the explicit block; remaining
+//     `params:` entries are left as query parameters by design.
+//   - `body: []` (explicit empty) is the escape hatch for write endpoints
+//     that genuinely take only query parameters and carry no JSON body.
+//   - Mixed `params:` + non-empty `body:` is allowed but not auto-merged.
+//     The author is asserting that those `params:` entries are URL query
+//     parameters, not body fields. Authors who want them in the body must
+//     move them under `body:` themselves.
 func (s *APISpec) promoteParamsToBodyForWriteEndpoints() {
 	for resourceName, r := range s.Resources {
 		s.promoteResourceParamsToBody(&r)
@@ -1604,7 +1644,7 @@ func promoteEndpointParamsToBody(e *Endpoint) {
 	default:
 		return
 	}
-	if len(e.Body) > 0 || len(e.Params) == 0 {
+	if e.BodySet || len(e.Body) > 0 || len(e.Params) == 0 {
 		return
 	}
 	keep := make([]Param, 0, len(e.Params))

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4032,7 +4032,11 @@ resources:
 		s, err := ParseBytes([]byte(input))
 		require.NoError(t, err)
 		ep := s.Resources["records"].Endpoints["remove"]
-		require.Len(t, ep.Params, 2, "id placeholder + cascade query stay in Params")
+		names := make([]string, len(ep.Params))
+		for i, p := range ep.Params {
+			names[i] = p.Name
+		}
+		assert.ElementsMatch(t, []string{"id", "cascade"}, names, "DELETE keeps the {id} placeholder enrichPathParams injected and the cascade query param")
 		assert.Empty(t, ep.Body, "DELETE keeps cascade as a query/flag, not body")
 	})
 
@@ -4058,5 +4062,77 @@ resources:
 		ep := s.Resources["channels"].SubResources["messages"].Endpoints["post"]
 		require.Len(t, ep.Body, 1)
 		assert.Equal(t, "text", ep.Body[0].Name)
+	})
+
+	t.Run("explicit empty body: [] opts out of promotion", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  pipelines:
+    description: Pipeline endpoints
+    endpoints:
+      trigger:
+        method: POST
+        path: /pipelines/trigger
+        description: Trigger a pipeline
+        params:
+          - name: dry_run
+            type: boolean
+        body: []
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["pipelines"].Endpoints["trigger"]
+		assert.True(t, ep.BodySet, "explicit `body: []` should set BodySet")
+		assert.Empty(t, ep.Body, "explicit empty body stays empty")
+		require.Len(t, ep.Params, 1, "params stay as query params when author opted out")
+		assert.Equal(t, "dry_run", ep.Params[0].Name)
+	})
+
+	t.Run("mixed params and explicit body leaves params as query strings", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  uploads:
+    description: Upload endpoints
+    endpoints:
+      create:
+        method: POST
+        path: /uploads
+        description: Create upload
+        params:
+          - name: idempotency_key
+            type: string
+        body:
+          - name: filename
+            type: string
+            required: true
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["uploads"].Endpoints["create"]
+		assert.True(t, ep.BodySet)
+		require.Len(t, ep.Params, 1, "idempotency_key stays as query/flag, not silently moved into body")
+		assert.Equal(t, "idempotency_key", ep.Params[0].Name)
+		require.Len(t, ep.Body, 1)
+		assert.Equal(t, "filename", ep.Body[0].Name)
+	})
+
+	t.Run("absent body key leaves BodySet false and triggers promotion", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  notes:
+    description: Note endpoints
+    endpoints:
+      create:
+        method: POST
+        path: /notes
+        description: Create note
+        params:
+          - name: title
+            type: string
+            required: true
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["notes"].Endpoints["create"]
+		assert.False(t, ep.BodySet, "no body key in source -> BodySet false")
+		require.Len(t, ep.Body, 1, "title was promoted to body")
+		assert.Equal(t, "title", ep.Body[0].Name)
 	})
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3872,3 +3872,191 @@ func TestWalkerConfig_YAMLRoundTrip(t *testing.T) {
 		assert.NotContains(t, string(data), "key_param")
 	})
 }
+
+func TestPromoteParamsToBodyForWriteEndpoints(t *testing.T) {
+	t.Parallel()
+
+	const header = `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+resources:
+`
+
+	t.Run("POST endpoint with params and no body promotes to body", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  messages:
+    description: Slack-style message endpoints
+    endpoints:
+      post_message:
+        method: POST
+        path: /chat.postMessage
+        description: Send a message
+        params:
+          - name: channel
+            type: string
+            required: true
+          - name: text
+            type: string
+            required: true
+          - name: thread_ts
+            type: string
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["messages"].Endpoints["post_message"]
+		assert.Empty(t, ep.Params, "non-path params should have moved to Body")
+		require.Len(t, ep.Body, 3)
+		bodyNames := []string{ep.Body[0].Name, ep.Body[1].Name, ep.Body[2].Name}
+		assert.ElementsMatch(t, []string{"channel", "text", "thread_ts"}, bodyNames)
+	})
+
+	t.Run("POST endpoint preserves path placeholders in Params", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  widgets:
+    description: Widget endpoints
+    endpoints:
+      activate:
+        method: POST
+        path: /widgets/{id}/activate
+        description: Activate a widget
+        params:
+          - name: reason
+            type: string
+            required: true
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["widgets"].Endpoints["activate"]
+		require.Len(t, ep.Params, 1, "id placeholder should remain in Params")
+		assert.Equal(t, "id", ep.Params[0].Name)
+		assert.True(t, ep.Params[0].Positional)
+		require.Len(t, ep.Body, 1)
+		assert.Equal(t, "reason", ep.Body[0].Name)
+	})
+
+	t.Run("POST endpoint with explicit body is left untouched", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  items:
+    description: Item endpoints
+    endpoints:
+      create:
+        method: POST
+        path: /items
+        description: Create item
+        params:
+          - name: org_id
+            type: string
+        body:
+          - name: name
+            type: string
+            required: true
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["items"].Endpoints["create"]
+		require.Len(t, ep.Params, 1)
+		assert.Equal(t, "org_id", ep.Params[0].Name)
+		require.Len(t, ep.Body, 1)
+		assert.Equal(t, "name", ep.Body[0].Name)
+	})
+
+	t.Run("GET endpoint params are not promoted", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  lookup:
+    description: Lookup endpoints
+    endpoints:
+      query:
+        method: GET
+        path: /lookup
+        description: Lookup
+        params:
+          - name: q
+            type: string
+            required: true
+          - name: limit
+            type: integer
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["lookup"].Endpoints["query"]
+		require.Len(t, ep.Params, 2)
+		assert.Empty(t, ep.Body)
+	})
+
+	t.Run("PUT and PATCH are also promoted", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  records:
+    description: Record endpoints
+    endpoints:
+      replace:
+        method: PUT
+        path: /records/{id}
+        description: Replace record
+        params:
+          - name: name
+            type: string
+      modify:
+        method: PATCH
+        path: /records/{id}
+        description: Patch record
+        params:
+          - name: status
+            type: string
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		put := s.Resources["records"].Endpoints["replace"]
+		require.Len(t, put.Body, 1)
+		assert.Equal(t, "name", put.Body[0].Name)
+
+		patch := s.Resources["records"].Endpoints["modify"]
+		require.Len(t, patch.Body, 1)
+		assert.Equal(t, "status", patch.Body[0].Name)
+	})
+
+	t.Run("DELETE is not promoted", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  records:
+    description: Record endpoints
+    endpoints:
+      remove:
+        method: DELETE
+        path: /records/{id}
+        description: Delete record
+        params:
+          - name: cascade
+            type: boolean
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["records"].Endpoints["remove"]
+		require.Len(t, ep.Params, 2, "id placeholder + cascade query stay in Params")
+		assert.Empty(t, ep.Body, "DELETE keeps cascade as a query/flag, not body")
+	})
+
+	t.Run("subresource endpoints are walked", func(t *testing.T) {
+		t.Parallel()
+		input := header + `  channels:
+    description: Channel endpoints
+    sub_resources:
+      messages:
+        description: Channel messages
+        endpoints:
+          post:
+            method: POST
+            path: /channels/{channelId}/messages
+            description: Post message
+            params:
+              - name: text
+                type: string
+                required: true
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		ep := s.Resources["channels"].SubResources["messages"].Endpoints["post"]
+		require.Len(t, ep.Body, 1)
+		assert.Equal(t, "text", ep.Body[0].Name)
+	})
+}


### PR DESCRIPTION
## Intent

Generated CLIs send an empty `{}` body to the API for `POST`/`PUT`/`PATCH` endpoints whose payload fields are listed under `params:` instead of `body:`. The flags are registered, validation passes, the request fires — but the body is empty and the API rejects with `missing required field`. In production this means `slack-pp-cli` is unable to perform any write operation; the `--stdin` workaround is the only escape hatch.

Issue: Closes #790

## Approach

After parse, normalize each endpoint:

- For `POST`/`PUT`/`PATCH` only.
- If `Body` is empty and there are non-path, non-positional `Params`, move them into `Body`.
- Path placeholders (`PathParam: true`) and positional args stay in `Params` so URL substitution still works.
- Endpoints with an explicit `body:` block are left untouched — author intent wins.
- `DELETE` is not promoted because the template has no body-assembly branch for it.

Implemented as a new pass `promoteParamsToBodyForWriteEndpoints` in `internal/spec/spec.go`, called right after `enrichPathParams` so path placeholders are already marked. No template changes — once the spec carries the right shape, the existing `bodyMap` logic in the generator does the right thing.

## Scope

Primary area: `internal/spec`

Why this belongs in this repo: every CLI in the public library that follows this spec shape is broken on every write endpoint. The slack CLI was the discovery surface but the issue affects the generator's interpretation of internal-YAML specs broadly. Per AGENTS.md ("Default to machine changes"), the fix belongs in the generator rather than in any one printed CLI.

## Risk

- **Generator output diff:** every CLI generated from a spec where write fields were declared under `params:` will now serialize them into the request body. Goldens caught no false positives; intentional diffs are limited to the body-assembly block in those endpoints' command files.
- **Specs with explicit `body:` are unaffected** (early return on `len(e.Body) > 0`).
- **GET-only specs are unaffected** (early return on method).
- **Public library:** existing CLIs in the library will regenerate cleanly — body assembly was already broken there, so the diff is strictly a fix.
- **Edge case:** a write endpoint that legitimately uses URL query params and no body would have `params` moved to `body`. This is observed-behavior change, but the prior behavior was a silent body-drop for those flags — so any caller relying on the old behavior was already broken. If a real spec hits this, the spec author should add an explicit empty `body: []` or restructure; happy to add a flag/escape hatch if reviewers prefer.

## Output Contract

Generator output diff is intentional and limited to the bodies of `command_endpoint.go` files for write endpoints whose specs put body fields under `params:`. Goldens were re-verified after the change; results in Verification.

## Verification

- `go test ./...` — all green (including new `TestPromoteParamsToBodyForWriteEndpoints` covering POST/PUT/PATCH promotion, path-placeholder preservation, explicit-body preservation, GET non-promotion, DELETE non-promotion, and subresource walking).
- `scripts/golden.sh verify` — all 16 cases pass; no generator-output diff against the test fixtures.
- End-to-end: locally rebuilt `slack-pp-cli` from the `.manuscripts` spec under this branch, confirmed `slack-pp-cli messages post_message --channel general --text 'hi' --agent` now sends `{"channel":"general","text":"hi"}` to `/chat.postMessage` instead of `{}`.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
