### PR TITLE
docs(skills): clarify wrapper-only catalog entries have no generator path

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -695,14 +695,14 @@ If the catalog has an entry for this API, branch on the entry type:
 - If catalog config: use the spec_url from the catalog entry, skip the research/discovery phase
 - If full discovery: proceed with the normal research workflow
 
-**Wrapper-only entry** (no `spec_url`, `wrapper_libraries` populated) — this is a reverse-engineered API that has no official spec but has known community libraries the generator can use as implementation backing. Do not try to resolve or browser-sniff a spec. Instead, surface the wrapper options to the user via `AskUserQuestion`:
+**Wrapper-only entry** (no `spec_url`, `wrapper_libraries` populated) — this is a reverse-engineered API that has no official spec but has known community libraries. The catalog entry is a **discovery aid only**: `printing-press generate` requires `--spec` and does not consume wrapper-library metadata, so there is no direct generation path from a wrapper-only entry today. Tell the user this up front via `AskUserQuestion`:
 
-> "<API> has no official spec. The catalog knows about these community-maintained implementations:"
+> "<API> has no official spec. The catalog knows about these community-maintained wrappers, but the Printing Press cannot generate a CLI directly from a wrapper. The next step has to be either browser-sniffing the upstream to author an internal YAML spec, or hand-writing a Go module that imports the wrapper. Which path do you want?"
 
-Present each `wrapper_libraries` entry as a selectable option with language, integration mode, and notes. Example for `google-flights`:
+Present each `wrapper_libraries` entry alongside the question with language, integration mode, and notes so the user can see what implementation backing exists. Example for `google-flights`:
 - **krisukox/google-flights-api** (Go, native, MIT) — Pure Go, importable; single-binary CLI with no runtime deps.
 
-Capture the user's choice and record it in `$API_RUN_DIR/state.json` under an `implementation` field: `{ "library": "<name>", "url": "<url>", "integration_mode": "native|subprocess|html-scrape" }`. Phase 3 generation reads this to decide whether to `go get` a wrapper, emit a subprocess shell-out, or emit HTML-scrape code. Skip the spec-analysis step entirely — there is no spec.
+Record the user's choice (and the selected wrapper, when relevant) in `$API_RUN_DIR/state.json` under an `implementation` field so later phases can read it: `{ "library": "<name>", "url": "<url>", "integration_mode": "native|subprocess|html-scrape", "next_step": "browser-sniff|hand-written-module" }`. This field is for skill bookkeeping; the generator does not currently read it. If the user picks browser-sniff, route into the Phase 1.7 browser-sniff path to produce a spec, then run `generate --spec` against it. If the user picks a hand-written module, stop the press here and hand off — there is no generator path to drop them into.
 
 **No catalog hit** — proceed normally without mentioning the catalog.
 


### PR DESCRIPTION
## Intent

The Wrapper-only branch in Phase 1's catalog-check section of `skills/printing-press/SKILL.md` told the agent that "Phase 3 generation reads this to decide whether to `go get` a wrapper, emit a subprocess shell-out, or emit HTML-scrape code." `printing-press generate` only consumes `--spec` and has no wrapper-mode plumbing, so the skill silently dead-ended users on `google-flights`-style catalog entries: the discovery flow runs, the choice is captured, then `generate` rejects it.

This PR is the Option B fix from the issue (document the limitation) so the skill stops promising a path the generator does not implement. A `--wrapper` generation mode (Option A) is the bigger design call that should be a separate maintainer-driven RFC.

Issue: Refs #870

## Approach

Replace the 8 lines of skill prose at the Wrapper-only branch with text that matches what the binary actually does:

- State up front that the catalog entry is a discovery aid only and that there is no direct generation path from a wrapper-only entry today.
- Rewrite the `AskUserQuestion` text to offer the two real next steps: browser-sniff the upstream to author an internal YAML spec, or hand-write a Go module that imports the wrapper.
- Reframe `state.json.implementation` as skill bookkeeping rather than generator input, and add a `next_step` field so later phases can branch on which path the user picked.
- Route the browser-sniff choice into Phase 1.7 (which already exists); call out the hand-written path as a hand-off rather than something the press continues to drive.

`docs/CATALOG.md` already says wrapper-only entries do not by themselves make `printing-press generate <name>` work; this brings `SKILL.md` in line with that contract.

## Scope

Primary area: `skills` (the printing-press skill prose only).

Why this belongs in this repo: per AGENTS.md "Skill Authoring," skill prose that promises a generator capability has to track what the generator actually does. The mismatch is in this repo's `SKILL.md`, not in any printed CLI.

## Risk

Low. Prose-only change, no generator/template/parser code touched.

- Generator behavior: unchanged. Existing `--spec` flows are unaffected.
- Catalog validator: unchanged. `wrapper_libraries` shape is unmodified.
- Contract tests in `internal/pipeline/contracts_test.go` that assert SKILL.md setup blocks, workspace variables, and the run-root state file pass against the new prose.
- Skill behavioral contract for spec-based and "no catalog hit" branches: unchanged.

## Output Contract

N/A. No generated artifacts, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts changed by this PR. Golden harness re-verified to confirm.

## Verification

Run on macOS, against the branch at `e0d93e91`:

- `go fmt ./...` — clean
- `go vet ./...` — clean (`Go vet: No issues found`)
- `go build -o ./printing-press ./cmd/printing-press` — passes
- `go test ./... -count=1` — `3629 passed in 34 packages`
- `golangci-lint run ./...` — clean (`No issues found`)
- `scripts/golden.sh verify` — `Golden verify passed: 16 case(s).`
- `git diff --check` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change