### PR TITLE
fix(cli): skip Windows Python Store stub in verify-skill

### DIFF
--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
@@ -24,6 +25,12 @@ import (
 var verifySkillScript string
 
 const canonicalSectionsCheckName = "canonical-sections"
+
+const (
+	pythonPython3 = "python3"
+	pythonPy      = "py"
+	pythonPython  = "python"
+)
 
 type verifySkillRunResult struct {
 	Stdout   string
@@ -71,7 +78,7 @@ func runVerifySkillScript(dir string, only []string, asJSON bool, strict bool) (
 		pyArgs = append(pyArgs, "--strict")
 	}
 
-	py := exec.Command("python3", pyArgs...)
+	py := exec.Command(resolvePython(), pyArgs...)
 	py.Stdin = os.Stdin
 	py.Env = pythonUTF8Env(os.Environ())
 	var stdout, stderr bytes.Buffer
@@ -333,6 +340,37 @@ func emitMergedJSON(pyResult verifySkillRunResult, runCanonical, hasCanonicalFin
 	}
 	fmt.Println(string(out))
 	return nil
+}
+
+// resolvePython picks the interpreter name to pass to exec.Command for the
+// embedded verify-skill script. The Windows fallback chain exists because
+// exec.LookPath("python3") on Windows often resolves to the Microsoft Store
+// launcher stub, which is on PATH but exits with a "Python was not found"
+// Store-redirect message instead of running the script.
+func resolvePython() string {
+	if runtime.GOOS != "windows" {
+		return pythonPython3
+	}
+	if path, err := exec.LookPath(pythonPython3); err == nil && !isWindowsStorePython(path) {
+		return pythonPython3
+	}
+	if _, err := exec.LookPath(pythonPy); err == nil {
+		return pythonPy
+	}
+	if path, err := exec.LookPath(pythonPython); err == nil && !isWindowsStorePython(path) {
+		return pythonPython
+	}
+	return pythonPython3
+}
+
+// LookPath succeeds against the Microsoft Store Python launcher stub at
+// .../WindowsApps/python*.exe, so the only pre-exec signal is the path itself.
+func isWindowsStorePython(path string) bool {
+	if path == "" {
+		return false
+	}
+	lower := strings.ToLower(path)
+	return strings.Contains(lower, "windowsapps") && strings.Contains(lower, "python")
 }
 
 // pythonUTF8Env returns base with PYTHONIOENCODING and PYTHONUTF8 forced to

--- a/internal/cli/verify_skill_internal_test.go
+++ b/internal/cli/verify_skill_internal_test.go
@@ -64,3 +64,32 @@ func TestPythonUTF8Env_EmptyBase(t *testing.T) {
 		t.Errorf("expected both UTF-8 entries, got %v", got)
 	}
 }
+
+func TestIsWindowsStorePython(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"store stub python3", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python3.exe`, true},
+		{"store stub python", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python.exe`, true},
+		{"store stub mixed case", `C:\Users\alice\AppData\Local\Microsoft\WINDOWSAPPS\Python3.exe`, true},
+		{"store stub forward slashes", `C:/Users/alice/AppData/Local/Microsoft/WindowsApps/python3.exe`, true},
+		{"real python install", `C:\Python314\python.exe`, false},
+		{"py launcher", `C:\Windows\py.exe`, false},
+		{"unix path", "/usr/bin/python3", false},
+		{"unrelated windowsapps binary", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\winget.exe`, false},
+		{"empty path", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isWindowsStorePython(tc.path); got != tc.want {
+				t.Errorf("isWindowsStorePython(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/verify_skill_internal_test.go
+++ b/internal/cli/verify_skill_internal_test.go
@@ -75,6 +75,7 @@ func TestIsWindowsStorePython(t *testing.T) {
 	}{
 		{"store stub python3", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python3.exe`, true},
 		{"store stub python", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python.exe`, true},
+		{"store stub versioned python3.13", `C:\Users\alice\AppData\Local\Microsoft\WindowsApps\python3.13.exe`, true},
 		{"store stub mixed case", `C:\Users\alice\AppData\Local\Microsoft\WINDOWSAPPS\Python3.exe`, true},
 		{"store stub forward slashes", `C:/Users/alice/AppData/Local/Microsoft/WindowsApps/python3.exe`, true},
 		{"real python install", `C:\Python314\python.exe`, false},


### PR DESCRIPTION
## Intent

Windows verify-skill crashed before any check ran because `exec.LookPath("python3")` resolves to the Microsoft Store launcher stub at `.../WindowsApps/python3.exe`. The stub is on PATH but exits with "Python was not found; run without arguments to install from the Microsoft Store" instead of executing the embedded verifier.

Issue: Closes #876

## Approach

`runVerifySkillScript` now calls a new `resolvePython()` helper instead of hard-coding `"python3"`. The helper:

- Returns `"python3"` unchanged on non-Windows hosts (no extra `LookPath` cost).
- On Windows, tries `python3` first, rejecting it when the resolved path matches the Store stub (`isWindowsStorePython`). Falls back to the Python Launcher `py`, then `python` (also stub-checked), then `python3` as a last-resort no-op.

`isWindowsStorePython` checks for both `windowsapps` and `python` in the lower-cased path. Path-based detection is the only signal — `LookPath` succeeds against the stub because it is a real executable that exits non-zero on launch.

Sub-bugs 2 (UTF-8 file decode) and 3 (UTF-8 stdout encode) from issue #876 were already resolved by #985 (`read_utf8` helper plus `pythonUTF8Env` env vars and `sys.stdout.reconfigure`); this PR only covers the remaining interpreter-selection cascade.

## Scope

Primary area: `internal/cli/verify_skill.go`. Machine change only — no generator templates, catalog, MCP surface, or printed-CLI output affected.

Why this belongs in this repo: this is the `printing-press verify-skill` runtime in the Press binary itself, not a generated CLI. Failure mode reproduces on every Windows `shipcheck` against any printed CLI whose SKILL.md contains non-ASCII content.

## Risk

Low. Non-Windows hosts hit a single `runtime.GOOS` check and the prior code path. On Windows, the worst case (no real Python anywhere, only the Store stub) reaches the same failing exec the unfixed binary already produced. The added helpers are pure functions with no shared state.

## Output Contract

N/A — no generator output, catalog, manifest, MCP schema, or scorecard text changes. `scripts/golden.sh verify` passes unchanged.

## Verification

- `go fmt ./...`
- `go vet ./...`
- `go test ./...` — 3687 passed in 34 packages
- `golangci-lint run ./...`
- `scripts/golden.sh verify` — 16 cases pass
- Unit tests added: `TestIsWindowsStorePython` (9 table cases covering stub paths, mixed case, forward slashes, real installs, `py` launcher, Unix path, unrelated WindowsApps binary, empty path).

Windows runtime behavior of `resolvePython` is not directly covered by Linux/macOS Go tests — the four fallback paths can only fire when `runtime.GOOS == "windows"`. Restructuring the helper to inject `runtime.GOOS` + `exec.LookPath` for testability was discussed during review and accepted-for-later: the helper is six lines, the path-detection logic (`isWindowsStorePython`) is fully unit-tested, and the testing reviewer assessed the residual risk as acceptable given the simplicity.