### PR TITLE
fix(cli): gate refreshAccessToken emission on Auth.TokenURL non-empty

### DIFF
--- a/internal/generator/auth_none_dead_code_test.go
+++ b/internal/generator/auth_none_dead_code_test.go
@@ -10,36 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Symbols that exist solely to support an `auth` subcommand. They must
-// disappear from generated config.go / client.go for `auth.type: "none"`
+// Config-side symbols that exist solely to support an `auth` subcommand.
+// They must disappear from generated config.go for `auth.type: "none"`
 // CLIs (no caller can populate them) and stay for any non-none auth flow.
-var (
-	configTokenScaffolding = []string{
-		"AccessToken",
-		"RefreshToken",
-		"TokenExpiry",
-		"ClientID",
-		"ClientSecret",
-		"SaveTokens",
-		"ClearTokens",
-	}
-	clientTokenScaffolding = []string{
-		"refreshAccessToken",
-		"c.Config.AccessToken",
-		"c.Config.RefreshToken",
-		"c.Config.TokenExpiry",
-	}
-)
+//
+// Client-side refresh plumbing (refreshAccessToken et al.) follows a
+// tighter gate (shouldEmitAuth + Auth.TokenURL != "") and is covered by
+// TestRefreshAccessToken_GatedByTokenURL in client_refresh_token_gate_test.go.
+var configTokenScaffolding = []string{
+	"AccessToken",
+	"RefreshToken",
+	"TokenExpiry",
+	"ClientID",
+	"ClientSecret",
+	"SaveTokens",
+	"ClearTokens",
+}
 
 // TestTokenScaffoldingFollowsAuthSurface pins all three branches of
 // shouldEmitAuth(): Auth.Type != "none", Auth.AuthorizationURL != "", and a
 // graphql_persisted_query traffic-analysis hint each independently keep the
-// OAuth-shape token scaffolding emitting; only when all three are absent do
-// the symbols disappear (otherwise they would be dead code with no caller on
-// the CLI surface). The cases also verify that the generated CLI still
-// compiles with the gating in place — gated imports falling out of sync with
-// gated function bodies would otherwise pass the symbol-absence assertions
-// but ship a non-buildable CLI.
+// OAuth-shape token scaffolding emitting in config.go; only when all three
+// are absent do the symbols disappear (otherwise they would be dead code
+// with no caller on the CLI surface). The cases also verify that the
+// generated CLI still compiles with the gating in place — gated imports
+// falling out of sync with gated function bodies would otherwise pass the
+// symbol-absence assertions but ship a non-buildable CLI.
 func TestTokenScaffoldingFollowsAuthSurface(t *testing.T) {
 	t.Parallel()
 
@@ -97,11 +93,6 @@ func TestTokenScaffoldingFollowsAuthSurface(t *testing.T) {
 			configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
 			for _, sym := range configTokenScaffolding {
 				tt.expect(t, configSrc, sym)
-			}
-
-			clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
-			for _, sym := range clientTokenScaffolding {
-				tt.expect(t, clientSrc, sym)
 			}
 
 			// Catch import-gating mistakes: an orphan reference to a gated

--- a/internal/generator/client_refresh_token_gate_test.go
+++ b/internal/generator/client_refresh_token_gate_test.go
@@ -1,0 +1,106 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards #1200: refreshAccessToken() and its call site must only be emitted
+// when the spec actually carries an OAuth token-refresh endpoint
+// (Auth.TokenURL != ""). For bearer-only CLIs (api_key, bearer_token with
+// no TokenURL) the method becomes a guaranteed no-op that silently swallows
+// every refresh call, leaving users to hit a 1-hour token expiry wall with
+// no error and `auth status` cheerfully reporting `has_refresh_token: ...`.
+//
+// Both prongs must hold: the method definition and the do()-path call site
+// share the same gate, so dropping one without the other leaves either an
+// orphan symbol or an undefined-symbol compile error.
+func TestRefreshAccessToken_GatedByTokenURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		auth spec.AuthConfig
+		want bool
+	}{
+		{
+			name: "bearer_only_omits_refresh",
+			auth: spec.AuthConfig{
+				Type:    "bearer_token",
+				Header:  "Authorization",
+				Format:  "Bearer {token}",
+				EnvVars: []string{"BEARER_ONLY_TOKEN"},
+			},
+			want: false,
+		},
+		{
+			name: "api_key_omits_refresh",
+			auth: spec.AuthConfig{
+				Type:    "api_key",
+				Header:  "Authorization",
+				Format:  "Bearer {token}",
+				EnvVars: []string{"API_KEY_TOKEN"},
+			},
+			want: false,
+		},
+		{
+			name: "oauth2_authorization_code_emits_refresh",
+			auth: spec.AuthConfig{
+				Type:             "oauth2",
+				Header:           "Authorization",
+				Format:           "Bearer {token}",
+				EnvVars:          []string{"AUTHCODE_TOKEN"},
+				AuthorizationURL: "https://example.com/oauth/authorize",
+				TokenURL:         "https://example.com/oauth/token",
+			},
+			want: true,
+		},
+		{
+			// Pins the gate on TokenURL specifically — an oauth2 spec
+			// with an AuthorizationURL but no TokenURL must still drop
+			// refresh plumbing. Without this case the gate could be
+			// silently re-keyed on Auth.Type ("oauth2") and the
+			// authorization_code-emits-refresh case alone would still pass.
+			name: "oauth2_without_token_url_omits_refresh",
+			auth: spec.AuthConfig{
+				Type:             "oauth2",
+				Header:           "Authorization",
+				Format:           "Bearer {token}",
+				EnvVars:          []string{"NO_TOKEN_URL_TOKEN"},
+				AuthorizationURL: "https://example.com/oauth/authorize",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec(tt.name)
+			apiSpec.Auth = tt.auth
+
+			outputDir := filepath.Join(t.TempDir(), tt.name+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+
+			methodPresent := strings.Contains(clientSrc, "func (c *Client) refreshAccessToken()")
+			callPresent := strings.Contains(clientSrc, "c.refreshAccessToken()")
+			assert.Equal(t, tt.want, methodPresent,
+				"refreshAccessToken method definition emission must follow Auth.TokenURL non-empty")
+			assert.Equal(t, tt.want, callPresent,
+				"refreshAccessToken call-site emission must follow Auth.TokenURL non-empty")
+
+			// Catch import-gating mistakes: an orphan reference to a gated
+			// symbol would pass the substring asserts but produce
+			// non-buildable generated source. Skipped under -short.
+			runGoCommand(t, outputDir, "build", "./...")
+		})
+	}
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1223,7 +1223,7 @@ func (c *Client) authHeader() (string, error) {
 		}
 		c.ccMu.Unlock()
 	}
-{{- else if .HasAuthCommand}}
+{{- else if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" {
 		if err := c.refreshAccessToken(); err != nil {
 			return "", err
@@ -1321,13 +1321,12 @@ func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
 }
 {{- end}}
 
-{{- if .HasAuthCommand}}
+{{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 
 func (c *Client) refreshAccessToken() error {
 	if c.Config == nil {
 		return nil
 	}
-{{- if .Auth.TokenURL}}
 	if c.Config.RefreshToken == "" {
 		return nil
 	}
@@ -1335,9 +1334,6 @@ func (c *Client) refreshAccessToken() error {
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {
 		tokenURL = "{{.Auth.TokenURL}}"
-	}
-	if tokenURL == "" {
-		return nil
 	}
 
 	params := url.Values{
@@ -1385,7 +1381,6 @@ func (c *Client) refreshAccessToken() error {
 	if err := c.Config.SaveTokens(c.Config.ClientID, c.Config.ClientSecret, tokenResp.AccessToken, refreshToken, expiry); err != nil {
 		return fmt.Errorf("saving refreshed token: %w", err)
 	}
-{{- end}}
 
 	return nil
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -484,9 +484,6 @@ func (c *Client) refreshAccessToken() error {
 	if tokenURL == "" {
 		tokenURL = "https://api.cc.example/oauth/token"
 	}
-	if tokenURL == "" {
-		return nil
-	}
 
 	params := url.Values{
 		"grant_type":    {"refresh_token"},

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -362,20 +362,7 @@ func (c *Client) authHeader() (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" {
-		if err := c.refreshAccessToken(); err != nil {
-			return "", err
-		}
-	}
 	return c.Config.AuthHeader(), nil
-}
-
-func (c *Client) refreshAccessToken() error {
-	if c.Config == nil {
-		return nil
-	}
-
-	return nil
 }
 
 // sanitizeJSONResponse strips known JSONP/XSSI prefixes and UTF-8 BOM from

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -475,20 +475,7 @@ func (c *Client) authHeader() (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" {
-		if err := c.refreshAccessToken(); err != nil {
-			return "", err
-		}
-	}
 	return c.Config.AuthHeader(), nil
-}
-
-func (c *Client) refreshAccessToken() error {
-	if c.Config == nil {
-		return nil
-	}
-
-	return nil
 }
 
 // sanitizeJSONResponse strips known JSONP/XSSI prefixes and UTF-8 BOM from


### PR DESCRIPTION
## Intent

Bearer-only printed CLIs (api_key, bearer_token, OAuth2 specs lacking a TokenURL) were shipping a `refreshAccessToken()` Go method that silently returned `nil` on every call because the templated runtime `tokenURL` was empty. `authHeader()` invoked it whenever an access token expired, hiding the real failure: users hit the OAuth refresh wall with no error and `auth status` reported `has_refresh_token: ...` as if everything was wired up. The issue counted nine of ten surveyed published bearer CLIs with `tokenURL := ""` baked in.

Issue: Closes #1200

## Approach

Tighten both `{{- if .HasAuthCommand}}` gates in `internal/generator/templates/client.go.tmpl` (the method definition and its call site inside `authHeader()`) to `{{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}`. With the outer gate now guaranteeing `.Auth.TokenURL` is non-empty, the redundant inner `{{- if .Auth.TokenURL}}` block in the function body is dropped, and a now-unreachable runtime `if tokenURL == "" { return nil }` guard inside the function body goes with it. Pure subtraction.

The fix follows the co-gating pattern established by PR #704 / [docs/solutions/logic-errors/auth-none-dead-code-in-config-client-2026-05-08.md](docs/solutions/logic-errors/auth-none-dead-code-in-config-client-2026-05-08.md) — extending it from "any auth emits scaffolding" to "auth with a real TokenURL emits refresh plumbing."

## Scope

Primary area: `cli` (generator template + test).

Why this belongs in this repo: This is a machine change per AGENTS.md. Every bearer-token CLI generated today reproduces the bug; fixing it in one printed CLI's source would not generalize and would re-break on the next regen.

## Risk

Low, by design — pure subtraction of dead plumbing for CLIs that lack a TokenURL.

- **Bearer-only specs** (no TokenURL): the method and call site stop emitting. Their `refreshAccessToken()` already silently returned `nil`, so the runtime behavior was already "no-op" — only the dead symbols are removed.
- **OAuth2 authorization_code specs with TokenURL**: emission is unchanged. Pinned by the new `oauth2_authorization_code_emits_refresh` subtest.
- **OAuth2 client_credentials specs**: emission of `refreshAccessToken()` is unchanged (the function is still defined, although the CC flow uses its own `mintClientCredentials()` path inside `authHeader()` rather than the refresh call site). Pre-existing orphan-emission residual flagged by review — out of scope for this PR; worth a separate issue.
- **`auth.type: none` specs**: unchanged — `shouldEmitAuth()` returns false, no emission either way.

## Output Contract

Three golden client.go fixtures updated:

- `testdata/golden/expected/generate-golden-api/.../client.go`: removes the dead `refreshAccessToken()` definition and its call site inside `authHeader()`.
- `testdata/golden/expected/generate-tier-routing-api/.../client.go`: same.
- `testdata/golden/expected/generate-golden-api-oauth2-cc/.../client.go`: keeps `refreshAccessToken()` (the CC spec has a TokenURL), but removes the now-unreachable second `if tokenURL == "" { return nil }` guard inside the function body.

No other generated artifacts change.

## Verification

Commands actually run, on macOS / Go 1.24:

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./... -short` — all packages green, including new `TestRefreshAccessToken_GatedByTokenURL` (4 subtests) and updated `TestTokenScaffoldingFollowsAuthSurface`
- `scripts/golden.sh verify` — 17/17 cases pass
- `golangci-lint run ./...` — 0 issues

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change