### PR TITLE
fix(generator): support single-env basic auth credentials

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -960,8 +960,11 @@ func basicAuthEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
 			})
 		}
 	}
-	if len(envVars) < 2 {
+	if len(envVars) == 0 {
 		return nil
+	}
+	if len(envVars) == 1 {
+		return envVars
 	}
 	return envVars[:2]
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1335,6 +1335,62 @@ func TestBasicAuthHeader(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "./internal/config")
 }
 
+func TestGenerateHTTPBasicAuthHeaderEncodesSingleCredential(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "basic-single",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			In:      "header",
+			Header:  "Authorization",
+			Format:  "Basic {token}:",
+			EnvVars: []string{"BASIC_TOKEN"},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "BASIC_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/basic-single/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/items",
+						Description: "List items",
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	const inlineTest = `package config
+
+import "testing"
+
+func TestSingleCredentialBasicAuthHeader(t *testing.T) {
+	cfg := &Config{BasicToken: "secret"}
+	if got := cfg.AuthHeader(); got != "Basic c2VjcmV0Og==" {
+		t.Fatalf("AuthHeader() = %q", got)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "config", "basic_auth_single_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/config")
+}
+
 func countFiles(t *testing.T, root string) int {
 	t.Helper()
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -237,11 +237,21 @@ func (c *Config) AuthHeader() string {
 {{- end}}
 {{- if eq .Auth.Type "api_key"}}
 {{- if $basicAuthEnvVars}}
+{{- if eq (len $basicAuthEnvVars) 1}}
+	if c.{{resolveEnvVarField (index $basicAuthEnvVars 0).Name}} == "" {
+		return ""
+	}
+	credentials := c.{{resolveEnvVarField (index $basicAuthEnvVars 0).Name}} + ":"
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(credentials))
+{{- else if eq (len $basicAuthEnvVars) 2}}
 	if c.{{resolveEnvVarField (index $basicAuthEnvVars 0).Name}} == "" || c.{{resolveEnvVarField (index $basicAuthEnvVars 1).Name}} == "" {
 		return ""
 	}
 	credentials := c.{{resolveEnvVarField (index $basicAuthEnvVars 0).Name}} + ":" + c.{{resolveEnvVarField (index $basicAuthEnvVars 1).Name}}
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(credentials))
+{{- else}}
+	return ""
+{{- end}}
 {{- else if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {


### PR DESCRIPTION
## Summary
- handle Basic auth templates backed by a single environment variable
- preserve username/password behavior when two environment variables are configured
- return an empty auth header for unsupported Basic auth env layouts

Fixes #1297.

## Tests
- go test ./internal/generator -count=1