### PR TITLE
fix(skills): extend retro pre-upload scrub with jurisdiction-specific PII patterns

### DIFF
--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -183,6 +183,9 @@ After all layers complete, do a final scan for obvious leaks:
 ```bash
 FINAL_CHECK=false
 CRED_REGEX='(sk_live_|sk_test_|ghp_|gho_|Bearer [A-Za-z0-9]{20})'
+# PII_REGEX must mirror the shapes in PII_PATTERNS above; update both together
+# (e.g. when adding Partita IVA with an allowlist) so the verification step
+# does not silently stop checking a shape the scrub loop still redacts.
 PII_REGEX='(\b[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]\b|\b(AD|AT|BE|BG|CH|CY|CZ|DE|DK|EE|ES|FI|FR|GB|GI|GR|HR|HU|IE|IS|IT|LI|LT|LU|LV|MC|MT|NL|NO|PL|PT|RO|SE|SI|SK|SM|VA)[0-9]{2}[A-Z0-9]{11,30}\b|\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b)'
 for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
   [ -d "$dir" ] || continue

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -99,8 +99,9 @@ for entry in "${PII_PATTERNS[@]}"; do
   for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
     [ -d "$dir" ] || continue
     find "$dir" -type f -print0 | while IFS= read -r -d '' f; do
-      if grep -qE "$regex" "$f" 2>/dev/null; then
-        perl -i -pe "s/$regex/$tag/g" "$f" 2>/dev/null
+      # Case-insensitive: API JSON routinely lowercases IBANs and other identifiers.
+      if grep -qiE "$regex" "$f" 2>/dev/null; then
+        perl -i -pe "s/$regex/$tag/gi" "$f" 2>/dev/null
         echo "Redacted $name in $(basename "$f")"
       fi
     done
@@ -186,7 +187,7 @@ PII_REGEX='(\b[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]\b|\b(AD|AT|BE|BG|C
 for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
   [ -d "$dir" ] || continue
   CRED_MATCHES=$(grep -rEi "$CRED_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
-  PII_MATCHES=$(grep -rE "$PII_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
+  PII_MATCHES=$(grep -rEi "$PII_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
   if [ -n "$CRED_MATCHES" ] || [ -n "$PII_MATCHES" ]; then
     [ -n "$CRED_MATCHES" ] && echo "$CRED_MATCHES"
     [ -n "$PII_MATCHES" ] && echo "$PII_MATCHES"

--- a/skills/printing-press-retro/references/secret-scrubbing.md
+++ b/skills/printing-press-retro/references/secret-scrubbing.md
@@ -76,6 +76,50 @@ for entry in "${PATTERNS[@]}"; do
 done
 ```
 
+### Jurisdiction-specific PII scanning
+
+Live-API responses captured during browser-sniff or live-key dogfood routinely
+include identifying data of the data subject and any third parties the API
+surfaced. These patterns redact common high-confidence shapes before upload.
+They are defense-in-depth, not bulletproof — free-form names, descriptive
+fields, and unenumerated jurisdictions still slip through.
+
+The `|` field separator collides with the `(IT|DE|...)` country-code
+alternation in the IBAN regex, so PII patterns use `~` as the field separator.
+
+```bash
+PII_PATTERNS=(
+  'codice-fiscale~\b[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]\b~<REDACTED:pii-codice-fiscale>'
+  'eu-iban~\b(AD|AT|BE|BG|CH|CY|CZ|DE|DK|EE|ES|FI|FR|GB|GI|GR|HR|HU|IE|IS|IT|LI|LT|LU|LV|MC|MT|NL|NO|PL|PT|RO|SE|SI|SK|SM|VA)[0-9]{2}[A-Z0-9]{11,30}\b~<REDACTED:pii-eu-iban>'
+  'us-ssn~\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b~<REDACTED:pii-us-ssn>'
+)
+
+for entry in "${PII_PATTERNS[@]}"; do
+  IFS='~' read -r name regex tag <<< "$entry"
+  for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
+    [ -d "$dir" ] || continue
+    find "$dir" -type f -print0 | while IFS= read -r -d '' f; do
+      if grep -qE "$regex" "$f" 2>/dev/null; then
+        perl -i -pe "s/$regex/$tag/g" "$f" 2>/dev/null
+        echo "Redacted $name in $(basename "$f")"
+      fi
+    done
+  done
+done
+```
+
+Pattern notes:
+
+- **Codice Fiscale** (Italian tax code) is a 16-character `LLLLLLDDLDDLDDDL` shape with no plausible collision against ordinary text.
+- **EU IBAN** is anchored to the SEPA country-code prefix list, so the broad `[A-Z0-9]{11,30}` body cannot match a generic phone number, order ID, or vendor SKU.
+- **US SSN** uses the `DDD-DD-DDDD` dashed form, which avoids collisions with bare 9-digit runs in other identifiers.
+
+Out of scope (deferred to follow-up work):
+
+- Bare 11-digit Partita IVA / VAT numbers (false-positive rate against order IDs, phone numbers, and timestamps is too high without an allowlist).
+- Free-form residential addresses (not regex-matchable with acceptable precision).
+- Refusing upload when `discovery/sample-*.json` files are present (a separate gate at the staging-copy step, tracked separately).
+
 ### Env var assignment scanning
 
 Separately scan for hardcoded secret assignments in source code:
@@ -137,16 +181,20 @@ After all layers complete, do a final scan for obvious leaks:
 
 ```bash
 FINAL_CHECK=false
+CRED_REGEX='(sk_live_|sk_test_|ghp_|gho_|Bearer [A-Za-z0-9]{20})'
+PII_REGEX='(\b[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]\b|\b(AD|AT|BE|BG|CH|CY|CZ|DE|DK|EE|ES|FI|FR|GB|GI|GR|HR|HU|IE|IS|IT|LI|LT|LU|LV|MC|MT|NL|NO|PL|PT|RO|SE|SI|SK|SM|VA)[0-9]{2}[A-Z0-9]{11,30}\b|\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b)'
 for dir in "$STAGING_MANUSCRIPTS" "$STAGING_CLI_SOURCE"; do
   [ -d "$dir" ] || continue
-  MATCHES=$(grep -rEi '(sk_live_|sk_test_|ghp_|gho_|Bearer [A-Za-z0-9]{20})' "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
-  if [ -n "$MATCHES" ]; then
-    echo "$MATCHES"
+  CRED_MATCHES=$(grep -rEi "$CRED_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
+  PII_MATCHES=$(grep -rE "$PII_REGEX" "$dir" 2>/dev/null | grep -v 'REDACTED' | head -5)
+  if [ -n "$CRED_MATCHES" ] || [ -n "$PII_MATCHES" ]; then
+    [ -n "$CRED_MATCHES" ] && echo "$CRED_MATCHES"
+    [ -n "$PII_MATCHES" ] && echo "$PII_MATCHES"
     FINAL_CHECK=true
   fi
 done
 if [ "$FINAL_CHECK" = true ]; then
-  echo "WARNING: Potential secrets still found after scrubbing. Review the matches above."
+  echo "WARNING: Potential secrets or PII still found after scrubbing. Review the matches above."
   echo "Artifacts will NOT be uploaded until this is resolved."
 fi
 ```


### PR DESCRIPTION
## Intent

Issue: Refs #1291

The retro skill's Phase 6 pre-upload scrub in `skills/printing-press-retro/references/secret-scrubbing.md` was US-token-only (`sk_live_`, `ghp_`, `Bearer`, JWT). Live-API responses captured during browser-sniff or live-key dogfood routinely carry jurisdiction-specific identity numbers that match none of those patterns, which is how a real Italian-fiscal-data leak (Codice Fiscale, IBAN, Partita IVA, residential address) reached a public catbox URL linked from a public GitHub issue before any human review.

## Approach

Direction A from the issue: add a `Jurisdiction-specific PII scanning` subsection to Layer 2 covering three high-confidence shapes:

- **Italian Codice Fiscale** — fixed 16-char `LLLLLLDDLDDLDDDL` form; no plausible collision with ordinary text.
- **EU IBAN** — anchored to the SEPA country-code prefix list (`AD|AT|BE|...|VA`), so the broad `[A-Z0-9]{11,30}` body can't match phone numbers, order IDs, or vendor SKUs.
- **US SSN** — dashed `DDD-DD-DDDD` form.

The new array uses `~` as its field separator because the IBAN regex needs `|` for the country-code alternation. Post-scrub verification is extended in lockstep so PII shapes that slip past Layer 2 still surface and block the upload step.

Directions B (refuse-upload gate on `discovery/sample-*.json`) and C (content-summary confirm prompt) from the issue are explicitly deferred and called out as out-of-scope in the doc.

## Risk

Skill-only change. No Go code, generator templates, manifests, or golden fixtures are touched. The PII redaction step is gated on its own regex matches, so the worst credible regression is a false-positive redaction of a string that happens to match one of the three shapes — bounded by the country-code prefix on IBAN and the dashed form on SSN.

## Verification

- Smoke-tested all three regex shapes end-to-end against a sample JSON containing the issue's acceptance values (`AAAAAA00A00A000A`, `IT00X0000000000000000000000`, `123-45-6789`) plus a phone-shaped digit run that must survive: all three redact, phone is preserved.
- `go fmt ./...`, `go build ./...`, `go vet ./...`, `go test ./...` (3885 pass), `golangci-lint run ./...`, `scripts/golden.sh verify` (17 cases pass), `git diff --check`.