### PR TITLE
fix(cli): force UTF-8 stdio in verify-skill Python subprocess

### DIFF
--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -73,6 +73,7 @@ func runVerifySkillScript(dir string, only []string, asJSON bool, strict bool) (
 
 	py := exec.Command("python3", pyArgs...)
 	py.Stdin = os.Stdin
+	py.Env = pythonUTF8Env(os.Environ())
 	var stdout, stderr bytes.Buffer
 	py.Stdout = &stdout
 	py.Stderr = &stderr
@@ -332,6 +333,24 @@ func emitMergedJSON(pyResult verifySkillRunResult, runCanonical, hasCanonicalFin
 	}
 	fmt.Println(string(out))
 	return nil
+}
+
+// pythonUTF8Env returns base with PYTHONIOENCODING and PYTHONUTF8 forced to
+// UTF-8. Windows consoles default to cp1252, which cannot encode the ✓/✘
+// glyphs the Python script prints; without these env vars the subprocess
+// crashes with UnicodeEncodeError even though the underlying checks passed.
+// The Python script also calls sys.stdout.reconfigure() as a self-contained
+// defense; this env propagation is the belt-and-suspenders half.
+func pythonUTF8Env(base []string) []string {
+	env := make([]string, 0, len(base)+2)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "PYTHONIOENCODING=") || strings.HasPrefix(kv, "PYTHONUTF8=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, "PYTHONIOENCODING=utf-8", "PYTHONUTF8=1")
+	return env
 }
 
 // indentLines prefixes every line of s with prefix. Used for human-readable

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -1019,7 +1019,21 @@ def format_json(report: Report) -> str:
     return json.dumps(out, indent=2)
 
 
+def _force_utf8_stdio() -> None:
+    # Windows consoles default to cp1252, which cannot encode the ✓/✘ glyphs
+    # this script prints. Reconfigure stdout/stderr to UTF-8 so the human
+    # output renders cleanly instead of raising UnicodeEncodeError mid-print.
+    # The Go wrapper also sets PYTHONIOENCODING/PYTHONUTF8 as belt-and-suspenders;
+    # this call covers direct `python3 verify_skill.py ...` invocations.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            pass
+
+
 def main():
+    _force_utf8_stdio()
     p = argparse.ArgumentParser(
         description="Verify SKILL.md matches shipped CLI source."
     )

--- a/internal/cli/verify_skill_internal_test.go
+++ b/internal/cli/verify_skill_internal_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 trevin-chow. Licensed under Apache-2.0. See LICENSE.
+
+package cli
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestPythonUTF8Env_AppendsEncodingVarsWhenAbsent guards the Windows cp1252
+// crash fix: the verify-skill Python subprocess must receive UTF-8 stdio
+// env vars so its ✓/✘ glyph prints don't raise UnicodeEncodeError on Windows.
+func TestPythonUTF8Env_AppendsEncodingVarsWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := pythonUTF8Env([]string{"PATH=/usr/bin", "HOME=/tmp"})
+
+	if !slices.Contains(got, "PYTHONIOENCODING=utf-8") {
+		t.Errorf("expected PYTHONIOENCODING=utf-8 in env, got %v", got)
+	}
+	if !slices.Contains(got, "PYTHONUTF8=1") {
+		t.Errorf("expected PYTHONUTF8=1 in env, got %v", got)
+	}
+	if !slices.Contains(got, "PATH=/usr/bin") {
+		t.Errorf("expected PATH=/usr/bin to be preserved, got %v", got)
+	}
+}
+
+// TestPythonUTF8Env_OverridesUserSetting ensures a user's existing
+// PYTHONIOENCODING (e.g. inherited cp1252 on Windows) cannot defeat the fix:
+// the helper drops conflicting entries and re-appends the UTF-8 values.
+func TestPythonUTF8Env_OverridesUserSetting(t *testing.T) {
+	t.Parallel()
+
+	got := pythonUTF8Env([]string{
+		"PYTHONIOENCODING=cp1252",
+		"PYTHONUTF8=0",
+		"PATH=/usr/bin",
+	})
+
+	for _, kv := range got {
+		if kv == "PYTHONIOENCODING=cp1252" || kv == "PYTHONUTF8=0" {
+			t.Errorf("conflicting env entry %q should have been removed, got env %v", kv, got)
+		}
+	}
+	if !slices.Contains(got, "PYTHONIOENCODING=utf-8") {
+		t.Errorf("expected PYTHONIOENCODING=utf-8 in env, got %v", got)
+	}
+	if !slices.Contains(got, "PYTHONUTF8=1") {
+		t.Errorf("expected PYTHONUTF8=1 in env, got %v", got)
+	}
+}
+
+// TestPythonUTF8Env_EmptyBase covers the edge case where os.Environ()
+// returns nothing — the helper should still emit both UTF-8 vars.
+func TestPythonUTF8Env_EmptyBase(t *testing.T) {
+	t.Parallel()
+
+	got := pythonUTF8Env(nil)
+	if len(got) != 2 {
+		t.Fatalf("expected exactly the two UTF-8 entries, got %v", got)
+	}
+	if !slices.Contains(got, "PYTHONIOENCODING=utf-8") || !slices.Contains(got, "PYTHONUTF8=1") {
+		t.Errorf("expected both UTF-8 entries, got %v", got)
+	}
+}

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -1019,7 +1019,21 @@ def format_json(report: Report) -> str:
     return json.dumps(out, indent=2)
 
 
+def _force_utf8_stdio() -> None:
+    # Windows consoles default to cp1252, which cannot encode the ✓/✘ glyphs
+    # this script prints. Reconfigure stdout/stderr to UTF-8 so the human
+    # output renders cleanly instead of raising UnicodeEncodeError mid-print.
+    # The Go wrapper also sets PYTHONIOENCODING/PYTHONUTF8 as belt-and-suspenders;
+    # this call covers direct `python3 verify_skill.py ...` invocations.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            pass
+
+
 def main():
+    _force_utf8_stdio()
     p = argparse.ArgumentParser(
         description="Verify SKILL.md matches shipped CLI source."
     )


### PR DESCRIPTION
## What

Windows consoles default to cp1252, which cannot encode the `✓`/`✘` glyphs the verify-skill Python script prints. The subprocess crashed with `UnicodeEncodeError` mid-print, and the shipcheck umbrella reported `verify-skill FAIL` even when every underlying check passed. The ship verdict was wrong for every Windows user.

## Fix (defense in depth)

1. **Python side** — `sys.stdout.reconfigure(encoding="utf-8")` and `sys.stderr.reconfigure(encoding="utf-8")` at the top of `main()` in [scripts/verify-skill/verify_skill.py](scripts/verify-skill/verify_skill.py) and the bundled copy at [internal/cli/verify_skill_bundled.py](internal/cli/verify_skill_bundled.py). Self-contained, no env dependency, covers direct `python3 verify_skill.py …` invocations. Guarded by `try/except (AttributeError, OSError)` so an older Python or a non-reconfigurable stdout falls through cleanly. The helper lives on `main()` so importers (`test_resolve_command_path.py`) aren't affected.
2. **Go side** — new `pythonUTF8Env()` helper in [internal/cli/verify_skill.go](internal/cli/verify_skill.go) forces `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` on the subprocess env, dropping any conflicting parent values first. Robust even if a future edit removes the Python-side guard.

Either change alone closes the bug; both together is belt-and-suspenders against env stripping or script edits.

## Tests

- `TestPythonUTF8Env_AppendsEncodingVarsWhenAbsent`
- `TestPythonUTF8Env_OverridesUserSetting` — ensures a cp1252 inherited from the parent shell is dropped, not preserved
- `TestPythonUTF8Env_EmptyBase`
- `TestVerifySkillScriptInSync` (existing) confirms the bundled copy matches the canonical
- Existing `python3 scripts/verify-skill/test_resolve_command_path.py`: 14/14 pass (helper guard doesn't fire on import)

Full suite: `go test ./...` → 3474 passed.
Lint: `golangci-lint run ./...` → clean.
Golden: `scripts/golden.sh verify` → 16/16 pass.

## Scope boundary

- IN: verify-skill Python stdio + Go subprocess env propagation.
- OUT: other Python scripts in the scorer suite (each can get the same one-line fix independently if it prints non-ASCII).

Closes #976
Closes #819