### PR TITLE
fix(cli): close ResolveByName json_extract injection + dedupe cacheKey AuthHeader call

### DIFF
--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -30,7 +30,9 @@ func TestClientCacheKeyScopesByBaseURLAndAuthIdentity(t *testing.T) {
 
 	require.Contains(t, body, `"|base_url=" + c.BaseURL`, "cache keys must isolate staging/prod or per-tenant base URLs")
 	require.Contains(t, body, `"|auth_source=" + c.Config.AuthSource`, "cache keys should distinguish env/config/profile auth sources")
-	require.Contains(t, body, `sha256.Sum256([]byte(c.Config.AuthHeader()))`, "cache keys should include an auth fingerprint without storing the raw token")
+	require.Contains(t, body, `authHeader := c.Config.AuthHeader()`, "cache keys should capture AuthHeader() once")
+	require.Contains(t, body, `sha256.Sum256([]byte(authHeader))`, "cache keys should include an auth fingerprint without storing the raw token")
+	require.NotContains(t, body, `sha256.Sum256([]byte(c.Config.AuthHeader()))`, "cache keys should reuse the captured authHeader, not call AuthHeader() twice")
 	require.Contains(t, body, `sort.Strings(paramKeys)`, "cache keys should be deterministic for map params")
 }
 

--- a/internal/generator/store_resolve_by_name_guard_test.go
+++ b/internal/generator/store_resolve_by_name_guard_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStoreResolveByNameValidatesField pins the SQL-injection guard on
-// ResolveByName's caller-supplied field names. json_extract path components
-// can't be bound as SQL parameters, so the splice is structurally required
-// — but every field must be validated against validIdentifierRE before
-// being substituted into the query.
 func TestStoreResolveByNameValidatesField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/store_resolve_by_name_guard_test.go
+++ b/internal/generator/store_resolve_by_name_guard_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -23,10 +24,9 @@ func TestStoreResolveByNameValidatesField(t *testing.T) {
 
 	require.Contains(t, body, `for _, field := range matchFields {`,
 		"ResolveByName must iterate matchFields")
-	require.Contains(t, body, `if !validIdentifierRE.MatchString(field) {`,
-		"ResolveByName must validate each field name before splicing into json_extract path")
-	require.Contains(t, body, `continue`,
-		"unsafe field names must be skipped, not used to build the query")
+	guard := regexp.MustCompile(`if !validIdentifierRE\.MatchString\(field\) \{\s*continue\s*\}`)
+	require.Regexp(t, guard, body,
+		"ResolveByName must validate each field name and continue past invalid entries before splicing into the json_extract path; the continue must be inside the validIdentifierRE guard, not the pre-existing query-error continue")
 }
 
 func resolveByNameBody(t *testing.T, content string) string {

--- a/internal/generator/store_resolve_by_name_guard_test.go
+++ b/internal/generator/store_resolve_by_name_guard_test.go
@@ -1,0 +1,46 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreResolveByNameValidatesField pins the SQL-injection guard on
+// ResolveByName's caller-supplied field names. json_extract path components
+// can't be bound as SQL parameters, so the splice is structurally required
+// — but every field must be validated against validIdentifierRE before
+// being substituted into the query.
+func TestStoreResolveByNameValidatesField(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("resolve-guard")
+	outputDir := filepath.Join(t.TempDir(), "resolve-guard-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	store := string(storeSrc)
+	body := resolveByNameBody(t, store)
+
+	require.Contains(t, body, `for _, field := range matchFields {`,
+		"ResolveByName must iterate matchFields")
+	require.Contains(t, body, `if !validIdentifierRE.MatchString(field) {`,
+		"ResolveByName must validate each field name before splicing into json_extract path")
+	require.Contains(t, body, `continue`,
+		"unsafe field names must be skipped, not used to build the query")
+}
+
+func resolveByNameBody(t *testing.T, content string) string {
+	t.Helper()
+	start := strings.Index(content, "func (s *Store) ResolveByName(")
+	require.NotEqual(t, -1, start, "ResolveByName function must be emitted")
+	body := content[start:]
+	if next := strings.Index(body[1:], "\nfunc "); next != -1 {
+		body = body[:next+1]
+	}
+	return body
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -397,7 +397,7 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	if c.Config != nil {
 		key += "|auth_source=" + c.Config.AuthSource
 		if authHeader := c.Config.AuthHeader(); authHeader != "" {
-			authHash := sha256.Sum256([]byte(c.Config.AuthHeader()))
+			authHash := sha256.Sum256([]byte(authHeader))
 			key += "|auth=" + hex.EncodeToString(authHash[:8])
 		}
 		if c.Config.Path != "" {

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1221,6 +1221,11 @@ func (s *Store) Status() (map[string]int, error) {
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").
+//
+// json_extract path components cannot be bound as SQL parameters, so each
+// field is validated against validIdentifierRE before being spliced into
+// the query. Fields that fail validation are skipped so callers may pass
+// untrusted strings without risk.
 func (s *Store) ResolveByName(resourceType string, input string, matchFields ...string) (string, error) {
 	if IsUUID(input) {
 		return input, nil
@@ -1228,6 +1233,9 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 
 	var matches []string
 	for _, field := range matchFields {
+		if !validIdentifierRE.MatchString(field) {
+			continue
+		}
 		query := fmt.Sprintf(
 			`SELECT id FROM resources WHERE resource_type = ? AND LOWER(json_extract(data, '$.%s')) = LOWER(?)`,
 			field,

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1224,8 +1224,7 @@ func (s *Store) Status() (map[string]int, error) {
 //
 // json_extract path components cannot be bound as SQL parameters, so each
 // field is validated against validIdentifierRE before being spliced into
-// the query. Fields that fail validation are skipped so callers may pass
-// untrusted strings without risk.
+// the query.
 func (s *Store) ResolveByName(resourceType string, input string, matchFields ...string) (string, error) {
 	if IsUUID(input) {
 		return input, nil

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -101,7 +101,7 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	if c.Config != nil {
 		key += "|auth_source=" + c.Config.AuthSource
 		if authHeader := c.Config.AuthHeader(); authHeader != "" {
-			authHash := sha256.Sum256([]byte(c.Config.AuthHeader()))
+			authHash := sha256.Sum256([]byte(authHeader))
 			key += "|auth=" + hex.EncodeToString(authHash[:8])
 		}
 		if c.Config.Path != "" {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -95,7 +95,7 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	if c.Config != nil {
 		key += "|auth_source=" + c.Config.AuthSource
 		if authHeader := c.Config.AuthHeader(); authHeader != "" {
-			authHash := sha256.Sum256([]byte(c.Config.AuthHeader()))
+			authHash := sha256.Sum256([]byte(authHeader))
 			key += "|auth=" + hex.EncodeToString(authHash[:8])
 		}
 		if c.Config.Path != "" {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1112,8 +1112,7 @@ func (s *Store) Status() (map[string]int, error) {
 //
 // json_extract path components cannot be bound as SQL parameters, so each
 // field is validated against validIdentifierRE before being spliced into
-// the query. Fields that fail validation are skipped so callers may pass
-// untrusted strings without risk.
+// the query.
 func (s *Store) ResolveByName(resourceType string, input string, matchFields ...string) (string, error) {
 	if IsUUID(input) {
 		return input, nil

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1109,6 +1109,11 @@ func (s *Store) Status() (map[string]int, error) {
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").
+//
+// json_extract path components cannot be bound as SQL parameters, so each
+// field is validated against validIdentifierRE before being spliced into
+// the query. Fields that fail validation are skipped so callers may pass
+// untrusted strings without risk.
 func (s *Store) ResolveByName(resourceType string, input string, matchFields ...string) (string, error) {
 	if IsUUID(input) {
 		return input, nil
@@ -1116,6 +1121,9 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 
 	var matches []string
 	for _, field := range matchFields {
+		if !validIdentifierRE.MatchString(field) {
+			continue
+		}
 		query := fmt.Sprintf(
 			`SELECT id FROM resources WHERE resource_type = ? AND LOWER(json_extract(data, '$.%s')) = LOWER(?)`,
 			field,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -190,7 +190,7 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	if c.Config != nil {
 		key += "|auth_source=" + c.Config.AuthSource
 		if authHeader := c.Config.AuthHeader(); authHeader != "" {
-			authHash := sha256.Sum256([]byte(c.Config.AuthHeader()))
+			authHash := sha256.Sum256([]byte(authHeader))
 			key += "|auth=" + hex.EncodeToString(authHash[:8])
 		}
 		if c.Config.Path != "" {


### PR DESCRIPTION
## Intent

Close two remaining template-level findings from [Greptile's review of printing-press-library#416](https://github.com/mvanhorn/printing-press-library/pull/416). The first finding from that review (`ListIDs` SQL injection) was already closed by #1000; this PR finishes the other two so the next regen of any printed CLI doesn't overwrite the in-CLI patch.

Issue: Refs https://github.com/mvanhorn/cli-printing-press/issues/1249

Finding #4 from the issue thread (eval `--dataset` default path) is out of scope — there's no eval template in the generator (`internal/generator/templates/internal/cli/eval.go.tmpl` does not exist); eval in uk-train-goat is a hand-written novel command, not a generator-emitted one.

## Approach

**`store.go.tmpl` ResolveByName.** `json_extract` path components cannot be bound as SQL parameters, so the existing `fmt.Sprintf("$.%s", field)` splice is structurally required. Validate each `field` against `validIdentifierRE` (the same regex `ListField` already uses ~110 lines above) and `continue` past invalid entries. Same defense pattern, no new regex, no new helper.

**`client.go.tmpl` cacheKey.** The block already captured `authHeader := c.Config.AuthHeader()` for the empty check, then called `AuthHeader()` a second time to feed `sha256.Sum256`. Reuse the captured variable. Pure dedupe; no behavior change.

## Scope

Primary area: `internal/generator/templates/store.go.tmpl`, `internal/generator/templates/client.go.tmpl`.

Why this belongs in this repo: per AGENTS.md "Default to machine changes." Both flaws live in templates that ship with every printed CLI. The in-CLI patch in [printing-press-library@1c4d54f](https://github.com/mvanhorn/printing-press-library/commit/1c4d54f) closed it for uk-train-goat only and would be overwritten on next regen.

## Risk

**Behavior preserved.**
- `ResolveByName`: existing callers pass schema-controlled field names like `"name"`, `"key"`, `"email"` — all match `validIdentifierRE`. A current caller passing an unsafe field hits the `continue` (same as if no rows matched), so the function still returns the existing "not found" error rather than panicking.
- `cacheKey`: `authHeader` is the immediate return of `AuthHeader()`; no rotation can happen between the two calls in single-threaded request setup. The dedupe is a pure no-op behaviorally.

Backfill against the public library: every CLI in the public library still ships the old templates until natural regen cadence picks them up.

## Output Contract

Four golden fixtures pick up the template changes:
- 3 client.go fixtures gain the `authHeader` reuse.
- 1 store.go fixture (`sync-walker-golden`) gains the `validIdentifierRE` guard and its 4-line doc comment.

Diffs are exactly the patch shape and nothing else — confirmed via `scripts/golden.sh verify` before update.

## Verification

- `go build -o ./printing-press ./cmd/printing-press` — pass
- `go vet ./...` — pass
- `go test ./...` — 3905 pass, 0 fail
- `golangci-lint run ./...` — pass
- `scripts/golden.sh verify` — 17/17 pass
- `git diff --check` — clean

Regression coverage:
- Updated `TestClientCacheKeyScopesByBaseURLAndAuthIdentity` to assert the captured-reuse pattern and forbid the double-call pattern.
- Added `TestStoreResolveByNameValidatesField` to pin the `validIdentifierRE` guard on the json_extract splice.
- Both tests fail on the pre-fix templates.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change