### PR TITLE
fix(ci): exempt release-please PRs from Greptile review requirement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,6 +19,11 @@ queue_rules:
         - check-success = Greptile Review
         - check-neutral = Greptile Review
         - check-skipped = Greptile Review
+        # release-please PRs are auto-generated changelog + version bumps;
+        # Greptile reliably silent-skips them so no check-run is ever posted.
+        - and:
+          - head = release-please--branches--main
+          - "title ~= ^chore\\(main\\): release"
     merge_method: squash
     update_method: rebase
     # OSS plan: batch_size and max_parallel_checks must both be 1.
@@ -56,3 +61,8 @@ merge_protections:
         - check-success = Greptile Review
         - check-neutral = Greptile Review
         - check-skipped = Greptile Review
+        # release-please PRs are auto-generated changelog + version bumps;
+        # Greptile reliably silent-skips them so no check-run is ever posted.
+        - and:
+          - head = release-please--branches--main
+          - "title ~= ^chore\\(main\\): release"


### PR DESCRIPTION
## Summary

Stop Mergify from blocking release-please PRs forever because Greptile silently skipped them.

## Problem

The current `.mergify.yml` requires `Greptile Review` to be one of `check-success | check-neutral | check-skipped` for any PR against `main`, in both `queue_rules.queue_conditions` and `merge_protections.success_conditions`. All three conditions require the check-run to **exist** in some terminal state.

Greptile reliably silent-skips release-please PRs — it never creates a `Greptile Review` check-run at all. With no check-run, none of the three sub-conditions match, the `or` block fails, and the `Mergify Merge Protections` check sits `in_progress` indefinitely. mvanhorn/cli-printing-press#1261 is the latest example: every other gate (`build-and-test`, `generated-test`, `go-lint`, `golden`, `pr-title`, `test`) green, only Mergify pending.

## Fix

Add a fourth branch to each of the two Greptile `or` blocks: an `and:` clause matching release-please's head ref (`release-please--branches--main`) and title prefix (`chore(main): release …`). Mirrors the same exemption pattern already in `merge_protections.success_conditions` for the `ready-to-merge` label gate.

The other CI gates still apply to release PRs unchanged — only the Greptile requirement is relaxed for this PR class, since release-please PRs are auto-generated changelog + version-bump content where AI code review adds no signal.

## Test plan

- [ ] Land this PR.
- [ ] Next release-please PR (or a manual re-eval of #1261 after rebase) should clear Mergify Merge Protections without `@greptileai review` intervention.
- [ ] Non-release PRs still require the Greptile gate (verify by spot-checking the next normal PR's protections status).