### PR TITLE
fix(cli): sync skips resources with unresolved {key} placeholders

### DIFF
--- a/internal/generator/sync_unresolved_path_key_test.go
+++ b/internal/generator/sync_unresolved_path_key_test.go
@@ -73,17 +73,20 @@ func TestGenerateSyncSkipsUnresolvedPathKeys(t *testing.T) {
 	// Structural assertion 1: the regex var declaration is present.
 	assert.Contains(t, syncContent, "unresolvedPathKeyRE",
 		"generated sync.go should declare unresolvedPathKeyRE var")
-	assert.Contains(t, syncContent, "regexp.MustCompile(`\\{[a-z_][a-z0-9_]*\\}`)",
-		"unresolvedPathKeyRE should match lowercase {key} placeholders")
+	assert.Contains(t, syncContent, "regexp.MustCompile(`\\{[a-zA-Z_][a-zA-Z0-9_]*\\}`)",
+		"unresolvedPathKeyRE should match {key} placeholders including camelCase (YouTube Data v3, etc.)")
 
 	// Structural assertion 2: the FindAllString check is wired in syncResource.
 	assert.Contains(t, syncContent, "unresolvedPathKeyRE.FindAllString(path, -1)",
 		"syncResource should scan the resolved path for unresolved {key}s")
 
 	// Structural assertion 3: the sync_warning event payload is correct.
-	assert.Contains(t, syncContent, `"event":"sync_warning"`,
+	// Payload is marshalled from a typed struct (so resource/path get proper
+	// JSON escaping); we assert on the struct field literals rather than the
+	// hand-built JSON string that previous versions emitted.
+	assert.Contains(t, syncContent, `Event:    "sync_warning"`,
 		"skip branch should emit a sync_warning event")
-	assert.Contains(t, syncContent, `"reason":"unfilled_path_key"`,
+	assert.Contains(t, syncContent, `Reason:   "unfilled_path_key"`,
 		"skip branch should use reason=unfilled_path_key")
 
 	// Structural assertion 4: the skip branch returns a Warn (non-fatal),

--- a/internal/generator/sync_unresolved_path_key_test.go
+++ b/internal/generator/sync_unresolved_path_key_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0.
+
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateSyncSkipsUnresolvedPathKeys verifies that the sync template
+// includes the unresolved-{key} skip block. Hierarchical-API specs (Yahoo
+// Fantasy, Reddit pre-2024, YouTube Data v3) have resource paths whose
+// {key} placeholders cannot be filled from flat-list context. Sync should
+// emit a sync_warning and skip the resource instead of aborting the run.
+//
+// Structural test — asserts the generated sync.go contains the skip wiring.
+// A runtime assertion would require spinning up a mock HTTP server and
+// invoking the generated binary; we cover that path via the integration
+// suite. This test guards the template against template-level regression.
+//
+// Refs #1006.
+func TestGenerateSyncSkipsUnresolvedPathKeys(t *testing.T) {
+	t.Parallel()
+
+	// One resource whose path contains an unresolved {key}. The placeholder
+	// `{external_team_uuid}` is intentionally non-derivable from any other
+	// resource name in this spec, so the dependent-resource auto-detector
+	// won't claim it — the resource lands in the flat sync path where the
+	// new skip block fires.
+	apiSpec := &spec.APISpec{
+		Name:    "hierarchical-sample",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.test/v1",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"HIERARCHICAL_SAMPLE_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/hierarchical-sample-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items scoped by an external parent key",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/parent/{external_team_uuid}/items",
+						Description: "List items under an external parent",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+
+	// Structural assertion 1: the regex var declaration is present.
+	assert.Contains(t, syncContent, "unresolvedPathKeyRE",
+		"generated sync.go should declare unresolvedPathKeyRE var")
+	assert.Contains(t, syncContent, "regexp.MustCompile(`\\{[a-z_][a-z0-9_]*\\}`)",
+		"unresolvedPathKeyRE should match lowercase {key} placeholders")
+
+	// Structural assertion 2: the FindAllString check is wired in syncResource.
+	assert.Contains(t, syncContent, "unresolvedPathKeyRE.FindAllString(path, -1)",
+		"syncResource should scan the resolved path for unresolved {key}s")
+
+	// Structural assertion 3: the sync_warning event payload is correct.
+	assert.Contains(t, syncContent, `"event":"sync_warning"`,
+		"skip branch should emit a sync_warning event")
+	assert.Contains(t, syncContent, `"reason":"unfilled_path_key"`,
+		"skip branch should use reason=unfilled_path_key")
+
+	// Structural assertion 4: the skip branch returns a Warn (non-fatal),
+	// not an Err. The orchestrator's exit policy depends on this distinction.
+	assert.Contains(t, syncContent, `Warn:     fmt.Errorf("skipped %s: unresolved path keys`,
+		"unresolved-key skip should populate syncResult.Warn, not Err")
+
+	// Sanity: the generated code should still compile. `go build` for the
+	// full generated project is exercised by TestGenerateDependentSyncCompiles
+	// and friends; here we just verify the template renders without producing
+	// a syntax error by checking that the regex literal is well-formed.
+	assert.NotContains(t, syncContent, "regexp.MustCompile(``)",
+		"unresolvedPathKeyRE pattern should not render as empty literal")
+}
+
+// TestGenerateSyncFlatAPIUnaffected verifies the skip block is a no-op for
+// flat APIs whose paths contain no {key} placeholders. The generated code
+// is identical except for the new constant and check, and the runtime
+// branch never fires.
+func TestGenerateSyncFlatAPIUnaffected(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "flat-sample",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.test/v1",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"FLAT_SAMPLE_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/flat-sample-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"users": {
+				Description: "Manage users",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/users",
+						Description: "List users",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+
+	// The skip-block template is unconditionally rendered (it's a runtime
+	// check, not a template conditional), so the var declaration and check
+	// are present even for flat APIs. The runtime branch is a no-op when
+	// no path contains an unresolved {key}.
+	assert.Contains(t, syncContent, "unresolvedPathKeyRE",
+		"unresolvedPathKeyRE should be present even on flat-API CLIs (no-op at runtime)")
+
+	// The flat resource's sync path map entry should NOT contain a {key},
+	// so we expect no runtime trigger.
+	assert.Contains(t, syncContent, `"users": "/users"`,
+		"flat users resource should have a clean path with no placeholders")
+}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -22,6 +22,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// unresolvedPathKeyRE matches `{key}` placeholders left in a sync path
+// after syncResourcePath() resolution. Hierarchical APIs (Yahoo Fantasy,
+// Reddit pre-2024, YouTube Data v3, MLB Stats, etc.) declare paths like
+// "/league/{league_key}/players" that can only be filled from parent
+// context — flat-list sync cannot fill them. Resources with unresolved
+// keys emit sync_warning and are skipped without aborting the run, so
+// sync still completes for resources that DO have resolvable paths.
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
 	Resource string
@@ -322,6 +331,31 @@ func syncResource(c interface {
 	if err != nil {
 		return syncResult{Resource: resource, Err: err, Duration: time.Since(started)}
 	}
+
+	// Skip resources whose path template still contains unresolved `{key}`
+	// placeholders after syncResourcePath() resolution. These paths require
+	// parent context (league_key, team_key, channel_id, etc.) that flat-list
+	// sync cannot fill. Emit a sync_warning describing the missing keys and
+	// continue — sync exits 0 if any resource succeeded, so this keeps
+	// hierarchical-API CLIs functional for the resources they CAN sync flat.
+	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
+		if !humanFriendly {
+			// Identifiers are lowercase ASCII; safe to embed without escaping.
+			keysJSON, _ := json.Marshal(missingKeys)
+			fmt.Fprintf(os.Stdout,
+				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
+				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+		} else {
+			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
+				resource, strings.Join(missingKeys, ", "))
+		}
+		return syncResult{
+			Resource: resource,
+			Warn:     fmt.Errorf("skipped %s: unresolved path keys %v", resource, missingKeys),
+			Duration: time.Since(started),
+		}
+	}
+
 	var totalCount int
 
 	// Resume cursor from sync_state (unless --full cleared it)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -29,7 +29,7 @@ import (
 // context — flat-list sync cannot fill them. Resources with unresolved
 // keys emit sync_warning and are skipped without aborting the run, so
 // sync still completes for resources that DO have resolvable paths.
-var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
@@ -340,11 +340,23 @@ func syncResource(c interface {
 	// hierarchical-API CLIs functional for the resources they CAN sync flat.
 	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
 		if !humanFriendly {
-			// Identifiers are lowercase ASCII; safe to embed without escaping.
-			keysJSON, _ := json.Marshal(missingKeys)
-			fmt.Fprintf(os.Stdout,
-				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
-				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+			payload := struct {
+				Event    string   `json:"event"`
+				Resource string   `json:"resource"`
+				Reason   string   `json:"reason"`
+				Keys     []string `json:"keys"`
+				Path     string   `json:"path"`
+				Message  string   `json:"message"`
+			}{
+				Event:    "sync_warning",
+				Resource: resource,
+				Reason:   "unfilled_path_key",
+				Keys:     missingKeys,
+				Path:     path,
+				Message:  fmt.Sprintf("path %s requires parent context (%s); resource skipped", path, strings.Join(missingKeys, ", ")),
+			}
+			payloadJSON, _ := json.Marshal(payload)
+			fmt.Fprintf(os.Stdout, "%s\n", payloadJSON)
 		} else {
 			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
 				resource, strings.Join(missingKeys, ", "))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -18,6 +18,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// unresolvedPathKeyRE matches `{key}` placeholders left in a sync path
+// after syncResourcePath() resolution. Hierarchical APIs (Yahoo Fantasy,
+// Reddit pre-2024, YouTube Data v3, MLB Stats, etc.) declare paths like
+// "/league/{league_key}/players" that can only be filled from parent
+// context — flat-list sync cannot fill them. Resources with unresolved
+// keys emit sync_warning and are skipped without aborting the run, so
+// sync still completes for resources that DO have resolvable paths.
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
 	Resource string
@@ -300,6 +309,31 @@ func syncResource(c interface {
 	if err != nil {
 		return syncResult{Resource: resource, Err: err, Duration: time.Since(started)}
 	}
+
+	// Skip resources whose path template still contains unresolved `{key}`
+	// placeholders after syncResourcePath() resolution. These paths require
+	// parent context (league_key, team_key, channel_id, etc.) that flat-list
+	// sync cannot fill. Emit a sync_warning describing the missing keys and
+	// continue — sync exits 0 if any resource succeeded, so this keeps
+	// hierarchical-API CLIs functional for the resources they CAN sync flat.
+	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
+		if !humanFriendly {
+			// Identifiers are lowercase ASCII; safe to embed without escaping.
+			keysJSON, _ := json.Marshal(missingKeys)
+			fmt.Fprintf(os.Stdout,
+				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
+				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+		} else {
+			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
+				resource, strings.Join(missingKeys, ", "))
+		}
+		return syncResult{
+			Resource: resource,
+			Warn:     fmt.Errorf("skipped %s: unresolved path keys %v", resource, missingKeys),
+			Duration: time.Since(started),
+		}
+	}
+
 	var totalCount int
 
 	// Resume cursor from sync_state (unless --full cleared it)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -25,7 +25,7 @@ import (
 // context — flat-list sync cannot fill them. Resources with unresolved
 // keys emit sync_warning and are skipped without aborting the run, so
 // sync still completes for resources that DO have resolvable paths.
-var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
@@ -318,11 +318,23 @@ func syncResource(c interface {
 	// hierarchical-API CLIs functional for the resources they CAN sync flat.
 	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
 		if !humanFriendly {
-			// Identifiers are lowercase ASCII; safe to embed without escaping.
-			keysJSON, _ := json.Marshal(missingKeys)
-			fmt.Fprintf(os.Stdout,
-				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
-				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+			payload := struct {
+				Event    string   `json:"event"`
+				Resource string   `json:"resource"`
+				Reason   string   `json:"reason"`
+				Keys     []string `json:"keys"`
+				Path     string   `json:"path"`
+				Message  string   `json:"message"`
+			}{
+				Event:    "sync_warning",
+				Resource: resource,
+				Reason:   "unfilled_path_key",
+				Keys:     missingKeys,
+				Path:     path,
+				Message:  fmt.Sprintf("path %s requires parent context (%s); resource skipped", path, strings.Join(missingKeys, ", ")),
+			}
+			payloadJSON, _ := json.Marshal(payload)
+			fmt.Fprintf(os.Stdout, "%s\n", payloadJSON)
 		} else {
 			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
 				resource, strings.Join(missingKeys, ", "))

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -19,6 +19,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// unresolvedPathKeyRE matches `{key}` placeholders left in a sync path
+// after syncResourcePath() resolution. Hierarchical APIs (Yahoo Fantasy,
+// Reddit pre-2024, YouTube Data v3, MLB Stats, etc.) declare paths like
+// "/league/{league_key}/players" that can only be filled from parent
+// context — flat-list sync cannot fill them. Resources with unresolved
+// keys emit sync_warning and are skipped without aborting the run, so
+// sync still completes for resources that DO have resolvable paths.
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
 	Resource string
@@ -277,6 +286,31 @@ func syncResource(c interface {
 	if err != nil {
 		return syncResult{Resource: resource, Err: err, Duration: time.Since(started)}
 	}
+
+	// Skip resources whose path template still contains unresolved `{key}`
+	// placeholders after syncResourcePath() resolution. These paths require
+	// parent context (league_key, team_key, channel_id, etc.) that flat-list
+	// sync cannot fill. Emit a sync_warning describing the missing keys and
+	// continue — sync exits 0 if any resource succeeded, so this keeps
+	// hierarchical-API CLIs functional for the resources they CAN sync flat.
+	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
+		if !humanFriendly {
+			// Identifiers are lowercase ASCII; safe to embed without escaping.
+			keysJSON, _ := json.Marshal(missingKeys)
+			fmt.Fprintf(os.Stdout,
+				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
+				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+		} else {
+			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
+				resource, strings.Join(missingKeys, ", "))
+		}
+		return syncResult{
+			Resource: resource,
+			Warn:     fmt.Errorf("skipped %s: unresolved path keys %v", resource, missingKeys),
+			Duration: time.Since(started),
+		}
+	}
+
 	var totalCount int
 
 	// Resume cursor from sync_state (unless --full cleared it)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -26,7 +26,7 @@ import (
 // context — flat-list sync cannot fill them. Resources with unresolved
 // keys emit sync_warning and are skipped without aborting the run, so
 // sync still completes for resources that DO have resolvable paths.
-var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-z_][a-z0-9_]*\}`)
+var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
@@ -295,11 +295,23 @@ func syncResource(c interface {
 	// hierarchical-API CLIs functional for the resources they CAN sync flat.
 	if missingKeys := unresolvedPathKeyRE.FindAllString(path, -1); len(missingKeys) > 0 {
 		if !humanFriendly {
-			// Identifiers are lowercase ASCII; safe to embed without escaping.
-			keysJSON, _ := json.Marshal(missingKeys)
-			fmt.Fprintf(os.Stdout,
-				`{"event":"sync_warning","resource":"%s","reason":"unfilled_path_key","keys":%s,"path":"%s","message":"path %s requires parent context (%s); resource skipped"}`+"\n",
-				resource, string(keysJSON), path, path, strings.Join(missingKeys, ", "))
+			payload := struct {
+				Event    string   `json:"event"`
+				Resource string   `json:"resource"`
+				Reason   string   `json:"reason"`
+				Keys     []string `json:"keys"`
+				Path     string   `json:"path"`
+				Message  string   `json:"message"`
+			}{
+				Event:    "sync_warning",
+				Resource: resource,
+				Reason:   "unfilled_path_key",
+				Keys:     missingKeys,
+				Path:     path,
+				Message:  fmt.Sprintf("path %s requires parent context (%s); resource skipped", path, strings.Join(missingKeys, ", ")),
+			}
+			payloadJSON, _ := json.Marshal(payload)
+			fmt.Fprintf(os.Stdout, "%s\n", payloadJSON)
 		} else {
 			fmt.Fprintf(os.Stderr, "  %s skipped (requires parent context: %s)\n",
 				resource, strings.Join(missingKeys, ", "))


### PR DESCRIPTION
## Intent

Hierarchical APIs (Yahoo Fantasy, Reddit pre-2024, YouTube Data v3, MLB Stats) declare resource paths like `/league/{league_key}/players` that the flat-list sync cannot fill from context. Today the unresolved `{key}` placeholder is sent verbatim to the API, gets HTTP 500, and aborts the entire sync run on the first failed resource. Surfaced during a yahoo-fantasy generation session — sync failed on the user resource and the flagship `lineup recommend` / `waiver suggest` commands (which depend on synced data) had nothing to read.

Issue: Closes #1006

## Approach

In `syncResource()`, after `syncResourcePath()` returns the resolved path, scan for remaining `{key}` placeholders with a precompiled regex (`unresolvedPathKeyRE` matching `\{[a-z_][a-z0-9_]*\}`). If any are present:

1. Emit a structured `sync_warning` event naming the missing keys and the unresolvable path. Falls through to a human-friendly stderr line when `humanFriendly` is set, consistent with other event emission in the file.
2. Return `syncResult{Warn: ...}` (not `Err`), so the orchestrator's existing exit-policy treats it as warned, not errored. Sync still exits 0 if at least one resource synced; the warn counter increments by one per skipped resource.

Tier 1 only: graceful skip + warning. The bigger Tier 2 work (a `sync.walker` spec parameter for hierarchical orchestration) stays out of this PR — it's a separate retro after more catalog evidence accumulates.

## Scope

Primary area: `internal/generator/templates/sync.go.tmpl`

Why this belongs in this repo: This is a generator template change — every printed CLI will pick up the skip block on the next regen. Per-CLI patching of `internal/cli/sync.go` in `~/printing-press/library/<api>/` would only help that one CLI; the bug is in the template that generates them all.

## Risk

- **Flat APIs (most of the catalog):** No behavior change. Their resolved sync paths contain no `{key}` placeholders, so `unresolvedPathKeyRE.FindAllString()` returns `nil` and the new branch is a no-op. Verified by `TestGenerateSyncFlatAPIUnaffected` and by the unchanged golden fixtures for `loops`, `stytch`, `clerk`, etc.
- **Hierarchical APIs that explicitly declare parent-child relationships (via `dependentResourceDefs`):** No behavior change. Those resources are routed through `syncDependentResources()` which substitutes parent IDs before the path reaches `syncResource()`, so no unresolved keys remain by the time my check runs.
- **Hierarchical APIs whose specs don't declare the parent relationship (the Yahoo case):** Behavior change is the intended fix. Previously: HTTP 500 + run abort. Now: structured warning + sync continues.
- **Existing event consumers:** The new event uses `event=sync_warning` (already defined) with a new `reason=unfilled_path_key`. Consumers that filter on `event` continue working; consumers that filter on specific `reason` values get a new value to handle (additive).

## Output Contract

Template change affects emitted `internal/cli/sync.go` for every generated CLI:

- New top-level `var unresolvedPathKeyRE = regexp.MustCompile(...)` declaration.
- New skip block at the top of `syncResource()`, before the resume-cursor read.

Golden fixtures regenerated to capture this:

- `testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go` (+34 lines)
- `testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go` (+34 lines)

No other goldens changed. `scripts/golden.sh verify` is clean post-update.

## Verification

```bash
# Targeted new tests
go test ./internal/generator/ -run 'TestGenerateSyncSkipsUnresolvedPathKeys|TestGenerateSyncFlatAPIUnaffected' -v
# Both PASS.

# Full generator suite
go test ./internal/generator/...
# PASS, 176s, no regressions.

# Lint + format
go vet ./internal/generator/...     # clean
go fmt ./internal/generator/...     # no changes (already formatted)

# Golden harness
GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update   # 2 fixtures refreshed, 14 unchanged
scripts/golden.sh verify                         # 16/16 PASS
```

`golangci-lint run ./...` — 0 issues (run locally with golangci-lint 2.12.2 after addressing review feedback).

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

