### PR TITLE
fix(cli): drop shell line comments + skip happy_path on missing file fixtures

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -41,6 +41,7 @@ const reasonMutatingDryRunOnly = "mutating command dry-run only"
 const reasonMutatingErrorPath = "mutating command; error_path would call live API without --dry-run"
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
 const reasonUnavailableRunnerCredentials = "unavailable for runner credentials"
+const reasonFileFixtureRequired = "file fixture required"
 
 type LiveDogfoodOptions struct {
 	CLIDir              string
@@ -674,13 +675,20 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	mutating := liveDogfoodCommandMutates(command)
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
+	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
 	resolvedArgs, resolveSkipped, resolveReason := resolveCommandPositionals(command, happyArgs, ctx)
-	if resolveSkipped {
+	switch {
+	case fixtureSkip != "":
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, fixtureSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, fixtureSkip),
+		)
+	case resolveSkipped:
 		results = append(results,
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, resolveReason),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, resolveReason),
 		)
-	} else {
+	default:
 		happyArgs = resolvedArgs
 
 		runArgs := happyArgs
@@ -976,6 +984,66 @@ func endpointTargetsAuthResource(endpoint, path string) bool {
 	return slices.ContainsFunc(strings.Split(strings.ToLower(endpoint), "."), func(segment string) bool {
 		return destructiveAuthResources[segment]
 	})
+}
+
+// happyPathFileFixtureSkip returns a skip reason when the parsed Example
+// references a file-flag value that doesn't exist on disk relative to
+// cliDir. Flag names containing "file" or "csv" trigger the check; the
+// motivating cases are `--file accounts.csv` / `--csv prospects.csv` shapes
+// where the example would otherwise fail with `open <path>: no such file
+// or directory`, masking the signal that the command is callable.
+func happyPathFileFixtureSkip(args []string, cliDir string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(a, "--")
+		var value string
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			value = name[eq+1:]
+			name = name[:eq]
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			value = args[i+1]
+			i++
+		}
+		if !flagNameSuggestsFile(name) {
+			continue
+		}
+		if value == "" || strings.Contains(value, "://") {
+			continue
+		}
+		if fileExistsRelativeTo(value, cliDir) {
+			continue
+		}
+		return fmt.Sprintf("%s: --%s %s", reasonFileFixtureRequired, name, value)
+	}
+	return ""
+}
+
+func flagNameSuggestsFile(name string) bool {
+	n := strings.ToLower(name)
+	return strings.Contains(n, "file") || strings.Contains(n, "csv")
+}
+
+func fileExistsRelativeTo(p, cliDir string) bool {
+	if p == "" {
+		return false
+	}
+	if filepath.IsAbs(p) {
+		_, err := os.Stat(p)
+		return err == nil
+	}
+	candidates := []string{p}
+	if cliDir != "" {
+		candidates = append(candidates, filepath.Join(cliDir, p))
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1023,7 +1023,14 @@ func happyPathFileFixtureSkip(args []string, cliDir string) string {
 
 func flagNameSuggestsFile(name string) bool {
 	n := strings.ToLower(name)
-	return strings.Contains(n, "file") || strings.Contains(n, "csv")
+	if n == "file" || n == "csv" {
+		return true
+	}
+	// Anchor on a separator so `--profile` (contains "file") and similar
+	// non-file flags don't trigger spurious skips. Common shapes covered:
+	// `--input-file`, `--output_file`, `--import-csv`, `--config-csv`.
+	return strings.HasSuffix(n, "-file") || strings.HasSuffix(n, "_file") ||
+		strings.HasSuffix(n, "-csv") || strings.HasSuffix(n, "_csv")
 }
 
 func fileExistsRelativeTo(p, cliDir string) bool {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -166,6 +166,243 @@ func TestLiveDogfoodCommandMutatesPrefersEndpointMethod(t *testing.T) {
 	}))
 }
 
+func TestHappyPathFileFixtureSkip(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	existing := filepath.Join(cliDir, "fixture.csv")
+	require.NoError(t, os.WriteFile(existing, []byte("header\nvalue\n"), 0o600))
+
+	cases := []struct {
+		name       string
+		args       []string
+		wantSkip   bool
+		wantPrefix string
+	}{
+		{
+			name:     "no file flag",
+			args:     []string{"sync", "--limit", "5"},
+			wantSkip: false,
+		},
+		{
+			name:       "missing csv fixture",
+			args:       []string{"vet", "--csv", "prospects.csv"},
+			wantSkip:   true,
+			wantPrefix: "file fixture required: --csv prospects.csv",
+		},
+		{
+			name:       "missing file fixture",
+			args:       []string{"import-csv", "--file", "accounts.csv"},
+			wantSkip:   true,
+			wantPrefix: "file fixture required: --file accounts.csv",
+		},
+		{
+			name:       "missing fixture via --flag=value form",
+			args:       []string{"import-csv", "--file=accounts.csv"},
+			wantSkip:   true,
+			wantPrefix: "file fixture required: --file accounts.csv",
+		},
+		{
+			name:     "existing fixture in cliDir",
+			args:     []string{"vet", "--csv", "fixture.csv"},
+			wantSkip: false,
+		},
+		{
+			name:     "URL value does not trigger skip",
+			args:     []string{"upload", "--file", "https://example.com/data.csv"},
+			wantSkip: false,
+		},
+		{
+			name:     "unrelated flag name ignored",
+			args:     []string{"resolve", "--query", "anything.csv"},
+			wantSkip: false,
+		},
+		{
+			name:     "case-insensitive flag match",
+			args:     []string{"upload", "--CSV", "missing.csv"},
+			wantSkip: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := happyPathFileFixtureSkip(tc.args, cliDir)
+			if tc.wantSkip {
+				assert.NotEmpty(t, got, "expected skip reason")
+				if tc.wantPrefix != "" {
+					assert.Equal(t, tc.wantPrefix, got)
+				}
+			} else {
+				assert.Empty(t, got, "expected no skip")
+			}
+		})
+	}
+}
+
+func TestRunLiveDogfoodHappyPathHandlesShellCommentInExample(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodShellCommentScript(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "sync", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected sync happy_path result")
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status,
+		"trailing '# comment' in Cobra Example must not bleed into happy_path argv (reason=%q)", happy.Reason)
+	assert.Equal(t, []string{"sync"}, happy.Args,
+		"happy_path argv must contain only the subcommand path, not the comment text")
+}
+
+func writeLiveDogfoodShellCommentScript(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"sync"}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
+  cat <<'HELP'
+Refresh local cache.
+
+Usage:
+  fixture-pp-cli sync [flags]
+
+Examples:
+  fixture-pp-cli sync                       # full schema + records refresh
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "sync" ]; then
+  # Anything past 'sync' means the example's trailing comment leaked into
+  # argv — fail loudly so the test catches the regression.
+  if [ "$#" -gt 1 ] && [ "${2}" != "--json" ]; then
+    echo "unexpected sync args: $*" >&2
+    exit 4
+  fi
+  if [ "${2:-}" = "--json" ]; then
+    echo '{"synced":true}'
+    exit 0
+  fi
+  echo 'synced'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
+func TestRunLiveDogfoodSkipsHappyPathOnMissingFileFixture(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodFileFixtureScript(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "import-csv", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected import-csv happy_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Contains(t, happy.Reason, reasonFileFixtureRequired)
+	assert.Contains(t, happy.Reason, "accounts.csv")
+
+	json := findResultByCommandKind(report, "import-csv", LiveDogfoodTestJSON)
+	require.NotNil(t, json, "expected import-csv json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, json.Status)
+	assert.Contains(t, json.Reason, reasonFileFixtureRequired)
+
+	help := findResultByCommandKind(report, "import-csv", LiveDogfoodTestHelp)
+	require.NotNil(t, help, "expected import-csv help result")
+	assert.Equal(t, LiveDogfoodStatusPass, help.Status, "help check must still pass when the only failure is a missing fixture")
+}
+
+func writeLiveDogfoodFileFixtureScript(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"import-csv"}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "import-csv" ] && [ "${2:-}" = "--help" ]; then
+  cat <<'HELP'
+Import accounts from a CSV file.
+
+Usage:
+  fixture-pp-cli import-csv [flags]
+
+Examples:
+  fixture-pp-cli import-csv --file accounts.csv
+
+Flags:
+      --file string   Path to the CSV file
+      --json          Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "import-csv" ]; then
+  # Without a real fixture, this would error out. The test exercises the
+  # skip path; the actual subprocess should never be invoked for happy_path.
+  echo 'open accounts.csv: no such file or directory' >&2
+  exit 1
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
 func TestValidLiveDogfoodJSONOutputAcceptsNDJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -222,6 +222,35 @@ func TestHappyPathFileFixtureSkip(t *testing.T) {
 			args:     []string{"upload", "--CSV", "missing.csv"},
 			wantSkip: true,
 		},
+		{
+			// --profile contains "file" as a substring but is not a file
+			// flag; spurious skips here would silently drop test signal.
+			name:     "profile flag does not trigger skip",
+			args:     []string{"deploy", "--profile", "staging"},
+			wantSkip: false,
+		},
+		{
+			name:     "hyphenated suffix matches",
+			args:     []string{"upload", "--input-file", "missing.txt"},
+			wantSkip: true,
+		},
+		{
+			name:     "underscore suffix matches",
+			args:     []string{"upload", "--output_file", "missing.txt"},
+			wantSkip: true,
+		},
+		{
+			name:     "csv suffix matches",
+			args:     []string{"import", "--import-csv", "missing.csv"},
+			wantSkip: true,
+		},
+		{
+			// --file-format takes a format identifier (csv/json), not a path.
+			// Greptile's suggestion correctly excludes the prefix shape.
+			name:     "file prefix without suffix anchor does not match",
+			args:     []string{"export", "--file-format", "csv"},
+			wantSkip: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/shellargs/shellargs.go
+++ b/internal/shellargs/shellargs.go
@@ -49,6 +49,16 @@ func Split(s string) ([]string, error) {
 		case '"':
 			inQuote = true
 			tokenStarted = true
+		case '#':
+			if !tokenStarted {
+				// Shell line comment: '#' at the start of a word drops the
+				// rest of the input. Cobra Example fields routinely append
+				// trailing comments ("sync # full refresh"); without this
+				// branch a downstream consumer runs the binary with the
+				// comment text as positional args.
+				return tokens, nil
+			}
+			current.WriteRune(r)
 		case ' ', '\t', '\n', '\r':
 			if tokenStarted {
 				flush()

--- a/internal/shellargs/shellargs_test.go
+++ b/internal/shellargs/shellargs_test.go
@@ -19,6 +19,19 @@ func TestSplit(t *testing.T) {
 		{"cli --name foo\\\nbar", []string{"cli", "--name", "foobar"}},
 		{"cli --name \"foo\\\nbar\"", []string{"cli", "--name", "foobar"}},
 		{`cli regex \\d+\\s+goat`, []string{"cli", "regex", `\d+\s+goat`}},
+		// Shell line comments: '#' at the start of a word drops the rest of
+		// the input. Cobra Example fields routinely use trailing comments.
+		{`cli sync                       # full schema + records refresh`, []string{"cli", "sync"}},
+		{`cli # whole-line comment`, []string{"cli"}},
+		{`cli foo --bar baz  # explanation`, []string{"cli", "foo", "--bar", "baz"}},
+		// Quoted '#' is part of the value, not a comment.
+		{`cli query "# not a comment"`, []string{"cli", "query", "# not a comment"}},
+		// '#' embedded inside an unquoted token (no leading whitespace) is a
+		// literal character — bash semantics treat '#' as a comment only at
+		// the start of a word.
+		{`cli regex foo#bar`, []string{"cli", "regex", "foo#bar"}},
+		// Escaped '#' is a literal.
+		{`cli \#literal`, []string{"cli", "#literal"}},
 	}
 	for _, tc := range cases {
 		got, err := Split(tc.in)


### PR DESCRIPTION
## Intent

Closes #1125.

`printing-press dogfood --live`'s happy_path matrix walked Cobra `Example:` strings through a whitespace tokenizer that didn't know about shell `#` comments and didn't notice missing file fixtures. Two distinct FAIL classes on the issue's `unify` run:

- `unify-pp-cli sync                       # full schema + records refresh` parsed to `['sync', '#', 'full', 'schema', …]` and ran the binary with the comment text as positional args.
- `unify-pp-cli vet --csv prospects.csv` / `import-csv --file accounts.csv` shipped paths that don't exist at the dogfood CWD, exiting with `open accounts.csv: no such file or directory`.

Both classes masked real signal and forced authors to either drop comments from their Examples or pre-stage fixtures on every run.

## Approach

1. **shellargs.Split** now honours `#` as a line comment at the start of a word — quoted `"# not a comment"` and embedded `foo#bar` pass through untouched, escaped `\#` is a literal. `narrativecheck` and live-dogfood's example parser both consume `shellargs`, so the fix is a single-site change.
2. **live_dogfood**'s happy_path adds a `happyPathFileFixtureSkip` guard that detects `--file=<path>` / `--csv <path>` flags whose value doesn't resolve relative to `cliDir` and emits `file fixture required: --<flag> <value>` skips for happy_path + json_fidelity. error_path keeps running (it constructs its own argv).

The detection is intentionally narrow — flag name contains `file` or `csv`, value isn't a URL, value isn't on disk — to avoid false-positive skips on URL-shaped `--path` values.

## Scope

Primary area: `internal/shellargs` (tokenizer), `internal/pipeline` (live_dogfood happy_path matrix).

Machine fix: the same tokenizer powers `narrativecheck` (validate-narrative), so this also addresses part of #884's tokenizer overlap.

## Risk

Low. Behaviour change is gated to inputs containing `#` outside a quote (previously misparsed, now produces correct shorter token list) or `--file`/`--csv` flags with missing values (previously FAIL, now SKIP with reason). All 4032 existing tests pass; golden harness clean.

## Output Contract

N/A. No golden surface touched — no generated CLI templates, no scorecard output, no MCP schema, no catalog rendering. Existing dogfood-verdict-matrix golden fixtures don't exercise `#` comments or `--file`/`--csv` flags.

## Verification

- `go test ./...` (4032 passed)
- `go vet ./...`
- `go build -o ./printing-press ./cmd/printing-press`
- `golangci-lint run ./internal/shellargs/... ./internal/pipeline/...` (0 issues)
- `scripts/golden.sh verify` (18 cases passed)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission