### PR TITLE
fix(cli): honor --resources filter in dependent sync fan-out

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5784,6 +5784,19 @@ func TestGenerateDependentSyncCompiles(t *testing.T) {
 	assert.Contains(t, syncContent, `"messages"`, "sync.go should reference messages as a dependent resource")
 	assert.Contains(t, syncContent, `"channels"`, "sync.go should reference channels as the parent")
 
+	// --resources must filter the dependent fan-out the same way it filters
+	// flat resources. The capture must happen before defaults expand the
+	// slice, and the filter must flow through to syncDependentResources
+	// where it gates each dependent.
+	assert.Contains(t, syncContent, "parentFilter := append([]string(nil), resources...)",
+		"sync.go should capture user --resources filter before default expansion")
+	assert.Contains(t, syncContent, "maxPages, parentFilter",
+		"sync.go should pass the captured filter into syncDependentResources")
+	assert.Contains(t, syncContent, "parentFilter []string",
+		"syncDependentResources should accept a parent filter")
+	assert.Contains(t, syncContent, "!allow[dep.ParentTable] && !allow[dep.Name]",
+		"syncDependentResources should gate dependents on parent name or dep name")
+
 	// The generated project should compile and the generated store tests
 	// should pass — including TestUpsertBatch_SetsMessagesParentID, which
 	// verifies dependent-resource sync fills the typed parent_id column

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -111,6 +111,12 @@ Exit codes & warnings:
 			}
 			defer db.Close()
 
+{{- if .DependentSyncResources}}
+			// Snapshot before defaults expand, so an empty user filter stays empty
+			// and dependents inherit "sync everything" instead of the default list.
+			parentFilter := append([]string(nil), resources...)
+{{- end}}
+
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
 				resources = defaultSyncResources()
@@ -224,7 +230,7 @@ Exit codes & warnings:
 
 {{- if .DependentSyncResources}}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(c, db, sinceTS, full, maxPages{{if .Pagination.DateRangeParam}}, syncDates{{end}})
+			depResults := syncDependentResources(c, db, sinceTS, full, maxPages, parentFilter{{if .Pagination.DateRangeParam}}, syncDates{{end}})
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -1056,12 +1062,21 @@ func dependentResourceDefs() []dependentResourceDef {
 }
 
 // syncDependentResources iterates parent tables and syncs child resources per parent ID.
+// parentFilter mirrors the user's --resources flag (empty = sync everything). A dependent
+// runs when its parent table or its own name appears in the filter.
 func syncDependentResources(c {{if .HasTierRouting}}*client.Client{{else}}interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}{{end}}, db *store.Store, sinceTS string, full bool, maxPages int{{if .Pagination.DateRangeParam}}, dates string{{end}}) []syncResult {
+}{{end}}, db *store.Store, sinceTS string, full bool, maxPages int, parentFilter []string{{if .Pagination.DateRangeParam}}, dates string{{end}}) []syncResult {
+	allow := make(map[string]bool, len(parentFilter))
+	for _, r := range parentFilter {
+		allow[r] = true
+	}
 	var results []syncResult
 	for _, dep := range dependentResourceDefs() {
+		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
+			continue
+		}
 		res := syncDependentResource({{if .HasTierRouting}}syncClientForResource(c, dep.Name){{else}}c{{end}}, db, dep, sinceTS, full, maxPages{{if .Pagination.DateRangeParam}}, dates{{end}})
 		results = append(results, res)
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -99,6 +99,9 @@ Exit codes & warnings:
 				return fmt.Errorf("opening local database: %w", err)
 			}
 			defer db.Close()
+			// Snapshot before defaults expand, so an empty user filter stays empty
+			// and dependents inherit "sync everything" instead of the default list.
+			parentFilter := append([]string(nil), resources...)
 
 			// If no specific resources, sync top-level resources
 			if len(resources) == 0 {
@@ -206,7 +209,7 @@ Exit codes & warnings:
 				}
 			}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(c, db, sinceTS, full, maxPages)
+			depResults := syncDependentResources(c, db, sinceTS, full, maxPages, parentFilter)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -954,12 +957,21 @@ func dependentResourceDefs() []dependentResourceDef {
 }
 
 // syncDependentResources iterates parent tables and syncs child resources per parent ID.
+// parentFilter mirrors the user's --resources flag (empty = sync everything). A dependent
+// runs when its parent table or its own name appears in the filter.
 func syncDependentResources(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, sinceTS string, full bool, maxPages int) []syncResult {
+}, db *store.Store, sinceTS string, full bool, maxPages int, parentFilter []string) []syncResult {
+	allow := make(map[string]bool, len(parentFilter))
+	for _, r := range parentFilter {
+		allow[r] = true
+	}
 	var results []syncResult
 	for _, dep := range dependentResourceDefs() {
+		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
+			continue
+		}
 		res := syncDependentResource(c, db, dep, sinceTS, full, maxPages)
 		results = append(results, res)
 	}


### PR DESCRIPTION
## Intent

Closes #873.

`syncDependentResources` iterated `dependentResourceDefs()` unconditionally, so generated CLIs only filtered flat resources when `--resources <name>` was passed. Dependents ran on every resource and produced unexpected work plus retry storms on parent tables the user never requested (see #873 for the rentalworks-home reproduction: `sync --resources order --max-pages 1` looped for 60s before being killed).

## Approach

In `internal/generator/templates/sync.go.tmpl`, snapshot the user's `--resources` slice into `parentFilter` before defaults expand it, then thread `parentFilter` into `syncDependentResources`. A dependent runs when its parent table or its own name appears in the filter (matches both `--resources <parent>` and `--resources <dep>`). An empty filter preserves the existing "sync everything" default. The capture and the new parameter are wrapped in the existing `{{- if .DependentSyncResources}}` guard so CLIs without dependent resources emit no extra code.

## Scope

Primary area: generator template (the Go binary's `sync.go.tmpl`).

Why this belongs in this repo: the bug is universal across CLIs the generator emits with parent-child relationships (Stripe, GitHub, Linear, etc.). Per AGENTS.md "Machine vs Printed CLI", a recurring printed-CLI symptom on a generator-owned surface defaults to a machine change.

## Risk

`sync` behavior changes only when `--resources` is set AND the spec has at least one dependent. Existing default (no `--resources`) sync still runs every flat resource and every dependent. Generator output is regenerable; the golden fixture under `testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go` is refreshed to match.

## Output Contract

Generated `sync.go` for any CLI with `DependentSyncResources` now contains:
- a `parentFilter := append([]string(nil), resources...)` snapshot before the default expansion
- a new `parentFilter []string` argument to `syncDependentResources`
- an `allow` set built from `parentFilter` with the gate `if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] { continue }`

CLIs without dependents are unchanged.

## Verification

- `go build ./...` — pass
- `go test ./...` — 3626 passed in 34 packages
- `go vet ./...` — clean
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 16/16 pass (one intentional update under `generate-golden-api`)
- `TestGenerateDependentSyncCompiles` extended with substring assertions on the new filter shape

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change