### PR TITLE
fix(cli): doctor preserves configured User-Agent when API uses UA as auth credential

### DIFF
--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -163,8 +163,8 @@ func TestDoctorPreservesConfiguredUserAgentWhenAuthInIsEmpty(t *testing.T) {
 
 	apiSpec := minimalSpec("ua-auth-empty-in")
 	apiSpec.Auth = spec.AuthConfig{
-		Type:       "api_key",
-		Header:     "User-Agent",
+		Type:   "api_key",
+		Header: "User-Agent",
 		// Auth.In intentionally left empty to exercise the default.
 		VerifyPath: "/alerts/active",
 		EnvVars:    []string{"UA_AUTH_EMPTY_IN_USER_AGENT"},

--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -89,3 +89,95 @@ func TestDoctorOAuth2PerCallRequiredEnvVarDefersToConfigAuth(t *testing.T) {
 			}`,
 		"per_call+Required env-var check must route missing-required through the authConfigured else chain, not as an unconditional append")
 }
+
+// TestDoctorPreservesConfiguredUserAgentWhenAuthHeaderIsUserAgent pins the
+// fix for the "User-Agent IS the auth credential" case. When the API spec
+// declares Auth.Header == "User-Agent" + Auth.In == "header" (e.g. the
+// weather.gov userAgent securityScheme), the credential-probe code path
+// must keep the user's configured UA on authHeaders["User-Agent"]; the
+// hardcoded "<name>-pp-cli" fallback must NOT emit, because it would
+// overwrite the operator's identity and make the probe test the wrong UA.
+func TestDoctorPreservesConfiguredUserAgentWhenAuthHeaderIsUserAgent(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("ua-auth-fixture")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:       "api_key",
+		Header:     "User-Agent",
+		In:         "header",
+		VerifyPath: "/alerts/active",
+		EnvVars:    []string{"UA_AUTH_FIXTURE_USER_AGENT"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "ua-auth-fixture-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctor := string(doctorSrc)
+
+	// The configured UA must be set on the probe.
+	require.Contains(t, doctor, `authHeaders["User-Agent"] = authHeader`,
+		"doctor probe must assign the configured UA (via authHeader) to authHeaders[\"User-Agent\"]")
+
+	// The hardcoded fallback must NOT clobber the configured UA.
+	require.NotContains(t, doctor, `authHeaders["User-Agent"] = "ua-auth-fixture-pp-cli"`,
+		"doctor must not overwrite authHeaders[\"User-Agent\"] with the hardcoded fallback when Auth.Header itself is User-Agent")
+}
+
+// TestDoctorEmitsHardcodedUserAgentForBearerAuthSpecs guards the converse:
+// when Auth.Header is Authorization (the common bearer case), the
+// hardcoded User-Agent fallback must still emit so the probe identifies
+// itself. This pins that the UA-preservation fix is scoped to the
+// UA-as-auth case and does not regress the default path.
+func TestDoctorEmitsHardcodedUserAgentForBearerAuthSpecs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-auth-fixture")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:       "bearer_token",
+		Header:     "Authorization",
+		VerifyPath: "/me",
+		EnvVars:    []string{"BEARER_AUTH_FIXTURE_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-auth-fixture-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctor := string(doctorSrc)
+
+	require.Contains(t, doctor, `authHeaders["User-Agent"] = "bearer-auth-fixture-pp-cli"`,
+		"doctor must continue to emit the hardcoded UA fallback for bearer-auth specs where the API does not use User-Agent itself as the credential")
+}
+
+// TestDoctorPreservesConfiguredUserAgentWhenAuthInIsEmpty pins the
+// default-Auth.In behaviour: when Auth.In is empty, the doctor template
+// treats it as the header-auth path (the query-auth branch is the
+// special case). The UA-preservation gate must trip on this default
+// too — otherwise a spec that omits Auth.In would silently regress.
+func TestDoctorPreservesConfiguredUserAgentWhenAuthInIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("ua-auth-empty-in")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:       "api_key",
+		Header:     "User-Agent",
+		// Auth.In intentionally left empty to exercise the default.
+		VerifyPath: "/alerts/active",
+		EnvVars:    []string{"UA_AUTH_EMPTY_IN_USER_AGENT"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "ua-auth-empty-in-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctor := string(doctorSrc)
+
+	require.Contains(t, doctor, `authHeaders["User-Agent"] = authHeader`,
+		"doctor probe must assign the configured UA when Auth.In is empty (defaults to header)")
+	require.NotContains(t, doctor, `authHeaders["User-Agent"] = "ua-auth-empty-in-pp-cli"`,
+		"doctor must not emit the hardcoded UA fallback when Auth.Header is User-Agent, even with Auth.In empty")
+}

--- a/internal/generator/doctor_auth_status_test.go
+++ b/internal/generator/doctor_auth_status_test.go
@@ -137,6 +137,7 @@ func TestDoctorEmitsHardcodedUserAgentForBearerAuthSpecs(t *testing.T) {
 	apiSpec.Auth = spec.AuthConfig{
 		Type:       "bearer_token",
 		Header:     "Authorization",
+		In:         "header",
 		VerifyPath: "/me",
 		EnvVars:    []string{"BEARER_AUTH_FIXTURE_TOKEN"},
 	}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -429,7 +429,20 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- range .RequiredHeaders}}
 						authHeaders["{{.Name}}"] = "{{.Value}}"
 {{- end}}
-{{- if and (not .UsesBrowserManagedUserAgent) (not (.HasRequiredHeader "User-Agent"))}}
+{{- /*
+	Emit the hardcoded User-Agent fallback only when no other code path has
+	already populated authHeaders["User-Agent"]. Three cases skip the fallback:
+	  1. UsesBrowserManagedUserAgent — the browser transport sets the UA.
+	  2. HasRequiredHeader "User-Agent" — the RequiredHeaders range above set it.
+	  3. Auth.In is "header" (or empty default) AND Auth.Header is "User-Agent" —
+	     the API uses the User-Agent header itself as the auth credential
+	     (NWS-style), so the "authHeaders[Auth.Header] = authHeader" line above
+	     already set it to the configured value. The hardcoded fallback would
+	     overwrite the operator's configured UA and make the credential probe
+	     test the wrong identity.
+*/}}
+{{- $authUsesUA := and .Auth (or (eq .Auth.In "") (eq .Auth.In "header")) (eq (lower .Auth.Header) "user-agent")}}
+{{- if and (not .UsesBrowserManagedUserAgent) (not (.HasRequiredHeader "User-Agent")) (not $authUsesUA)}}
 						authHeaders["User-Agent"] = "{{.Name}}-pp-cli"
 {{- end}}
 						_, authErr := c.GetWithHeaders(verifyPath, authParams, authHeaders)


### PR DESCRIPTION
## Intent

When an API spec declares its auth credential AS the `User-Agent` header (e.g. the weather.gov `userAgent` securityScheme: `Auth.Header == \"User-Agent\"`, `Auth.In == \"header\"`), the `doctor` template's credential-probe block emitted two consecutive assignments to the same map key:

```go
authHeaders[\"User-Agent\"] = authHeader              // configured UA
authHeaders[\"User-Agent\"] = \"<name>-pp-cli\"       // hardcoded fallback
```

The fallback unconditionally clobbered the operator's configured UA, so the credential probe tested the wrong identity. For NWS (api.weather.gov), the probe hit the API with the hardcoded \"<name>-pp-cli\" instead of the operator's contact-info UA, defeating the entire point of NWS's UA-based auth.

Surfaced by a Codex review of a generated NWS CLI on 2026-05-13.

Issue: N/A (machine-side fix to template emit)

## Approach

`internal/generator/templates/doctor.go.tmpl` gated the hardcoded User-Agent fallback (lines 432-434 on main) only on `.UsesBrowserManagedUserAgent` and `.HasRequiredHeader \"User-Agent\"`. It missed the case where the line just above — \`authHeaders[\"{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}\"] = authHeader\` — had already populated \`authHeaders[\"User-Agent\"]\` when the auth header IS \`User-Agent\`.

Fix: add a third skip condition. Compute \`\$authUsesUA\` = \`Auth.In\` is \`\"header\"\` (or empty, which defaults to header — the query-auth branch is the special case above) AND \`lower(Auth.Header) == \"user-agent\"\`. Skip the fallback when true.

The bearer-auth path (where \`Auth.Header\` is \`Authorization\`) is unaffected — the fallback still emits so the probe identifies itself when User-Agent isn't the credential.

## Scope

Primary area: \`internal/generator/templates/doctor.go.tmpl\` (machine, not printed-CLI)

Why this belongs in this repo: this is a template emit bug. Every API spec that uses User-Agent as its auth credential (NWS, similar contact-info-as-auth schemes) regenerates with the wrong probe identity. A printed-CLI patch would only fix one CLI; the generator change fixes every future regen of every UA-as-auth API.

## Risk

- **Scoped**: gate fires only when \`Auth.Header == \"User-Agent\"\` AND \`Auth.In\` is header (or empty default). Bearer/Authorization-header specs still emit the fallback (regression-tested).
- **No golden impact**: \`scripts/golden.sh verify\` passes; no existing fixture uses UA-as-auth.
- **No MCP/auth/catalog/publish/verifier/scorer surface changes**: doctor-only template change, behind a narrow guard.

## Output Contract

The hardcoded \`authHeaders[\"User-Agent\"] = \"<name>-pp-cli\"\` line in generated \`doctor.go\` files is suppressed for specs where \`Auth.Header\` is (case-insensitively) \`User-Agent\` and \`Auth.In\` is \`\"header\"\` or empty. Existing CLIs whose specs use any other auth header (Authorization, X-API-Key, etc.) emit unchanged.

## Verification

- \`go test ./internal/generator/... 2>&1 | tail -3\` -> \`ok ... 42.047s\`
- \`go test ./...\` -> all packages pass
- \`scripts/golden.sh verify\` -> \`Golden verify passed: 18 case(s).\`
- New tests in \`internal/generator/doctor_auth_status_test.go\`:
  - \`TestDoctorPreservesConfiguredUserAgentWhenAuthHeaderIsUserAgent\` — asserts the fallback line is suppressed and \`authHeaders[\"User-Agent\"] = authHeader\` survives when \`Auth.Header == \"User-Agent\"\` + \`Auth.In == \"header\"\`.
  - \`TestDoctorPreservesConfiguredUserAgentWhenAuthInIsEmpty\` — same with \`Auth.In\` left empty (default-header semantics).
  - \`TestDoctorEmitsHardcodedUserAgentForBearerAuthSpecs\` — regression guard: \`Authorization\`-header specs MUST still emit the hardcoded fallback so the probe identifies itself.
- Codex review of the patch: PASS (gating correct, default \`Auth.In\` handled, no other unguarded same-key UA overwrites in templates).
- Live test against a regenerated NWS CLI: \`gridpoints forecast gridpoint --wfo OKX 32 65\` returns a real forecast (bonus — also exercises the already-fixed positional-arg off-by-one in the existing #1211 fix).

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission