### PR TITLE
chore(ci): raise mergify batch_size and add queue safety knobs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,7 +11,9 @@ queue_rules:
       - check-success = test
     merge_method: squash
     update_method: rebase
-    batch_size: 1
+    batch_size: 3
+    speculative_checks: 2
+    checks_timeout: 60m
 
 merge_queue:
   queued_label: queued

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,10 +12,10 @@ queue_rules:
     merge_method: squash
     update_method: rebase
     batch_size: 3
-    speculative_checks: 2
     checks_timeout: 60m
 
 merge_queue:
+  max_parallel_checks: 2
   queued_label: queued
   dequeued_label: dequeued
   status_comments: outcomes


### PR DESCRIPTION
## Intent

The Mergify merge queue had been serializing ~8 ready-to-merge PRs through `batch_size: 1`. Head-of-queue PR #1278 sat for ~7.5 hours despite all required checks reporting green, and 5 throwaway embark/speculative PRs (#1281, #1283, #1286, #1290, #1299) accumulated open as the queue grew the train (1→5 PRs) without draining.

Issue: N/A

## Approach

Three knobs on the `default` queue rule:

- `batch_size: 1 → 3` — merge up to 3 ready PRs together per CI run. ~3x drain rate in the all-green case; on failure, Mergify bisects (one extra batch run), which is cheap relative to the wait this is fixing.
- `speculative_checks: 2` — run the next batch's CI in parallel with the one currently merging, so the queue doesn't stall on the post-merge commit hop.
- `checks_timeout: 60m` — any required check that hasn't reported in 60 min is treated as failed and the PR is dequeued. Floor against the "Greptile / full-test hangs forever and the queue head sits all day" pattern.

Numbers chosen conservatively: `batch_size: 3` is the modest end of the safe range; `speculative_checks: 2` adds only one parallel CI run, not a fan-out; 60m is well above the observed p95 of the longest jobs (`full-test` ~10-15 min) so legitimate slow runs are not killed.

## Scope

Primary area: `ci`

Why this belongs in this repo: `.mergify.yml` is the only place these knobs live; it controls merge-queue behavior for `main`.

## Risk

- If a batch of 3 contains a flaky/failing PR, Mergify bisects — costs one extra CI run, no merge corruption.
- `speculative_checks: 2` ~doubles peak CI minute usage during a busy queue. Acceptable vs. the wall-clock cost it replaces.
- `checks_timeout: 60m` could theoretically dequeue a legitimately slow PR if CI gets pathologically slow; observed long jobs are well under this.
- No change to merge method (still `squash`), update method (still `rebase`), required checks, branch protections, or release-please pathway.

## Output Contract

N/A — no template, generator, manifest, or catalog change.

## Verification

- `git diff .mergify.yml` reviewed locally.
- Mergify config is YAML-validated by Mergify itself on push; no local linter to run.
- Not run: end-to-end queue behavior — only observable after merge, on the next batch of ready-to-merge PRs.

Before this lands, the 5 stale embark PRs (#1281, #1283, #1286, #1290, #1299) and possibly the queue head itself should be checked in the Mergify dashboard — if something upstream of CI duration is wedged, this config change alone won't unstick it.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change