### PR TITLE
fix(skills): emit PRINTING_PRESS_BIN marker so later phases survive PATH non-inheritance

### DIFF
--- a/skills/printing-press-catalog/SKILL.md
+++ b/skills/printing-press-catalog/SKILL.md
@@ -46,7 +46,9 @@ _scope_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
 _scope_dir="$(cd "$_scope_dir" && pwd -P)"
 
 # Prefer local build when running from inside the printing-press repo.
+_press_repo=false
 if [ -x "$_scope_dir/printing-press" ] && [ -d "$_scope_dir/cmd/printing-press" ]; then
+  _press_repo=true
   export PATH="$_scope_dir:$PATH"
   echo "Using local build: $_scope_dir/printing-press"
 elif ! command -v printing-press >/dev/null 2>&1; then
@@ -59,6 +61,19 @@ elif ! command -v printing-press >/dev/null 2>&1; then
   fi
   return 1 2>/dev/null || exit 1
 fi
+
+# Resolve and emit the absolute path the agent must use for every later
+# `printing-press` invocation. `export PATH` above only affects this one
+# Bash tool call; subsequent calls open a fresh shell and resolve bare
+# `printing-press` against the user's default PATH, where a stale global
+# can silently shadow the local build. The agent captures this marker and
+# substitutes the absolute path into every later invocation.
+if [ "$_press_repo" = "true" ]; then
+  PRINTING_PRESS_BIN="$_scope_dir/printing-press"
+else
+  PRINTING_PRESS_BIN="$(command -v printing-press 2>/dev/null || true)"
+fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
@@ -74,7 +89,9 @@ mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY"
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-After running the setup contract, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `printing-press version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
+After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
 
 Generated CLIs are published to `$PRESS_LIBRARY/`, not to the repo.
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -46,7 +46,9 @@ _scope_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
 _scope_dir="$(cd "$_scope_dir" && pwd -P)"
 
 # Prefer local build when running from inside the printing-press repo.
+_press_repo=false
 if [ -x "$_scope_dir/printing-press" ] && [ -d "$_scope_dir/cmd/printing-press" ]; then
+  _press_repo=true
   export PATH="$_scope_dir:$PATH"
   echo "Using local build: $_scope_dir/printing-press"
 elif ! command -v printing-press >/dev/null 2>&1; then
@@ -59,6 +61,19 @@ elif ! command -v printing-press >/dev/null 2>&1; then
   fi
   return 1 2>/dev/null || exit 1
 fi
+
+# Resolve and emit the absolute path the agent must use for every later
+# `printing-press` invocation. `export PATH` above only affects this one
+# Bash tool call; subsequent calls open a fresh shell and resolve bare
+# `printing-press` against the user's default PATH, where a stale global
+# can silently shadow the local build. The agent captures this marker and
+# substitutes the absolute path into every later invocation.
+if [ "$_press_repo" = "true" ]; then
+  PRINTING_PRESS_BIN="$_scope_dir/printing-press"
+else
+  PRINTING_PRESS_BIN="$(command -v printing-press 2>/dev/null || true)"
+fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
@@ -76,7 +91,9 @@ mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-After running the setup contract, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `printing-press version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
+After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
 
 ## Configuration
 

--- a/skills/printing-press-score/SKILL.md
+++ b/skills/printing-press-score/SKILL.md
@@ -42,7 +42,9 @@ _scope_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
 _scope_dir="$(cd "$_scope_dir" && pwd -P)"
 
 # Prefer local build when running from inside the printing-press repo.
+_press_repo=false
 if [ -x "$_scope_dir/printing-press" ] && [ -d "$_scope_dir/cmd/printing-press" ]; then
+  _press_repo=true
   export PATH="$_scope_dir:$PATH"
   echo "Using local build: $_scope_dir/printing-press"
 elif ! command -v printing-press >/dev/null 2>&1; then
@@ -55,6 +57,19 @@ elif ! command -v printing-press >/dev/null 2>&1; then
   fi
   return 1 2>/dev/null || exit 1
 fi
+
+# Resolve and emit the absolute path the agent must use for every later
+# `printing-press` invocation. `export PATH` above only affects this one
+# Bash tool call; subsequent calls open a fresh shell and resolve bare
+# `printing-press` against the user's default PATH, where a stale global
+# can silently shadow the local build. The agent captures this marker and
+# substitutes the absolute path into every later invocation.
+if [ "$_press_repo" = "true" ]; then
+  PRINTING_PRESS_BIN="$_scope_dir/printing-press"
+else
+  PRINTING_PRESS_BIN="$(command -v printing-press 2>/dev/null || true)"
+fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
@@ -72,7 +87,9 @@ mkdir -p "$PRESS_RUNSTATE" "$PRESS_LIBRARY" "$PRESS_MANUSCRIPTS" "$PRESS_CURRENT
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-After running the setup contract, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `printing-press version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
+After running the setup contract, capture the `PRINTING_PRESS_BIN=<abs-path>` line from stdout. **Every subsequent `printing-press ...` invocation in this skill must use that absolute path** (substitute the value, not the literal `$PRINTING_PRESS_BIN` token) — `export PATH` above only affects the single Bash tool call it runs in, so later calls open a fresh shell where bare `printing-press` resolves against the user's default `PATH` and a stale global can shadow the local build.
+
+After capturing the binary path, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest` to update."
 
 Current-run state is resolved from `$PRESS_RUNSTATE`. Published CLIs are resolved from `$PRESS_LIBRARY`. Archived manuscripts are resolved from `$PRESS_MANUSCRIPTS`.
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -177,6 +177,46 @@ if ! command -v go >/dev/null 2>&1; then
   return 1 2>/dev/null || exit 1
 fi
 
+# Resolve and emit the absolute path the agent must use for every later
+# `printing-press` invocation. `export PATH` above only affects this one
+# Bash tool call; subsequent calls open a fresh shell and resolve bare
+# `printing-press` against the user's default PATH. When a global is
+# installed at a stale version, that silently shadows the local build the
+# preflight just chose. Handing the agent an absolute path eliminates the
+# shadow.
+if [ "$_press_repo" = "true" ] && [ -x "$_scope_dir/printing-press" ]; then
+  PRINTING_PRESS_BIN="$_scope_dir/printing-press"
+else
+  PRINTING_PRESS_BIN="$(command -v printing-press 2>/dev/null || true)"
+fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+
+# Shadow detector (advisory). When a local build is in use, surface any
+# differing global so the user can see at a glance that the two binaries
+# disagree. Detect-only: the absolute path emitted above is the one the
+# agent will actually invoke; this warning does not change selection.
+if [ "$_press_repo" = "true" ] && [ -x "$_scope_dir/printing-press" ]; then
+  _global_bin=""
+  for _candidate in "$HOME/go/bin/printing-press" "/usr/local/bin/printing-press" "/opt/homebrew/bin/printing-press"; do
+    if [ -x "$_candidate" ] && [ "$_candidate" != "$_scope_dir/printing-press" ]; then
+      _global_bin="$_candidate"
+      break
+    fi
+  done
+  if [ -n "$_global_bin" ]; then
+    _local_v="$("$_scope_dir/printing-press" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
+    _global_v="$("$_global_bin" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
+    if [ -n "$_local_v" ] && [ -n "$_global_v" ] && [ "$_local_v" != "$_global_v" ]; then
+      echo ""
+      echo "[binary-shadow] local build v$_local_v differs from global v$_global_v at $_global_bin"
+      echo "PRESS_BIN_LOCAL_VERSION=$_local_v"
+      echo "PRESS_BIN_GLOBAL_VERSION=$_global_v"
+      echo "PRESS_BIN_GLOBAL_PATH=$_global_bin"
+      echo ""
+    fi
+  fi
+fi
+
 PRESS_BASE="$(basename "$_scope_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]/-/g; s/^-+//; s/-+$//')"
 if [ -z "$PRESS_BASE" ]; then
   PRESS_BASE="workspace"
@@ -333,9 +373,11 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles five signals the contract emits to stdout: `[setup-error]` (refuse to run, surface the install instructions), `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), and `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, or hit a mid-flight install prompt if browser-sniff is later needed. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles six signals the contract emits to stdout: `[setup-error]` (refuse to run, surface the install instructions), `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent `printing-press` invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global on `PATH` shadowed the local build. Do not skip.
 
-Only after preflight completes successfully (no `[setup-error]`; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user) should you proceed to the Orientation & Briefing section below.
+**Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `printing-press generate ...` for readability — replace `printing-press` with the captured absolute path each time you actually run one.
+
+Only after preflight completes successfully (no `[setup-error]`; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user; `PRINTING_PRESS_BIN` is captured) should you proceed to the Orientation & Briefing section below.
 
 ## Orientation & Briefing
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -2,7 +2,15 @@
 
 Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle six signals the contract emits to stdout: `[setup-error]`, `[repo-upgrade-available]`, the `min-binary-version` compatibility check, `[upgrade-available]`, `[browser-tools-missing]`, and the always-emitted `PRINTING_PRESS_BIN=<abs-path>` marker (with optional `[binary-shadow]` advisory).
 
-Apply these in order. Each section is conditional — do nothing if its trigger isn't present, except section 6 which is unconditional.
+Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
+
+## Preamble: Capture the absolute binary path (unconditional)
+
+Before applying any numbered section below, capture the `PRINTING_PRESS_BIN=<absolute path to the binary>` line the contract emitted to stdout. Every `printing-press ...` invocation referenced anywhere below — including the `version --json` calls in sections 3 and 4 — must be made using that absolute path (substitute the captured value, not the literal `$PRINTING_PRESS_BIN` token). The contract's `export PATH=...` line only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells where bare `printing-press` resolves against the user's default `PATH`, and a stale globally-installed binary (`$HOME/go/bin/printing-press` from an earlier `go install`, a Homebrew copy, etc.) will silently shadow the local repo build the contract selected. Using the absolute path eliminates the shadow.
+
+If `PRINTING_PRESS_BIN` was emitted as an empty value (`PRINTING_PRESS_BIN=`), the contract was unable to resolve a binary; this should have already been surfaced as `[setup-error]` (handled in section 1 below). Treat an empty value here as a setup-error fallback and stop.
+
+This rule applies to *all* `printing-press` references in the rest of this document. Where sections below write `printing-press version --json` or similar, read that as shorthand for `<PRINTING_PRESS_BIN> version --json` with the captured value substituted.
 
 ## 1. Refusal: missing prerequisite
 
@@ -56,7 +64,7 @@ If no `[repo-upgrade-available]` line was emitted, skip this section entirely.
 
 ## 3. Min-binary-version compatibility
 
-Check binary version compatibility against the skill's declared minimum. Read the `min-binary-version` field from the skill's YAML frontmatter. Run `printing-press version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules.
+Check binary version compatibility against the skill's declared minimum. Read the `min-binary-version` field from the skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` (using the absolute path captured in the preamble — not bare `printing-press`, which would resolve against the user's default `PATH` and could interrogate a stale global) and parse the version from the output. Compare it to `min-binary-version` using semver rules.
 
 If the installed binary is older than the minimum, stop the skill immediately and tell the user:
 
@@ -86,7 +94,7 @@ If the user picks **Yes**, run:
 go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest
 ```
 
-After it completes, confirm with `printing-press version --json` and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).**
+After it completes, confirm with `<PRINTING_PRESS_BIN> version --json` if the captured path is still valid for the freshly installed binary (it is, when the contract resolved `PRINTING_PRESS_BIN` from `command -v printing-press` and the new `go install` overwrote that same path; the upgrade replaces the binary in-place), and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).**
 
 Separately, as out-of-band advice for the user's *next* session (not a stop signal for this run), tell them they can also refresh their installed skill files outside the repo checkout by running one of:
 
@@ -166,23 +174,9 @@ If the user picks **Skip for this run**, continue without prompting further this
 
 If no `[browser-tools-missing]` line was emitted, skip this section entirely.
 
-## 6. Absolute binary path (unconditional)
+## 6. Optional shadow advisory
 
-The setup contract always emits one line of the form:
-
-```
-PRINTING_PRESS_BIN=<absolute path to the binary>
-```
-
-Capture this value. Every subsequent `printing-press ...` invocation in this skill, in reference docs it loads, and in any sub-skill it delegates to (`printing-press-publish`, `printing-press-polish`, `printing-press-score`, etc.) must be made using this absolute path, **not** bare `printing-press`. Substitute the captured path each time you compose a Bash command — `$PRINTING_PRESS_BIN` is not a live shell variable across Bash tool calls; only the literal absolute path it expands to in preflight survives.
-
-This rule exists because the contract's `export PATH=...` line only affects the single Bash tool call it runs in. Subsequent Bash tool calls open fresh shells with the user's default `PATH`. When a global `printing-press` is installed at a stale version (e.g. `$HOME/go/bin/printing-press` from an earlier `go install`), bare `printing-press` resolves to the stale global and silently shadows the local repo build that preflight selected. Using the absolute path the contract emitted eliminates the shadow.
-
-If `PRINTING_PRESS_BIN` was emitted as an empty value (`PRINTING_PRESS_BIN=`), the contract was unable to resolve a binary; this should have already been surfaced as `[setup-error]` and the skill should have stopped at section 1. Treat an empty value here as a setup-error fallback and stop.
-
-### Optional shadow advisory
-
-If the setup contract output also contains a line starting with `[binary-shadow]`, parse the follow-up lines:
+If the setup contract output contains a line starting with `[binary-shadow]`, parse the follow-up lines:
 
 - `PRESS_BIN_LOCAL_VERSION=<version reported by the local build>`
 - `PRESS_BIN_GLOBAL_VERSION=<version reported by the differing global on PATH>`
@@ -192,6 +186,6 @@ Surface a single-line note to the user before continuing — informational only,
 
 > "Note: a global printing-press v`<global>` is installed at `<path>` but the local repo build is v`<local>`. This run will use the local build (the absolute path the preflight selected); the global is unchanged."
 
-Then continue. Do not modify or remove the global. The note exists so the user can reconcile the divergence on their own time (typically with `go install ...@latest` in the global once they want the new version everywhere).
+Then continue. Do not modify or remove the global. The note exists so the user can reconcile the divergence on their own time (typically with `go install ...@latest` once they want the new version everywhere).
 
 If no `[binary-shadow]` line was emitted, skip the advisory and continue.

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,8 +1,8 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle five signals the contract emits to stdout: `[setup-error]`, `[repo-upgrade-available]`, `[upgrade-available]`, `[browser-tools-missing]`, and the `min-binary-version` compatibility check.
+Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle six signals the contract emits to stdout: `[setup-error]`, `[repo-upgrade-available]`, the `min-binary-version` compatibility check, `[upgrade-available]`, `[browser-tools-missing]`, and the always-emitted `PRINTING_PRESS_BIN=<abs-path>` marker (with optional `[binary-shadow]` advisory).
 
-Apply these in order. Each section is conditional — do nothing if its trigger isn't present.
+Apply these in order. Each section is conditional — do nothing if its trigger isn't present, except section 6 which is unconditional.
 
 ## 1. Refusal: missing prerequisite
 
@@ -165,3 +165,33 @@ If an install command fails (no Python, no Node.js, network error), surface the 
 If the user picks **Skip for this run**, continue without prompting further this run. The decision is not cached — the prompt re-fires on the next run if the tool is still missing.
 
 If no `[browser-tools-missing]` line was emitted, skip this section entirely.
+
+## 6. Absolute binary path (unconditional)
+
+The setup contract always emits one line of the form:
+
+```
+PRINTING_PRESS_BIN=<absolute path to the binary>
+```
+
+Capture this value. Every subsequent `printing-press ...` invocation in this skill, in reference docs it loads, and in any sub-skill it delegates to (`printing-press-publish`, `printing-press-polish`, `printing-press-score`, etc.) must be made using this absolute path, **not** bare `printing-press`. Substitute the captured path each time you compose a Bash command — `$PRINTING_PRESS_BIN` is not a live shell variable across Bash tool calls; only the literal absolute path it expands to in preflight survives.
+
+This rule exists because the contract's `export PATH=...` line only affects the single Bash tool call it runs in. Subsequent Bash tool calls open fresh shells with the user's default `PATH`. When a global `printing-press` is installed at a stale version (e.g. `$HOME/go/bin/printing-press` from an earlier `go install`), bare `printing-press` resolves to the stale global and silently shadows the local repo build that preflight selected. Using the absolute path the contract emitted eliminates the shadow.
+
+If `PRINTING_PRESS_BIN` was emitted as an empty value (`PRINTING_PRESS_BIN=`), the contract was unable to resolve a binary; this should have already been surfaced as `[setup-error]` and the skill should have stopped at section 1. Treat an empty value here as a setup-error fallback and stop.
+
+### Optional shadow advisory
+
+If the setup contract output also contains a line starting with `[binary-shadow]`, parse the follow-up lines:
+
+- `PRESS_BIN_LOCAL_VERSION=<version reported by the local build>`
+- `PRESS_BIN_GLOBAL_VERSION=<version reported by the differing global on PATH>`
+- `PRESS_BIN_GLOBAL_PATH=<absolute path to the differing global>`
+
+Surface a single-line note to the user before continuing — informational only, do not prompt:
+
+> "Note: a global printing-press v`<global>` is installed at `<path>` but the local repo build is v`<local>`. This run will use the local build (the absolute path the preflight selected); the global is unchanged."
+
+Then continue. Do not modify or remove the global. The note exists so the user can reconcile the divergence on their own time (typically with `go install ...@latest` in the global once they want the new version everywhere).
+
+If no `[binary-shadow]` line was emitted, skip the advisory and continue.

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -94,7 +94,19 @@ If the user picks **Yes**, run:
 go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest
 ```
 
-After it completes, confirm with `<PRINTING_PRESS_BIN> version --json` if the captured path is still valid for the freshly installed binary (it is, when the contract resolved `PRINTING_PRESS_BIN` from `command -v printing-press` and the new `go install` overwrote that same path; the upgrade replaces the binary in-place), and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).**
+After `go install` completes, **re-resolve `PRINTING_PRESS_BIN`** before confirming. `go install` writes to `$(go env GOBIN)` if set, otherwise `$(go env GOPATH)/bin` — which may not be the same path the contract originally captured (e.g. when the pre-upgrade binary was at `/opt/homebrew/bin/printing-press` or `/usr/local/bin/printing-press`, the new binary lives at `$GOPATH/bin/printing-press` and the old one is unchanged). Run this re-resolution in a single Bash call so its stdout becomes the new captured value:
+
+```bash
+_gobin="$(go env GOBIN 2>/dev/null)"
+[ -z "$_gobin" ] && _gobin="$(go env GOPATH 2>/dev/null)/bin"
+if [ -x "$_gobin/printing-press" ]; then
+  echo "PRINTING_PRESS_BIN=$_gobin/printing-press"
+else
+  echo "PRINTING_PRESS_BIN=$(command -v printing-press 2>/dev/null || true)"
+fi
+```
+
+Capture the new `PRINTING_PRESS_BIN=<abs-path>` value and use it for every subsequent `printing-press ...` invocation in the rest of this run, overriding the value captured in the preamble. Then confirm with `<PRINTING_PRESS_BIN> version --json` and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).**
 
 Separately, as out-of-band advice for the user's *next* session (not a stop signal for this run), tell them they can also refresh their installed skill files outside the repo checkout by running one of:
 


### PR DESCRIPTION
## Summary

Closes #1259.

The Printing Press skills' preflight setup contracts did `export PATH="$_scope_dir:$PATH"` to prefer the local repo build of `printing-press` over a globally-installed one. But `export` only affects the single Bash tool call it runs in. Every subsequent Bash tool call opens a fresh shell where the user's default `PATH` resolves bare `printing-press` to whatever was last `go install`-ed globally — silently shadowing the local build preflight just chose. Justin's yahoo-fantasy reprint ran the whole pipeline on v4.2.2 while preflight reported v4.5.1 was selected; the upgrade prompt fired but the upgrade never took effect.

## Fix (Option 1 + Option 3 from the issue)

Resolve the absolute binary path in preflight and emit it as a captured `PRINTING_PRESS_BIN=<abs-path>` marker. The agent substitutes that absolute path into every later `printing-press ...` invocation, matching the existing prose-substitution pattern the skills already use for `$PRESS_SCOPE` / `$PRESS_RUNSTATE` (variables that also don't survive across Bash tool calls).

In the main `printing-press` skill, also add a `[binary-shadow]` advisory that surfaces a one-line note when the local build version differs from a global on `$HOME/go/bin`, `/usr/local/bin`, or `/opt/homebrew/bin`. Detect-only — doesn't change which binary the agent invokes, but lets the user see at a glance that the two binaries disagree.

Same root cause exists in three sibling skills (`printing-press-catalog`, `printing-press-publish`, `printing-press-score`); they get the same minimal change (emission + absolute-path rule prose). No mass rewrite of the existing `printing-press ...` examples in skill bodies — the prose rule + setup-checks doc cover agent behavior, and that's the same pattern already used for other captured vars.

## Files

- `skills/printing-press/SKILL.md` — emit `PRINTING_PRESS_BIN` + `[binary-shadow]` advisory in preflight; add absolute-path rule prose right after the contract block; update the "MANDATORY: setup-checks.md" enumeration from five signals to six.
- `skills/printing-press/references/setup-checks.md` — header rewritten to "six signals"; new **section 6** documenting the marker, the substitution rule, the rationale (no PATH inheritance across Bash tool calls), and the optional `[binary-shadow]` subsection.
- `skills/printing-press-catalog/SKILL.md`, `skills/printing-press-publish/SKILL.md`, `skills/printing-press-score/SKILL.md` — same minimal pair (emission + one-paragraph absolute-path rule).

## Test plan

- [x] `bash -n` against each extracted contract block (4 of 4 syntax-clean)
- [x] Executed the main contract bash locally against a worktree build; verified stdout contains `PRINTING_PRESS_BIN=/Users/.../printing-press` with the expected absolute path
- [x] `go fmt ./...`, `go vet ./...` clean
- [x] `go build -o ./printing-press ./cmd/printing-press` succeeds
- [x] `go test ./...` — 4034 passed across 34 packages
- [x] `golangci-lint run ./...` — no issues
- [x] `scripts/golden.sh verify` — 18 cases PASS, no diff (skill-only change, no generator surface touched)

## Acceptance criteria (from issue)

- **Positive (local > global, in-repo)**: preflight emits `PRINTING_PRESS_BIN=<abs-path-to-local-build>`, agent uses that absolute path everywhere, downstream invocations resolve to the local build regardless of what's on `PATH`. ✅
- **Positive (no local build, outside repo)**: preflight emits `PRINTING_PRESS_BIN=$(command -v printing-press)` from the global; agent uses that. ✅
- **Negative (binary genuinely missing)**: `[setup-error]` still fires with the existing install instructions; `PRINTING_PRESS_BIN` line never reached. ✅
- **Negative (no manual go install required)**: fix is automatic when the local build exists. ✅