### PR TITLE
docs(cli): require /printing-press-publish skill for CLI publish PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,16 @@ Run `govulncheck` in default mode only, scoped to the generated or publishing CL
 ## Local Artifacts
 Generated artifacts live under `~/printing-press/`, not in this repo: `library/<api-slug>/`, `manuscripts/<api-slug>/`, and `.runstate/<scope>/`. The API slug is derived by the generator from the spec title (`cleanSpecName`), and the binary name is `<api-slug>-pp-cli`. Never hardcode an API slug when the generator can derive it. See [`docs/ARTIFACTS.md`](docs/ARTIFACTS.md) for local-vs-public flow and divergence rules.
 
+## Publishing to the Public Library
+The only supported path for **publishing a generated CLI** (adding or updating an entry under `library/<category>/<api-slug>/` in [mvanhorn/printing-press-library](https://github.com/mvanhorn/printing-press-library)) is to invoke the `/printing-press-publish` skill. The skill runs the required `gh`/`git` commands itself; do not reproduce them by hand.
+- Invoke `/printing-press-publish` and let it drive the fork, branch, manifest checks, `cli-skills/pp-<api-slug>/SKILL.md` regen, push, and PR creation. Following its prompts is the supported flow.
+- Do not skip the skill and improvise the same steps from scratch (manual `gh repo fork` / `cp -r` into a library clone / `gh pr create --repo mvanhorn/printing-press-library …` / branch push to a fork without the skill driving it). The commands look similar; the difference is the preflight checks and conventions the skill enforces before they run.
+- Do not edit `registry.json` or README catalog cells in a publish PR — the public library refreshes those post-merge from `.printing-press.json` / `manifest.json`.
+
+Why this matters: the publish skill enforces preflight checks (printer sentinel validation, manifest shape, vendor-spec PII scope, govulncheck scoped to the changed module) and mirrors the public library's own `AGENTS.md` requirements. An agent operating in this repo's CWD never loads the public library's `AGENTS.md`, so those rules are invisible unless the skill is the entry point.
+
+If `/printing-press-publish` fails, fix the underlying issue (or report it as a machine bug) — do not bypass the skill to land a CLI-publish PR.
+
 ## Internal Skills
 `.claude/skills/` contains internal skills for developing the Printing Press itself (for example `printing-press-retro`). These load automatically when Claude Code is started from inside this repo.
 If you are running Claude Code from a different directory and need these skills available, install them globally:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2960,7 +2960,9 @@ If the shipcheck report contains a `## Known Gaps` block, prepend: "Note: shipch
 
 ### If "Publish now"
 
-Invoke `/printing-press publish <api>`. The publish skill handles everything from there.
+Invoke `/printing-press-publish <api>`. The publish skill handles everything from there — fork, branch, manifest checks, `cli-skills/pp-<api-slug>/SKILL.md` regen, push, and PR creation.
+
+**Do not improvise the publish flow.** Even though the publish skill itself runs `gh repo fork`, `git push`, and `gh pr create --repo mvanhorn/printing-press-library …` internally, running those commands by hand from this phase skips the preflight checks (printer sentinel validation, manifest shape, vendor-spec PII scope, govulncheck on the changed module) and the public library's own `AGENTS.md` requirements that the skill mirrors. The CWD here is `cli-printing-press`, so the public library's `AGENTS.md` is not loaded — the skill is the only entry point that brings those rules into context. If the publish skill fails, fix the underlying issue (or report it as a machine bug); do not bypass it. See [`AGENTS.md`](AGENTS.md) "Publishing to the Public Library" for the full rule.
 
 **After publish returns success**, offer retro as a soft tail. This is where retro lives on the ship-path — it has no business being a peer of publish on the headline menu, but a post-publish optional offer lets users compound learnings without forcing the choice up front. Retro at this point sees the publish step as part of the session it analyzes.
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2981,7 +2981,7 @@ Invoke `/printing-press-polish <api>`. The polish skill runs another diagnostic-
 
 ### If "Done for now"
 
-End normally. The CLI is in `$PRESS_LIBRARY/<api>` and the user can run `/printing-press publish`, `/printing-press-polish`, or `/printing-press-retro` later.
+End normally. The CLI is in `$PRESS_LIBRARY/<api>` and the user can run `/printing-press-publish`, `/printing-press-polish`, or `/printing-press-retro` later.
 
 ### Hold-path menu
 


### PR DESCRIPTION
## Intent

Agents running `/printing-press` in this repo have been hand-rolling publish PRs against the public library (e.g. mvanhorn/printing-press-library#481, #465, #456, #447, #453), skipping the preflight checks that `/printing-press-publish` enforces. The public library's own `AGENTS.md` isn't loaded because the agent's CWD is `cli-printing-press`, so those rules are invisible unless the skill is the entry point.

Issue: N/A (operational pattern observed across recent library PRs)

## Approach

Two parallel surfaces, scoped to the actual decision point:

1. **`AGENTS.md`** — new "Publishing to the Public Library" section between "Local Artifacts" and "Internal Skills." Loaded for any agent in this repo's CWD regardless of which skill (if any) is active. Scopes the rule to *publishing a generated CLI*, not all PRs against the library repo (workflow fixes, README edits, etc. follow the library's own AGENTS.md and aren't covered).
2. **`skills/printing-press/SKILL.md`** Phase 6 "If Publish now" block — reinforces the rule at the actual handoff point in the generation flow, with a back-reference to AGENTS.md.

Phrased the prohibitions about **improvising the publish flow** rather than the specific `gh`/`git` commands, since the publish skill itself runs `gh repo fork`, `git push`, and `gh pr create --repo mvanhorn/printing-press-library …` internally — a command-pattern rule would contradict the skill it's trying to enforce.

Also aligned the slash-command invocation form (`/printing-press-publish <api>`) with sibling references in the same skill (`/printing-press-polish`, `/printing-press-retro`).

## Scope

Primary area: skills (documentation), AGENTS.md

Why this belongs in this repo: this is the only AGENTS.md an agent operating in `cli-printing-press` CWD reliably loads. The fix has to live here, not in the public library, because the violating agents never reach the public library's `AGENTS.md`.

## Risk

Doc-only change. No generator behavior, no template output, no manifest shape, no MCP surface affected. The rule is policy that agents read; it does not change any command the publish skill executes.

One thing reviewers may want to push back on: I considered adding a `PreToolUse` hook to block manual `gh pr create --repo mvanhorn/printing-press-library` invocations, but withdrew it — the publish skill itself runs that exact command, so a pattern-match hook would block the legitimate flow. Distinguishing "skill ran it" from "agent hand-rolled it" requires a brittle env-var marker that's trivially bypassable. The doc-level intervention is the right layer.

## Output Contract

N/A — no generated artifacts, manifests, command output, MCP schemas, scorecard, catalog, or pipeline artifacts change.

## Verification

- Re-read both edits in context to confirm wording is consistent with surrounding AGENTS.md style (command-shaped, pointer to longer rationale) and the skill's Phase 6 prose.
- Cross-checked `/printing-press-publish` invocation form against sibling skill references at [skills/printing-press/SKILL.md:2980](skills/printing-press/SKILL.md:2980) and [skills/printing-press/SKILL.md:3002](skills/printing-press/SKILL.md:3002).
- No goldens affected; no tests touched. `scripts/golden.sh verify` not run (doc-only change per AGENTS.md "Generator Output Stability" criteria).