### PR TITLE
fix(cli): use spec resource key for typed dispatch case strings

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2598,6 +2598,108 @@ func TestGenerateStoreUpsertBatchDispatchesToTypedTable(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/store")
 }
 
+// TestUpsertDispatchPreservesMultiWordResourceCasing is the regression test
+// for issue #1064: dispatch case strings must use the spec resource key,
+// not the snake-cased table name, or kebab multi-word resources silently
+// skip the typed upsert and FTS search paths.
+func TestUpsertDispatchPreservesMultiWordResourceCasing(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "media",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/media-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"audio-isolation": {
+				Description: "Isolated audio tracks",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/v1/audio-isolation",
+						Description: "List isolation jobs",
+						Response:    spec.ResponseDef{Type: "array", Item: "AudioIsolation"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"AudioIsolation": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+					// Two FTS-eligible text fields force the schema builder
+					// to emit FTS5, which in turn emits the search dispatch
+					// switch that #1064 also affects.
+					{Name: "description", Type: "string"},
+					{Name: "status", Type: "string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	store := string(storeSrc)
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	sync := string(syncSrc)
+
+	searchSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "search.go"))
+	require.NoError(t, err)
+	search := string(searchSrc)
+
+	// The typed helper name keeps its snake-derived PascalCase shape — the
+	// fix only changes the case-string discriminant, not the Go identifier.
+	assert.Contains(t, store, "func (s *Store) upsertAudioIsolationTx(",
+		"typed Tx helper should still be PascalCase-named from snake schema name")
+	assert.Contains(t, store, "func (s *Store) UpsertAudioIsolation(",
+		"public typed upsert should still be PascalCase-named from snake schema name")
+	assert.Contains(t, store, "func (s *Store) SearchAudioIsolation(",
+		"FTS5 search helper should still be PascalCase-named from snake schema name")
+
+	// UpsertBatch must dispatch on the runtime resource form (kebab) to
+	// match defaultSyncResources/syncResourcePath/resourceIDFieldOverrides.
+	assert.Regexp(t,
+		`(?s)func \(s \*Store\) UpsertBatch\(.*case "audio-isolation":\s+if err := s\.upsertAudioIsolationTx\(`,
+		store,
+		"UpsertBatch must dispatch on \"audio-isolation\" — the snake case string never matches the kebab runtime resource (issue #1064)")
+
+	// upsertSingleObject must dispatch the same way.
+	assert.Regexp(t,
+		`(?s)func upsertSingleObject\(.*case "audio-isolation":\s+return db\.UpsertAudioIsolation\(data\)`,
+		sync,
+		"upsertSingleObject must dispatch on \"audio-isolation\" so single-object responses reach the typed table (issue #1064)")
+
+	// search.go's --type filter has the same shape — the user passes the
+	// kebab name (matching what `sync` advertises), so the case must too.
+	assert.Regexp(t,
+		`(?s)switch resourceType \{.*case "audio-isolation":\s+results, err = db\.SearchAudioIsolation\(query, limit\)`,
+		search,
+		"search dispatch must accept \"audio-isolation\" so --type <kebab-resource> reaches the FTS index (issue #1064)")
+
+	// And the old snake-case discriminants must be absent — leaving them in
+	// would mean the dispatch is fixed in one place but not the other.
+	for _, src := range []string{store, sync, search} {
+		assert.NotContains(t, src, `case "audio_isolation":`,
+			"snake_case case string is the bug; only kebab-case should match the runtime resource")
+	}
+
+	// Compile and run the generated store package. The emitted
+	// TestUpsertBatch_PopulatesAudioIsolationTable calls
+	// UpsertBatch("audio-isolation", ...) against the kebab dispatch case;
+	// a regression that re-broke either side would fail here at runtime.
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/store")
+}
+
 // TestGenerateStoreSubResourceUpsertBindingOrder asserts that the typed
 // upsert for a sub-resource table binds its argument values in the same
 // order as the SQL column declarations. buildSubResourceTable puts the

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -8,7 +8,11 @@ import (
 )
 
 type TableDef struct {
+	// Name is the snake_cased SQL/Go identifier (table DDL, Pascal-derived
+	// method names). Resource is the original spec key used by callers that
+	// dispatch on the runtime resource string, which preserves spec casing.
 	Name         string
+	Resource     string
 	Columns      []ColumnDef
 	Indexes      []IndexDef
 	FTS5         bool
@@ -65,8 +69,9 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 		tableName := toSnakeCase(name)
 
 		table := TableDef{
-			Name:    tableName,
-			Columns: append([]ColumnDef(nil), baseTableColumns...),
+			Name:     tableName,
+			Resource: name,
+			Columns:  append([]ColumnDef(nil), baseTableColumns...),
 		}
 
 		if gravity >= 2 {
@@ -143,7 +148,10 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 	// author naming a top-level resource the same thing the shard synthesizes
 	// (e.g. top-level "gists_commits" plus a multi-parent "commits" under
 	// "gists") would otherwise emit two CREATE TABLE statements and two
-	// duplicate Upsert<X>Tx methods, breaking the build on regen.
+	// duplicate Upsert<X>Tx methods, breaking the build on regen. Top-level
+	// tables are appended before sub-resource tables, so on a Name collision
+	// the kept entry carries the top-level Resource (raw spec key) rather
+	// than the sub-resource's snake-cased form.
 	seen := make(map[string]bool)
 	deduped := make([]TableDef, 0, len(tables))
 	for _, t := range tables {
@@ -155,7 +163,8 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 	tables = deduped
 
 	tables = append(tables, TableDef{
-		Name: "sync_state",
+		Name:     "sync_state",
+		Resource: "sync_state",
 		Columns: []ColumnDef{
 			{Name: "resource_type", Type: "TEXT", PrimaryKey: true},
 			{Name: "last_cursor", Type: "TEXT"},
@@ -372,8 +381,9 @@ func buildSubResourceTable(name string, r spec.Resource, parentTable string) Tab
 	columns = append(columns, baseTableColumns[1:]...) // data, synced_at
 
 	return TableDef{
-		Name:    tableName,
-		Columns: columns,
+		Name:     tableName,
+		Resource: tableName,
+		Columns:  columns,
 		Indexes: []IndexDef{
 			{
 				Name:      "idx_" + tableName + "_" + parentCol,

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -171,7 +171,7 @@ In local mode: searches locally synced data only.`,
 			switch resourceType {
 {{- range .Tables}}
 {{- if .FTS5}}
-			case "{{.Name}}":
+			case "{{.Resource}}":
 				results, err = db.Search{{pascal .Name}}(query, limit)
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -838,7 +838,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, "{{.Name}}", id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, "{{.Resource}}", id, data); err != nil {
 		return err
 	}
 	if err := s.upsert{{pascal .Name}}Tx(tx, id, obj, data); err != nil {
@@ -937,7 +937,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		switch resourceType {
 {{- range .Tables}}
 {{- if hasTypedTable .}}
-		case "{{.Name}}":
+		case "{{.Resource}}":
 			if err := s.upsert{{pascal .Name}}Tx(tx, id, obj, item); err != nil {
 				return 0, extractFailures, fmt.Errorf("typed upsert for %s/%s: %w", resourceType, id, err)
 			}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -288,14 +288,14 @@ func TestUpsertBatch_Populates{{pascal .Name}}Table(t *testing.T) {
 		json.RawMessage(`{"id": "test-002"}`),
 		json.RawMessage(`{"id": "test-003"}`),
 	}
-	if _, _, err := s.UpsertBatch("{{.Name}}", items); err != nil {
+	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 
 	db := s.DB()
 
 	var generic int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Name}}").Scan(&generic); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Resource}}").Scan(&generic); err != nil {
 		t.Fatalf("count resources: %v", err)
 	}
 	if generic != len(items) {
@@ -329,7 +329,7 @@ func TestUpsertBatch_Sets{{pascal .Name}}ParentID(t *testing.T) {
 		json.RawMessage(`{"id": "child-002", "parent_id": "parent-A"}`),
 		json.RawMessage(`{"id": "child-003", "parent_id": "parent-B"}`),
 	}
-	if _, _, err := s.UpsertBatch("{{.Name}}", items); err != nil {
+	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -958,7 +958,7 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 	switch resource {
 {{- range .Tables}}
 {{- if hasTypedTable .}}
-	case "{{.Name}}":
+	case "{{.Resource}}":
 		return db.Upsert{{pascal .Name}}(data)
 {{- end}}
 {{- end}}


### PR DESCRIPTION
## Intent

Fix #1064. Three generator templates (`store.go.tmpl::UpsertBatch`, `sync.go.tmpl::upsertSingleObject`, `search.go.tmpl::--type` filter) dispatched on `case "{{.Name}}"` — but `TableDef.Name` is snake-cased for SQL DDL while the runtime resource variable is the un-converted spec key (kebab for kebab-keyed specs like elevenlabs). Every multi-word resource missed the switch: paginated syncs left typed tables empty, single-object responses fell through to the generic upsert, and `search --type <kebab-resource>` returned zero results.

Issue: Refs #1064

## Approach

Followed the dual-key pattern already established for `Owner`/`OwnerName` and the `IdentName`/`Name` pair in this repo (see `docs/solutions/design-patterns/dual-key-identity-fields-2026-05-06.md` and `identifier-collision-uniquification-pattern-2026-05-08.md`). One canonical value flowing into two surfaces with different shape requirements gets a second struct field rather than a desanitizing pass:

- Add `TableDef.Resource string` — the un-transformed spec resource key, populated at all three TableDef construction sites (top-level `BuildSchema` loop, `sync_state` synthetic, `buildSubResourceTable`).
- Switch case strings in the three dispatch templates use `{{.Resource}}`. SQL identifiers and Pascal-derived Go method names still derive from `{{.Name}}`.
- `store.go.tmpl::Upsert<X>` singular helper's call to `upsertGenericResourceTx` switched to `{{.Resource}}` as well, so the generic `resources` table's `resource_type` column stores the same identifier on both the singular and batch write paths.
- Generated `store_upsert_batch_test.go.tmpl` updated to call `UpsertBatch` with `{{.Resource}}` and filter on the same value, keeping `{{.Name}}` only where it identifies the typed SQL table.

`Resource` choice for sub-resources is `tableName` (snake) — matches the profiler's `DependentResource.Name` (also snake-cased via `spec.ToSnakeCase`), so sub-resource dispatch keeps working without behavior change.

## Scope

Primary area: `internal/generator/` — schema_builder.go and four templates under `internal/generator/templates/`.

Why this belongs in this repo: it's a generator-side defect that affects every printed CLI with multi-word kebab-keyed resources. Fixing it once in the templates corrects all future regenerations of elevenlabs, Stripe (`customer-balance-transactions`, `payment-method-configurations`), GitHub (`pull-request-reviews`, `commit-comments`, `issue-events`), and any other API with kebab resource keys.

## Risk

- Generated output for **kebab-keyed multi-word specs** changes: switch case strings in `store.go`, `sync.go`, `search.go` flip from `"audio_isolation"` → `"audio-isolation"`. This is the intended fix — those case strings were unreachable.
- Generated output for **snake-keyed or single-word specs** is byte-identical (snake = snake, single = single).
- Golden harness: all 16 cases still pass — no existing golden fixture uses a kebab multi-word resource, so no goldens diff.
- MCP surface: no annotation changes. The `sync` and `search` MCP tools were registered correctly; only their downstream dispatch was silently degraded. Agent-native parity is restored, not redefined.
- No catalog/publish/scorer/release changes.

## Output Contract

- Template diff: `case "{{.Name}}"` → `case "{{.Resource}}"` at three dispatch sites; `s.upsertGenericResourceTx(tx, "{{.Name}}", ...)` → `"{{.Resource}}"` for the singular helper; `s.UpsertBatch("{{.Name}}", ...)` → `"{{.Resource}}"` plus matching `resource_type` filter in the generated `TestUpsertBatch_Populates*Table` test.
- For kebab-keyed specs, `internal/store/store.go` and `internal/cli/{sync,search}.go` will regenerate with kebab case strings. Re-running `printing-press regen <api>` against affected CLIs will surface the diff.
- `TableDef` adds an exported `Resource string` field. Additive — no callers needed Resource before; the three template sites are the only consumers.

## Verification

- `go fmt ./...` — clean
- `go vet ./...` — no issues
- `go test ./...` — 3667 tests pass, including the new regression `TestUpsertDispatchPreservesMultiWordResourceCasing` which generates a CLI for an `audio-isolation` resource, asserts all three dispatch sites use the kebab case string, and runs `go test ./internal/store` against the generated CLI so the populate test exercises kebab dispatch end-to-end
- `scripts/golden.sh verify` — 16/16 cases pass
- `golangci-lint run ./internal/generator/...` — no issues
- `git diff --check` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change