### PR TITLE
chore(gitignore): Ignore OMX workspace folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 catalog/specs/*.graphql
 .cache/
 .gotmp/
+.omx/
 .claude/worktrees/
 /refactor/artifacts/
 /tests/artifacts/perf/


### PR DESCRIPTION
## Summary
- Add `.omx/` to the root ignore list so OpenClaw/OMX runtime state created during user work does not show up as untracked files.

## Testing
- Not run (not requested)