### PR TITLE
fix(generator): treat trailing '_test' stems as build-excluded, rename to *_test_cmd.go (#1020)

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3651,22 +3651,25 @@ var goarchTokens = map[string]struct{}{
 
 // safeResourceFileStem returns a basename (without .go) safe to write under
 // internal/cli/, suffixing "_cmd" if the bare stem matches Go's filename-based
-// build-constraint pattern (*_<GOOS>.go, *_<GOARCH>.go, *_<GOOS>_<GOARCH>.go).
-// Without this rename, a file like scheduling_windows.go would get an implicit
-// Windows-only build tag and be silently excluded on macOS/Linux builds.
+// build-constraint pattern (*_<GOOS>.go, *_<GOARCH>.go, *_<GOOS>_<GOARCH>.go)
+// or Go's test-file pattern (*_test.go). Without this rename a file like
+// scheduling_windows.go would get an implicit Windows-only build tag and be
+// silently excluded on macOS/Linux builds, and a file like webhook_test.go
+// would be treated as a test file and excluded from the normal package build.
 //
 // The reserved-name collision is handled separately at spec-parse time
 // (see ReservedCLIResourceNames) because the function-name collision needs a
 // hard error rather than a silent rename — `new<Name>Cmd` would clash with
 // the reserved template's identically-named cobra builder.
 //
-// The suffix "_cmd" is never itself a GOOS or GOARCH token, so a single
-// application is sufficient.
+// The suffix "_cmd" is never itself a GOOS, GOARCH, or "test" token, so a
+// single application is sufficient.
 //
 // Examples:
 //
 //	safeResourceFileStem("scheduling_windows")     -> "scheduling_windows_cmd"
 //	safeResourceFileStem("foo_linux_amd64")        -> "foo_linux_amd64_cmd"
+//	safeResourceFileStem("webhook_test")           -> "webhook_test_cmd"
 //	safeResourceFileStem("scheduling_window_days") -> "scheduling_window_days" (no change)
 //	safeResourceFileStem("feedback")               -> "feedback" (no change; rejected at parse)
 func safeResourceFileStem(stem string) string {
@@ -3677,6 +3680,12 @@ func safeResourceFileStem(stem string) string {
 			return stem + "_cmd"
 		}
 		if _, isArch := goarchTokens[last]; isArch {
+			return stem + "_cmd"
+		}
+		if last == "test" {
+			// Go treats *_test.go as a test file and excludes it from
+			// the normal package build. Suffix "_cmd" keeps the file in
+			// the normal build.
 			return stem + "_cmd"
 		}
 	}

--- a/internal/generator/safe_filename_test.go
+++ b/internal/generator/safe_filename_test.go
@@ -86,6 +86,30 @@ func TestSafeResourceFileStem(t *testing.T) {
 			expected: "store_arm64_endpoint",
 			why:      "'endpoint' is not a GOARCH/GOOS; only triggers on the last token",
 		},
+		{
+			name:     "trailing 'test' triggers rename",
+			stem:     "webhook_test",
+			expected: "webhook_test_cmd",
+			why:      "Go treats *_test.go as a test file and excludes it from the normal package build",
+		},
+		{
+			name:     "trailing 'test' from multi-segment stem triggers rename",
+			stem:     "connector_verify_test",
+			expected: "connector_verify_test_cmd",
+			why:      "only the trailing token matters; nested operationIds ending in 'test' also collide",
+		},
+		{
+			name:     "embedded 'test' in middle position unchanged",
+			stem:     "test_helpers_endpoint",
+			expected: "test_helpers_endpoint",
+			why:      "'test' must be the trailing token for the *_test.go rule to apply",
+		},
+		{
+			name:     "stem with 'tester' suffix unchanged",
+			stem:     "load_tester",
+			expected: "load_tester",
+			why:      "'tester' is not 'test'; only exact-suffix tokens trigger",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #1020.

## What

`safeResourceFileStem` already renames trailing GOOS/GOARCH tokens to dodge Go's filename-based build constraints (`scheduling_windows.go` → `scheduling_windows_cmd.go`). This adds the same handling for the `test` suffix, which Go reserves for test files.

## Why

Any OpenAPI operationId whose lowercase form is `test<Resource>` (or any path nesting whose endpoint name resolves to `test`) produces `<resource>_test.go`, which Go excludes from the normal package build. The parent grouper file (e.g., `webhook.go`) still references `newWebhookTestCmd`, so the package fails to compile:

```
internal/cli/webhook.go:20:17: undefined: newWebhookTestCmd
```

govulncheck catches this in the validate gate, but `go build ./...` of the test binary does not, so the failure is opaque without running validate.

## Repro

Discovered generating a CLI for Salesforce Spiff. The operationId `testWebhook` (natural in the upstream Spiff docs at developer.salesforce.com/docs/sales/spiff) blew up generation on a clean spec.

## Fix

```go
if last == "test" {
    return stem + "_cmd"
}
```

Slotted into the same `len(parts) >= 2` block as the GOOS/GOARCH checks. The suffix `_cmd` is not itself `test`, so a single application is sufficient.

## Tests

Four new cases in `safe_filename_test.go`:
- `webhook_test` → `webhook_test_cmd` (trailing rename)
- `connector_verify_test` → `connector_verify_test_cmd` (multi-segment, trailing rename)
- `test_helpers_endpoint` → `test_helpers_endpoint` (embedded `test`, no rename)
- `load_tester` → `load_tester` (`tester`, not `test`, no rename)

All pass. End-to-end verified: regenerating the Spiff CLI with `operationId: testWebhook` now produces `internal/cli/webhook_test_cmd.go` and passes `govulncheck`/`go vet`/`go build`/runtime smoke.

## Test plan

- [x] `go test ./internal/generator/ -run TestSafeResourceFileStem -v` passes (16/16 cases including 4 new)
- [x] Hand-authored OpenAPI spec with `operationId: testWebhook` previously failing `govulncheck` now passes all validate gates
- [x] Generated `webhook_test_cmd.go` builds cleanly under `go build`, runs under `go vet`