### PR TITLE
chore(cli): ignore local AI agent instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ catalog/specs/*.graphql
 library/
 dist/
 claude-upgrade-progress.json
+
+# Local AI agent instructions (not for sharing)
+CLAUDE.local.md
+AGENTS.override.md
+.claude/settings.local.json


### PR DESCRIPTION
## Intent

Keep per-developer AI agent overrides out of commits. These files are local-only by convention, but nothing was stopping them from being staged.

## Approach

Add three entries to `.gitignore`:

- `CLAUDE.local.md`
- `AGENTS.override.md`
- `.claude/settings.local.json`

## Risk

None. No tracked files match these patterns.

## Verification

- `git status` clean after change
- `git check-ignore` would now match the three paths

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission