### PR TITLE
chore(ci): enable greptile status checks

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,4 @@
+{
+  "statusCheck": true,
+  "triggerOnUpdates": true
+}


### PR DESCRIPTION
Greptile can now publish a required GitHub status check for each PR review, and reviews will refresh when new commits land on an open PR. This is the repo-side config needed before wiring the exact Greptile check name into Mergify.

Validated with `jq empty greptile.json`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
