### PR TITLE
fix(cli): bind typed upsert values in column-declaration order

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2561,6 +2561,78 @@ func TestGenerateStoreUpsertBatchDispatchesToTypedTable(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/store")
 }
 
+// TestGenerateStoreSubResourceUpsertBindingOrder asserts that the typed
+// upsert for a sub-resource table binds its argument values in the same
+// order as the SQL column declarations. buildSubResourceTable puts the
+// FK column between id and data, so the bindings have to match —
+// otherwise JSON blobs land in the FK column, timestamps land in data,
+// and FK values land in synced_at, silently corrupting every row.
+func TestGenerateStoreSubResourceUpsertBindingOrder(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "subres",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"SUBRES_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/subres-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"domains": {
+				Description: "Manage domains",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/domains", Description: "List domains"},
+				},
+				SubResources: map[string]spec.Resource{
+					"verify": {
+						Description: "Verify a domain",
+						Endpoints: map[string]spec.Endpoint{
+							"get": {
+								Method:      "GET",
+								Path:        "/domains/{domainId}/verify",
+								Description: "Get verification status",
+								Params:      []spec.Param{{Name: "domainId", Type: "string", Required: true, Positional: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	src := string(storeSrc)
+
+	// buildSubResourceTable inserts the FK column between id and data, so
+	// the column declaration order is (id, domains_id, data, synced_at).
+	assert.Contains(t, src, "INSERT INTO verify (id, domains_id, data, synced_at)",
+		"sub-resource table should declare FK column between id and data")
+
+	// The argument bindings must follow that same order.
+	assert.Regexp(t,
+		`(?s)id,\s+lookupFieldValue\(obj, "domains_id"\),\s+string\(data\),\s+time\.Now\(\),`,
+		src,
+		"upsertVerifyTx binding order must match (id, domains_id, data, synced_at) column order")
+
+	// And the swapped order must be absent.
+	assert.NotRegexp(t,
+		`(?s)id,\s+string\(data\),\s+time\.Now\(\),\s+lookupFieldValue\(obj, "domains_id"\),`,
+		src,
+		"swapped (id, data, synced_at, fk) binding order must not be emitted")
+}
+
 func TestGenerateSimilarCommandUsesCompositeResourceKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -786,11 +786,14 @@ func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]a
 		`INSERT INTO {{safeName .Name}} ({{columnNames .Columns}})
 		 VALUES ({{columnPlaceholders .Columns}})
 		 ON CONFLICT(id) DO UPDATE SET {{updateSet .Columns}}`,
-		id,
-		string(data),
-		time.Now(),
 {{- range .Columns}}
-{{- if and (ne .Name "id") (ne .Name "data") (ne .Name "synced_at")}}
+{{- if eq .Name "id"}}
+		id,
+{{- else if eq .Name "data"}}
+		string(data),
+{{- else if eq .Name "synced_at"}}
+		time.Now(),
+{{- else}}
 		lookupFieldValue(obj, "{{.Name}}"),
 {{- end}}
 {{- end}}


### PR DESCRIPTION
## Intent

Issue: Closes #1014

Sub-resource typed-upsert helpers emitted bindings in `(id, data, synced_at, fk)` order while the SQL column list was `(id, fk, data, synced_at)`. Every paginated sync into a sub-resource table silently corrupted rows: JSON blobs landed in the FK column, timestamps landed in `data`, and FK strings landed in `synced_at`. SQLite accepted it because the columns were all TEXT-compatible. Top-level gravity-2+ tables and dependent-sync tables happened to align because their non-base columns were appended after `data`/`synced_at`; the bug only surfaced for sub-resource tables built by `buildSubResourceTable`, which inserts the FK column between `id` and `data`.

## Approach

In `internal/generator/templates/store.go.tmpl`, replace the three hard-coded leading bindings (`id`, `string(data)`, `time.Now()`) plus the filtered loop over the rest with a single loop that walks `.Columns` in declaration order and emits the matching expression per column. The argument order now follows `columnNames` by construction, so adding a column anywhere in the slice cannot desynchronize the bindings again.

## Scope

Primary area: generator template (`store.go.tmpl`).

Why this belongs in this repo: the bug is in a Printing Press template emitted into every printed CLI with FK-bearing typed tables. Fixing the printed CLI alone (as already done in printing-press-library#289) doesn't compound to future generations.

Out of scope: the issue's secondary audit note about `ResolveByName` using `fmt.Sprintf` to interpolate a `field` parameter into a SQL JSON path. Callers currently pass safe constants; tightening that path is a separate change.

## Risk

Generator template change: every CLI regenerated after this lands will get bindings in column-declaration order. For tables where the order already aligned (top-level gravity-2+ tables, dep-sync tables with `parent_id` appended), the emitted Go is functionally identical — only sub-resource and any future mid-list-FK tables change behavior. Existing CLIs with already-corrupted typed columns still need a `sync --reset` (or DB delete) to rebuild; that's downstream work, not part of this PR.

## Output Contract

Generator template diff. Existing golden harness exercises top-level tables only, so no golden fixtures change. Verified with `scripts/golden.sh verify` (16/16 pass).

## Verification

- `go test ./internal/generator/ -count=1` — 699 passed (includes new `TestGenerateStoreSubResourceUpsertBindingOrder`)
- `go test ./... -count=1` — 3489 passed across 34 packages
- `go fmt ./...` — clean
- `go vet ./...` — no issues
- `golangci-lint run ./...` — no issues
- `scripts/golden.sh verify` — 16/16 pass
- `git diff --check` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change