### PR TITLE
fix(cli): dedupe nested body-field flatten collisions with sibling scalars

### DIFF
--- a/internal/generator/body_collision_test.go
+++ b/internal/generator/body_collision_test.go
@@ -112,6 +112,62 @@ func TestGenerateRenamesBodyFieldCollidingWithQueryParam(t *testing.T) {
 	assert.Contains(t, mcpSource, `PublicName: "tags-2", WireName: "tags", Location: "body"`)
 }
 
+// TestGenerateDeduplicatesNestedBodyFieldCollidingWithSiblingScalar guards
+// the dot-flatten/sibling-scalar collision class. When a body schema declares
+// both a top-level convenience scalar (e.g., `leadAccountId`) and a nested
+// object whose dot-flattened path camelizes to the same Go identifier (e.g.,
+// `lead.accountId`), both produce `bodyLeadAccountId` after camelization. The
+// dedup pass must walk Body recursively so the post-flatten collision is
+// detected; otherwise the generated handler emits duplicate `var
+// bodyLeadAccountId` declarations and refuses to compile.
+func TestGenerateDeduplicatesNestedBodyFieldCollidingWithSiblingScalar(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("collide-nested")
+	apiSpec.Resources["components"] = spec.Resource{
+		Description: "Components",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/components",
+				Description: "Create a component with deprecated and canonical lead fields",
+				Body: []spec.Param{
+					{Name: "leadAccountId", Type: "string", Description: "Deprecated convenience scalar"},
+					{Name: "lead", Type: "object", Description: "Canonical nested object", Fields: []spec.Param{
+						{Name: "accountId", Type: "string", Description: "Account id of the lead"},
+					}},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/components/{id}",
+				Description: "Get one component",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "collide-nested-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	bodyVars, flagBindings := parseBodyDeclarations(t,
+		filepath.Join(outputDir, "internal", "cli", "components_create.go"))
+
+	assertNoDuplicates(t, bodyVars,
+		"a nested-object leaf must produce a Go identifier distinct from a sibling scalar that camelizes to the same name")
+	assertNoDuplicates(t, flagBindings,
+		"a nested-object leaf must register a cobra flag name distinct from a sibling scalar")
+	require.Len(t, bodyVars, 2,
+		"both the convenience scalar and the nested field must survive dedup")
+	assert.Contains(t, bodyVars, "bodyLeadAccountId",
+		"one of the colliding fields keeps the canonical Go identifier")
+	assert.Contains(t, bodyVars, "bodyLeadAccountId2",
+		"the deduped field uses the _2 suffix convention")
+	assert.Contains(t, flagBindings, "lead-account-id",
+		"one of the colliding fields keeps the canonical cobra flag name")
+	assert.Contains(t, flagBindings, "lead-account-id-2",
+		"the deduped field's cobra flag carries the -2 suffix")
+}
+
 // TestGenerateRenamesBodyFieldCollidingWithStdin guards against a body field
 // literally named `stdin` colliding with the `--stdin` flag the template
 // emits for POST/PUT/PATCH endpoints (command_endpoint.go.tmpl:525).

--- a/internal/generator/flag_collision.go
+++ b/internal/generator/flag_collision.go
@@ -81,9 +81,68 @@ func dedupeEndpointIdentifiers(resKey, epName string, ep spec.Endpoint, asyncJob
 			bodyFlagNames[publicFlagName(p)] = struct{}{}
 		}
 	}
-	ep.Body = uniquifyIdentifiers(ep.Body, "body", nil, bodyFlagNames)
+	// renderBodyVarDecls and renderBodyFlagRegs recurse into nested object
+	// Fields on the JSON-body path, so the dedup pass must walk the same
+	// tree to see post-flatten identifiers like body<Parent><Child>; a
+	// flat top-level walk misses parent-prefixed leaves that collide with
+	// sibling scalars. Multipart/form bodies skip the recursion because
+	// their emission keeps one var/flag per top-level param.
+	if bodyUsesFlatEmission(ep) {
+		ep.Body = uniquifyIdentifiers(ep.Body, "body", nil, bodyFlagNames)
+	} else {
+		usedIdents := map[string]struct{}{}
+		usedFlags := map[string]struct{}{}
+		for k := range bodyFlagNames {
+			usedFlags[k] = struct{}{}
+		}
+		ep.Body = uniquifyBodyTree(ep.Body, "", "", usedIdents, usedFlags)
+	}
 
 	return ep, nil
+}
+
+// uniquifyBodyTree walks Body recursively in the same shape that
+// renderBodyVarDecls and renderBodyFlagRegs emit on the JSON-body path.
+// usedIdents and usedFlags carry the accumulated reservations across all
+// levels so a nested leaf whose post-flatten Go identifier collides with a
+// sibling scalar at any level gets its IdentName suffixed via the existing
+// _2, _3, ... convention.
+func uniquifyBodyTree(body []spec.Param, identPrefix, flagPrefix string, usedIdents, usedFlags map[string]struct{}) []spec.Param {
+	out := make([]spec.Param, len(body))
+	for i, p := range body {
+		if p.Type == "object" && len(p.Fields) > 0 {
+			childIdent := identPrefix + toCamel(paramIdent(p))
+			childFlag := joinFlag(flagPrefix, publicFlagName(p))
+			p.Fields = uniquifyBodyTree(p.Fields, childIdent, childFlag, usedIdents, usedFlags)
+			out[i] = p
+			continue
+		}
+		ident := "body" + identPrefix + toCamel(paramIdent(p))
+		flag := joinFlag(flagPrefix, publicFlagName(p))
+		_, identTaken := usedIdents[ident]
+		_, flagTaken := usedFlags[flag]
+		if !identTaken && !flagTaken {
+			usedIdents[ident] = struct{}{}
+			usedFlags[flag] = struct{}{}
+			out[i] = p
+			continue
+		}
+		for n := 2; ; n++ {
+			candidate := fmt.Sprintf("%s_%d", p.Name, n)
+			candIdent := "body" + identPrefix + toCamel(candidate)
+			candFlag := joinFlag(flagPrefix, flagName(candidate))
+			_, identTaken := usedIdents[candIdent]
+			_, flagTaken := usedFlags[candFlag]
+			if !identTaken && !flagTaken {
+				p.IdentName = candidate
+				usedIdents[candIdent] = struct{}{}
+				usedFlags[candFlag] = struct{}{}
+				out[i] = p
+				break
+			}
+		}
+	}
+	return out
 }
 
 // reservedFlagNamesForEndpoint returns identifiers and cobra flag names that


### PR DESCRIPTION
## Intent

When a body schema declares both a top-level convenience scalar and a nested object whose dot-flattened path camelizes to the same Go identifier (e.g. `leadAccountId` and `lead.accountId` both produce `bodyLeadAccountId`), the generator emits duplicate `var bodyLeadAccountId` declarations and duplicate `--lead-account-id` Cobra registrations, breaking compilation. Atlassian's Component create/update body schema is the confirmed instance.

Issue: Closes #1043

## Approach

The existing body dedup walked only top-level params (`uniquifyIdentifiers` in `internal/generator/flag_collision.go`) and never saw the parent-prefixed leaves that `renderBodyVarDecls` emits by recursing into `Param.Fields`. The collision was structurally invisible to dedup even though both occurrences hashed to the same `body<Camel>` identifier.

The fix adds `uniquifyBodyTree`, which mirrors the same recursion shape that `renderBodyVarDecls` / `renderBodyFlagRegs` / `renderBodyRequiredChecks` use in `internal/generator/generator.go`. It walks Body depth-first, accumulates `identPrefix` and `flagPrefix` across object boundaries, and shares the used-identifier and used-flag sets across all levels so a nested leaf that collides with a sibling scalar (or any earlier leaf) gets its `IdentName` suffixed via the existing `_2`, `_3`, ... convention.

Multipart and form-encoded bodies stay on the flat top-level dedup path because their emission (`multipartBodyMaps` / `formBodyMaps`) never recurses into nested Fields — only the JSON-body path needs the deeper walk.

## Scope

Primary area: `internal/generator/flag_collision.go` — generator-internal dedup pass.

Why this belongs in this repo: this is a machine change that applies to every future printed CLI whose API spec exposes both a flat convenience scalar and a nested-object representation of the same value. Atlassian Component is one confirmed instance; the pattern recurs across APIs that retain deprecated flat fields alongside newer nested representations.

## Risk

- The change is gated by `bodyUsesFlatEmission(ep)`, so multipart/form endpoints are unaffected.
- Existing collision tests (`TestGenerateDeduplicatesCamelCollidingBodyFields`, `TestGenerateRenamesBodyFieldCollidingWithQueryParam`, `TestGenerateRenamesBodyFieldCollidingWithStdin`) continue to pass — they exercise top-level body collisions, which the new recursive walker handles identically at depth 0.
- Golden harness shows no fixture diffs: no existing fixture has the convenience-scalar-plus-nested-object pattern.
- Known limitations carried forward from the existing implementation (not regressions): `validateAuthoredPublicFlags` is still top-level-only, so a nested leaf with an explicit `FlagName` colliding with `stdin`/`wait`/`all` would not be caught at the validation pre-check. The recursive emission already had this property; the dedup change does not widen it.

## Output Contract

N/A — no template or generated-output behavior changed; this is a dedup pass that fires only when the new collision class is present.

## Verification

- `go test ./...` — all 3855 tests pass (includes the new `TestGenerateDeduplicatesNestedBodyFieldCollidingWithSiblingScalar` and the three existing body collision tests).
- `go vet ./...` — clean.
- `golangci-lint run ./...` — clean.
- `scripts/golden.sh verify` — all 17 cases pass.
- `go build -o ./printing-press ./cmd/printing-press` — clean.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change