### PR TITLE
fix(cli): propagate --timeout to surf transport ResponseHeaderTimeout

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1503,6 +1503,18 @@ func TestGenerateBrowserChromeH3Transport(t *testing.T) {
 	// competing default.
 	assert.NotContains(t, string(clientGo), `req.Header.Set("Accept",`)
 
+	// ResponseHeaderTimeout override must emit on the H3 path too —
+	// surf's per-stage timeout (10s default) caps any browser-impersonate
+	// transport regardless of the H2/H3 variant. Without these asserts a
+	// future refactor could silently strip the override from the H3
+	// branch and slow-streaming H3 endpoints would fail at surf's default
+	// with no test catching it. Mirrors the assertions in
+	// TestBrowserTransport_OverridesResponseHeaderTimeout (which exercises
+	// the H2 default).
+	assert.Contains(t, string(clientGo), `enetxhttp "github.com/enetx/http"`)
+	assert.Contains(t, string(clientGo), "surfClient.GetTransport().(*enetxhttp.Transport)")
+	assert.Contains(t, string(clientGo), "t.ResponseHeaderTimeout = timeout")
+
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/client")
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -31,6 +31,7 @@ import (
 	"time"
 
 {{- if .UsesBrowserHTTPTransport}}
+	enetxhttp "github.com/enetx/http"
 	"github.com/enetx/surf"
 {{ end}}
 	"{{modulePath}}/internal/cliutil"
@@ -287,6 +288,22 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 		builder = builder.Session()
 	}
 	surfClient := builder.Build().Unwrap()
+	// Surf's underlying *http.Transport sets ResponseHeaderTimeout to
+	// its package default (10s in surf v1.x), which caps how long we
+	// wait for the FIRST response byte independent of the overall
+	// client Timeout. Slow-streaming endpoints (RAG queries, LLM
+	// completions, server-side rendering) routinely take longer than
+	// that to emit headers; without this override the user-facing
+	// --timeout flag has no effect on transport-layer cutoffs and
+	// requests fail with "net/http: timeout awaiting response headers"
+	// at the package default regardless of --timeout. Override so the
+	// transport-layer ceiling tracks the user's intent.
+	// surf's GetTransport returns *enetxhttp.Transport (surf's HTTP fork
+	// used for browser-impersonate features), NOT *net/http.Transport,
+	// so the assertion targets the enetx package's Transport type.
+	if t, ok := surfClient.GetTransport().(*enetxhttp.Transport); ok {
+		t.ResponseHeaderTimeout = timeout
+	}
 	httpClient := surfClient.Std()
 	httpClient.Timeout = timeout
 	if jar != nil {

--- a/internal/generator/transport_timeout_test.go
+++ b/internal/generator/transport_timeout_test.go
@@ -1,0 +1,91 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBrowserTransport_OverridesResponseHeaderTimeout asserts the generator
+// emits the surf transport's ResponseHeaderTimeout override in every CLI
+// that uses the browser-impersonate transport (SpecSource="sniffed" triggers
+// it). Without the override, the user-facing --timeout flag flows into
+// httpClient.Timeout but never reaches the underlying *http.Transport's
+// per-stage ResponseHeaderTimeout, which surf sets to its 10s package
+// default. Slow-streaming endpoints (RAG queries, LLM completions) fail
+// with "net/http: timeout awaiting response headers" at the surf default
+// regardless of how --timeout is set.
+//
+// This canary asserts the structural fix: surfClient.GetTransport() is
+// type-asserted to *http.Transport and ResponseHeaderTimeout is set to
+// the requested timeout, before the wrapping Std() client is built.
+func TestBrowserTransport_OverridesResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:       "transport-timeout-canary",
+		Version:    "0.1.0",
+		BaseURL:    "https://www.example.com",
+		SpecSource: "sniffed", // triggers UsesBrowserHTTPTransport
+		Owner:      "test-owner",
+		OwnerName:  "Test Author",
+		Auth:       spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/transport-timeout-canary-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"posts": {
+				Description: "Browse posts",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/", Description: "List posts"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	src := string(clientSrc)
+
+	// Sanity: the test fixture must actually exercise the browser path.
+	require.Contains(t, src, "Impersonate()",
+		"test fixture must trigger UsesBrowserHTTPTransport — Impersonate() should be in the emitted client")
+
+	require.Contains(t, src, `enetxhttp "github.com/enetx/http"`,
+		"client.go must import enetx/http aliased so the transport type assertion has a name")
+	require.Contains(t, src, "surfClient.GetTransport().(*enetxhttp.Transport)",
+		"surfClient.GetTransport() must be type-asserted to *enetxhttp.Transport — surf returns the enetx HTTP fork's RoundTripper, not stdlib's, so a stdlib type-assertion is impossible")
+	require.Contains(t, src, "t.ResponseHeaderTimeout = timeout",
+		"ResponseHeaderTimeout must be set to the user-supplied timeout so --timeout reaches the transport layer")
+}
+
+// TestNonBrowserTransport_DoesNotEmitOverride asserts the override only
+// fires inside the browser-transport branch. Vanilla *http.Client CLIs
+// already honor --timeout via http.Client.Timeout — they have no surf
+// middleware overriding ResponseHeaderTimeout, so emitting the override
+// there would be dead code (and would fail compilation since the surf
+// package isn't imported in non-browser branches).
+func TestNonBrowserTransport_DoesNotEmitOverride(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("plain-transport-canary")
+	// Default SpecSource ("") does NOT trigger UsesBrowserHTTPTransport.
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	src := string(clientSrc)
+
+	require.NotContains(t, src, "Impersonate()",
+		"sanity: plain transport CLIs must not emit Impersonate()")
+	require.NotContains(t, src, "ResponseHeaderTimeout",
+		"plain transport CLIs must not emit the surf-specific ResponseHeaderTimeout override")
+}


### PR DESCRIPTION
## Intent

Make the user-facing `--timeout` flag actually reach the transport layer in CLIs that use the browser-impersonate (surf) path. Today the flag sets `httpClient.Timeout` but never touches the underlying `*http.Transport.ResponseHeaderTimeout`, which surf sets to its 10s package default. That per-stage cap kills any request that takes longer than 10s to emit its first response byte — slow-streaming endpoints (RAG queries, LLM completions, server-rendered docs) fail with `net/http: timeout awaiting response headers` at the surf default no matter what the user passed to `--timeout`.

Issue: N/A (downstream finding from the rok-cockpit-cli pilot)

## Approach

After `surfClient := builder.Build().Unwrap()`, type-assert `surfClient.GetTransport()` to `*enetxhttp.Transport` and set `ResponseHeaderTimeout` to the user-supplied `timeout` before wrapping in `surfClient.Std()`.

The key gotcha: `surfClient.GetTransport()` returns `github.com/enetx/http.RoundTripper`, **not** stdlib `net/http.RoundTripper` — surf uses an HTTP fork for its impersonate features. So the assertion targets the enetx package's `Transport` type, which means `client.go` needs `enetxhttp "github.com/enetx/http"` as a conditional import (added only inside the `UsesBrowserHTTPTransport` branch, where it can compile). `go mod tidy` (already part of the engine's post-generate flow) picks up the new direct dep automatically.

This is a strict superset: when `timeout=0` (no overall timeout) the assignment sets `ResponseHeaderTimeout=0` which is the stdlib idiom for "no per-stage timeout." When the assertion fails for any reason (future surf rewrite, custom transport injected elsewhere) the `if ok` guard makes it a silent no-op rather than a panic.

## Scope

Primary area: `cli` (generator template change in the browser-transport branch only)

Why this belongs in this repo: the bug is in `client.go.tmpl`'s emitted `newHTTPClient`, shared by every generated CLI that uses surf's Chrome-impersonate transport. The fix has to land at the template layer; no printed-CLI hand-edit can durably solve this since regeneration would clobber it.

## Risk

Low. Strict superset of current behavior:

- Only fires inside `{{- if .UsesBrowserHTTPTransport}}` — plain `net/http.Client` CLIs are unchanged. (Asserted by the new `TestNonBrowserTransport_DoesNotEmitOverride`.)
- `if ok` guard makes the assertion a no-op if surf ever changes the underlying transport type.
- `timeout=0` correctly cascades to "no per-stage timeout" (stdlib `*http.Transport` ResponseHeaderTimeout semantics).
- Adds one direct dep (`github.com/enetx/http`) to the consumer CLI's go.mod via post-generate `go mod tidy` — it's already a transitive dep through surf, so no new module bytes.

## Output Contract

Template change to `client.go.tmpl` in the browser-transport branch only. No golden fixture changes — none of the goldened fixtures use the browser-transport path (verified by `scripts/golden.sh verify` returning clean after the change with no diffs).

Generated CLIs using `SpecSource: "sniffed"` (which triggers `UsesBrowserHTTPTransport`) will gain:
- `enetxhttp "github.com/enetx/http"` in their `client.go` imports
- A 4-line override block after `builder.Build().Unwrap()`
- One direct dep entry in `go.mod` (auto-added by `go mod tidy`)

## Verification

- `go test ./...` — full upstream suite green (29 packages, 0 fails)
- `go vet ./...` — clean
- `go fmt ./...` — clean
- `TestGenerateBrowserChromeH3Transport` (existing test that compiles the generated CLI with `go build`) — passes, confirming the new `enetxhttp` import + type assertion compile cleanly
- New `TestBrowserTransport_OverridesResponseHeaderTimeout` pins the emit
- New `TestNonBrowserTransport_DoesNotEmitOverride` pins the conditional emit
- `scripts/golden.sh verify` — 17 cases pass with no diff (no golden fixture uses browser transport)
- `golangci-lint`: not run locally (not installed); pre-push and CI will catch any issues. `go vet` is clean.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

## Discovery Context

This dropped out of the rok-cockpit-cli pilot — a thesis test comparing CLI vs curl token cost on agent-driven workflows. The pilot's highest-leverage endpoint (`/api/briefings/request`, a ~65s server-side LLM call that produces a markdown briefing) hard-failed in CLI mode at ~41s with this exact error:

```
$ ./rok-cockpit-pp-cli briefings request --persona intelligence_research_lead \
    --topic "capital allocation discipline" --vault rok-cockpit \
    --agent --timeout 180s
Error: POST /api/briefings/request: Post "http://localhost:3838/api/briefings/request":
  net/http: timeout awaiting response headers
real    0m41.034s
```

Re-running with `--timeout 240s` and `--timeout 300s` reproduced the same ~41s cutoff three times — confirming the user-facing flag never reaches the transport layer. The same call via curl with `--max-time 180` succeeded in 67s.

The diagnosis pinned the root cause to `internal/client/client.go`'s `newHTTPClient` (surf's transport's package-default `ResponseHeaderTimeout` bypasses the wrapper config). Because it's a generator template bug, every printed CLI fronting any slow API hits this — not just Cockpit. Fix lives here so all future regenerations pick it up.

The pilot's full AB_RESULTS, including this finding as item (1) of its "concrete follow-ups," is at `klatt42/rok-cockpit-cli/AB_RESULTS.md` (private repo; happy to share artifacts if useful).