### PR TITLE
fix(cli): preserve unknown-shape records in compactListFields

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3332,6 +3332,39 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 	assert.Contains(t, content, `envelope["success"] = false`)
 }
 
+// TestCompactListFieldsPreservesUnknownShapes pins the two contracts that
+// keep `--agent` / `--compact` from silently emitting {} for records that
+// don't match the canonical id/name/title allowlist: a per-item fallback
+// to the original item, and a wider scalar allowlist that covers
+// monetary, metric, locale, and identity-adjacent keys.
+//
+// Pinned at the template level because the helper renders into every
+// printed CLI's helpers.go and a per-fixture assertion would miss future
+// copies that drift in.
+func TestCompactListFieldsPreservesUnknownShapes(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("templates", "helpers.go.tmpl")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "template must exist: %s", path)
+	body := string(data)
+
+	assert.Contains(t, body, "if len(compact) == 0 {",
+		"compactListFields must preserve the original item when no allowlist keys match — otherwise records with domain-specific field names get reduced to {}")
+	assert.Contains(t, body, "compact = item",
+		"compactListFields must assign the original item as the per-item fallback")
+
+	for _, key := range []string{
+		`"price":`, `"fare":`, `"currency":`,
+		`"rating":`,
+		`"locale":`, `"language":`,
+		`"code":`,
+	} {
+		assert.Contains(t, body, key,
+			"compactListFields allowlist must include %s so canonical-schema records keep high-signal scalars across business/travel/commerce/locale APIs", key)
+	}
+}
+
 // TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the
 // piped-output auto-JSON gate must defer to explicit --csv / --quiet /
 // --plain flags so piped consumers that asked for a non-JSON format

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -777,12 +777,31 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
+// When an item carries none of these keys the original is preserved, so
+// `--agent` does not silently emit {} for APIs whose response shapes use
+// domain-specific field names (travel: airline/destination; commerce: vendor).
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
+		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
-		"status": true, "state": true, "type": true, "priority": true,
-		"url": true, "email": true, "key": true,
+		"code": true, "slug": true, "key": true,
+		// Categorization
+		"status": true, "state": true, "type": true, "kind": true, "priority": true,
+		// Communication
+		"url": true, "email": true,
+		// Monetary
+		"price": true, "amount": true, "cost": true, "fare": true,
+		"rate": true, "currency": true,
+		// Metrics
+		"rating": true, "score": true, "count": true,
+		// Locale / geo
+		"language": true, "locale": true, "country": true, "region": true,
+		"city": true, "domain": true,
+		// Temporal
 		"created_at": true, "updated_at": true, "createdAt": true, "updatedAt": true,
+		"date": true,
+		// Versioning
+		"version": true,
 	}
 
 	filtered := make([]map[string]any, 0, len(items))
@@ -792,6 +811,9 @@ func compactListFields(items []map[string]any) json.RawMessage {
 			if keepFields[k] {
 				compact[k] = v
 			}
+		}
+		if len(compact) == 0 {
+			compact = item
 		}
 		filtered = append(filtered, compact)
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -579,12 +579,31 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
+// When an item carries none of these keys the original is preserved, so
+// `--agent` does not silently emit {} for APIs whose response shapes use
+// domain-specific field names (travel: airline/destination; commerce: vendor).
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
+		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
-		"status": true, "state": true, "type": true, "priority": true,
-		"url": true, "email": true, "key": true,
+		"code": true, "slug": true, "key": true,
+		// Categorization
+		"status": true, "state": true, "type": true, "kind": true, "priority": true,
+		// Communication
+		"url": true, "email": true,
+		// Monetary
+		"price": true, "amount": true, "cost": true, "fare": true,
+		"rate": true, "currency": true,
+		// Metrics
+		"rating": true, "score": true, "count": true,
+		// Locale / geo
+		"language": true, "locale": true, "country": true, "region": true,
+		"city": true, "domain": true,
+		// Temporal
 		"created_at": true, "updated_at": true, "createdAt": true, "updatedAt": true,
+		"date": true,
+		// Versioning
+		"version": true,
 	}
 
 	filtered := make([]map[string]any, 0, len(items))
@@ -594,6 +613,9 @@ func compactListFields(items []map[string]any) json.RawMessage {
 			if keepFields[k] {
 				compact[k] = v
 			}
+		}
+		if len(compact) == 0 {
+			compact = item
 		}
 		filtered = append(filtered, compact)
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -582,12 +582,31 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
+// When an item carries none of these keys the original is preserved, so
+// `--agent` does not silently emit {} for APIs whose response shapes use
+// domain-specific field names (travel: airline/destination; commerce: vendor).
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
+		// Identity
 		"id": true, "name": true, "title": true, "identifier": true,
-		"status": true, "state": true, "type": true, "priority": true,
-		"url": true, "email": true, "key": true,
+		"code": true, "slug": true, "key": true,
+		// Categorization
+		"status": true, "state": true, "type": true, "kind": true, "priority": true,
+		// Communication
+		"url": true, "email": true,
+		// Monetary
+		"price": true, "amount": true, "cost": true, "fare": true,
+		"rate": true, "currency": true,
+		// Metrics
+		"rating": true, "score": true, "count": true,
+		// Locale / geo
+		"language": true, "locale": true, "country": true, "region": true,
+		"city": true, "domain": true,
+		// Temporal
 		"created_at": true, "updated_at": true, "createdAt": true, "updatedAt": true,
+		"date": true,
+		// Versioning
+		"version": true,
 	}
 
 	filtered := make([]map[string]any, 0, len(items))
@@ -597,6 +616,9 @@ func compactListFields(items []map[string]any) json.RawMessage {
 			if keepFields[k] {
 				compact[k] = v
 			}
+		}
+		if len(compact) == 0 {
+			compact = item
 		}
 		filtered = append(filtered, compact)
 	}


### PR DESCRIPTION
## Intent

`compactListFields` in every printed CLI's `internal/cli/helpers.go` reduced any list item that didn't carry one of a narrow id/name/title/status/url/timestamps allowlist to `{}`. The helper runs whenever a user passes `--agent` (which expands to `--compact`), so any printed CLI whose API responses use domain-specific field names (travel: `fare`/`airline`; commerce: `vendor`/`price`; locale: `domain`/`language`) silently emitted empty objects to agent consumers. Records that did match `id`/`name` also lost useful business scalars (`price`, `rating`, `currency`) because they were not in the allowlist.

Issue:

Closes #1046

## Approach

Two changes in [internal/generator/templates/helpers.go.tmpl](internal/generator/templates/helpers.go.tmpl):

1. **Per-item fallback.** After the keep-loop, if the compacted map is empty, preserve the original item. This is the safety net — records that don't match any allowlist key round-trip whole instead of being nuked.
2. **Wider scalar allowlist.** Extend the keepFields map with high-signal scalars across categories: identity-adjacent (`code`, `slug`), monetary (`price`, `amount`, `cost`, `fare`, `rate`, `currency`), metrics (`rating`, `score`, `count`), locale/geo (`language`, `locale`, `country`, `region`, `city`, `domain`), temporal (`date`), versioning (`version`), categorization (`kind`).

Pinned via a new template-level test ([generator_test.go](internal/generator/generator_test.go)) mirroring `TestPipedJsonGateRespectsExplicitFormatFlags` — the same helper renders into every printed CLI's `helpers.go` so a per-fixture assertion would miss future copies that drift in. Goldens regenerated to reflect the new template output.

## Scope

Primary area: generator template — affects every future regen of every printed CLI.

Why this belongs in this repo: the bug is in the machine-emitted helper, not a single printed CLI. Per AGENTS.md "Default to machine changes" — fixing the template raises the floor for every API whose response shape uses domain-specific field names.

## Risk

- `--agent`/`--compact` output shape changes for any list item that previously emitted `{}`: it now emits the full record. This is the intended fix; agent consumers parsing `--agent` JSON should see real data where they previously got empty objects.
- Items that previously emitted just `{id, name}` may now also include `price`, `rating`, etc. when present — small payload-size increase per record on canonical-schema responses; same JSON shape contract (`{key: value, ...}`).
- Typed MCP endpoint mirrors do **not** route through `compactFields` (verified at `internal/generator/templates/mcp_tools.go.tmpl:476` — returns API data verbatim via `mcplib.NewToolResultText`), so the MCP contract agents rely on is unchanged. Cobratree walker shellouts that forward `--compact` do route through this helper and benefit from the fix.
- Pre-existing asymmetry: list-side fallback now preserves verbose fields (`description`, `body`) for unknown shapes while `compactObjectFields` strips them for single-object responses. Accepted design — symmetric stripping on the fallback path would defeat the safety net for records that happen to carry a description plus only one other field.

## Output Contract

Generator template change. Goldens regenerated:
- `testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go`
- `testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go`

Only `compactListFields` rendering changed; no other generated artifacts shifted.

## Verification

```
go fmt ./...                     # clean
go vet ./...                     # no issues
go test ./...                    # 3627 passed in 34 packages
golangci-lint run ./...          # no issues
scripts/golden.sh verify         # 16 cases pass
```

Behavioral spot-check with the new helper compiled into a scratch binary against the issue's reproduction cases:

| Input | Before | After |
|-------|--------|-------|
| `{"domain":"x","language":"en","locale":"en_US"}` | `{}` | `{"domain":"x","language":"en","locale":"en_US"}` (allowlist hits) |
| `{"airline":"JL","fare":12345,"currency":"USD","destination":"NRT"}` | `{}` | `{"currency":"USD","fare":12345}` (partial — `airline`/`destination` drop, `--select` retrieves them) |
| `{"some_obscure_field":"v","another":42}` | `{}` | `{"some_obscure_field":"v","another":42}` (fallback fires) |
| `{"id":7,"name":"Widget","description":"verbose...","price":9.99,"rating":4.5}` | `{"id":7,"name":"Widget"}` | `{"id":7,"name":"Widget","price":9.99,"rating":4.5}` (allowlist keeps business scalars) |