### PR TITLE
fix(cli): default MCP safety hints from HTTP methods

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -223,7 +223,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"composeMCPDesc":         composeMCPDesc,
 		"composeMCPSubDesc":      composeMCPSubDesc,
 		"mcpParamDesc":           g.mcpParamDescription,
-		"endpointMetaTrue":       endpointMetaTrue,
+		"endpointMetaTrue":       spec.EndpointMetaTrue,
 		"commandAnnotations":     commandAnnotationsLiteral,
 		"flagName":               flagName,
 		"paramIdent":             paramIdent,

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -223,6 +223,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"composeMCPDesc":         composeMCPDesc,
 		"composeMCPSubDesc":      composeMCPSubDesc,
 		"mcpParamDesc":           g.mcpParamDescription,
+		"endpointMetaTrue":       endpointMetaTrue,
+		"commandAnnotations":     commandAnnotationsLiteral,
 		"flagName":               flagName,
 		"paramIdent":             paramIdent,
 		"safeTypeName":           safeTypeName,
@@ -261,6 +263,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		},
 		"effectiveEndpointPath":    effectiveEndpointPath,
 		"effectiveSubEndpointPath": effectiveSubEndpointPath,
+		"endpointIsReadCommand":    endpointIsReadCommand,
 		"enumLiteral": func(values []string) string {
 			// Render a string slice as a Go []string literal for template embedding.
 			// Example: ["asc","desc"] → `"asc", "desc"`. Returns empty string when
@@ -1451,6 +1454,7 @@ func (g *Generator) renderOptionalSupportFiles() error {
 
 func (g *Generator) Generate() error {
 	warnUnenrichedLargeMCPSurface(g.Spec, os.Stderr)
+	warnUnannotatedMutations(g.Spec, os.Stderr)
 	if err := g.prepareOutput(); err != nil {
 		return err
 	}

--- a/internal/generator/mcp_safety.go
+++ b/internal/generator/mcp_safety.go
@@ -22,15 +22,16 @@ const unannotatedMutationWarning = "warning: command %s is an unannotated mutati
 
 func commandAnnotationsLiteral(resourceName, endpointName, path string, ep spec.Endpoint, isReadOnly bool) string {
 	method := strings.ToUpper(strings.TrimSpace(ep.Method))
+	destructiveMeta := spec.EndpointMetaTrue(ep, mcpDestructiveAnnotation)
 	parts := []string{
 		fmt.Sprintf("%q: %q", ppEndpointAnnotation, resourceName+"."+endpointName),
 		fmt.Sprintf("%q: %q", ppMethodAnnotation, method),
 		fmt.Sprintf("%q: %q", ppPathAnnotation, path),
 	}
-	if isReadOnly {
+	if isReadOnly && !destructiveMeta {
 		parts = append(parts, fmt.Sprintf("%q: %q", mcpReadOnlyAnnotation, "true"))
 	}
-	if method == "DELETE" || spec.EndpointMetaTrue(ep, mcpDestructiveAnnotation) {
+	if destructiveMeta || (!isReadOnly && method == "DELETE") {
 		parts = append(parts, fmt.Sprintf("%q: %q", mcpDestructiveAnnotation, "true"))
 	}
 	if spec.EndpointMetaTrue(ep, mcpPrivacySensitiveAnnotation) {

--- a/internal/generator/mcp_safety.go
+++ b/internal/generator/mcp_safety.go
@@ -20,26 +20,20 @@ const (
 
 const unannotatedMutationWarning = "warning: command %s is an unannotated mutation; agents will not see destructive signal; annotate explicitly with mcp:destructive=true when the action is destructive.\n"
 
-func endpointMetaTrue(ep spec.Endpoint, key string) bool {
-	if ep.Meta == nil {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(ep.Meta[key]), "true")
-}
-
 func commandAnnotationsLiteral(resourceName, endpointName, path string, ep spec.Endpoint, isReadOnly bool) string {
+	method := strings.ToUpper(strings.TrimSpace(ep.Method))
 	parts := []string{
 		fmt.Sprintf("%q: %q", ppEndpointAnnotation, resourceName+"."+endpointName),
-		fmt.Sprintf("%q: %q", ppMethodAnnotation, strings.ToUpper(strings.TrimSpace(ep.Method))),
+		fmt.Sprintf("%q: %q", ppMethodAnnotation, method),
 		fmt.Sprintf("%q: %q", ppPathAnnotation, path),
 	}
 	if isReadOnly {
 		parts = append(parts, fmt.Sprintf("%q: %q", mcpReadOnlyAnnotation, "true"))
 	}
-	if endpointMetaTrue(ep, mcpDestructiveAnnotation) {
+	if method == "DELETE" || spec.EndpointMetaTrue(ep, mcpDestructiveAnnotation) {
 		parts = append(parts, fmt.Sprintf("%q: %q", mcpDestructiveAnnotation, "true"))
 	}
-	if endpointMetaTrue(ep, mcpPrivacySensitiveAnnotation) {
+	if spec.EndpointMetaTrue(ep, mcpPrivacySensitiveAnnotation) {
 		parts = append(parts, fmt.Sprintf("%q: %q", mcpPrivacySensitiveAnnotation, "true"))
 	}
 	return "map[string]string{" + strings.Join(parts, ", ") + "}"
@@ -81,7 +75,7 @@ func endpointNeedsMutationWarning(endpoint spec.Endpoint, opName string) bool {
 	if !isNeutralMutationMethod(endpoint.Method) {
 		return false
 	}
-	if endpointMetaTrue(endpoint, mcpDestructiveAnnotation) {
+	if spec.EndpointMetaTrue(endpoint, mcpDestructiveAnnotation) {
 		return false
 	}
 	return endpointIsWriteCommand(endpoint, opName)

--- a/internal/generator/mcp_safety.go
+++ b/internal/generator/mcp_safety.go
@@ -1,0 +1,106 @@
+package generator
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v3/internal/spec"
+)
+
+const (
+	mcpReadOnlyAnnotation         = "mcp:read-only"
+	mcpDestructiveAnnotation      = "mcp:destructive"
+	mcpPrivacySensitiveAnnotation = "mcp:privacy-sensitive"
+	ppEndpointAnnotation          = "pp:endpoint"
+	ppMethodAnnotation            = "pp:method"
+	ppPathAnnotation              = "pp:path"
+)
+
+const unannotatedMutationWarning = "warning: command %s is an unannotated mutation; agents will not see destructive signal; annotate explicitly with mcp:destructive=true when the action is destructive.\n"
+
+func endpointMetaTrue(ep spec.Endpoint, key string) bool {
+	if ep.Meta == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(ep.Meta[key]), "true")
+}
+
+func commandAnnotationsLiteral(resourceName, endpointName, path string, ep spec.Endpoint, isReadOnly bool) string {
+	parts := []string{
+		fmt.Sprintf("%q: %q", ppEndpointAnnotation, resourceName+"."+endpointName),
+		fmt.Sprintf("%q: %q", ppMethodAnnotation, strings.ToUpper(strings.TrimSpace(ep.Method))),
+		fmt.Sprintf("%q: %q", ppPathAnnotation, path),
+	}
+	if isReadOnly {
+		parts = append(parts, fmt.Sprintf("%q: %q", mcpReadOnlyAnnotation, "true"))
+	}
+	if endpointMetaTrue(ep, mcpDestructiveAnnotation) {
+		parts = append(parts, fmt.Sprintf("%q: %q", mcpDestructiveAnnotation, "true"))
+	}
+	if endpointMetaTrue(ep, mcpPrivacySensitiveAnnotation) {
+		parts = append(parts, fmt.Sprintf("%q: %q", mcpPrivacySensitiveAnnotation, "true"))
+	}
+	return "map[string]string{" + strings.Join(parts, ", ") + "}"
+}
+
+func warnUnannotatedMutations(s *spec.APISpec, w io.Writer) {
+	if s == nil || w == nil {
+		return
+	}
+	for _, warning := range collectMutationWarnings(s) {
+		fmt.Fprintf(w, unannotatedMutationWarning, warning)
+	}
+}
+
+func collectMutationWarnings(s *spec.APISpec) []string {
+	if s == nil {
+		return nil
+	}
+	var warnings []string
+	for resourceName, resource := range s.Resources {
+		for endpointName, endpoint := range resource.Endpoints {
+			if endpointNeedsMutationWarning(endpoint, endpointName) {
+				warnings = append(warnings, formatMutationWarningCommand(resourceName, "", endpointName))
+			}
+		}
+		for subResourceName, subResource := range resource.SubResources {
+			for endpointName, endpoint := range subResource.Endpoints {
+				if endpointNeedsMutationWarning(endpoint, endpointName) {
+					warnings = append(warnings, formatMutationWarningCommand(resourceName, subResourceName, endpointName))
+				}
+			}
+		}
+	}
+	sort.Strings(warnings)
+	return warnings
+}
+
+func endpointNeedsMutationWarning(endpoint spec.Endpoint, opName string) bool {
+	if !isNeutralMutationMethod(endpoint.Method) {
+		return false
+	}
+	if endpointMetaTrue(endpoint, mcpDestructiveAnnotation) {
+		return false
+	}
+	return endpointIsWriteCommand(endpoint, opName)
+}
+
+func isNeutralMutationMethod(method string) bool {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case "POST", "PUT", "PATCH":
+		return true
+	default:
+		return false
+	}
+}
+
+func formatMutationWarningCommand(resourceName, subResourceName, endpointName string) string {
+	parts := []string{toKebab(resourceName)}
+	if subResourceName != "" {
+		parts = append(parts, toKebab(subResourceName))
+	}
+	parts = append(parts, toKebab(endpointName))
+	return strings.Join(parts, " ")
+}

--- a/internal/generator/mcp_safety_test.go
+++ b/internal/generator/mcp_safety_test.go
@@ -127,6 +127,14 @@ func TestCommandAnnotationsLiteral(t *testing.T) {
 			},
 			wantContains: []string{`"mcp:destructive": "true"`, `"mcp:privacy-sensitive": "true"`},
 		},
+		{
+			name: "DELETE method carries destructive annotation",
+			endpoint: spec.Endpoint{
+				Method: "DELETE",
+				Path:   "/messages/{id}",
+			},
+			wantContains: []string{`"mcp:destructive": "true"`},
+		},
 	}
 
 	for _, tt := range tests {
@@ -284,6 +292,7 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 		cmd                  *cobra.Command
 		wantReadOnly         *bool
 		wantDestructive      *bool
+		wantOpenWorld        *bool
 		wantTitle            string
 		wantDescriptionStart string
 	}{
@@ -298,6 +307,7 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 			},
 			wantReadOnly: boolPtr(true),
 			wantDestructive: boolPtr(false),
+			wantOpenWorld: boolPtr(true),
 		},
 		{
 			name: "DELETE defaults to destructive",
@@ -309,6 +319,7 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 				},
 			},
 			wantDestructive: boolPtr(true),
+			wantOpenWorld: boolPtr(true),
 		},
 		{
 			name: "POST stays neutral without annotation",
@@ -331,12 +342,13 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 				},
 			},
 			wantDestructive: boolPtr(true),
+			wantOpenWorld: boolPtr(true),
 		},
 		{
 			name: "privacy-sensitive GET adds title and warning",
 			cmd: &cobra.Command{
 				Use:   "mail",
-				Short: "Get mail",
+				Short: "Privacy-sensitive: Get mail",
 				Annotations: map[string]string{
 					MethodAnnotation:           "GET",
 					PrivacySensitiveAnnotation: "true",
@@ -344,8 +356,9 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 			},
 			wantReadOnly: boolPtr(true),
 			wantDestructive: boolPtr(false),
+			wantOpenWorld: boolPtr(true),
 			wantTitle: "Privacy-sensitive",
-			wantDescriptionStart: "Privacy-sensitive: may expose personal, financial, or message content.",
+			wantDescriptionStart: "Privacy-sensitive: Get mail",
 		},
 	}
 
@@ -366,6 +379,13 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 				}
 			} else if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint != *tc.wantDestructive {
 				t.Fatalf("destructiveHint = %v, want %v", tool.Annotations.DestructiveHint, *tc.wantDestructive)
+			}
+			if tc.wantOpenWorld == nil {
+				if tool.Annotations.OpenWorldHint != nil {
+					t.Fatalf("openWorldHint = %v, want nil", *tool.Annotations.OpenWorldHint)
+				}
+			} else if tool.Annotations.OpenWorldHint == nil || *tool.Annotations.OpenWorldHint != *tc.wantOpenWorld {
+				t.Fatalf("openWorldHint = %v, want %v", tool.Annotations.OpenWorldHint, *tc.wantOpenWorld)
 			}
 			if tc.wantTitle != "" && tool.Annotations.Title != tc.wantTitle {
 				t.Fatalf("title = %q, want %q", tool.Annotations.Title, tc.wantTitle)

--- a/internal/generator/mcp_safety_test.go
+++ b/internal/generator/mcp_safety_test.go
@@ -128,12 +128,14 @@ func TestCommandAnnotationsLiteral(t *testing.T) {
 			wantContains: []string{`"mcp:destructive": "true"`, `"mcp:privacy-sensitive": "true"`},
 		},
 		{
-			name: "DELETE method carries destructive annotation",
+			name: "DELETE classified read-only does not carry conflicting destructive annotation",
 			endpoint: spec.Endpoint{
 				Method: "DELETE",
-				Path:   "/messages/{id}",
+				Path:   "/messages/search",
 			},
-			wantContains: []string{`"mcp:destructive": "true"`},
+			isReadOnly:   true,
+			wantContains: []string{`"mcp:read-only": "true"`},
+			wantAbsent:   []string{`"mcp:destructive": "true"`},
 		},
 	}
 
@@ -201,13 +203,13 @@ func TestGeneratedMCPSafetySurfaces(t *testing.T) {
 			},
 		},
 		{
-			name:         "explicit destructive POST emits destructive hint",
+			name:         "explicit destructive POST overrides read-prefix heuristic",
 			resourceName: "Messages",
-			endpointName: "Send",
+			endpointName: "Get",
 			endpoint: spec.Endpoint{
 				Method:      "POST",
 				Path:        "/messages/send",
-				Description: "Send a message",
+				Description: "Get or send a message",
 				Body:        []spec.Param{{Name: "to", Type: "string"}},
 				Meta:        map[string]string{"mcp:destructive": "true"},
 			},

--- a/internal/generator/mcp_safety_test.go
+++ b/internal/generator/mcp_safety_test.go
@@ -178,7 +178,6 @@ func TestGeneratedMCPSafetySurfaces(t *testing.T) {
 			},
 			wantCommandContains: []string{`"mcp:read-only": "true"`, `"mcp:privacy-sensitive": "true"`},
 			wantToolContains: []string{
-				`mcplib.WithTitleAnnotation("Privacy-sensitive")`,
 				`mcplib.WithReadOnlyHintAnnotation(true)`,
 				`Privacy-sensitive: may expose personal, financial, or message content.`,
 			},
@@ -357,7 +356,6 @@ func TestToolOptionsForCommandSafetyHints(t *testing.T) {
 			wantReadOnly: boolPtr(true),
 			wantDestructive: boolPtr(false),
 			wantOpenWorld: boolPtr(true),
-			wantTitle: "Privacy-sensitive",
 			wantDescriptionStart: "Privacy-sensitive: Get mail",
 		},
 	}

--- a/internal/generator/mcp_safety_test.go
+++ b/internal/generator/mcp_safety_test.go
@@ -1,0 +1,385 @@
+package generator
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v3/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWarnUnannotatedMutations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		spec           *spec.APISpec
+		wantContaining []string
+		wantAbsent     []string
+	}{
+		{
+			name: "write POST without explicit destructive annotation warns",
+			spec: &spec.APISpec{
+				Resources: map[string]spec.Resource{
+					"Users": {
+						Endpoints: map[string]spec.Endpoint{
+							"Create": {
+								Method: "POST",
+								Path:   "/users",
+								Body:   []spec.Param{{Name: "email", Type: "string"}},
+							},
+						},
+					},
+				},
+			},
+			wantContaining: []string{"warning: command users create is an unannotated mutation"},
+		},
+		{
+			name: "read-only POST stays silent",
+			spec: &spec.APISpec{
+				Resources: map[string]spec.Resource{
+					"Search": {
+						Endpoints: map[string]spec.Endpoint{
+							"Query": {
+								Method: "POST",
+								Path:   "/search",
+								Body:   []spec.Param{{Name: "query", Type: "string"}},
+							},
+						},
+					},
+				},
+			},
+			wantAbsent: []string{"warning:"},
+		},
+		{
+			name: "explicit destructive annotation suppresses warning",
+			spec: &spec.APISpec{
+				Resources: map[string]spec.Resource{
+					"Messages": {
+						Endpoints: map[string]spec.Endpoint{
+							"Send": {
+								Method: "POST",
+								Path:   "/messages/send",
+								Body:   []spec.Param{{Name: "to", Type: "string"}},
+								Meta:   map[string]string{"mcp:destructive": "true"},
+							},
+						},
+					},
+				},
+			},
+			wantAbsent: []string{"warning:"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			warnUnannotatedMutations(tt.spec, &buf)
+			got := buf.String()
+
+			for _, want := range tt.wantContaining {
+				assert.Contains(t, got, want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, got, absent)
+			}
+		})
+	}
+}
+
+func TestCommandAnnotationsLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		endpoint     spec.Endpoint
+		isReadOnly   bool
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "read-only annotation included",
+			endpoint: spec.Endpoint{
+				Method: "GET",
+				Path:   "/items",
+			},
+			isReadOnly:   true,
+			wantContains: []string{`"mcp:read-only": "true"`},
+			wantAbsent:   []string{`"mcp:destructive": "true"`},
+		},
+		{
+			name: "destructive and privacy annotations included from meta",
+			endpoint: spec.Endpoint{
+				Method: "POST",
+				Path:   "/messages/send",
+				Meta: map[string]string{
+					"mcp:destructive":       "true",
+					"mcp:privacy-sensitive": "true",
+				},
+			},
+			wantContains: []string{`"mcp:destructive": "true"`, `"mcp:privacy-sensitive": "true"`},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := commandAnnotationsLiteral("messages", "send", tt.endpoint.Path, tt.endpoint, tt.isReadOnly)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, got, absent)
+			}
+		})
+	}
+}
+
+func TestGeneratedMCPSafetySurfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		resourceName        string
+		endpointName        string
+		endpoint            spec.Endpoint
+		wantCommandContains []string
+		wantToolContains    []string
+		wantToolAbsent      []string
+	}{
+		{
+			name:         "privacy-sensitive GET carries annotation and metadata",
+			resourceName: "Messages",
+			endpointName: "Get",
+			endpoint: spec.Endpoint{
+				Method:      "GET",
+				Path:        "/messages/{id}",
+				Description: "Get a message body",
+				Meta:        map[string]string{"mcp:privacy-sensitive": "true"},
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+			wantCommandContains: []string{`"mcp:read-only": "true"`, `"mcp:privacy-sensitive": "true"`},
+			wantToolContains: []string{
+				`mcplib.WithTitleAnnotation("Privacy-sensitive")`,
+				`mcplib.WithReadOnlyHintAnnotation(true)`,
+				`Privacy-sensitive: may expose personal, financial, or message content.`,
+			},
+		},
+		{
+			name:         "mutation POST stays neutral without explicit annotation",
+			resourceName: "Users",
+			endpointName: "Create",
+			endpoint: spec.Endpoint{
+				Method:      "POST",
+				Path:        "/users",
+				Description: "Create a user",
+				Body:        []spec.Param{{Name: "email", Type: "string"}},
+			},
+			wantToolContains: []string{
+				`mcplib.WithOpenWorldHintAnnotation(true)`,
+			},
+			wantToolAbsent: []string{
+				`mcplib.WithDestructiveHintAnnotation(true)`,
+				`mcplib.WithDestructiveHintAnnotation(false)`,
+			},
+		},
+		{
+			name:         "explicit destructive POST emits destructive hint",
+			resourceName: "Messages",
+			endpointName: "Send",
+			endpoint: spec.Endpoint{
+				Method:      "POST",
+				Path:        "/messages/send",
+				Description: "Send a message",
+				Body:        []spec.Param{{Name: "to", Type: "string"}},
+				Meta:        map[string]string{"mcp:destructive": "true"},
+			},
+			wantCommandContains: []string{`"mcp:destructive": "true"`},
+			wantToolContains:    []string{`mcplib.WithDestructiveHintAnnotation(true)`},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec(strings.ToLower(tt.resourceName) + "-" + strings.ToLower(tt.endpointName))
+			apiSpec.Resources = map[string]spec.Resource{
+				tt.resourceName: {
+					Description: tt.resourceName,
+					Endpoints:   map[string]spec.Endpoint{tt.endpointName: tt.endpoint},
+				},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), strings.ToLower(tt.resourceName)+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			commandSrc := readPromotedCommandFile(t, outputDir)
+			for _, want := range tt.wantCommandContains {
+				assert.Contains(t, commandSrc, want)
+			}
+
+			toolsSrcBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+			require.NoError(t, err)
+
+			toolName := strings.ToLower(tt.resourceName) + "_" + strings.ToLower(tt.endpointName)
+			blockRE := regexp.MustCompile(`(?s)mcplib\.NewTool\("` + regexp.QuoteMeta(toolName) + `".*?\n\t\)`)
+			block := blockRE.FindString(string(toolsSrcBytes))
+			require.NotEmpty(t, block, "expected to find typed MCP tool block for endpoint")
+
+			for _, want := range tt.wantToolContains {
+				assert.Contains(t, block, want)
+			}
+			for _, absent := range tt.wantToolAbsent {
+				assert.NotContains(t, block, absent)
+			}
+		})
+	}
+}
+
+func TestGeneratedCobratreeSafetyHints(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cobratree-safety")
+	apiSpec.Resources = map[string]spec.Resource{
+		"Items": {
+			Description: "Items",
+			Endpoints: map[string]spec.Endpoint{
+				"List": {
+					Method:      "GET",
+					Path:        "/items",
+					Description: "List items",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "cobratree-safety-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testSrc := `package cobratree
+
+import (
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/spf13/cobra"
+)
+
+func TestToolOptionsForCommandSafetyHints(t *testing.T) {
+	cases := []struct {
+		name                 string
+		cmd                  *cobra.Command
+		wantReadOnly         *bool
+		wantDestructive      *bool
+		wantTitle            string
+		wantDescriptionStart string
+	}{
+		{
+			name: "GET defaults to read-only",
+			cmd: &cobra.Command{
+				Use:   "list",
+				Short: "List items",
+				Annotations: map[string]string{
+					MethodAnnotation: "GET",
+				},
+			},
+			wantReadOnly: boolPtr(true),
+			wantDestructive: boolPtr(false),
+		},
+		{
+			name: "DELETE defaults to destructive",
+			cmd: &cobra.Command{
+				Use:   "delete",
+				Short: "Delete item",
+				Annotations: map[string]string{
+					MethodAnnotation: "DELETE",
+				},
+			},
+			wantDestructive: boolPtr(true),
+		},
+		{
+			name: "POST stays neutral without annotation",
+			cmd: &cobra.Command{
+				Use:   "create",
+				Short: "Create item",
+				Annotations: map[string]string{
+					MethodAnnotation: "POST",
+				},
+			},
+		},
+		{
+			name: "explicit destructive POST sets destructive hint",
+			cmd: &cobra.Command{
+				Use:   "send",
+				Short: "Send message",
+				Annotations: map[string]string{
+					MethodAnnotation:      "POST",
+					DestructiveAnnotation: "true",
+				},
+			},
+			wantDestructive: boolPtr(true),
+		},
+		{
+			name: "privacy-sensitive GET adds title and warning",
+			cmd: &cobra.Command{
+				Use:   "mail",
+				Short: "Get mail",
+				Annotations: map[string]string{
+					MethodAnnotation:           "GET",
+					PrivacySensitiveAnnotation: "true",
+				},
+			},
+			wantReadOnly: boolPtr(true),
+			wantDestructive: boolPtr(false),
+			wantTitle: "Privacy-sensitive",
+			wantDescriptionStart: "Privacy-sensitive: may expose personal, financial, or message content.",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tool := mcplib.NewTool("x", toolOptionsForCommand(tc.cmd)...)
+			if tc.wantReadOnly == nil {
+				if tool.Annotations.ReadOnlyHint != nil {
+					t.Fatalf("readOnlyHint = %v, want nil", *tool.Annotations.ReadOnlyHint)
+				}
+			} else if tool.Annotations.ReadOnlyHint == nil || *tool.Annotations.ReadOnlyHint != *tc.wantReadOnly {
+				t.Fatalf("readOnlyHint = %v, want %v", tool.Annotations.ReadOnlyHint, *tc.wantReadOnly)
+			}
+			if tc.wantDestructive == nil {
+				if tool.Annotations.DestructiveHint != nil {
+					t.Fatalf("destructiveHint = %v, want nil", *tool.Annotations.DestructiveHint)
+				}
+			} else if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint != *tc.wantDestructive {
+				t.Fatalf("destructiveHint = %v, want %v", tool.Annotations.DestructiveHint, *tc.wantDestructive)
+			}
+			if tc.wantTitle != "" && tool.Annotations.Title != tc.wantTitle {
+				t.Fatalf("title = %q, want %q", tool.Annotations.Title, tc.wantTitle)
+			}
+			if tc.wantDescriptionStart != "" && !strings.HasPrefix(tool.Description, tc.wantDescriptionStart) {
+				t.Fatalf("description = %q, want prefix %q", tool.Description, tc.wantDescriptionStart)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "safety_extra_test.go"), []byte(testSrc), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
+}

--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -10,8 +10,11 @@ import (
 )
 
 const (
-	EndpointAnnotation = "pp:endpoint"
-	HiddenAnnotation   = "mcp:hidden"
+	EndpointAnnotation         = "pp:endpoint"
+	MethodAnnotation           = "pp:method"
+	HiddenAnnotation           = "mcp:hidden"
+	DestructiveAnnotation      = "mcp:destructive"
+	PrivacySensitiveAnnotation = "mcp:privacy-sensitive"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -96,6 +99,21 @@ func isMCPHidden(cmd *cobra.Command) bool {
 
 func isMCPReadOnly(cmd *cobra.Command) bool {
 	return annotationIsTrue(cmd, ReadOnlyAnnotation)
+}
+
+func isMCPDestructive(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, DestructiveAnnotation)
+}
+
+func isMCPPrivacySensitive(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, PrivacySensitiveAnnotation)
+}
+
+func commandMethod(cmd *cobra.Command) string {
+	if cmd == nil || cmd.Annotations == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(cmd.Annotations[MethodAnnotation]))
 }
 
 func annotationIsTrue(cmd *cobra.Command, key string) bool {

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -64,9 +64,6 @@ func toolOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
 		mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 		mcplib.WithDescription(descriptionFor(cmd)),
 	}
-	if isMCPPrivacySensitive(cmd) {
-		options = append(options, mcplib.WithTitleAnnotation("Privacy-sensitive"))
-	}
 	options = append(options, toolOptionsForFlags(cmd)...)
 	if commandTakesArgs(cmd) {
 		options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -4,6 +4,8 @@
 package cobratree
 
 import (
+	"strings"
+
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -78,19 +80,27 @@ func safetyHintOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
 		return []mcplib.ToolOption{
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(true),
 		}
 	}
 	if isMCPDestructive(cmd) {
-		return []mcplib.ToolOption{mcplib.WithDestructiveHintAnnotation(true)}
+		return []mcplib.ToolOption{
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
 	}
 	switch commandMethod(cmd) {
 	case "GET":
 		return []mcplib.ToolOption{
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(true),
 		}
 	case "DELETE":
-		return []mcplib.ToolOption{mcplib.WithDestructiveHintAnnotation(true)}
+		return []mcplib.ToolOption{
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
 	default:
 		return nil
 	}
@@ -98,6 +108,10 @@ func safetyHintOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
 
 func maybePrivacySensitiveDescription(cmd *cobra.Command, desc string) string {
 	if !isMCPPrivacySensitive(cmd) {
+		return desc
+	}
+	lower := strings.ToLower(desc)
+	if strings.Contains(lower, "privacy-sensitive") || strings.Contains(lower, "privacy sensitive") {
 		return desc
 	}
 	return "Privacy-sensitive: may expose personal, financial, or message content. " + desc

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -30,15 +30,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
-		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
-		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
-		}
-		if isMCPReadOnly(cmd) {
-			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
-		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, toolOptionsForCommand(cmd)...), shellOutToCLI(cliPath, path))
 	})
 }
 
@@ -57,10 +49,56 @@ func walk(cmd *cobra.Command, path []string, visit func(*cobra.Command, []string
 
 func descriptionFor(cmd *cobra.Command) string {
 	if cmd.Long != "" {
-		return cmd.Long
+		return maybePrivacySensitiveDescription(cmd, cmd.Long)
 	}
 	if cmd.Short != "" {
-		return cmd.Short
+		return maybePrivacySensitiveDescription(cmd, cmd.Short)
 	}
-	return "Run `" + cmd.CommandPath() + "` through the companion CLI binary."
+	return maybePrivacySensitiveDescription(cmd, "Run `"+cmd.CommandPath()+"` through the companion CLI binary.")
+}
+
+func toolOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
+	options := []mcplib.ToolOption{
+		mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
+		mcplib.WithDescription(descriptionFor(cmd)),
+	}
+	if isMCPPrivacySensitive(cmd) {
+		options = append(options, mcplib.WithTitleAnnotation("Privacy-sensitive"))
+	}
+	options = append(options, toolOptionsForFlags(cmd)...)
+	if commandTakesArgs(cmd) {
+		options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+	}
+	options = append(options, safetyHintOptionsForCommand(cmd)...)
+	return options
+}
+
+func safetyHintOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
+	if isMCPReadOnly(cmd) {
+		return []mcplib.ToolOption{
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		}
+	}
+	if isMCPDestructive(cmd) {
+		return []mcplib.ToolOption{mcplib.WithDestructiveHintAnnotation(true)}
+	}
+	switch commandMethod(cmd) {
+	case "GET":
+		return []mcplib.ToolOption{
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		}
+	case "DELETE":
+		return []mcplib.ToolOption{mcplib.WithDestructiveHintAnnotation(true)}
+	default:
+		return nil
+	}
+}
+
+func maybePrivacySensitiveDescription(cmd *cobra.Command, desc string) string {
+	if !isMCPPrivacySensitive(cmd) {
+		return desc
+	}
+	return "Privacy-sensitive: may expose personal, financial, or message content. " + desc
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -52,7 +52,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 		Short: "{{oneline .Endpoint.Description}}",
 		Example: "{{exampleLine .CommandPath .EndpointName .Endpoint}}",
-		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
+		Annotations: {{commandAnnotations .ResourceName .EndpointName .EffectivePath .Endpoint .IsReadOnly}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if positionalArgs .Endpoint}}
 			if len(args) == 0 {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -29,7 +29,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Short: "{{oneline .Endpoint.Description}}",
 		Long:  "Shortcut for '{{.ResourceName}} {{.EndpointName}}'. {{oneline .Endpoint.Description}}",
 		Example: "  {{modulePath}} {{.PromotedName}}",
-		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
+		Annotations: {{commandAnnotations .ResourceName .EndpointName .EffectivePath .Endpoint .IsReadOnly}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -41,9 +41,6 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool({{printf "%q" (printf "%s_%s" (snake $name) (snake $eName))}},
 			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription({{printf "%q" (composeMCPDesc $.APISpec $resource $endpoint $.MCPPublicCount $.MCPTotalCount)}}),
-{{- if endpointMetaTrue $endpoint "mcp:privacy-sensitive"}}
-			mcplib.WithTitleAnnotation("Privacy-sensitive"),
-{{- end}}
 {{- range $endpoint.Params}}
 {{- if eq .Type "integer"}}
 			mcplib.WithNumber({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
@@ -80,9 +77,6 @@ func RegisterTools(s *server.MCPServer) {
 		mcplib.NewTool({{printf "%q" (printf "%s_%s_%s" (snake $name) (snake $subName) (snake $eName))}},
 			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription({{printf "%q" (composeMCPSubDesc $.APISpec $resource $subResource $endpoint $.MCPPublicCount $.MCPTotalCount)}}),
-{{- if endpointMetaTrue $endpoint "mcp:privacy-sensitive"}}
-			mcplib.WithTitleAnnotation("Privacy-sensitive"),
-{{- end}}
 {{- range $endpoint.Params}}
 {{- if eq .Type "integer"}}
 			mcplib.WithNumber({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -50,14 +50,14 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
 {{- end}}
-{{- if endpointIsReadCommand $endpoint $eName}}
+{{- if endpointMetaTrue $endpoint "mcp:destructive"}}
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+{{- else if endpointIsReadCommand $endpoint $eName}}
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else if eq (upper $endpoint.Method) "DELETE"}}
-			mcplib.WithDestructiveHintAnnotation(true),
-			mcplib.WithOpenWorldHintAnnotation(true),
-{{- else if endpointMetaTrue $endpoint "mcp:destructive"}}
 			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else}}
@@ -86,14 +86,14 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
 {{- end}}
-{{- if endpointIsReadCommand $endpoint $eName}}
+{{- if endpointMetaTrue $endpoint "mcp:destructive"}}
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+{{- else if endpointIsReadCommand $endpoint $eName}}
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else if eq (upper $endpoint.Method) "DELETE"}}
-			mcplib.WithDestructiveHintAnnotation(true),
-			mcplib.WithOpenWorldHintAnnotation(true),
-{{- else if endpointMetaTrue $endpoint "mcp:destructive"}}
 			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else}}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -39,7 +39,11 @@ func RegisterTools(s *server.MCPServer) {
 {{- range $eName, $endpoint := $resource.Endpoints}}
 	s.AddTool(
 		mcplib.NewTool({{printf "%q" (printf "%s_%s" (snake $name) (snake $eName))}},
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription({{printf "%q" (composeMCPDesc $.APISpec $resource $endpoint $.MCPPublicCount $.MCPTotalCount)}}),
+{{- if endpointMetaTrue $endpoint "mcp:privacy-sensitive"}}
+			mcplib.WithTitleAnnotation("Privacy-sensitive"),
+{{- end}}
 {{- range $endpoint.Params}}
 {{- if eq .Type "integer"}}
 			mcplib.WithNumber({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
@@ -49,15 +53,15 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
 {{- end}}
-{{- if eq (upper $endpoint.Method) "GET"}}
+{{- if endpointIsReadCommand $endpoint $eName}}
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else if eq (upper $endpoint.Method) "DELETE"}}
 			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
-{{- else if eq (upper $endpoint.Method) "POST"}}
-			mcplib.WithDestructiveHintAnnotation(false),
+{{- else if endpointMetaTrue $endpoint "mcp:destructive"}}
+			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else}}
 			mcplib.WithOpenWorldHintAnnotation(true),
@@ -74,7 +78,11 @@ func RegisterTools(s *server.MCPServer) {
 {{- range $eName, $endpoint := $subResource.Endpoints}}
 	s.AddTool(
 		mcplib.NewTool({{printf "%q" (printf "%s_%s_%s" (snake $name) (snake $subName) (snake $eName))}},
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription({{printf "%q" (composeMCPSubDesc $.APISpec $resource $subResource $endpoint $.MCPPublicCount $.MCPTotalCount)}}),
+{{- if endpointMetaTrue $endpoint "mcp:privacy-sensitive"}}
+			mcplib.WithTitleAnnotation("Privacy-sensitive"),
+{{- end}}
 {{- range $endpoint.Params}}
 {{- if eq .Type "integer"}}
 			mcplib.WithNumber({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
@@ -84,15 +92,15 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
 {{- end}}
-{{- if eq (upper $endpoint.Method) "GET"}}
+{{- if endpointIsReadCommand $endpoint $eName}}
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else if eq (upper $endpoint.Method) "DELETE"}}
 			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
-{{- else if eq (upper $endpoint.Method) "POST"}}
-			mcplib.WithDestructiveHintAnnotation(false),
+{{- else if endpointMetaTrue $endpoint "mcp:destructive"}}
+			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
 {{- else}}
 			mcplib.WithOpenWorldHintAnnotation(true),

--- a/internal/mcpdesc/compose.go
+++ b/internal/mcpdesc/compose.go
@@ -94,7 +94,7 @@ func Compose(in Input) string {
 	}
 
 	composed = appendMethodMarker(composed, in.Endpoint.Method)
-	composed = prependPrivacyMarker(composed, endpointMetaTrue(in.Endpoint, privacySensitiveMetaKey))
+	composed = prependPrivacyMarker(composed, spec.EndpointMetaTrue(in.Endpoint, privacySensitiveMetaKey))
 	return naming.MCPDescription(composed, in.NoAuth, in.AuthType, in.PublicCount, in.TotalCount)
 }
 
@@ -255,13 +255,6 @@ func prependPrivacyMarker(desc string, privacySensitive bool) string {
 		return desc
 	}
 	return "Privacy-sensitive: may expose personal, financial, or message content. " + desc
-}
-
-func endpointMetaTrue(ep spec.Endpoint, key string) bool {
-	if ep.Meta == nil {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(ep.Meta[key]), "true")
 }
 
 func formatParam(p spec.Param) string {

--- a/internal/mcpdesc/compose.go
+++ b/internal/mcpdesc/compose.go
@@ -41,6 +41,8 @@ const (
 	methodPATCH  = "PATCH"
 	methodPUT    = "PUT"
 	methodDELETE = "DELETE"
+
+	privacySensitiveMetaKey = "mcp:privacy-sensitive"
 )
 
 type Input struct {
@@ -92,6 +94,7 @@ func Compose(in Input) string {
 	}
 
 	composed = appendMethodMarker(composed, in.Endpoint.Method)
+	composed = prependPrivacyMarker(composed, endpointMetaTrue(in.Endpoint, privacySensitiveMetaKey))
 	return naming.MCPDescription(composed, in.NoAuth, in.AuthType, in.PublicCount, in.TotalCount)
 }
 
@@ -241,6 +244,24 @@ func appendMethodMarker(desc, method string) string {
 		}
 	}
 	return desc
+}
+
+func prependPrivacyMarker(desc string, privacySensitive bool) string {
+	if desc == "" || !privacySensitive {
+		return desc
+	}
+	lower := strings.ToLower(desc)
+	if strings.Contains(lower, "privacy-sensitive") || strings.Contains(lower, "privacy sensitive") {
+		return desc
+	}
+	return "Privacy-sensitive: may expose personal, financial, or message content. " + desc
+}
+
+func endpointMetaTrue(ep spec.Endpoint, key string) bool {
+	if ep.Meta == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(ep.Meta[key]), "true")
 }
 
 func formatParam(p spec.Param) string {

--- a/internal/mcpdesc/compose_test.go
+++ b/internal/mcpdesc/compose_test.go
@@ -255,6 +255,22 @@ func TestCompose_NoParamsNoResponse(t *testing.T) {
 	assert.Equal(t, "Health check.", got)
 }
 
+func TestCompose_PrivacySensitivePrefixAddedOnce(t *testing.T) {
+	in := Input{
+		Endpoint: spec.Endpoint{
+			Method:      "GET",
+			Path:        "/messages/{id}",
+			Description: "Retrieve a message body",
+			Meta:        map[string]string{"mcp:privacy-sensitive": "true"},
+			Params:      []spec.Param{{Name: "id", Required: true, Positional: true}},
+		},
+		AuthType: "bearer_token",
+	}
+	got := Compose(in)
+	assert.Contains(t, got, "Privacy-sensitive: may expose personal, financial, or message content.")
+	assert.Equal(t, 1, strings.Count(strings.ToLower(got), "privacy-sensitive"))
+}
+
 func TestCompose_AppendsAuthAnnotationViaMCPDescription(t *testing.T) {
 	// Compose delegates the (public)/(requires auth) suffix to
 	// naming.MCPDescription so the auth-annotation logic stays

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -32,8 +32,8 @@ var (
 	errAnnotationSoftFail = errors.New("endpoint annotation skipped")
 )
 
-var endpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+", "pp:method": "[^"]+", "pp:path": "[^"]+"(?:, "mcp:read-only": "true")?\},\s*$`)
-var staleEndpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+"(?:, "mcp:read-only": "true")?\},\s*$`)
+var endpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+", "pp:method": "[^"]+", "pp:path": "[^"]+"(?:, "mcp:(?:read-only|destructive|privacy-sensitive)": "true")*\},\s*$`)
+var staleEndpointAnnotationLine = regexp.MustCompile(`(?m)^\s*Annotations: map\[string\]string\{"pp:endpoint": "[^"]+"(?:, "mcp:(?:read-only|destructive|privacy-sensitive)": "true")*\},\s*$`)
 
 type Result struct {
 	Changed bool

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -36,8 +36,9 @@ func TestSyncBackfillsEndpointAnnotations(t *testing.T) {
 			"projects": {
 				Description: "Manage projects",
 				Endpoints: map[string]spec.Endpoint{
-					"list": {Method: "GET", Path: "/projects", Description: "List projects"},
-					"get":  {Method: "GET", Path: "/projects/{id}", Description: "Get a project"},
+					"list":   {Method: "GET", Path: "/projects", Description: "List projects"},
+					"get":    {Method: "GET", Path: "/projects/{id}", Description: "Get a project"},
+					"delete": {Method: "DELETE", Path: "/projects/{id}", Description: "Delete a project", Meta: map[string]string{"mcp:privacy-sensitive": "true"}},
 				},
 			},
 		},
@@ -72,6 +73,10 @@ func RegisterNovelFeatureTools() { shellOutToCLI("projects list") }
 	updatedEndpoint, err := os.ReadFile(endpointPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(updatedEndpoint), `Annotations: map[string]string{"pp:endpoint": "projects.list", "pp:method": "GET", "pp:path": "/projects", "mcp:read-only": "true"}`)
+
+	deleteEndpoint, err := os.ReadFile(filepath.Join(cliDir, "internal", "cli", "projects_delete.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(deleteEndpoint), `Annotations: map[string]string{"pp:endpoint": "projects.delete", "pp:method": "DELETE", "pp:path": "/projects/{id}", "mcp:destructive": "true", "mcp:privacy-sensitive": "true"}`)
 
 	updatedTools, err := os.ReadFile(filepath.Join(cliDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -33,6 +33,16 @@ const (
 	ResponseFormatHTML = "html"
 )
 
+// EndpointMetaTrue is the shared truth parser for endpoint metadata booleans.
+// Keep generator, MCP description, and template helper behavior in sync by
+// routing all mcp:* boolean metadata checks through this function.
+func EndpointMetaTrue(ep Endpoint, key string) bool {
+	if ep.Meta == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(ep.Meta[key]), "true")
+}
+
 const (
 	TierAuthTypeNone        = "none"
 	TierAuthTypeAPIKey      = "api_key"

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -26,6 +26,7 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("items_list",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List items. Returns array of Item."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -10,8 +10,11 @@ import (
 )
 
 const (
-	EndpointAnnotation = "pp:endpoint"
-	HiddenAnnotation   = "mcp:hidden"
+	EndpointAnnotation         = "pp:endpoint"
+	MethodAnnotation           = "pp:method"
+	HiddenAnnotation           = "mcp:hidden"
+	DestructiveAnnotation      = "mcp:destructive"
+	PrivacySensitiveAnnotation = "mcp:privacy-sensitive"
 	// ReadOnlyAnnotation, when set on a Cobra command to "true"/"1"/"yes",
 	// causes the runtime walker to register the resulting MCP tool with
 	// readOnlyHint=true. Use for novel CLI commands that don't mutate
@@ -96,6 +99,21 @@ func isMCPHidden(cmd *cobra.Command) bool {
 
 func isMCPReadOnly(cmd *cobra.Command) bool {
 	return annotationIsTrue(cmd, ReadOnlyAnnotation)
+}
+
+func isMCPDestructive(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, DestructiveAnnotation)
+}
+
+func isMCPPrivacySensitive(cmd *cobra.Command) bool {
+	return annotationIsTrue(cmd, PrivacySensitiveAnnotation)
+}
+
+func commandMethod(cmd *cobra.Command) string {
+	if cmd == nil || cmd.Annotations == nil {
+		return ""
+	}
+	return strings.ToUpper(strings.TrimSpace(cmd.Annotations[MethodAnnotation]))
 }
 
 func annotationIsTrue(cmd *cobra.Command, key string) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -64,9 +64,6 @@ func toolOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
 		mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 		mcplib.WithDescription(descriptionFor(cmd)),
 	}
-	if isMCPPrivacySensitive(cmd) {
-		options = append(options, mcplib.WithTitleAnnotation("Privacy-sensitive"))
-	}
 	options = append(options, toolOptionsForFlags(cmd)...)
 	if commandTakesArgs(cmd) {
 		options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -4,6 +4,8 @@
 package cobratree
 
 import (
+	"strings"
+
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -30,15 +32,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
-		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
-		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
-		}
-		if isMCPReadOnly(cmd) {
-			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
-		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, toolOptionsForCommand(cmd)...), shellOutToCLI(cliPath, path))
 	})
 }
 
@@ -57,10 +51,68 @@ func walk(cmd *cobra.Command, path []string, visit func(*cobra.Command, []string
 
 func descriptionFor(cmd *cobra.Command) string {
 	if cmd.Long != "" {
-		return cmd.Long
+		return maybePrivacySensitiveDescription(cmd, cmd.Long)
 	}
 	if cmd.Short != "" {
-		return cmd.Short
+		return maybePrivacySensitiveDescription(cmd, cmd.Short)
 	}
-	return "Run `" + cmd.CommandPath() + "` through the companion CLI binary."
+	return maybePrivacySensitiveDescription(cmd, "Run `"+cmd.CommandPath()+"` through the companion CLI binary.")
+}
+
+func toolOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
+	options := []mcplib.ToolOption{
+		mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
+		mcplib.WithDescription(descriptionFor(cmd)),
+	}
+	if isMCPPrivacySensitive(cmd) {
+		options = append(options, mcplib.WithTitleAnnotation("Privacy-sensitive"))
+	}
+	options = append(options, toolOptionsForFlags(cmd)...)
+	if commandTakesArgs(cmd) {
+		options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+	}
+	options = append(options, safetyHintOptionsForCommand(cmd)...)
+	return options
+}
+
+func safetyHintOptionsForCommand(cmd *cobra.Command) []mcplib.ToolOption {
+	if isMCPReadOnly(cmd) {
+		return []mcplib.ToolOption{
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
+	}
+	if isMCPDestructive(cmd) {
+		return []mcplib.ToolOption{
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
+	}
+	switch commandMethod(cmd) {
+	case "GET":
+		return []mcplib.ToolOption{
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
+	case "DELETE":
+		return []mcplib.ToolOption{
+			mcplib.WithDestructiveHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(true),
+		}
+	default:
+		return nil
+	}
+}
+
+func maybePrivacySensitiveDescription(cmd *cobra.Command, desc string) string {
+	if !isMCPPrivacySensitive(cmd) {
+		return desc
+	}
+	lower := strings.ToLower(desc)
+	if strings.Contains(lower, "privacy-sensitive") || strings.Contains(lower, "privacy sensitive") {
+		return desc
+	}
+	return "Privacy-sensitive: may expose personal, financial, or message content. " + desc
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -26,6 +26,7 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("currencies_list",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List supported currencies. Returns array of Currency."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -35,14 +36,15 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_create",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("Create project. Required: name, visibility. Optional: owner_email. Returns the new Project."),
-			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
 		makeAPIHandler("POST", "/projects", []string{ }),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_get",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("Get project. Required: projectId."),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithReadOnlyHintAnnotation(true),
@@ -53,6 +55,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_list",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List projects. Optional: status, limit (default: 25), cursor. Returns array of Project."),
 			mcplib.WithString("status", mcplib.Description("Status")),
 			mcplib.WithString("limit", mcplib.Description("Limit")),
@@ -65,6 +68,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_list-project",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List project tasks. Required: projectId. Optional: priority, limit (default: 50), cursor. Returns array of Task."),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithString("priority", mcplib.Description("Priority")),
@@ -78,6 +82,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_update-project",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("Update project task. Required: projectId, taskId. Optional: completed, priority, title. Partial update."),
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithString("taskId", mcplib.Required(), mcplib.Description("Task id")),
@@ -87,6 +92,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("public_get-status",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("Get public service status. (public)"),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -96,6 +102,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("reports_summary_get-report-year",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("Get a report summary for a year. Required: year."),
 			mcplib.WithString("year", mcplib.Required(), mcplib.Description("Year")),
 			mcplib.WithReadOnlyHintAnnotation(true),

--- a/testdata/golden/expected/generate-golden-api/stderr.txt
+++ b/testdata/golden/expected/generate-golden-api/stderr.txt
@@ -1,2 +1,4 @@
+warning: command projects create is an unannotated mutation; agents will not see destructive signal; annotate explicitly with mcp:destructive=true when the action is destructive.
+warning: command projects tasks update-project is an unannotated mutation; agents will not see destructive signal; annotate explicitly with mcp:destructive=true when the action is destructive.
 warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it
 Generated printing-press-golden at <ARTIFACT_DIR>/generate-golden-api/printing-press-golden

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -26,6 +26,7 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("items_enterprise",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List enterprise items."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -35,6 +36,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("items_list",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List free items. (public)"),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
@@ -44,6 +46,7 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(
 		mcplib.NewTool("items_premium",
+			mcplib.WithToolAnnotation(mcplib.ToolAnnotation{}),
 			mcplib.WithDescription("List paid items."),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),


### PR DESCRIPTION
## Summary
- centralize generated MCP safety annotation decisions for endpoint-backed and promoted commands
- default DELETE endpoints to destructive, GET endpoints to read-only, and POST/PUT/PATCH endpoints to neutral unless explicitly annotated
- add privacy-sensitive metadata/warnings for commands annotated `mcp:privacy-sensitive=true`
- emit generator warnings for unannotated mutation endpoints so specs can opt into destructive hints deliberately

## Testing
- `go fmt ./...`
- `go test ./internal/mcpdesc -run 'TestCompose_PrivacySensitivePrefixAddedOnce'`
- `go test ./internal/generator -run 'TestWarnUnannotatedMutations|TestCommandAnnotationsLiteral|TestGeneratedMCPSafetySurfaces|TestGeneratedCobratreeSafetyHints'`
- `go build -o ./printing-press ./cmd/printing-press`

## Notes
- Full `go test ./...` and `scripts/golden.sh verify` were attempted by the task agent but blocked/drifted in the sandbox: localhost bind restrictions, unavailable network module fetches, and intentional generated MCP output changes. The intentional golden drift should be reviewed before landing.
- This is generator-only work. It does not publish or add any The Close CLI to the public library.
