### PR TITLE
fix(cli): scope HTTP cache to <api>/http so invalidateCache spares siblings

### DIFF
--- a/internal/generator/client_invalidate_cache_test.go
+++ b/internal/generator/client_invalidate_cache_test.go
@@ -61,3 +61,31 @@ func TestGenerateEmitsInvalidateCacheSymmetry(t *testing.T) {
 	assert.Contains(t, clientGo, "func (c *Client) writeCache(",
 		"client.go must still define writeCache; symmetry presupposes both")
 }
+
+// TestGenerateCacheDirIsHTTPSubdir guards #1126: cacheDir must point at
+// ~/.cache/<api>/http (not ~/.cache/<api>) so that invalidateCache's
+// os.RemoveAll only wipes the HTTP cache and leaves sibling state files
+// (SQLite mirrors, FTS5 stores, watchlists) intact.
+func TestGenerateCacheDirIsHTTPSubdir(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "stytch.yaml"))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	clientGoBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientGo := string(clientGoBytes)
+
+	cliName := naming.CLI(apiSpec.Name)
+	wantSubdir := `filepath.Join(homeDir, ".cache", "` + cliName + `", "http")`
+	wantOldShape := `filepath.Join(homeDir, ".cache", "` + cliName + `")`
+
+	assert.Contains(t, clientGo, wantSubdir,
+		"client.go must place cacheDir under <api>/http so invalidateCache spares siblings (#1126)")
+	assert.NotContains(t, clientGo, wantOldShape,
+		"client.go must not point cacheDir at the bare ~/.cache/<api>/ root (#1126)")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -300,7 +300,7 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "{{.Name}}-pp-cli")
+	cacheDir := filepath.Join(homeDir, ".cache", "{{.Name}}-pp-cli", "http")
 {{- if eq .Auth.Type "session_handshake"}}
 	sess := newSessionManager(timeout)
 	httpClient := newHTTPClient(timeout, sess.CookieJar())

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -55,7 +55,7 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-oauth2-pp-cli")
+	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-oauth2-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	return &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -49,7 +49,7 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-golden-pp-cli")
+	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	return &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -143,7 +143,7 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "tier-routing-golden-pp-cli")
+	cacheDir := filepath.Join(homeDir, ".cache", "tier-routing-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	return &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),


### PR DESCRIPTION
## Intent

Issue: Fixes #1126

`invalidateCache()` runs `os.RemoveAll(c.cacheDir)` after every `POST/PUT/PATCH/DELETE`. With `cacheDir` set to `~/.cache/<api>/`, any sibling state files an agent or future scaffold places in that parent directory (SQLite mirrors, FTS5 stores, snapshot history, watchlists) get wiped along with the HTTP cache. The retro on `unify-pp-cli` lost ~30 min to "writes succeed but reads return zero" before the operator moved the store to XDG data dir to dodge the collision.

## Approach

One-line template change: point `cacheDir` at `~/.cache/<api>/http/` instead of `~/.cache/<api>/`. `invalidateCache()` now wipes only the `http/` subdir, leaving siblings under `~/.cache/<api>/` alone. HTTP caching behavior is unchanged; existing on-disk caches simply rebuild on the next request after upgrade.

## Scope

Primary area: `internal/generator/templates/client.go.tmpl`

Why this belongs here: machine change. Every future printed CLI inherits the safer directory shape, and regens of existing CLIs pick it up on next print. Unblocks the aux-table escape hatch tracked in #1051 by removing the directory collision at the parent level.

## Risk

Generated output: every printed CLI's `internal/client/client.go` now writes/reads cache files at `~/.cache/<api>/http/<hash>.json`. Old cache files at `~/.cache/<api>/<hash>.json` become orphans — harmless, one-time, will not be read. No MCP, auth, catalog, or publish-flow surface changes.

## Output Contract

Generator output change in `internal/client/client.go`:
- Before: `cacheDir := filepath.Join(homeDir, ".cache", "<api>-pp-cli")`
- After:  `cacheDir := filepath.Join(homeDir, ".cache", "<api>-pp-cli", "http")`

Three golden fixtures (`generate-golden-api`, `generate-golden-api-oauth2-cc`, `generate-tier-routing-api`) refreshed to match. Scorer's `.cache` substring check (`internal/pipeline/scorecard.go:798`) still matches under the new path.

## Verification

- `go build -o ./printing-press ./cmd/printing-press` — pass
- `go test ./...` — 3802 passed in 34 packages
- `go fmt ./...` — clean
- `go vet ./...` — no issues
- `golangci-lint run ./...` — no issues
- `scripts/golden.sh verify` — 17 cases pass after refresh
- New guard test `TestGenerateCacheDirIsHTTPSubdir` in `internal/generator/client_invalidate_cache_test.go` asserts the http subdir shape so a future refactor cannot silently revert.