### PR TITLE
fix(cli): percent-encode path param values in replacePathParam

### DIFF
--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -1,0 +1,90 @@
+package generator
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplacePathParamPercentEncodesValue pins the helpers.go template so the
+// emitted replacePathParam routes the user-supplied value through
+// url.PathEscape before substituting it into the URL path. Without the escape,
+// values that contain path-reserved characters (e.g. "src/main.go" for the
+// GitHub Contents API or "https://example.com/" for Search Console's siteUrl)
+// silently produce malformed request URLs that 404 against the live API.
+//
+// We assert at the template-output level (helpers.go contains the escape call
+// and imports net/url) so the contract is checked once and every printed CLI
+// inherits the fix.
+func TestReplacePathParamPercentEncodesValue(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "encpath",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/encpath-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "GET",
+						Path:        "/v1/items/{itemId}",
+						Description: "Get an item",
+						Params: []spec.Param{
+							{Name: "itemId", Type: "string", Required: true, Positional: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	helpersPath := filepath.Join(outputDir, "internal", "cli", "helpers.go")
+	helpersGo, err := os.ReadFile(helpersPath)
+	require.NoError(t, err)
+	src := string(helpersGo)
+
+	assert.Contains(t, src, `"net/url"`,
+		"helpers.go must import net/url when replacePathParam is emitted")
+	assert.Contains(t, src,
+		`return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))`,
+		"replacePathParam must percent-encode the value via url.PathEscape so "+
+			"path-reserved characters (/, :, ?, #, space, %) don't produce a malformed URL")
+}
+
+// TestURLPathEscapeBehaviorPinsContract is a stdlib-behavior pin: if Go ever
+// changed url.PathEscape's encoding shape, every printed CLI's request URLs
+// would change too. We document the inputs the issue cited (opaque IDs round-
+// trip; slashes/colons encode) so a future stdlib regression is caught here
+// rather than in a live-API 404.
+func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"abc-123-def", "abc-123-def"},
+		{"2026-01-15", "2026-01-15"},
+		{"src/cli/main.go", "src%2Fcli%2Fmain.go"},
+		{"https://example.com/", "https:%2F%2Fexample.com%2F"},
+		{"sc-domain:example.com", "sc-domain:example.com"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, url.PathEscape(c.in), "input %q", c.in)
+	}
+}

--- a/internal/generator/path_param_encoding_test.go
+++ b/internal/generator/path_param_encoding_test.go
@@ -85,6 +85,9 @@ func TestURLPathEscapeBehaviorPinsContract(t *testing.T) {
 		{"sc-domain:example.com", "sc-domain:example.com"},
 	}
 	for _, c := range cases {
-		assert.Equal(t, c.want, url.PathEscape(c.in), "input %q", c.in)
+		t.Run(c.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, url.PathEscape(c.in))
+		})
 	}
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-{{- if .HasEmbeddedPaged}}
+{{- if or .HasEmbeddedPaged .HasPathParams}}
 	"net/url"
 {{- end}}
 	"os"
@@ -578,8 +578,10 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 }
 
 {{- if .HasPathParams}}
+// replacePathParam percent-encodes value so path-reserved characters in
+// user input do not collapse into extra path segments.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", value)
+	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
 }
 {{- end}}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -380,8 +380,11 @@ func truncate(s string, max int) string {
 func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
+
+// replacePathParam percent-encodes value so path-reserved characters in
+// user input do not collapse into extra path segments.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", value)
+	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
 }
 
 // paginatedGet fetches pages and concatenates array results. The headers

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"printing-press-golden-pp-cli/internal/client"
@@ -379,8 +380,11 @@ func truncate(s string, max int) string {
 func newTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
 }
+
+// replacePathParam percent-encodes value so path-reserved characters in
+// user input do not collapse into extra path segments.
 func replacePathParam(path, name, value string) string {
-	return strings.ReplaceAll(path, "{"+name+"}", value)
+	return strings.ReplaceAll(path, "{"+name+"}", url.PathEscape(value))
 }
 
 // paginatedGet fetches pages and concatenates array results. The headers


### PR DESCRIPTION
## Intent

Closes #1192.

Generated `helpers.go` substituted path-param values via a bare
`strings.ReplaceAll`, so any value containing a path-reserved character
(`/`, `:`, `?`, `#`, space, `%`) silently produced a malformed request URL.
The issue cites Search Console (`siteUrl` = `sc-domain:example.com` or
`https://example.com/`), GitHub Contents API (`{path}` = `src/cli/main.go`),
and GCS object names as concrete 404 cases.

## Approach

Route the value through `url.PathEscape` inside `replacePathParam`.
`PathEscape` is byte-identical for `[A-Za-z0-9-._~]` so opaque IDs,
dashed/dotted values, and dates round-trip unchanged; slashes encode to
`%2F` so a value can't collapse into extra path segments. Widen the
`net/url` import gate in `helpers.go.tmpl` so `HasPathParams` alone is
sufficient (it was previously gated only on `HasEmbeddedPaged`).

Option 2 from the issue (spec-driven `format: uri` → `url.QueryEscape`
for properties like Google's documented `siteUrl` shape) is out of scope
and tracked separately for follow-up.

## Scope

Primary area: generator (`internal/generator/templates/helpers.go.tmpl`).

Why this belongs in this repo: this template is emitted into every
printed CLI, so a generator fix retroactively unblocks every API whose
path params can contain a reserved character.

## Risk

Behavior change for every regenerated CLI: any future request URL that
substitutes a value through `replacePathParam` will now percent-encode
path-reserved characters in that value. The "no-op" set covers the
common shapes (UUIDs, alphanumeric SIDs, dates), so existing happy-path
calls are byte-identical. The risk surface is APIs whose router
*relies* on receiving an already-encoded or raw multi-segment value; the
linked issue confirms the Search Console / Contents / GCS families
break *without* encoding, so the net is correctness.

Not modified: `auth_browser.go.tmpl` cookie-path substitution and
query/header encoding (separate concerns called out in the issue's
scope boundary).

## Output Contract

Two golden cases under `testdata/golden/expected/` refresh:

- `generate-embedded-paged-api/.../helpers.go` — new `url.PathEscape`
  call site in `replacePathParam` (import already present via
  `HasEmbeddedPaged`).
- `generate-golden-api/.../helpers.go` — same call-site change plus a
  new `net/url` import (widened gate).

A new doc comment on `replacePathParam` documents the WHY. Every other
golden fixture is byte-identical.

## Verification

- `go build ./...`
- `go test ./...` (3948 passed, including new `TestReplacePathParamPercentEncodesValue` and `TestURLPathEscapeBehaviorPinsContract`)
- `go vet ./...`
- `gofmt -l` (clean)
- `golangci-lint run ./internal/generator/...` (no issues)
- `scripts/golden.sh verify` (18/18 pass after `update`)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission