### PR TITLE
fix(cli): infer pagination defaults from plain params; preserve cursor=0 in paginatedGet

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3589,6 +3589,22 @@ func TestCompactListFieldsPreservesUnknownShapes(t *testing.T) {
 	}
 }
 
+// The cursor param's "0" must survive paginatedGet's zero-value strip:
+// offset-paginated APIs require offset=0 on the first page request.
+func TestPaginatedGetExemptsCursorParamFromZeroStripping(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("templates", "helpers.go.tmpl")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "template must exist: %s", path)
+	body := string(data)
+
+	assert.Contains(t, body, "if k == cursorParam || (v != \"0\" && v != \"false\") {",
+		"paginatedGet must keep the cursor param when its value is \"0\" so offset-paginated APIs receive offset=0 on the first page")
+	assert.NotContains(t, body, "if v != \"\" && v != \"0\" && v != \"false\" {",
+		"the unconditional zero/false strip is wrong for the cursor param — every k must be checked against cursorParam first")
+}
+
 // TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the
 // piped-output auto-JSON gate must defer to explicit --csv / --quiet /
 // --plain flags so piped consumers that asked for a non-JSON format

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3599,10 +3599,16 @@ func TestPaginatedGetExemptsCursorParamFromZeroStripping(t *testing.T) {
 	require.NoError(t, err, "template must exist: %s", path)
 	body := string(data)
 
-	assert.Contains(t, body, "if k == cursorParam || (v != \"0\" && v != \"false\") {",
-		"paginatedGet must keep the cursor param when its value is \"0\" so offset-paginated APIs receive offset=0 on the first page")
-	assert.NotContains(t, body, "if v != \"\" && v != \"0\" && v != \"false\" {",
-		"the unconditional zero/false strip is wrong for the cursor param — every k must be checked against cursorParam first")
+	cleanStart := strings.Index(body, "clean := map[string]string{}")
+	require.GreaterOrEqual(t, cleanStart, 0, "paginatedGet must declare a clean map")
+	loopEnd := strings.Index(body[cleanStart:], "if !fetchAll")
+	require.GreaterOrEqual(t, loopEnd, 0, "expected fetchAll branch after clean loop")
+	cleanBlock := body[cleanStart : cleanStart+loopEnd]
+
+	assert.Contains(t, cleanBlock, "cursorParam",
+		"paginatedGet's clean loop must reference cursorParam so the cursor key is exempt from zero-stripping")
+	assert.NotContains(t, cleanBlock, `if v != "" && v != "0" && v != "false"`,
+		`the unconditional v != "" && v != "0" && v != "false" filter incorrectly drops cursor="0" for offset-paginated APIs`)
 }
 
 // TestPipedJsonGateRespectsExplicitFormatFlags pins the contract: the

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -587,10 +587,14 @@ func replacePathParam(path, name, value string) string {
 func paginatedGet(c interface {
 	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Clean zero-value params
+	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
+	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
 	for k, v := range params {
-		if v != "" && v != "0" && v != "false" {
+		if v == "" {
+			continue
+		}
+		if k == cursorParam || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -397,6 +397,21 @@ func Profile(s *spec.APISpec) *APIProfile {
 				if endpoint.Pagination.LimitParam != "" {
 					pageSizeParams[endpoint.Pagination.LimitParam]++
 				}
+			} else {
+				// Fallback for specs that expose pagination via plain params
+				// instead of a structured pagination: block.
+				for _, param := range endpoint.Params {
+					if param.PathParam || param.Positional {
+						continue
+					}
+					lower := strings.ToLower(param.Name)
+					if cursorParamCandidates[lower] {
+						cursorParams[param.Name]++
+					}
+					if pageSizeParamCandidates[lower] {
+						pageSizeParams[param.Name]++
+					}
+				}
 			}
 			if endpoint.ResponsePath != "" {
 				responsePaths[endpoint.ResponsePath]++
@@ -672,26 +687,37 @@ func dataFit(v bool) int {
 	return 1
 }
 
-// hasRequiredScopeParams returns true if the endpoint has required query parameters
-// that aren't pagination-related. These are "scoped list" endpoints (e.g., GetFriendList
+// Lowercase-keyed candidate sets shared by the profiler's pagination
+// inference path and hasRequiredScopeParams.
+var (
+	pageSizeParamCandidates = map[string]bool{
+		"limit": true, "per_page": true, "page_size": true, "pagesize": true,
+		"first": true, "count": true, "max_results": true, "page[size]": true,
+	}
+	cursorParamCandidates = map[string]bool{
+		"after": true, "cursor": true, "page_token": true, "offset": true,
+		"page": true, "before": true, "starting_after": true, "page[cursor]": true,
+	}
+)
+
+// hasRequiredScopeParams flags "scoped list" endpoints (e.g., GetFriendList
 // requires steamid) that can't be synced without runtime context.
 func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
-	paginationParams := map[string]bool{
-		"limit": true, "per_page": true, "page_size": true, "pageSize": true, "first": true, "count": true, "max_results": true,
-		"after": true, "cursor": true, "page_token": true, "offset": true, "page": true, "before": true, "starting_after": true,
-		"page[cursor]": true, "page[size]": true,
+	temporalOrFormatParams := map[string]bool{
 		"since": true, "updated_after": true, "modified_since": true, "since_id": true,
-		"key": true, "format": true, // auth and format params, not scope
+		"key": true, "format": true,
 	}
 	for _, param := range endpoint.Params {
 		if param.Required && !param.Positional && !param.PathParam {
-			if !paginationParams[param.Name] && !paginationParams[strings.ToLower(param.Name)] {
-				// Enum params with 2+ values are handled by enum expansion, not scope
-				if len(param.Enum) >= 2 {
-					continue
-				}
-				return true
+			lower := strings.ToLower(param.Name)
+			if pageSizeParamCandidates[lower] || cursorParamCandidates[lower] || temporalOrFormatParams[lower] {
+				continue
 			}
+			// Enum params with 2+ values are handled by enum expansion, not scope
+			if len(param.Enum) >= 2 {
+				continue
+			}
+			return true
 		}
 	}
 	return false

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1696,3 +1696,122 @@ func TestProfileSpecWalker_MultiPlaceholderPathWarns(t *testing.T) {
 		assert.True(t, found, "walker with explicit key_param must produce a dependent entry")
 	})
 }
+
+// Specs that declare pagination via plain offset+count query params (no
+// explicit pagination: block) must infer the cursor and limit names from
+// those params instead of falling back to "after"/"limit".
+func TestProfilePagination_InfersFromPlainParamsWhenNoExplicitBlock(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "plain-param-pagination",
+		Resources: map[string]spec.Resource{
+			"agents": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/agents",
+						Params:   []spec.Param{{Name: "offset", Type: "int"}, {Name: "count", Type: "int"}},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"builds": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/builds",
+						Params:   []spec.Param{{Name: "offset", Type: "int"}, {Name: "count", Type: "int"}},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	assert.Equal(t, "offset", profile.Pagination.CursorParam, "plain offset param must be picked up")
+	assert.Equal(t, "count", profile.Pagination.PageSizeParam, "plain count param must be picked up as limit")
+}
+
+// Explicit pagination: blocks must continue to win over plain-param inference.
+// Mixing the two on the same endpoint would otherwise double-count or let
+// inference shadow the author's deliberate choice.
+func TestProfilePagination_ExplicitBlockWinsOverInference(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "explicit",
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/items",
+						Params: []spec.Param{
+							{Name: "offset", Type: "int"},
+							{Name: "count", Type: "int"},
+						},
+						Pagination: &spec.Pagination{
+							Type:        "cursor",
+							CursorParam: "foo",
+							LimitParam:  "bar",
+						},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	assert.Equal(t, "foo", profile.Pagination.CursorParam, "explicit cursor_param must win")
+	assert.Equal(t, "bar", profile.Pagination.PageSizeParam, "explicit limit_param must win")
+}
+
+// Specs with no recognizable pagination shape must keep the historical
+// after/limit defaults so existing golden output doesn't churn.
+func TestProfilePagination_NoPaginationParamsKeepsDefaults(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "no-pagination",
+		Resources: map[string]spec.Resource{
+			"things": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/things",
+						Params:   []spec.Param{{Name: "filter", Type: "string"}},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	assert.Equal(t, "after", profile.Pagination.CursorParam)
+	assert.Equal(t, "limit", profile.Pagination.PageSizeParam)
+}
+
+// Inference must skip path params and positional args even when their names
+// match candidate sets (e.g. an /items/{page} path segment named "page").
+func TestProfilePagination_SkipsPathAndPositionalParams(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "scoped",
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/items/{page}",
+						Params: []spec.Param{
+							{Name: "page", Type: "string", PathParam: true},
+							{Name: "offset", Type: "int", Positional: true},
+						},
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	assert.Equal(t, "after", profile.Pagination.CursorParam, "path-param 'page' must not be treated as a cursor")
+	assert.Equal(t, "limit", profile.Pagination.PageSizeParam)
+}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -387,10 +387,14 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 func paginatedGet(c interface {
 	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Clean zero-value params
+	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
+	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
 	for k, v := range params {
-		if v != "" && v != "0" && v != "false" {
+		if v == "" {
+			continue
+		}
+		if k == cursorParam || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -390,10 +390,14 @@ func replacePathParam(path, name, value string) string {
 func paginatedGet(c interface {
 	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
-	// Clean zero-value params
+	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
+	// APIs send offset=0 on the first page.
 	clean := map[string]string{}
 	for k, v := range params {
-		if v != "" && v != "0" && v != "false" {
+		if v == "" {
+			continue
+		}
+		if k == cursorParam || (v != "0" && v != "false") {
 			clean[k] = v
 		}
 	}


### PR DESCRIPTION
## Intent

Issue: Refs #927

Internal YAML specs that declare pagination via plain query params (offset, count, limit, etc.) without an explicit `pagination:` block emit broken sync code. The profiler only counts `cursorParams` / `pageSizeParams` when `endpoint.Pagination != nil`, so the global `PaginationProfile` falls back to the literal `after` / `limit` defaults. Generated `sync.go` then requests `?after=…&limit=…` against APIs that expect `?offset=…&count=…`, producing HTTP 406 errors against OneDev, Clerk, and similar APIs.

Separately, `paginatedGet`'s clean loop strips the literal `"0"` for every param. When the cursor flag is an int defaulting to 0, it formats to `"0"`, gets stripped, and offset-paginated APIs reject the request as missing offset.

## Approach

Two narrow changes:

1. **Profiler inference fallback.** When an endpoint has no explicit `pagination:` block, walk `endpoint.Params` and increment `cursorParams` / `pageSizeParams` for non-positional, non-path params whose lowercase name matches the existing candidate sets. Explicit `pagination:` blocks still win because the `Pagination != nil` branch runs first. Lifted the candidate sets to package-level vars so `hasRequiredScopeParams` shares them; behavior of that function is unchanged.

2. **Cursor exempt from zero-strip.** `paginatedGet` keeps the cursor param when its value is `"0"` while still dropping non-cursor `"0"` / `"false"` filter defaults.

## Scope

Primary area: `internal/profiler/profiler.go`, `internal/generator/templates/helpers.go.tmpl`

Why this belongs in this repo: machine-level fix — internal-YAML-authored specs are the dominant style and currently emit silently-wrong pagination param names. Affects every future printed CLI generated from such a spec.

## Risk

- Generated `sync.go` for specs **with** explicit `pagination:` blocks: unchanged. The `Pagination != nil` branch still wins.
- Generated `sync.go` for specs **without** explicit `pagination:` blocks: cursor/limit param names are now inferred. Visible in the goldens (helpers.go).
- Specs with no recognizable pagination params: still default to `after` / `limit` (covered by `TestProfilePagination_NoPaginationParamsKeepsDefaults`).
- `paginatedGet`: cursor=`"0"` now survives the clean loop. Non-cursor filters that format to `"0"` / `"false"` are still stripped (pinned by `TestPaginatedGetExemptsCursorParamFromZeroStripping`).

Known follow-ups (not addressed here):
- Inference walks all endpoints regardless of HTTP method — matches existing explicit-counter behavior; would require a broader change to gate both paths.
- `sync.go.tmpl`'s page loop only sets `params[cursorParam]` when `cursor != ""`. APIs that require an explicit `offset=0` on first page need a separate fix in that loop. Out of scope for this PR.

## Output Contract

Generated `paginatedGet` body changes (4 added lines, 2 modified). Two `testdata/golden/expected/.../internal/cli/helpers.go` fixtures updated via `scripts/golden.sh update` to reflect the new template output.

## Verification

- `go fmt ./...`
- `go build ./...`
- `go vet ./...`
- `go test ./...` — 3799 passed
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 17 cases pass after update
- `git diff --check` — clean