### PR TITLE
fix(skills): forward --research-dir to scorecard --live-check in mid-pipeline polish

### DIFF
--- a/skills/printing-press-output-review/SKILL.md
+++ b/skills/printing-press-output-review/SKILL.md
@@ -45,15 +45,16 @@ Bugs that rule-based checks miss, typically surfaced by 5 minutes of hands-on te
 # $PRESS_RUNSTATE/runs/<id>/working/<cli> and research.json lives at
 # $PRESS_RUNSTATE/runs/<id>/research.json. Without the fallback, scorecard
 # reports `unable: true` mid-pipeline and we SKIP the most informative review.
-RESEARCH_FLAG=""
+# Use a bash array so the flag survives paths with spaces.
+RESEARCH_ARGS=()
 if [ ! -f "$CLI_DIR/research.json" ]; then
   _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
   if [ -f "$_grandparent/research.json" ]; then
-    RESEARCH_FLAG="--research-dir $_grandparent"
+    RESEARCH_ARGS=(--research-dir "$_grandparent")
   fi
 fi
 
-printing-press scorecard --dir "$CLI_DIR" $RESEARCH_FLAG --live-check --json > /tmp/output-review-livecheck.json 2>&1 || true
+printing-press scorecard --dir "$CLI_DIR" "${RESEARCH_ARGS[@]}" --live-check --json > /tmp/output-review-livecheck.json 2>&1 || true
 ```
 
 If the scorecard call fails or `/tmp/output-review-livecheck.json` is empty, return the SKIP result (Step 3) without dispatching the reviewer.

--- a/skills/printing-press-output-review/SKILL.md
+++ b/skills/printing-press-output-review/SKILL.md
@@ -39,7 +39,21 @@ Bugs that rule-based checks miss, typically surfaced by 5 minutes of hands-on te
 ### Step 1: Gather sample data
 
 ```bash
-printing-press scorecard --dir "$CLI_DIR" --live-check --json > /tmp/output-review-livecheck.json 2>&1 || true
+# Locate research.json. Adjacent to the binary covers the post-promote
+# layout (standalone polish, shipcheck against the library copy). The
+# grandparent fallback covers mid-pipeline invocations where $CLI_DIR is
+# $PRESS_RUNSTATE/runs/<id>/working/<cli> and research.json lives at
+# $PRESS_RUNSTATE/runs/<id>/research.json. Without the fallback, scorecard
+# reports `unable: true` mid-pipeline and we SKIP the most informative review.
+RESEARCH_FLAG=""
+if [ ! -f "$CLI_DIR/research.json" ]; then
+  _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
+  if [ -f "$_grandparent/research.json" ]; then
+    RESEARCH_FLAG="--research-dir $_grandparent"
+  fi
+fi
+
+printing-press scorecard --dir "$CLI_DIR" $RESEARCH_FLAG --live-check --json > /tmp/output-review-livecheck.json 2>&1 || true
 ```
 
 If the scorecard call fails or `/tmp/output-review-livecheck.json` is empty, return the SKIP result (Step 3) without dispatching the reviewer.

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -153,32 +153,39 @@ fi
 # Without this flag, legacy CLIs whose manifest predates the
 # novel_features schema fail publish-validate's transcendence gate.
 #
-# Two layouts to handle:
-#  1. Post-promote (standalone polish): research.json lives at
+# Two layouts to handle, keyed on $CLI_DIR path structure (NOT on the
+# absence of a manuscripts entry — re-generating a previously-published
+# API leaves stale manuscript entries from prior runs that would point
+# scorecard at the wrong research.json):
+#  1. Mid-pipeline polish (invoked from the main printing-press flow
+#     before promote): $CLI_DIR is under $PRESS_RUNSTATE/.../runs/<id>/working/<cli>
+#     (i.e. the path contains `.runstate/`), and research.json lives at
+#     $PRESS_RUNSTATE/.../runs/<id>/research.json — $CLI_DIR's grandparent.
+#  2. Post-promote (standalone polish): research.json lives at
 #     manuscripts/<api>/<run-id>/research.json.
-#  2. Mid-pipeline polish (invoked from the main printing-press flow
-#     before promote): $CLI_DIR is $PRESS_RUNSTATE/runs/<id>/working/<cli>
-#     and research.json lives at $PRESS_RUNSTATE/runs/<id>/research.json
-#     (two directories above $CLI_DIR).
 RESEARCH_DIR=""
-for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json; do
-  if [ -f "$d" ]; then
-    RESEARCH_DIR="$(dirname "$d")"
-    break
-  fi
-done
+case "$CLI_DIR" in
+  *.runstate/*)
+    _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
+    if [ -f "$_grandparent/research.json" ]; then
+      RESEARCH_DIR="$_grandparent"
+    fi
+    ;;
+  *)
+    for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json; do
+      if [ -f "$d" ]; then
+        RESEARCH_DIR="$(dirname "$d")"
+        break
+      fi
+    done
+    ;;
+esac
 
-# Fallback for mid-pipeline polish: derive from $CLI_DIR's grandparent.
-if [ -z "$RESEARCH_DIR" ]; then
-  _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
-  if [ -f "$_grandparent/research.json" ]; then
-    RESEARCH_DIR="$_grandparent"
-  fi
-fi
-
-RESEARCH_FLAG=""
+# Use a bash array so the flag survives paths with spaces (e.g. when
+# $HOME or $PRESS_RUNSTATE resolves through a path containing spaces).
+RESEARCH_ARGS=()
 if [ -n "$RESEARCH_DIR" ]; then
-  RESEARCH_FLAG="--research-dir $RESEARCH_DIR"
+  RESEARCH_ARGS=(--research-dir "$RESEARCH_DIR")
 fi
 ```
 
@@ -223,11 +230,11 @@ cd "$CLI_DIR"
 # Build
 go build -o "$CLI_NAME" ./cmd/"$CLI_NAME" 2>&1
 
-# Diagnostics. SPEC_FLAG and RESEARCH_FLAG are set in the "Find spec
-# and research dir" step above. RESEARCH_FLAG enables dogfood to
+# Diagnostics. SPEC_FLAG and RESEARCH_ARGS are set in the "Find spec
+# and research dir" step above. RESEARCH_ARGS enables dogfood to
 # verify novel features and sync them into .printing-press.json
 # (required for publish-validate's transcendence gate).
-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG $RESEARCH_FLAG 2>&1
+printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
 printing-press verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
 printing-press workflow-verify --dir "$CLI_DIR" --json > /tmp/polish-workflow-verify.json 2>&1 || true
 printing-press verify-skill --dir "$CLI_DIR" --json > /tmp/polish-verify-skill.json 2>&1 || true
@@ -235,11 +242,11 @@ printing-press publish validate --dir "$CLI_DIR" --json > /tmp/polish-publish-va
 # --live-check samples novel-feature outputs and populates
 # live_check.features[].warnings (Wave B entity detection) — required for
 # the "Output entity warnings" row below to have data to read.
-# RESEARCH_FLAG points scorecard at the run's research.json when the
+# RESEARCH_ARGS points scorecard at the run's research.json when the
 # CLI lives under $PRESS_RUNSTATE/runs/<id>/working/<cli> (mid-pipeline
 # polish). Without it, scorecard looks adjacent to the binary, doesn't
 # find research.json, and reports `unable: true`.
-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG $RESEARCH_FLAG --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
+printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
 printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
 printing-press tools-audit "$CLI_DIR" --json > /tmp/polish-tools-audit-before.json 2>&1 || true
 go vet ./... 2>&1

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -500,7 +500,11 @@ gofmt -w .
 Re-run the diagnostic sweep on the fixed CLI:
 
 ```bash
-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG 2>&1
+# RESEARCH_ARGS must travel with dogfood here too — without it,
+# checkNovelFeatures doesn't re-sync novel_features_built after Phase 2
+# edits, and publish-validate's transcendence gate reads stale state
+# from Phase 1's pass.
+printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
 printing-press verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
 printing-press workflow-verify --dir "$CLI_DIR" --json 2>&1
 printing-press verify-skill --dir "$CLI_DIR" --json 2>&1

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -147,12 +147,19 @@ if [ -n "$SPEC_PATH" ]; then
   SPEC_FLAG="--spec $SPEC_PATH"
 fi
 
-# Locate the research dir (parent of the spec's research/ folder, i.e.
-# manuscripts/<api>/<run-id>/). dogfood's --research-dir triggers
+# Locate the research dir. dogfood's --research-dir triggers
 # checkNovelFeatures, which writes novel_features_built back into
 # research.json AND syncs the verified list into .printing-press.json.
 # Without this flag, legacy CLIs whose manifest predates the
 # novel_features schema fail publish-validate's transcendence gate.
+#
+# Two layouts to handle:
+#  1. Post-promote (standalone polish): research.json lives at
+#     manuscripts/<api>/<run-id>/research.json.
+#  2. Mid-pipeline polish (invoked from the main printing-press flow
+#     before promote): $CLI_DIR is $PRESS_RUNSTATE/runs/<id>/working/<cli>
+#     and research.json lives at $PRESS_RUNSTATE/runs/<id>/research.json
+#     (two directories above $CLI_DIR).
 RESEARCH_DIR=""
 for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json; do
   if [ -f "$d" ]; then
@@ -160,6 +167,14 @@ for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manusc
     break
   fi
 done
+
+# Fallback for mid-pipeline polish: derive from $CLI_DIR's grandparent.
+if [ -z "$RESEARCH_DIR" ]; then
+  _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
+  if [ -f "$_grandparent/research.json" ]; then
+    RESEARCH_DIR="$_grandparent"
+  fi
+fi
 
 RESEARCH_FLAG=""
 if [ -n "$RESEARCH_DIR" ]; then
@@ -220,7 +235,11 @@ printing-press publish validate --dir "$CLI_DIR" --json > /tmp/polish-publish-va
 # --live-check samples novel-feature outputs and populates
 # live_check.features[].warnings (Wave B entity detection) — required for
 # the "Output entity warnings" row below to have data to read.
-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
+# RESEARCH_FLAG points scorecard at the run's research.json when the
+# CLI lives under $PRESS_RUNSTATE/runs/<id>/working/<cli> (mid-pipeline
+# polish). Without it, scorecard looks adjacent to the binary, doesn't
+# find research.json, and reports `unable: true`.
+printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG $RESEARCH_FLAG --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
 printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
 printing-press tools-audit "$CLI_DIR" --json > /tmp/polish-tools-audit-before.json 2>&1 || true
 go vet ./... 2>&1


### PR DESCRIPTION
## Summary

Polish skill computed `\$RESEARCH_FLAG` and forwarded it to `dogfood` but not to `scorecard --live-check`, and the `output-review` sub-skill invoked scorecard with no research-dir hint at all. In mid-pipeline mode (`\$CLI_DIR` under `\$PRESS_RUNSTATE/runs/<id>/working/<cli>`), `research.json` lives two directories up — scorecard's live-check defaulted to looking adjacent to the binary, found nothing, and returned `unable: true`. Output-review then SKIPped the most informative review window (immediately after generation, with context fresh).

## What changed

- **`skills/printing-press-polish/SKILL.md`**
  - Extend `RESEARCH_DIR` detection: keep the existing `manuscripts/<api>/<run-id>/research.json` glob, then fall back to `\$CLI_DIR`'s grandparent for the mid-pipeline layout (manuscripts isn't populated until after promote).
  - Pass `\$RESEARCH_FLAG` to the `scorecard --dir … --live-check --json` call so live-check can find `research.json` mid-pipeline.

- **`skills/printing-press-output-review/SKILL.md`**
  - Self-detect the research dir: prefer `\$CLI_DIR/research.json`, fall back to `\$CLI_DIR`'s grandparent, then forward `--research-dir` to scorecard. Keeps the sub-skill robust regardless of which parent invokes it (main printing-press Phase 4.85 or polish diagnostic loop).

The Go-side `--research-dir` flag on `scorecard` and `LiveCheckOptions.ResearchDir` already existed (added in PR #305). The bug was purely on the skill-invocation side.

## Acceptance

- **Positive (mid-pipeline polish):** `/printing-press <api>` → polish in mid-pipeline mode → output-review reports PASS/WARN/findings instead of SKIP. Both polish's own scorecard call and the output-review sub-skill's scorecard call now find `research.json`.
- **Negative (standalone polish):** `/printing-press-polish <api>` after promote → `\$CLI_DIR/research.json` exists adjacent to the binary, `RESEARCH_FLAG` stays empty (or is set from the manuscripts glob), behavior unchanged.

## Verification

- `go build`, `go vet`, `go test ./...` (3451 passed), `golangci-lint run ./...`, `git diff --check` — all clean.
- No generator-affecting diff; no golden update needed.

Closes #795