### PR TITLE
fix(cli): exempt CLI-root vendor spec files from PII audit scope

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -163,6 +163,20 @@ var excludedFiles = map[string]bool{
 	ToolsPolishLedgerFilename: true,
 }
 
+// rootVendorSpecFiles are the CLI-root basenames the generator embeds
+// as vendor source — the OpenAPI/internal spec the operator passed to
+// `--spec`. Vendor-published `example:` values (emails, phones,
+// addresses) are documentation, not customer PII, so a Stripe/Zendesk/
+// GitHub spec doesn't false-fail every promote. Exemption is depth-1
+// only; a spec.yaml nested under .manuscripts/ or testdata/ is captured
+// content and stays in scope. Mirrors findArchivedSpec()'s candidate
+// set in internal/pipeline/climanifest.go.
+var rootVendorSpecFiles = map[string]bool{
+	"spec.json": true,
+	"spec.yaml": true,
+	"spec.yml":  true,
+}
+
 // skippedDirs are subtree names the walker never descends into at the
 // top level. Scoping to depth-1 is deliberate — `.git` and friends as
 // direct children of the cli-dir are infrastructure; the same names
@@ -239,6 +253,9 @@ func FindPII(root string) ([]PIIFinding, error) {
 func isHighRiskFile(relSlash string) bool {
 	base := filepath.Base(relSlash)
 	if excludedFiles[base] {
+		return false
+	}
+	if !strings.Contains(relSlash, "/") && rootVendorSpecFiles[base] {
 		return false
 	}
 	parts := strings.Split(relSlash, "/")

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -212,16 +212,22 @@ func TestFindPII_RootVendorSpecExempt(t *testing.T) {
 	assert.Contains(t, files, "config.yaml")
 }
 
-// Negative: nested spec.yaml files (under .manuscripts/, testdata/, or
-// research dirs) are captured content, not vendor source. They stay in
-// scope so browser-sniff captures keep flagging.
+// Negative: nested spec.yaml files are captured content, not vendor
+// source. They stay in scope so browser-sniff captures keep flagging.
+// Two scope re-entry paths are exercised:
+//   - high-risk dirs (.manuscripts/, testdata/) match via highRiskDirGlobs
+//   - arbitrary subdirs (output/) match via the *.yaml entry in
+//     highRiskFileGlobs; pinned here as a regression guard against a
+//     future tweak that broadens the exemption from depth-1 to all paths
 func TestFindPII_NestedSpecYamlStillScans(t *testing.T) {
 	root := t.TempDir()
 	pii := `"email": "captured@victim.com"`
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run1", "research"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "output"), 0755))
 	write(t, filepath.Join(root, ".manuscripts", "run1", "research", "spec.yaml"), pii)
 	write(t, filepath.Join(root, "testdata", "spec.yaml"), pii)
+	write(t, filepath.Join(root, "output", "spec.yaml"), pii)
 
 	findings, err := FindPII(root)
 	require.NoError(t, err)
@@ -229,6 +235,7 @@ func TestFindPII_NestedSpecYamlStillScans(t *testing.T) {
 	files := uniqueFiles(findings)
 	assert.Contains(t, files, ".manuscripts/run1/research/spec.yaml")
 	assert.Contains(t, files, "testdata/spec.yaml")
+	assert.Contains(t, files, "output/spec.yaml")
 }
 
 func TestFindPII_BinaryFileSkip(t *testing.T) {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -188,6 +188,49 @@ func TestFindPII_ExcludedFiles(t *testing.T) {
 	assert.Contains(t, files, "data.json")
 }
 
+// CLI-root vendor spec files (the source the operator passed to --spec)
+// are exempt because vendor-published `example:` blocks are not customer
+// PII. The exemption is depth-1 only; a spec.yaml nested under
+// .manuscripts/ is captured content and stays in scope.
+func TestFindPII_RootVendorSpecExempt(t *testing.T) {
+	root := t.TempDir()
+	pii := `"email": "jenny@example.com"`
+	write(t, filepath.Join(root, "spec.yaml"), pii)
+	write(t, filepath.Join(root, "spec.yml"), pii)
+	write(t, filepath.Join(root, "spec.json"), pii)
+	// Sibling yaml at the root must still scan — only the literal
+	// vendor-spec basenames are exempt.
+	write(t, filepath.Join(root, "config.yaml"), pii)
+
+	findings, err := FindPII(root)
+	require.NoError(t, err)
+
+	files := uniqueFiles(findings)
+	assert.NotContains(t, files, "spec.yaml")
+	assert.NotContains(t, files, "spec.yml")
+	assert.NotContains(t, files, "spec.json")
+	assert.Contains(t, files, "config.yaml")
+}
+
+// Negative: nested spec.yaml files (under .manuscripts/, testdata/, or
+// research dirs) are captured content, not vendor source. They stay in
+// scope so browser-sniff captures keep flagging.
+func TestFindPII_NestedSpecYamlStillScans(t *testing.T) {
+	root := t.TempDir()
+	pii := `"email": "captured@victim.com"`
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run1", "research"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata"), 0755))
+	write(t, filepath.Join(root, ".manuscripts", "run1", "research", "spec.yaml"), pii)
+	write(t, filepath.Join(root, "testdata", "spec.yaml"), pii)
+
+	findings, err := FindPII(root)
+	require.NoError(t, err)
+
+	files := uniqueFiles(findings)
+	assert.Contains(t, files, ".manuscripts/run1/research/spec.yaml")
+	assert.Contains(t, files, "testdata/spec.yaml")
+}
+
 func TestFindPII_BinaryFileSkip(t *testing.T) {
 	root := t.TempDir()
 	// Planted PII in a "json" file with embedded nulls (mimics binary)

--- a/skills/printing-press-polish/references/pii-polish.md
+++ b/skills/printing-press-polish/references/pii-polish.md
@@ -70,6 +70,8 @@ When a downstream consumer (parser, schema validator) needs a valid-shape value,
 
 **Manuscripts (`.manuscripts/<runID>/`).** Highest-risk source — captured browser-sniff content is by construction where customer values entered. Acceptance for manuscript findings requires the explicit `evidence_context`-cited justification; "captured data" alone is not sufficient. When in doubt, replace the value in the manuscript file directly (it's local working state) and use a hand-authored fixture with synthetic values for any downstream tests.
 
+**Vendor spec files at the CLI root (`spec.yaml`, `spec.yml`, `spec.json`).** Exempt from the audit by design — these are the OpenAPI/internal source the operator passed to `--spec`, and vendor `example:` blocks (Stripe `jenny@example.com`, GitHub user-schema example phones) are documentation, not customer PII. The exemption is depth-1 only; the same basename nested under `.manuscripts/` or `testdata/` is captured content and stays in scope.
+
 ## Forbidden accept patterns
 
 The binary enforces these via gate failures, not just convention:


### PR DESCRIPTION
## Intent

Issue: Closes #1117

The PII audit hard-fails promote on vendor-shipped OpenAPI example data inside the CLI's embedded `spec.yaml`. The Zendesk spec ships 229 `example:` values (e.g. `roge@example.org`, fake phone-shape ids) that the audit treats as customer PII, and the polish ruleset forbids the only ledger shape (bulk-accept of >=10 identical-rationale findings) that would clear them. Stripe and GitHub specs ship the same shapes; every OpenAPI-sourced CLI is affected.

## Approach

In `internal/artifacts/pii.go`, exempt depth-1 `spec.yaml`, `spec.yml`, and `spec.json` from the high-risk file scope. These are the embedded vendor source the operator passed to `--spec`, and vendor `example:` values are documentation, not customer PII. The basename set mirrors `findArchivedSpec()` in `internal/pipeline/climanifest.go`.

The exemption is depth-1 only. A `spec.yaml` nested under `.manuscripts/<runID>/` or `testdata/` is captured content (browser-sniff specs land there) and stays in scope, so the leak path the amazon-orders retro flagged keeps firing.

`skills/printing-press-polish/references/pii-polish.md` gets a one-paragraph note under "Special cases" so agents know vendor-spec exemption is by design rather than an inconsistency to work around.

## Scope

Primary area: `comp:scorer` (PII audit file-scope filter).

Why this belongs in this repo: cross-API generator behavior; affects every OpenAPI-sourced CLI's promote/publish gate.

## Risk

Detection scope shrinks by the `spec.{yaml,yml,json}` triple at depth-1 only. The negative test (`TestFindPII_NestedSpecYamlStillScans`) pins that nested copies under `.manuscripts/` and `testdata/` keep scanning, so browser-sniff captures named `spec.yaml` (not the typical `<api>-browser-sniff-spec.yaml` shape, but possible) still flag.

If a real customer-PII value somehow ended up in the CLI-root vendor spec, this exemption would skip it. That value would have to come from the operator's `--spec` input itself; the operator-controlled input is the wrong layer to defend at, and the repro is contrived enough that the false-fail rate on legitimate vendor specs (Stripe/Zendesk/GitHub) outweighs it.

## Output Contract

N/A. PII audit findings list shrinks for affected CLIs but no machine-readable contract changes; `pii-audit --json` for an unaffected CLI returns an identical shape.

## Verification

- `go test ./...` (3801 passed)
- `go fmt ./...`
- `go vet ./...` (clean)
- `golangci-lint run ./internal/artifacts/...` (clean)
- `scripts/golden.sh verify` (17 cases passed)
- New tests: `TestFindPII_RootVendorSpecExempt`, `TestFindPII_NestedSpecYamlStillScans`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change