### PR TITLE
test(cli): pin doctor authConfigured short-circuit for OAuth2 + EnvVarSpecs

### DIFF
--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -34,4 +35,55 @@ func TestDoctorReportsConfigAuthAsEnvVarsSatisfied(t *testing.T) {
 			}
 
 			if authEnvSet == 0 {`, "legacy EnvVars branch must not report zero env vars when config auth is already valid")
+}
+
+// TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth pins the
+// authConfigured short-circuit on the kind-aware EnvVarSpecs path for
+// oauth2 specs (issue #879). When a user authenticates via `auth login`,
+// AccessToken populates the config and AuthHeader() returns a Bearer; a
+// missing per_call+Required env var must surface as "credentials available
+// from" and route through the "OK" arm of the env_vars switch, never as
+// "ERROR missing required".
+func TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("doctor-oauth2-envspec")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		AuthorizationURL: "https://example.com/oauth/authorize",
+		TokenURL:         "https://example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "DOCTOR_OAUTH2_ENVSPEC_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "doctor-oauth2-envspec-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctor := string(doctorSrc)
+
+	require.Contains(t, doctor, "authConfigured := false")
+	require.Contains(t, doctor, "authConfigured = true")
+	require.Contains(t, doctor, `} else if authConfigured {`,
+		"per_call+Required env var must defer to authConfigured before flagging missing")
+	require.Contains(t, doctor, `authEnvInfo = append(authEnvInfo, "credentials available from "+authSource)`,
+		"missing env var should explain that config auth covers it")
+	require.Contains(t, doctor, `case len(authEnvInfo) > 0 && authConfigured:`,
+		"env_vars switch needs the authConfigured arm to elevate INFO to OK")
+
+	// The error-arm string is generated as a fallback (still present in
+	// the file), but it must not fire when only the per_call+Required var
+	// is missing — that branch lives behind the authConfigured guard
+	// above. Verify the structural order: the missing-required append is
+	// inside the inner else, after the authConfigured branch.
+	idxConfigured := strings.Index(doctor, `} else if authConfigured {`)
+	idxMissing := strings.Index(doctor, `authEnvRequiredMissing = append(authEnvRequiredMissing, "DOCTOR_OAUTH2_ENVSPEC_TOKEN")`)
+	require.NotEqual(t, -1, idxConfigured, "authConfigured branch must be emitted for this case")
+	require.NotEqual(t, -1, idxMissing, "fallback missing-required append must still exist for the unauthenticated case")
+	require.Less(t, idxConfigured, idxMissing,
+		"missing-required append must be the trailing else, not run unconditionally")
 }

--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -3,7 +3,6 @@ package generator
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -68,22 +67,25 @@ func TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth(t *testing.T) {
 
 	require.Contains(t, doctor, "authConfigured := false")
 	require.Contains(t, doctor, "authConfigured = true")
-	require.Contains(t, doctor, `} else if authConfigured {`,
-		"per_call+Required env var must defer to authConfigured before flagging missing")
-	require.Contains(t, doctor, `authEnvInfo = append(authEnvInfo, "credentials available from "+authSource)`,
-		"missing env var should explain that config auth covers it")
 	require.Contains(t, doctor, `case len(authEnvInfo) > 0 && authConfigured:`,
 		"env_vars switch needs the authConfigured arm to elevate INFO to OK")
 
-	// The error-arm string is generated as a fallback (still present in
-	// the file), but it must not fire when only the per_call+Required var
-	// is missing — that branch lives behind the authConfigured guard
-	// above. Verify the structural order: the missing-required append is
-	// inside the inner else, after the authConfigured branch.
-	idxConfigured := strings.Index(doctor, `} else if authConfigured {`)
-	idxMissing := strings.Index(doctor, `authEnvRequiredMissing = append(authEnvRequiredMissing, "DOCTOR_OAUTH2_ENVSPEC_TOKEN")`)
-	require.NotEqual(t, -1, idxConfigured, "authConfigured branch must be emitted for this case")
-	require.NotEqual(t, -1, idxMissing, "fallback missing-required append must still exist for the unauthenticated case")
-	require.Less(t, idxConfigured, idxMissing,
-		"missing-required append must be the trailing else, not run unconditionally")
+	// Pin the full else-if-else chain as a contiguous substring. A weaker
+	// "both substrings exist" check would pass even if a refactor flattened
+	// authEnvRequiredMissing back to an unconditional append (the exact
+	// shape of the original #879 bug). Asserting the contiguous block
+	// guarantees the missing-required append is the trailing else, gated
+	// by authConfigured.
+	require.Contains(t, doctor, `if os.Getenv("DOCTOR_OAUTH2_ENVSPEC_TOKEN") != "" {
+				authEnvSet = append(authEnvSet, "DOCTOR_OAUTH2_ENVSPEC_TOKEN")
+			} else if authConfigured {
+				authSource, _ := report["auth_source"].(string)
+				if authSource == "" {
+					authSource = "config"
+				}
+				authEnvInfo = append(authEnvInfo, "credentials available from "+authSource)
+			} else {
+				authEnvRequiredMissing = append(authEnvRequiredMissing, "DOCTOR_OAUTH2_ENVSPEC_TOKEN")
+			}`,
+		"per_call+Required env-var check must route missing-required through the authConfigured else chain, not as an unconditional append")
 }


### PR DESCRIPTION
## Summary
- Issue #879 was already fixed by [1a8f68ee](https://github.com/mvanhorn/cli-printing-press/commit/1a8f68ee) (PR #853, shipped in v4.2.2): the doctor template now sets `authConfigured := false` and flips it true whenever `cfg.AuthHeader() != ""`, then the per_call+Required env-var check routes a missing var into `authEnvInfo` ("credentials available from <source>") behind `} else if authConfigured {` and the switch promotes it to `"OK ..."` via `case len(authEnvInfo) > 0 && authConfigured:`.
- Existing coverage in `TestDoctorReportsConfigAuthAsEnvVarsSatisfied` only exercises the legacy `EnvVars` path with `bearer_token`. The YouTube-shape failure mode — `oauth2` type + kind-aware `EnvVarSpecs` with a `per_call+Required` entry — was not directly pinned, so a future refactor could silently regress it.
- This PR adds `TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth` to lock that shape down. It generates the spec, asserts the `authConfigured` branch is emitted, asserts the missing-required append exists as the trailing `else` (positional check via index ordering), and asserts the switch's `authConfigured` arm is present.

## What changed
- `internal/generator/doctor_auth_status_test.go`: new test only. No template, generator, or runtime behavior change.

## Verification
- `go test ./...` — 3492 passed across 34 packages.
- `go test ./internal/generator/ -run TestDoctor` — 5 passed.
- `scripts/golden.sh verify` — 16 cases pass (no template change, so no golden diff expected).
- `golangci-lint run ./internal/generator/...` — clean.

## Test plan
- [x] `go test ./internal/generator/ -run TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth -v`
- [x] `go test ./...`
- [x] `scripts/golden.sh verify`
- [x] `golangci-lint run ./internal/generator/...`

Refs #879