### PR TITLE
fix(cli): validate ListIDs resourceType to close SQL injection

### DIFF
--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -903,11 +903,21 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
+//
+// resourceType is never interpolated into SQL directly. We resolve it to a real
+// table name via a parameterized sqlite_master lookup; only that trusted name is
+// substituted (double-quoted) into the SELECT. Callers may pass any string.
 func (s *Store) ListIDs(resourceType string) ([]string, error) {
-	// Try domain table first (tables are named after the resource type)
-	query := fmt.Sprintf("SELECT id FROM %s", resourceType)
-	rows, err := s.db.Query(query)
-	if err != nil {
+	var table string
+	err := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`,
+		resourceType,
+	).Scan(&table)
+	var rows *sql.Rows
+	if err == nil && table != "" {
+		rows, err = s.db.Query(fmt.Sprintf(`SELECT id FROM "%s"`, table))
+	}
+	if err != nil || table == "" {
 		// Fall back to generic resources table
 		rows, err = s.db.Query("SELECT id FROM resources WHERE resource_type = ?", resourceType)
 		if err != nil {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -915,7 +915,7 @@ func (s *Store) ListIDs(resourceType string) ([]string, error) {
 	).Scan(&table)
 	var rows *sql.Rows
 	if err == nil && table != "" {
-		rows, err = s.db.Query(fmt.Sprintf(`SELECT id FROM "%s"`, table))
+		rows, err = s.db.Query(fmt.Sprintf(`SELECT id FROM "%s"`, strings.ReplaceAll(table, `"`, `""`)))
 	}
 	if err != nil || table == "" {
 		// Fall back to generic resources table


### PR DESCRIPTION
## Intent

`Store.ListIDs(resourceType)` in `store.go.tmpl` interpolates the caller-supplied string directly into a `SELECT` — a classic SQL-injection sink. The method is exported, so every printed CLI ships the same flaw.

Issue: N/A (caught by Greptile on mvanhorn/printing-press-library#408, the outlook-calendar PR).

## Approach

Resolve the table name with a parameterized `sqlite_master` lookup, then substitute only the trusted name (double-quoted) into the SELECT. If the lookup misses, fall back to the existing `SELECT id FROM resources WHERE resource_type = ?` path — same semantics as before, just with the unsafe interpolation removed. Callers can now pass any string without risk.

## Scope

Primary area: `internal/generator/templates/store.go.tmpl`.

Why this belongs in this repo: the bug lives in a generator template, so every CLI rendered by the Printing Press carries it. Fixing only the printed CLI would regress on the next regen and would leave every already-printed CLI vulnerable. Per `AGENTS.md` "Default to machine changes" — this is the canonical case.

The same fix has been mirrored into the in-flight outlook-calendar PR (`mvanhorn/printing-press-library#408`) so that PR can ship clean; future regens of any CLI will pick up the template fix automatically.

## Risk

Behavior preserved: callers using existing well-known resource types (`events`, `attachments`, etc.) hit the same code path with the same results. Callers passing unknown names now fall through to the generic `resources` table — same outcome as the original `Query` error fallback. No template variable changes, no schema changes, no MCP-surface changes.

## Output Contract

N/A — generated `store.go` body changes (function internals), but no exported API, MCP shape, or scorecard output is affected. `scripts/golden.sh verify` was run and passes (16 cases).

## Verification

- `go build ./...` — clean.
- `scripts/golden.sh verify` — 16/16 PASS.
- Mirrored patch on `outlook-calendar/internal/store/store.go` in the library PR: `go build ./...`, `go vet ./...`, `go test ./...` all clean.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change