### PR TITLE
fix(skills): generate absolute manuscript URLs in publish PR body

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -734,6 +734,16 @@ git push --force-with-lease -u origin feat/<api-slug>
 git push -u origin feat/<api-slug>
 ```
 
+### Capture the pushed commit SHA
+
+After pushing, capture the head commit SHA. This is used to build durable manuscript links in the PR body (see "Build the PR description" below).
+
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+The SHA stays resolvable on `mvanhorn/printing-press-library` for the life of the PR (GitHub mirrors fork-PR head commits to `refs/pull/<N>/head` on the upstream), and remains valid after the PR is merged and the branch is deleted. Each invocation of this skill captures a fresh `HEAD_SHA` after its push and rewrites the body, so links stay current across updates the skill performs. If the branch is force-pushed outside this skill, re-run `/printing-press-publish` to refresh the body — the prior links will still resolve, but they'll point at the manuscript contents from before the out-of-band push.
+
 ### Create or update PR
 
 Read `access` and `gh_user` from `$PUBLISH_CONFIG`. These determine how `gh pr create` is called.
@@ -747,7 +757,7 @@ Build the PR description from:
 - The manifest's `novel_features` array from the packaged CLI after Step 6
 - The `help_output` captured in Step 4
 - The CLI's README (first 2-3 paragraphs, or note that README is missing)
-- Links to `.manuscripts/<run-id>/research/` and `.manuscripts/<run-id>/proofs/` within the PR branch
+- Links to every file under `.manuscripts/<run-id>/research/` and `.manuscripts/<run-id>/proofs/`. Each link must be a full `https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/<subdir>/<filename>` URL — never a relative path (GitHub resolves those against `…/pull/`, producing broken `…/pull/library/…` URLs) and never a directory (the blob view requires a file). Enumerate the actual files; do not invent or skip them.
 - The validation results from Step 4
 - A Gaps section listing any missing manifest fields
 
@@ -821,8 +831,10 @@ $ <cli-name> --help
 
 ### Manuscripts
 
-- [Research Brief](<link to library/<category>/<api-slug>/.manuscripts/<run-id>/research/>)
-- [Shipcheck Results](<link to library/<category>/<api-slug>/.manuscripts/<run-id>/proofs/>)
+<For each file actually present under `$PUBLISH_REPO_DIR/library/<category>/<api-slug>/.manuscripts/<run-id>/research/` and `.../proofs/`, emit one bullet using the form below. Use the human label that matches the file (e.g. `Research Brief`, `Absorb Manifest`, `Novel Features Brainstorm`, `Phase 5 Acceptance`). Substitute `<HEAD_SHA>` with the value captured after push. Do NOT use relative paths.>
+
+- [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/research/<filename>)
+- [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/proofs/<filename>)
 
 ### Validation Results
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -831,10 +831,14 @@ $ <cli-name> --help
 
 ### Manuscripts
 
-<For each file actually present under `$PUBLISH_REPO_DIR/library/<category>/<api-slug>/.manuscripts/<run-id>/research/` and `.../proofs/`, emit one bullet using the form below. Use the human label that matches the file (e.g. `Research Brief`, `Absorb Manifest`, `Novel Features Brainstorm`, `Phase 5 Acceptance`). Substitute `<HEAD_SHA>` with the value captured after push. Do NOT use relative paths.>
+<!-- One bullet per file, NOT one per directory. Repeat the research/ row for every file in research/, and the proofs/ row for every file in proofs/. Use a human label that matches the file (e.g. `Research Brief`, `Absorb Manifest`, `Novel Features Brainstorm`, `Phase 5 Acceptance`). Substitute `<HEAD_SHA>` with the value captured after push. Do NOT use relative paths. -->
 
 - [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/research/<filename>)
+- [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/research/<filename>)
+- … (one bullet for each remaining file in `.manuscripts/<run-id>/research/`)
 - [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/proofs/<filename>)
+- [<label>](https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/proofs/<filename>)
+- … (one bullet for each remaining file in `.manuscripts/<run-id>/proofs/`)
 
 ### Validation Results
 


### PR DESCRIPTION
## Intent

PR bodies produced by `/printing-press-publish` were emitting relative paths like `library/<category>/<slug>/.manuscripts/...` for the Manuscripts section. GitHub resolved those against the PR page URL and rendered them as broken `https://github.com/mvanhorn/printing-press-library/pull/library/...` links — example: [mvanhorn/printing-press-library#497](https://github.com/mvanhorn/printing-press-library/pull/497).

Issue: N/A (surfaced in conversation)

## Approach

Three coordinated edits in [skills/printing-press-publish/SKILL.md](skills/printing-press-publish/SKILL.md):

1. **New \"Capture the pushed commit SHA\" sub-step in Step 8** — runs `HEAD_SHA=\$(git rev-parse HEAD)` immediately after the branch push so the PR body has a durable ref to substitute.
2. **Rewrote the bullet describing manuscript links** to require a full `https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/...` URL and to call out the failure mode explicitly (relative path → `…/pull/library/…` 404; directory → blob view 404).
3. **Rewrote the `### Manuscripts` template** to enumerate every actual file under `…/research/` and `…/proofs/` and emit one absolute blob URL per file.

Why head SHA rather than the branch ref or `main`:

- Branch refs (`blob/feat/<slug>/...`) 404 after merge + auto-delete-branch (the GitHub default).
- `main` refs 404 pre-merge, which is when reviewers actually click these links.
- Head SHA URLs resolve in all three phases (pre-merge, post-merge, post-branch-deletion) because GitHub mirrors fork-PR heads to `refs/pull/<N>/head` on the upstream and keeps PR-referenced commits forever.
- Every skill-driven update rebuilds the body with a freshly captured SHA, so force-pushes the skill performs keep links current. Out-of-band force-pushes need a publish-skill re-run, which is noted in the new sub-step.

## Scope

Primary area: skills

Why this belongs in this repo: the publish skill is the machine; this is a generator/skill bug, not a printed-CLI fix. Fixing it here means every future publish gets working manuscript links.

## Risk

Documentation-only edit in a skill. No code paths or templates changed, no generator output affected. Reviewers reading old PRs will still see relative-path links there (those existing bodies are not rewritten by this change); the existing PR #497 can be manually re-edited via `gh pr edit` if desired.

## Output Contract

N/A — skill prose only; no generated files, manifests, or scorecard output affected.

## Verification

- Read the diff to confirm the three edits land coherently around lines 736-746, 760, and 832-837.
- Traced the data flow: HEAD_SHA captured after push → consumed by both `gh pr edit … --body-file` (update path) and `gh pr create … --body-file` (new PR path).
- No `go test` / `golden.sh` run — change is in `skills/`, not in code or templates that affect generator output.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission