### PR TITLE
chore(ci): require Greptile Review via Mergify, not branch protection

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,11 +15,15 @@ queue_rules:
         - check-skipped = Greptile Review
     merge_method: squash
     update_method: rebase
-    batch_size: 3
+    # OSS plan: batch_size must be 1 and max_parallel_checks must be 1 to
+    # stay in in-place mode. The draft `mergify/merge-queue/*` PR train
+    # (used when batch_size > 1 or max_parallel_checks > 1) is the paid
+    # "Merge Queue Batch" feature.
+    batch_size: 1
     checks_timeout: 60m
 
 merge_queue:
-  max_parallel_checks: 2
+  max_parallel_checks: 1
   queued_label: queued
   dequeued_label: dequeued
   status_comments: outcomes

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,10 @@ queue_rules:
       - check-success = golden
       - check-success = pr-title
       - check-success = test
+      - or:
+        - check-success = Greptile Review
+        - check-neutral = Greptile Review
+        - check-skipped = Greptile Review
     merge_method: squash
     update_method: rebase
     batch_size: 3
@@ -41,3 +45,7 @@ merge_protections:
       - check-success = golden
       - check-success = pr-title
       - check-success = test
+      - or:
+        - check-success = Greptile Review
+        - check-neutral = Greptile Review
+        - check-skipped = Greptile Review


### PR DESCRIPTION
## Intent

Restore "Greptile must pass before any code lands on main" as an enforced gate, but at the layer that can actually evaluate it.

Issue: N/A (paired with branch-protection change to remove `Greptile Review` from `main`'s required checks).

## Approach

Move Greptile from GitHub branch protection into `.mergify.yml`:

- Add `Greptile Review` (accepting `success`, `neutral`, or `skipped`) to `queue_rules.default.merge_conditions` — gates queue entry, evaluated against the source PR's head SHA where Greptile actually runs.
- Mirror the same predicate in `merge_protections.require-ready-label-and-ci.success_conditions` so the `Mergify Merge Protections` status check (which IS required in branch protection) fails when Greptile hasn't passed.

The `or` block (success/neutral/skipped) preserves the semantics the branch-protection rule had — Greptile may report `neutral` on PRs it deems trivial, and that still counts as "reviewed."

## Why the move

PR #1268 enabled Greptile as a required GitHub status check on `main`. Source PRs satisfied it fine, but Mergify's queue-train draft PRs (`mergify/merge-queue/*` branches) never received a Greptile check — Greptile's app skips bot-authored branches. GitHub branch protection enforces required checks on the *to-be-merged* SHA (the queue branch), so every queued PR sat `BLOCKED` after passing all its own CI. Head-of-queue #1280 was stuck ~9 hours and the queue grew a 5-PR speculative train (#1310–#1314) that never drained.

Mergify's `merge_conditions` and `success_conditions` are evaluated against the source PR, not the synthesized queue branch, so they don't have this problem. The other six required checks already live in `merge_conditions` and not in branch protection, which is why they don't hit this — Greptile is the only one we accidentally double-enforced.

## Scope

Primary area: `ci`. Single file, eight added lines (four lines × two locations).

No change to merge method, batch size, queue rules, release-please path, or any other gate. Generator/templates/skills untouched.

## Risk

- If Greptile fails to post a check at all (app outage), source PRs will sit in queue until Greptile recovers — same blast radius as the prior branch-protection setup, just with cleaner failure surface (queue-pending vs. merge-blocked).
- Branch protection on `main` no longer lists `Greptile Review`, so a hypothetical merge path that bypassed Mergify (admin override + direct push) would skip Greptile. The Mergify queue is the only sanctioned path, so this is theoretical.

## Output Contract

N/A — no template, generator, manifest, or catalog change.

## Verification

- `git diff .mergify.yml` — eight added lines, two locations, indentation aligned with surrounding `or` block (the `release-please` branch above uses the same shape).
- Mergify validates `.mergify.yml` server-side on push; no local linter.
- End-to-end behavior only observable post-merge on the next queued PR; existing queued PRs (#1278, #1279, #1280, #1285, #1287, #1300, #1301, #1302, #1306) have Greptile = success already, so they should embark normally.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change