### PR TITLE
fix(cli): use slash paths for embedded templates

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -2703,7 +2704,7 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -90,7 +91,7 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}

--- a/internal/generator/template_path_test.go
+++ b/internal/generator/template_path_test.go
@@ -1,0 +1,43 @@
+package generator
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedTemplateReadsUseSlashPaths(t *testing.T) {
+	t.Parallel()
+
+	for _, filename := range []string{"generator.go", "plan_generate.go"} {
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, filename, nil, 0)
+			require.NoError(t, err)
+
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				selector, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || selector.Sel.Name != "Join" {
+					return true
+				}
+				ident, ok := selector.X.(*ast.Ident)
+				if !ok || ident.Name != "filepath" || len(call.Args) == 0 {
+					return true
+				}
+				firstArg, ok := call.Args[0].(*ast.BasicLit)
+				require.Falsef(t, ok && firstArg.Value == `"templates"`, "%s uses filepath.Join for an embed.FS template path at %s", filename, fset.Position(call.Pos()))
+				return true
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Windows generation now reads embedded templates with slash-separated paths, so embed.FS lookups work across OSes. The fix keeps OS-specific path handling for generated output files and adds a regression test that fails if embedded template reads go back to `filepath.Join("templates", ...)`.

Closes #792.

## Test plan

- `go test ./internal/generator -run TestEmbeddedTemplateReadsUseSlashPaths -count=1`
- `go test ./internal/generator -count=1`
- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
