### PR TITLE
fix(ci): collapse Mergify two-step CI to enable in-place mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,14 @@
 queue_rules:
   - name: default
+    # Single condition block (no separate merge_conditions) so Mergify uses
+    # in-place mode instead of draft_pr mode. In-place mode rebases the
+    # source PR's branch directly; CI re-runs on the source PR where
+    # Greptile (and any other PR-only review apps) can actually post.
+    # The draft `mergify/merge-queue/*` mechanism creates bot-owned branches
+    # that Greptile skips, which was the root cause of every queued PR
+    # timing out waiting for Greptile.
     queue_conditions:
       - base = main
-    merge_conditions:
       - check-success = build-and-test
       - check-success = generated-test
       - check-success = go-lint
@@ -15,10 +21,7 @@ queue_rules:
         - check-skipped = Greptile Review
     merge_method: squash
     update_method: rebase
-    # OSS plan: batch_size must be 1 and max_parallel_checks must be 1 to
-    # stay in in-place mode. The draft `mergify/merge-queue/*` PR train
-    # (used when batch_size > 1 or max_parallel_checks > 1) is the paid
-    # "Merge Queue Batch" feature.
+    # OSS plan: batch_size and max_parallel_checks must both be 1.
     batch_size: 1
     checks_timeout: 60m
 


### PR DESCRIPTION
## Intent

Force Mergify into in-place mode so CI runs on the source PR (where Greptile posts) instead of synthesized \`mergify/merge-queue/*\` draft PRs (which Greptile skips).

Issue: every queued PR has been timing out at the 1h \`checks_timeout\` because Mergify keeps waiting for \`Greptile Review\` on bot branches that Greptile never reviews.

## Approach

Per Mergify's docs, in-place mode activates only when ALL of:
- \`batch_size: 1\` ✅ (already set)
- \`max_parallel_checks: 1\` ✅ (set in #1321)
- **no two-step CI configured** ← missing piece

"Two-step CI" means \`queue_conditions\` and \`merge_conditions\` are both defined and different. We had \`queue_conditions: [base = main]\` and \`merge_conditions: [six CI checks + Greptile]\`. Mergify saw the asymmetry and kept using \`draft_pr\` mode regardless of the batch knobs.

This PR collapses both blocks into a single \`queue_conditions\`. No more \`merge_conditions\`. Single condition set → single-step → in-place mode.

## Why the previous attempt didn't work

#1321's \`max_parallel_checks: 1\` was necessary but not sufficient. \`mergify queue show 1278\` still reported \`check_type: draft_pr\` after #1321 landed, which is what gave away the missing piece.

## Scope

- One file, eight lines of diff (mostly moving lines from one block to the other, plus an explanatory comment).
- No change to merge method, queue rule name, label automation, release-please path, or \`merge_protections.success_conditions\` (which still drives the \`Mergify Merge Protections\` required check on source PRs).

## Risk

- If a PR is queued before all its CI checks pass, it will get rejected at the queue gate instead of being queued and waiting. This is acceptable: \`auto_merge_conditions: [label = ready-to-merge]\` plus \`autoqueue\` semantics mean Mergify re-evaluates when checks complete, so the PR will queue automatically once green.
- In-place rebase force-pushes to the source PR's branch. This is what was happening before in the draft_pr path's "update phase" anyway; the only difference is the branch identity (source vs. bot). Authors should expect the rebase, same as before.
- No change to which checks gate merging. Greptile is still required.

## Output Contract

N/A — config-only change.

## Verification

- \`git diff .mergify.yml\` reviewed locally (8 lines added, 5 removed).
- Mergify validates \`.mergify.yml\` server-side on push.
- End-to-end only observable after merge, on the next queued PR.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change