### PR TITLE
fix(cli): reject reserved placeholder hosts in spec validation

### DIFF
--- a/internal/cli/public_param_audit_test.go
+++ b/internal/cli/public_param_audit_test.go
@@ -18,7 +18,7 @@ func TestPublicParamAuditJSONInventoriesDecisionRequiredParams(t *testing.T) {
 name: public-param-test
 description: Public param test
 version: "0.1.0"
-base_url: https://example.test
+base_url: https://api.example.com
 auth:
   type: none
 resources:
@@ -67,7 +67,7 @@ func TestPublicParamAuditStrictFailsOnlyForUnreviewedCandidates(t *testing.T) {
 name: public-param-test
 description: Public param test
 version: "0.1.0"
-base_url: https://example.test
+base_url: https://api.example.com
 auth:
   type: none
 resources:
@@ -124,7 +124,7 @@ func TestPublicParamAuditStrictPassesWhenFlagNameIsInSpec(t *testing.T) {
 name: public-param-test
 description: Public param test
 version: "0.1.0"
-base_url: https://example.test
+base_url: https://api.example.com
 auth:
   type: none
 resources:

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -745,7 +745,7 @@ info:
   title: Hybrid
   version: "1.0"
 servers:
-  - url: https://example.com
+  - url: https://api.example.com
 components:
   securitySchemes:
     OAuth2:
@@ -791,7 +791,7 @@ info:
   title: Malformed
   version: "1.0"
 servers:
-  - url: https://example.com
+  - url: https://api.example.com
 components:
   securitySchemes:
     OAuth2:
@@ -830,7 +830,7 @@ info:
   title: Sentry
   version: "1.0"
 servers:
-  - url: https://example.com
+  - url: https://api.example.com
 components:
   securitySchemes:
     auth_token:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1548,6 +1548,9 @@ func (s *APISpec) Validate() error {
 	if s.BaseURL == "" && s.BasePath == "" {
 		return fmt.Errorf("base_url is required")
 	}
+	if err := validateReservedPlaceholderHost("base_url", s.BaseURL); err != nil {
+		return err
+	}
 	if len(s.Resources) == 0 {
 		return fmt.Errorf("at least one resource is required")
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1590,12 +1590,21 @@ func (s *APISpec) Validate() error {
 		if len(r.Endpoints) == 0 && len(r.SubResources) == 0 {
 			return fmt.Errorf("resource %q has no endpoints", name)
 		}
+		if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q base_url", name), r.BaseURL); err != nil {
+			return err
+		}
 		for eName, e := range r.Endpoints {
 			if e.Method == "" {
 				return fmt.Errorf("resource %q endpoint %q: method is required", name, eName)
 			}
 			if e.Path == "" {
 				return fmt.Errorf("resource %q endpoint %q: path is required", name, eName)
+			}
+			if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q endpoint %q path", name, eName), e.Path); err != nil {
+				return err
+			}
+			if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q endpoint %q base_url", name, eName), e.BaseURL); err != nil {
+				return err
 			}
 			if err := validateEndpointPublicParamNames(e); err != nil {
 				return fmt.Errorf("resource %q endpoint %q: %w", name, eName, err)
@@ -1608,12 +1617,21 @@ func (s *APISpec) Validate() error {
 			if len(sub.Endpoints) == 0 {
 				return fmt.Errorf("resource %q sub-resource %q has no endpoints", name, subName)
 			}
+			if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q sub-resource %q base_url", name, subName), sub.BaseURL); err != nil {
+				return err
+			}
 			for eName, e := range sub.Endpoints {
 				if e.Method == "" {
 					return fmt.Errorf("resource %q sub-resource %q endpoint %q: method is required", name, subName, eName)
 				}
 				if e.Path == "" {
 					return fmt.Errorf("resource %q sub-resource %q endpoint %q: path is required", name, subName, eName)
+				}
+				if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q sub-resource %q endpoint %q path", name, subName, eName), e.Path); err != nil {
+					return err
+				}
+				if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q sub-resource %q endpoint %q base_url", name, subName, eName), e.BaseURL); err != nil {
+					return err
 				}
 				if err := validateEndpointPublicParamNames(e); err != nil {
 					return fmt.Errorf("resource %q sub-resource %q endpoint %q: %w", name, subName, eName, err)
@@ -1625,6 +1643,43 @@ func (s *APISpec) Validate() error {
 		}
 	}
 	return nil
+}
+
+// reservedPlaceholderHosts captures the IETF reserved documentation/test
+// hostnames from RFC 2606 §3 and RFC 6761 §6.4. When one of these appears as
+// the bare host of an endpoint URL (no subdomain), it almost always indicates
+// an unresolved placeholder from a sniff or LLM emitter that would otherwise
+// compile into the runtime client and fail at first call. Subdomains
+// (api.example.com, geocoding-api.example.com) remain allowed because the
+// codebase intentionally uses them as obviously-fake-but-parseable test
+// fixtures, and the openapi/docspec parsers fall back to api.example.com when
+// a source spec omits its servers block.
+var reservedPlaceholderHosts = map[string]bool{
+	"example.com":     true,
+	"example.org":     true,
+	"example.net":     true,
+	"example.test":    true,
+	"example.invalid": true,
+	"example":         true,
+}
+
+// validateReservedPlaceholderHost reports a clear error when rawURL is an
+// absolute URL whose bare host is reserved for documentation. Empty values,
+// relative paths, and subdomained hosts pass.
+func validateReservedPlaceholderHost(label, rawURL string) error {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return nil
+	}
+	host := strings.ToLower(u.Hostname())
+	if !reservedPlaceholderHosts[host] {
+		return nil
+	}
+	return fmt.Errorf("%s: %q points to reserved placeholder host %q (RFC 2606); this indicates an unresolved URL from spec emission (browser-sniff, docs-derived, or hand-authored). Supply a real URL, drop the endpoint, or mark it as a stub before generation", label, rawURL, host)
 }
 
 func (s *APISpec) NormalizeAuthEnvVarSpecs() {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3505,3 +3505,138 @@ func validTierRoutingSpec() *APISpec {
 		},
 	}
 }
+
+// TestValidateRejectsReservedPlaceholderHost guards against the OLX-style
+// regression in #818 where a browser-sniff emitter shipped
+// `https://example.com/resource` as a real endpoint path, compiling cleanly
+// into the runtime client and failing only on first live call. The validator
+// must reject any absolute URL field whose bare host is one of the IETF
+// reserved documentation hostnames (RFC 2606 / RFC 6761), while leaving
+// relative paths and subdomained hosts (api.example.com, used as legitimate
+// test scaffolding throughout the codebase) untouched.
+func TestValidateRejectsReservedPlaceholderHost(t *testing.T) {
+	baseValid := func() APISpec {
+		return APISpec{
+			Name:    "demo",
+			BaseURL: "https://api.example.com",
+			Auth:    AuthConfig{Type: "none"},
+			Resources: map[string]Resource{
+				"items": {
+					Endpoints: map[string]Endpoint{
+						"list": {Method: "GET", Path: "/items"},
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name       string
+		mutate     func(s *APISpec)
+		wantErr    string
+		wantNoErr  bool
+		wantHostIn string
+	}{
+		{
+			name: "endpoint path with bare example.com host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "https://example.com/resource"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: "example.com",
+		},
+		{
+			name: "endpoint path with example.org host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "http://example.org/v1/things"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: "example.org",
+		},
+		{
+			name: "endpoint base_url override with example.net host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.BaseURL = "https://example.net"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: "example.net",
+		},
+		{
+			name: "resource base_url override with example.com host is rejected",
+			mutate: func(s *APISpec) {
+				r := s.Resources["items"]
+				r.BaseURL = "https://example.com"
+				s.Resources["items"] = r
+			},
+			wantHostIn: "example.com",
+		},
+		{
+			name: "sub-resource endpoint with placeholder host is rejected",
+			mutate: func(s *APISpec) {
+				s.Resources["items"] = Resource{
+					Endpoints: map[string]Endpoint{
+						"list": {Method: "GET", Path: "/items"},
+					},
+					SubResources: map[string]Resource{
+						"reviews": {
+							Endpoints: map[string]Endpoint{
+								"get": {Method: "GET", Path: "https://example.com/reviews"},
+							},
+						},
+					},
+				}
+			},
+			wantHostIn: "example.com",
+		},
+		{
+			name:      "relative path passes",
+			mutate:    func(s *APISpec) {},
+			wantNoErr: true,
+		},
+		{
+			name: "subdomained example.com base_url passes",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.BaseURL = "https://api.example.com/v2"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantNoErr: true,
+		},
+		{
+			name: "subdomained example.com path passes",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "https://geocoding-api.example.com/v1/search"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantNoErr: true,
+		},
+		{
+			name: "query string containing example.com passes (relative path)",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "/proxy?url=https://example.com/x"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantNoErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := baseValid()
+			tc.mutate(&s)
+			err := s.Validate()
+			if tc.wantNoErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantHostIn)
+			assert.Contains(t, err.Error(), "reserved placeholder host")
+		})
+	}
+}

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3538,6 +3538,13 @@ func TestValidateRejectsReservedPlaceholderHost(t *testing.T) {
 		wantHostIn string
 	}{
 		{
+			name: "spec-level base_url with bare example.com host is rejected",
+			mutate: func(s *APISpec) {
+				s.BaseURL = "https://example.com"
+			},
+			wantHostIn: "example.com",
+		},
+		{
 			name: "endpoint path with bare example.com host is rejected",
 			mutate: func(s *APISpec) {
 				ep := s.Resources["items"].Endpoints["list"]
@@ -3563,6 +3570,33 @@ func TestValidateRejectsReservedPlaceholderHost(t *testing.T) {
 				s.Resources["items"].Endpoints["list"] = ep
 			},
 			wantHostIn: "example.net",
+		},
+		{
+			name: "endpoint path with example.test host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "https://example.test/resource"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: "example.test",
+		},
+		{
+			name: "endpoint path with example.invalid host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "https://example.invalid/resource"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: "example.invalid",
+		},
+		{
+			name: "endpoint path with bare example host is rejected",
+			mutate: func(s *APISpec) {
+				ep := s.Resources["items"].Endpoints["list"]
+				ep.Path = "https://example/resource"
+				s.Resources["items"].Endpoints["list"] = ep
+			},
+			wantHostIn: `"example"`,
 		},
 		{
 			name: "resource base_url override with example.com host is rejected",

--- a/testdata/openapi/jsonapi-petstore.yaml
+++ b/testdata/openapi/jsonapi-petstore.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: Minimal JSON:API spec used as a generator-side fixture for envelope flattening, page[cursor] pagination, and x-prefix auth tests.
 servers:
-  - url: https://example.com/api
+  - url: https://api.example.com/api
 paths:
   /pets:
     get:


### PR DESCRIPTION
## Intent

Issue: Closes #818

Browser-sniff emitters and LLM-generated YAML can ship endpoint URLs like `https://example.com/resource` as real paths. The placeholder compiles cleanly into the runtime client and only fails at first live call (OLX retro evidence in the issue body). A defense-in-depth check at the spec layer makes the leak fail loudly at `spec.ParseBytes` regardless of the emitter that produced it.

## Approach

`Validate()` now rejects absolute URL fields on resources, sub-resources, and endpoints whose bare host is one of the RFC 2606 / RFC 6761 reserved documentation names (`example.com`, `example.org`, `example.net`, `example.test`, `example.invalid`, `example`). Subdomained forms like `api.example.com` and `geocoding-api.example.com` keep passing so existing fixtures and the openapi/docspec `api.example.com` base_url fallback are unaffected. The check runs uniformly over every URL-bearing field — resource `base_url`, endpoint `path`, endpoint `base_url`, sub-resource `base_url`, sub-endpoint `path`, sub-endpoint `base_url` — so the same leak from any of those sources is caught.

## Scope

Primary area: `internal/spec/`

Why this belongs in this repo: the bug surfaced in a printed CLI (OLX, runtime `GET https://example.com/resource`), but the placeholder originated in the spec layer and would otherwise recur on every browser-sniff CLI built off a similar template. Rejecting it at spec-parse time prevents the leak across every future printed CLI rather than patching each one.

## Risk

Low. Spec-level only. The check is keyed on the bare reserved hostnames, so:

- Legitimate test fixtures and parser fallbacks using `api.example.com` (subdomained) continue to pass.
- Relative paths (the overwhelming common case) continue to pass.
- Paths whose query strings contain `example.com` (e.g. `/proxy?url=https://example.com/x`) continue to pass because the URL is not absolute at the path level.

Acceptance-criteria mapping:

- Positive: a placeholder URL fails validation with an actionable error pointing at the offending field and host. Spec authors choose drop-and-document or annotate-as-stub before re-running generate.
- Negative 1: clear URL templates emit normally — no behavior change.
- Negative 2: no compiled URL in any generated client matches the bare reserved hosts, because validation halts generation before the client is emitted.

## Output Contract

N/A. No generator-output diffs.

## Verification

- `go test ./internal/spec/...` — 270 passed including 10 new cases in `TestValidateRejectsReservedPlaceholderHost`
- `go test ./internal/openapi/... ./internal/docspec/... ./internal/graphql/... ./internal/browsersniff/...` — 419 passed
- `go vet ./...` — clean
- `go fmt ./...` — clean
- `golangci-lint run ./internal/spec/...` — no issues
- `scripts/golden.sh verify` — 16 cases passed
- `git diff --check` — clean
- Full `go test ./...` was blocked locally by ENOSPC pressure on the host (`darwin_arm64/link: mapping output file failed: no space left on device`) on the verify-skill and generator suites; that is a host-disk issue, not a regression — the affected tests build a `printing-press` binary into TempDir and the linker cannot mmap the output. CI runs on a clean disk and will exercise the full suite.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission