### PR TITLE
fix(cli): route explicit --csv/--quiet/--plain above piped-pipe gate

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3195,8 +3195,10 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 	assert.Contains(t, content, `"resource":`)
 	assert.Contains(t, content, `"status":   statusCode`)
 	assert.Contains(t, content, `"success":  statusCode >= 200 && statusCode < 300`)
-	// Envelope fires on both --json and auto-JSON (piped/non-TTY)
-	assert.Contains(t, content, `flags.asJSON || !isTerminal(cmd.OutOrStdout())`)
+	// Envelope fires on --json and on piped output, but explicit format flags
+	// (--csv, --quiet, --plain) opt out of the auto-JSON path so piped agents
+	// that asked for a non-JSON format actually get it.
+	assert.Contains(t, content, `flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain)`)
 
 	// --quiet is respected before envelope output
 	assert.Contains(t, content, "if flags.quiet {")
@@ -3215,6 +3217,41 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 	assert.Contains(t, content, `envelope["dry_run"] = true`)
 	assert.Contains(t, content, `envelope["status"] = 0`)
 	assert.Contains(t, content, `envelope["success"] = false`)
+}
+
+// TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the
+// piped-output auto-JSON gate must defer to explicit --csv / --quiet /
+// --plain flags so piped consumers that asked for a non-JSON format
+// actually get it. Before the fix, the gate read
+// `flags.asJSON || !isTerminal(...)` and emitted JSON whenever stdout was
+// piped, which is the common case for agents and shell pipelines, so
+// `--csv | head` produced JSON instead of CSV. The fix adds the
+// `&& !flags.csv && !flags.quiet && !flags.plain` clause so an explicit
+// format choice opts out of the auto-JSON path.
+//
+// Read the templates directly to pin every gate site at once: the
+// command_endpoint and command_promoted templates emit into hundreds of
+// generated files (pet_add.go, pet_list.go, every promoted command), and
+// a per-file assertion would miss any new gate copies that drift in.
+func TestPipedJsonGateRespectsExplicitFormatFlags(t *testing.T) {
+	t.Parallel()
+
+	expected := `flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain)`
+	stale := `flags.asJSON || !isTerminal(cmd.OutOrStdout())`
+
+	for _, path := range []string{
+		filepath.Join("templates", "command_endpoint.go.tmpl"),
+		filepath.Join("templates", "command_promoted.go.tmpl"),
+	} {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err, "template must exist: %s", path)
+		body := string(data)
+
+		assert.Contains(t, body, expected,
+			"%s must gate auto-JSON behind format-flag escape hatch so piped --csv/--quiet/--plain reach the standard pipeline", path)
+		assert.NotContains(t, body, stale,
+			"%s still contains the bare piped-pipe gate; every site must include the format-flag escape hatch", path)
+	}
 }
 
 func TestGeneratedOutput_GetCommandsLackMutationEnvelope(t *testing.T) {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -491,7 +491,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 					}
 				}
 			}
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				if flags.quiet {
 					return nil
 				}
@@ -540,8 +540,10 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -250,14 +250,12 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 				printProvenance(cmd, len(countItems), prov)
 			}
-			// CSV bypasses JSON pipe path so --csv works when piped
-			if flags.csv {
-				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
-			}
 			// For JSON output, wrap with provenance envelope. --select wins over
 			// --compact when both are set; --compact only runs when no explicit
-			// fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// fields were requested. Explicit format flags (--csv, --quiet, --plain)
+			// opt out of the auto-JSON path so piped consumers that asked for a
+			// non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -85,7 +85,7 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				if flags.quiet {
 					return nil
 				}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -58,8 +58,10 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -63,8 +63,10 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -88,7 +88,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				if flags.quiet {
 					return nil
 				}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -44,14 +44,12 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 				printProvenance(cmd, len(countItems), prov)
 			}
-			// CSV bypasses JSON pipe path so --csv works when piped
-			if flags.csv {
-				return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
-			}
 			// For JSON output, wrap with provenance envelope. --select wins over
 			// --compact when both are set; --compact only runs when no explicit
-			// fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// fields were requested. Explicit format flags (--csv, --quiet, --plain)
+			// opt out of the auto-JSON path so piped consumers that asked for a
+			// non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -74,7 +74,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				if flags.quiet {
 					return nil
 				}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -39,8 +39,10 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -40,8 +40,10 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -39,8 +39,10 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 			}
 			// For JSON output, wrap with provenance envelope before passing through flags.
 			// --select wins over --compact when both are set; --compact only runs when
-			// no explicit fields were requested.
-			if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				filtered := data
 				if flags.selectFields != "" {
 					filtered = filterFields(filtered, flags.selectFields)


### PR DESCRIPTION
## Intent

Fix bug #1 of [#918](https://github.com/mvanhorn/cli-printing-press/issues/918) — the `--csv`/`--quiet`/`--plain` flags were ignored when stdout is piped. The gate at the top of `command_endpoint.go.tmpl` and `command_promoted.go.tmpl` read `flags.asJSON || !isTerminal(...)`, so piped output (the common case for agents and shell pipelines) silently rendered as a JSON envelope regardless of an explicit format flag.

Issue: Refs #918

## Approach

Add `&& !flags.csv && !flags.quiet && !flags.plain` to the auto-JSON clause at every gate site so an explicit format choice opts out of the auto-JSON path and falls through to the standard pipeline (`printOutputWithFlags`). The smart-default principle (terminal=table, pipe=JSON) now yields to the user's explicit override.

The now-redundant `if flags.csv { return printOutputWithFlags(...) }` short-circuit in `command_promoted.go.tmpl` is removed: post-fix, `--csv` reaches the standard pipeline through the same path as `--quiet`/`--plain`, so the per-flag carve-out is dead code.

## Scope

Primary area: generator templates (`internal/generator/templates/command_endpoint.go.tmpl`, `command_promoted.go.tmpl`).

Bugs #2 (nested-envelope pagination introspection in `internal/openapi/parser.go`) and #3 (silent `printQuiet`, missing `printPlain` in `helpers.go.tmpl`) from the same issue are independent surfaces and ship as follow-up PRs. Bug #3 in particular needs design choices for the `printQuiet` selector and `printPlain` column shape that don't fit a surgical fix.

## Risk

Behavior change for piped consumers passing an explicit format flag:

- **`--csv` piped**: was JSON envelope → now CSV (the documented behavior).
- **`--quiet` piped**: was JSON envelope → now silent (matches the existing `printOutputWithFlags` `if flags.quiet { return nil }` branch). This is bug #3 becoming visible; tracked in the issue, will be fixed in the follow-up PR that implements `printQuiet` per the help text.
- **`--plain` piped**: was JSON envelope → now JSON via the `printOutput` self-defaulting path. Same end behavior; `--plain` is unimplemented and tracked in bug #3.
- **`--json` piped or no format flag piped**: unchanged. The gate still emits the auto-JSON envelope.

Per AGENTS.md, this is `fix(cli):` not `feat(cli)!`: it corrects incorrect behavior of an already-shipping flag and does not remove or rename a documented surface.

## Output Contract

Generator-output diff: every `*_list.go` / mutating-endpoint file and promoted-command file emits the new gate clause. Sample (`projects_list.go`):

```diff
- if flags.asJSON || !isTerminal(cmd.OutOrStdout()) {
+ if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
```

Promoted commands additionally drop the `flags.csv` carve-out block (4 lines).

12 golden fixtures across 3 cases (`generate-golden-api`, `generate-public-param-names`, `generate-tier-routing-api`) regenerated to reflect the new gate. No other golden cases touched.

## Verification

- `go test ./...` — 3436 passed
- `go vet ./...` — clean
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 16 cases pass post-update
- `git diff --check` — clean

## Tests

- `TestPipedJsonGateRespectsExplicitFormatFlags` — new; reads both gate templates and asserts the new gate string is present and the stale bare gate is absent.
- `TestGeneratedOutput_MutatingCommandsHaveEnvelope` — updated; existing assertion now expects the format-flag escape clause.