### PR TITLE
docs(cli): clarify catalog entry inclusion rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,14 +148,18 @@ Releases are automated by release-please. Never manually edit version numbers.
 See [`docs/RELEASE.md`](docs/RELEASE.md) for the merge-the-release-PR flow.
 
 ## Adding Catalog Entries
-When adding or editing `catalog/*.yaml`, the entry must pass `internal/catalog` validation.
+When adding or editing `catalog/*.yaml`, first decide whether the entry belongs in the curated blueprint catalog. The embedded catalog is not a public-library index or a shortcut for reprinting existing CLIs; reprint from the current local/public library artifact when that is the source of truth. Add catalog entries only when they represent a distinct, reusable Printing Press pattern and have a real user-facing workflow, a reachable maintained source, and a reproducible generation route: vendor spec, docs-derived in-repo spec, verified sniffed spec, or wrapper-only backing that truthfully describes what the generator can do today. Do not add aspirational entries, dead wrappers, unproven private endpoints, personalized app flows without an auth model, duplicate examples of an already-covered pattern, or scrape ideas without live crawl evidence.
+- Document provenance in the PR: source URL(s), source type (`official`, `docs`, `sniffed`, `community`, or wrapper-only), live smoke evidence, auth requirements, and what is intentionally out of scope.
+- If the entry should make `printing-press generate <name>` work, provide a real `spec_url` or in-repo spec; wrapper-only entries are discovery/backing notes unless the generator has a concrete spec path.
+- If catalog output intentionally changes, update `testdata/golden/expected/catalog-list/stdout.txt`.
+- The entry must pass `internal/catalog` validation.
 - Required fields: `name`, `display_name`, `description`, `category`, and `tier`, plus `spec_url` and `spec_format` unless the entry is wrapper-only (`wrapper_libraries` is set and `spec_url` is omitted).
 - `spec_url`, when present, must use HTTPS.
 - `category` must be one of `ai`, `auth`, `cloud`, `commerce`, `developer-tools`, `devices`, `food-and-dining`, `marketing`, `media-and-entertainment`, `monitoring`, `payments`, `productivity`, `project-management`, `sales-and-crm`, `social-and-messaging`, `travel`, or `other`. The validator also accepts `example` as a test-only catch-all; do not use it for real catalog entries.
 - `tier` must be `official` or `community`.
 - `bearer_refresh`, when present, must include `bundle_url` and `pattern`; `bundle_url` must use HTTPS, and `pattern` must compile as a Go regexp.
 - Rebuild the binary after editing; `catalog.FS` is a Go embed.
-See [`docs/CATALOG.md`](docs/CATALOG.md) for validation rationale, the wrapper-only entry shape, and bearer-refresh metadata.
+See [`docs/CATALOG.md`](docs/CATALOG.md) for the inclusion rubric, evidence checklist, validation rationale, wrapper-only entry shape, and bearer-refresh metadata.
 
 ## Testing
 When you change code, check for a `_test.go` file in the same package. If one exists, read it; your change likely requires a test update. If tests fail after your change, investigate whether it is a bug in your code or a stale test; do not just delete the test.

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -2,11 +2,57 @@
 
 Catalog entries in `catalog/` are validated by [`internal/catalog/catalog.go`](../internal/catalog/catalog.go). Keep the inline `AGENTS.md` rule in sync with that validator; when the validator's applicability or allowed values change, update the inline trigger sentence in the same PR.
 
+## Purpose
+
+The embedded catalog is the Printing Press's curated blueprint set. It should preserve representative source patterns that teach and test how to print different classes of CLIs, not exhaustively mirror every printed CLI in the public library.
+
+Do not use the embedded catalog as the primary way to reprint an existing CLI. Reprint from the current local or public library artifact when that artifact already exists, because it carries the fuller source of truth: the spec that actually shipped, generated code, manifest, README, skill, auth notes, and any post-generation fixes. A catalog entry is intentionally smaller and more lossy.
+
+Add entries when they broaden or sharpen the blueprint set: official OpenAPI, docs-derived specs, sniffed/browser APIs, wrapper/community-backed APIs, HTML or sitemap extraction, unusual auth, read-only versus mutating surfaces, or other distinct generator/runtime patterns. Do not add near-duplicates merely because they are useful APIs or members of the same product category.
+
 ## Why the inline rule is strict
 
 The catalog is embedded into the printing-press binary via `catalog.FS`, so a bad entry is not a local typo; it becomes part of every rebuilt binary. The inline `AGENTS.md` rule keeps the write-time fence close to the edit, while this doc carries the longer rationale and the wrapper-only shape.
 
 `category` and `tier` are deliberately finite enums because they drive catalog browsing, risk expectations, and downstream copy. `other` is the public catch-all. `example` is accepted only as a test-only bucket for fixtures such as `catalog/petstore.yaml`; do not use it for real catalog entries.
+
+## Inclusion rubric
+
+Passing schema validation is not enough. The catalog is a curated blueprint list for APIs and sites that exercise distinct Printing Press generation patterns. Add an entry only when all of these are true:
+
+- The target demonstrates a meaningfully different source, auth, runtime, data-shaping, or agent-surface pattern from entries already present.
+- The target has a concrete user-facing workflow that belongs in a generated CLI or MCP surface.
+- The target has a maintained, reachable source path: a vendor spec, official docs that can support an in-repo spec, a verified sniffed/browser-captured spec, a credible community wrapper, or a live public HTML/JSON surface.
+- The generation route is reproducible from the entry and PR evidence. A reviewer should understand whether `printing-press generate <name>` works directly, whether a local in-repo spec is required, or whether the entry is only wrapper/discovery backing.
+- The auth model is explicit. Public, optional-auth, API-key, OAuth, cookie, browser-token, or harvested-token flows must be described accurately, and personalized flows must not be implied to work anonymously.
+- The entry identifies the safe default surface. Read/browse/sync operations are easier to include than mutating actions; external actions such as ordering, sending, posting, purchasing, or launching a browser need explicit opt-in behavior in the generated CLI.
+
+Do not add entries that are only ideas for future scraping, depend on dead or unmaintained endpoints with no live fallback, require private app secrets without a legal/user-supplied auth path, duplicate an existing catalog pattern without a distinct lesson, or duplicate an existing public-library artifact without explaining why the embedded blueprint needs a new source entry.
+
+## Source types
+
+Use the source type to set reviewer expectations:
+
+- `official`: Vendor-published OpenAPI or equivalent machine-readable spec. Prefer this when available.
+- `docs`: An in-repo spec derived from official docs. The PR must link the docs and identify any endpoints inferred from live probing or non-doc sources.
+- `sniffed`: A spec derived from browser or traffic capture. The PR must name the capture surface, auth/session assumptions, and one or more live smoke checks.
+- `community`: A third-party spec or library-backed source. The PR must explain why the source is credible and whether it is maintained.
+- Wrapper-only: No direct spec. The entry documents a wrapper library or reverse-engineering technique. Use this when the source is useful catalog backing but does not by itself make `printing-press generate <name>` work.
+
+If an entry should be directly generatable from the catalog, provide a real `spec_url` and `spec_format`. For specs maintained in this repo, place them under `catalog/specs/` and point `spec_url` at the raw GitHub URL. Wrapper-only entries are acceptable, but they must not imply direct generation unless the generator has a concrete spec path.
+
+## Evidence checklist
+
+For each catalog PR, include the following in the PR body:
+
+- Source URL(s) and source type.
+- Live smoke evidence for the primary source path, with dates or command output summarized.
+- Auth requirements and which commands are public, optional-auth, or auth-required.
+- Scope boundaries for risky or personalized flows.
+- Whether `testdata/golden/expected/catalog-list/stdout.txt` changed, and why.
+- Verification commands actually run, or a clear reason they were not run.
+
+For HTML or scrape-backed entries, also verify crawlability and extractable data, not just page availability. A `200` on a marketing page is not enough; the PR must show that the data needed for the intended CLI surface is present in public HTML, embedded JSON, sitemaps, or documented endpoints.
 
 ## Wrapper-only entries
 
@@ -17,7 +63,16 @@ Wrapper-only entries are the carve-out where `spec_url` and `spec_format` stop b
 - Wrapper library URLs must use HTTPS.
 - `spec_format` is optional, but if present it must still be one of the allowed formats.
 
-Use the wrapper-only carve-out only when the API is genuinely reached through wrapper libraries rather than a direct spec. If the validator or enum values change, update both this doc and the inline `AGENTS.md` rule together.
+Use the wrapper-only carve-out only when the API is genuinely reached through wrapper libraries or documented reverse-engineering backing rather than a direct spec. A wrapper-only entry should name what is proven today and what remains out of scope. If the intended result is a generated CLI, prefer adding or referencing an internal spec instead of leaving the catalog entry as a scrape note.
+
+Wrapper-only entries should not:
+
+- Claim that the generator will emit endpoints unless a real spec path exists.
+- Depend on dead community wrappers without a live replacement source.
+- Include mutating workflows as default-safe just because a wrapper exposes them.
+- Treat private mobile-app endpoints, extracted client secrets, or personalized app flows as public API surface without an auth model.
+
+If the validator or enum values change, update both this doc and the inline `AGENTS.md` rule together.
 
 ## Bearer refresh metadata
 


### PR DESCRIPTION
## Summary

Catalog entry reviews now distinguish the embedded catalog from the public library: the catalog is a curated blueprint set for distinct Printing Press patterns, while existing CLIs should be reprinted from their current library artifacts. The guidance gives agents a short AGENTS.md decision gate and gives reviewers a fuller docs/CATALOG.md rubric for source types, evidence, auth boundaries, wrapper-only entries, and duplicate-pattern rejection.

This should make decisions on proposals like scrape-backed restaurant entries less subjective: "can be printed" is no longer enough unless the entry teaches or preserves a distinct source/auth/runtime pattern.

## Verification

- `git diff --check`

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
