### PR TITLE
docs(skills): document x-mcp as the OpenAPI form of the mcp: enrichment block

### DIFF
--- a/internal/generator/mcp_warning.go
+++ b/internal/generator/mcp_warning.go
@@ -10,12 +10,13 @@ import (
 const largeMCPSurfaceWarning = `warning: spec exposes %d MCP endpoint tools (>%d threshold). The default
          endpoint-mirror surface burns agent context at this scale and will
          score poorly on the scorecard's MCP architectural dimensions. Consider
-         enriching the spec's mcp: block before generation:
+         enriching the spec's mcp: (internal YAML) or x-mcp: (OpenAPI) block
+         before generation:
            mcp:
              transport: [stdio, http]    # remote-capable; reaches hosted agents
              orchestration: code         # thin <api>_search + <api>_execute pair
              endpoint_tools: hidden      # suppress raw per-endpoint mirrors
-         See docs/SPEC-EXTENSIONS.md for the full mcp: schema.
+         See docs/SPEC-EXTENSIONS.md for the full mcp:/x-mcp: schema.
 `
 
 // warnUnenrichedLargeMCPSurface honors the contract on

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1874,7 +1874,8 @@ The total is what an agent loads at MCP server start.
 | >50 | Default to recommending the Cloudflare pattern (transport + code orchestration + hidden endpoint tools). The generator will also print a warning at this size. |
 
 **The Cloudflare pattern** (recommended for large surfaces) — edit the spec's
-`mcp:` block before running `generate`:
+`mcp:` block (internal YAML) or `x-mcp:` block (OpenAPI) before running
+`generate`:
 
 ```yaml
 mcp:
@@ -1893,6 +1894,12 @@ agents (Managed Agents, web clients) can connect. `mcp.orchestration: code`
 emits the thin search+execute pair that covers the full surface in ~1K tokens.
 `mcp.endpoint_tools: hidden` removes the raw per-endpoint tools that would
 otherwise still show up alongside the orchestration pair.
+
+For OpenAPI input specs, declare these fields under `x-mcp:` at the document
+root (OpenAPI 3.0 `x-*` vendor extensions). The shape is identical to the
+internal-YAML `mcp:` block above — same field names, just nested under a
+vendor-extension key. See [`docs/SPEC-EXTENSIONS.md`](../../docs/SPEC-EXTENSIONS.md) for the canonical
+schema and `info`-level placement option.
 
 **Smaller-surface variants:**
 


### PR DESCRIPTION
## Intent

The SKILL's Pre-Generation MCP Enrichment section only showed the internal-YAML
`mcp:` form, leaving agents working from OpenAPI specs to guess the
vendor-extension key. In the telegram-pp-cli retro (#1049), the agent guessed
`x-pp-mcp` (Printing Press's `pp:` annotation prefix); the generator silently
no-op'd the enrichment, and the CLI shipped 74 raw endpoint tools with the
corresponding scorecard penalty. The generator's >50-tool warning had the
same gap — it told the agent which fields to set but not which key to set
them under.

Issue: Closes #1049

## Approach

Two-line additions in two places, both docs-only:

1. `skills/printing-press/SKILL.md` — the Cloudflare-pattern intro names both
   keys (`mcp:` for internal YAML, `x-mcp:` for OpenAPI), and a short paragraph
   after the field descriptions points at `docs/SPEC-EXTENSIONS.md` for the
   canonical schema and `info`-level placement option.
2. `internal/generator/mcp_warning.go` — the `largeMCPSurfaceWarning` text
   now names both forms ("the spec's `mcp:` (internal YAML) or `x-mcp:`
   (OpenAPI) block") so the symptom message points at the right key for the
   right format.

The example YAML stays in internal-YAML shape — same fields, just a different
parent key on OpenAPI input — so the prose stays focused on the enrichment
recipe rather than fan out into two near-duplicate code blocks.

## Scope

Primary area: skills + generator-emitted warning

Why this belongs in this repo: the SKILL.md and the runtime warning text both
live in the machine. `x-mcp` is already the parsed key on OpenAPI input
(`internal/openapi/parser.go`, `APISpec.MCP`, documented in
`docs/SPEC-EXTENSIONS.md`); this PR only fixes discoverability, not parsing.

## Risk

Pure docs / docstring text change. No template, manifest, generator-output, or
parser behavior changes. Mechanical tests for the warning string (which match
substrings like `"endpoint-mirror surface burns agent context"` and
`"warning: spec exposes 60 MCP endpoint tools (>50"`) continue to pass —
those substrings are unchanged.

## Output Contract

N/A — no generator-output or manifest changes.

## Verification

- `go fmt ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `go test ./...` (3855 tests pass)
- `golangci-lint run ./...` (0 issues)
- `scripts/golden.sh verify` (17 cases pass)
- `git diff --check`