### PR TITLE
fix(cli): preserve novel-command keys in --compact partial-strip path

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3556,11 +3556,17 @@ func TestGeneratedOutput_MutatingCommandsHaveEnvelope(t *testing.T) {
 	assert.Contains(t, content, `envelope["success"] = false`)
 }
 
-// TestCompactListFieldsPreservesUnknownShapes pins the two contracts that
-// keep `--agent` / `--compact` from silently emitting {} for records that
-// don't match the canonical id/name/title allowlist: a per-item fallback
-// to the original item, and a wider scalar allowlist that covers
-// monetary, metric, locale, and identity-adjacent keys.
+// TestCompactListFieldsPreservesUnknownShapes pins the contracts that keep
+// `--agent` / `--compact` from silently emitting {} or partial-strip rows
+// for records that don't match the canonical id/name/title allowlist:
+//
+//  1. The static allow-list covers canonical scalars (price/fare/locale/code/...).
+//  2. A data-driven extension keeps any scalar key present in 80%+ of rows,
+//     so hand-written novel commands whose output keys aren't on the
+//     allow-list (object_name, match_key, snippet) survive projection.
+//  3. Verbose fields (description, body, ...) are excluded from the
+//     extension regardless of frequency.
+//  4. A per-item fallback preserves the original item when no key matches.
 //
 // Pinned at the template level because the helper renders into every
 // printed CLI's helpers.go and a per-fixture assertion would miss future
@@ -3574,7 +3580,7 @@ func TestCompactListFieldsPreservesUnknownShapes(t *testing.T) {
 	body := string(data)
 
 	assert.Contains(t, body, "if len(compact) == 0 {",
-		"compactListFields must preserve the original item when no allowlist keys match — otherwise records with domain-specific field names get reduced to {}")
+		"compactListFields must preserve the original item when no keep keys match — otherwise records with domain-specific field names get reduced to {}")
 	assert.Contains(t, body, "compact = item",
 		"compactListFields must assign the original item as the per-item fallback")
 
@@ -3587,6 +3593,19 @@ func TestCompactListFieldsPreservesUnknownShapes(t *testing.T) {
 		assert.Contains(t, body, key,
 			"compactListFields allowlist must include %s so canonical-schema records keep high-signal scalars across business/travel/commerce/locale APIs", key)
 	}
+
+	// Data-driven extension: pin the symbols that make the 80%-frequency
+	// rule fire. Without these, partial-strip silently drops novel-command
+	// fields whenever a row happens to also carry one allow-list key
+	// (e.g. {"id":"x","object_name":"users","match_key":"uuid"} -> {"id":"x"}).
+	assert.Contains(t, body, "keyCounts",
+		"compactListFields must count per-key occurrence so frequent novel-command keys survive")
+	assert.Contains(t, body, "isCompactScalar",
+		"compactListFields must filter the data-driven extension by scalar type so nested objects/arrays don't bloat --compact output")
+	assert.Contains(t, body, "compactVerboseFields",
+		"compactListFields must exclude description/body/content from the data-driven extension regardless of frequency")
+	assert.Contains(t, body, "threshold",
+		"compactListFields must compute a frequency threshold for the data-driven extension")
 }
 
 // The cursor param's "0" must survive paginatedGet's zero-value strip:

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -878,6 +878,14 @@ func extractResponseData(data json.RawMessage) json.RawMessage {
 	}
 }
 
+// compactVerboseFields are the prose-shaped fields stripped by both the
+// list and single-object compact paths. Centralised so the contract stays
+// in lockstep across both helpers.
+var compactVerboseFields = map[string]bool{
+	"description": true, "body": true, "content": true,
+	"comments": true, "attachments": true, "html": true, "markdown": true,
+}
+
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
@@ -898,9 +906,23 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
-// When an item carries none of these keys the original is preserved, so
-// `--agent` does not silently emit {} for APIs whose response shapes use
-// domain-specific field names (travel: airline/destination; commerce: vendor).
+//
+// Two-layer keep rule:
+//
+//  1. A static allow-list covers canonical scalars (id/name/price/status/...).
+//  2. A data-driven extension also keeps any scalar key present in at least
+//     80% of input rows. This catches hand-written novel commands whose
+//     output keys (object_name, match_key, snippet) aren't on the canonical
+//     allow-list, without forcing every printed CLI to expand the list.
+//
+// Verbose fields (description, body, content, etc.) are excluded from the
+// data-driven extension regardless of frequency, so the compact intent
+// (short identifying values for agent consumption, not full prose) is
+// preserved.
+//
+// When an item still carries none of the keep keys, the original is
+// preserved so `--agent` does not silently emit {} for shapes whose key
+// names are entirely off-canonical.
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
@@ -924,6 +946,24 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		// Versioning
 		"version": true,
 	}
+	if len(items) > 0 {
+		keyCounts := map[string]int{}
+		for _, item := range items {
+			for k, v := range item {
+				if compactVerboseFields[k] || !isCompactScalar(v) {
+					continue
+				}
+				keyCounts[k]++
+			}
+		}
+		// ceil(len(items) * 0.8) without importing math
+		threshold := (len(items)*4 + 4) / 5
+		for k, count := range keyCounts {
+			if count >= threshold {
+				keepFields[k] = true
+			}
+		}
+	}
 
 	filtered := make([]map[string]any, 0, len(items))
 	for _, item := range items {
@@ -942,17 +982,26 @@ func compactListFields(items []map[string]any) json.RawMessage {
 	return result
 }
 
+// isCompactScalar reports whether v is a small primitive (string, number,
+// bool, null) suitable for --compact projection. Objects and arrays are
+// rejected: they almost always represent nested structure that defeats the
+// "short identifying value" intent of --compact, and including them in the
+// data-driven keep set would bloat agent output.
+func isCompactScalar(v any) bool {
+	switch v.(type) {
+	case nil, bool, float64, string:
+		return true
+	default:
+		return false
+	}
+}
+
 // compactObjectFields strips known-verbose fields from single-object responses.
 // Uses a blocklist so it works across all API domains (project management, payments, CRM, etc.).
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	stripFields := map[string]bool{
-		"description": true, "body": true, "content": true,
-		"comments": true, "attachments": true, "html": true, "markdown": true,
-	}
-
 	compact := map[string]any{}
 	for k, v := range obj {
-		if !stripFields[k] {
+		if !compactVerboseFields[k] {
 			compact[k] = v
 		}
 	}
@@ -1124,8 +1173,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	// Count scalar vs complex fields to decide format
 	scalarCount := 0
 	for _, v := range items[0] {
-		switch v.(type) {
-		case string, float64, bool, nil:
+		if isCompactScalar(v) {
 			scalarCount++
 		}
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -956,8 +956,15 @@ func compactListFields(items []map[string]any) json.RawMessage {
 				keyCounts[k]++
 			}
 		}
-		// ceil(len(items) * 0.8) without importing math
+		// ceil(len(items) * 0.8) without importing math. Capped at len-1 for
+		// len >= 2 so a single missing row cannot veto a key on small lists
+		// (without the cap, ceil(0.8*n) == n for n in {2,3,4}, which silently
+		// reintroduces the partial-strip bug whenever a heterogeneous 2-4 row
+		// response mixes one allow-list key with novel keys).
 		threshold := (len(items)*4 + 4) / 5
+		if len(items) >= 2 && threshold > len(items)-1 {
+			threshold = len(items) - 1
+		}
 		for k, count := range keyCounts {
 			if count >= threshold {
 				keepFields[k] = true

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -678,6 +678,14 @@ func extractResponseData(data json.RawMessage) json.RawMessage {
 	}
 }
 
+// compactVerboseFields are the prose-shaped fields stripped by both the
+// list and single-object compact paths. Centralised so the contract stays
+// in lockstep across both helpers.
+var compactVerboseFields = map[string]bool{
+	"description": true, "body": true, "content": true,
+	"comments": true, "attachments": true, "html": true, "markdown": true,
+}
+
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
@@ -698,9 +706,23 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
-// When an item carries none of these keys the original is preserved, so
-// `--agent` does not silently emit {} for APIs whose response shapes use
-// domain-specific field names (travel: airline/destination; commerce: vendor).
+//
+// Two-layer keep rule:
+//
+//  1. A static allow-list covers canonical scalars (id/name/price/status/...).
+//  2. A data-driven extension also keeps any scalar key present in at least
+//     80% of input rows. This catches hand-written novel commands whose
+//     output keys (object_name, match_key, snippet) aren't on the canonical
+//     allow-list, without forcing every printed CLI to expand the list.
+//
+// Verbose fields (description, body, content, etc.) are excluded from the
+// data-driven extension regardless of frequency, so the compact intent
+// (short identifying values for agent consumption, not full prose) is
+// preserved.
+//
+// When an item still carries none of the keep keys, the original is
+// preserved so `--agent` does not silently emit {} for shapes whose key
+// names are entirely off-canonical.
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
@@ -724,6 +746,24 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		// Versioning
 		"version": true,
 	}
+	if len(items) > 0 {
+		keyCounts := map[string]int{}
+		for _, item := range items {
+			for k, v := range item {
+				if compactVerboseFields[k] || !isCompactScalar(v) {
+					continue
+				}
+				keyCounts[k]++
+			}
+		}
+		// ceil(len(items) * 0.8) without importing math
+		threshold := (len(items)*4 + 4) / 5
+		for k, count := range keyCounts {
+			if count >= threshold {
+				keepFields[k] = true
+			}
+		}
+	}
 
 	filtered := make([]map[string]any, 0, len(items))
 	for _, item := range items {
@@ -742,17 +782,26 @@ func compactListFields(items []map[string]any) json.RawMessage {
 	return result
 }
 
+// isCompactScalar reports whether v is a small primitive (string, number,
+// bool, null) suitable for --compact projection. Objects and arrays are
+// rejected: they almost always represent nested structure that defeats the
+// "short identifying value" intent of --compact, and including them in the
+// data-driven keep set would bloat agent output.
+func isCompactScalar(v any) bool {
+	switch v.(type) {
+	case nil, bool, float64, string:
+		return true
+	default:
+		return false
+	}
+}
+
 // compactObjectFields strips known-verbose fields from single-object responses.
 // Uses a blocklist so it works across all API domains (project management, payments, CRM, etc.).
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	stripFields := map[string]bool{
-		"description": true, "body": true, "content": true,
-		"comments": true, "attachments": true, "html": true, "markdown": true,
-	}
-
 	compact := map[string]any{}
 	for k, v := range obj {
-		if !stripFields[k] {
+		if !compactVerboseFields[k] {
 			compact[k] = v
 		}
 	}
@@ -924,8 +973,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	// Count scalar vs complex fields to decide format
 	scalarCount := 0
 	for _, v := range items[0] {
-		switch v.(type) {
-		case string, float64, bool, nil:
+		if isCompactScalar(v) {
 			scalarCount++
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -756,8 +756,15 @@ func compactListFields(items []map[string]any) json.RawMessage {
 				keyCounts[k]++
 			}
 		}
-		// ceil(len(items) * 0.8) without importing math
+		// ceil(len(items) * 0.8) without importing math. Capped at len-1 for
+		// len >= 2 so a single missing row cannot veto a key on small lists
+		// (without the cap, ceil(0.8*n) == n for n in {2,3,4}, which silently
+		// reintroduces the partial-strip bug whenever a heterogeneous 2-4 row
+		// response mixes one allow-list key with novel keys).
 		threshold := (len(items)*4 + 4) / 5
+		if len(items) >= 2 && threshold > len(items)-1 {
+			threshold = len(items) - 1
+		}
 		for k, count := range keyCounts {
 			if count >= threshold {
 				keepFields[k] = true

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 56
+    "total": 57
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -759,8 +759,15 @@ func compactListFields(items []map[string]any) json.RawMessage {
 				keyCounts[k]++
 			}
 		}
-		// ceil(len(items) * 0.8) without importing math
+		// ceil(len(items) * 0.8) without importing math. Capped at len-1 for
+		// len >= 2 so a single missing row cannot veto a key on small lists
+		// (without the cap, ceil(0.8*n) == n for n in {2,3,4}, which silently
+		// reintroduces the partial-strip bug whenever a heterogeneous 2-4 row
+		// response mixes one allow-list key with novel keys).
 		threshold := (len(items)*4 + 4) / 5
+		if len(items) >= 2 && threshold > len(items)-1 {
+			threshold = len(items) - 1
+		}
 		for k, count := range keyCounts {
 			if count >= threshold {
 				keepFields[k] = true

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -681,6 +681,14 @@ func extractResponseData(data json.RawMessage) json.RawMessage {
 	}
 }
 
+// compactVerboseFields are the prose-shaped fields stripped by both the
+// list and single-object compact paths. Centralised so the contract stays
+// in lockstep across both helpers.
+var compactVerboseFields = map[string]bool{
+	"description": true, "body": true, "content": true,
+	"comments": true, "attachments": true, "html": true, "markdown": true,
+}
+
 // compactFields keeps only the most important fields for agent consumption.
 // For arrays: allowlist of high-gravity fields (no descriptions).
 // For single objects: blocklist that strips known-verbose fields (descriptions, comments, etc.).
@@ -701,9 +709,23 @@ func compactFields(data json.RawMessage) json.RawMessage {
 }
 
 // compactListFields keeps only high-gravity fields for array responses.
-// When an item carries none of these keys the original is preserved, so
-// `--agent` does not silently emit {} for APIs whose response shapes use
-// domain-specific field names (travel: airline/destination; commerce: vendor).
+//
+// Two-layer keep rule:
+//
+//  1. A static allow-list covers canonical scalars (id/name/price/status/...).
+//  2. A data-driven extension also keeps any scalar key present in at least
+//     80% of input rows. This catches hand-written novel commands whose
+//     output keys (object_name, match_key, snippet) aren't on the canonical
+//     allow-list, without forcing every printed CLI to expand the list.
+//
+// Verbose fields (description, body, content, etc.) are excluded from the
+// data-driven extension regardless of frequency, so the compact intent
+// (short identifying values for agent consumption, not full prose) is
+// preserved.
+//
+// When an item still carries none of the keep keys, the original is
+// preserved so `--agent` does not silently emit {} for shapes whose key
+// names are entirely off-canonical.
 func compactListFields(items []map[string]any) json.RawMessage {
 	keepFields := map[string]bool{
 		// Identity
@@ -727,6 +749,24 @@ func compactListFields(items []map[string]any) json.RawMessage {
 		// Versioning
 		"version": true,
 	}
+	if len(items) > 0 {
+		keyCounts := map[string]int{}
+		for _, item := range items {
+			for k, v := range item {
+				if compactVerboseFields[k] || !isCompactScalar(v) {
+					continue
+				}
+				keyCounts[k]++
+			}
+		}
+		// ceil(len(items) * 0.8) without importing math
+		threshold := (len(items)*4 + 4) / 5
+		for k, count := range keyCounts {
+			if count >= threshold {
+				keepFields[k] = true
+			}
+		}
+	}
 
 	filtered := make([]map[string]any, 0, len(items))
 	for _, item := range items {
@@ -745,17 +785,26 @@ func compactListFields(items []map[string]any) json.RawMessage {
 	return result
 }
 
+// isCompactScalar reports whether v is a small primitive (string, number,
+// bool, null) suitable for --compact projection. Objects and arrays are
+// rejected: they almost always represent nested structure that defeats the
+// "short identifying value" intent of --compact, and including them in the
+// data-driven keep set would bloat agent output.
+func isCompactScalar(v any) bool {
+	switch v.(type) {
+	case nil, bool, float64, string:
+		return true
+	default:
+		return false
+	}
+}
+
 // compactObjectFields strips known-verbose fields from single-object responses.
 // Uses a blocklist so it works across all API domains (project management, payments, CRM, etc.).
 func compactObjectFields(obj map[string]any) json.RawMessage {
-	stripFields := map[string]bool{
-		"description": true, "body": true, "content": true,
-		"comments": true, "attachments": true, "html": true, "markdown": true,
-	}
-
 	compact := map[string]any{}
 	for k, v := range obj {
-		if !stripFields[k] {
+		if !compactVerboseFields[k] {
 			compact[k] = v
 		}
 	}
@@ -927,8 +976,7 @@ func printAutoTable(w io.Writer, items []map[string]any) error {
 	// Count scalar vs complex fields to decide format
 	scalarCount := 0
 	for _, v := range items[0] {
-		switch v.(type) {
-		case string, float64, bool, nil:
+		if isCompactScalar(v) {
 			scalarCount++
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #1127.

`compactListFields` had a partial-strip bug: if a row contained even one static allow-list key (e.g. `id`), the rest of the row's keys were stripped, even when they carried real data the agent needed. Example from issue #1127:

```
input:  {"id":"x","object_name":"users","match_key":"uuid","snippet":"..."}
before: {"id":"x"}            // object_name, match_key, snippet silently dropped
after:  {"id":"x","object_name":"users","match_key":"uuid","snippet":"..."}
```

The fix adds a data-driven extension on top of the existing static allow-list: any scalar key present in 80%+ of input rows is kept too. The verbose blocklist (`description`, `body`, `content`, `comments`, `attachments`, `html`, `markdown`) is excluded from the extension regardless of frequency, so the compact intent — short identifying values for agent consumption, not full prose — is preserved. PR #1078's per-item fallback still fires when no key matches at all.

Side cleanups in the same diff:
- Pulled the verbose blocklist into a package-level `compactVerboseFields` shared by `compactListFields` and `compactObjectFields` (was duplicated as `verboseFields` / `stripFields`).
- `printAutoTable`'s inline scalar type-switch now reuses the new `isCompactScalar` predicate.

## Scope

Machine change — `internal/generator/templates/helpers.go.tmpl`. Rendered into every printed CLI's `internal/cli/helpers.go`. MCP endpoint mirrors bypass `compactFields` (verified at `internal/generator/templates/mcp_tools.go.tmpl` per PR #1078), so this affects the CLI surface for both human users and agents driving the cobratree walker. Endpoint-mirror typed MCP tools are unchanged.

## Behavior table (per row, single-row response unless noted)

| Input | Before | After |
|-------|--------|-------|
| `{"id":"x","object_name":"users","match_key":"uuid"}` | `{"id":"x"}` (partial strip) | full row (frequency=100% on scalar keys) |
| `{"airline":"JL","fare":12345,"currency":"USD","destination":"NRT"}` | `{"currency":"USD","fare":12345}` (allow-list only) | full row (all scalar, all 100%) |
| `{"id":7,"name":"W","description":"long blurb","price":9.99,"rating":4.5}` | `{"id":7,"name":"W","price":9.99,"rating":4.5}` | unchanged — `description` still stripped by verbose blocklist |
| `{"some_obscure_field":"v","another":42}` | original (fallback fires) | original (now via 100% frequency, same shape) |
| List with mostly-nested rows | nested objects stripped via allow-list | unchanged — `isCompactScalar` excludes maps/slices from the extension |

## Test plan

- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 3801 passing across 34 packages
- [x] `golangci-lint run ./...` — no issues
- [x] `scripts/golden.sh verify` — 17 cases pass after regenerating goldens for the template change
- [x] `TestCompactListFieldsPreservesUnknownShapes` extended with assertions for the new symbols (`keyCounts`, `isCompactScalar`, `compactVerboseFields`, `threshold`)

## Related work

- Builds on #1078, which added the per-item fallback for "row has zero allow-list keys."
- The class of bug (narrow classifier with asymmetric failure cost — false-drop > false-keep) is documented in `docs/solutions/design-patterns/avoid-classification-when-failure-is-asymmetric-2026-05-06.md`. The frequency-rule fix matches the documented "structural detection over enumerative allow-list expansion" pattern.