### PR TITLE
fix(cli): strip embedded .git/ and .gitmodules in pipeline.CopyDir

### DIFF
--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -553,6 +553,21 @@ func CopyDir(src, dst string) error {
 			return nil
 		}
 
+		// Drop git plumbing wherever it appears in the tree. A stray .git
+		// from `git init` in a working CLI dir, or a nested submodule, would
+		// otherwise be carried into the library and re-staged downstream as
+		// a submodule pointer when `git add` runs in the publish repo.
+		// .gitignore / .gitattributes are legitimate CLI content and stay.
+		if d.Name() == ".git" {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == ".gitmodules" {
+			return nil
+		}
+
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
 			return err

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -80,6 +80,78 @@ func TestCopyDir(t *testing.T) {
 	}
 }
 
+func TestCopyDirStripsGitPlumbing(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	// Top-level .git/ from a stray `git init` in a working CLI dir.
+	require.NoError(t, os.MkdirAll(filepath.Join(src, ".git", "objects", "pack"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".git", "objects", "pack", "pack-abc.idx"), []byte("idx"), 0o644))
+
+	// Nested .git/ (submodule).
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "vendor", "submod", ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "vendor", "submod", ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "vendor", "submod", "module.go"), []byte("package submod"), 0o644))
+
+	// .gitmodules at the root.
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".gitmodules"), []byte("[submodule \"submod\"]\n\tpath = vendor/submod\n"), 0o644))
+
+	// Legitimate CLI content that must be preserved.
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".gitignore"), []byte("/build\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, ".gitattributes"), []byte("* text=auto\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0o644))
+
+	require.NoError(t, CopyDir(src, dst))
+
+	assert.NoDirExists(t, filepath.Join(dst, ".git"))
+	assert.NoDirExists(t, filepath.Join(dst, "vendor", "submod", ".git"))
+	assert.NoFileExists(t, filepath.Join(dst, ".gitmodules"))
+
+	assert.FileExists(t, filepath.Join(dst, ".gitignore"))
+	assert.FileExists(t, filepath.Join(dst, ".gitattributes"))
+	assert.FileExists(t, filepath.Join(dst, "main.go"))
+	assert.FileExists(t, filepath.Join(dst, "vendor", "submod", "module.go"))
+}
+
+// A worktree-style ".git" can be a regular file pointing at the parent
+// gitdir, or a symlink pointing outside the source tree. CopyDir would
+// otherwise reject the symlink for escaping the source root, defeating the
+// strip. Both shapes must drop silently like the directory shape.
+func TestCopyDirStripsGitFileAndSymlink(t *testing.T) {
+	t.Run("git as regular file", func(t *testing.T) {
+		src := filepath.Join(t.TempDir(), "src")
+		dst := filepath.Join(t.TempDir(), "dst")
+		require.NoError(t, os.MkdirAll(src, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(src, ".git"), []byte("gitdir: /elsewhere\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0o644))
+
+		require.NoError(t, CopyDir(src, dst))
+
+		assert.NoFileExists(t, filepath.Join(dst, ".git"))
+		assert.FileExists(t, filepath.Join(dst, "main.go"))
+	})
+
+	t.Run("git as external symlink", func(t *testing.T) {
+		root := t.TempDir()
+		src := filepath.Join(root, "src")
+		dst := filepath.Join(root, "dst")
+		require.NoError(t, os.MkdirAll(src, 0o755))
+
+		outside := filepath.Join(root, "real-gitdir")
+		require.NoError(t, os.MkdirAll(outside, 0o755))
+		require.NoError(t, os.Symlink(outside, filepath.Join(src, ".git")))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0o644))
+
+		require.NoError(t, CopyDir(src, dst))
+
+		_, err := os.Lstat(filepath.Join(dst, ".git"))
+		assert.True(t, os.IsNotExist(err), "external .git symlink should be skipped, not copied or rejected")
+		assert.FileExists(t, filepath.Join(dst, "main.go"))
+	})
+}
+
 func TestCopyDirRejectsExternalSymlinks(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Intent

Closes #1304.

A stray `.git/` in the working CLI dir (from `git init` per codex-mode snapshots, or contributor experimentation) is carried verbatim through `lock promote` into the library and through `publish package` into the staging tree. When `git add library/<api>/` later runs in the publish repo's managed clone, the staged CLI registers as a submodule pointer (`Am`) instead of regular files, and the PR ships with no actual file diff. None of the existing publish gates (printer attribution, vendor-prefix scan, build, govulncheck) catch the submodule-pointer state.

## Approach

Filter at the choke point: `pipeline.CopyDir` now drops any `.git` entry (directory, file, or symlink) and any `.gitmodules` file, at any depth. `.gitignore` and `.gitattributes` stay — they're legitimate CLI content.

This covers all three current copy-out sites in one place — `Promote`, `PublishWorkingCLI`, and `publish package` — instead of duplicating a strip step at each caller. There's prior art for the same skip-name pattern in `internal/pipeline/regenmerge/helpers.go` (skips `.git`, `node_modules`, `vendor`, etc. during walks).

The git-as-symlink case matters because it would otherwise trip the existing `points outside source tree` rejection — silently skipping it is correct here since the contents shouldn't be copied either way.

## Scope

Primary area: `internal/pipeline/publish.go` (CopyDir choke point) + new tests in `internal/pipeline/publish_test.go`.

Why this belongs in this repo: this is the Printing Press generator/publisher behavior that ships every CLI through the library. A printed CLI can't fix this for itself.

## Risk

- All existing `CopyDir` callers (`Promote`, `PublishWorkingCLI`, `publish package`, `regenmerge`, manuscript copies, emboss) already shouldn't carry `.git/` — the change is additive and safer for every site.
- Existing `TestCopyDirRejectsExternalSymlinks` still passes; the new tests confirm the strip wins over the external-symlink rejection only for `.git` specifically.

## Output Contract

N/A — no changes to templates, generated files, manifests, or pipeline artifacts. `scripts/golden.sh verify` passes 18/18.

## Verification

- `go build -o ./printing-press ./cmd/printing-press` — green
- `go vet ./...` — green
- `go test ./...` — 3946 passed across 34 packages
- `go fmt ./...` — clean
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 18/18 passed
- New unit tests cover: top-level `.git/`, nested `.git/` (submodule shape), `.gitmodules`, `.git` as a regular file (worktree gitlink shape), `.git` as an external symlink, and the preservation of `.gitignore`/`.gitattributes`.