### PR TITLE
fix(cli): stage runstate manuscripts during lock promote

### DIFF
--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -5,6 +5,7 @@ Generated artifacts live under the user's home directory, not in this repo.
 ## Local artifacts
 
 - `~/printing-press/library/<api-slug>/` — local library: printed CLIs the generator has produced. Directory names are keyed by API slug, not CLI name. The binary inside is still `<api-slug>-pp-cli`.
+- `~/printing-press/library/<api-slug>/.manuscripts/<run-id>/` — per-run manuscripts (proofs, research, discovery) embedded inside the printed CLI by `printing-press lock promote`. Mirrors what `publish package` later copies into a packaged tarball, so `publish validate` can find the Phase 5 acceptance marker on a freshly promoted CLI without manual `cp -r` from the runstate.
 - `~/printing-press/manuscripts/<api-slug>/` — archived research and verification proofs, keyed by API slug. One API can have multiple runs.
 - `~/printing-press/.runstate/<scope>/` — mutable per-workspace state such as current run and sync cursors.
 

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -266,6 +266,13 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 		return fmt.Errorf("copying to staging directory: %w", err)
 	}
 
+	// Phase 5 writes acceptance markers to the runstate, but the published
+	// copy is the path downstream consumers see — embed them before the swap.
+	if err := stageRunstateManuscripts(stagingDir, state); err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return fmt.Errorf("staging runstate manuscripts: %w", err)
+	}
+
 	// Update state to reflect promotion.
 	state.PublishedDir = libraryDir
 
@@ -333,6 +340,50 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	default:
 		return nil
 	}
+}
+
+// A pre-existing subtree in the staging copy wins so artifacts that generate
+// or polish wrote directly into the working dir are never overwritten by an
+// older runstate snapshot. No-op when state has no RunID — the
+// NewMinimalState path for plan-driven CLIs has no runstate to stage from.
+func stageRunstateManuscripts(stagingDir string, state *PipelineState) error {
+	if state == nil || state.RunID == "" {
+		return nil
+	}
+	// The leaf component of each source path becomes the subdir name in
+	// staging (proofs/research/discovery). This pairs with the directory
+	// shape established by paths.go's RunProofsDir, RunResearchDir, and
+	// RunDiscoveryDir helpers; if those rename their leaf names, the
+	// destination layout follows automatically.
+	sources := []string{
+		state.ProofsDir(),
+		state.ResearchDir(),
+		state.DiscoveryDir(),
+	}
+	dstRoot := filepath.Join(stagingDir, ".manuscripts", state.RunID)
+	for _, src := range sources {
+		name := filepath.Base(src)
+		info, err := os.Stat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("inspecting runstate %s: %w", name, err)
+		}
+		if !info.IsDir() {
+			continue
+		}
+		target := filepath.Join(dstRoot, name)
+		if _, statErr := os.Stat(target); statErr == nil {
+			continue
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("checking %s in staging: %w", target, statErr)
+		}
+		if err := CopyDir(src, target); err != nil {
+			return fmt.Errorf("copying runstate %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func validatePhase5GateForPromote(workingDir string, state *PipelineState) error {

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -626,6 +626,150 @@ func TestPromoteWorkingCLI_MinimalStateNoRunstate(t *testing.T) {
 	assert.Equal(t, libDir, state.PublishedDir)
 }
 
+func TestPromoteWorkingCLI_StagesRunstateManuscripts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	_, err := AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewStateWithRun("test", workDir, "run-stage-001", "test-scope")
+	writePhase5PassForState(t, state, "none")
+
+	// Plant research and discovery alongside the phase5 marker so we can
+	// assert the whole runstate triplet gets staged into the published copy.
+	require.NoError(t, os.MkdirAll(state.ResearchDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(state.ResearchDir(), "notes.md"), []byte("research notes\n"), 0o644))
+	require.NoError(t, os.MkdirAll(state.DiscoveryDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "endpoints.json"), []byte("{}\n"), 0o644))
+
+	err = PromoteWorkingCLI("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	manuRoot := filepath.Join(libDir, ".manuscripts", state.RunID)
+
+	// phase5-acceptance.json must be reachable at the path publish validate
+	// looks at first: <lib>/.manuscripts/<run-id>/proofs/.
+	_, err = os.Stat(filepath.Join(manuRoot, "proofs", Phase5AcceptanceFilename))
+	assert.NoError(t, err, "phase5 acceptance marker should be staged into the published copy")
+
+	data, err := os.ReadFile(filepath.Join(manuRoot, "research", "notes.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "research notes\n", string(data))
+
+	data, err = os.ReadFile(filepath.Join(manuRoot, "discovery", "endpoints.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "{}\n", string(data))
+}
+
+func TestPromoteWorkingCLI_PreservesPreexistingManuscripts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	_, err := AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewStateWithRun("test", workDir, "run-stage-002", "test-scope")
+	writePhase5PassForState(t, state, "none")
+
+	// Working dir already carries a proofs subtree at the destination path
+	// with a sentinel file. We must not clobber it during staging.
+	preexistingProofs := filepath.Join(workDir, ".manuscripts", state.RunID, "proofs")
+	require.NoError(t, os.MkdirAll(preexistingProofs, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(preexistingProofs, "sentinel.txt"), []byte("keep-me\n"), 0o644))
+
+	// Also seed a different, non-overlapping research dir in runstate so
+	// non-conflicting subdirs still get staged on the same run.
+	require.NoError(t, os.MkdirAll(state.ResearchDir(), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(state.ResearchDir(), "notes.md"), []byte("from runstate\n"), 0o644))
+
+	err = PromoteWorkingCLI("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	manuRoot := filepath.Join(libDir, ".manuscripts", state.RunID)
+
+	data, err := os.ReadFile(filepath.Join(manuRoot, "proofs", "sentinel.txt"))
+	require.NoError(t, err, "pre-existing proofs subtree should survive staging")
+	assert.Equal(t, "keep-me\n", string(data))
+
+	data, err = os.ReadFile(filepath.Join(manuRoot, "research", "notes.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "from runstate\n", string(data))
+}
+
+func TestPromoteWorkingCLI_StagesPartialRunstate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	_, err := AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewStateWithRun("test", workDir, "run-stage-003", "test-scope")
+	// Only proofs is populated — research and discovery dirs do not exist
+	// in the runstate. The staging step must skip them via os.IsNotExist
+	// without aborting the promote.
+	writePhase5PassForState(t, state, "none")
+
+	err = PromoteWorkingCLI("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	manuRoot := filepath.Join(libDir, ".manuscripts", state.RunID)
+
+	_, err = os.Stat(filepath.Join(manuRoot, "proofs", Phase5AcceptanceFilename))
+	assert.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(manuRoot, "research"))
+	assert.True(t, os.IsNotExist(statErr), "research subdir should not be created when runstate has none")
+	_, statErr = os.Stat(filepath.Join(manuRoot, "discovery"))
+	assert.True(t, os.IsNotExist(statErr), "discovery subdir should not be created when runstate has none")
+}
+
+func TestPromoteWorkingCLI_StagingNoopForMinimalState(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	state := NewMinimalState("test-pp-cli", workDir)
+	require.Empty(t, state.RunID, "minimal state should have no RunID")
+
+	err := PromoteWorkingCLI("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	_, statErr := os.Stat(filepath.Join(libDir, ".manuscripts"))
+	assert.True(t, os.IsNotExist(statErr), "minimal-state promote should not create a .manuscripts dir")
+}
+
 func TestIsStale(t *testing.T) {
 	fresh := &LockState{UpdatedAt: time.Now()}
 	assert.False(t, IsStale(fresh))


### PR DESCRIPTION
## Intent

Issue: Closes #889

`lock promote` was leaving the published library copy without the runstate manuscripts that Phase 5 had just written. `printing-press publish validate --dir $PRESS_LIBRARY/<api>` then failed its `phase5` leg even though the acceptance marker was sitting in `$PRESS_HOME/.runstate/<scope>/runs/<run-id>/proofs/` — every successful generation tripped this until the operator manually `cp -r`'d the dirs in front of the validator.

## Approach

Direction B from the issue. `PromoteWorkingCLI` now stages the runstate's `proofs/research/discovery` trees into `<staging>/.manuscripts/<run-id>/` before the atomic swap, so the published library copy is self-contained and `publish validate`'s phase5 leg finds the marker without a manual step.

- No-op when state has no `RunID` (the `NewMinimalState` path for plan-driven CLIs) — preserves today's behavior on that branch.
- A pre-existing subtree in the staging copy wins, so artifacts that `generate` or `polish` wrote directly into the working dir are never overwritten by an older runstate snapshot.
- Failure in the new stage rolls back via the same `os.RemoveAll(stagingDir)` pattern the surrounding promote code already uses.
- The destination dir-name pairing relies on `state.Proofs/Research/DiscoveryDir()` returning paths whose leaf is `"proofs"`/`"research"`/`"discovery"`. Documented inline.

## Scope

Primary area: `internal/pipeline/` (the generator binary's `lock promote` subcommand).

Why this belongs in this repo: behavior change in the Printing Press's promote-to-library flow. Every printed CLI promoted through the binary benefits; not specific to any one API.

## Risk

- Promote now has an extra file-copy step; failures are caught and the existing rollback discards the staging dir before the live library is touched, so a stage error never corrupts an already-published CLI.
- `CopyDir` already rejects symlinks pointing outside the source root, so staging a runstate cannot leak files out of the library tree.
- Plan-driven (`NewMinimalState`) promotes are unchanged.

## Output Contract

`publish validate`'s phase5 leg now passes on freshly promoted CLIs without manual manuscript staging. The new `.manuscripts/<run-id>/` subtree inside the local library is documented in [docs/ARTIFACTS.md](docs/ARTIFACTS.md).

## Verification

- `go test ./...` — all 3751 tests pass, including 4 new tests in `internal/pipeline/lock_test.go`:
  - `TestPromoteWorkingCLI_StagesRunstateManuscripts` — full triplet path
  - `TestPromoteWorkingCLI_PreservesPreexistingManuscripts` — no-clobber guarantee
  - `TestPromoteWorkingCLI_StagesPartialRunstate` — proofs only, research/discovery absent
  - `TestPromoteWorkingCLI_StagingNoopForMinimalState` — back-compat for plan-driven CLIs
- `go vet ./...` clean
- `golangci-lint run ./...` clean
- `scripts/golden.sh verify` — 17/17 pass (no generated output changes; the stage happens at promote time, after generation)
- `git diff --check` clean