### PR TITLE
fix(cli): infer resource-prefixed IDField from item-schema properties

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2865,17 +2865,16 @@ func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) strin
 	if singular == "" {
 		return ""
 	}
-	suffixes := []string{"_id", "_uuid", "_guid"}
-	for _, suffix := range suffixes {
+	// Sort property names so behavior is deterministic across Go map
+	// iteration order; this only matters when a schema declares multiple
+	// keys that snake-case to the same target, which is unusual.
+	propNames := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+	for _, suffix := range []string{"_id", "_uuid", "_guid"} {
 		target := singular + suffix
-		// Sort property names so behavior is deterministic across Go map
-		// iteration order; this only matters when a schema declares multiple
-		// keys that snake-case to the same target, which is unusual.
-		propNames := make([]string, 0, len(schema.Properties))
-		for name := range schema.Properties {
-			propNames = append(propNames, name)
-		}
-		sort.Strings(propNames)
 		for _, propName := range propNames {
 			if toSnakeCase(propName) == target {
 				return propName
@@ -2906,6 +2905,13 @@ func singularizeIdentifier(s string) string {
 		"statuses":   "status",
 		"addresses":  "address",
 		"analyses":   "analysis",
+		// `<stem>+s` plurals on `ie`/`ix`-ending stems that the generic
+		// `ies → y` rule would otherwise mangle (`movies → movy`).
+		"movies":   "movie",
+		"series":   "series",
+		"matrices": "matrix",
+		"indices":  "index",
+		"vertices": "vertex",
 	}
 	if singular, ok := irregulars[last]; ok {
 		return prefix + singular

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1699,7 +1699,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			if pathResourceIDOverride != "" {
 				endpoint.IDField = pathResourceIDOverride
 			} else {
-				endpoint.IDField = resolveIDFieldFromResponseSchema(op)
+				endpoint.IDField = resolveIDFieldFromResponseSchema(op, targetResourceName)
 			}
 			endpoint.Critical = pathCritical
 
@@ -2787,13 +2787,18 @@ func readTierExtension(extensions map[string]any, context string) string {
 	return strings.TrimSpace(tier)
 }
 
-// resolveIDFieldFromResponseSchema implements tiers 2-4 of the IDField fallback
-// chain: prefer "id", then "name", then the first scalar field listed in the
+// resolveIDFieldFromResponseSchema implements tiers 2-5 of the IDField fallback
+// chain: prefer "id", then a resource-prefixed key (`<singular>_id` /
+// `_uuid` / `_guid`), then "name", then the first scalar field listed in the
 // response schema's `required:` array (walking properties in their schema order).
 // Returns "" when no field qualifies; templates fall through to runtime list
 // scanning. Tier 1 (`x-resource-id` extension) is handled separately by the
 // caller — it overrides every tier here.
-func resolveIDFieldFromResponseSchema(op *openapi3.Operation) string {
+//
+// resourceName is the parser's targetResourceName for this operation; it drives
+// the resource-prefixed heuristic and may be empty for synthetic endpoints,
+// in which case that tier is skipped.
+func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName string) string {
 	if op == nil || op.Responses == nil {
 		return ""
 	}
@@ -2816,12 +2821,22 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation) string {
 	if _, ok := itemSchema.Properties["id"]; ok {
 		return "id"
 	}
-	// Tier 3: explicit `name`
+
+	// Tier 3: resource-prefixed key. Catches APIs whose item schemas key off
+	// `<singular>_id` instead of a bare `id` (e.g. podscan's Category with
+	// `category_id`/`category_name`). Both the resource name and each property
+	// name are normalized to snake_case, so `categoryId`/`category_id` and
+	// `auth-tokens`/`auth_token_id` match through the same comparison.
+	if id := resourcePrefixedIDField(itemSchema, resourceName); id != "" {
+		return id
+	}
+
+	// Tier 4: explicit `name`
 	if _, ok := itemSchema.Properties["name"]; ok {
 		return "name"
 	}
 
-	// Tier 4: first scalar field appearing in the schema's required[] array,
+	// Tier 5: first scalar field appearing in the schema's required[] array,
 	// matched against properties in their schema-declared order. kin-openapi
 	// preserves YAML/JSON property order in MapKeys/Extensions but not via
 	// range over Properties (it's a Go map). Fall back to iterating the
@@ -2838,6 +2853,72 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation) string {
 	}
 
 	return ""
+}
+
+// resourcePrefixedIDField returns the first property whose snake-cased name
+// matches `<singular_resource>_id`, then `_uuid`, then `_guid`. Returns "" when
+// the resource name is empty or no property matches. Property names are
+// returned verbatim so callers preserve the spec's original casing (e.g.
+// `categoryId` rather than `category_id`).
+func resourcePrefixedIDField(schema *openapi3.Schema, resourceName string) string {
+	singular := singularizeIdentifier(toSnakeCase(resourceName))
+	if singular == "" {
+		return ""
+	}
+	suffixes := []string{"_id", "_uuid", "_guid"}
+	for _, suffix := range suffixes {
+		target := singular + suffix
+		// Sort property names so behavior is deterministic across Go map
+		// iteration order; this only matters when a schema declares multiple
+		// keys that snake-case to the same target, which is unusual.
+		propNames := make([]string, 0, len(schema.Properties))
+		for name := range schema.Properties {
+			propNames = append(propNames, name)
+		}
+		sort.Strings(propNames)
+		for _, propName := range propNames {
+			if toSnakeCase(propName) == target {
+				return propName
+			}
+		}
+	}
+	return ""
+}
+
+// singularizeIdentifier returns a simple singular form of a snake-cased
+// identifier. Mirrors spec.singularize for parser-local use without exporting
+// the spec helper. Only the trailing token is singularized so multi-word
+// identifiers like `auth_tokens` become `auth_token`.
+func singularizeIdentifier(s string) string {
+	if s == "" {
+		return ""
+	}
+	idx := strings.LastIndex(s, "_")
+	prefix, last := "", s
+	if idx >= 0 {
+		prefix, last = s[:idx+1], s[idx+1:]
+	}
+	irregulars := map[string]string{
+		"properties": "property",
+		"companies":  "company",
+		"categories": "category",
+		"entries":    "entry",
+		"statuses":   "status",
+		"addresses":  "address",
+		"analyses":   "analysis",
+	}
+	if singular, ok := irregulars[last]; ok {
+		return prefix + singular
+	}
+	switch {
+	case strings.HasSuffix(last, "ies") && len(last) > 3:
+		return prefix + last[:len(last)-3] + "y"
+	case strings.HasSuffix(last, "ses"), strings.HasSuffix(last, "xes"), strings.HasSuffix(last, "zes"):
+		return prefix + last[:len(last)-2]
+	case strings.HasSuffix(last, "s") && !strings.HasSuffix(last, "ss") && len(last) > 1:
+		return prefix + last[:len(last)-1]
+	}
+	return prefix + last
 }
 
 // unwrapItemSchema returns the schema of items inside a list response. Handles

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3661,6 +3661,154 @@ paths:
 	}
 }
 
+// TestParseIDFieldResourcePrefixedHeuristic covers list responses whose item
+// schemas key off `<singular_resource>_id` (or `_uuid`/`_guid`) instead of a
+// bare `id`. Without this heuristic, APIs like podscan whose Category items
+// only carry `category_id` would fall through every fallback tier and leave
+// IDField empty, causing sync to silently drop every row.
+func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		schemaYAML string
+		wantID     string
+	}{
+		{
+			name: "plural resource picks <singular>_id",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    category_id: {type: string}
+                    category_name: {type: string}
+                    category_display_name: {type: string}
+`,
+			wantID: "category_id",
+		},
+		{
+			name: "singular resource picks <name>_id",
+			path: "/user",
+			schemaYAML: `                  type: object
+                  properties:
+                    user_id: {type: string}
+                    user_name: {type: string}
+`,
+			wantID: "user_id",
+		},
+		{
+			name: "id wins over <singular>_id (REST convention)",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    id: {type: string}
+                    category_id: {type: string}
+`,
+			wantID: "id",
+		},
+		{
+			name: "<singular>_id wins over name",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    name: {type: string}
+                    category_id: {type: string}
+`,
+			wantID: "category_id",
+		},
+		{
+			name: "_uuid suffix is recognized when _id is absent",
+			path: "/sessions",
+			schemaYAML: `                  type: object
+                  properties:
+                    session_uuid: {type: string}
+                    started_at: {type: string}
+`,
+			wantID: "session_uuid",
+		},
+		{
+			name: "_guid suffix is recognized when _id and _uuid are absent",
+			path: "/devices",
+			schemaYAML: `                  type: object
+                  properties:
+                    device_guid: {type: string}
+                    last_seen: {type: string}
+`,
+			wantID: "device_guid",
+		},
+		{
+			name: "camelCase property name normalizes to snake match",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    categoryId: {type: string}
+                    categoryName: {type: string}
+`,
+			wantID: "categoryId",
+		},
+		{
+			name: "kebab-case path resource singularizes correctly",
+			path: "/auth-tokens",
+			schemaYAML: `                  type: object
+                  properties:
+                    auth_token_id: {type: string}
+                    issued_at: {type: string}
+`,
+			wantID: "auth_token_id",
+		},
+		{
+			name: "_id precedence: prefers _id over _uuid",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    category_id: {type: string}
+                    category_uuid: {type: string}
+`,
+			wantID: "category_id",
+		},
+		{
+			name: "no <singular>_id falls through to remaining tiers",
+			path: "/things",
+			schemaYAML: `                  type: object
+                  properties:
+                    name: {type: string}
+                    other_id: {type: string}
+`,
+			wantID: "name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  ` + tt.path + `:
+    get:
+      operationId: list
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+` + tt.schemaYAML)
+			parsed, err := Parse(yamlSpec)
+			require.NoError(t, err)
+
+			ep := findEndpoint(t, parsed, tt.path)
+			assert.Equal(t, tt.wantID, ep.IDField)
+		})
+	}
+}
+
 // TestParseXResourceIDAppliesToEveryOperationOnPath exercises the "extensions
 // live on the path item" rule — both GET and POST operations under /widgets
 // inherit the x-resource-id and x-critical values, even though x-critical is

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3776,6 +3776,18 @@ func TestParseIDFieldResourcePrefixedHeuristic(t *testing.T) {
 `,
 			wantID: "name",
 		},
+		{
+			// Without the irregulars override, `movies` would singularize
+			// via the `ies → y` rule to `movy`, missing `movie_id`.
+			name: "ie-ending stem keeps singular form (movies → movie)",
+			path: "/movies",
+			schemaYAML: `                  type: object
+                  properties:
+                    movie_id: {type: string}
+                    title: {type: string}
+`,
+			wantID: "movie_id",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds a resource-prefixed key heuristic to the OpenAPI parser's IDField fallback chain so APIs whose item schemas key off `<singular_resource>_id` (instead of a bare `id`) get a non-empty `Endpoint.IDField` at parse time. Without this, sync silently consumes pages and stores zero rows, exiting with code 0 — exactly the failure mode reported in #915 against podscan's `Category` resource.

The heuristic slots in between the existing `id` tier and the existing `name` tier:

1. `x-resource-id` extension (unchanged)
2. bare `id` (unchanged)
3. **NEW**: `<singular>_id`, then `<singular>_uuid`, then `<singular>_guid` against item-schema properties
4. bare `name` (unchanged)
5. first scalar in `required[]` (unchanged)

Resource name and property name are both normalized via `toSnakeCase` before comparison, so `categoryId` ↔ `category_id` and `/auth-tokens` ↔ `auth_token_id` match through the same path. `singularizeIdentifier` handles the irregular plurals (`categories` → `category`, `entries` → `entry`) and only singularizes the trailing token of a snake-cased identifier so multi-word resources keep their prefix.

## Behavior

- Item schema with `id` and `category_id` → `id` wins (REST convention preserved).
- Item schema with only `category_id` → `category_id` wins (was empty before).
- Item schema with `name` and `category_id` → `category_id` wins.
- `_id` is preferred over `_uuid`, which is preferred over `_guid`.
- Synthetic endpoints with no resource name skip the new tier and fall through unchanged.

## Out of scope

- Promoting `all_items_failed_id_extraction` to a critical severity (called out in the issue as a related-but-separate ask).
- Library-wide regen sweep to refresh published CLIs that ship empty `resourceIDFieldOverrides{}`.

## Test plan

- [x] `rtk go test ./internal/openapi/ -run TestParseIDFieldResourcePrefixedHeuristic -v` — 10 new sub-cases covering plural, singular, kebab path, camelCase property, suffix precedence, and existing-tier interactions.
- [x] `rtk go test ./...` — 3428 tests in 34 packages, all passing.
- [x] `rtk scripts/golden.sh verify` — 16 cases, all passing (no goldens shifted).
- [x] `rtk go vet ./...`, `rtk golangci-lint run ./...`, `rtk git diff --check` — clean.

Closes  #915