### PR TITLE
chore(ci): speed up PR checks via shard split + lighter lint cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,12 +49,25 @@ jobs:
         run: |
           echo "Skipping golangci-lint: no Go, module, lint config, or lint workflow files changed."
 
+      # setup-go's bundled cache restores both GOMODCACHE and GOCACHE as one
+      # ~1GB tarball; on this repo that adds ~75s of extract time per job.
+      # The lint job sees little payoff from a warm GOCACHE (golangci-lint
+      # has its own 1 MB analyzer cache that's already hit cleanly), so we
+      # skip the bundled cache and restore only the module cache manually.
       - uses: actions/setup-go@v6
         if: steps.changes.outputs.needs_lint == 'true'
         with:
           go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
+
+      - name: Cache Go modules
+        if: steps.changes.outputs.needs_lint == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: lint-gomodcache-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            lint-gomodcache-${{ runner.os }}-
 
       - uses: golangci/golangci-lint-action@v9
         if: steps.changes.outputs.needs_lint == 'true'
@@ -107,7 +120,8 @@ jobs:
       matrix:
         include:
           - shard: generator
-          - shard: pipeline-cli
+          - shard: pipeline
+          - shard: cli
           - shard: rest
     steps:
       - uses: actions/checkout@v6
@@ -127,8 +141,11 @@ jobs:
             generator)
               packages=(./internal/generator)
               ;;
-            pipeline-cli)
-              packages=(./internal/pipeline ./internal/cli)
+            pipeline)
+              packages=(./internal/pipeline)
+              ;;
+            cli)
+              packages=(./internal/cli)
               ;;
             rest)
               mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)$')


### PR DESCRIPTION
## Intent

Reduce wall-clock time of the PR CI workflow (`.github/workflows/lint.yml`). On a recent PR (#871), the workflow took 4:16 with two long-pole jobs at ~3:40 each (`test (pipeline-cli)` and `go-lint`). The slow loop discourages quick iteration on PRs.

Issue: N/A — observation while iterating on PR #871.

## Approach

Two targeted edits to `.github/workflows/lint.yml`, derived from reading the actual job timings and step logs of the previous PR run (id `25619063212`):

**A. Split the `pipeline-cli` test shard into separate `pipeline` and `cli` shards.** The matrix currently runs `internal/pipeline` and `internal/cli` serially in one shard (~238s on CI; ~85s locally). Splitting them lets the Go runtime parallelize across two runners, dropping the shard's contribution to the critical path from ~238s to ~140s (the slower of the two). The `rest` shard's exclusion regex (`/internal/(generator|pipeline|cli)$`) already excludes both packages, so no regex change is needed. `cli` and `pipeline` use the same `setup-go` step the other shards already use.

**B. Trim the `setup-go` cache footprint on the lint job.** From the lint step log, `actions/setup-go@v6` restored a **~1085 MB** bundled cache (GOCACHE + GOMODCACHE) that took **~75s** to extract — for a job whose actual lint work is 125s. golangci-lint maintains its own analyzer cache (~1 MB, hit cleanly per the same log: `Cache hit occurred on the primary key... not saving cache`), so the lint job sees little payoff from a warm Go *build* cache. The fix uses `cache: false` on `setup-go` and adds an explicit `actions/cache@v4` for `~/go/pkg/mod` only, with `restore-keys` for cross-PR fallback. The Go build cache rebuilds inside lint, but golangci-lint's typecheck pass under cold GOCACHE is faster than the 75s tar extract it replaces.

The other shards (`generator`, `rest`, `generated-test (h3)`, `golden`) keep `setup-go: cache: true` because their workload (full test compilation) genuinely benefits from a warm GOCACHE.

## Scope

Primary area: `ci` — only `.github/workflows/lint.yml` changes. No generator, template, or printed-CLI behavior touched.

Why this belongs in this repo: workflows live here, and this is the developer-facing CI loop for every PR. No printed-CLI surface is involved.

## Risk

- **Lint job's first run after merge will miss the new cache key (`lint-gomodcache-Linux-...`)**. Modules will download cold (~30s once). Subsequent runs hit the cache normally.
- **Lint without warm GOCACHE may be slower in absolute terms than today's lint with warm GOCACHE.** The bet is that 75s of saved tar-extract outweighs the additional cold-compile time inside golangci-lint. If that bet is wrong on the post-merge run, the change is one-line revertable.
- **Test sharding semantics unchanged.** `pipeline` and `cli` shards run the exact same `go test -short -json -timeout 12m` command the previous combined shard ran, just with different package lists. The merge-protection check `test` aggregates all shards via `if: ${{ always() }}` + `result == "success"`, so adding shards is transparent to branch protection.
- **`main-ci.yml`'s full-test job is unaffected.** It runs `go test ./...` in a single job and is intentionally redundant as a stable signal for branch protection; this PR does not touch it.

## Output Contract

N/A. No templates, generated files, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts change.

## Verification

- `ruby -ryaml -e 'YAML.load_file(...)'` on `.github/workflows/lint.yml` — parses cleanly; `test-shard.strategy.matrix.include` now contains `[generator, pipeline, cli, rest]`; `lint.steps` contains the new `Cache Go modules` step between `setup-go` and `golangci-lint-action`.
- Reviewed the full `gh run view 25619063212 --log` output for the lint job to confirm:
  - The 75s extract is on `actions/setup-go` (not `golangci-lint-action`).
  - golangci-lint's analyzer cache is already hit cleanly (1 MB, primary-key hit, no save).
  - Cache size is reported as `~1085 MB` for the bundled setup-go tarball.
- Did not modify any Go code; existing `go test`, `go vet`, golden, or generated-test passes are unaffected by this change in isolation. CI on this PR is the canonical verification.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)