### PR TITLE
fix(skills): preflight Go toolchain before generation runs

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -96,6 +96,20 @@ func TestPrintingPressSkillUsesRunRootStateFile(t *testing.T) {
 	assert.Contains(t, skill, `"working_dir": "$CLI_WORK_DIR"`)
 }
 
+func TestPrintingPressSkillPreflightChecksGoToolchain(t *testing.T) {
+	skillPath := filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")
+	full := readContractFile(t, skillPath)
+	block := extractContractBlock(t, full)
+
+	// Unconditional Go-toolchain presence check fires regardless of whether the
+	// printing-press binary is found, so binary-present + Go-absent fails fast
+	// instead of crashing 5+ minutes later in the post-generation `go mod tidy`
+	// quality gate.
+	assert.Contains(t, block, `if ! command -v go >/dev/null 2>&1; then`)
+	assert.Contains(t, block, `[setup-error] Go toolchain not found.`)
+	assert.Contains(t, block, `https://go.dev/dl/`)
+}
+
 func TestPrintingPressSkillUsesRunstateForBuilds(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -101,10 +101,10 @@ func TestPrintingPressSkillPreflightChecksGoToolchain(t *testing.T) {
 	full := readContractFile(t, skillPath)
 	block := extractContractBlock(t, full)
 
-	// Unconditional Go-toolchain presence check fires regardless of whether the
-	// printing-press binary is found, so binary-present + Go-absent fails fast
-	// instead of crashing 5+ minutes later in the post-generation `go mod tidy`
-	// quality gate.
+	// The Go-toolchain presence check fires after the binary detection block
+	// exits cleanly (binary found or PATH-augmented). It catches binary-present
+	// + Go-absent and fails fast instead of crashing 5+ minutes later in the
+	// post-generation `go mod tidy` quality gate.
 	assert.Contains(t, block, `if ! command -v go >/dev/null 2>&1; then`)
 	assert.Contains(t, block, `[setup-error] Go toolchain not found.`)
 	assert.Contains(t, block, `https://go.dev/dl/`)

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -160,6 +160,23 @@ elif ! command -v printing-press >/dev/null 2>&1; then
   fi
 fi
 
+# Verify the Go toolchain is on PATH. Generation runs Go-based quality gates
+# (go mod tidy, go vet, etc.) after writing thousands of lines of scaffolding,
+# so a missing `go` only surfaces 5+ minutes in. Fail-fast costs one command -v
+# call when Go is present and converts a late, opaque failure into a 30-second
+# actionable abort.
+if ! command -v go >/dev/null 2>&1; then
+  echo ""
+  echo "[setup-error] Go toolchain not found."
+  echo ""
+  echo "The Printing Press generator runs Go-based quality gates after generation."
+  echo "Install Go 1.26.3 or newer from https://go.dev/dl/, then verify with:"
+  echo "  go version"
+  echo "Then re-run /printing-press."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
   PRESS_BASE="workspace"

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -4,13 +4,13 @@ Post-contract checks the skill must run after executing the bash setup contract 
 
 Apply these in order. Each section is conditional — do nothing if its trigger isn't present.
 
-## 1. Refusal: missing binary
+## 1. Refusal: missing prerequisite
 
-If the setup contract output contains a line starting with `[setup-error]`, the printing-press binary is not installed and the contract has already exited non-zero.
+If the setup contract output contains a line starting with `[setup-error]`, a required prerequisite is missing (the printing-press binary or the Go toolchain) and the contract has already exited non-zero.
 
-**Stop the skill immediately.** Do not proceed to research, generation, or any other work. Surface the message the contract printed (it includes the exact `go install` command) verbatim to the user.
+**Stop the skill immediately.** Do not proceed to research, generation, or any other work. Surface the message the contract printed (it includes the exact install command or download URL) verbatim to the user.
 
-The user must install the binary in their terminal before re-running. Do not offer to auto-install — the README's two-step install is the source of truth, and silent auto-install hides failure modes (network, wrong GOPATH) inside an opaque skill invocation.
+The user must install the missing prerequisite in their terminal before re-running. Do not offer to auto-install — the README's two-step install is the source of truth for the binary, and silent auto-install hides failure modes (network, wrong GOPATH, no Go toolchain) inside an opaque skill invocation.
 
 ## 2. Interactive repo upgrade prompt
 


### PR DESCRIPTION
## Intent

Fail-fast on a missing Go toolchain in `/printing-press` preflight, before generation produces ~10K LOC of scaffolding that the post-generation `go mod tidy` quality gate cannot validate.

Issue: Closes #793

## Approach

The setup contract already runs `command -v go` once, but only inside the binary-not-found error fallback to pick between two install messages. When the binary IS present and `go` is NOT, that check never runs, and the failure punts to the post-generation `go mod tidy` gate ~5+ minutes later.

This PR adds an unconditional `command -v go` check directly after binary detection in [skills/printing-press/SKILL.md](skills/printing-press/SKILL.md). When `go` is missing, the contract emits a `[setup-error] Go toolchain not found.` block (with the install URL and minimum supported version), then exits non-zero. The existing `[setup-error]` handler in [references/setup-checks.md](skills/printing-press/references/setup-checks.md) section 1 already stops the skill and surfaces the printed message verbatim; that section is generalized to mention either missing prerequisite (binary or Go), since the same handler now covers both.

Locked in with a new contract test, `TestPrintingPressSkillPreflightChecksGoToolchain` in [internal/pipeline/contracts_test.go](internal/pipeline/contracts_test.go), that asserts the unconditional `command -v go` line, the `[setup-error]` marker, and the install URL all live inside the contract block.

## Scope

Primary area: skills (preflight setup contract)

Why this belongs in this repo: The setup contract is a checked-in skill artifact. The fix is a single-skill change to the main `printing-press` SKILL.md; the other skills (`-score`, `-catalog`, `-publish`) don't run `go mod tidy` after their commands and are intentionally untouched.

## Risk

Low. No generator code, template, or generated-output change. Only the preflight bash block runs differently — the new `command -v go` check fires once per `/printing-press` invocation. When Go is present, behavior is unchanged. When Go is missing, the user sees the new `[setup-error]` block and the skill stops before any `AskUserQuestion`.

The new check fires unconditionally, including the local-build path. That path requires Go to have been installed at build time, but a stale `./printing-press` binary plus a since-removed Go install would still be caught — strictly an improvement over the current behavior.

## Output Contract

N/A. No generator templates, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts changed.

## Verification

- `go test ./...` — 3451 passed in 34 packages.
- `go vet ./...` — No issues.
- `golangci-lint run ./...` — No issues.
- `go fmt ./...` — clean.
- `go build -o ./printing-press ./cmd/printing-press` — built.
- `scripts/golden.sh verify` — 16 cases passed.
- `git diff --check` — clean.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change