### PR TITLE
fix(cli): infer resource-prefix IDField when generic chain returns empty

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1699,7 +1699,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			if pathResourceIDOverride != "" {
 				endpoint.IDField = pathResourceIDOverride
 			} else {
-				endpoint.IDField = resolveIDFieldFromResponseSchema(op)
+				endpoint.IDField = resolveIDFieldFromResponseSchema(op, targetResourceName)
 			}
 			endpoint.Critical = pathCritical
 
@@ -2787,13 +2787,17 @@ func readTierExtension(extensions map[string]any, context string) string {
 	return strings.TrimSpace(tier)
 }
 
-// resolveIDFieldFromResponseSchema implements tiers 2-4 of the IDField fallback
-// chain: prefer "id", then "name", then the first scalar field listed in the
-// response schema's `required:` array (walking properties in their schema order).
-// Returns "" when no field qualifies; templates fall through to runtime list
-// scanning. Tier 1 (`x-resource-id` extension) is handled separately by the
-// caller — it overrides every tier here.
-func resolveIDFieldFromResponseSchema(op *openapi3.Operation) string {
+// resolveIDFieldFromResponseSchema implements tiers 2-5 of the IDField
+// fallback chain: prefer "id", then "name", then the first scalar field
+// listed in the response schema's `required:` array (walking properties in
+// their schema order), then a resource-name-prefix probe (e.g. category_id
+// for resource "categories"). Returns "" when no field qualifies; templates
+// fall through to runtime list scanning. Tier 1 (`x-resource-id` extension)
+// is handled separately by the caller — it overrides every tier here.
+//
+// resourceName is the kebab-case resource slug the parser derived for this
+// path (the same value used to key Resources). Empty disables tier 5.
+func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName string) string {
 	if op == nil || op.Responses == nil {
 		return ""
 	}
@@ -2837,6 +2841,56 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation) string {
 		}
 	}
 
+	// Tier 5: resource-name-prefix probe. APIs that prefix every key field
+	// with the resource name ({category_id, category_name, ...}) leave tier 4
+	// empty when `required:` is unannotated, which then causes runtime
+	// extractID to fall through the generic list and silently drop every row.
+	// Try {singular}_id, {resource}_id, {singular}_uuid, {resource}_uuid,
+	// {singular}_guid, {resource}_guid in that order.
+	if name := resolveIDFieldFromResourceNamePrefix(itemSchema, resourceName); name != "" {
+		return name
+	}
+
+	return ""
+}
+
+// resolveIDFieldFromResourceNamePrefix probes the array-item schema for a
+// scalar property named "<resource>_id", "<singular>_id", or the same
+// patterns with _uuid / _guid suffixes. Returns "" when no candidate
+// matches. resourceName is normalized to lowercase snake_case (kebab "-"
+// becomes "_") so kebab-case paths still match snake_case JSON fields.
+func resolveIDFieldFromResourceNamePrefix(itemSchema *openapi3.Schema, resourceName string) string {
+	if itemSchema == nil || resourceName == "" {
+		return ""
+	}
+	base := strings.ReplaceAll(strings.ToLower(resourceName), "-", "_")
+	if base == "" {
+		return ""
+	}
+	singular := strings.ReplaceAll(strings.ToLower(spec.Singularize(resourceName)), "-", "_")
+
+	seen := map[string]bool{}
+	candidates := make([]string, 0, 6)
+	add := func(c string) {
+		if c == "" || seen[c] {
+			return
+		}
+		seen[c] = true
+		candidates = append(candidates, c)
+	}
+	for _, suffix := range []string{"_id", "_uuid", "_guid"} {
+		add(singular + suffix)
+		add(base + suffix)
+	}
+	for _, name := range candidates {
+		propRef, ok := itemSchema.Properties[name]
+		if !ok || propRef == nil || propRef.Value == nil {
+			continue
+		}
+		if isScalarSchema(propRef.Value) {
+			return name
+		}
+	}
 	return ""
 }
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2864,9 +2864,6 @@ func resolveIDFieldFromResourceNamePrefix(itemSchema *openapi3.Schema, resourceN
 		return ""
 	}
 	base := strings.ReplaceAll(strings.ToLower(resourceName), "-", "_")
-	if base == "" {
-		return ""
-	}
 	singular := strings.ReplaceAll(strings.ToLower(spec.Singularize(resourceName)), "-", "_")
 
 	seen := map[string]bool{}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2864,7 +2864,7 @@ func resolveIDFieldFromResourceNamePrefix(itemSchema *openapi3.Schema, resourceN
 		return ""
 	}
 	base := strings.ReplaceAll(strings.ToLower(resourceName), "-", "_")
-	singular := strings.ReplaceAll(strings.ToLower(spec.Singularize(resourceName)), "-", "_")
+	singular := strings.ReplaceAll(strings.ToLower(singularizeKebab(resourceName)), "-", "_")
 
 	seen := map[string]bool{}
 	candidates := make([]string, 0, 6)
@@ -2889,6 +2889,21 @@ func resolveIDFieldFromResourceNamePrefix(itemSchema *openapi3.Schema, resourceN
 		}
 	}
 	return ""
+}
+
+// singularizeKebab applies spec.Singularize to the last segment of a kebab
+// identifier and rejoins. spec.Singularize's irregulars table only matches
+// bare lowercase words, so feeding it a compound name like "pod-analyses"
+// would skip the irregular ("analyses" -> "analysis") and produce
+// "pod-analyse" via the suffix-strip path. Splitting first preserves the
+// irregular handling on the entity word at the tail of the path.
+func singularizeKebab(s string) string {
+	if !strings.Contains(s, "-") {
+		return spec.Singularize(s)
+	}
+	parts := strings.Split(s, "-")
+	parts[len(parts)-1] = spec.Singularize(parts[len(parts)-1])
+	return strings.Join(parts, "-")
 }
 
 // unwrapItemSchema returns the schema of items inside a list response. Handles

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3530,6 +3530,138 @@ paths:
 	}
 }
 
+// TestParseIDFieldResourcePrefixHeuristic covers the {singular}_id /
+// {resource}_id (and _uuid / _guid) fallback that fires when the existing
+// id/name/required-scalar tiers all fail. APIs that prefix every key field
+// with the resource name (Podscan-style {category_id, category_name, ...})
+// silently dropped rows before this tier — runtime extractID couldn't
+// resolve a primary key, sync stored 0 of N consumed items.
+func TestParseIDFieldResourcePrefixHeuristic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		schemaYAML string
+		wantID     string
+	}{
+		{
+			name: "singular {resource}_id from plural path: category_id for /categories",
+			path: "/categories",
+			schemaYAML: `                  type: object
+                  properties:
+                    category_id: {type: string}
+                    category_name: {type: string}
+                    category_display_name: {type: string}
+`,
+			wantID: "category_id",
+		},
+		{
+			name: "exact {resource}_id when resource is already singular",
+			path: "/notification",
+			schemaYAML: `                  type: object
+                  properties:
+                    notification_id: {type: string}
+                    body: {type: string}
+`,
+			wantID: "notification_id",
+		},
+		{
+			name: "kebab-case resource maps to snake_case prefix: marker_types_id",
+			path: "/marker-types",
+			schemaYAML: `                  type: object
+                  properties:
+                    marker_types_id: {type: string}
+                    description: {type: string}
+`,
+			wantID: "marker_types_id",
+		},
+		{
+			name: "_uuid suffix when {resource}_id is absent",
+			path: "/widgets",
+			schemaYAML: `                  type: object
+                  properties:
+                    widget_uuid: {type: string}
+                    label: {type: string}
+`,
+			wantID: "widget_uuid",
+		},
+		{
+			name: "_guid suffix when {resource}_id and _uuid are absent",
+			path: "/widgets",
+			schemaYAML: `                  type: object
+                  properties:
+                    widget_guid: {type: string}
+                    label: {type: string}
+`,
+			wantID: "widget_guid",
+		},
+		{
+			name: "tier 2 (id) still wins when both id and {resource}_id present",
+			path: "/widgets",
+			schemaYAML: `                  type: object
+                  properties:
+                    id: {type: string}
+                    widget_id: {type: string}
+`,
+			wantID: "id",
+		},
+		{
+			name: "object-typed prefix property is skipped (must be scalar)",
+			path: "/widgets",
+			schemaYAML: `                  type: object
+                  properties:
+                    widget_id:
+                      type: object
+                      properties:
+                        inner: {type: string}
+                    widget_uuid: {type: string}
+`,
+			wantID: "widget_uuid",
+		},
+		{
+			name: "no match: bottoms out empty",
+			path: "/widgets",
+			schemaYAML: `                  type: object
+                  properties:
+                    label: {type: string}
+                    description: {type: string}
+`,
+			wantID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  ` + tt.path + `:
+    get:
+      operationId: list
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+` + tt.schemaYAML)
+			parsed, err := Parse(yamlSpec)
+			require.NoError(t, err)
+
+			ep := findEndpoint(t, parsed, tt.path)
+			assert.Equal(t, tt.wantID, ep.IDField)
+		})
+	}
+}
+
 // TestParseIDFieldEnvelopeUnwrapping covers list responses whose payload is an
 // object envelope wrapping a single named array (e.g. {events: [...],
 // cursor: "..."}; many list APIs use this shape with the resource name as the

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3629,6 +3629,20 @@ func TestParseIDFieldResourcePrefixHeuristic(t *testing.T) {
 `,
 			wantID: "",
 		},
+		{
+			// pod-analyses -> "pod-analysis" via per-segment singularize, then
+			// snake-case probe lookup -> pod_analysis_id. Without per-segment
+			// handling, spec.Singularize("pod-analyses") would fall through to
+			// the "ses" suffix rule and produce "pod-analyse" instead.
+			name: "compound kebab path with irregular plural tail singularizes per segment",
+			path: "/pod-analyses",
+			schemaYAML: `                  type: object
+                  properties:
+                    pod_analysis_id: {type: string}
+                    summary: {type: string}
+`,
+			wantID: "pod_analysis_id",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1501,6 +1501,13 @@ func operationIDParams(idParam, singularName string) []Param {
 	}}
 }
 
+// Singularize returns a simple singular form of a plural noun. Exported so
+// other packages (notably the OpenAPI parser's resource-prefix ID heuristic)
+// can reuse the same rules without re-implementing the irregulars table.
+func Singularize(s string) string {
+	return singularize(s)
+}
+
 // singularize returns a simple singular form of a plural noun.
 // Handles common patterns; irregular forms use a lookup table.
 func singularize(s string) string {


### PR DESCRIPTION
## Summary

The OpenAPI parser's IDField fallback chain (`id`, `name`, required-scalar) returned `""` for APIs whose item schemas prefix every key field with the resource name (`{category_id, category_name, ...}`) and whose specs don't annotate `required:`. Empty IDField → empty `resourceIDFieldOverrides` map → runtime `extractID` falls through the generic list (`id, ID, name, uuid, slug, key, code, uid`) → `all_items_failed_id_extraction` → 0 rows stored, exit 0. Surfaced on Podscan (`Category` shape) and Spypoint runs.

This adds a **tier 5** to `resolveIDFieldFromResponseSchema` that probes the array-item schema for `{singular_resource_name}_id`, `{resource}_id`, and the same patterns with `_uuid` / `_guid` suffixes. Kebab-case resource slugs (e.g. `markers-types`) map to snake_case field names (`markers_types_id`) so the schema lookup matches typical JSON shapes.

## Behavior

- **Tier 1 (`x-resource-id`)** — unchanged, still wins.
- **Tiers 2-4 (`id` / `name` / required-scalar)** — unchanged.
- **Tier 5 (NEW)** — fires only when tiers 2-4 return `""`. APIs with a plain `id` field keep their current IDField; the test `tier 2 (id) still wins when both id and {resource}_id present` pins this contract.
- Property values must be scalar to match (object-typed `widget_id` is skipped, falls through to `_uuid` / `_guid`).

## Files

- `internal/openapi/parser.go` — extends `resolveIDFieldFromResponseSchema` and adds `resolveIDFieldFromResourceNamePrefix` helper. Call site passes `targetResourceName`.
- `internal/spec/spec.go` — exports `Singularize` as a public wrapper over the existing private `singularize` so the parser can reuse the irregulars table without duplicating it.
- `internal/openapi/parser_test.go` — eight new table-driven cases covering plural→singular, already-singular, kebab-case, `_uuid` / `_guid` fallbacks, scalar-only requirement, the bottom-out case, and the existing-tier-wins guarantee.

## Verification

- `go test ./...` — 3426 passed
- `go vet ./...` — clean
- `go fmt ./...` — clean
- `scripts/golden.sh verify` — 16/16 cases passed (no generator-output drift)
- `golangci-lint run ./...` — clean

Refs #915

---

Replaces draft PR #946, which was branched from a stale worktree base and ended up carrying orphan commits from the squash-merged #854.