### PR TITLE
fix(ci): drop cancel-in-progress from pr-title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   pull-requests: read
 


### PR DESCRIPTION
## Summary

The `pr-title` workflow declared:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On Mergify merge-queue draft PRs (`mergify/merge-queue/*`), the draft's rapid open/sync sequence triggers two `pull_request` events on the same `github.ref`. `cancel-in-progress: true` cancels attempt 1 before the `Skip Mergify merge queue batches` step finishes. Mergify treats the cancelled check as a failed check and dequeues the original PR — even though attempt 2 later completes `success`.

Symptom: PRs with `ready-to-merge` and all checks green get repeatedly dequeued with `Failing checks: pr-title`, with no actual title-format problem. Reproduced today on #994 and #1000, where attempt 1 of the queue draft's `pr-title` was cancelled within 1–6 seconds and attempt 2 succeeded ~1 hour later (well after dequeue).

The check is a ~2-second title regex; cancelling in-progress runs saves nothing and creates this flake on every queue batch. Drop the `concurrency` block entirely.

## Why not gate the workflow on head_ref?

Skipping the workflow on `mergify/merge-queue/*` via a job-level `if:` produces a `skipped` check, not `success`. Mergify's queue condition `check-success = pr-title` would never be satisfied, so queue drafts would stall instead of merging. The existing in-workflow `Skip Mergify merge queue batches` step is already the right design — it just needs to finish without being cancelled.

## Test plan

- [ ] Merge this PR.
- [ ] Re-queue #994 and #1000 with `@mergifyio queue`.
- [ ] Verify the queue draft's `pr-title` check reports `success` and Mergify does not dequeue with a `pr-title` failure.