### PR TITLE
fix(cli): Store.Get propagates sql.ErrNoRows so callers can gate on existence

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2140,6 +2140,42 @@ func TestGenerateStoreMigrateUsesBeginImmediate(t *testing.T) {
 		"migrate must read PRAGMA user_version BEFORE entering withMigrationLock so newer-DB rejection happens before lock acquisition")
 }
 
+// TestGenerateStoreGetPropagatesErrNoRows pins that the emitted Store.Get
+// propagates sql.ErrNoRows and that the one in-template caller detects
+// missing rows via errors.Is, not a (item == nil) shape.
+func TestGenerateStoreGetPropagatesErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("errnorows-canary")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	storeCode := stripGoComments(string(storeSrc))
+
+	assert.NotRegexp(t, `(?s)func \(s \*Store\) Get\([^)]*\) \([^)]*\) \{[^}]*sql\.ErrNoRows[^}]*return nil, nil`, storeCode,
+		"Store.Get must propagate sql.ErrNoRows; callers gating on existence rely on errors.Is(err, sql.ErrNoRows)")
+	assert.Regexp(t, `(?s)func \(s \*Store\) Get\([^)]*\) \([^)]*\) \{[^}]*return nil, err`, storeCode,
+		"Store.Get must surface the underlying error so sql.ErrNoRows reaches callers; a refactor that adds a nested block before the return would silently bypass the NotRegexp above")
+
+	dataSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "data_source.go"))
+	require.NoError(t, err)
+	dataCode := stripGoComments(string(dataSrc))
+
+	assert.Contains(t, dataCode, "errors.Is(err, sql.ErrNoRows)",
+		"data_source.go must detect missing rows via errors.Is(err, sql.ErrNoRows)")
+	assert.NotContains(t, dataCode, "if item == nil {",
+		"data_source.go must not use (item == nil) to detect missing rows; Get returns sql.ErrNoRows instead")
+
+	storeTestSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "schema_version_test.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(storeTestSrc), "func TestGet_MissingRowReturnsErrNoRows(",
+		"template-level Get contract test must land in the emitted store package; dropping it would leave the runtime contract uncovered in printed CLIs")
+}
+
 // TestGenerateMCPSQLToolUsesReadOnlyStore guards the agent-native security
 // model. The MCP sql and search tools advertise readOnlyHint=true to MCP
 // hosts so the host auto-approves invocations; a false readOnlyHint on a

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2140,9 +2140,9 @@ func TestGenerateStoreMigrateUsesBeginImmediate(t *testing.T) {
 		"migrate must read PRAGMA user_version BEFORE entering withMigrationLock so newer-DB rejection happens before lock acquisition")
 }
 
-// TestGenerateStoreGetPropagatesErrNoRows pins that the emitted Store.Get
-// propagates sql.ErrNoRows and that the one in-template caller detects
-// missing rows via errors.Is, not a (item == nil) shape.
+// Callers gating on existence rely on errors.Is(err, sql.ErrNoRows); the
+// emitted Store.Get must surface the sentinel rather than swallow it into
+// a nil-shape that bypasses the caller's err check.
 func TestGenerateStoreGetPropagatesErrNoRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -5,7 +5,9 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -253,10 +255,10 @@ func resolveLocal(ctx context.Context, resourceType string, isList bool, path st
 
 	item, err := db.Get(resourceType, id)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, DataProvenance{}, fmt.Errorf("resource %q with ID %q not found in local store. Run '{{.Name}}-pp-cli sync' first", resourceType, id)
+		}
 		return nil, DataProvenance{}, fmt.Errorf("querying local store: %w", err)
-	}
-	if item == nil {
-		return nil, DataProvenance{}, fmt.Errorf("resource %q with ID %q not found in local store. Run '{{.Name}}-pp-cli sync' first", resourceType, id)
 	}
 	return item, prov, nil
 }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -642,15 +642,14 @@ func (s *Store) Upsert(resourceType, id string, data json.RawMessage) error {
 	return tx.Commit()
 }
 
+// Propagates sql.ErrNoRows on a miss so callers can distinguish absence from
+// other scan errors via errors.Is.
 func (s *Store) Get(resourceType, id string) (json.RawMessage, error) {
 	var data string
 	err := s.db.QueryRow(
 		`SELECT data FROM resources WHERE resource_type = ? AND id = ?`,
 		resourceType, id,
 	).Scan(&data)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -302,9 +302,8 @@ func TestResources_CompositeKeyPreservesOverlappingIDs(t *testing.T) {
 	}
 }
 
-// TestGet_MissingRowReturnsErrNoRows pins that callers can detect missing
-// rows via errors.Is(err, sql.ErrNoRows); present rows return the JSON
-// payload with a nil error.
+// Callers detect missing rows via errors.Is(err, sql.ErrNoRows); present
+// rows return the JSON payload with a nil error.
 func TestGet_MissingRowReturnsErrNoRows(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -302,6 +302,37 @@ func TestResources_CompositeKeyPreservesOverlappingIDs(t *testing.T) {
 	}
 }
 
+// TestGet_MissingRowReturnsErrNoRows pins that callers can detect missing
+// rows via errors.Is(err, sql.ErrNoRows); present rows return the JSON
+// payload with a nil error.
+func TestGet_MissingRowReturnsErrNoRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	data, err := s.Get("missing_type", "missing_id")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("Get missing row err = %v, want sql.ErrNoRows", err)
+	}
+	if data != nil {
+		t.Fatalf("Get missing row data = %s, want nil", data)
+	}
+
+	if err := s.Upsert("present_type", "present_id", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, err := s.Get("present_type", "present_id")
+	if err != nil {
+		t.Fatalf("Get present row: %v", err)
+	}
+	if string(got) != `{"ok":true}` {
+		t.Fatalf("Get present row data = %s, want {\"ok\":true}", got)
+	}
+}
+
 func TestMigrate_ResourcesCompositeKeyUpgrade(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 


### PR DESCRIPTION
## Intent

Fixes #962. Generator's `Store.Get` template swallowed `sql.ErrNoRows` into `(nil, nil)`, which silently bypassed `if err != nil { return err }` checks at every novel-command call site — `saved rm <missing-name>`-style commands could exit 0 instead of returning `notFoundErr`.

## Approach

Direction A from the issue: propagate `sql.ErrNoRows` directly so callers use `errors.Is(err, sql.ErrNoRows)`. Updated the one in-template caller (`data_source.go.tmpl::resolveLocal`) to detect missing rows via `errors.Is` inside the `if err != nil` branch, replacing the now-dead `if item == nil` post-check.

Coverage is dual-tier:
- **Generator-level** ([generator_test.go:2143](internal/generator/generator_test.go#L2143)): renders the template, asserts the rendered `Store.Get` doesn't swallow into `(nil, nil)`, surfaces the underlying error, the caller uses `errors.Is`, and the runtime test lands in the emitted store package.
- **Template-level** ([store_schema_version_test.go.tmpl:305](internal/generator/templates/store_schema_version_test.go.tmpl#L305)): asserts the runtime contract — missing row returns `sql.ErrNoRows`, present row returns payload.

## Scope

Primary area: `internal/generator/templates/store.go.tmpl` + `data_source.go.tmpl`.

Per the issue's scope boundary ("Only `Get`. Don't touch `List`, `Insert`, `Update`, `Delete` semantics"), other `sql.ErrNoRows` swallows in the same template (`ensureColumn` line 154, `GetSyncState` line 1013) are deliberately left alone — those are valid empty-state boundaries (no migration needed / no sync yet), not the silent-footgun pattern. Same for `share.go.tmpl` line 668.

## Risk

**Breaking contract change for hand-written novel-command callers in the public library.** Any caller still gating on the old `(data == nil)` shape after regen will fall through to the `err != nil` branch with a less friendly error string. Audited the three current hand-written `db.Get` callers in the library (pagliacci, pagliacci-pizza, producthunt); all use the compound `err == nil && data != nil` guard which is safe under both contracts. Risk surface is hypothetical new novel commands authored against stale snippets; the issue explicitly accepted this ("Direction A is breaking; one-time migration cost reveals silent failures across the fleet").

## Output Contract

Templates under `internal/generator/templates/` changed. No golden fixtures contain `store.go` or `data_source.go` (verified by `find testdata/golden/expected -name "store.go" -o -name "data_source.go"`); `scripts/golden.sh verify` passes 16/16 unchanged.

## Verification

- `go fmt ./...` clean
- `go build -o ./printing-press ./cmd/printing-press` clean
- `go test ./...` — 3490 passed in 34 packages
- `go vet ./...` clean
- `golangci-lint run ./...` clean
- `scripts/golden.sh verify` — 16/16 PASS
- `git diff --check` clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change