### PR TITLE
fix(cli): populate parent FK in generated UpsertBatch typed-table test fixture

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3076,6 +3076,65 @@ func TestGenerateStoreSubResourceUpsertBindingOrder(t *testing.T) {
 		"swapped (id, data, synced_at, fk) binding order must not be emitted")
 }
 
+// TestGenerateStoreSubResourceUpsertBatchTestSatisfiesNotNullFK pins the
+// emitted TestUpsertBatch_Populates<Name>Table fixture against the NOT NULL
+// parent FK column declared by buildSubResourceTable. Without an injected
+// FK value, the typed insert fails the NOT NULL constraint on a freshly
+// generated CLI.
+func TestGenerateStoreSubResourceUpsertBatchTestSatisfiesNotNullFK(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "subres-fk",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/subres-fk-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"domains": {
+				Description: "Manage domains",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/domains", Description: "List domains"},
+				},
+				SubResources: map[string]spec.Resource{
+					"verify": {
+						Description: "Verify a domain",
+						Endpoints: map[string]spec.Endpoint{
+							"get": {
+								Method:      "GET",
+								Path:        "/domains/{domainId}/verify",
+								Description: "Get verification status",
+								Params:      []spec.Param{{Name: "domainId", Type: "string", Required: true, Positional: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	testSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "upsert_batch_test.go"))
+	require.NoError(t, err)
+	// Anchor all three FK injections to the function body so go test -short
+	// (which skips runGoCommand build/test) still gates a regression that
+	// moved the FK into a comment or only one of the three rows.
+	assert.Regexp(t,
+		`(?s)func TestUpsertBatch_PopulatesVerifyTable\(.*?"domains_id":\s*"[^"]+".*?"domains_id":\s*"[^"]+".*?"domains_id":\s*"[^"]+"`,
+		string(testSrc),
+		"TestUpsertBatch_PopulatesVerifyTable fixture must populate the parent FK column declared NOT NULL by buildSubResourceTable in all three items")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/store")
+}
+
 func TestGenerateSimilarCommandUsesCompositeResourceKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -267,8 +267,18 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 {{- if $hasTyped }}
 {{- range .Tables}}
 {{- if hasTypedTable .}}
+{{- /* $parentFKCol captures buildSubResourceTable's NOT NULL parent FK
+       (e.g. "domains_id"). The fixture must populate it or the typed
+       insert fails the NOT NULL constraint. The predicate is
+       first-match-wins: buildSubResourceTable emits parentCol second
+       (after id, before data/synced_at), so it wins even if a future
+       schema change introduces another NotNull non-PK column. */ -}}
 {{- $hasParentID := false }}
-{{- range .Columns}}{{if eq .Name "parent_id"}}{{$hasParentID = true}}{{end}}{{end}}
+{{- $parentFKCol := "" }}
+{{- range .Columns}}
+{{- if eq .Name "parent_id"}}{{$hasParentID = true}}{{end}}
+{{- if and .NotNull (not .PrimaryKey) (ne .Name "data") (eq $parentFKCol "")}}{{$parentFKCol = .Name}}{{end}}
+{{- end}}
 
 // TestUpsertBatch_Populates{{pascal .Name}}Table verifies that UpsertBatch
 // dispatches paginated items into both the generic resources table AND the
@@ -284,9 +294,9 @@ func TestUpsertBatch_Populates{{pascal .Name}}Table(t *testing.T) {
 	defer s.Close()
 
 	items := []json.RawMessage{
-		json.RawMessage(`{"id": "test-001"}`),
-		json.RawMessage(`{"id": "test-002"}`),
-		json.RawMessage(`{"id": "test-003"}`),
+		json.RawMessage(`{"id": "test-001"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
+		json.RawMessage(`{"id": "test-002"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
+		json.RawMessage(`{"id": "test-003"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
 	}
 	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)


### PR DESCRIPTION
## Intent

Issue: Closes #1063

`buildSubResourceTable` emits the parent FK column as `NOT NULL` (e.g. `domains_id NOT NULL` on a `verify` sub-resource of `domains`). The generated `TestUpsertBatch_Populates<Name>Table` fixture only supplied `{"id": "..."}`, so the typed insert failed with `NOT NULL constraint failed: <table>.<parent>_id` on a freshly generated sub-resource CLI. The CLI itself still shipped, but every generator regen had a red baseline test, masking real future regressions.

## Approach

The test template now detects `buildSubResourceTable`'s parent FK and injects a synthetic value into the fixture JSON. Detection is first-match-wins on `NotNull && !PrimaryKey && Name != "data"` — the only NotNull non-PK non-`data` column the schema emits is the parent FK from `buildSubResourceTable`, and that constructor places it second (after `id`), so the first-match guard remains correct even if a future schema change adds another required non-PK column.

For top-level tables (no sub-resource), `$parentFKCol` stays empty and the fixture stays byte-identical to before — confirmed by `scripts/golden.sh verify` passing untouched.

The regression test pins both surfaces:
- A regex on the generated source asserts the FK key appears inside `TestUpsertBatch_PopulatesVerifyTable`'s items slice three times, so `go test -short` (which skips compile-and-run) still catches FK-injection regressions.
- A `go test ./internal/store` invocation in the full test lane is the load-bearing gate — without the fix, SQLite raises the NOT NULL error at INSERT time.

## Scope

Primary area: generator (`comp:generator`)

Why this belongs in this repo: the bug is in the embedded test template (`internal/generator/templates/store_upsert_batch_test.go.tmpl`). Every printed CLI with sub-resource tables hits the same failure mode, so the fix compounds across future regenerations.

## Risk

- Generated output: only sub-resource typed-table tests change. Flat (top-level only) specs produce byte-identical output, golden suite passes untouched.
- MCP surface: unchanged.
- Auth, catalog, publish flow, verifier, scorer, release: unchanged.

## Test plan

- [x] New regression test `TestGenerateStoreSubResourceUpsertBatchTestSatisfiesNotNullFK` fails on `main`, passes after the fix
- [x] Tier 1 (regex on source) gates the `-short` lane
- [x] Tier 2 (`go test ./internal/store`) gates the full lane against the actual NOT NULL failure
- [x] `go test ./internal/generator/ -short` passes (694 tests)
- [x] `scripts/golden.sh verify` passes (17 cases unchanged)
- [x] `go vet`, `go fmt`, `golangci-lint` clean