### PR TITLE
feat(cli): point users at where to get a token (URL + instructions + auth setup --launch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ When adding or editing `catalog/*.yaml`, the entry must pass `internal/catalog` 
 - `tier` must be `official` or `community`.
 - `bearer_refresh`, when present, must include `bundle_url` and `pattern`; `bundle_url` must use HTTPS, and `pattern` must compile as a Go regexp.
 - `auth_key_url`, when present, must use HTTPS. It overrides any URL inferred from the spec and surfaces in the printed CLI as `Get a key at: <URL>`.
+- `auth_instructions`, when present, is a one-line string rendered under the URL. It overrides any `x-auth-instructions` value from the spec.
 - Rebuild the binary after editing; `catalog.FS` is a Go embed.
 See [`docs/CATALOG.md`](docs/CATALOG.md) for validation rationale, the wrapper-only entry shape, and bearer-refresh metadata.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ When adding or editing `catalog/*.yaml`, the entry must pass `internal/catalog` 
 - `category` must be one of `ai`, `auth`, `cloud`, `commerce`, `developer-tools`, `devices`, `food-and-dining`, `marketing`, `media-and-entertainment`, `monitoring`, `payments`, `productivity`, `project-management`, `sales-and-crm`, `social-and-messaging`, `travel`, or `other`. The validator also accepts `example` as a test-only catch-all; do not use it for real catalog entries.
 - `tier` must be `official` or `community`.
 - `bearer_refresh`, when present, must include `bundle_url` and `pattern`; `bundle_url` must use HTTPS, and `pattern` must compile as a Go regexp.
+- `auth_key_url`, when present, must use HTTPS. It overrides any URL inferred from the spec and surfaces in the printed CLI as `Get a key at: <URL>`.
 - Rebuild the binary after editing; `catalog.FS` is a Go embed.
 See [`docs/CATALOG.md`](docs/CATALOG.md) for validation rationale, the wrapper-only entry shape, and bearer-refresh metadata.
 

--- a/catalog/asana.yaml
+++ b/catalog/asana.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://developers.asana.com/reference
+auth_key_url: https://app.asana.com/0/my-apps
 notes: None.

--- a/catalog/asana.yaml
+++ b/catalog/asana.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://developers.asana.com/reference
 auth_key_url: https://app.asana.com/0/my-apps
+auth_instructions: "Create a personal access token under Apps & Integrations."
 notes: None.

--- a/catalog/digitalocean.yaml
+++ b/catalog/digitalocean.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://docs.digitalocean.com/reference/api
 auth_key_url: https://cloud.digitalocean.com/account/api/tokens
+auth_instructions: "Generate a personal access token with read or write scope as needed."
 notes: None.

--- a/catalog/digitalocean.yaml
+++ b/catalog/digitalocean.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://docs.digitalocean.com/reference/api
+auth_key_url: https://cloud.digitalocean.com/account/api/tokens
 notes: None.

--- a/catalog/discord.yaml
+++ b/catalog/discord.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://discord.com/developers/docs
 auth_key_url: https://discord.com/developers/applications
+auth_instructions: "Create an application, add a bot, and copy the bot token from the Bot tab."
 notes: Very large spec (1MB+). Generator truncates to 50 resources / 20 endpoints per resource.

--- a/catalog/discord.yaml
+++ b/catalog/discord.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.1"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://discord.com/developers/docs
+auth_key_url: https://discord.com/developers/applications
 notes: Very large spec (1MB+). Generator truncates to 50 resources / 20 endpoints per resource.

--- a/catalog/front.yaml
+++ b/catalog/front.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://dev.frontapp.com/reference
 auth_key_url: https://app.frontapp.com/settings/tokens
+auth_instructions: "Generate an API token under Settings -> Developers -> API tokens."
 notes: None.

--- a/catalog/front.yaml
+++ b/catalog/front.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://dev.frontapp.com/reference
+auth_key_url: https://app.frontapp.com/settings/tokens
 notes: None.

--- a/catalog/github.yaml
+++ b/catalog/github.yaml
@@ -9,6 +9,7 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://docs.github.com/en/rest
 auth_key_url: https://github.com/settings/tokens
+auth_instructions: "Generate a fine-grained personal access token (or classic) with the scopes your workflow needs."
 notes: Very large spec. Generator truncates significantly.
 known_alternatives:
   - name: gh

--- a/catalog/github.yaml
+++ b/catalog/github.yaml
@@ -8,6 +8,7 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://docs.github.com/en/rest
+auth_key_url: https://github.com/settings/tokens
 notes: Very large spec. Generator truncates significantly.
 known_alternatives:
   - name: gh

--- a/catalog/hubspot.yaml
+++ b/catalog/hubspot.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://developers.hubspot.com/docs/api
+auth_key_url: https://app.hubspot.com/private-apps
 notes: Only covers CRM Contacts endpoint. HubSpot has many separate specs.

--- a/catalog/hubspot.yaml
+++ b/catalog/hubspot.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://developers.hubspot.com/docs/api
 auth_key_url: https://app.hubspot.com/private-apps
+auth_instructions: "Create a private app, grant CRM scopes, and copy the access token."
 notes: Only covers CRM Contacts endpoint. HubSpot has many separate specs.

--- a/catalog/launchdarkly.yaml
+++ b/catalog/launchdarkly.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: community
 verified_date: "2026-03-24"
 homepage: https://launchdarkly.com
+auth_key_url: https://app.launchdarkly.com/settings/authorization
 notes: "221 paths, API key auth. Flat 'api' resource due to /api/v2/ prefix."

--- a/catalog/launchdarkly.yaml
+++ b/catalog/launchdarkly.yaml
@@ -9,4 +9,5 @@ tier: community
 verified_date: "2026-03-24"
 homepage: https://launchdarkly.com
 auth_key_url: https://app.launchdarkly.com/settings/authorization
+auth_instructions: "Create an access token with the role and project scope your workflow needs."
 notes: "221 paths, API key auth. Flat 'api' resource due to /api/v2/ prefix."

--- a/catalog/mercury.yaml
+++ b/catalog/mercury.yaml
@@ -8,6 +8,7 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-05-06"
 homepage: https://docs.mercury.com/reference
+auth_key_url: https://app.mercury.com/settings/tokens
 owner_name: Cathryn Lavery
 mcp:
   transport: [stdio, http]

--- a/catalog/mercury.yaml
+++ b/catalog/mercury.yaml
@@ -9,6 +9,7 @@ tier: official
 verified_date: "2026-05-06"
 homepage: https://docs.mercury.com/reference
 auth_key_url: https://app.mercury.com/settings/tokens
+auth_instructions: "Create an API token under Settings -> API and treat it as production credentials."
 owner_name: Cathryn Lavery
 mcp:
   transport: [stdio, http]

--- a/catalog/pipedrive.yaml
+++ b/catalog/pipedrive.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-25"
 homepage: https://developers.pipedrive.com
+auth_key_url: https://app.pipedrive.com/settings/personal/api
 notes: "Zero CLI competition. CRM from the terminal."

--- a/catalog/pipedrive.yaml
+++ b/catalog/pipedrive.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-25"
 homepage: https://developers.pipedrive.com
 auth_key_url: https://app.pipedrive.com/settings/personal/api
+auth_instructions: "Copy your personal API token from Personal preferences -> API."
 notes: "Zero CLI competition. CRM from the terminal."

--- a/catalog/plaid.yaml
+++ b/catalog/plaid.yaml
@@ -8,6 +8,7 @@ openapi_version: "3.0"
 tier: community
 verified_date: "2026-03-25"
 homepage: https://plaid.com/docs/api
+auth_key_url: https://dashboard.plaid.com/team/keys
 notes: "Fintech devs' go-to banking API. Abandoned community CLI (57 stars) proves demand."
 known_alternatives:
   - name: plaid-cli

--- a/catalog/plaid.yaml
+++ b/catalog/plaid.yaml
@@ -9,6 +9,7 @@ tier: community
 verified_date: "2026-03-25"
 homepage: https://plaid.com/docs/api
 auth_key_url: https://dashboard.plaid.com/team/keys
+auth_instructions: "Use Sandbox keys (PLAID_ENV=sandbox) until you have completed Plaid review for production."
 notes: "Fintech devs' go-to banking API. Abandoned community CLI (57 stars) proves demand."
 known_alternatives:
   - name: plaid-cli

--- a/catalog/sentry.yaml
+++ b/catalog/sentry.yaml
@@ -9,4 +9,5 @@ tier: community
 verified_date: "2026-03-24"
 homepage: https://sentry.io
 auth_key_url: https://sentry.io/settings/account/api/auth-tokens/
+auth_instructions: "Create an auth token with the scopes your workflow needs (project:read, event:read, etc.)."
 notes: "126 paths, bearer auth. Templated base URL {region}.sentry.io needs manual config."

--- a/catalog/sentry.yaml
+++ b/catalog/sentry.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: community
 verified_date: "2026-03-24"
 homepage: https://sentry.io
+auth_key_url: https://sentry.io/settings/account/api/auth-tokens/
 notes: "126 paths, bearer auth. Templated base URL {region}.sentry.io needs manual config."

--- a/catalog/stripe.yaml
+++ b/catalog/stripe.yaml
@@ -9,6 +9,7 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://stripe.com/docs/api
 auth_key_url: https://dashboard.stripe.com/apikeys
+auth_instructions: "Use a test mode key (sk_test_*) unless you intend to charge live cards."
 notes: Very large spec (~500 endpoints). Generator truncates significantly.
 known_alternatives:
   - name: stripe-cli

--- a/catalog/stripe.yaml
+++ b/catalog/stripe.yaml
@@ -8,6 +8,7 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://stripe.com/docs/api
+auth_key_url: https://dashboard.stripe.com/apikeys
 notes: Very large spec (~500 endpoints). Generator truncates significantly.
 known_alternatives:
   - name: stripe-cli

--- a/catalog/stytch.yaml
+++ b/catalog/stytch.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://stytch.com/docs
+auth_key_url: https://stytch.com/dashboard/api-keys
 notes: None.

--- a/catalog/stytch.yaml
+++ b/catalog/stytch.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://stytch.com/docs
 auth_key_url: https://stytch.com/dashboard/api-keys
+auth_instructions: "Use Test environment keys until you have switched the project to Live."
 notes: None.

--- a/catalog/twilio.yaml
+++ b/catalog/twilio.yaml
@@ -9,4 +9,5 @@ tier: official
 verified_date: "2026-03-23"
 homepage: https://www.twilio.com/docs/usage/api
 auth_key_url: https://console.twilio.com/
+auth_instructions: "Copy your Account SID and Auth Token from the console homepage."
 notes: None.

--- a/catalog/twilio.yaml
+++ b/catalog/twilio.yaml
@@ -8,4 +8,5 @@ openapi_version: "3.0"
 tier: official
 verified_date: "2026-03-23"
 homepage: https://www.twilio.com/docs/usage/api
+auth_key_url: https://console.twilio.com/
 notes: None.

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -35,3 +35,9 @@ Precedence:
 - Otherwise, the parser infers a URL from the security scheme description, `info.description` (with auth cues), `externalDocs.url`, and `info.contact.url`, in that order.
 
 Set `auth_key_url:` when the inference would land on a generic homepage and you know the specific token-acquisition page. The validator only checks that the URL starts with `https://`; it does not probe reachability.
+
+## Auth instructions
+
+Catalog entries may also declare `auth_instructions:` — a one-line string of free-form guidance ("Settings → Personal access tokens → Generate new") that the printed CLI prints under the `Get a key at:` line. Use this when the URL lands on a docs page rather than the keys UI: the URL says where to start, the instruction says what to do once there.
+
+Catalog `auth_instructions` overrides any value from the spec's [`x-auth-instructions`](SPEC-EXTENSIONS.md#x-auth-instructions) extension. The printed CLI surfaces it in auth prompts, `doctor`, and the new `auth setup` command (which also takes `--launch` to open the URL in a browser).

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -32,7 +32,7 @@ Catalog entries may declare `auth_key_url:` — an HTTPS page where the user can
 Precedence:
 - Catalog `auth_key_url` overrides any URL from the spec.
 - Otherwise, an OpenAPI spec's [`x-auth-key-url`](SPEC-EXTENSIONS.md#x-auth-key-url) is used.
-- Otherwise, the parser infers a URL from the security scheme description, `info.description` (with auth cues), `externalDocs.url`, and `info.contact.url`, in that order.
+- Otherwise, the parser infers a URL from the selected security scheme's `description`, then from `info.description` when the surrounding text mentions credential cues. `externalDocs.url` and `info.contact.url` are intentionally **not** fallbacks — those typically point at the docs landing page or company homepage, not the keys UI. When `KeyURL` is empty, the printed CLI surfaces those URLs under a separate `See API docs:` line instead. See [`SPEC-EXTENSIONS.md`](SPEC-EXTENSIONS.md#x-auth-key-url) for details.
 
 Set `auth_key_url:` when the inference would land on a generic homepage and you know the specific token-acquisition page. The validator only checks that the URL starts with `https://`; it does not probe reachability.
 

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -24,3 +24,14 @@ Use the wrapper-only carve-out only when the API is genuinely reached through wr
 Catalog entries for browser-facing APIs with rotating public client bearer tokens may declare `bearer_refresh`. When present, both `bearer_refresh.bundle_url` and `bearer_refresh.pattern` are required, the bundle URL must use HTTPS, and the pattern must compile as a Go regexp.
 
 The generator copies this metadata into the printed CLI so `doctor --refresh-bearer` and the agent-accessible `refresh-bearer` command can refresh the user's stored token from the live source bundle.
+
+## Auth key URL
+
+Catalog entries may declare `auth_key_url:` — an HTTPS page where the user can obtain credentials (personal access token, API key, OAuth client, etc.). The generator surfaces it in the printed CLI's auth prompts and `doctor` output as `Get a key at: <URL>`.
+
+Precedence:
+- Catalog `auth_key_url` overrides any URL from the spec.
+- Otherwise, an OpenAPI spec's [`x-auth-key-url`](SPEC-EXTENSIONS.md#x-auth-key-url) is used.
+- Otherwise, the parser infers a URL from the security scheme description, `info.description` (with auth cues), `externalDocs.url`, and `info.contact.url`, in that order.
+
+Set `auth_key_url:` when the inference would land on a generic homepage and you know the specific token-acquisition page. The validator only checks that the URL starts with `https://`; it does not probe reachability.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -381,8 +381,13 @@ through the following sources in order and uses the first plausible HTTPS URL:
 2. `info.description`, but only when the surrounding text mentions
    credential-related cues (`token`, `api key`, `credential`, `register`,
    `sign up`, etc.) so an unrelated URL doesn't get picked.
-3. `externalDocs.url`.
-4. `info.contact.url`.
+
+`externalDocs.url` and `info.contact.url` are intentionally **not** fallbacks
+for `KeyURL`. Those almost always point at the API's docs landing page or the
+company homepage, neither of which is where users actually create a token.
+When `KeyURL` ends up empty, the printed CLI uses `WebsiteURL` (already
+populated from `externalDocs.url`, `info.contact.url`, and `x-website`) under
+a separate `See API docs: <URL>` line — honest framing for those URLs.
 
 Catalog YAML's `auth_key_url:` (see [`CATALOG.md`](CATALOG.md)) overrides the
 inference. The result drives the printed CLI's `Get a key at: <URL>` output in

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -388,6 +388,23 @@ Catalog YAML's `auth_key_url:` (see [`CATALOG.md`](CATALOG.md)) overrides the
 inference. The result drives the printed CLI's `Get a key at: <URL>` output in
 auth prompts and `doctor`.
 
+### `x-auth-instructions`
+
+Free-form one-line guidance shown alongside `x-auth-key-url`, e.g. "Settings →
+Personal access tokens → Generate new". The printed CLI surfaces this under
+the URL in auth prompts, `doctor`, and the `auth setup` command.
+
+Parsed field: `APISpec.Auth.Instructions`
+
+Rules:
+- Optional.
+- Must be a string.
+- Leading and trailing whitespace is trimmed.
+- Use this when `x-auth-key-url` lands on a docs page rather than the keys UI;
+  the URL says where to start, the instruction says what to do once there.
+
+Catalog YAML's `auth_instructions:` overrides any spec-supplied value.
+
 ### `x-auth-title`
 
 Overrides the title shown for the credential field in install/config surfaces.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -374,6 +374,20 @@ Rules:
 - Leading and trailing whitespace is trimmed.
 - The parser does not validate the URL shape.
 
+When the extension is absent and the spec has any auth, the parser falls back
+through the following sources in order and uses the first plausible HTTPS URL:
+
+1. The selected security scheme's `description` (extracted via regex).
+2. `info.description`, but only when the surrounding text mentions
+   credential-related cues (`token`, `api key`, `credential`, `register`,
+   `sign up`, etc.) so an unrelated URL doesn't get picked.
+3. `externalDocs.url`.
+4. `info.contact.url`.
+
+Catalog YAML's `auth_key_url:` (see [`CATALOG.md`](CATALOG.md)) overrides the
+inference. The result drives the printed CLI's `Get a key at: <URL>` output in
+auth prompts and `doctor`.
+
 ### `x-auth-title`
 
 Overrides the title shown for the credential field in install/config surfaces.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -134,6 +134,13 @@ type Entry struct {
 	// doctor output. Overrides any URL inferred from the spec; the spec's
 	// x-auth-key-url and parser inference fallbacks are used when this is empty.
 	AuthKeyURL string `yaml:"auth_key_url,omitempty"`
+	// AuthInstructions is one-line free-form guidance shown alongside
+	// AuthKeyURL — e.g. "Settings → Personal access tokens → Generate new".
+	// Renders under the URL in auth prompts and doctor output, and is the
+	// human-readable companion to the URL when the URL is a generic docs page
+	// rather than a deep link to the keys UI. Overrides any spec-supplied
+	// x-auth-instructions value.
+	AuthInstructions string `yaml:"auth_instructions,omitempty"`
 	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
 	// Values: rest, proxy-envelope, graphql.
 	ClientPattern string `yaml:"client_pattern,omitempty"`

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -128,6 +128,12 @@ type Entry struct {
 	SpecSource string `yaml:"spec_source,omitempty"`
 	// AuthRequired indicates whether the API needs authentication. Empty means unknown.
 	AuthRequired *bool `yaml:"auth_required,omitempty"`
+	// AuthKeyURL is an HTTPS URL pointing the user at the page where they can
+	// obtain credentials (a personal access token, API key, OAuth client, etc.).
+	// Surfaces as "Get a key at: <URL>" in the printed CLI's auth prompts and
+	// doctor output. Overrides any URL inferred from the spec; the spec's
+	// x-auth-key-url and parser inference fallbacks are used when this is empty.
+	AuthKeyURL string `yaml:"auth_key_url,omitempty"`
 	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
 	// Values: rest, proxy-envelope, graphql.
 	ClientPattern string `yaml:"client_pattern,omitempty"`
@@ -300,6 +306,9 @@ func (e *Entry) Validate() error {
 	}
 	if err := validateBearerRefresh(e.BearerRefresh); err != nil {
 		return err
+	}
+	if e.AuthKeyURL != "" && !strings.HasPrefix(e.AuthKeyURL, "https://") {
+		return fmt.Errorf(`auth_key_url must start with "https://"`)
 	}
 
 	return nil

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -167,6 +167,13 @@ func TestValidateEntry(t *testing.T) {
 			},
 			wantErr: "bearer_refresh.pattern is not a valid regexp",
 		},
+		{
+			name: "non https auth_key_url",
+			mutate: func(e *Entry) {
+				e.AuthKeyURL = "http://example.com/keys"
+			},
+			wantErr: `auth_key_url must start with "https://"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1274,6 +1274,9 @@ func enrichSpecFromCatalogEntry(apiSpec *spec.APISpec, entry *catalog.Entry) {
 	if entry.AuthKeyURL != "" && apiSpec.Auth.Type != "none" {
 		apiSpec.Auth.KeyURL = entry.AuthKeyURL
 	}
+	if entry.AuthInstructions != "" && apiSpec.Auth.Type != "none" {
+		apiSpec.Auth.Instructions = entry.AuthInstructions
+	}
 }
 
 func mcpConfigured(m spec.MCPConfig) bool {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1271,6 +1271,9 @@ func enrichSpecFromCatalogEntry(apiSpec *spec.APISpec, entry *catalog.Entry) {
 	if entry.BearerRefresh.Pattern != "" && apiSpec.BearerRefresh.Pattern == "" {
 		apiSpec.BearerRefresh.Pattern = entry.BearerRefresh.Pattern
 	}
+	if entry.AuthKeyURL != "" && apiSpec.Auth.Type != "none" {
+		apiSpec.Auth.KeyURL = entry.AuthKeyURL
+	}
 }
 
 func mcpConfigured(m spec.MCPConfig) bool {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4330,6 +4330,47 @@ func TestGeneratedHelpers_AuthWithKeyURL_Compiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// Adversarial Instructions values must not break generated Go. The auth setup,
+// helpers (401/403 hint paths), and MCP tool description templates all embed
+// .Auth.Instructions inside Go string literals; without %q escaping a value
+// containing " or \ produces a syntax error at template-render time.
+func TestGeneratedHelpers_AuthInstructionsWithSpecialChars_Compiles(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "instrescape",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:         "api_key",
+			Header:       "Authorization",
+			In:           "header",
+			EnvVars:      []string{"INSTRESCAPE_API_KEY"},
+			KeyURL:       "https://example.com/keys",
+			Instructions: `Settings → "Personal access tokens" → \Generate new\`,
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/instrescape-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"users": {
+				Description: "Manage users",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/users", Description: "List users"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "instrescape-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 // --- Unit 4: Doctor Auth Hint Tests ---
 
 func TestGeneratedDoctor_AuthHintsWithKeyURL(t *testing.T) {

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -58,7 +58,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
 {{- if .Auth.Instructions}}
-			fmt.Fprintln(w, "  {{.Auth.Instructions}}")
+			fmt.Fprintln(w, {{printf "%q" (printf "  %s" .Auth.Instructions)}})
 {{- end}}
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "Then run:")

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -72,7 +72,9 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 				fmt.Fprintf(w, "would launch: %s\n", launchURL)
 				return nil
 			}
-			openBrowser(launchURL)
+			if err := openSetupURL(launchURL); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "could not open browser automatically: %v\nopen this URL manually: %s\n", err, launchURL)
+			}
 {{- else}}
 			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
 {{- end}}
@@ -82,6 +84,29 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
 	return cmd
 }
+
+{{- if or .Auth.KeyURL .WebsiteURL}}
+
+// openSetupURL opens url in the OS default browser and returns any error
+// from the launch. Distinct from openBrowser (used by `auth login`) because
+// `auth setup --launch` prints a manual-fallback message on failure rather
+// than silently failing. Per the side-effect rule, the caller short-circuits
+// with cliutil.IsVerifyEnv() before this is reached.
+func openSetupURL(url string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", url)
+	case "linux":
+		c = exec.Command("xdg-open", url)
+	case "windows":
+		c = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+	return c.Start()
+}
+{{- end}}
 
 func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	var clientID string

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -18,6 +18,9 @@ import (
 	"strings"
 	"time"
 
+{{- if .Auth.KeyURL}}
+	"{{modulePath}}/internal/cliutil"
+{{- end}}
 	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -28,10 +31,52 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Short: {{printf "%q" (authCommandShort .APISpec)}},
 	}
 
+	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthLoginCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
 
+	return cmd
+}
+
+// newAuthSetupCmd prints concrete steps for registering an OAuth app and
+// obtaining client credentials. Side-effect rule: print by default, --launch
+// to open the registration URL, short-circuit when the verifier is running.
+func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
+	var launch bool
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Print steps for registering an OAuth app (use --launch to open the URL)",
+		Example: "  {{.Name}}-pp-cli auth setup\n  {{.Name}}-pp-cli auth setup --launch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+{{- if .Auth.KeyURL}}
+			fmt.Fprintln(w, "Register an app and copy your credentials at: {{.Auth.KeyURL}}")
+{{- else}}
+			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
+{{- end}}
+{{- if .Auth.Instructions}}
+			fmt.Fprintln(w, "  {{.Auth.Instructions}}")
+{{- end}}
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Then run:")
+			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth login --client-id <id> --client-secret <secret>")
+			if !launch {
+				return nil
+			}
+{{- if .Auth.KeyURL}}
+			if cliutil.IsVerifyEnv() {
+				fmt.Fprintln(w, "would launch: {{.Auth.KeyURL}}")
+				return nil
+			}
+			openBrowser("{{.Auth.KeyURL}}")
+{{- else}}
+			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
+{{- end}}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
 	return cmd
 }
 

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
 	"{{modulePath}}/internal/config"
@@ -52,6 +52,8 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			w := cmd.OutOrStdout()
 {{- if .Auth.KeyURL}}
 			fmt.Fprintln(w, "Register an app and copy your credentials at: {{.Auth.KeyURL}}")
+{{- else if .WebsiteURL}}
+			fmt.Fprintln(w, "See API docs for OAuth app registration: {{.WebsiteURL}}")
 {{- else}}
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
@@ -64,12 +66,13 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			if !launch {
 				return nil
 			}
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
+			launchURL := {{if .Auth.KeyURL}}"{{.Auth.KeyURL}}"{{else}}"{{.WebsiteURL}}"{{end}}
 			if cliutil.IsVerifyEnv() {
-				fmt.Fprintln(w, "would launch: {{.Auth.KeyURL}}")
+				fmt.Fprintf(w, "would launch: %s\n", launchURL)
 				return nil
 			}
-			openBrowser("{{.Auth.KeyURL}}")
+			openBrowser(launchURL)
 {{- else}}
 			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
 {{- end}}

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -5,10 +5,17 @@ package cli
 
 import (
 	"fmt"
+{{- if .Auth.KeyURL}}
+	"os/exec"
+	"runtime"
+{{- end}}
 {{- if .Auth.EnvVars}}
 	"os"
 {{- end}}
 
+{{- if .Auth.KeyURL}}
+	"{{modulePath}}/internal/cliutil"
+{{- end}}
 	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -19,12 +26,90 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Short: {{printf "%q" (authCommandShort .APISpec)}},
 	}
 
+	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
 
 	return cmd
 }
+
+// newAuthSetupCmd prints concrete steps for getting a credential. Side-effect
+// rule: print by default, --launch opt-in to open the URL, short-circuit when
+// the verifier is running this in a sandboxed subprocess.
+func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
+	var launch bool
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Print steps for obtaining a credential (use --launch to open the URL)",
+		Example: "  {{.Name}}-pp-cli auth setup\n  {{.Name}}-pp-cli auth setup --launch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+{{- if .Auth.KeyURL}}
+			fmt.Fprintln(w, "Get a key at: {{.Auth.KeyURL}}")
+{{- else}}
+			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
+{{- end}}
+{{- if .Auth.Instructions}}
+			fmt.Fprintln(w, "  {{.Auth.Instructions}}")
+{{- end}}
+{{- if .Auth.EnvVarSpecs}}
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Then set:")
+{{- range .Auth.EnvVarSpecs}}
+{{- if isRequestAuthEnvVar .}}
+			fmt.Fprintln(w, "  export {{.Name}}=\"<your-token>\"")
+{{- end}}
+{{- end}}
+			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth set-token <token>")
+{{- else if .Auth.EnvVars}}
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Then set:")
+{{- range .Auth.EnvVars}}
+			fmt.Fprintln(w, "  export {{.}}=\"<your-token>\"")
+{{- end}}
+			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth set-token <token>")
+{{- end}}
+			if !launch {
+				return nil
+			}
+{{- if .Auth.KeyURL}}
+			if cliutil.IsVerifyEnv() {
+				fmt.Fprintln(w, "would launch: {{.Auth.KeyURL}}")
+				return nil
+			}
+			if err := openSetupURL("{{.Auth.KeyURL}}"); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "could not open browser automatically: %v\nopen this URL manually: {{.Auth.KeyURL}}\n", err)
+			}
+{{- else}}
+			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
+{{- end}}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
+	return cmd
+}
+
+{{- if .Auth.KeyURL}}
+
+// openSetupURL opens url in the OS default browser. Per the side-effect rule,
+// the caller short-circuits with cliutil.IsVerifyEnv() before this is reached.
+func openSetupURL(url string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", url)
+	case "linux":
+		c = exec.Command("xdg-open", url)
+	case "windows":
+		c = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+	return c.Start()
+}
+{{- end}}
 
 func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -5,7 +5,7 @@ package cli
 
 import (
 	"fmt"
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
 	"os/exec"
 	"runtime"
 {{- end}}
@@ -13,7 +13,7 @@ import (
 	"os"
 {{- end}}
 
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
 	"{{modulePath}}/internal/config"
@@ -47,6 +47,8 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			w := cmd.OutOrStdout()
 {{- if .Auth.KeyURL}}
 			fmt.Fprintln(w, "Get a key at: {{.Auth.KeyURL}}")
+{{- else if .WebsiteURL}}
+			fmt.Fprintln(w, "See API docs: {{.WebsiteURL}}")
 {{- else}}
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
@@ -73,13 +75,14 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			if !launch {
 				return nil
 			}
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
+			launchURL := {{if .Auth.KeyURL}}"{{.Auth.KeyURL}}"{{else}}"{{.WebsiteURL}}"{{end}}
 			if cliutil.IsVerifyEnv() {
-				fmt.Fprintln(w, "would launch: {{.Auth.KeyURL}}")
+				fmt.Fprintf(w, "would launch: %s\n", launchURL)
 				return nil
 			}
-			if err := openSetupURL("{{.Auth.KeyURL}}"); err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "could not open browser automatically: %v\nopen this URL manually: {{.Auth.KeyURL}}\n", err)
+			if err := openSetupURL(launchURL); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "could not open browser automatically: %v\nopen this URL manually: %s\n", err, launchURL)
 			}
 {{- else}}
 			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
@@ -91,7 +94,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 	return cmd
 }
 
-{{- if .Auth.KeyURL}}
+{{- if or .Auth.KeyURL .WebsiteURL}}
 
 // openSetupURL opens url in the OS default browser. Per the side-effect rule,
 // the caller short-circuits with cliutil.IsVerifyEnv() before this is reached.

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -53,7 +53,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
 {{- if .Auth.Instructions}}
-			fmt.Fprintln(w, "  {{.Auth.Instructions}}")
+			fmt.Fprintln(w, {{printf "%q" (printf "  %s" .Auth.Instructions)}})
 {{- end}}
 {{- if .Auth.EnvVarSpecs}}
 			fmt.Fprintln(w, "")

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -202,6 +202,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- if .Auth.KeyURL}}
 					report["auth_key_url"] = "{{.Auth.KeyURL}}"
 {{- end}}
+{{- if .Auth.Instructions}}
+					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
+{{- end}}
 				} else {
 					report["auth"] = "configured"
 					report["auth_source"] = cfg.AuthSource
@@ -516,6 +519,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- if .Auth.KeyURL}}
 			if keyURL, ok := report["auth_key_url"]; ok {
 				fmt.Fprintf(w, "  Get a key at: %v\n", keyURL)
+			}
+{{- end}}
+{{- if .Auth.Instructions}}
+			if instructions, ok := report["auth_instructions"]; ok {
+				fmt.Fprintf(w, "  %v\n", instructions)
 			}
 {{- end}}
 {{- if .HasStore}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -201,6 +201,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- if .Auth.KeyURL}}
 					report["auth_key_url"] = "{{.Auth.KeyURL}}"
+{{- else if .WebsiteURL}}
+					report["auth_docs_url"] = "{{.WebsiteURL}}"
 {{- end}}
 {{- if .Auth.Instructions}}
 					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
@@ -519,6 +521,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- if .Auth.KeyURL}}
 			if keyURL, ok := report["auth_key_url"]; ok {
 				fmt.Fprintf(w, "  Get a key at: %v\n", keyURL)
+			}
+{{- else if .WebsiteURL}}
+			if docsURL, ok := report["auth_docs_url"]; ok {
+				fmt.Fprintf(w, "  See API docs: %v\n", docsURL)
 			}
 {{- end}}
 {{- if .Auth.Instructions}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -311,6 +311,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
 {{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
+{{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status."+
 			"\n      Response: "+cliutil.SanitizeErrorBody(msg), err))
 {{- end}}
@@ -325,6 +328,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
 {{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
+{{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if eq .Auth.Type "bearer_token"}}
 		return authErr(fmt.Errorf("%w\nhint: check your token. Set it with: {{.Name}}-pp-cli auth set-token <token>"+
@@ -335,6 +341,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if eq .Auth.Type "api_key"}}
@@ -347,6 +356,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
 {{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
+{{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else}}
 		return authErr(fmt.Errorf("%w\nhint: check your API credentials."+
@@ -357,6 +369,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- end}}
@@ -370,6 +385,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if or (eq .Auth.Type "") (eq .Auth.Type "none")}}
@@ -385,6 +403,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- end}}
+{{- if .Auth.Instructions}}
+			"\n      {{.Auth.Instructions}}"+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- end}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -310,6 +310,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -327,6 +329,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -341,6 +345,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -355,6 +361,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -369,6 +377,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -385,6 +395,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+
@@ -403,6 +415,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"\n      Get a key at: {{.Auth.KeyURL}}"+
+{{- else if .WebsiteURL}}
+			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			"\n      {{.Auth.Instructions}}"+

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -314,7 +314,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status."+
 			"\n      Response: "+cliutil.SanitizeErrorBody(msg), err))
@@ -333,7 +333,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if eq .Auth.Type "bearer_token"}}
@@ -349,7 +349,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if eq .Auth.Type "api_key"}}
@@ -365,7 +365,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else}}
@@ -381,7 +381,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- end}}
@@ -399,7 +399,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- else if or (eq .Auth.Type "") (eq .Auth.Type "none")}}
@@ -419,7 +419,7 @@ func classifyAPIError(err error, flags *rootFlags) error {
 			"\n      See API docs: {{.WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
-			"\n      {{.Auth.Instructions}}"+
+			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
 {{- end}}
 			"\n      Run '{{.Name}}-pp-cli doctor' to check auth status.", err))
 {{- end}}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -283,6 +283,9 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
 {{- end}}
+{{- if .Auth.Instructions}}
+					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
+{{- end}}
 					{{printf "%q" (printf "\n      Run '%s-pp-cli doctor' to check auth status." .Name)}}), nil
 {{- end}}
 			case strings.Contains(msg, "HTTP 401"):
@@ -302,6 +305,9 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
 {{- end}}
+{{- if .Auth.Instructions}}
+					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
+{{- end}}
 					{{printf "%q" (printf "\n      Run '%s-pp-cli doctor' to check auth status." .Name)}}), nil
 			case strings.Contains(msg, "HTTP 403"):
 				return mcplib.NewToolResultError("permission denied: " + {{if and .Auth.Type (ne .Auth.Type "none")}}cliutil.SanitizeErrorBody(msg){{else}}msg{{end}} +
@@ -317,6 +323,9 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- end}}
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
+{{- end}}
+{{- if .Auth.Instructions}}
+					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
 {{- end}}
 					{{printf "%q" (printf "\n      Run '%s-pp-cli doctor' to check auth status." .Name)}}), nil
 			case strings.Contains(msg, "HTTP 404"):
@@ -546,6 +555,9 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"key_url": {{printf "%q" .Auth.KeyURL}},
+{{- end}}
+{{- if .Auth.Instructions}}
+			"instructions": {{printf "%q" .Auth.Instructions}},
 {{- end}}
 		},
 {{- end}}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -282,6 +282,8 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- end}}
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
+{{- else if .WebsiteURL}}
+					{{printf "%q" (printf "\n      See API docs: %s" .WebsiteURL)}} +
 {{- end}}
 {{- if .Auth.Instructions}}
 					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
@@ -304,6 +306,8 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- end}}
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
+{{- else if .WebsiteURL}}
+					{{printf "%q" (printf "\n      See API docs: %s" .WebsiteURL)}} +
 {{- end}}
 {{- if .Auth.Instructions}}
 					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
@@ -323,6 +327,8 @@ func makeAPIHandler(method, pathTemplate string, bindings []mcpParamBinding, pos
 {{- end}}
 {{- if .Auth.KeyURL}}
 					{{printf "%q" (printf "\n      Get a key at: %s" .Auth.KeyURL)}} +
+{{- else if .WebsiteURL}}
+					{{printf "%q" (printf "\n      See API docs: %s" .WebsiteURL)}} +
 {{- end}}
 {{- if .Auth.Instructions}}
 					{{printf "%q" (printf "\n      %s" .Auth.Instructions)}} +
@@ -555,6 +561,8 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 {{- end}}
 {{- if .Auth.KeyURL}}
 			"key_url": {{printf "%q" .Auth.KeyURL}},
+{{- else if .WebsiteURL}}
+			"docs_url": {{printf "%q" .WebsiteURL}},
 {{- end}}
 {{- if .Auth.Instructions}}
 			"instructions": {{printf "%q" .Auth.Instructions}},

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -201,7 +201,7 @@ When you know what you want to do but not which command does it, ask the CLI dir
 {{- else if eq .Auth.Type "api_key"}}
 
 {{- with $canonicalEnvVar}}
-Set your API key via environment variable:
+Run `{{$.Name}}-pp-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
 
 ```bash
 export {{.Name}}="<your-key>"
@@ -211,7 +211,7 @@ Or persist it in `{{$.Config.Path}}`.
 {{- end}}
 {{- else if eq .Auth.Type "oauth2"}}
 
-Authenticate via the browser:
+Run `{{.Name}}-pp-cli auth setup` for the registration URL and steps (add `--launch` to open the URL). Then authenticate:
 
 ```bash
 {{.Name}}-pp-cli auth login
@@ -220,7 +220,7 @@ Authenticate via the browser:
 Tokens are stored locally and refreshed automatically.
 {{- else if eq .Auth.Type "bearer_token"}}
 
-Store your access token:
+Run `{{.Name}}-pp-cli auth setup` for the URL and steps to obtain a token (add `--launch` to open the URL). Then store it:
 
 ```bash
 {{.Name}}-pp-cli auth set-token YOUR_TOKEN_HERE

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -233,30 +233,36 @@ func parseWithLocation(data []byte, lenient bool, location *url.URL) (*spec.APIS
 	// with '#'). The Render Public API spec has 314 cross-referenced schemas;
 	// kin-openapi's DefaultRefNameResolver-driven recursion runs > 10 minutes
 	// on it. Lazy ref resolution still works for in-document refs during access.
+	//
+	// Format-agnostic scan: matches both JSON (`"$ref": "..."`) and YAML
+	// (`$ref: '...'` or unquoted `$ref: ./schemas/foo.yaml`). A `$ref` whose
+	// value's first non-quote character is anything but '#' is external, and
+	// we must call InternalizeRefs to resolve it.
 	hasExternalRef := false
 	for off := 0; off < len(data); {
-		idx := bytes.Index(data[off:], []byte("\"$ref\""))
+		idx := bytes.Index(data[off:], []byte("$ref"))
 		if idx < 0 {
 			break
 		}
-		off += idx + len("\"$ref\"")
-		colon := bytes.IndexByte(data[off:], ':')
-		if colon < 0 {
+		off += idx + len("$ref")
+		// Skip optional closing quote (JSON `"$ref"`) and whitespace before the colon.
+		for off < len(data) && (data[off] == '"' || data[off] == '\'' || data[off] == ' ' || data[off] == '\t') {
+			off++
+		}
+		if off >= len(data) || data[off] != ':' {
+			continue
+		}
+		off++
+		for off < len(data) && (data[off] == ' ' || data[off] == '\t') {
+			off++
+		}
+		if off < len(data) && (data[off] == '"' || data[off] == '\'') {
+			off++
+		}
+		if off >= len(data) {
 			break
 		}
-		off += colon + 1
-		q1 := bytes.IndexByte(data[off:], '"')
-		if q1 < 0 {
-			break
-		}
-		off += q1 + 1
-		q2 := bytes.IndexByte(data[off:], '"')
-		if q2 < 0 {
-			break
-		}
-		val := data[off : off+q2]
-		off += q2 + 1
-		if len(val) > 0 && val[0] != '#' {
+		if data[off] != '#' {
 			hasExternalRef = true
 			break
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -636,12 +636,14 @@ func allDigits(s string) bool {
 //  2. URL embedded in info.description, but only when the surrounding text
 //     mentions auth/credential cues (so we don't pick a URL describing an
 //     unrelated feature)
-//  3. externalDocs.url, when HTTPS
-//  4. info.contact.url, when HTTPS
 //
-// Returns "" when no plausible URL is found. The result is surfaced by the
-// printed CLI's auth prompts as "Get a key at: <URL>", so a wrong URL here is
-// worse than no URL — every step is intentionally conservative.
+// Returns "" when no plausible URL is found. The printed CLI surfaces the
+// result as "Get a key at: <URL>", so a wrong URL here is worse than no URL.
+// We deliberately do NOT fall back to externalDocs.url or info.contact.url —
+// those almost always point at the API's docs landing page or the company
+// homepage, neither of which is where users actually create a token. When this
+// returns "", the printed CLI falls back to a separate "See API docs: <URL>"
+// line driven by WebsiteURL, which is honest framing for those URLs.
 func inferAuthKeyURL(doc *openapi3.T, schemeName string) string {
 	if doc == nil {
 		return ""
@@ -657,16 +659,6 @@ func inferAuthKeyURL(doc *openapi3.T, schemeName string) string {
 	}
 	if doc.Info != nil {
 		if u := firstAuthRelatedURL(doc.Info.Description); u != "" {
-			return u
-		}
-	}
-	if doc.ExternalDocs != nil {
-		if u := normalizeHTTPSURL(doc.ExternalDocs.URL); u != "" {
-			return u
-		}
-	}
-	if doc.Info != nil && doc.Info.Contact != nil {
-		if u := normalizeHTTPSURL(doc.Info.Contact.URL); u != "" {
 			return u
 		}
 	}
@@ -709,18 +701,6 @@ func firstAuthRelatedURL(s string) string {
 		return ""
 	}
 	return firstHTTPSURL(s)
-}
-
-// normalizeHTTPSURL trims s and returns it only if it parses as an HTTPS URL.
-func normalizeHTTPSURL(s string) string {
-	s = strings.TrimSpace(s)
-	if !strings.HasPrefix(s, "https://") {
-		return ""
-	}
-	if _, err := url.Parse(s); err != nil {
-		return ""
-	}
-	return s
 }
 
 func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]any) {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -35,6 +35,7 @@ const (
 	extensionAuthVars         = "x-auth-vars"
 	extensionAuthOptional     = "x-auth-optional"
 	extensionAuthKeyURL       = "x-auth-key-url"
+	extensionAuthInstructions = "x-auth-instructions"
 	extensionAuthTitle        = "x-auth-title"
 	extensionAuthDescription  = "x-auth-description"
 	extensionSpeakeasyExample = "x-speakeasy-example"
@@ -738,6 +739,9 @@ func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]an
 	}
 	if keyURL := stringExtension(extensions, extensionAuthKeyURL); keyURL != "" {
 		auth.KeyURL = keyURL
+	}
+	if instructions := stringExtension(extensions, extensionAuthInstructions); instructions != "" {
+		auth.Instructions = instructions
 	}
 	if title := stringExtension(extensions, extensionAuthTitle); title != "" {
 		auth.Title = title

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -227,7 +228,41 @@ func parseWithLocation(data []byte, lenient bool, location *url.URL) (*spec.APIS
 		fmt.Fprintf(os.Stderr, "info: spec loaded after stripping broken references\n")
 	}
 
-	doc.InternalizeRefs(context.Background(), nil)
+	// Skip InternalizeRefs when the spec has no external $refs (every $ref starts
+	// with '#'). The Render Public API spec has 314 cross-referenced schemas;
+	// kin-openapi's DefaultRefNameResolver-driven recursion runs > 10 minutes
+	// on it. Lazy ref resolution still works for in-document refs during access.
+	hasExternalRef := false
+	for off := 0; off < len(data); {
+		idx := bytes.Index(data[off:], []byte("\"$ref\""))
+		if idx < 0 {
+			break
+		}
+		off += idx + len("\"$ref\"")
+		colon := bytes.IndexByte(data[off:], ':')
+		if colon < 0 {
+			break
+		}
+		off += colon + 1
+		q1 := bytes.IndexByte(data[off:], '"')
+		if q1 < 0 {
+			break
+		}
+		off += q1 + 1
+		q2 := bytes.IndexByte(data[off:], '"')
+		if q2 < 0 {
+			break
+		}
+		val := data[off : off+q2]
+		off += q2 + 1
+		if len(val) > 0 && val[0] != '#' {
+			hasExternalRef = true
+			break
+		}
+	}
+	if hasExternalRef {
+		doc.InternalizeRefs(context.Background(), nil)
+	}
 
 	name := "api"
 	description := ""
@@ -324,6 +359,9 @@ func parseWithLocation(data []byte, lenient bool, location *url.URL) (*spec.APIS
 	auth := mapAuthWithDescriptionInference(doc, name, !metadata.explicitEmptySecuritySchemes)
 	if auth.Type != "none" && allOperationsAllowAnonymous(doc) {
 		auth = spec.AuthConfig{Type: "none"}
+	}
+	if auth.Type != "none" && auth.KeyURL == "" {
+		auth.KeyURL = inferAuthKeyURL(doc, auth.Scheme)
 	}
 
 	tierRouting, err := parseTypedExtension[spec.TierRoutingConfig](doc, extensionTierRouting)
@@ -589,6 +627,99 @@ func allDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// inferAuthKeyURL returns a best-effort HTTPS URL pointing the user at where
+// they can obtain a credential when x-auth-key-url is not set. Precedence:
+//  1. URL embedded in the selected security scheme's description
+//  2. URL embedded in info.description, but only when the surrounding text
+//     mentions auth/credential cues (so we don't pick a URL describing an
+//     unrelated feature)
+//  3. externalDocs.url, when HTTPS
+//  4. info.contact.url, when HTTPS
+//
+// Returns "" when no plausible URL is found. The result is surfaced by the
+// printed CLI's auth prompts as "Get a key at: <URL>", so a wrong URL here is
+// worse than no URL — every step is intentionally conservative.
+func inferAuthKeyURL(doc *openapi3.T, schemeName string) string {
+	if doc == nil {
+		return ""
+	}
+	if schemeName != "" && doc.Components != nil {
+		if ref, ok := doc.Components.SecuritySchemes[schemeName]; ok {
+			if scheme := securitySchemeValue(ref); scheme != nil {
+				if u := firstHTTPSURL(scheme.Description); u != "" {
+					return u
+				}
+			}
+		}
+	}
+	if doc.Info != nil {
+		if u := firstAuthRelatedURL(doc.Info.Description); u != "" {
+			return u
+		}
+	}
+	if doc.ExternalDocs != nil {
+		if u := normalizeHTTPSURL(doc.ExternalDocs.URL); u != "" {
+			return u
+		}
+	}
+	if doc.Info != nil && doc.Info.Contact != nil {
+		if u := normalizeHTTPSURL(doc.Info.Contact.URL); u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+var httpsURLPattern = regexp.MustCompile(`https://[^\s)>\]"',]+`)
+
+// firstHTTPSURL returns the first https:// substring found in s, with trailing
+// sentence punctuation trimmed.
+func firstHTTPSURL(s string) string {
+	if s == "" {
+		return ""
+	}
+	m := httpsURLPattern.FindString(s)
+	return strings.TrimRight(m, ".,;:!?)")
+}
+
+// firstAuthRelatedURL returns the first HTTPS URL in s, but only when s also
+// contains language indicating the URL is about credentials. Avoids picking a
+// URL that happens to appear in a description of an unrelated feature.
+func firstAuthRelatedURL(s string) string {
+	if s == "" {
+		return ""
+	}
+	lower := strings.ToLower(s)
+	cues := []string{
+		"token", "api key", "api_key", "apikey",
+		"credential", "register", "sign up", "signup",
+		"create an app", "create an application", "personal access",
+	}
+	matched := false
+	for _, c := range cues {
+		if strings.Contains(lower, c) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return ""
+	}
+	return firstHTTPSURL(s)
+}
+
+// normalizeHTTPSURL trims s and returns it only if it parses as an HTTPS URL.
+func normalizeHTTPSURL(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "https://") {
+		return ""
+	}
+	if _, err := url.Parse(s); err != nil {
+		return ""
+	}
+	return s
 }
 
 func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]any) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2140,6 +2140,7 @@ components:
         - FLIGHTAWARE_API_KEY
       x-auth-optional: true
       x-auth-key-url: https://flightaware.com/commercial/aeroapi/
+      x-auth-instructions: Sign up for FlightAware AeroAPI and copy the personal API key.
       x-auth-title: FlightAware AeroAPI Key
       x-auth-description: Optional FlightAware AeroAPI credential for enriched flight data.
 paths:
@@ -2156,6 +2157,7 @@ paths:
 	assert.Equal(t, []string{"FLIGHTAWARE_API_KEY"}, parsed.Auth.EnvVars)
 	assert.True(t, parsed.Auth.Optional)
 	assert.Equal(t, "https://flightaware.com/commercial/aeroapi/", parsed.Auth.KeyURL)
+	assert.Equal(t, "Sign up for FlightAware AeroAPI and copy the personal API key.", parsed.Auth.Instructions)
 	assert.Equal(t, "FlightAware AeroAPI Key", parsed.Auth.Title)
 	assert.Equal(t, "Optional FlightAware AeroAPI credential for enriched flight data.", parsed.Auth.Description)
 }

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2222,7 +2222,7 @@ paths:
 			expected: "https://example.com/account/api-keys",
 		},
 		{
-			name: "fallback to externalDocs.url when scheme has no description",
+			name: "no inference when only externalDocs.url is set (docs URL is not a credentials page)",
 			yaml: `openapi: "3.0.3"
 info:
   title: Figma API
@@ -2243,10 +2243,10 @@ paths:
       responses:
         "200": { description: OK }
 `,
-			expected: "https://developers.figma.com/docs/rest-api/",
+			expected: "",
 		},
 		{
-			name: "fallback to info.contact.url when externalDocs missing",
+			name: "no inference when only info.contact.url is set (homepage is not a credentials page)",
 			yaml: `openapi: "3.0.3"
 info:
   title: Example
@@ -2267,7 +2267,7 @@ paths:
       responses:
         "200": { description: OK }
 `,
-			expected: "https://example.com/developers",
+			expected: "",
 		},
 		{
 			name: "info.description URL only used when auth-related cues present",
@@ -2315,7 +2315,7 @@ paths:
       responses:
         "200": { description: OK }
 `,
-			expected: "https://example.com/developers",
+			expected: "",
 		},
 		{
 			name: "no inference when auth.type is none",

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2160,6 +2160,190 @@ paths:
 	assert.Equal(t, "Optional FlightAware AeroAPI credential for enriched flight data.", parsed.Auth.Description)
 }
 
+func TestOpenAPIAuthKeyURLInference(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		yaml     string
+		expected string
+	}{
+		{
+			name: "explicit x-auth-key-url wins over inference",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+externalDocs:
+  url: https://docs.example.com/rest-api/
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+      description: "Visit https://example.com/wrong-page to get a key"
+      x-auth-key-url: https://example.com/keys
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://example.com/keys",
+		},
+		{
+			name: "url from security scheme description",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+externalDocs:
+  url: https://docs.example.com/rest-api/
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+      description: "Generate a token at https://example.com/account/api-keys."
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://example.com/account/api-keys",
+		},
+		{
+			name: "fallback to externalDocs.url when scheme has no description",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Figma API
+  version: "1.0.0"
+externalDocs:
+  url: https://developers.figma.com/docs/rest-api/
+servers:
+  - url: https://api.figma.com
+components:
+  securitySchemes:
+    PersonalAccessToken:
+      type: apiKey
+      in: header
+      name: X-Figma-Token
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://developers.figma.com/docs/rest-api/",
+		},
+		{
+			name: "fallback to info.contact.url when externalDocs missing",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+  contact:
+    url: https://example.com/developers
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://example.com/developers",
+		},
+		{
+			name: "info.description URL only used when auth-related cues present",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+  description: "Generate an API key at https://example.com/account/keys before calling."
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://example.com/account/keys",
+		},
+		{
+			name: "info.description URL ignored without auth cue",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+  description: "See https://example.com/changelog for release notes."
+  contact:
+    url: https://example.com/developers
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "https://example.com/developers",
+		},
+		{
+			name: "no inference when auth.type is none",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+externalDocs:
+  url: https://docs.example.com/rest-api/
+servers:
+  - url: https://api.example.com
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := Parse([]byte(tc.yaml))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, parsed.Auth.KeyURL)
+		})
+	}
+}
+
 func TestOpenAPIAuthEnvVarsPopulateRichDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -435,11 +435,12 @@ type AuthConfig struct {
 	Format           string       `yaml:"format" json:"format"`
 	EnvVars          []string     `yaml:"env_vars" json:"env_vars"`
 	EnvVarSpecs      []AuthEnvVar `yaml:"env_var_specs,omitempty" json:"env_var_specs,omitempty"`
-	Optional         bool         `yaml:"optional,omitempty" json:"optional,omitempty"` // true when the key enhances a subset of features (e.g., USDA nutrition backfill) rather than gating core functionality; doctor treats unconfigured optional auth as INFO not FAIL and README frames the section as "Optional"
-	Scheme           string       `yaml:"scheme,omitempty" json:"scheme,omitempty"`     // OpenAPI security scheme name
-	In               string       `yaml:"in,omitempty" json:"in,omitempty"`             // header, query, cookie
-	KeyURL           string       `yaml:"key_url,omitempty" json:"key_url,omitempty"`   // URL where users can register for an API key
-	Title            string       `yaml:"title,omitempty" json:"title,omitempty"`       // user-facing credential field title for install/config surfaces
+	Optional         bool         `yaml:"optional,omitempty" json:"optional,omitempty"`         // true when the key enhances a subset of features (e.g., USDA nutrition backfill) rather than gating core functionality; doctor treats unconfigured optional auth as INFO not FAIL and README frames the section as "Optional"
+	Scheme           string       `yaml:"scheme,omitempty" json:"scheme,omitempty"`             // OpenAPI security scheme name
+	In               string       `yaml:"in,omitempty" json:"in,omitempty"`                     // header, query, cookie
+	KeyURL           string       `yaml:"key_url,omitempty" json:"key_url,omitempty"`           // URL where users can register for an API key
+	Instructions     string       `yaml:"instructions,omitempty" json:"instructions,omitempty"` // one-line guidance shown alongside KeyURL, e.g. "Settings → Personal access tokens → Generate new"
+	Title            string       `yaml:"title,omitempty" json:"title,omitempty"`               // user-facing credential field title for install/config surfaces
 	Description      string       `yaml:"description,omitempty" json:"description,omitempty"`
 	AuthorizationURL string       `yaml:"authorization_url,omitempty" json:"authorization_url,omitempty"`
 	TokenURL         string       `yaml:"token_url,omitempty" json:"token_url,omitempty"`

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -53,7 +53,7 @@ printing-press-rich-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 ## Auth Setup
-Set your API key via environment variable:
+Run `printing-press-rich-pp-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
 
 ```bash
 export RICH_AUTH_API_KEY="<your-key>"

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/auth.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"os"
-
 	"printing-press-rich-pp-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +16,41 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Short: "Manage authentication for Printing Press Rich",
 	}
 
+	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
 
+	return cmd
+}
+
+// newAuthSetupCmd prints concrete steps for getting a credential. Side-effect
+// rule: print by default, --launch opt-in to open the URL, short-circuit when
+// the verifier is running this in a sandboxed subprocess.
+func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
+	var launch bool
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Print steps for obtaining a credential (use --launch to open the URL)",
+		Example: "  printing-press-rich-pp-cli auth setup\n  printing-press-rich-pp-cli auth setup --launch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Then set:")
+			fmt.Fprintln(w, "  export RICH_AUTH_API_KEY=\"<your-token>\"")
+			fmt.Fprintln(w, "  export RICH_AUTH_OPTIONAL_TOKEN=\"<your-token>\"")
+			fmt.Fprintln(w, "  export RICH_AUTH_BOT_TOKEN=\"<your-token>\"")
+			fmt.Fprintln(w, "  export RICH_AUTH_USER_TOKEN=\"<your-token>\"")
+			fmt.Fprintln(w, "  printing-press-rich-pp-cli auth set-token <token>")
+			if !launch {
+				return nil
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
 	return cmd
 }
 

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -71,8 +71,8 @@
   "verdict": "WARN",
   "wiring_check": {
     "command_tree": {
-      "defined": 40,
-      "registered": 40
+      "defined": 41,
+      "registered": 41
     },
     "config_consistency": {
       "consistent": true

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -62,7 +62,7 @@ printing-press-golden-pp-cli which "<capability in your own words>"
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
 
 ## Auth Setup
-Set your API key via environment variable:
+Run `printing-press-golden-pp-cli auth setup` to print the URL and steps for getting a key (add `--launch` to open the URL). Then set:
 
 ```bash
 export PRINTING_PRESS_GOLDEN_API_KEY="<your-key>"

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/auth.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"os"
-
 	"printing-press-golden-pp-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +16,38 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Short: "Manage authentication for Printing Press Studio",
 	}
 
+	cmd.AddCommand(newAuthSetupCmd(flags))
 	cmd.AddCommand(newAuthStatusCmd(flags))
 	cmd.AddCommand(newAuthSetTokenCmd(flags))
 	cmd.AddCommand(newAuthLogoutCmd(flags))
 
+	return cmd
+}
+
+// newAuthSetupCmd prints concrete steps for getting a credential. Side-effect
+// rule: print by default, --launch opt-in to open the URL, short-circuit when
+// the verifier is running this in a sandboxed subprocess.
+func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
+	var launch bool
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Print steps for obtaining a credential (use --launch to open the URL)",
+		Example: "  printing-press-golden-pp-cli auth setup\n  printing-press-golden-pp-cli auth setup --launch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "Then set:")
+			fmt.Fprintln(w, "  export PRINTING_PRESS_GOLDEN_API_KEY=\"<your-token>\"")
+			fmt.Fprintln(w, "  printing-press-golden-pp-cli auth set-token <token>")
+			if !launch {
+				return nil
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), "no setup URL configured; cannot launch")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&launch, "launch", false, "Open the setup URL in your default browser")
 	return cmd
 }
 


### PR DESCRIPTION
## Intent

When a printed CLI prompts the user for a missing token, it should not just say "set FOO_TOKEN" — it should tell them **where** to obtain one and **how**, and ideally just open the page for them. Today the printed CLI says nothing about where the token lives, and `auth login` only exists for OAuth flows; api_key / bearer_token CLIs leave the user to grep the docs.

Issue: N/A — driven by a user report on the Figma flow.

## Approach

Three coordinated changes, all in the machine, all opt-in for any printed CLI whose spec declares auth:

1. **`Auth.KeyURL` inference (deliberately conservative) + catalog override.** `internal/openapi/parser.go` infers a credentials URL only from the selected security scheme's `description` or from `info.description` when the surrounding text contains credential cues (`token`, `api key`, `register`, etc.). It does **not** fall back to `externalDocs.url` or `info.contact.url` — those are docs landing pages or homepages, not credentials pages, and labeling a docs URL as "Get a key at:" is misleading. Catalog `auth_key_url:` (HTTPS-validated) overrides anything inferred from the spec.
2. **`Auth.Instructions` text + catalog override.** Free-form one-liner that renders under the URL ("Settings → Personal access tokens → Generate new") so users know what to do once they land on the page. Wired through `x-auth-instructions` and catalog `auth_instructions:`.
3. **Honest framing for docs URLs.** When `KeyURL` ends up empty but the spec has a docs URL (already populated as `WebsiteURL` from `externalDocs.url`, `info.contact.url`, or `x-website`), the printed CLI surfaces it under a separate **`See API docs: <URL>`** line — not the credential-shaped `Get a key at:` line. Same URL, honest framing.
4. **New `auth setup` subcommand with `--launch`.** Emits in `auth.go.tmpl` and `auth_simple.go.tmpl`. Prints the URL + instructions + the env var to set; `--launch` opens the URL in the OS default browser. Short-circuits when `cliutil.IsVerifyEnv()` is true so verifier subprocesses don't pop tabs (per the Side-Effect Commands rule in `AGENTS.md`). When KeyURL is empty, the launch URL falls back to `WebsiteURL` so `--launch` still does something useful, just labeled honestly.

Backfilled `auth_key_url` + `auth_instructions` for 14 catalog entries (GitHub, Stripe, Sentry, DigitalOcean, HubSpot, Asana, Discord, LaunchDarkly, Pipedrive, Plaid, Mercury, Front, Stytch, Twilio). Skipped where the right URL isn't obvious (`google-cloud-run`, `google-flights`, `kayak`, `petstore`, `postman-explore`, `producthunt`, `telegram`).

`AGENTS.md`, `docs/SPEC-EXTENSIONS.md`, `docs/CATALOG.md`, and the `skill.md.tmpl` are updated in the same change to satisfy the pointer-rot rule for the catalog validator and the skill-authoring rule.

## Example outputs

The user-facing UX changes show up in three surfaces. The two examples below show the difference between an inferred docs URL (Figma — no `x-auth-key-url`, parser falls back to `WebsiteURL`) and a curated catalog entry (GitHub — explicit `auth_key_url`).

### 1. `doctor` — runs on every health check

**Before:**
```
FAIL Auth: not configured
FAIL Env Vars: ERROR missing required: FIGMA_OAUTH2
hint: export FIGMA_OAUTH2=<your-key>
```

**After (Figma — only docs URL available, framed honestly):**
```
FAIL Auth: not configured
FAIL Env Vars: ERROR missing required: FIGMA_OAUTH2
hint: export FIGMA_OAUTH2=<your-key>
See API docs: https://developers.figma.com/docs/rest-api/
```

**After (GitHub — curated catalog entry with deep-link credential URL + instruction):**
```
FAIL Auth: not configured
hint: export GITHUB_TOKEN=<your-key>
Get a key at: https://github.com/settings/tokens
Generate a fine-grained personal access token (or classic) with the scopes your workflow needs.
```

### 2. The 401 / 403 error path — fired by `helpers.go` when the API rejects a request

**After (Figma):**
```
hint: permission denied. Your credentials are valid but lack access to this resource.
      Check that your API key has the required permissions.
      Set it with: export FIGMA_OAUTH2=<your-key>
      See API docs: https://developers.figma.com/docs/rest-api/
      Run 'figma-pp-cli doctor' to check auth status.
```

### 3. New `auth setup` command — the dedicated discovery surface

**Without `--launch` (always safe to run, prints only):**

`auth_simple.go.tmpl` flow with curated catalog entry (api_key / bearer_token):
```
$ testapi-pp-cli auth setup
Get a key at: https://example.com/account/keys
  Settings → API → Create new key

Then set:
  export TESTAPI_API_KEY="<your-token>"
  testapi-pp-cli auth set-token <token>
```

`auth.go.tmpl` flow (OAuth2, Figma — no credentials URL, only docs):
```
$ figma-pp-cli auth setup
See API docs for OAuth app registration: https://developers.figma.com/docs/rest-api/

Then run:
  figma-pp-cli auth login --client-id <id> --client-secret <secret>
```

**With `--launch` (opens the URL in the OS default browser):**
```
$ figma-pp-cli auth setup --launch
See API docs for OAuth app registration: https://developers.figma.com/docs/rest-api/
…
# (the browser opens https://developers.figma.com/docs/rest-api/)
```

**Under the verifier (short-circuits via `cliutil.IsVerifyEnv()`):**
```
$ PRINTING_PRESS_VERIFY=1 figma-pp-cli auth setup --launch
See API docs for OAuth app registration: https://developers.figma.com/docs/rest-api/
…
would launch: https://developers.figma.com/docs/rest-api/
```

## Scope

Primary area: `cli` — generator parser + catalog schema + embedded catalog data + five templates (`auth.go.tmpl`, `auth_simple.go.tmpl`, `doctor.go.tmpl`, `helpers.go.tmpl`, `mcp_tools.go.tmpl`) + `skill.md.tmpl` for the agent surface.

Why this belongs in this repo: the bare prompt is a symptom that shows up in *every* printed CLI with auth. Per `AGENTS.md` ("default to machine changes"), this is a machine change — touching the generator, parser, and templates that every future CLI inherits — not a per-CLI fix.

## AGENTS.md compliance audit

- **Side-Effect Commands rule** (§ Agent-Native Surface): the new `auth setup --launch` is print-by-default + explicit opt-in flag + `cliutil.IsVerifyEnv()` short-circuit. Verified end-to-end with `PRINTING_PRESS_VERIFY=1`.
- **MCP surface** (§ Default: expose; skip rules are exceptions): `auth setup` is correctly **not** exposed via MCP. The parent `auth` is in `frameworkCommands` in `cobratree/classify.go.tmpl`, and `walker.go.tmpl` does not recurse into framework-classified parents — confirmed by reading the walker. No `mcp:hidden` annotation needed.
- **Generator-reserved namespaces**: no hand-authored code added under `internal/cliutil/` or `internal/mcp/cobratree/`; `auth setup` lives in command-package templates and only *imports* `cliutil.IsVerifyEnv`.
- **Pointer-rot rule** (§ Editing AGENTS.md): the catalog validator gained `auth_instructions:`; the inline `Adding Catalog Entries` rule and `docs/CATALOG.md` are updated in this same PR. `docs/SPEC-EXTENSIONS.md` documents the inference precedence and the deliberate exclusion of `externalDocs.url` / `info.contact.url`.
- **Skill Authoring**: the api_key, oauth2, and bearer_token branches in `skill.md.tmpl` now name `auth setup` as the discovery step. Skill goldens regenerated to match.
- **Commit Style**: four commits, all `feat(cli):` / `docs(cli):` / `fix(cli):` with required scope. PR title carries `feat(cli):`.
- **Code & Comment Hygiene**: comments explain WHY (the side-effect rule, why `externalDocs.url` is intentionally not a fallback) rather than restating field names.

## Risk

- **Generator output diff for any auth-bearing CLI.** The new `auth setup` subcommand is unconditionally emitted by `auth.go.tmpl` and `auth_simple.go.tmpl`. Five goldens shifted: two `auth.go` files (gain `auth setup`), one `dogfood.json` (command count 40 → 41), and two `SKILL.md` files (skill template now mentions `auth setup`). The diffs are intentional and small — see the regenerated goldens in this PR.
- **Catalog schema additions.** Two new optional fields (`auth_key_url`, `auth_instructions`). Existing entries continue to validate.
- **Browser launch on a side-effect path.** Default behavior is print-only; `--launch` is opt-in; `cliutil.IsVerifyEnv()` short-circuits even when `--launch` is passed.

## Output Contract

The printed CLI's auth-prompt text gains an optional `Get a key at: <URL>` line (only when `KeyURL` is set) or a `See API docs: <URL>` line (only when `KeyURL` is empty and `WebsiteURL` is set), plus an optional instruction line under the URL. Every auth-bearing CLI now ships an `auth setup` subcommand with `--launch`. Catalog YAML schema gains optional `auth_key_url` (HTTPS) and `auth_instructions` (free text). Spec extensions gain `x-auth-key-url` (already existed) and `x-auth-instructions` (new). `SKILL.md` for auth-bearing CLIs now names `auth setup` in the auth-setup section.

## Verification

- `go test ./...` — all packages pass after fixing one test that asserted unused-import behavior in `auth.go` when `KeyURL` is empty (`TestTokenScaffoldingFollowsAuthSurface`).
- `go vet ./...` — clean.
- `go fmt ./...` — clean.
- `scripts/golden.sh verify` — 16/16 pass after `scripts/golden.sh update` for the five intentional diffs above.
- End-to-end with the upstream Figma OpenAPI spec:
  - `figma-pp-cli doctor` prints `See API docs: https://developers.figma.com/docs/rest-api/` (the docs URL is honestly framed; we do not pretend it's a keys page).
  - `figma-pp-cli auth setup` prints "See API docs for OAuth app registration: <URL>" + the next-step `auth login` command.
  - `auth setup --launch` works under `PRINTING_PRESS_VERIFY=1` (prints `would launch:` and exits without opening a browser).
- Tested simple-auth path with a synthetic `x-auth-key-url` spec: `auth setup` prints URL + instructions + `export TESTAPI_API_KEY=...` + `auth set-token` lines, and doctor surfaces both URL and instructions.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)