### PR TITLE
fix(cli): classify doctor HTTP 403 as scope-limited WARN, not invalid FAIL

### DIFF
--- a/internal/generator/auth_status_test.go
+++ b/internal/generator/auth_status_test.go
@@ -51,6 +51,36 @@ func TestDoctorWithVerifyPathCanClaimCredentialsValid(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestDoctorClassifiesHTTP401AsInvalidAnd403AsScopeLimited(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("doctor-scope")
+	apiSpec.Auth.VerifyPath = "/account"
+
+	outputDir := filepath.Join(t.TempDir(), "doctor-scope-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	src := string(doctorSrc)
+
+	require.Contains(t, src, "case authAPIErr.StatusCode == 401:",
+		"doctor must keep a dedicated 401 branch so HTTP 401 reports as invalid credentials")
+	require.Contains(t, src, `"invalid (HTTP %d) — check your credentials"`,
+		"doctor's 401 message must continue to direct users to check the credential value")
+
+	require.Contains(t, src, "case authAPIErr.StatusCode == 403:",
+		"doctor must split 401 and 403 so 403 (scope-limited) is not misreported as invalid")
+	require.Contains(t, src, `"scope-limited (HTTP %d) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope."`,
+		"doctor's 403 message must surface as scope-limited and point at dashboard scope, not the credential value")
+
+	require.NotContains(t, src, "authAPIErr.StatusCode == 401 || authAPIErr.StatusCode == 403",
+		"doctor must not collapse 401 and 403 into a single invalid branch")
+
+	require.Contains(t, src, `case strings.Contains(s, "scope-limited"):`,
+		"doctor's human-readable indicator switch must classify scope-limited as WARN, not FAIL")
+}
+
 func TestAuthStatusReportsCredentialsPresentNotVerified(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4757,7 +4757,9 @@ func TestGeneratedDoctor_AuthVerifyPathProbesEndpoint(t *testing.T) {
 	assert.Contains(t, content, `verifyPath := "/me?fields=id"`)
 	assert.Contains(t, content, `c.GetWithHeaders(verifyPath`)
 	assert.NotContains(t, content, `&http.Client{`)
-	// When verify_path is set, 401/403 keeps the strict "invalid" verdict
+	// When verify_path is set, HTTP 401 keeps the strict "invalid" verdict.
+	// 403 is handled separately as scope-limited; see
+	// TestDoctorClassifiesHTTP401AsInvalidAnd403AsScopeLimited.
 	assert.Contains(t, content, `"invalid (HTTP %d) — check your credentials"`)
 	// And does NOT emit the inconclusive fallback wording
 	assert.NotContains(t, content, "inconclusive (HTTP %d from base URL")

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -434,8 +434,10 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 							report["credentials"] = "valid"
 						case errors.As(authErr, &authAPIErr):
 							switch {
-							case authAPIErr.StatusCode == 401 || authAPIErr.StatusCode == 403:
+							case authAPIErr.StatusCode == 401:
 								report["credentials"] = fmt.Sprintf("invalid (HTTP %d) — check your credentials", authAPIErr.StatusCode)
+							case authAPIErr.StatusCode == 403:
+								report["credentials"] = fmt.Sprintf("scope-limited (HTTP %d) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.", authAPIErr.StatusCode)
 							default:
 								// Non-auth HTTP error (404, 500, etc.) — don't blame credentials
 								report["credentials"] = fmt.Sprintf("ok (HTTP %d from %s, but auth was accepted)", authAPIErr.StatusCode, verifyPath)
@@ -497,6 +499,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				case strings.HasPrefix(s, "optional"):
 					// Optional-auth CLI with no key set — informational, not a failure.
 					indicator = yellow("INFO")
+				case strings.Contains(s, "scope-limited"):
+					indicator = yellow("WARN")
 				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
 					indicator = red("FAIL")
 				case s == "not required":

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -279,6 +279,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				case strings.HasPrefix(s, "optional"):
 					// Optional-auth CLI with no key set — informational, not a failure.
 					indicator = yellow("INFO")
+				case strings.Contains(s, "scope-limited"):
+					indicator = yellow("WARN")
 				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
 					indicator = red("FAIL")
 				case s == "not required":

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -227,6 +227,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				case strings.HasPrefix(s, "optional"):
 					// Optional-auth CLI with no key set — informational, not a failure.
 					indicator = yellow("INFO")
+				case strings.Contains(s, "scope-limited"):
+					indicator = yellow("WARN")
 				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
 					indicator = red("FAIL")
 				case s == "not required":

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -249,6 +249,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				case strings.HasPrefix(s, "optional"):
 					// Optional-auth CLI with no key set — informational, not a failure.
 					indicator = yellow("INFO")
+				case strings.Contains(s, "scope-limited"):
+					indicator = yellow("WARN")
 				case strings.Contains(s, "error") || strings.Contains(s, "not configured") || strings.Contains(s, "unreachable") || strings.Contains(s, "invalid") || strings.Contains(s, "missing"):
 					indicator = red("FAIL")
 				case s == "not required":


### PR DESCRIPTION
## Intent

Doctor's credentials probe lumped HTTP 401 and 403 into one branch and reported both as `invalid (HTTP %d) — check your credentials`. A 403 means the credential was accepted but lacks scope for the configured `verify_path` endpoint — telling users to re-check the credential value wastes their time when the real fix is adjusting the dashboard API key scope.

Issue: Closes #895

## Approach

Split the 401/403 case in `internal/generator/templates/doctor.go.tmpl`:

- `case authAPIErr.StatusCode == 401:` keeps the existing invalid wording (FAIL).
- `case authAPIErr.StatusCode == 403:` emits `scope-limited (HTTP 403) — credentials are valid but lack permission for this endpoint. Check your dashboard's API key scope.`

Adds a matching `case strings.Contains(s, "scope-limited"):` branch in the human-readable indicator switch so the terminal output renders WARN rather than falling through to the FAIL substring match. The new case is placed before the FAIL branch by style; functionally the order isn't load-bearing because `scope-limited` contains none of the FAIL substrings (`error`, `not configured`, `unreachable`, `invalid`, `missing`).

`doctorExitForFailOn` is unchanged. Its `worstError` substring set still doesn't match `scope-limited`, so `--fail-on=error` continues to ignore a scope-limited credential — the desired warn-not-fail behavior.

## Scope

Primary area: generator template (`internal/generator/templates/doctor.go.tmpl`).

Why this belongs in this repo: The polish skill already patches this per-CLI (per the bird-pp-cli retro that filed #895). Raising the floor in the template is the machine-side fix per AGENTS.md `Machine vs Printed CLI`.

## Risk

- Any CLI that today reports `invalid (HTTP 403)` will start reporting `scope-limited (HTTP 403)` and rendering WARN instead of FAIL. The `--fail-on=error` exit-code contract is unchanged.
- Agents that today substring-match `invalid (HTTP 403)` in JSON output will need to match `scope-limited (HTTP 403)` instead. The 401 wording is preserved.
- No change to MCP surface, catalog, manifest, publish flow, scorer, or verifier.

## Output Contract

- Generator output changes for any printed CLI whose spec sets `auth.verify_path`: doctor's `report["credentials"]` value diverges between 401 and 403.
- Indicator switch in the rendered doctor.go gains one extra case (visible in 3 updated golden fixtures).

## Verification

- `go fmt ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./...` clean
- `go test ./...` — 3492 passed in 34 packages
- `scripts/golden.sh verify` — 16 cases pass after updating goldens for the indicator-switch addition
- New test: `TestDoctorClassifiesHTTP401AsInvalidAnd403AsScopeLimited` asserts both case branches and the WARN classifier are present in the rendered doctor.go.

## Residual / out-of-scope

- **Golden fixture coverage for the case-split itself.** The 401/403 branch lives inside `{{- if .Auth.VerifyPath}}`, and `VerifyPath` is set only via the internal-spec format — `internal/openapi/parser.go` has no `verify_path` extension parsing, so no current OpenAPI-based golden fixture exercises that block. The new unit test covers the contract; extending the OpenAPI parser to recognize an `x-pp-verify-path` extension (or adding an internal-spec-format golden) is a separate change. Surfaced by the project-standards reviewer; maintainer discretion.
- **Structured `credentials_status` JSON field.** The doctor report uses single prose strings for every check key (config, auth, env_vars, api, credentials). Adding a parallel structured discriminator just for credentials would diverge from that pattern. Out of scope for the bug fix.
- **Pre-existing**: `doctorExitForFailOn` advertises `--fail-on=warn` in its usage example but only implements `error` and `stale`. Unrelated to this fix.