### PR TITLE
fix(cli): emit AccessToken-only AuthHeader for all OAuth2 grants

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -57,37 +57,60 @@ func TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars(t *testing.T) {
 	assert.Less(t, verifyIdx, mintIdx, "mock verification must not dial the real token endpoint")
 }
 
-func TestAuthHeader_OAuth2AuthorizationCodeUsesToken(t *testing.T) {
+// TestAuthHeader_OAuth2DoesNotUseSetupEnvVars pins that for every OAuth2
+// grant (authorization_code via the default, client_credentials via explicit
+// OAuth2Grant) the configured env vars (e.g. CLIENT_ID / CLIENT_SECRET) are
+// never emitted as bearer headers. The minted AccessToken is the only usable
+// bearer; sending CLIENT_ID as `Authorization: Bearer` surfaces as
+// token_rejected at the API.
+func TestAuthHeader_OAuth2DoesNotUseSetupEnvVars(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("oauth-precedence")
-	apiSpec.Auth = spec.AuthConfig{
-		Type:             "oauth2",
-		Header:           "Authorization",
-		Format:           "Bearer {token}",
-		EnvVars:          []string{"OAUTH_AUTH_TEST_TOKEN"},
-		AuthorizationURL: "https://example.com/auth",
-		TokenURL:         "https://example.com/token",
+	cases := []struct {
+		name  string
+		grant string
+	}{
+		{"authorization_code", ""},
+		{"client_credentials", spec.OAuth2GrantClientCredentials},
 	}
 
-	outputDir := filepath.Join(t.TempDir(), "oauth-precedence-pp-cli")
-	require.NoError(t, New(apiSpec, outputDir).Generate())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
-	require.NoError(t, err)
-	content := string(cfgSrc)
+			apiSpec := minimalSpec("oauth-precedence-" + tc.name)
+			apiSpec.Auth = spec.AuthConfig{
+				Type:   "oauth2",
+				Header: "Authorization",
+				Format: "Bearer {token}",
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "OAUTH_AUTH_TEST_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+					{Name: "OAUTH_AUTH_TEST_CLIENT_SECRET", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: true},
+				},
+				AuthorizationURL: "https://example.com/auth",
+				TokenURL:         "https://example.com/token",
+				OAuth2Grant:      tc.grant,
+			}
 
-	envCheck := "if c." + resolveEnvVarField("OAUTH_AUTH_TEST_TOKEN") + ` != ""`
-	tokenCheck := `if c.AccessToken != ""`
+			outputDir := filepath.Join(t.TempDir(), "oauth-precedence-"+tc.name+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
 
-	require.Contains(t, content, envCheck)
-	require.Contains(t, content, tokenCheck)
+			cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+			require.NoError(t, err)
+			content := string(cfgSrc)
 
-	body := authHeaderBody(t, content)
-	envIdx := strings.Index(body, envCheck)
-	tokenIdx := strings.Index(body, tokenCheck)
-	assert.Less(t, envIdx, tokenIdx,
-		"env-var bearer fallback should win over file token for OAuth2 authorization_code")
+			clientIDCheck := "if c." + resolveEnvVarField("OAUTH_AUTH_TEST_CLIENT_ID") + ` != ""`
+			clientSecretCheck := "if c." + resolveEnvVarField("OAUTH_AUTH_TEST_CLIENT_SECRET") + ` != ""`
+			tokenCheck := `if c.AccessToken != ""`
+
+			body := authHeaderBody(t, content)
+			require.Contains(t, body, tokenCheck, "AuthHeader must check AccessToken")
+			require.Contains(t, body, `applyAuthFormat("Bearer {token}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})`,
+				"AuthHeader must return the AccessToken via applyAuthFormat")
+			require.NotContains(t, body, clientIDCheck, "client ID must not be used as a bearer token")
+			require.NotContains(t, body, clientSecretCheck, "client secret must not be used as a bearer token")
+		})
+	}
 }
 
 func TestAuthLoginEnvVarsUseShellSafePrefix(t *testing.T) {

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -292,9 +292,12 @@ func (c *Config) AuthHeader() string {
 	{{- end}}
 {{- end}}
 {{- else if or (eq .Auth.Type "bearer_token") (eq .Auth.Type "oauth2")}}
-{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
-	// Under OAuth2 client_credentials the env var is the Client ID, not a
-	// usable bearer; the minted AccessToken must win.
+{{- if or (eq .Auth.Type "oauth2") (and (eq .Auth.Type "bearer_token") (eq .Auth.EffectiveOAuth2Grant "client_credentials"))}}
+	// Under OAuth2 (and bearer_token specs running the client_credentials
+	// grant) the configured env vars hold client credentials (client_id /
+	// client_secret), not a usable bearer; the minted AccessToken must
+	// win. Sending the client_id as Authorization: Bearer surfaces as
+	// token_rejected at the API.
 	if c.AccessToken != "" {
 		c.AuthSource = "oauth2"
 		{{- if .Auth.Format}}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -97,8 +97,11 @@ func (c *Config) AuthHeader() string {
 	if c.AuthHeaderVal != "" {
 		return c.AuthHeaderVal
 	}
-	// Under OAuth2 client_credentials the env var is the Client ID, not a
-	// usable bearer; the minted AccessToken must win.
+	// Under OAuth2 (and bearer_token specs running the client_credentials
+	// grant) the configured env vars hold client credentials (client_id /
+	// client_secret), not a usable bearer; the minted AccessToken must
+	// win. Sending the client_id as Authorization: Bearer surfaces as
+	// token_rejected at the API.
 	if c.AccessToken != "" {
 		c.AuthSource = "oauth2"
 		return "Bearer " + c.AccessToken


### PR DESCRIPTION
## Intent

OAuth2 CLIs (any grant) were emitting the configured `<API>_CLIENT_ID` env var as the `Authorization: Bearer` value before falling through to the persisted `AccessToken`, breaking every live API call with `token_rejected`. Users following the standard OAuth setup (export `<API>_CLIENT_ID`) hit this immediately after a successful `auth login`.

Issue: Closes #1005

## Approach

The `AuthHeader()` template's AccessToken-only branch in [internal/generator/templates/config.go.tmpl](internal/generator/templates/config.go.tmpl#L295) was gated on `EffectiveOAuth2Grant == "client_credentials"` only. For `auth.type: oauth2` with the default `authorization_code` grant, control fell through to the env-var-wins block (lines 320-355) and emitted `CLIENT_ID` as a bearer fallback.

Broaden the gate to `(eq .Auth.Type "oauth2") || (Type=="bearer_token" && EffectiveOAuth2Grant=="client_credentials")`. The first disjunct handles every OAuth2 spec (both `authorization_code` and `client_credentials` grants); the second disjunct preserves the existing carve-out for plain `bearer_token` specs declared with the client_credentials grant, pinned by `TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars`. The structure makes the carve-out explicit so the inner gate doesn't read as redundant with the outer `(bearer_token || oauth2)` guard.

The existing test `TestAuthHeader_OAuth2AuthorizationCodeUsesToken` pinned the bug. It is rewritten as a table-driven test `TestAuthHeader_OAuth2DoesNotUseSetupEnvVars` covering both OAuth2 grants and asserting both that `CLIENT_ID` / `CLIENT_SECRET` never appear as bearer checks AND that AuthHeader actually returns the AccessToken via `applyAuthFormat`.

Aligns with the documented design pattern in [docs/solutions/design-patterns/avoid-classification-when-failure-is-asymmetric-2026-05-06.md](docs/solutions/design-patterns/avoid-classification-when-failure-is-asymmetric-2026-05-06.md).

## Scope

Primary area: `comp:generator` (template emission for OAuth2 auth headers).

Why this belongs in this repo: machine change — affects every OAuth2 CLI on next regen, not a single printed CLI.

## Risk

- Behavioral change for every generated OAuth2 CLI: `AuthHeader()` no longer falls back to env-var-as-bearer. Any user relying on `<API>_CLIENT_ID` as a bearer fallback (which would have produced `token_rejected` regardless) gets a `""` return instead — same effective outcome (no successful API call) but cleaner failure mode that surfaces via `auth status` rather than `token_rejected`.
- Manual override via `AuthHeaderVal` still wins for both grants (unchanged).
- `bearer_token + grant=client_credentials` path is preserved by the second disjunct and the existing CC test still passes.
- `bearer_token` with any non-CC grant (including default authorization_code) is unchanged — still uses env-var-wins precedence per `TestAuthHeader_EnvVarWinsOverFileToken`.
- No effect on the `auth login` flow itself; env vars remain the way OAuth client credentials are passed in.

## Output Contract

Generated `internal/config/config.go` for OAuth2 specs now emits a single `AccessToken != ""` check (with the broadened comment) and no env-var bearer fallback. The byte-level diff for the existing `generate-golden-api-oauth2-cc` golden is comment-only; the behavioral code is identical (this fixture uses `client_credentials`, which already had this code path).

**Golden coverage decision (per AGENTS.md "Generator Output Stability"):** No new golden fixture added for `oauth2 + authorization_code`. The existing `oauth2-cc` golden already pins the byte-identical `AuthHeader` text shape this fix emits for both grants. Coverage for the `authorization_code` grant is provided by the new table-driven unit test, which asserts the generated source contains the AccessToken return and excludes CLIENT_ID/CLIENT_SECRET bearer checks for both grants.

## Verification

- `go test ./... -count=1` — 3490 passed
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./...` — clean
- `go build -o ./printing-press ./cmd/printing-press` — clean
- `scripts/golden.sh verify` — 16/16 PASS

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change