### PR TITLE
fix(generator): unbreak generation on Windows

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2705,7 +2705,7 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 
 	// embed.FS uses forward-slash paths regardless of OS; filepath.Join here
 	// breaks on Windows (yields "templates\foo" which embed.FS rejects).
-	content, err := templateFS.ReadFile("templates/" + tmplName)
+	content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2703,7 +2703,9 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	// embed.FS uses forward-slash paths regardless of OS; filepath.Join here
+	// breaks on Windows (yields "templates\foo" which embed.FS rejects).
+	content, err := templateFS.ReadFile("templates/" + tmplName)
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -90,7 +90,8 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		// embed.FS uses forward-slash paths; filepath.Join breaks on Windows.
+		content, err := templateFS.ReadFile("templates/" + tmplName)
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -91,7 +91,7 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 
 	render := func(tmplName, outPath string, data any) error {
 		// embed.FS uses forward-slash paths; filepath.Join breaks on Windows.
-		content, err := templateFS.ReadFile("templates/" + tmplName)
+		content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -24,6 +25,12 @@ const qualityGateTimeout = 5 * time.Minute
 
 func (g *Generator) Validate() error {
 	binPath := filepath.Join(g.OutputDir, naming.ValidationBinary(g.Spec.Name))
+	if runtime.GOOS == "windows" && !strings.HasSuffix(binPath, ".exe") {
+		// `go build -o <path>` appends `.exe` on Windows; the validation
+		// gate must invoke the real filename (path is absolute, so exec
+		// does not search PATH and does not auto-append).
+		binPath += ".exe"
+	}
 	if err := artifacts.CleanupGeneratedCLI(g.OutputDir, artifacts.CleanupOptions{
 		RemoveValidationBinaries: true,
 		RemoveRecursiveCopies:    true,


### PR DESCRIPTION
## What

Two small Windows-only fixes that unblock `printing-press generate` on Windows. Verified end-to-end against four real specs (FRED, SEC EDGAR, Coinbase Exchange public subset, Mattermost).

## Why it currently breaks

### 1. `embed.FS` template paths

`internal/generator/generator.go:2706` and `internal/generator/plan_generate.go:93` both call:

```go
templateFS.ReadFile(filepath.Join("templates", tmplName))
```

`filepath.Join` uses the OS-native separator. On Windows that yields `templates\foo.go.tmpl`. But `embed.FS` paths are always forward-slash, regardless of OS — so every template load returns `file does not exist` and generation fails partway through with errors like:

```
Error: generating project: rendering profile.go.tmpl: reading template profile.go.tmpl:
       open templates\profile.go.tmpl: file does not exist
```

Each template fails individually, so on Windows you'd hit a different missing template every fix attempt.

### 2. Validation gate binary path

`internal/generator/validate.go:26` builds the validation binary path with `naming.ValidationBinary()` (which doesn't include `.exe`). Later the gate `<name>-pp-cli --help` runs that path. On Windows `go build -o <path>` writes `<path>.exe` — but the gate invokes the path-without-suffix, which `exec.LookPath` doesn't auto-resolve when the path is absolute. Result on Windows:

```
Error: validating generated project: gate "<cli> --help" failed:
       exec: "...\\<cli>-pp-cli-validation": executable file not found in %PATH%
```

The generated source is fine (`go build ./...` PASSes); only the gate's exec fails.

## Patches

Both are small, localized, and don't change behavior on Linux/macOS (`runtime.GOOS == "windows"` guard on the second fix; the first fix is a literal `"/"` separator which embed.FS already requires).

```diff
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2703,7 +2703,9 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	// embed.FS uses forward-slash paths regardless of OS; filepath.Join here
+	// breaks on Windows (yields "templates\foo" which embed.FS rejects).
+	content, err := templateFS.ReadFile("templates/" + tmplName)
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -90,7 +90,8 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		// embed.FS uses forward-slash paths; filepath.Join breaks on Windows.
+		content, err := templateFS.ReadFile("templates/" + tmplName)
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -24,6 +25,12 @@ const qualityGateTimeout = 5 * time.Minute
 
 func (g *Generator) Validate() error {
 	binPath := filepath.Join(g.OutputDir, naming.ValidationBinary(g.Spec.Name))
+	if runtime.GOOS == "windows" && !strings.HasSuffix(binPath, ".exe") {
+		// `go build -o <path>` appends `.exe` on Windows; the validation
+		// gate must invoke the real filename (path is absolute, so exec
+		// does not search PATH and does not auto-append).
+		binPath += ".exe"
+	}
 	if err := artifacts.CleanupGeneratedCLI(g.OutputDir, artifacts.CleanupOptions{
 		RemoveValidationBinaries: true,
 		RemoveRecursiveCopies:    true,
```

## Verification

Built locally on Windows (Go 1.26.3, Win 11) and re-ran `printing-press generate` end-to-end against four specs:

- `fred-schema.yaml` (community FRED OpenAPI) — 31 endpoints
- `openapi-SEC-EDGAR.json` (FinTechTonic SEC EDGAR OpenAPI) — 4 endpoints
- `coinbase-public.json` (hand-pruned subset of `metalocal/coinbase-exchange-api`) — 10 endpoints
- `mattermost-readonly.yaml` (hand-pruned read-only subset of `saturninoabril/mattermost-openapi-insomnia`) — 57 endpoints

After the patch, all six validation gates pass for each:

```
PASS go mod tidy
PASS govulncheck ./...
PASS go vet ./...
PASS go build ./...
PASS build runnable binary
PASS <name>-pp-cli --help
PASS <name>-pp-cli version
PASS <name>-pp-cli doctor
```

## No tests added

The first fix is a one-character path-separator change; testing it would require a Windows-specific test harness or a mocked `embed.FS`, both of which feel heavier than the bug. The second fix is a Windows-only `runtime.GOOS` guard around an existing path; the same applies. Happy to add tests if a maintainer prefers — just point me at the patterns you want followed.
