### PR TITLE
fix(cli): preserve x-mcp config when merging combo specs

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1211,6 +1211,136 @@ func TestMergeSpecsLeavesPathsUnchangedWhenHostsDiffer(t *testing.T) {
 	assert.Equal(t, "/bar", merged.Resources["bar"].Endpoints["list"].Path)
 }
 
+// TestMergeSpecsCarriesMCPConfigFromFirstDeclaringSpec verifies that a combo
+// run preserves x-mcp configuration from the first input spec that declares
+// it. Without this precedence loop, mergeSpecs silently drops MCP config and
+// the downstream code-orchestration gate falls back to the endpoint-mirror
+// surface no matter what the input specs requested.
+func TestMergeSpecsCarriesMCPConfigFromFirstDeclaringSpec(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:      "a",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:      "b",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Orchestration: "code",
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "combo")
+
+	assert.True(t, merged.MCP.IsCodeOrchestration(), "merged MCP should retain x-mcp.orchestration=code from specB")
+}
+
+// TestMergeSpecsLeavesMCPZeroWhenNoSpecDeclares verifies that combos without
+// any x-mcp declaration produce a zero-valued merged MCP, so the existing
+// endpoint-mirror default and "consider code-orchestration" advisory keep
+// working unchanged.
+func TestMergeSpecsLeavesMCPZeroWhenNoSpecDeclares(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:      "a",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:      "b",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "combo")
+
+	assert.False(t, merged.MCP.IsCodeOrchestration())
+	assert.Empty(t, merged.MCP.Transport)
+	assert.Empty(t, merged.MCP.Intents)
+}
+
+// TestMergeSpecsCarriesMCPFullFieldsFromDeclaringSpec exercises the merge
+// loop with a non-Orchestration trigger field (Transport) and asserts that
+// Addr and Intents propagate alongside it. Without this case, a regression to
+// a partial field-by-field copy or an mcpConfigured branch that ignored
+// non-Orchestration fields would slip past the other tests.
+func TestMergeSpecsCarriesMCPFullFieldsFromDeclaringSpec(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:      "a",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Transport: []string{"stdio", "http"},
+			Addr:      ":7777",
+			Intents: []spec.Intent{
+				{Name: "search_things"},
+			},
+		},
+	}
+	specB := &spec.APISpec{
+		Name:      "b",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "combo")
+
+	assert.Equal(t, []string{"stdio", "http"}, merged.MCP.Transport)
+	assert.Equal(t, ":7777", merged.MCP.Addr)
+	assert.Len(t, merged.MCP.Intents, 1)
+	assert.Equal(t, "search_things", merged.MCP.Intents[0].Name)
+}
+
+// TestMergeSpecsFirstDeclaringMCPWins verifies that when more than one input
+// spec declares x-mcp, the first declaring spec wins, mirroring the existing
+// first-wins precedence used for Auth.AuthorizationURL.
+func TestMergeSpecsFirstDeclaringMCPWins(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:      "a",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Orchestration: "code",
+		},
+	}
+	specB := &spec.APISpec{
+		Name:      "b",
+		Version:   "0.1.0",
+		BaseURL:   "https://api.example.com",
+		Resources: map[string]spec.Resource{},
+		Types:     map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Orchestration: "intent",
+		},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "combo")
+
+	assert.Equal(t, "code", merged.MCP.Orchestration)
+}
+
 func TestNormalizeHTTPTransportAllowsBrowserChromeH3(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -771,6 +771,10 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 		if s.Auth.AuthorizationURL != "" && merged.Auth.AuthorizationURL == "" {
 			merged.Auth = s.Auth
 		}
+
+		if mcpConfigured(s.MCP) && !mcpConfigured(merged.MCP) {
+			merged.MCP = s.MCP
+		}
 	}
 
 	return merged


### PR DESCRIPTION
## Summary

Closes #1044.

`mergeSpecs` (internal/cli/root.go:706) iterated input specs once and copied `Auth.AuthorizationURL` via a first-wins precedence pattern but never copied `MCP`. Combo runs with `x-mcp` declared on any input spec lost the config silently — the downstream code-orchestration gate (`IsCodeOrchestration()`) saw the zero value, so combo CLIs fell back to the default endpoint-mirror MCP surface regardless of what the input specs requested. The atlassian-pp-cli combo (Jira + Confluence + Jira Software) emitted 937 endpoint-mirror tools and no `code_orch.go` despite all three input specs declaring `x-mcp.orchestration: code`.

## Approach

Add the missing precedence block inside the existing per-spec loop:

```go
if mcpConfigured(s.MCP) && !mcpConfigured(merged.MCP) {
    merged.MCP = s.MCP
}
```

Mirrors the adjacent `Auth.AuthorizationURL` first-wins guard. Reuses the already-defined `mcpConfigured` helper at `internal/cli/root.go:1549`, which is already used the same way in `applyCatalogEntry` at line 1532.

## Tests

Four new tests in `internal/cli/generate_test.go`:

- `TestMergeSpecsCarriesMCPConfigFromFirstDeclaringSpec` — positive case: one spec declares `Orchestration: "code"`, merged carries it.
- `TestMergeSpecsCarriesMCPFullFieldsFromDeclaringSpec` — exercises the merge loop with a non-`Orchestration` trigger field (`Transport`) and asserts `Addr` and `Intents` also propagate. Guards against a regression to a partial field-by-field copy.
- `TestMergeSpecsLeavesMCPZeroWhenNoSpecDeclares` — negative case: combos with no `x-mcp` keep the existing endpoint-mirror default and the existing scale advisory.
- `TestMergeSpecsFirstDeclaringMCPWins` — first-wins precedence when two specs both declare `x-mcp`.

## Output contract

- Single-spec inputs (the `len(specs) == 1` early return at line 707) bypass `mergeSpecs` entirely — unchanged.
- Combos where no input spec declares `x-mcp` keep the zero-value `merged.MCP` — unchanged.
- Combos where at least one input spec declares `x-mcp` now carry the first such spec's `MCP` through to the generator and emit the requested surface.

## Golden harness

Ran `scripts/golden.sh verify` — 17/17 pass. No new golden fixture is added: the change is logic-only inside `mergeSpecs` and does not alter template emission for any single-spec fixture; downstream MCP emission gated by `IsCodeOrchestration()` already has its own coverage. A combo+MCP golden fixture would be useful generally, but adding one is out of scope of this bug fix.

## Verification

- `go test ./...` — 3854 passed
- `go vet ./...` — clean
- `golangci-lint run ./internal/cli/...` — clean
- `scripts/golden.sh verify` — 17/17 pass