### PR TITLE
fix: doctor reports 'not configured' for query-param auth APIs

### DIFF
--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -190,6 +190,29 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- else}}
 			if cfg != nil {
 				header := cfg.AuthHeader()
+{{- if and .Auth .Auth.In (eq .Auth.In "query")}}
+				// Auth is sent as a query parameter, not a header — AuthHeader()
+				// returns "" by design. Check the credential field directly.
+				if header == "" && cfg.AuthSource != "" {
+					report["auth"] = "configured (API key)"
+					report["auth_source"] = cfg.AuthSource
+				} else if header == "" {
+{{- if .Auth.Optional}}
+					report["auth"] = "optional — not configured"
+{{- else}}
+					report["auth"] = "not configured"
+{{- end}}
+{{- with $canonicalEnvVar}}
+					report["auth_hint"] = "export {{.Name}}=<your-key>"
+{{- end}}
+{{- if .Auth.KeyURL}}
+					report["auth_key_url"] = "{{.Auth.KeyURL}}"
+{{- end}}
+				} else {
+					report["auth"] = "configured"
+					report["auth_source"] = cfg.AuthSource
+				}
+{{- else}}
 				if header == "" {
 {{- if .Auth.Optional}}
 					report["auth"] = "optional — not configured"
@@ -206,6 +229,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["auth"] = "configured"
 					report["auth_source"] = cfg.AuthSource
 				}
+{{- end}}
 			}
 {{- end}}
 


### PR DESCRIPTION
## Summary

- When `Auth.In == "query"`, `AuthHeader()` deliberately returns `""` because the credential goes as a `?key=` query parameter, not an `Authorization` header
- The `doctor.go.tmpl` template only checked `AuthHeader()`, causing it to report `FAIL Auth: not configured` even when the API key env var is set and working
- Fix: when `Auth.In == "query"`, check `cfg.AuthSource` (populated during `config.Load()` when the env var is present) instead of `AuthHeader()`
- Reports `"configured (API key)"` for query-param auth with valid credentials

## Affected APIs

YouTube Data API v3 and any future CLI where the OpenAPI spec declares `apiKey` auth with `in: query`.

## Reproduction

```bash
export YOUTUBE_DATA_OAUTH2C=AIzaSy...
youtube-pp-cli doctor
# Before: FAIL Auth: not configured
#         OK Env Vars: OK 1/1 available   <-- contradicts Auth line
# After:  OK Auth: configured (API key)
#         OK Env Vars: OK 1/1 available
```

## Golden test impact

None — all three golden fixtures (`golden-api`, `rich-auth`, `tier-routing`) use `in: header` for top-level auth. The new `{{if eq .Auth.In "query"}}` branch only triggers for query-param auth specs.

Closes mvanhorn/printing-press-library#339

## Test plan

- [ ] Verify golden tests still pass (`go test ./internal/generator/...`)
- [ ] Generate a CLI from a spec with `in: query` auth and verify doctor reports correctly
- [ ] Verify existing `in: header` CLIs are unaffected

Generated with [Claude Code](https://claude.ai/code)