### PR TITLE
fix(catalog): Align Google Flights catalog with Flight Goat's current wrapper

### DIFF
--- a/catalog/google-flights.yaml
+++ b/catalog/google-flights.yaml
@@ -1,15 +1,14 @@
 name: google-flights
 display_name: Google Flights
-description: Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers.
-category: other
+description: Flight search via Google Flights. No public API — reached through a community-maintained reverse-engineered wrapper.
+category: travel
 tier: community
-verified_date: "2026-04-11"
+verified_date: "2026-05-09"
 homepage: https://www.google.com/travel/flights
 notes: |
-  Google does not publish a Flights API. The wrapper libraries below reverse-engineer
+  Google does not publish a Flights API. The wrapper library below reverse-engineers
   the internal protobuf protocol that powers the website. Prefer the native Go wrapper
-  for printed CLIs so the resulting binary has no Python runtime dependency. Fall back
-  to the subprocess option when the Go wrapper is missing coverage the user needs.
+  for printed CLIs so the resulting binary has no Python runtime dependency.
 
   When this entry is returned for a combo-CLI source, the skill should surface the
   wrapper options to the user rather than searching for an OpenAPI spec.
@@ -19,10 +18,4 @@ wrapper_libraries:
     language: go
     license: MIT
     integration_mode: native
-    notes: Pure Go, importable. Preferred default — produces a single-binary CLI with no runtime deps.
-  - name: punitarani/fli
-    url: https://github.com/punitarani/fli
-    language: python
-    license: MIT
-    integration_mode: subprocess
-    notes: Python library with broader feature coverage (multi-leg, cabin class filters). Invoke as a subprocess and parse JSON output. Requires Python 3.10+ at runtime.
+    notes: Pure Go, importable. Produces a single-binary CLI with no Python runtime dependency.

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -409,7 +409,10 @@ func TestEmbeddedCatalogParsesWrapperOnlyEntries(t *testing.T) {
 	entry, err := LookupFS(catalogfs.FS, "google-flights")
 	require.NoError(t, err)
 	assert.True(t, entry.IsWrapperOnly())
-	assert.NotEmpty(t, entry.WrapperLibraries)
+	assert.Equal(t, "travel", entry.Category)
+	require.Len(t, entry.WrapperLibraries, 1)
+	assert.Equal(t, "krisukox/google-flights-api", entry.WrapperLibraries[0].Name)
+	assert.Equal(t, "native", entry.WrapperLibraries[0].IntegrationMode)
 }
 
 func TestPublicCategoriesExcludeExample(t *testing.T) {

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -637,7 +637,6 @@ If the catalog has an entry for this API, branch on the entry type:
 
 Present each `wrapper_libraries` entry as a selectable option with language, integration mode, and notes. Example for `google-flights`:
 - **krisukox/google-flights-api** (Go, native, MIT) — Pure Go, importable; single-binary CLI with no runtime deps.
-- **punitarani/fli** (Python, subprocess, MIT) — broader feature coverage (multi-leg, cabin class); requires Python 3.10+ at runtime.
 
 Capture the user's choice and record it in `$API_RUN_DIR/state.json` under an `implementation` field: `{ "library": "<name>", "url": "<url>", "integration_mode": "native|subprocess|html-scrape" }`. Phase 3 generation reads this to decide whether to `go get` a wrapper, emit a subprocess shell-out, or emit HTML-scrape code. Skip the spec-analysis step entirely — there is no spec.
 
@@ -853,7 +852,7 @@ For each named source, run the "When to offer browser-sniff" decision matrix ind
 | Source | Spec state | Expected decision |
 |--------|------------|-------------------|
 | `flightaware` | Documented OpenAPI spec found (53 endpoints, appears complete) | `skip-silent` with reason `spec-complete` |
-| `google-flights` | No official spec, but community wrapper exists (`fli`) | Ask via `AskUserQuestion` → record user's answer |
+| `google-flights` | No official spec, but community wrapper exists (`krisukox/google-flights-api`) | Ask via `AskUserQuestion` → record user's answer |
 | `kayak-direct` | No spec, no wrapper, user named this as a key feature | Ask via `AskUserQuestion` → record user's answer |
 
 The marker file for this run would contain three entries. Phase 1.5 would HALT if any were missing.

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -20,7 +20,6 @@ monitoring:
   sentry               Error tracking and performance monitoring - projects, issues, events, releases
 
 other:
-  google-flights       Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers.
   kayak                Flight, hotel, and car rental aggregator. No public API and no maintained community wrappers — reached by scraping embedded JSON from server-rendered pages.
 
 payments:
@@ -40,4 +39,7 @@ social-and-messaging:
   front                Customer communication platform API
   telegram             Telegram Bot API for building bots - send messages, manage chats, webhooks, stickers
   twilio               Communication APIs for SMS, voice, and messaging
+
+travel:
+  google-flights       Flight search via Google Flights. No public API — reached through a community-maintained reverse-engineered wrapper.
 


### PR DESCRIPTION
## Summary
- Remove the stale `punitarani/fli` entry from the Google Flights catalog and keep only the active `krisukox/google-flights-api` wrapper.
- Update the catalog metadata to match the current Flight Goat shape: `travel` category, refreshed verification date, and singular wrapper wording.
- Tighten catalog tests and skill guidance so the Google Flights source of truth does not drift back to the old wrapper selection.

## Testing
- `rtk go test ./internal/catalog ./internal/cli`
- `git diff --check`