### PR TITLE
docs(skills): document post-PR review contract in publish skill

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -891,7 +891,11 @@ Display the full PR URL (e.g., `https://github.com/mvanhorn/printing-press-libra
 
 Once the PR is open, it enters the public library repo's review contract. That contract is owned by [`mvanhorn/printing-press-library` AGENTS.md → "Automated code review with Greptile"](https://github.com/mvanhorn/printing-press-library/blob/main/AGENTS.md#automated-code-review-with-greptile); read it for the canonical version. An agent invoking this skill from `cli-printing-press` will not have loaded the library's AGENTS.md, so the obligations are summarized here:
 
-- **Resolve every Greptile finding.** Read with `gh pr view <PR> --comments`. For each P0/P1/P2 thread, either push a fix or reply with a concrete reason it shouldn't fire — not "won't fix", but *why* the code is right as written or *why* deferral is justified. The 0-5 score is a confidence signal, not a hard gate; 4/5 and 5/5 are both acceptable end states, and the score will land in that range naturally once threads are addressed.
+- **Resolve every Greptile finding.** Read findings from two surfaces — they don't overlap:
+  - `gh pr view <PR> --repo <owner>/<repo> --comments` returns the top-level issue conversation (Greptile's summary comment, score, CI bots).
+  - `gh api repos/<owner>/<repo>/pulls/<PR>/comments` returns the inline diff-anchored review comments — Greptile posts each P0/P1/P2 finding here, **and these are NOT included in `--comments`**. Skipping this call is how an agent silently declares "all findings resolved" while every inline thread is still open.
+
+  For each P0/P1/P2 thread, either push a fix or reply with a concrete reason it shouldn't fire — not "won't fix", but *why* the code is right as written or *why* deferral is justified. The 0-5 score is a confidence signal, not a hard gate; 4/5 and 5/5 are both acceptable end states, and the score will land in that range naturally once threads are addressed.
 - **All CI checks must pass.** `verify-library-conventions`, `Govulncheck`, and any other workflow on the PR must be green before merge.
 - **Don't merge with unresolved threads** even when CI is green and the score looks good.
 - **Don't hand-edit `registry.json` or `cli-skills/pp-<api-slug>/SKILL.md` to satisfy a finding** — both are bot-regenerated post-merge by `[skip ci]` commits and your edits will be overwritten.

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -887,6 +887,16 @@ rm -f "$PR_BODY_FILE"
 
 Display the full PR URL (e.g., `https://github.com/mvanhorn/printing-press-library/pull/10`), not the shorthand `org/repo#N` format. The full URL is clickable in all terminals and contexts.
 
+## After the PR opens
+
+Once the PR is open, it enters the public library repo's review contract. That contract is owned by [`mvanhorn/printing-press-library` AGENTS.md → "Automated code review with Greptile"](https://github.com/mvanhorn/printing-press-library/blob/main/AGENTS.md#automated-code-review-with-greptile); read it for the canonical version. An agent invoking this skill from `cli-printing-press` will not have loaded the library's AGENTS.md, so the obligations are summarized here:
+
+- **Resolve every Greptile finding.** Read with `gh pr view <PR> --comments`. For each P0/P1/P2 thread, either push a fix or reply with a concrete reason it shouldn't fire — not "won't fix", but *why* the code is right as written or *why* deferral is justified. The 0-5 score is a confidence signal, not a hard gate; 4/5 and 5/5 are both acceptable end states, and the score will land in that range naturally once threads are addressed.
+- **All CI checks must pass.** `verify-library-conventions`, `Govulncheck`, and any other workflow on the PR must be green before merge.
+- **Don't merge with unresolved threads** even when CI is green and the score looks good.
+- **Don't hand-edit `registry.json` or `cli-skills/pp-<api-slug>/SKILL.md` to satisfy a finding** — both are bot-regenerated post-merge by `[skip ci]` commits and your edits will be overwritten.
+- **Hand off once review-ready.** When all threads are resolved or replied to and CI is green, stop and tell the user. Don't loop polling for the merge; the user owns that decision.
+
 ## Secret & PII Protection
 
 Before creating the PR, verify that no secrets leaked into the packaged CLI.


### PR DESCRIPTION
## Intent

When an agent runs `/printing-press-publish` from a `cli-printing-press` checkout, it has not loaded the public library's [AGENTS.md](https://github.com/mvanhorn/printing-press-library/blob/main/AGENTS.md) and therefore does not see the contract that says "if you (an agent) opened the PR, you own driving it through Greptile review and CI before merge." The publish skill currently ends at `gh pr create` with no handoff, so the post-PR work either falls on the human or quietly gets skipped.

Issue: N/A

## Approach

Insert a new `## After the PR opens` section in `skills/printing-press-publish/SKILL.md` right after the PR-URL display step and before `## Secret & PII Protection`. The section:

- Points to the library AGENTS.md's `Automated code review with Greptile` section as the canonical source.
- States the obligations inline so an offline / first-time agent gets the rule without a doc round-trip: resolve every Greptile finding (with reasoning, not "won't fix"), all CI checks must pass, don't merge with unresolved threads, don't hand-edit `registry.json` or `cli-skills/pp-*/SKILL.md` (bot-regenerated post-merge), hand off when review-ready instead of polling toward the merge.
- Frames the Greptile score as a *confidence signal* with 4/5 or 5/5 both acceptable, matching the parallel softening in [mvanhorn/printing-press-library#490](https://github.com/mvanhorn/printing-press-library/pull/490). The primary obligation is resolving feedback; the score follows.

The "hand off, don't poll" bullet is deliberate — it preserves the [exit-with-handoff-not-full-loop](https://github.com/mvanhorn/cli-printing-press/pull/1145) shape rather than turning the publish flow into a watch loop.

## Scope

Primary area: `skills/printing-press-publish/SKILL.md`

Why this belongs in this repo: the publish skill ships with `cli-printing-press` and is what an agent invokes from this repo's working directory. The library's AGENTS.md cannot reach an agent who hasn't cloned the library; the publish skill can. This is the only place to close the visibility gap for that flow.

## Risk

- Prose-only change to one skill file. No generator code, templates, golden fixtures, or test surface touched.
- The new section's framing for the Greptile bar (4/5 or 5/5 both acceptable) is consistent with [mvanhorn/printing-press-library#490](https://github.com/mvanhorn/printing-press-library/pull/490). If that PR doesn't land, the link target's wording will differ slightly from the inline summary here, but the substantive obligations still match.

## Output Contract

N/A — no generator output, no template, no manifest, no command output changed.

## Verification

- `scripts/golden.sh verify` — 17 cases PASS.
- Diff inspection: single file, 10 insertions, 0 deletions, contained to one new section.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change