### PR TITLE
fix(catalog): refresh google-flights entry to reflect fli native port

### DIFF
--- a/catalog/google-flights.yaml
+++ b/catalog/google-flights.yaml
@@ -1,21 +1,56 @@
 name: google-flights
 display_name: Google Flights
-description: Flight search via Google Flights. No public API — reached through a community-maintained reverse-engineered wrapper.
+description: Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers (krisukox in Go, fli in Python).
 category: travel
 tier: community
-verified_date: "2026-05-09"
+verified_date: "2026-05-11"
 homepage: https://www.google.com/travel/flights
 notes: |
-  Google does not publish a Flights API. The wrapper library below reverse-engineers
-  the internal protobuf protocol that powers the website. Prefer the native Go wrapper
-  for printed CLIs so the resulting binary has no Python runtime dependency.
+  Google does not publish a Flights API. The wrapper libraries below reverse-engineer
+  the internal protobuf protocol that powers the website.
 
-  When this entry is returned for a combo-CLI source, the skill should surface the
-  wrapper options to the user rather than searching for an OpenAPI spec.
+  Two integration paths are viable:
+
+    1. Import krisukox/google-flights-api directly (native Go). Fastest to wire in, but
+       its Options struct only exposes Stops, Class, and TripType — flags for airlines,
+       bags, carry-on, emissions, layover, exclude-basic, expanded sort values, and
+       "show all results" are silently dropped at the wrapper boundary. Acceptable for
+       a minimal price-shopping CLI; insufficient if filter parity matters.
+
+    2. Port fli's FlightSearchFilters.format() to Go. fli (Python, MIT) has the most
+       complete f.req protobuf-shape implementation we know of. Reimplementing it in
+       Go produces a single-binary CLI with full filter parity and no Python runtime
+       dependency. flight-goat in printing-press-library/library/travel/flight-goat
+       does this in ~570 LOC and is a working reference (see
+       internal/gflights/flights_native.go).
+
+  When this entry is returned for a combo-CLI source, the skill should surface both
+  paths and let the user pick — filter coverage is usually the deciding factor.
 wrapper_libraries:
   - name: krisukox/google-flights-api
     url: https://github.com/krisukox/google-flights-api
     language: go
     license: MIT
     integration_mode: native
-    notes: Pure Go, importable. Produces a single-binary CLI with no Python runtime dependency.
+    notes: |
+      Pure Go, importable. Produces a single-binary CLI with no Python runtime
+      dependency. Filter coverage is limited — its Options struct only carries
+      Stops, Class, and TripType. Flags for airlines, bags, carry-on, emissions,
+      layover, exclude-basic, show-all-results, and the expanded sort values
+      (top_flights, best, emissions) have no slot to flow through and silently
+      become no-ops. Choose this only when the price-shopping flags above are
+      not required; otherwise port fli's f.req construction instead.
+  - name: punitarani/fli
+    url: https://github.com/punitarani/fli
+    language: python
+    license: MIT
+    integration_mode: subprocess
+    notes: |
+      Reference implementation with full filter parity. FlightSearchFilters.format()
+      in fli/models/google_flights/flights.py builds the protobuf-shaped f.req
+      payload Google's FlightsFrontendService expects, including airlines, bags,
+      carry-on, emissions, layover/max-layover, exclude-basic, show-all-results,
+      and all 7 sort values. Can be invoked as a subprocess (Python runtime
+      required) or — preferably — ported to Go directly. flight-goat in the
+      printing-press-library catalog repo carries a tested Go port at
+      internal/gflights/flights_native.go.

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -417,9 +417,11 @@ func TestEmbeddedCatalogParsesWrapperOnlyEntries(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, entry.IsWrapperOnly())
 	assert.Equal(t, "travel", entry.Category)
-	require.Len(t, entry.WrapperLibraries, 1)
+	require.Len(t, entry.WrapperLibraries, 2)
 	assert.Equal(t, "krisukox/google-flights-api", entry.WrapperLibraries[0].Name)
 	assert.Equal(t, "native", entry.WrapperLibraries[0].IntegrationMode)
+	assert.Equal(t, "punitarani/fli", entry.WrapperLibraries[1].Name)
+	assert.Equal(t, "subprocess", entry.WrapperLibraries[1].IntegrationMode)
 }
 
 func TestPublicCategoriesExcludeExample(t *testing.T) {

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -41,5 +41,5 @@ social-and-messaging:
   twilio               Communication APIs for SMS, voice, and messaging
 
 travel:
-  google-flights       Flight search via Google Flights. No public API — reached through a community-maintained reverse-engineered wrapper.
+  google-flights       Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers (krisukox in Go, fli in Python).
 


### PR DESCRIPTION
Fixes #1083.

## Why

The catalog entry for `google-flights` steered new prints to import `krisukox/google-flights-api` as a pure-Go native wrapper. The integration mode and the "no Python runtime dependency" framing are accurate, but the wrapper's `Options` struct only exposes `Stops`, `Class`, and `TripType` — flags for `--airlines`, `--bags`, `--carry-on`, `--emissions`, `--layover`, `--max-layover`, `--exclude-basic`, `--limited`, plus the expanded `--sort` values (`top_flights`, `best`, `emissions`) all silently become no-ops at the wrapper boundary.

The published `flight-goat` CLI in `printing-press-library` ([library/travel/flight-goat](https://github.com/mvanhorn/printing-press-library/tree/main/library/travel/flight-goat)) recently ported [`punitarani/fli`](https://github.com/punitarani/fli)'s `FlightSearchFilters.format()` to Go (~572 LOC in `internal/gflights/flights_native.go`) — landed in [printing-press-library#440](https://github.com/mvanhorn/printing-press-library/pull/440). That port has full filter parity with fli at zero Python runtime cost. The catalog should reflect this so the next print picks the right path with eyes open.

## What changes

`catalog/google-flights.yaml`:

- **Append filter-coverage caveats** to the `krisukox/google-flights-api` wrapper notes so future prints know what gets dropped if they import it as-is.
- **Add `punitarani/fli`** as a second wrapper option (Python, MIT, `integration_mode: subprocess`) with a pointer to the working Go port in flight-goat as the recommended pattern. `subprocess` is the most honest tag inside the existing `validIntegrationModes` set — a Go CLI can either subprocess fli or, preferably, port it.
- **Top-level `description` + `notes`** now surface both paths and call out which to pick based on whether filter parity matters.
- **`verified_date`** bumped to `2026-05-11`.

`internal/catalog/catalog_test.go`:

- `TestEmbeddedCatalogParsesWrapperOnlyEntries` updated to expect both wrappers (krisukox + fli).

## Validation

```
go test ./internal/catalog/... -count=1   # PASS
go test ./internal/cli/... -count=1       # PASS (~61s)
go build ./...                            # PASS
go vet ./catalog/... ./internal/catalog/... # PASS
go run ./cmd/printing-press catalog list   # google-flights row reflects new description
```

## Scope

No generator code changes — `WrapperLibraries` is consumed only in `internal/cli/catalog.go` for catalog inspection display; this PR is purely informational. A future PR could teach the generator to surface the wrapper choice to the user interactively when running `/printing-press google-flights`, but that's separate from the documentation drift this issue flagged.
