### PR TITLE
fix(cli): honor Spec.BasePath in generated client URL construction

### DIFF
--- a/internal/generator/client_basepath_test.go
+++ b/internal/generator/client_basepath_test.go
@@ -1,0 +1,147 @@
+package generator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientHonorsSpecBasePath checks that a spec declaring BaseURL plus a
+// separate BasePath produces a generated client that sends requests to
+// ${BaseURL}${BasePath}${path}. Some APIs split the host from the path mount
+// (e.g. base_url: https://host, base_path: /~api); previously that prefix was
+// dropped and every request 404'd.
+func TestClientHonorsSpecBasePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("basepath-honored")
+	apiSpec.BasePath = "/~api"
+
+	outputDir := filepath.Join(t.TempDir(), "basepath-honored-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	client := string(clientSrc)
+
+	assert.Contains(t, client, "BasePath   string",
+		"Client struct should expose a BasePath field when the spec declares one")
+	assert.Contains(t, client, "BasePath:   normalizeBasePath(cfg.BasePath)",
+		"New() should populate Client.BasePath from cfg.BasePath via the normalizer")
+	assert.Contains(t, client, "c.BaseURL + c.BasePath + path",
+		"do() should construct request URLs as BaseURL+BasePath+path")
+
+	cacheKeyBody := clientCacheKeyBody(t, client)
+	assert.Contains(t, cacheKeyBody, `"|base_path=" + c.BasePath`,
+		"cache key should include BasePath so a config change invalidates correctly")
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	config := string(configSrc)
+
+	assert.Contains(t, config, `BasePath       string `+"`"+`toml:"base_path"`+"`",
+		"Config struct should expose BasePath with a serialized tag matching the spec's config format")
+	assert.Contains(t, config, `BasePath: "/~api"`,
+		"Load() should seed cfg.BasePath from the spec default")
+	assert.Contains(t, config, `os.Getenv("BASEPATH_HONORED_BASE_PATH")`,
+		"Load() should accept an env-var override for BasePath")
+}
+
+// TestClientWithoutBasePathByteIdentical asserts the negative case: a spec
+// with no BasePath produces the same client.go and config.go content as
+// before this change (the conditional template guards must not leak when
+// .BasePath is empty).
+func TestClientWithoutBasePathByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("no-basepath")
+
+	outputDir := filepath.Join(t.TempDir(), "no-basepath-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	client := string(clientSrc)
+	assert.NotContains(t, client, "BasePath",
+		"client.go must not emit BasePath when the spec doesn't declare base_path")
+	assert.NotContains(t, client, "normalizeBasePath",
+		"client.go must not emit the normalizeBasePath helper when unused")
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	config := string(configSrc)
+	assert.NotContains(t, config, "BasePath",
+		"config.go must not emit BasePath when the spec doesn't declare base_path")
+	assert.NotContains(t, config, "_BASE_PATH",
+		"config.go must not emit the BASE_PATH env override when BasePath is empty")
+}
+
+// TestClientBasePathLiveRequest compiles a printed CLI from a BasePath spec
+// against a stub server and asserts the request URL hits the prefix. This is
+// the runtime test: template content matching can drift; only the live HTTP
+// path proves the fix.
+func TestClientBasePathLiveRequest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		gotPaths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPaths = append(gotPaths, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items": []}`))
+	}))
+	t.Cleanup(server.Close)
+
+	apiSpec := minimalSpec("bplive")
+	apiSpec.BaseURL = server.URL
+	apiSpec.BasePath = "/api/v1"
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"things": {
+			Description: "Manage things",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/things", Description: "List things"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bplive-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "bplive-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/bplive-pp-cli")
+
+	cmd := exec.Command(binaryPath, "things", "list", "--json")
+	cmd.Env = append(os.Environ(), "BPLIVE_BASE_URL="+server.URL)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Confirm the response decodes; the actual shape comes from the stub.
+	var resp any
+	require.NoError(t, json.Unmarshal(out, &resp), string(out))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, gotPaths, "stub server should have received at least one request")
+	for _, p := range gotPaths {
+		assert.True(t, strings.HasPrefix(p, "/api/v1/"),
+			"request path %q should start with the BasePath prefix /api/v1/", p)
+	}
+	assert.Contains(t, gotPaths, "/api/v1/things",
+		"the things.list endpoint should hit /api/v1/things, not /things")
+}

--- a/internal/generator/client_basepath_test.go
+++ b/internal/generator/client_basepath_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -34,9 +35,13 @@ func TestClientHonorsSpecBasePath(t *testing.T) {
 	require.NoError(t, err)
 	client := string(clientSrc)
 
-	assert.Contains(t, client, "BasePath   string",
+	// Whitespace-insensitive: gofmt may align columns differently than the
+	// template's literal indentation, so match field shape via regex.
+	clientBasePathField := regexp.MustCompile(`(?m)^\s*BasePath\s+string\b`)
+	assert.Regexp(t, clientBasePathField, client,
 		"Client struct should expose a BasePath field when the spec declares one")
-	assert.Contains(t, client, "BasePath:   normalizeBasePath(cfg.BasePath)",
+	clientNewAssign := regexp.MustCompile(`BasePath:\s+normalizeBasePath\(cfg\.BasePath\)`)
+	assert.Regexp(t, clientNewAssign, client,
 		"New() should populate Client.BasePath from cfg.BasePath via the normalizer")
 	assert.Contains(t, client, "c.BaseURL + c.BasePath + path",
 		"do() should construct request URLs as BaseURL+BasePath+path")
@@ -49,7 +54,8 @@ func TestClientHonorsSpecBasePath(t *testing.T) {
 	require.NoError(t, err)
 	config := string(configSrc)
 
-	assert.Contains(t, config, `BasePath       string `+"`"+`toml:"base_path"`+"`",
+	configBasePathField := regexp.MustCompile("(?m)^\\s*BasePath\\s+string\\s+`toml:\"base_path\"`")
+	assert.Regexp(t, configBasePathField, config,
 		"Config struct should expose BasePath with a serialized tag matching the spec's config format")
 	assert.Contains(t, config, `BasePath: "/~api"`,
 		"Load() should seed cfg.BasePath from the spec default")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -39,6 +39,11 @@ import (
 
 type Client struct {
 	BaseURL    string
+{{- if .BasePath}}
+	// BasePath sits between BaseURL and the request path; empty unless the
+	// spec declares base_path.
+	BasePath   string
+{{- end}}
 	Config     *config.Config
 	HTTPClient *http.Client
 	DryRun     bool
@@ -152,11 +157,11 @@ func (c *Client) baseURLForRequest() string {
 	{{- if $tier.BaseURL}}
 		return strings.TrimRight({{printf "%q" $tier.BaseURL}}, "/")
 	{{- else}}
-		return c.BaseURL
+		return c.BaseURL{{if $.BasePath}} + c.BasePath{{end}}
 	{{- end}}
 {{- end}}
 	default:
-		return c.BaseURL
+		return c.BaseURL{{if .BasePath}} + c.BasePath{{end}}
 	}
 }
 
@@ -302,6 +307,9 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	sess.AttachTo(httpClient)
 	return &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+{{- if .BasePath}}
+		BasePath:   normalizeBasePath(cfg.BasePath),
+{{- end}}
 		Config:     cfg,
 		HTTPClient: httpClient,
 		cacheDir:   cacheDir,
@@ -325,6 +333,9 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	httpClient := newHTTPClient(timeout, nil)
 	return &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+{{- if .BasePath}}
+		BasePath:   normalizeBasePath(cfg.BasePath),
+{{- end}}
 		Config:     cfg,
 		HTTPClient: httpClient,
 		cacheDir:   cacheDir,
@@ -377,6 +388,9 @@ func (c *Client) ProbeGet(path string) (int, error) {
 func (c *Client) cacheKey(path string, params map[string]string) string {
 	key := path
 	key += "|base_url=" + c.BaseURL
+{{- if .BasePath}}
+	key += "|base_path=" + c.BasePath
+{{- end}}
 {{- if .HasTierRouting}}
 	key += "|tier=" + c.requestTier + "|tier_base_url=" + c.baseURLForRequest()
 {{- end}}
@@ -636,13 +650,13 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 	if isAbsoluteURL(path) {
 		targetURL, urlErr = buildURL("", path, endpointVars)
 	} else {
-		targetURL, urlErr = buildURL({{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{end}}, path, endpointVars)
+		targetURL, urlErr = buildURL({{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{if .BasePath}} + c.BasePath{{end}}{{end}}, path, endpointVars)
 	}
 	if urlErr != nil {
 		return nil, 0, urlErr
 	}
 {{- else}}
-		targetURL, urlErr := buildURL({{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{end}}, path, endpointVars)
+		targetURL, urlErr := buildURL({{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{if .BasePath}} + c.BasePath{{end}}{{end}}, path, endpointVars)
 	if urlErr != nil {
 		return nil, 0, urlErr
 	}
@@ -656,10 +670,10 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 	if isAbsoluteURL(path) {
 		targetURL = path
 	} else {
-		targetURL = {{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{end}} + path
+		targetURL = {{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{if .BasePath}} + c.BasePath{{end}}{{end}} + path
 	}
 {{- else}}
-	targetURL := {{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{end}} + path
+	targetURL := {{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{if .BasePath}} + c.BasePath{{end}}{{end}} + path
 {{- end}}
 {{- end}}
 {{- end}}
@@ -1375,6 +1389,28 @@ func (c *Client) refreshAccessToken() error {
 // concat with c.BaseURL must be skipped for those calls).
 func isAbsoluteURL(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
+}
+
+{{end -}}
+{{if .BasePath -}}
+// normalizeBasePath trims surrounding whitespace and trailing slashes, then
+// guarantees a single leading slash so concatenation with c.BaseURL produces
+// well-formed URLs whether the operator wrote "/api/v1", "api/v1/", or
+// "/api/v1/". Empty input stays empty so an unset override doesn't inject a
+// stray "/" into the request URL.
+func normalizeBasePath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	p = strings.TrimRight(p, "/")
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
 }
 
 {{end -}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -25,6 +25,9 @@ import (
 
 type Config struct {
 	BaseURL        string `{{configTag .Config.Format}}:"base_url"`
+{{- if .BasePath}}
+	BasePath       string `{{configTag .Config.Format}}:"base_path"`
+{{- end}}
 	AuthHeaderVal  string `{{configTag .Config.Format}}:"auth_header"`
 	Headers        map[string]string `{{configTag .Config.Format}}:"headers,omitempty"`
 	AuthSource     string `{{configTag .Config.Format}}:"-"`
@@ -78,6 +81,9 @@ func Load(configPath string) (*Config, error) {
 	cfg := &Config{
 {{- if .BaseURL}}
 		BaseURL: "{{.BaseURL}}",
+{{- end}}
+{{- if .BasePath}}
+		BasePath: "{{.BasePath}}",
 {{- end}}
 	}
 
@@ -163,6 +169,11 @@ func Load(configPath string) (*Config, error) {
 	if v := os.Getenv("{{envName .Name}}_BASE_URL"); v != "" {
 		cfg.BaseURL = v
 	}
+{{- if .BasePath}}
+	if v := os.Getenv("{{envName .Name}}_BASE_PATH"); v != "" {
+		cfg.BasePath = v
+	}
+{{- end}}
 {{- if and .HasAuthCommand .Auth.AuthorizationURL}}
 	if v := os.Getenv("{{envName .Name}}_AUTHORIZATION_URL"); v != "" {
 		cfg.AuthorizationURL = v

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1671,6 +1671,9 @@ func (s *APISpec) Validate() error {
 	if s.ClientPattern == "proxy-envelope" && s.HasResourceBaseURLOverride() {
 		return fmt.Errorf("resource or endpoint base_url overrides are incompatible with client_pattern=proxy-envelope; the proxy POSTs every request to the spec-level BaseURL, so per-request overrides would be silently ignored")
 	}
+	if s.ClientPattern == "proxy-envelope" && s.BasePath != "" {
+		return fmt.Errorf("base_path is incompatible with client_pattern=proxy-envelope; the proxy routes via the envelope's Service/Path fields, not a URL-level prefix — fold the prefix into base_url instead")
+	}
 	for name, r := range s.Resources {
 		if len(r.Endpoints) == 0 && len(r.SubResources) == 0 {
 			return fmt.Errorf("resource %q has no endpoints", name)

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3258,6 +3258,31 @@ func TestValidateRejectsResourceBaseURLWithProxyEnvelope(t *testing.T) {
 	assert.Contains(t, err.Error(), "base_url")
 }
 
+// TestValidateRejectsBasePathWithProxyEnvelope — proxy-envelope routes via
+// the envelope's Service/Path fields, not a URL-level prefix; a BasePath
+// would be silently ignored by the proxy. Validate must fail-fast.
+func TestValidateRejectsBasePathWithProxyEnvelope(t *testing.T) {
+	t.Parallel()
+	s := &APISpec{
+		Name:          "proxypath",
+		Version:       "0.1.0",
+		BaseURL:       "https://proxy.example.com",
+		BasePath:      "/api/v1",
+		ClientPattern: "proxy-envelope",
+		Resources: map[string]Resource{
+			"items": {
+				Endpoints: map[string]Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List"},
+				},
+			},
+		},
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "proxy-envelope")
+	assert.Contains(t, err.Error(), "base_path")
+}
+
 // TestValidateAcceptsResourceBaseURLWithoutProxyEnvelope — the same
 // resource override is accepted when client_pattern is not the proxy
 // flavor. Negative cases (no resource override, proxy-envelope alone)


### PR DESCRIPTION
## Intent

`Spec.BasePath` was parsed and validated on `APISpec` but no template emitted it into the printed CLI. Specs that declare both `base_url` and `base_path` — OneDev (`/~api`), Forgejo / Gitea (`/api/v1`), and similar self-hosted apps — sent every request to `${BaseURL}${path}` instead of `${BaseURL}${BasePath}${path}` and 404'd silently.

Issue: Refs #926

## Approach

Wire `BasePath` through the generated `Client` and `Config` only when `Spec.BasePath != ""`:

- `config.go.tmpl`: add `BasePath` field with the format-appropriate struct tag, seed from the spec literal in `Load()`, and accept a `<API>_BASE_PATH` env override (mirrors the existing `<API>_BASE_URL` pattern).
- `client.go.tmpl`: add `BasePath` to `Client`, populate it in `New()` via a small `normalizeBasePath` helper (trim space and trailing slashes, ensure single leading slash, empty stays empty), use `c.BaseURL + c.BasePath + path` in `do()` across the four URL-construction branches (plain, with `EndpointTemplateVars`, with `HasResourceBaseURLOverride`, and with tier routing's fallthrough), include `BasePath` in the cache key, and append it in `baseURLForRequest()`'s default / no-tier-override case.
- Tier-specific BaseURL overrides keep their existing behavior — tier authors are expected to fold any prefix into their own URL (matches the issue's documented scope).

Existing specs without `base_path` produce byte-identical generated output via `{{- if .BasePath}}` template guards.

## Scope

Primary area: generator templates (`internal/generator/templates/client.go.tmpl`, `config.go.tmpl`).

Why this belongs in this repo: this is a machine change. The `BasePath` field is on `spec.APISpec` and the generator was emitting it nowhere. Fixing the templates makes every future printed CLI honor `base_path`; printed-CLI-only patches (the workaround that prompted this issue) compound exactly once.

## Risk

Generated output is byte-identical for any spec without `base_path` — confirmed by `scripts/golden.sh verify` (17 cases pass with no diff). Existing on-disk caches for any printed CLI regenerated with `base_path` will be one-time misses (cache key includes `|base_path=`) — orphaned, self-healing.

**Latent gap not addressed:** proxy-envelope `ClientPattern` does not apply `BasePath` in its URL construction (lines 631–640 of `client.go.tmpl`). No current spec combines proxy-envelope with `base_path`, but a future combination would silently drop the prefix. Worth a follow-up: either inject `BasePath` into proxy-envelope branches and `envelope.Path`, or guard the combination at `spec.Validate()`.

## Output Contract

Templates emit new fields and code only when `Spec.BasePath != ""`. Existing goldens unchanged. New code path:
- `Config` gains `BasePath string` with `base_path` tag.
- `Client` gains `BasePath string`.
- `do()` constructs URLs as `c.BaseURL + c.BasePath + path` (or via `buildURL` for placeholder paths).
- Cache key includes `|base_path=<value>`.
- New env var: `<API>_BASE_PATH`.

## Verification

- `scripts/golden.sh verify` — 17 cases pass, no diff.
- `go test ./...` — 3759 tests pass, including 3 new tests in `internal/generator/client_basepath_test.go`:
  - `TestClientHonorsSpecBasePath` — generated client.go + config.go contain the expected BasePath plumbing.
  - `TestClientWithoutBasePathByteIdentical` — specs without `base_path` produce no BasePath emission.
  - `TestClientBasePathLiveRequest` — compiles the generated CLI and asserts the live HTTP request hits `/api/v1/things`, not `/things`.
- `go vet ./...` — clean.
- `golangci-lint run ./...` — clean.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change