### PR TITLE
fix(cli): hide const-default query flags from --help

### DIFF
--- a/internal/generator/const_default_test.go
+++ b/internal/generator/const_default_test.go
@@ -33,6 +33,21 @@ func TestParamIsConstDefault(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "single-value enum with matching float default preserving fractional form",
+			p:    spec.Param{Name: "version", Type: "number", Enum: []string{"2.0"}, Default: float64(2.0)},
+			want: true,
+		},
+		{
+			name: "single-value enum with matching float default carrying real fraction",
+			p:    spec.Param{Name: "ratio", Type: "number", Enum: []string{"1.5"}, Default: float64(1.5)},
+			want: true,
+		},
+		{
+			name: "single-value float enum that does not match the default",
+			p:    spec.Param{Name: "ratio", Type: "number", Enum: []string{"1.5"}, Default: float64(2.5)},
+			want: false,
+		},
+		{
 			name: "single-value enum with mismatched default is not const",
 			p:    spec.Param{Name: "Command", Type: "string", Enum: []string{"a"}, Default: "b"},
 			want: false,

--- a/internal/generator/const_default_test.go
+++ b/internal/generator/const_default_test.go
@@ -1,0 +1,156 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParamIsConstDefault(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		p    spec.Param
+		want bool
+	}{
+		{
+			name: "single-value enum with matching string default",
+			p:    spec.Param{Name: "Command", Type: "string", Enum: []string{"namecheap.domains.getList"}, Default: "namecheap.domains.getList"},
+			want: true,
+		},
+		{
+			name: "single-value enum with matching integer default",
+			p:    spec.Param{Name: "version", Type: "integer", Enum: []string{"2"}, Default: 2},
+			want: true,
+		},
+		{
+			name: "single-value enum with matching boolean default",
+			p:    spec.Param{Name: "strict", Type: "boolean", Enum: []string{"true"}, Default: true},
+			want: true,
+		},
+		{
+			name: "single-value enum with mismatched default is not const",
+			p:    spec.Param{Name: "Command", Type: "string", Enum: []string{"a"}, Default: "b"},
+			want: false,
+		},
+		{
+			name: "multi-value enum with matching default is not const",
+			p:    spec.Param{Name: "order", Type: "string", Enum: []string{"asc", "desc"}, Default: "asc"},
+			want: false,
+		},
+		{
+			name: "single-value enum with no default is not const",
+			p:    spec.Param{Name: "Command", Type: "string", Enum: []string{"namecheap.x"}},
+			want: false,
+		},
+		{
+			name: "no enum but default is not const",
+			p:    spec.Param{Name: "limit", Type: "integer", Default: 25},
+			want: false,
+		},
+		{
+			name: "no enum and no default is not const",
+			p:    spec.Param{Name: "name", Type: "string"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, paramIsConstDefault(tt.p))
+		})
+	}
+}
+
+// TestGenerateMarksConstDefaultFlagsHidden is the end-to-end check that
+// when an endpoint Param has a single-value enum whose only value equals
+// the default, the generated command registers the flag (so the wire-side
+// default still flows) but marks it hidden so --help does not list a flag
+// whose only valid value is the default. This is the single-URL routing
+// API shape, where an operation is selected via a fixed query param.
+func TestGenerateMarksConstDefaultFlagsHidden(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("const-default")
+	constParam := spec.Param{
+		Name:        "Command",
+		Type:        "string",
+		Description: "Constant operation selector",
+		Required:    true,
+		Enum:        []string{"namecheap.domains.getList"},
+		Default:     "namecheap.domains.getList",
+	}
+	multiEnumParam := spec.Param{
+		Name:        "SortBy",
+		Type:        "string",
+		Description: "Sort field",
+		Enum:        []string{"name", "created"},
+		Default:     "name",
+	}
+
+	apiSpec.Resources["domains"] = spec.Resource{
+		Description: "Manage domains",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/",
+				Description: "List domains",
+				Params:      []spec.Param{constParam, multiEnumParam},
+			},
+			"renew": {
+				Method:      "POST",
+				Path:        "/",
+				Description: "Renew a domain",
+				Params:      []spec.Param{constParam},
+			},
+		},
+	}
+	apiSpec.Resources["dns"] = spec.Resource{
+		Description: "Manage DNS",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/",
+				Description: "List DNS records",
+				Params:      []spec.Param{constParam},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "const-default-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+
+	endpointSrc, err := os.ReadFile(filepath.Join(cliDir, "domains_list.go"))
+	require.NoError(t, err)
+	endpointGot := string(endpointSrc)
+
+	require.Contains(t, endpointGot, `cmd.Flags().StringVar(&flagCommand, "command",`,
+		"per-endpoint template: const-default flag must still be registered so its default is sent on the wire")
+	require.Contains(t, endpointGot, `_ = cmd.Flags().MarkHidden("command")`,
+		"per-endpoint template: const-default flag must be marked hidden")
+	require.Contains(t, endpointGot, `cmd.Flags().StringVar(&flagSortBy, "sort-by",`,
+		"per-endpoint template: multi-value-enum flag must remain visible")
+	require.NotContains(t, endpointGot, `_ = cmd.Flags().MarkHidden("sort-by")`,
+		"per-endpoint template: multi-value-enum flag must not be marked hidden")
+	// A required flag with a wired default never needs a runtime "required flag not set"
+	// check — the template gates that emission on `(not .Default)`. Lock that interaction
+	// so a future template edit re-enabling the check for Required:true would not produce
+	// a generated binary that errors at runtime on a hidden const-default flag.
+	require.NotContains(t, endpointGot, `required flag "command" not set`,
+		"per-endpoint template: required-check must be suppressed for const-default (Default is set)")
+
+	promotedSrc, err := os.ReadFile(filepath.Join(cliDir, "promoted_dns.go"))
+	require.NoError(t, err)
+	promotedGot := string(promotedSrc)
+
+	require.Contains(t, promotedGot, `cmd.Flags().StringVar(&flagCommand, "command",`,
+		"promoted template: const-default flag must still be registered so its default is sent on the wire")
+	require.Contains(t, promotedGot, `_ = cmd.Flags().MarkHidden("command")`,
+		"promoted template: const-default flag must be marked hidden")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3080,7 +3080,26 @@ func paramIsConstDefault(p spec.Param) bool {
 	if len(p.Enum) != 1 || p.Default == nil {
 		return false
 	}
-	return fmt.Sprintf("%v", p.Default) == p.Enum[0]
+	// Float defaults round-trip ambiguously under any single string format:
+	// fmt.Sprintf("%v", float64(2.0)) and strconv.FormatFloat with -1
+	// precision both yield "2", which would miss a heterogeneous spec
+	// declaring `enum: ["2.0"]` alongside `default: 2.0`. Parse the enum
+	// element as a float and compare numerically so "2", "2.0", and "2.00"
+	// are all equivalent to float64(2.0).
+	switch v := p.Default.(type) {
+	case float64:
+		if enumF, err := strconv.ParseFloat(p.Enum[0], 64); err == nil {
+			return enumF == v
+		}
+		return false
+	case float32:
+		if enumF, err := strconv.ParseFloat(p.Enum[0], 32); err == nil {
+			return float32(enumF) == v
+		}
+		return false
+	default:
+		return fmt.Sprintf("%v", p.Default) == p.Enum[0]
+	}
 }
 
 type jsonFlagSuggestion struct {
@@ -3372,6 +3391,13 @@ func renderBodyFlagRegs(b *strings.Builder, body []spec.Param, identPrefix, flag
 	}
 }
 
+// renderFlatBodyFlagReg emits cobra flag registrations for a single body
+// param. Const-default detection via paramIsConstDefault is intentionally
+// not wired through here yet: the primary use case is the query-param
+// routing-selector shape, not body fields. If a future API surfaces a
+// const-default body field, extend the emission here with a MarkHidden
+// line gated by paramIsConstDefault, mirroring the command_endpoint and
+// command_promoted templates.
 func renderFlatBodyFlagReg(b *strings.Builder, p spec.Param, identPrefix, flagPrefix string, topLevel bool) {
 	ident := identPrefix + toCamel(paramIdent(p))
 	flag := joinFlag(flagPrefix, publicFlagName(p))

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -209,6 +209,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"cobraFlagFuncForParam": cobraFlagFuncForParam,
 		"defaultVal":            defaultVal,
 		"defaultValForParam":    defaultValForParam,
+		"isConstDefault":        paramIsConstDefault,
 		"zeroVal":               zeroVal,
 		"zeroValForParam": func(name, t string) string {
 			kind := primitiveKind(t)
@@ -3067,6 +3068,19 @@ func defaultValForParam(p spec.Param) string {
 		return `""`
 	}
 	return defaultVal(p)
+}
+
+// paramIsConstDefault holds for single-value-enum params whose default
+// equals the only enum value. Templates emit MarkHidden for these so
+// --help does not list a flag whose only valid value is the default,
+// while the flag stays registered so the wire-side default still flows.
+// This catches the single-URL routing-selector shape, where an API
+// selects an operation via a fixed query param.
+func paramIsConstDefault(p spec.Param) bool {
+	if len(p.Enum) != 1 || p.Default == nil {
+		return false
+	}
+	return fmt.Sprintf("%v", p.Default) == p.Enum[0]
 }
 
 type jsonFlagSuggestion struct {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -566,6 +566,9 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- if not .Positional}}
 {{- $param := .}}
 	cmd.Flags().{{cobraFlagFuncForParam .Name .Type}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", {{defaultValForParam .}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
+{{- if isConstDefault .}}
+	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
+{{- end}}
 {{- range publicFlagAliases $param}}
 	cmd.Flags().{{cobraFlagFuncForParam $param.Name $param.Type}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParam $param}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
 	_ = cmd.Flags().MarkHidden("{{.}}")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -282,6 +282,9 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if not .Positional}}
 {{- $param := .}}
 	cmd.Flags().{{cobraFlagFuncForParam .Name .Type}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", {{defaultValForParam .}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
+{{- if isConstDefault .}}
+	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
+{{- end}}
 {{- range publicFlagAliases $param}}
 	cmd.Flags().{{cobraFlagFuncForParam $param.Name $param.Type}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParam $param}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
 	_ = cmd.Flags().MarkHidden("{{.}}")


### PR DESCRIPTION
## Intent

Const-default query params — single-value enum with matching default, the canonical case being single-URL routing APIs like Namecheap (`Command=namecheap.X.Y`) — were rendered as visible `--help` flags whose only valid value is the default. Users see and could mis-override them.

Issue: Closes #1273

## Approach

Adds `paramIsConstDefault(p spec.Param)` returning true when the param has a single enum value that equals its default. Both `command_endpoint.go.tmpl` and `command_promoted.go.tmpl` emit `_ = cmd.Flags().MarkHidden("<flag>")` after the StringVar registration when the helper holds. The flag stays registered so the wire-side default flows; only `--help` visibility changes.

## Scope

Primary area: generator (machine, not printed-CLI fix).

Why this belongs in this repo: the symptom is in every printed CLI that consumes a spec with this shape. The generator owns flag emission, so the fix raises the floor for all future prints (and for regen of existing CLIs).

## Risk

- **MCP surface (cobratree shell-out tools):** the cobratree walker's `addFlag` short-circuits on `flag.Hidden`, so hidden const-default flags drop from MCP input schemas. This is correct — agents have no alternate value to set; the registered default still flows on the wire. Typed endpoint tools generated from spec params (`pp:endpoint`) are unaffected.
- **Required-check interaction:** the existing template gate `(not .Default)` already suppresses the required-flag check when a default is set. The new test asserts this explicitly so a future template edit cannot silently re-enable it on a hidden flag.
- **Override path:** users who know the hidden flag name can still pass `--command=other`. The existing enum-validation block warns to stderr but does not error — pre-existing behavior, unchanged.

## Output Contract

Templates changed; new branch emits `_ = cmd.Flags().MarkHidden("<flag>")` only when `isConstDefault` holds. No existing golden fixture has a const-default param, so `scripts/golden.sh verify` (17 cases) is unchanged. The end-to-end generator test in this PR runs the real generator against a fresh spec and asserts MarkHidden emission across both template paths — narrower and less churn-prone than a new golden fixture would be. Documenting this as the explicit AGENTS.md "Generator Output Stability" decision: covered by e2e test; no fixture added.

## Verification

- `go test ./...` -- 3914 passed
- `go vet ./...` -- clean
- `golangci-lint run ./...` -- clean
- `go fmt ./...` -- clean
- `scripts/golden.sh verify` -- 17/17 passed
- `go build -o ./printing-press ./cmd/printing-press && ./printing-press version` -- builds, runs

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change