### PR TITLE
fix(cli): use platform.ExecutablePath for validation gate binary

### DIFF
--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/govulncheck"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 )
 
 type validationGate struct {
@@ -23,7 +24,7 @@ type validationGate struct {
 const qualityGateTimeout = 5 * time.Minute
 
 func (g *Generator) Validate() error {
-	binPath := filepath.Join(g.OutputDir, naming.ValidationBinary(g.Spec.Name))
+	binPath := platform.ExecutablePath(filepath.Join(g.OutputDir, naming.ValidationBinary(g.Spec.Name)))
 	if err := artifacts.CleanupGeneratedCLI(g.OutputDir, artifacts.CleanupOptions{
 		RemoveValidationBinaries: true,
 		RemoveRecursiveCopies:    true,


### PR DESCRIPTION
## Intent

Issue: Fixes #978

The generate-time validation gate exec'd a bare path on Windows, but `go build -o <name>` writes `<name>.exe`. The post-build `--help`, `version`, and `doctor` gates all failed with `executable file not found in %PATH%` on every Windows generation that used `--validate`.

## Approach

Wrap the validation binary path with the existing `platform.ExecutablePath` helper (already in use across [`internal/pipeline/dogfood.go`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/pipeline/dogfood.go#L1711), [`internal/pipeline/runtime_exec.go`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/pipeline/runtime_exec.go#L21), [`internal/cli/shipcheck.go`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/cli/shipcheck.go#L160), [`internal/cli/publish.go`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/cli/publish.go#L873)). One import line + one call-site wrap. `naming.ValidationBinary` stays platform-agnostic, and `artifacts.CleanupGeneratedCLI` already matches both `-validation` and `-validation.exe` suffixes, so no other adjustments are required.

Refs #877 and #1140 — P3 duplicates with the same root cause; maintainer can close after merge.

## Scope

Primary area: generator (machine change). Affects every printed CLI's generate-time `--validate` gate on Windows.

## Risk

None on non-Windows: `platform.ExecutablePath` is a no-op when `runtime.GOOS != "windows"`. On Windows: gate now exec's the file `go build` actually wrote. The helper is idempotent on `.exe` (case-insensitive), so a future rename of `naming.ValidationBinary` to include `.exe` would not double-suffix.

## Verification

- `go build ./...`
- `go vet ./...`
- `go fmt ./...`
- `go test ./...` (3801 pass)
- `golangci-lint run ./internal/generator/...`
- `scripts/golden.sh verify` (17 cases pass)
- `git diff --check`

Windows runtime path is not exercised by CI (existing `validate_test.go` skips on Windows — `fake shell go binary is Unix-only`). The wrapped helper `platform.ExecutablePath` has table-driven unit tests covering both Windows append and idempotency in [`internal/platform/executable_test.go`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/platform/executable_test.go).

Per AGENTS.md ("Skip tests for CLI glue, trivial wrappers, and code only meaningfully tested via integration"), no new test added for this two-line callsite substitution — the helper itself is already tested.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission