### PR TITLE
fix(cli): default Accept to application/json instead of */*

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1500,7 +1500,7 @@ func TestGenerateBrowserChromeH3Transport(t *testing.T) {
 	// surf's Chrome impersonation manages the Accept header alongside
 	// User-Agent on the H3 transport too; the generator must not emit a
 	// competing default.
-	assert.NotContains(t, string(clientGo), `req.Header.Set("Accept", "*/*")`)
+	assert.NotContains(t, string(clientGo), `req.Header.Set("Accept",`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/client")
@@ -5994,7 +5994,7 @@ func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	standardClient, err := os.ReadFile(filepath.Join(standardDir, "internal", "client", "client.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(standardClient), `req.Header.Set("User-Agent", "standard-pp-cli/0.1.0")`)
-	assert.Contains(t, string(standardClient), `req.Header.Set("Accept", "*/*")`)
+	assert.Contains(t, string(standardClient), `req.Header.Set("Accept", "application/json")`)
 	assert.Contains(t, string(standardClient), `if req.Header.Get("Accept") == "" {`)
 
 	browserDir := filepath.Join(t.TempDir(), "browser-pp-cli")
@@ -6006,7 +6006,7 @@ func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	assert.NotContains(t, string(browserClient), `req.Header.Set("User-Agent"`)
 	// surf's Chrome impersonation manages the Accept header alongside
 	// User-Agent; the generator must not emit a competing default for either.
-	assert.NotContains(t, string(browserClient), `req.Header.Set("Accept", "*/*")`)
+	assert.NotContains(t, string(browserClient), `req.Header.Set("Accept",`)
 	// auth.go is not emitted for auth.type:none specs (see Generator.renderAuthFiles).
 	// Stronger assertion than the previous "no newAuthRefreshCmd in auth.go": there's
 	// no auth.go at all for no-auth CLIs.
@@ -6028,7 +6028,7 @@ func TestGenerateRequiredAcceptHeaderBeatsDefaultAccept(t *testing.T) {
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	requiredIdx := strings.Index(clientSrc, `req.Header.Set("Accept", "application/vnd.api.v3+json")`)
-	defaultIdx := strings.Index(clientSrc, `req.Header.Set("Accept", "*/*")`)
+	defaultIdx := strings.Index(clientSrc, `req.Header.Set("Accept", "application/json")`)
 	require.GreaterOrEqual(t, requiredIdx, 0, "spec-required Accept header must be emitted")
 	require.GreaterOrEqual(t, defaultIdx, 0, "Accept fallback default must still be emitted")
 	assert.Less(t, requiredIdx, defaultIdx, "spec-required Accept must be set before the if-empty default")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -867,9 +867,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
 		// and answer with empty-body 5xx, 403, or a challenge redirect
-		// depending on vendor and rule tier.
+		// depending on vendor and rule tier. The value is application/json
+		// rather than */* because strict-JSON APIs (Zendesk, Atlassian REST,
+		// Salesforce) return 415 on anything that isn't literally
+		// application/json; specs that need a different content type
+		// (vendor mediatypes, XML, HTML) declare it via RequiredHeaders or
+		// per-endpoint headerOverrides, both of which run before this
+		// if-empty default.
 		if req.Header.Get("Accept") == "" {
-			req.Header.Set("Accept", "*/*")
+			req.Header.Set("Accept", "application/json")
 		}
 {{- end}}
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -257,9 +257,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
 		// and answer with empty-body 5xx, 403, or a challenge redirect
-		// depending on vendor and rule tier.
+		// depending on vendor and rule tier. The value is application/json
+		// rather than */* because strict-JSON APIs (Zendesk, Atlassian REST,
+		// Salesforce) return 415 on anything that isn't literally
+		// application/json; specs that need a different content type
+		// (vendor mediatypes, XML, HTML) declare it via RequiredHeaders or
+		// per-endpoint headerOverrides, both of which run before this
+		// if-empty default.
 		if req.Header.Get("Accept") == "" {
-			req.Header.Set("Accept", "*/*")
+			req.Header.Set("Accept", "application/json")
 		}
 
 		resp, err := c.HTTPClient.Do(req)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -251,9 +251,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
 		// and answer with empty-body 5xx, 403, or a challenge redirect
-		// depending on vendor and rule tier.
+		// depending on vendor and rule tier. The value is application/json
+		// rather than */* because strict-JSON APIs (Zendesk, Atlassian REST,
+		// Salesforce) return 415 on anything that isn't literally
+		// application/json; specs that need a different content type
+		// (vendor mediatypes, XML, HTML) declare it via RequiredHeaders or
+		// per-endpoint headerOverrides, both of which run before this
+		// if-empty default.
 		if req.Header.Get("Accept") == "" {
-			req.Header.Set("Accept", "*/*")
+			req.Header.Set("Accept", "application/json")
 		}
 
 		resp, err := c.HTTPClient.Do(req)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -354,9 +354,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,
 		// Cloudflare bot-mode, DataDome) flag the absence as a bot signal
 		// and answer with empty-body 5xx, 403, or a challenge redirect
-		// depending on vendor and rule tier.
+		// depending on vendor and rule tier. The value is application/json
+		// rather than */* because strict-JSON APIs (Zendesk, Atlassian REST,
+		// Salesforce) return 415 on anything that isn't literally
+		// application/json; specs that need a different content type
+		// (vendor mediatypes, XML, HTML) declare it via RequiredHeaders or
+		// per-endpoint headerOverrides, both of which run before this
+		// if-empty default.
 		if req.Header.Get("Accept") == "" {
-			req.Header.Set("Accept", "*/*")
+			req.Header.Set("Accept", "application/json")
 		}
 
 		resp, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
## Intent

Strict-JSON APIs (Zendesk, Atlassian REST, Salesforce) return HTTP 415 on the first call from a generated CLI because the client-template default `Accept: */*` is not literally `application/json`. Switching the default to `application/json` fixes the first-call failure while preserving the WAF presence-check motivation that prompted the original explicit default.

Issue: Closes #1119

## Approach

Single-line value change in `internal/generator/templates/client.go.tmpl`: the `if-empty` Accept fallback emits `application/json` instead of `*/*`. The override layering is unchanged — spec `RequiredHeaders` and per-endpoint `headerOverrides` still run before this default, so vendor mediatypes (`application/vnd.github.v3+json`), XML, HTML, or other content types declared in a spec continue to win. The comment in the template now records both motivations (WAF presence + strict-JSON acceptance) so a future reader doesn't lose the WAF reasoning that justified setting Accept at all.

## Scope

Primary area: `comp:generator` — `internal/generator/templates/client.go.tmpl`

Why this belongs in this repo: this is a machine change. Every future printed CLI inherits the default; per-CLI patching of the same line had to be done by hand on Zendesk and was implied by the cross-API evidence (Atlassian, Salesforce). Fixing the generator buys clean first-call behavior across every regeneration.

## Risk

- Generator output: every regenerated CLI now emits `req.Header.Set("Accept", "application/json")` instead of `"*/*"`. The browser-managed-User-Agent path (`HTTPTransportBrowserChrome`/`BrowserHTTP`/`BrowserHTTP3`) is still gated by `not .UsesBrowserManagedUserAgent`, so surf's Chrome impersonation keeps managing Accept on those transports — unchanged.
- WAF bot detection: presence-checking WAFs (Imperva, Akamai, Cloudflare bot-mode, DataDome) flag absence of Accept, not specific values. `application/json` is a real-browser-shaped value and continues to satisfy presence checks.
- APIs returning non-JSON: a spec that legitimately returns XML/HTML must declare its Accept via `RequiredHeaders` or per-endpoint `headerOverrides`. Both run before the if-empty default; a spec without that declaration would previously have lied about acceptance via `*/*` while parsing as JSON downstream — the new default doesn't change that mismatch, only surfaces it more loudly when the API enforces content negotiation.

## Output Contract

Templates / goldens changed:
- `internal/generator/templates/client.go.tmpl` — Accept default value + explanatory comment block.
- `testdata/golden/expected/generate-golden-api/.../client.go`, `generate-golden-api-oauth2-cc/.../client.go`, `generate-tier-routing-api/.../client.go` — re-baked to mirror the new default.

`scripts/golden.sh verify` passes after the re-bake. No other fixture, manifest, scorecard, catalog rendering, or MCP-surface artifact changes.

## Verification

- `go build ./...` — clean.
- `go fmt ./...` — clean.
- `go vet ./...` — clean.
- `go test ./...` — 3866 passed across 34 packages, including the three Accept-related tests (`TestGenerate_UserAgentOverrideGatedByBrowserTransport`, `TestGenerateRequiredAcceptHeaderBeatsDefaultAccept`, `TestGenerateBrowserHTTP3TransportForcesHTTP3`).
- `golangci-lint run ./...` — no issues.
- `scripts/golden.sh verify` — 17/17 cases pass after `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update` re-baked the three affected client.go fixtures.
- `git diff --check` — no whitespace issues in the diff.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change