### PR TITLE
fix(cli): descend --select into list-envelope responses

### DIFF
--- a/internal/generator/filter_fields_envelope_test.go
+++ b/internal/generator/filter_fields_envelope_test.go
@@ -1,0 +1,108 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterFieldsEnvelopeDescent_EmittedHelper guards the runtime behavior
+// of filterFields against list-envelope responses inside the cli-printing-press
+// repo's own test suite. The function is emitted into every printed CLI's
+// internal/cli/helpers.go from helpers.go.tmpl. Without this gate, regressions
+// in the envelope-descent fallback only surface when a user runs `go test ./...`
+// inside a generated CLI, which slows the feedback loop and risks shipping a
+// broken --select to every CLI built from a future bad commit.
+//
+// The test follows the TestRootFlagsPrintJSONHonorsOutputFlags pattern: it
+// generates a CLI to a temp dir, writes a fixture _test.go alongside the
+// emitted helpers, then runs `go test` on the generated module.
+func TestFilterFieldsEnvelopeDescent_EmittedHelper(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("envelope-descent")
+	outputDir := filepath.Join(t.TempDir(), "envelope-descent-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "filter_fields_envelope_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFilterFieldsEnvelopeDescent covers the four shapes printed CLIs see in
+// practice. The envelope cases pin the regression where wrapper-key + array
+// responses returned `+"`{}`"+` because the selector heads matched the inner
+// record fields, not the wrapper key.
+func TestFilterFieldsEnvelopeDescent(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		fields string
+		want   string
+	}{
+		{
+			"bare array element-wise",
+			`+"`"+`[{"id":"a","name":"x","other":"y"}]`+"`"+`,
+			"id,name",
+			`+"`"+`[{"id":"a","name":"x"}]`+"`"+`,
+		},
+		{
+			"envelope single array sibling",
+			`+"`"+`{"projects":[{"id":"a","name":"x","other":"y"}]}`+"`"+`,
+			"id,name",
+			`+"`"+`{"projects":[{"id":"a","name":"x"}]}`+"`"+`,
+		},
+		{
+			"envelope with metadata sibling preserves count",
+			`+"`"+`{"total_count":2,"items":[{"id":"a","other":"y"}]}`+"`"+`,
+			"id",
+			`+"`"+`{"items":[{"id":"a"}],"total_count":2}`+"`"+`,
+		},
+		{
+			"envelope preserves null pagination cursor verbatim",
+			`+"`"+`{"items":[{"id":"a"}],"next_cursor":null}`+"`"+`,
+			"id",
+			`+"`"+`{"items":[{"id":"a"}],"next_cursor":null}`+"`"+`,
+		},
+		{
+			"flat object no match returns empty",
+			`+"`"+`{"a":1,"b":2}`+"`"+`,
+			"c",
+			`+"`"+`{}`+"`"+`,
+		},
+		{
+			"selector matches envelope key suppresses descent",
+			`+"`"+`{"projects":[{"id":"a","other":"y"}]}`+"`"+`,
+			"projects",
+			`+"`"+`{"projects":[{"id":"a","other":"y"}]}`+"`"+`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterFields(json.RawMessage(tc.input), tc.fields)
+			var gotV, wantV interface{}
+			if err := json.Unmarshal(got, &gotV); err != nil {
+				t.Fatalf("invalid json output: %v (raw=%s)", err, string(got))
+			}
+			if err := json.Unmarshal([]byte(tc.want), &wantV); err != nil {
+				t.Fatalf("invalid want json: %v (raw=%s)", err, tc.want)
+			}
+			gotBytes, _ := json.Marshal(gotV)
+			wantBytes, _ := json.Marshal(wantV)
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("filterFields(%q, %q) = %s, want %s",
+					tc.input, tc.fields, string(gotBytes), string(wantBytes))
+			}
+		})
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestFilterFieldsEnvelopeDescent", "-count=1")
+}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -993,17 +993,47 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
+		matchedAny := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
+			matchedAny = true
 			if keepWhole[matched] {
 				filtered[k] = v
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
 				filtered[k] = filterFieldsRec(v, subs)
+			}
+		}
+		// Envelope fallback: when no top-level keys matched but at least one
+		// sibling is a non-null array, treat the object as a list envelope
+		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
+		// and apply the selector inside the array(s). Non-array siblings pass
+		// through verbatim so envelope metadata (counts, null pagination
+		// cursors) stays visible. The foundArray guard preserves the prior
+		// empty-object result for flat objects where no key matches and no
+		// array exists. The `arr != nil` check rejects JSON null, which
+		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
+		// nil slice and would coerce to `[]`.
+		if !matchedAny {
+			pending := map[string]json.RawMessage{}
+			foundArray := false
+			for k, v := range obj {
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					pending[k] = filterFieldsRec(v, paths)
+				} else {
+					pending[k] = v
+				}
+			}
+			if foundArray {
+				for k, v := range pending {
+					filtered[k] = v
+				}
 			}
 		}
 		result, _ := json.Marshal(filtered)

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -73,5 +74,132 @@ func TestExitCode_UsageError_WrappedAsCode2(t *testing.T) {
 	wrapped := usageErr(errors.New("unknown flag: --foob"))
 	if got := ExitCode(wrapped); got != 2 {
 		t.Errorf("ExitCode(usageErr(...)) = %d, want 2 (POSIX usage convention)", got)
+	}
+}
+
+// TestFilterFields covers --select projection against the four payload
+// shapes printed CLIs see in practice: bare arrays, direct objects,
+// list envelopes (Stripe/GitHub/Notion-style wrapper + array), and
+// flat objects. The envelope cases guard against a regression where
+// wrapper-key + array responses returned `{}` because the selector
+// heads matched the inner record fields, not the wrapper key.
+func TestFilterFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  string
+		fields string
+		want   string
+	}{
+		{
+			name:   "bare array element-wise",
+			input:  `[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]`,
+			fields: "id,name",
+			want:   `[{"id":"a","name":"x"},{"id":"b","name":"z"}]`,
+		},
+		{
+			name:   "direct object top-level match",
+			input:  `{"id":"a","name":"b","other":"c"}`,
+			fields: "id,name",
+			want:   `{"id":"a","name":"b"}`,
+		},
+		{
+			name:   "envelope single array sibling (orgo {projects:[...]})",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"projects":[{"id":"a","name":"x"}]}`,
+		},
+		{
+			name:   "envelope with metadata sibling (github {total_count,items:[...]})",
+			input:  `{"total_count":2,"items":[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"},{"id":"b","name":"z"}],"total_count":2}`,
+		},
+		{
+			name:   "envelope with metadata sibling (stripe {object,data:[...]})",
+			input:  `{"object":"list","data":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"data":[{"id":"a","name":"x"}],"object":"list"}`,
+		},
+		{
+			name:   "selector matches envelope key (no descent into array)",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects",
+			want:   `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+		},
+		{
+			name:   "dotted-path through envelope key still descends",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects.id",
+			want:   `{"projects":[{"id":"a"}]}`,
+		},
+		{
+			name:   "flat object no match returns empty (no array fallback)",
+			input:  `{"a":1,"b":2}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Null pagination cursors are common envelope metadata.
+			// json.Unmarshal accepts JSON null into []json.RawMessage as
+			// a nil slice without error, so the array check must reject
+			// nil explicitly or null siblings would be coerced to `[]`.
+			name:   "envelope preserves null sibling verbatim",
+			input:  `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+		},
+		{
+			// Without a real array sibling the envelope fallback does not
+			// fire, so a flat object whose only "extra" key is null still
+			// returns {} for a non-matching selector.
+			name:   "flat object with null sibling no match returns empty",
+			input:  `{"a":1,"b":null}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Multiple array siblings at the same level each receive the
+			// selector independently. Documents that the projection fans
+			// out across every array, not just the first one found.
+			name:   "envelope with two array siblings filters both",
+			input:  `{"events":[{"id":"e1","other":"x"}],"speakers":[{"id":"s1","other":"y"}]}`,
+			fields: "id",
+			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
+		},
+		{
+			// Envelope fallback is intentionally one level deep. A nested
+			// object envelope like {"data":{"items":[...]}} surfaces no
+			// array at the outer level, so the fallback does not fire and
+			// the result is the empty-object that flat-no-match would
+			// produce. Pins the boundary so a future deeper-walk change
+			// is an explicit decision, not an accident.
+			name:   "nested object envelope returns empty (one-level only)",
+			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			fields: "id",
+			want:   `{}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterFields(json.RawMessage(tc.input), tc.fields)
+			// Normalize both sides through json.Unmarshal+Marshal so
+			// map-iteration order does not produce false negatives.
+			var gotV, wantV interface{}
+			if err := json.Unmarshal(got, &gotV); err != nil {
+				t.Fatalf("got is invalid json: %v (raw=%s)", err, string(got))
+			}
+			if err := json.Unmarshal([]byte(tc.want), &wantV); err != nil {
+				t.Fatalf("want is invalid json: %v (raw=%s)", err, tc.want)
+			}
+			gotBytes, _ := json.Marshal(gotV)
+			wantBytes, _ := json.Marshal(wantV)
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("filterFields(%q, %q) = %s, want %s",
+					tc.input, tc.fields, string(gotBytes), string(wantBytes))
+			}
+		})
 	}
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -792,17 +792,47 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
+		matchedAny := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
+			matchedAny = true
 			if keepWhole[matched] {
 				filtered[k] = v
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
 				filtered[k] = filterFieldsRec(v, subs)
+			}
+		}
+		// Envelope fallback: when no top-level keys matched but at least one
+		// sibling is a non-null array, treat the object as a list envelope
+		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
+		// and apply the selector inside the array(s). Non-array siblings pass
+		// through verbatim so envelope metadata (counts, null pagination
+		// cursors) stays visible. The foundArray guard preserves the prior
+		// empty-object result for flat objects where no key matches and no
+		// array exists. The `arr != nil` check rejects JSON null, which
+		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
+		// nil slice and would coerce to `[]`.
+		if !matchedAny {
+			pending := map[string]json.RawMessage{}
+			foundArray := false
+			for k, v := range obj {
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					pending[k] = filterFieldsRec(v, paths)
+				} else {
+					pending[k] = v
+				}
+			}
+			if foundArray {
+				for k, v := range pending {
+					filtered[k] = v
+				}
 			}
 		}
 		result, _ := json.Marshal(filtered)

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -655,17 +655,47 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
+		matchedAny := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
+			matchedAny = true
 			if keepWhole[matched] {
 				filtered[k] = v
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
 				filtered[k] = filterFieldsRec(v, subs)
+			}
+		}
+		// Envelope fallback: when no top-level keys matched but at least one
+		// sibling is a non-null array, treat the object as a list envelope
+		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
+		// and apply the selector inside the array(s). Non-array siblings pass
+		// through verbatim so envelope metadata (counts, null pagination
+		// cursors) stays visible. The foundArray guard preserves the prior
+		// empty-object result for flat objects where no key matches and no
+		// array exists. The `arr != nil` check rejects JSON null, which
+		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
+		// nil slice and would coerce to `[]`.
+		if !matchedAny {
+			pending := map[string]json.RawMessage{}
+			foundArray := false
+			for k, v := range obj {
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					pending[k] = filterFieldsRec(v, paths)
+				} else {
+					pending[k] = v
+				}
+			}
+			if foundArray {
+				for k, v := range pending {
+					filtered[k] = v
+				}
 			}
 		}
 		result, _ := json.Marshal(filtered)

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -73,5 +74,132 @@ func TestExitCode_UsageError_WrappedAsCode2(t *testing.T) {
 	wrapped := usageErr(errors.New("unknown flag: --foob"))
 	if got := ExitCode(wrapped); got != 2 {
 		t.Errorf("ExitCode(usageErr(...)) = %d, want 2 (POSIX usage convention)", got)
+	}
+}
+
+// TestFilterFields covers --select projection against the four payload
+// shapes printed CLIs see in practice: bare arrays, direct objects,
+// list envelopes (Stripe/GitHub/Notion-style wrapper + array), and
+// flat objects. The envelope cases guard against a regression where
+// wrapper-key + array responses returned `{}` because the selector
+// heads matched the inner record fields, not the wrapper key.
+func TestFilterFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  string
+		fields string
+		want   string
+	}{
+		{
+			name:   "bare array element-wise",
+			input:  `[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]`,
+			fields: "id,name",
+			want:   `[{"id":"a","name":"x"},{"id":"b","name":"z"}]`,
+		},
+		{
+			name:   "direct object top-level match",
+			input:  `{"id":"a","name":"b","other":"c"}`,
+			fields: "id,name",
+			want:   `{"id":"a","name":"b"}`,
+		},
+		{
+			name:   "envelope single array sibling (orgo {projects:[...]})",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"projects":[{"id":"a","name":"x"}]}`,
+		},
+		{
+			name:   "envelope with metadata sibling (github {total_count,items:[...]})",
+			input:  `{"total_count":2,"items":[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"},{"id":"b","name":"z"}],"total_count":2}`,
+		},
+		{
+			name:   "envelope with metadata sibling (stripe {object,data:[...]})",
+			input:  `{"object":"list","data":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"data":[{"id":"a","name":"x"}],"object":"list"}`,
+		},
+		{
+			name:   "selector matches envelope key (no descent into array)",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects",
+			want:   `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+		},
+		{
+			name:   "dotted-path through envelope key still descends",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects.id",
+			want:   `{"projects":[{"id":"a"}]}`,
+		},
+		{
+			name:   "flat object no match returns empty (no array fallback)",
+			input:  `{"a":1,"b":2}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Null pagination cursors are common envelope metadata.
+			// json.Unmarshal accepts JSON null into []json.RawMessage as
+			// a nil slice without error, so the array check must reject
+			// nil explicitly or null siblings would be coerced to `[]`.
+			name:   "envelope preserves null sibling verbatim",
+			input:  `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+		},
+		{
+			// Without a real array sibling the envelope fallback does not
+			// fire, so a flat object whose only "extra" key is null still
+			// returns {} for a non-matching selector.
+			name:   "flat object with null sibling no match returns empty",
+			input:  `{"a":1,"b":null}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Multiple array siblings at the same level each receive the
+			// selector independently. Documents that the projection fans
+			// out across every array, not just the first one found.
+			name:   "envelope with two array siblings filters both",
+			input:  `{"events":[{"id":"e1","other":"x"}],"speakers":[{"id":"s1","other":"y"}]}`,
+			fields: "id",
+			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
+		},
+		{
+			// Envelope fallback is intentionally one level deep. A nested
+			// object envelope like {"data":{"items":[...]}} surfaces no
+			// array at the outer level, so the fallback does not fire and
+			// the result is the empty-object that flat-no-match would
+			// produce. Pins the boundary so a future deeper-walk change
+			// is an explicit decision, not an accident.
+			name:   "nested object envelope returns empty (one-level only)",
+			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			fields: "id",
+			want:   `{}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterFields(json.RawMessage(tc.input), tc.fields)
+			// Normalize both sides through json.Unmarshal+Marshal so
+			// map-iteration order does not produce false negatives.
+			var gotV, wantV interface{}
+			if err := json.Unmarshal(got, &gotV); err != nil {
+				t.Fatalf("got is invalid json: %v (raw=%s)", err, string(got))
+			}
+			if err := json.Unmarshal([]byte(tc.want), &wantV); err != nil {
+				t.Fatalf("want is invalid json: %v (raw=%s)", err, tc.want)
+			}
+			gotBytes, _ := json.Marshal(gotV)
+			wantBytes, _ := json.Marshal(wantV)
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("filterFields(%q, %q) = %s, want %s",
+					tc.input, tc.fields, string(gotBytes), string(wantBytes))
+			}
+		})
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -662,17 +662,47 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 			}
 		}
 		filtered := map[string]json.RawMessage{}
+		matchedAny := false
 		for k, v := range obj {
 			matched := matchSelectSegment(k, keepWhole, subPaths)
 			if matched == "" {
 				continue
 			}
+			matchedAny = true
 			if keepWhole[matched] {
 				filtered[k] = v
 				continue
 			}
 			if subs := subPaths[matched]; subs != nil {
 				filtered[k] = filterFieldsRec(v, subs)
+			}
+		}
+		// Envelope fallback: when no top-level keys matched but at least one
+		// sibling is a non-null array, treat the object as a list envelope
+		// (`{"items":[...]}`, `{"data":[...]}`, `{"total_count":N,"items":[...]}`)
+		// and apply the selector inside the array(s). Non-array siblings pass
+		// through verbatim so envelope metadata (counts, null pagination
+		// cursors) stays visible. The foundArray guard preserves the prior
+		// empty-object result for flat objects where no key matches and no
+		// array exists. The `arr != nil` check rejects JSON null, which
+		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
+		// nil slice and would coerce to `[]`.
+		if !matchedAny {
+			pending := map[string]json.RawMessage{}
+			foundArray := false
+			for k, v := range obj {
+				var arr []json.RawMessage
+				if json.Unmarshal(v, &arr) == nil && arr != nil {
+					foundArray = true
+					pending[k] = filterFieldsRec(v, paths)
+				} else {
+					pending[k] = v
+				}
+			}
+			if foundArray {
+				for k, v := range pending {
+					filtered[k] = v
+				}
 			}
 		}
 		result, _ := json.Marshal(filtered)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -73,5 +74,132 @@ func TestExitCode_UsageError_WrappedAsCode2(t *testing.T) {
 	wrapped := usageErr(errors.New("unknown flag: --foob"))
 	if got := ExitCode(wrapped); got != 2 {
 		t.Errorf("ExitCode(usageErr(...)) = %d, want 2 (POSIX usage convention)", got)
+	}
+}
+
+// TestFilterFields covers --select projection against the four payload
+// shapes printed CLIs see in practice: bare arrays, direct objects,
+// list envelopes (Stripe/GitHub/Notion-style wrapper + array), and
+// flat objects. The envelope cases guard against a regression where
+// wrapper-key + array responses returned `{}` because the selector
+// heads matched the inner record fields, not the wrapper key.
+func TestFilterFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  string
+		fields string
+		want   string
+	}{
+		{
+			name:   "bare array element-wise",
+			input:  `[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]`,
+			fields: "id,name",
+			want:   `[{"id":"a","name":"x"},{"id":"b","name":"z"}]`,
+		},
+		{
+			name:   "direct object top-level match",
+			input:  `{"id":"a","name":"b","other":"c"}`,
+			fields: "id,name",
+			want:   `{"id":"a","name":"b"}`,
+		},
+		{
+			name:   "envelope single array sibling (orgo {projects:[...]})",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"projects":[{"id":"a","name":"x"}]}`,
+		},
+		{
+			name:   "envelope with metadata sibling (github {total_count,items:[...]})",
+			input:  `{"total_count":2,"items":[{"id":"a","name":"x","other":"y"},{"id":"b","name":"z","other":"w"}]}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"},{"id":"b","name":"z"}],"total_count":2}`,
+		},
+		{
+			name:   "envelope with metadata sibling (stripe {object,data:[...]})",
+			input:  `{"object":"list","data":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "id,name",
+			want:   `{"data":[{"id":"a","name":"x"}],"object":"list"}`,
+		},
+		{
+			name:   "selector matches envelope key (no descent into array)",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects",
+			want:   `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+		},
+		{
+			name:   "dotted-path through envelope key still descends",
+			input:  `{"projects":[{"id":"a","name":"x","other":"y"}]}`,
+			fields: "projects.id",
+			want:   `{"projects":[{"id":"a"}]}`,
+		},
+		{
+			name:   "flat object no match returns empty (no array fallback)",
+			input:  `{"a":1,"b":2}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Null pagination cursors are common envelope metadata.
+			// json.Unmarshal accepts JSON null into []json.RawMessage as
+			// a nil slice without error, so the array check must reject
+			// nil explicitly or null siblings would be coerced to `[]`.
+			name:   "envelope preserves null sibling verbatim",
+			input:  `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+			fields: "id,name",
+			want:   `{"items":[{"id":"a","name":"x"}],"next_cursor":null}`,
+		},
+		{
+			// Without a real array sibling the envelope fallback does not
+			// fire, so a flat object whose only "extra" key is null still
+			// returns {} for a non-matching selector.
+			name:   "flat object with null sibling no match returns empty",
+			input:  `{"a":1,"b":null}`,
+			fields: "c",
+			want:   `{}`,
+		},
+		{
+			// Multiple array siblings at the same level each receive the
+			// selector independently. Documents that the projection fans
+			// out across every array, not just the first one found.
+			name:   "envelope with two array siblings filters both",
+			input:  `{"events":[{"id":"e1","other":"x"}],"speakers":[{"id":"s1","other":"y"}]}`,
+			fields: "id",
+			want:   `{"events":[{"id":"e1"}],"speakers":[{"id":"s1"}]}`,
+		},
+		{
+			// Envelope fallback is intentionally one level deep. A nested
+			// object envelope like {"data":{"items":[...]}} surfaces no
+			// array at the outer level, so the fallback does not fire and
+			// the result is the empty-object that flat-no-match would
+			// produce. Pins the boundary so a future deeper-walk change
+			// is an explicit decision, not an accident.
+			name:   "nested object envelope returns empty (one-level only)",
+			input:  `{"data":{"items":[{"id":"a","other":"y"}]}}`,
+			fields: "id",
+			want:   `{}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterFields(json.RawMessage(tc.input), tc.fields)
+			// Normalize both sides through json.Unmarshal+Marshal so
+			// map-iteration order does not produce false negatives.
+			var gotV, wantV interface{}
+			if err := json.Unmarshal(got, &gotV); err != nil {
+				t.Fatalf("got is invalid json: %v (raw=%s)", err, string(got))
+			}
+			if err := json.Unmarshal([]byte(tc.want), &wantV); err != nil {
+				t.Fatalf("want is invalid json: %v (raw=%s)", err, tc.want)
+			}
+			gotBytes, _ := json.Marshal(gotV)
+			wantBytes, _ := json.Marshal(wantV)
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("filterFields(%q, %q) = %s, want %s",
+					tc.input, tc.fields, string(gotBytes), string(wantBytes))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Intent

Fix the `--select` flag's silent-empty-result regression against list-envelope JSON responses across every printed CLI.

Closes #1143

## Approach

The runtime `filterFieldsRec` helper emitted into every printed CLI matched selector heads only against an object's top-level keys. So `--select id,name` against `{"projects":[...]}` (orgo), `{"data":[...]}` (stripe), `{"total_count":N,"items":[...]}` (github), or `{"object":"list","results":[...]}` (notion) returned `{}` because `id` / `name` lived inside the wrapped array, not on the envelope.

When no top-level key matches and at least one non-null array sibling exists, the helper now treats the object as a list envelope: applies the selector inside each array and preserves non-array siblings verbatim so envelope metadata (counts, pagination cursors) stays visible. Two guards keep the change conservative:

1. **`foundArray` guard:** preserves the prior empty-object result for flat objects with no array (`{"a":1,"b":2}` + `--select c` still returns `{}`).
2. **`arr != nil` guard:** rejects JSON null. `json.Unmarshal` otherwise accepts `null` into a `[]json.RawMessage` as a nil slice, which would coerce null pagination cursors into `[]`. Caught during code review; cited in the issue's pagination-cursor example.

## Scope

Primary area: `internal/generator/templates/helpers.go.tmpl` (machine change; affects every printed CLI's `internal/cli/helpers.go`).

Why this belongs in this repo: same projection runs on every list-endpoint response in every generated CLI. Cross-API evidence in the issue (stripe, github, notion, orgo).

## Risk

- Behavior change for users on existing CLIs: `--select` against an envelope used to return `{}`; now returns the projected envelope. Anyone branching on the prior empty-object behavior would see different output. The cross-API evidence in #1143 suggests the new behavior is what users expected all along; the empty result was the silent defect.
- Flat-object-no-match invariant preserved by `foundArray` guard.
- Map-iteration order: `filterFieldsRec` already marshals through `map[string]json.RawMessage`, which Go marshals with sorted keys. No new ordering risk.

## Output Contract

- Goldens regenerated: `helpers.go` and `root_test.go` in three golden CLIs (`generate-golden-api`, `generate-golden-api-rich-auth`, `generate-embedded-paged-api`).
- `dogfood.json` total function count unchanged at 58 — the refactor inlines what was briefly a separate `hasArrayValue` helper, so the public surface of the emitted helpers stays the same.
- No new commands, flags, or MCP tools. Existing `--select` flag's behavior is corrected for envelope responses; all other shapes behave identically.

## Verification

- `go build -o ./printing-press ./cmd/printing-press` — pass
- `go test ./...` — 4022/4022 pass (+1 new repo-side runtime test)
- `go vet ./...` — clean
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 18/18 pass
- New test `TestFilterFieldsEnvelopeDescent_EmittedHelper` generates a CLI to a temp dir, writes a fixture `_test.go`, runs `go test` on the generated module — closes the gap where the emitted function had no runtime coverage inside this repo's CI. Modeled on `TestRootFlagsPrintJSONHonorsOutputFlags`.
- Template-emitted tests cover bare arrays, direct objects, single/multi-array envelopes, metadata-sibling envelopes (stripe/github), null-cursor preservation, envelope-key-as-selector (suppresses descent), dotted-path descent, flat-no-match invariant, and the intentionally-not-descended nested-object case.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission