### PR TITLE
fix(generator): use path.Join for embed.FS template lookups

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -2703,7 +2704,7 @@ func (g *Generator) template(tmplName string) (*template.Template, error) {
 		return tmpl, nil
 	}
 
-	content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+	content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 	if err != nil {
 		return nil, fmt.Errorf("reading template %s: %w", tmplName, err)
 	}

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -90,7 +91,7 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 	}
 
 	render := func(tmplName, outPath string, data any) error {
-		content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+		content, err := templateFS.ReadFile(path.Join("templates", tmplName))
 		if err != nil {
 			return fmt.Errorf("reading template %s: %w", tmplName, err)
 		}


### PR DESCRIPTION
## Summary

`printing-press generate` fails on Windows with errors like:

```
Error: generating project: rendering client.go.tmpl: reading template client.go.tmpl: open templates\client.go.tmpl: file does not exist
```

even though the templates ARE properly embedded via `//go:embed templates`. Each subsequent invocation fails on a different template (LICENSE.tmpl, agent_context.go.tmpl, cobratree/walker.go.tmpl, …) — every template name the generator tries to read.

Tested with v4.2.0 on Windows 11 + Go 1.26.3.

## Root cause

`embed.FS` keys are always forward-slash separated, regardless of host OS — but two call sites use `filepath.Join` to build the lookup path:

- `internal/generator/generator.go:2706` — `(*Generator).template`
- `internal/generator/plan_generate.go:93` — `GenerateFromPlan`'s `render` closure

`filepath.Join` returns backslash-separated paths on Windows, so the lookup produces `templates\client.go.tmpl` — which doesn't match the `templates/client.go.tmpl` key in the embed.FS, and every template lookup fails.

## Fix

Swap to `path.Join` (always forward-slash, designed for virtual filesystems and URL-style paths) for the two embed.FS reads. `path/filepath` stays imported in both files because both use it elsewhere for real-OS file paths (output trees, etc.).

```diff
-       content, err := templateFS.ReadFile(filepath.Join("templates", tmplName))
+       content, err := templateFS.ReadFile(path.Join("templates", tmplName))
```

Two-line diff plus an `import "path"` in each file.

## Verification

Tested on Windows 11 + Go 1.26.3. With the fix, `printing-press generate --spec my-spec.yaml --output ./out` runs cleanly through to completion — both for fresh runs and `--force` regeneration. Previously, every template lookup raised "file does not exist."

macOS / Linux behavior is unchanged: `path.Join` and `filepath.Join` produce identical output on systems whose path separator is already `/`.

## How we hit this

Doing reliability work for a Flask app — printing a CLI from a HAR capture of an undocumented stats API. The Press toolchain is exactly the right shape for the problem (local SQLite mirror, agent-native compound queries), but the Windows blocker turned a 30-second print into a Docker workaround dance. Worth fixing upstream so the next Windows user doesn't repeat the cycle.

Happy to extend with a regression test if there's a Windows runner in CI you'd like targeted; the current shape works on `golang:1.26-alpine` already.