### PR TITLE
fix(cli): emit default Accept */* header in generated HTTP clients

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1496,6 +1496,10 @@ func TestGenerateBrowserChromeH3Transport(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(clientGo), `"github.com/enetx/surf"`)
 	assert.Contains(t, string(clientGo), "ForceHTTP3()")
+	// surf's Chrome impersonation manages the Accept header alongside
+	// User-Agent on the H3 transport too; the generator must not emit a
+	// competing default.
+	assert.NotContains(t, string(clientGo), `req.Header.Set("Accept", "*/*")`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/client")
@@ -5768,6 +5772,8 @@ func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	standardClient, err := os.ReadFile(filepath.Join(standardDir, "internal", "client", "client.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(standardClient), `req.Header.Set("User-Agent", "standard-pp-cli/0.1.0")`)
+	assert.Contains(t, string(standardClient), `req.Header.Set("Accept", "*/*")`)
+	assert.Contains(t, string(standardClient), `if req.Header.Get("Accept") == "" {`)
 
 	browserDir := filepath.Join(t.TempDir(), "browser-pp-cli")
 	browserSpec := baseSpec("browser")
@@ -5776,11 +5782,35 @@ func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	browserClient, err := os.ReadFile(filepath.Join(browserDir, "internal", "client", "client.go"))
 	require.NoError(t, err)
 	assert.NotContains(t, string(browserClient), `req.Header.Set("User-Agent"`)
+	// surf's Chrome impersonation manages the Accept header alongside
+	// User-Agent; the generator must not emit a competing default for either.
+	assert.NotContains(t, string(browserClient), `req.Header.Set("Accept", "*/*")`)
 	// auth.go is not emitted for auth.type:none specs (see Generator.renderAuthFiles).
 	// Stronger assertion than the previous "no newAuthRefreshCmd in auth.go": there's
 	// no auth.go at all for no-auth CLIs.
 	_, err = os.Stat(filepath.Join(browserDir, "internal", "cli", "auth.go"))
 	assert.True(t, os.IsNotExist(err), "auth.go should not be emitted for auth.type:none specs")
+}
+
+func TestGenerateRequiredAcceptHeaderBeatsDefaultAccept(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("acceptoverride")
+	apiSpec.RequiredHeaders = []spec.RequiredHeader{
+		{Name: "Accept", Value: "application/vnd.api.v3+json"},
+	}
+	apiSpec.Auth.VerifyPath = "/items"
+
+	outputDir := filepath.Join(t.TempDir(), "acceptoverride-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	requiredIdx := strings.Index(clientSrc, `req.Header.Set("Accept", "application/vnd.api.v3+json")`)
+	defaultIdx := strings.Index(clientSrc, `req.Header.Set("Accept", "*/*")`)
+	require.GreaterOrEqual(t, requiredIdx, 0, "spec-required Accept header must be emitted")
+	require.GreaterOrEqual(t, defaultIdx, 0, "Accept fallback default must still be emitted")
+	assert.Less(t, requiredIdx, defaultIdx, "spec-required Accept must be set before the if-empty default")
+	assert.Contains(t, clientSrc, `if req.Header.Get("Accept") == "" {`)
 }
 
 func TestGenerateRequiredUserAgentHeaderBeatsDefaultUserAgent(t *testing.T) {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -849,6 +849,13 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		if req.Header.Get("User-Agent") == "" {
 			req.Header.Set("User-Agent", "{{.Name}}-pp-cli/{{.Version}}")
 		}
+		// Go's net/http omits Accept by default; browsers, curl, and other
+		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
+		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
+		// and answer with HTTP 500.
+		if req.Header.Get("Accept") == "" {
+			req.Header.Set("Accept", "*/*")
+		}
 {{- end}}
 
 		resp, err := c.HTTPClient.Do(req)

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -852,7 +852,8 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Go's net/http omits Accept by default; browsers, curl, and other
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
-		// and answer with HTTP 500.
+		// and answer with empty-body 5xx, 403, or a challenge redirect
+		// depending on vendor and rule tier.
 		if req.Header.Get("Accept") == "" {
 			req.Header.Set("Accept", "*/*")
 		}

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -253,6 +253,13 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		if req.Header.Get("User-Agent") == "" {
 			req.Header.Set("User-Agent", "printing-press-oauth2-pp-cli/1.0.0")
 		}
+		// Go's net/http omits Accept by default; browsers, curl, and other
+		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
+		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
+		// and answer with HTTP 500.
+		if req.Header.Get("Accept") == "" {
+			req.Header.Set("Accept", "*/*")
+		}
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -256,7 +256,8 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Go's net/http omits Accept by default; browsers, curl, and other
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
-		// and answer with HTTP 500.
+		// and answer with empty-body 5xx, 403, or a challenge redirect
+		// depending on vendor and rule tier.
 		if req.Header.Get("Accept") == "" {
 			req.Header.Set("Accept", "*/*")
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -250,7 +250,8 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Go's net/http omits Accept by default; browsers, curl, and other
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
-		// and answer with HTTP 500.
+		// and answer with empty-body 5xx, 403, or a challenge redirect
+		// depending on vendor and rule tier.
 		if req.Header.Get("Accept") == "" {
 			req.Header.Set("Accept", "*/*")
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -247,6 +247,13 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		if req.Header.Get("User-Agent") == "" {
 			req.Header.Set("User-Agent", "printing-press-golden-pp-cli/2026.04")
 		}
+		// Go's net/http omits Accept by default; browsers, curl, and other
+		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
+		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
+		// and answer with HTTP 500.
+		if req.Header.Get("Accept") == "" {
+			req.Header.Set("Accept", "*/*")
+		}
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -353,7 +353,8 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// Go's net/http omits Accept by default; browsers, curl, and other
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
-		// and answer with HTTP 500.
+		// and answer with empty-body 5xx, 403, or a challenge redirect
+		// depending on vendor and rule tier.
 		if req.Header.Get("Accept") == "" {
 			req.Header.Set("Accept", "*/*")
 		}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -350,6 +350,13 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		if req.Header.Get("User-Agent") == "" {
 			req.Header.Set("User-Agent", "tier-routing-golden-pp-cli/1.0.0")
 		}
+		// Go's net/http omits Accept by default; browsers, curl, and other
+		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
+		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
+		// and answer with HTTP 500.
+		if req.Header.Get("Accept") == "" {
+			req.Header.Set("Accept", "*/*")
+		}
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
## Intent

Generated CLIs send no Accept header by default, so requests hit fingerprint-checking WAFs (Imperva, Akamai, Cloudflare bot-mode, DataDome) as empty-body HTTP 500s. Browsers, curl, and every non-Go stdlib send `Accept: */*` automatically; Go's `net/http` does not, and the absence is enough of a bot signal to break every reverse-engineered consumer API a printed CLI tries to call.

Issue: Closes #920

## Approach

Mirror the existing User-Agent default in `client.go.tmpl`'s `do()` method. An if-empty guard sets `Accept` to `*/*` only when nothing earlier in the request pipeline already set it. Per-endpoint `headerOverrides`, spec-declared `RequiredHeaders`, and content-negotiated overrides all win because they run before the guard.

The fallback is gated by the existing `UsesBrowserManagedUserAgent` template condition. Surf's Chrome impersonation transports already manage the full browser header bundle (User-Agent + Accept + the rest of the TLS-fingerprint set), so emitting a competing default there would be wrong — the new test mirrors that gating for browser-chrome and browser-chrome-h3.

## Scope

Primary area: generator template

Why this belongs in this repo: This is a generator-template change in `internal/generator/templates/client.go.tmpl` — every future printed CLI inherits the fix on regen. The symptom that motivated the issue (Resy on Imperva) was reproducible across the catalog (~20% of APIs sit behind fingerprint WAFs), so fixing it once in the press beats patching each printed CLI.

## Risk

Generated output for every non-browser-managed-UA printed CLI now sends `Accept: */*` by default. Three risks considered:

- A printed CLI whose previous behavior of omitting Accept was load-bearing — none expected; "no Accept header" is not a contract anyone targets intentionally.
- A printed CLI whose user config carries `Accept = ""` in `c.Config.Headers` — the new default overwrites that empty value. Same behavior as the existing User-Agent default, considered intentional.
- Surf-managed transports — gated out via `UsesBrowserManagedUserAgent`; both `browser-chrome` and `browser-chrome-h3` have explicit `NotContains` test assertions.

## Output Contract

Three golden fixtures updated (`generate-golden-api`, `generate-golden-api-oauth2-cc`, `generate-tier-routing-api`): each `client.go` adds the same 7-line block right after the User-Agent default. Diff is identical across all three.

## Verification

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go build -o ./printing-press ./cmd/printing-press` — success
- `go test ./...` — 3790 tests pass
- `scripts/golden.sh verify` — 17/17 pass after intentional update of 3 client.go fixtures
- `golangci-lint run ./...` — clean
- `rtk git diff --check` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change