### PR TITLE
fix(cli): delegate workflow archive to syncResource

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2174,12 +2174,16 @@ func (g *Generator) renderWorkflowFiles(visionData visionRenderData) ([]string, 
 			*spec.APISpec
 			SyncableResources  []profiler.SyncableResource
 			SearchableFields   map[string][]string
+			Pagination         profiler.PaginationProfile
 			AgentMoneyWorkflow AgentMoneyWorkflow
+			SyncEnabled        bool
 		}{
 			APISpec:            g.Spec,
 			SyncableResources:  g.profile.SyncableResources,
 			SearchableFields:   g.profile.SearchableFields,
+			Pagination:         g.profile.Pagination,
 			AgentMoneyWorkflow: visionData.AgentMoneyWorkflow,
+			SyncEnabled:        g.VisionSet.Sync,
 		}
 		if err := g.renderTemplate("channel_workflow.go.tmpl", filepath.Join("internal", "cli", "channel_workflow.go"), workflowData); err != nil {
 			return nil, fmt.Errorf("rendering workflow: %w", err)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4403,6 +4403,62 @@ func TestGeneratedOutput_AgentMoneyWorkflowPaymentPlan(t *testing.T) {
 	assert.Contains(t, string(out), "--purpose is required for domesticWire payment plans")
 }
 
+// TestGeneratedOutput_WorkflowArchiveDelegatesToSyncResource pins issue
+// #1077's fix: workflow archive must delegate to syncResource (so it
+// inherits the spec-driven path, envelope unwrap, and pagination params),
+// and the archive subcommand must only emit when Sync is enabled.
+// A regression that brings back the inline c.Get("/"+resource), bare
+// json.Unmarshal into []json.RawMessage, or hardcoded params["after"]
+// would silently re-introduce three P1 bugs across the printed library.
+func TestGeneratedOutput_WorkflowArchiveDelegatesToSyncResource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sync_enabled emits archive delegating to syncResource", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("archive-sync-on")
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		gen := New(apiSpec, outputDir)
+		gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+		require.NoError(t, gen.Generate())
+
+		workflowGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "channel_workflow.go"))
+		require.NoError(t, err)
+		src := string(workflowGo)
+
+		assert.Contains(t, src, "func newWorkflowArchiveCmd(flags *rootFlags) *cobra.Command",
+			"archive command must be emitted when Sync is enabled")
+		assert.Contains(t, src, "syncResource(",
+			"archive must delegate to syncResource so it inherits the hardened sync loop")
+
+		assert.NotContains(t, src, `c.Get("/"+resource`,
+			"archive must not hardcode `/<resource>` paths (#1077 Bug 1)")
+		assert.NotContains(t, src, `json.Unmarshal(data, &items)`,
+			"archive must not bare-unmarshal arrays; use extractPageItems via syncResource (#1077 Bug 2)")
+		assert.NotContains(t, src, `params["after"] = cursor`,
+			"archive must not hardcode `?after=` pagination; use determinePaginationDefaults via syncResource (#1077 Bug 3)")
+	})
+
+	t.Run("sync_disabled drops archive subcommand", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("archive-sync-off")
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		gen := New(apiSpec, outputDir)
+		gen.VisionSet = VisionTemplateSet{Store: true}
+		require.NoError(t, gen.Generate())
+
+		workflowGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "channel_workflow.go"))
+		require.NoError(t, err)
+		src := string(workflowGo)
+
+		assert.NotContains(t, src, "func newWorkflowArchiveCmd",
+			"archive must not be emitted when Sync is disabled (syncResource is absent)")
+		assert.NotContains(t, src, "newWorkflowArchiveCmd(flags)",
+			"archive must not be registered when Sync is disabled")
+		assert.Contains(t, src, "func newWorkflowStatusCmd",
+			"status subcommand must still be emitted")
+	})
+}
+
 func TestGeneratedOutput_PromotedCommandCompiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -13,7 +13,9 @@ import (
 {{- if .AgentMoneyWorkflow.Enabled}}
 	"strings"
 {{- end}}
+{{- if or .SyncEnabled .AgentMoneyWorkflow.Enabled}}
 	"time"
+{{- end}}
 
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
@@ -25,7 +27,9 @@ func newWorkflowCmd(flags *rootFlags) *cobra.Command {
 		Short: "Compound workflows that combine multiple API operations",
 	}
 
+{{- if .SyncEnabled}}
 	cmd.AddCommand(newWorkflowArchiveCmd(flags))
+{{- end}}
 	cmd.AddCommand(newWorkflowStatusCmd(flags))
 {{- if .AgentMoneyWorkflow.Enabled}}
 	cmd.AddCommand(newWorkflowPaymentPlanCmd(flags))
@@ -239,6 +243,7 @@ func workflowAmountArg(amount float64, integer bool) (string, error) {
 }
 {{- end}}
 
+{{- if .SyncEnabled}}
 func newWorkflowArchiveCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string
 	var full bool
@@ -273,65 +278,27 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			resources := []string{ {{- range .SyncableResources}}"{{.Name}}", {{end}} }
 			totalSynced := 0
 
+			// --full clears the cursor here because syncResource reads
+			// existingCursor unconditionally; its full param only gates the
+			// since filter, not cursor reset. Mirrors newSyncCmd's pattern.
+			if full {
+				for _, resource := range resources {
+					_ = s.SaveSyncState(resource, "", 0)
+				}
+			}
+
 			for _, resource := range resources {
-				cursor := ""
-				if !full {
-					existing, _, _, err := s.GetSyncState(resource)
-					if err == nil && existing != "" {
-						cursor = existing
-					}
+				res := syncResource({{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100{{if .Pagination.DateRangeParam}}, ""{{end}})
+				if res.Err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
+					continue
 				}
-
-				fmt.Fprintf(cmd.ErrOrStderr(), "Syncing %s...\n", resource)
-
-				params := map[string]string{"limit": "100"}
-				if cursor != "" {
-					params["after"] = cursor
+				if res.Warn != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: warning: %v\n", resource, res.Warn)
+					continue
 				}
-
-				count := 0
-				for {
-					data, fetchErr := c.Get("/"+resource, params)
-					if fetchErr != nil {
-						fmt.Fprintf(cmd.ErrOrStderr(), "  warning: %s: %v\n", resource, fetchErr)
-						break
-					}
-					var items []json.RawMessage
-					if err := json.Unmarshal(data, &items); err != nil {
-						// Might be a single object, not array
-						if err := s.Upsert(resource, resource+"-singleton", data); err != nil {
-							fmt.Fprintf(cmd.ErrOrStderr(), "  warning: store %s: %v\n", resource, err)
-						}
-						count++
-						break
-					}
-					if len(items) == 0 {
-						break
-					}
-					for _, item := range items {
-						var obj struct{ ID string `json:"id"` }
-						json.Unmarshal(item, &obj)
-						id := obj.ID
-						if id == "" {
-							id = fmt.Sprintf("%s-%d", resource, count)
-						}
-						if err := s.Upsert(resource, id, item); err != nil {
-							fmt.Fprintf(cmd.ErrOrStderr(), "  warning: store %s/%s: %v\n", resource, id, err)
-						}
-						cursor = id
-						count++
-					}
-					if len(items) < 100 {
-						break
-					}
-					params["after"] = cursor
-				}
-
-				if count > 0 {
-					s.SaveSyncState(resource, cursor, count)
-				}
-				totalSynced += count
-				fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %d items\n", resource, count)
+				totalSynced += res.Count
+				fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %d synced\n", resource, res.Count)
 			}
 
 			if flags.asJSON {
@@ -355,6 +322,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 
 	return cmd
 }
+{{- end}}
 
 func newWorkflowStatusCmd(flags *rootFlags) *cobra.Command {
 	var dbPath string

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -323,6 +323,8 @@ Exit codes & warnings:
 
 // syncResource handles the full paginated sync of a single resource.
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
+// channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
+// keep both call sites in sync if this signature changes.
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -298,6 +298,8 @@ Exit codes & warnings:
 
 // syncResource handles the full paginated sync of a single resource.
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
+// channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
+// keep both call sites in sync if this signature changes.
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -298,6 +298,8 @@ Exit codes & warnings:
 
 // syncResource handles the full paginated sync of a single resource.
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
+// channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
+// keep both call sites in sync if this signature changes.
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -272,6 +272,8 @@ Exit codes & warnings:
 
 // syncResource handles the full paginated sync of a single resource.
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
+// channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
+// keep both call sites in sync if this signature changes.
 func syncResource(c interface {
 	Get(string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64


### PR DESCRIPTION
Closes #1077.

## Summary

Issue #1077 documented three independent bugs in `internal/generator/templates/channel_workflow.go.tmpl` that shipped into 67 of 68 CLIs in the public library:

1. **Hardcoded `/<resource>` path missing API version prefix** → 404s on most modern APIs.
2. **Bare-array `json.Unmarshal` failing on envelope responses** → the entire envelope gets stored under a synthetic `<resource>-singleton` key while `workflow status` reports `count=1` regardless of how many records the API has.
3. **Hardcoded `?after=<cursor>` pagination** → silent truncation after page 1 for APIs paginated by page number, `starting_after`, etc.

All three fired silently: the command exited 0 and `workflow status` reported success, but the local store was either empty or held the wrong shape.

## Fix

Refactor the template to delegate per-resource sync to `syncResource` (already emitted in `sync.go.tmpl` / `graphql_sync.go.tmpl`). The printed CLI now inherits:

- Spec-driven resource paths via `syncResourcePath`
- Envelope unwrap via `extractPageItems` (handles `data`/`results`/`items`/`records`/`nodes`/`entries` plus single-array-key fallback)
- Cursor + page-size param detection via `determinePaginationDefaults` (uses the profiler's detected param names, not a hardcoded `after`)
- `sync_anomaly` telemetry, sticky-cursor detection, per-resource since-param handling

Each printed CLI's emitted `channel_workflow.go` is also ~50 lines smaller.

## Emission gating

`workflow archive` is now only emitted when `VisionSet.Sync = true`, since `syncResource` requires `sync.go.tmpl` (or `graphql_sync.go.tmpl`) to be rendered. In production `SelectVisionTemplates` enforces `Store => Sync` ([vision_templates.go:146](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/generator/vision_templates.go#L146)), so this is invisible to end users; the gate only matters for test-fixture isolation where `Store: true` is set without `Sync`.

## Test plan

- [x] All 3727 tests pass (added 3 new subtests).
- [x] `scripts/golden.sh verify` passes (16 cases). Two fixtures picked up the new 2-line comment at `syncResource`'s definition documenting the cross-template signature coupling — intentional, scoped to comment-only additions.
- [x] `go vet`, `golangci-lint`, `gofmt` clean.
- [x] New test `TestGeneratedOutput_WorkflowArchiveDelegatesToSyncResource` pins:
  - emitted `channel_workflow.go` contains `syncResource(` when Sync is enabled,
  - emitted file does NOT contain the three buggy patterns (`c.Get("/"+resource`, bare-array `json.Unmarshal(data, &items)`, `params["after"] = cursor`),
  - archive function is dropped when `Sync = false` while `Store = true`.

## Follow-ups (out of scope here)

Reviewers surfaced two structural cleanups worth filing separately:

- The `workflowData` anonymous struct in `renderWorkflowFiles` partly duplicates `visionRenderData`. Collapsing into a shared struct with a `SyncEnabled` field would remove the field-sync maintenance trap, but touches every consumer of `visionRenderData`.
- No golden fixture yet pins `channel_workflow.go`. AGENTS.md's "Generator Output Stability" rule asks for one when adding new deterministic emission; deferred to a separate fixture-authoring change.