### PR TITLE
fix(skills): correct install-internal-skills.sh path to repo skills/

### DIFF
--- a/.claude/scripts/install-internal-skills.sh
+++ b/.claude/scripts/install-internal-skills.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_SKILLS="$SCRIPT_DIR/../skills"
+REPO_SKILLS="$SCRIPT_DIR/../../skills"
 USER_SKILLS="$HOME/.claude/skills"
 
 if [ ! -d "$REPO_SKILLS" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,12 +192,11 @@ Why this matters: the publish skill enforces preflight checks (printer sentinel 
 If `/printing-press-publish` fails, fix the underlying issue (or report it as a machine bug) — do not bypass the skill to land a CLI-publish PR.
 
 ## Internal Skills
-`.claude/skills/` contains internal skills for developing the Printing Press itself (for example `printing-press-retro`). These load automatically when Claude Code is started from inside this repo.
-If you are running Claude Code from a different directory and need these skills available, install them globally:
+`skills/` at the repo root contains the Printing Press skills (for example `printing-press-retro`). To make them available to Claude Code regardless of working directory, install them globally:
 ```bash
 .claude/scripts/install-internal-skills.sh
 ```
-This copies the internal skills to `~/.claude/skills/`.
+This copies the skills to `~/.claude/skills/`.
 
 ## Skill Authoring
 When a machine change alters what an agent should do or what a command guarantees, update the relevant `SKILL.md` in the same change; do not leave the skill as a stale manual workaround for behavior the machine now owns.


### PR DESCRIPTION
## Intent

The installer documented in `AGENTS.md` aborts when run from a fresh clone because it resolves the skills directory to `<repo>/.claude/scripts/../skills` = `<repo>/.claude/skills/`, which does not exist in this repo. The actual skills live one level higher at top-level `skills/`.

Issue: Fixes #869

## Approach

One-character path fix in the script, plus a matching update to the `Internal Skills` section of `AGENTS.md` so its referenced location matches the repo's actual layout. Also drops the inaccurate "These load automatically when Claude Code is started from inside this repo" claim, since top-level `skills/` is not in Claude Code's auto-discovery path.

## Scope

Primary area: `skills` (setup contract)

Why this belongs in this repo: The broken script and the doc that references it are both shipped from this repo. Fixing both in the same change keeps the install contract internally consistent.

## Risk

Low. The script's behavior (recursive `cp -R` of each subdirectory into `~/.claude/skills/`) is unchanged. Smoke-tested locally by redirecting `$HOME` to a temp dir and confirming all 9 skills installed.

## Output Contract

N/A — no template, generator, manifest, scorecard, or catalog change.

## Verification

```
HOME=$(mktemp -d) .claude/scripts/install-internal-skills.sh
# -> "installed 9 skill(s) to /tmp/.../.claude/skills"
ls "$HOME/.claude/skills/"
# -> printing-press, printing-press-catalog, printing-press-import,
#    printing-press-output-review, printing-press-polish,
#    printing-press-publish, printing-press-reprint,
#    printing-press-retro, printing-press-score
```

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change