### PR TITLE
fix(cli): support $-prefixed pagination params for Socrata-style APIs

### DIFF
--- a/internal/generator/flag_collision.go
+++ b/internal/generator/flag_collision.go
@@ -304,13 +304,21 @@ func validatePublicFlagEntry(resKey, epName string, entry publicFlagEntry, reser
 // identifiers (via camel) or cobra flag names (via flagName). It is
 // IdentName when populated by the dedup pass and Name otherwise. The
 // resulting string must never be used for wire-side serialization;
-// callers writing URL params, JSON keys, or path substitutions read
-// Name directly.
+// callers writing URL params read paramWireName, while JSON keys, or
+// path substitutions read Name directly.
 func paramIdent(p spec.Param) string {
 	if p.IdentName != "" {
 		return p.IdentName
 	}
 	return p.Name
+}
+
+// paramWireName returns the URL query-key for this param. URLName overrides
+// when set (e.g., "$limit" for Socrata APIs); otherwise Name. Used by
+// generator templates for URL emission only — not for JSON body keys or
+// path substitution.
+func paramWireName(p spec.Param) string {
+	return p.WireName()
 }
 
 func publicFlagName(p spec.Param) string {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -248,6 +248,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"mcpParamDesc":           g.mcpParamDescription,
 		"flagName":               flagName,
 		"paramIdent":             paramIdent,
+		"paramWireName":          paramWireName,
 		"typeFieldIdent":         typeFieldIdent,
 		"safeTypeName":           safeTypeName,
 		"hasNonScalarType": func(types map[string]spec.TypeDef) bool {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -212,10 +212,10 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{.Name}}": args[{{positionalIndex $.Endpoint .Name}}],
+				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{.Name}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if .Endpoint.HeaderOverrides}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -223,10 +223,10 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			data, err := paginatedGet(c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{.Name}}": args[{{positionalIndex $.Endpoint .Name}}],
+				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{.Name}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if .Endpoint.HeaderOverrides}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -235,11 +235,11 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -121,11 +121,11 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			htmlRequestParams := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				htmlRequestParams["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				htmlRequestParams["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -136,10 +136,10 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, prov, err := resolvePaginatedRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{.Name}}": args[{{positionalIndex $.Endpoint .Name}}],
+				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{.Name}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, nil, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -147,10 +147,10 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, err := paginatedGet(c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{.Name}}": args[{{positionalIndex $.Endpoint .Name}}],
+				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{.Name}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, nil, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -160,11 +160,11 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}

--- a/internal/generator/url_name_test.go
+++ b/internal/generator/url_name_test.go
@@ -1,0 +1,128 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParamURLNameOverridesWireKey covers Socrata-style APIs where the URL
+// query key needs a literal "$" prefix ($limit, $offset, $where) while the
+// user-facing CLI flag stays clean (--limit, --offset, --where). The fix adds
+// an optional url_name field on Param that, when set, overrides Name as the
+// wire-side URL key without touching the CLI flag derivation.
+func TestParamURLNameOverridesWireKey(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("socrata-url-name")
+	apiSpec.Resources["records"] = spec.Resource{
+		Description: "Records",
+		Endpoints: map[string]spec.Endpoint{
+			"query": {
+				Method:      "GET",
+				Path:        "/records",
+				Description: "Query records",
+				Params: []spec.Param{
+					{Name: "limit", URLName: "$limit", Type: "integer", Description: "Max rows"},
+					{Name: "offset", URLName: "$offset", Type: "integer", Description: "Offset"},
+					{Name: "where", URLName: "$where", Type: "string", Description: "SoQL WHERE"},
+					{Name: "borough", Type: "integer", Description: "Plain (no override)"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "socrata-url-name-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	content := readGeneratedHandler(t, outputDir, "records")
+
+	// Wire-side URL keys must be the $-prefixed override
+	require.Contains(t, content, `params["$limit"]`, "URLName $limit must appear in the params map")
+	require.Contains(t, content, `params["$offset"]`, "URLName $offset must appear in the params map")
+	require.Contains(t, content, `params["$where"]`, "URLName $where must appear in the params map")
+
+	// Params without url_name must keep plain Name
+	require.Contains(t, content, `params["borough"]`, "Param without URLName must emit plain Name as URL key")
+
+	// CLI flag identifiers must stay plain (no $ in Go identifiers, no $ on cobra flag names)
+	require.Contains(t, content, "flagLimit", "Go identifier flagLimit must remain plain")
+	require.Contains(t, content, `"limit"`, "cobra flag --limit must remain plain")
+	require.NotContains(t, content, "flag$Limit", "no $ should leak into Go identifiers")
+	require.NotContains(t, content, "flag\\$Limit", "no escaped $ should leak into Go identifiers either")
+
+	// The Name field must NOT appear as a URL key when URLName is set (regression guard)
+	if strings.Contains(content, `params["limit"]`) {
+		t.Errorf("when URLName is $limit, params[\"limit\"] must not also be emitted as a URL key")
+	}
+}
+
+// TestParamWithoutURLNameUnchanged guards against regression: existing specs
+// without url_name must continue to emit Name as the URL key.
+func TestParamWithoutURLNameUnchanged(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("plain-param")
+	apiSpec.Resources["records"] = spec.Resource{
+		Description: "Records",
+		Endpoints: map[string]spec.Endpoint{
+			"query": {
+				Method: "GET", Path: "/records", Description: "Query records",
+				Params: []spec.Param{
+					{Name: "limit", Type: "integer", Description: "Max rows"},
+					{Name: "owner", Type: "string", Description: "Owner filter"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "plain-param-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	content := readGeneratedHandler(t, outputDir, "records")
+
+	require.Contains(t, content, `params["limit"]`, "plain Name limit must emit as URL key when URLName unset")
+	require.Contains(t, content, `params["owner"]`, "plain Name owner must emit as URL key when URLName unset")
+}
+
+// readGeneratedHandler returns the contents of the generated CLI handler for a
+// resource. The generator may emit it as either `<resource>.go` (multi-endpoint
+// resource) or `promoted_<resource>.go` (single-endpoint promoted pattern), so
+// try both.
+func readGeneratedHandler(t *testing.T, outputDir, resource string) string {
+	t.Helper()
+	candidates := []string{
+		filepath.Join(outputDir, "internal", "cli", resource+".go"),
+		filepath.Join(outputDir, "internal", "cli", "promoted_"+resource+".go"),
+	}
+	for _, p := range candidates {
+		if src, err := os.ReadFile(p); err == nil {
+			return string(src)
+		}
+	}
+	t.Fatalf("no generated handler found for resource %q (tried %v)", resource, candidates)
+	return ""
+}
+
+// TestParamWireNameUnit exercises the spec.Param.WireName() method directly.
+func TestParamWireNameUnit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, n, urlName, want string
+	}{
+		{"name only", "limit", "", "limit"},
+		{"url_name overrides", "limit", "$limit", "$limit"},
+		{"url_name empty falls back to Name", "where", "", "where"},
+		{"url_name with special chars", "complex", "$query.where", "$query.where"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := spec.Param{Name: c.n, URLName: c.urlName}
+			require.Equal(t, c.want, p.WireName())
+		})
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1184,6 +1184,7 @@ func (h *HTMLExtract) EffectiveScriptSelector() string {
 type Param struct {
 	Name        string   `yaml:"name" json:"name"`
 	FlagName    string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
+	URLName     string   `yaml:"url_name,omitempty" json:"url_name,omitempty"` // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
 	Aliases     []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
 	Type        string   `yaml:"type" json:"type"`
 	Required    bool     `yaml:"required" json:"required"`
@@ -1207,6 +1208,18 @@ type Param struct {
 	// It lets validation distinguish an omitted public name from invalid
 	// `flag_name: ""` while still allowing overlays to clear FlagName.
 	FlagNameSet bool `yaml:"-" json:"-"`
+}
+
+// WireName returns the URL query-key name for this param when emitted in a
+// generated HTTP request. URLName takes precedence when set (e.g., "$limit" for
+// Socrata-style APIs that require the literal "$" prefix on pagination + SoQL
+// params); otherwise Name is used. The CLI flag name is independent (derived
+// from FlagName or paramIdent), so this only affects what shows up in the URL.
+func (p Param) WireName() string {
+	if p.URLName != "" {
+		return p.URLName
+	}
+	return p.Name
 }
 
 func (p Param) PublicInputName() string {


### PR DESCRIPTION
## Problem

Press's generator emits paginated-GET handlers that put each Param's `Name` directly into the URL query string. Socrata-backed APIs (NYC OpenData and ~70 other major US municipal portals) require a literal `$` prefix on pagination + SoQL params:

- `$limit`, `$offset` (pagination)
- `$where`, `$select`, `$order`, `$group` (SoQL passthrough)

Generated CLIs against Socrata returned `HTTP 400 Unrecognized arguments [limit]` on every live call.

## Fix (Option 2 — per-param `url_name` override)

Adds an optional `url_name` field to `spec.Param` that overrides the URL query-key emission while leaving the CLI flag name, Go identifier, and JSON body emission unchanged.

```yaml
params:
  - name: limit
    url_name: "$limit"   # NEW — optional
    type: integer
```

`--limit` stays the CLI flag, `flagLimit` stays the Go identifier, but the URL emits `?$limit=N`.

## Why this approach (vs auto-detect)

Auto-detecting `*.socrata.com` / `*.cityofnewyork.us` would couple the generator to URL patterns, which doesn't scale to other custom-prefix APIs. A spec-level opt-in is non-breaking and explicit — existing specs work unchanged, new Socrata specs declare the prefix where they declare every other param attribute.

## What's NOT touched

- Path substitution, JSON body keys, MCP tool bindings still use `Name`. `url_name` affects URL query keys only.
- Pagination's `limit_param` / `cursor_param` already accepted user-supplied strings, so spec-level pagination config already worked. This fixes the remaining gap for non-pagination SoQL params (`$where`, `$select`, etc.) where the user declares them as ordinary params.
- ArcGIS, REST APIs, GraphQL — anything without `url_name` declared keeps emitting plain `Name`.

## Tests

New file `internal/generator/url_name_test.go`:

- `TestParamWireNameUnit` — `spec.Param.WireName()` returns URLName when set, Name when empty
- `TestParamURLNameOverridesWireKey` — generated handler emits `params["$limit"]` for a param with `url_name: "$limit"`, plain `params["borough"]` for a sibling param without override, and CLI flag identifiers stay clean (no `$` leak into Go)
- `TestParamWithoutURLNameUnchanged` — regression guard: specs without `url_name` keep plain `params["limit"]`, `params["owner"]` emission

Full `internal/spec/` + `internal/generator/` test suite green:

```
ok  internal/spec      0.555s
ok  internal/generator 82.551s
```

## Live verification

**Before** (working around the bug by stripping `limit` from the spec):
```bash
nyc-liens-pp-cli records query --borough 3 --water-debt-only YES
# HTTP 400 if any of limit / where / select supplied
```

**After** (with `url_name` declared):
```bash
nyc-liens-pp-cli records query --borough 3 --water-debt-only YES --limit 2
# Returns 2 valid Brooklyn water-only lien records, structured JSON
```

**Regression check** — `bexar-cad-pp-cli` (ArcGIS, no `url_name` anywhere):
```bash
bexar-cad-pp-cli parcels query --where "Owner LIKE '%PULTE%'" --result-record-count 1
# Returns live PULTE HOMES TX data, unchanged
```

Inspected generated handler for bexar-cad-test confirms plain emission preserved:
```go
params["f"] = fmt.Sprintf("%v", flagF)
params["outFields"] = fmt.Sprintf("%v", flagOutFields)
params["geometry"] = fmt.Sprintf("%v", flagGeometry)
```

And for nyc-liens-test (mixed plain + url_name):
```go
"borough":         fmt.Sprintf("%v", flagBorough),         // plain
"water_debt_only": fmt.Sprintf("%v", flagWaterDebtOnly),   // plain
"$where":          fmt.Sprintf("%v", flagWhere),           // url_name override
"$select":         fmt.Sprintf("%v", flagSelect),          // url_name override
"$limit":          fmt.Sprintf("%v", flagLimit),           // url_name override
```

## Diff size

6 files, +166 / -16. Five files modified, one new test file.

## Follow-up — NOT addressed in this PR

Press's `id_field` extraction fails on Socrata because Socrata only returns its `:id` row identifier when explicitly `$select`-ed. Generated sync runs produce `all_items_failed_id_extraction` warnings on Socrata datasets. The clean fix is to detect `id_field: ":id"` in the spec (or any field starting with `:`) and auto-inject `$select=:id,*` (or the union of explicit `$select` + `:id`) into the URL. Filing as a separate PR to keep this one scoped.

## Unlocks

This change unblocks every Socrata-backed CLI Factory target:
- NYC: ACRIS, PLUTO, DOF Property Charges Balance, HPD Violations, DOB Violations, Tax Lien Sale Lists, etc. (600+ datasets)
- Cook County / Chicago, Boston, SF, Seattle, Austin, Denver — every major US city on Socrata