### PR TITLE
fix(cli): make cookie-auth login --chrome work on Windows

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6326,6 +6326,66 @@ func TestGenerate_CookieAuthUsesBrowserTemplate(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// TestGenerate_CookieAuthWindowsCompatibility asserts the cookie-auth template
+// emits a portable Python resolver and a Windows-aware fallback for the
+// `auth login --chrome` flow. Regression for issue #1101: hardcoded `python3`
+// and a non-Windows-friendly install hint made every cookie-auth CLI unusable
+// on Windows.
+func TestGenerate_CookieAuthWindowsCompatibility(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "winapp",
+		Version: "0.1.0",
+		BaseURL: "https://app.example.com",
+		Auth: spec.AuthConfig{
+			Type:         "cookie",
+			Header:       "Cookie",
+			In:           "cookie",
+			CookieDomain: ".example.com",
+			EnvVars:      []string{"WINAPP_COOKIES"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/winapp-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Manage items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/api/items", Description: "List items"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "winapp-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	auth, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	content := string(auth)
+
+	// Python resolver tries all three common binary names rather than only `python3`.
+	assert.Contains(t, content, "resolvePythonBinary")
+	assert.Contains(t, content, `"python3"`)
+	assert.Contains(t, content, `"python"`)
+	assert.Contains(t, content, `"py"`)
+	assert.Contains(t, content, `"-3"`)
+
+	// pycookiecheat is skipped on Windows because it raises OSError there.
+	assert.Contains(t, content, `runtime.GOOS != "windows"`)
+	assert.Contains(t, content, "pycookiecheat does not support Windows")
+
+	// Extraction must use the resolved binary, not a hardcoded `python3`.
+	assert.NotContains(t, content, `exec.Command("python3", "-c", script)`)
+	assert.Contains(t, content, `exec.Command(bin,`)
+
+	// Windows users get a workable next step instead of the Unix install hint.
+	assert.Contains(t, content, "auth login --browser")
+	assert.Contains(t, content, "cookie-scoop-cli")
+}
+
 func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6367,19 +6367,24 @@ func TestGenerate_CookieAuthWindowsCompatibility(t *testing.T) {
 	content := string(auth)
 
 	// Python resolver tries all three common binary names rather than only `python3`.
+	// Match the struct-literal needles so `"python"` isn't vacuously satisfied as
+	// a substring of `"python3"`.
 	assert.Contains(t, content, "resolvePythonBinary")
-	assert.Contains(t, content, `"python3"`)
-	assert.Contains(t, content, `"python"`)
-	assert.Contains(t, content, `"py"`)
-	assert.Contains(t, content, `"-3"`)
+	assert.Contains(t, content, `{"python3", nil}`)
+	assert.Contains(t, content, `{"python", nil}`)
+	assert.Contains(t, content, `{"py", []string{"-3"}}`)
 
 	// pycookiecheat is skipped on Windows because it raises OSError there.
 	assert.Contains(t, content, `runtime.GOOS != "windows"`)
 	assert.Contains(t, content, "pycookiecheat does not support Windows")
 
-	// Extraction must use the resolved binary, not a hardcoded `python3`.
+	// The resolved (bin, args) pair is carried on cookieTool so detection and
+	// extraction cannot disagree about which interpreter to invoke.
+	assert.Contains(t, content, "type cookieTool struct")
+	assert.Contains(t, content, "pyBin")
+	assert.Contains(t, content, "pyArgs")
 	assert.NotContains(t, content, `exec.Command("python3", "-c", script)`)
-	assert.Contains(t, content, `exec.Command(bin,`)
+	assert.Contains(t, content, `exec.Command(tool.pyBin,`)
 
 	// Windows users get a workable next step instead of the Unix install hint.
 	assert.Contains(t, content, "auth login --browser")

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -132,13 +132,13 @@ profile by name when the installed backend supports it.`,
 				return authErr(fmt.Errorf("no cookie tool found"))
 			}
 
-			if profileFlag != "" && !cookieToolSupportsProfiles(tool) {
-				return authErr(fmt.Errorf("%s does not support --profile; install pycookiecheat or cookie-scoop-cli", tool))
+			if profileFlag != "" && !cookieToolSupportsProfiles(tool.name) {
+				return authErr(fmt.Errorf("%s does not support --profile; install pycookiecheat or cookie-scoop-cli", tool.name))
 			}
 
 			// Step 2: Resolve which Chrome profile to use when the backend can honor it
 			profileDir := ""
-			if cookieToolSupportsProfiles(tool) {
+			if cookieToolSupportsProfiles(tool.name) {
 				profileDir, err = resolveChromeProfile(w, cmd.InOrStdin(), domain, profileFlag)
 				if err != nil {
 					loginURL := "https://" + strings.TrimPrefix(domain, ".")
@@ -1163,47 +1163,57 @@ func resolvePythonBinary() (string, []string, bool) {
 	return "", nil, false
 }
 
+// cookieTool bundles the detected tool name with any auxiliary invocation
+// data the extraction call needs. For pycookiecheat we carry the Python
+// binary and its leading args so detection and extraction cannot disagree
+// if PATH mutates between calls.
+type cookieTool struct {
+	name   string
+	pyBin  string
+	pyArgs []string
+}
+
 // detectCookieTool checks for available cookie extraction tools in preference order.
 // pycookiecheat is skipped on Windows because upstream raises
 // `OSError("This script only works on MacOS or Linux.")` regardless of whether
 // the import probe succeeds.
-func detectCookieTool() (string, error) {
+func detectCookieTool() (cookieTool, error) {
 	if runtime.GOOS != "windows" {
 		if bin, args, ok := resolvePythonBinary(); ok {
 			probeArgs := append(append([]string{}, args...), "-c", "import pycookiecheat")
 			if err := exec.Command(bin, probeArgs...).Run(); err == nil {
-				return "pycookiecheat", nil
+				return cookieTool{name: "pycookiecheat", pyBin: bin, pyArgs: args}, nil
 			}
 		}
 	}
 	if err := exec.Command("cookies", "--help").Run(); err == nil {
-		return "cookies", nil
+		return cookieTool{name: "cookies"}, nil
 	}
 	if err := exec.Command("cookie-scoop", "--help").Run(); err == nil {
-		return "cookie-scoop", nil
+		return cookieTool{name: "cookie-scoop"}, nil
 	}
 	if runtime.GOOS == "windows" {
-		return "", fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --browser` (live Chrome via CDP) or install cookie-scoop-cli")
+		return cookieTool{}, fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --browser` (live Chrome via CDP) or install cookie-scoop-cli")
 	}
-	return "", fmt.Errorf("no cookie extraction tool found; install one: pip install pycookiecheat")
+	return cookieTool{}, fmt.Errorf("no cookie extraction tool found; install one: pip install pycookiecheat")
 }
 
 // extractCookies shells out to the detected tool and returns a Cookie header value string.
 // profileDir selects which Chrome profile to read from (e.g. "Default", "Profile 1").
-func extractCookies(tool, domain, profileDir string) (string, error) {
-	switch tool {
+func extractCookies(tool cookieTool, domain, profileDir string) (string, error) {
+	switch tool.name {
 	case "pycookiecheat":
-		return extractViaPycookiecheat(domain, profileDir)
+		return extractViaPycookiecheat(tool, domain, profileDir)
 	case "cookies":
 		return extractViaCookiesCLI(domain)
 	case "cookie-scoop":
 		return extractViaCookieScoop(domain, profileDir)
 	default:
-		return "", fmt.Errorf("unknown cookie tool: %s", tool)
+		return "", fmt.Errorf("unknown cookie tool: %s", tool.name)
 	}
 }
 
-func extractViaPycookiecheat(domain, profileDir string) (string, error) {
+func extractViaPycookiecheat(tool cookieTool, domain, profileDir string) (string, error) {
 	cleanDomain := strings.TrimPrefix(domain, ".")
 	cookiePath := ""
 	if profileDir != "" && profileDir != "Default" {
@@ -1228,12 +1238,8 @@ func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 		)
 	}
 
-	bin, args, ok := resolvePythonBinary()
-	if !ok {
-		return "", fmt.Errorf("python interpreter not found on PATH (tried python3, python, py)")
-	}
 	var out bytes.Buffer
-	cmd := exec.Command(bin, append(append([]string{}, args...), "-c", script)...)
+	cmd := exec.Command(tool.pyBin, append(append([]string{}, tool.pyArgs...), "-c", script)...)
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -118,10 +118,17 @@ profile by name when the installed backend supports it.`,
 			if err != nil {
 				fmt.Fprintln(w, red("No cookie extraction tool found."))
 				fmt.Fprintln(w, "")
-				fmt.Fprintln(w, "Install one of:")
-				fmt.Fprintln(w, "  pip install pycookiecheat          # Python (recommended)")
-				fmt.Fprintln(w, "  brew install barnardb/cookies/cookies  # Homebrew")
-				fmt.Fprintln(w, "  cargo install cookie-scoop-cli     # Rust")
+				if runtime.GOOS == "windows" {
+					fmt.Fprintln(w, "pycookiecheat does not support Windows. Read cookies from a live Chrome session instead:")
+					fmt.Fprintf(w, "\n  {{.Name}}-pp-cli auth login --browser\n\n")
+					fmt.Fprintln(w, "Or install a cross-platform reader:")
+					fmt.Fprintln(w, "  cargo install cookie-scoop-cli     # Rust")
+				} else {
+					fmt.Fprintln(w, "Install one of:")
+					fmt.Fprintln(w, "  pip install pycookiecheat          # Python (recommended)")
+					fmt.Fprintln(w, "  brew install barnardb/cookies/cookies  # Homebrew")
+					fmt.Fprintln(w, "  cargo install cookie-scoop-cli     # Rust")
+				}
 				return authErr(fmt.Errorf("no cookie tool found"))
 			}
 
@@ -1135,21 +1142,48 @@ func resolveProfileByName(name string) (string, error) {
 
 // --- Cookie extraction tools ---
 
-// detectCookieTool checks for available cookie extraction tools in preference order.
-func detectCookieTool() (string, error) {
-	tools := []struct {
-		name  string
-		check []string
+// resolvePythonBinary finds a usable Python 3 interpreter, returning the
+// executable name and any leading args (e.g. `py -3` on Windows). pycookiecheat
+// is the only tool the CLI shells into Python for, and Windows ships
+// `python.exe` or the `py` launcher rather than `python3`.
+func resolvePythonBinary() (string, []string, bool) {
+	candidates := []struct {
+		bin  string
+		args []string
 	}{
-		{"pycookiecheat", []string{"python3", "-c", "import pycookiecheat"}},
-		{"cookies", []string{"cookies", "--help"}},
-		{"cookie-scoop", []string{"cookie-scoop", "--help"}},
+		{"python3", nil},
+		{"python", nil},
+		{"py", []string{"-3"}},
 	}
-
-	for _, tool := range tools {
-		if err := exec.Command(tool.check[0], tool.check[1:]...).Run(); err == nil {
-			return tool.name, nil
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c.bin); err == nil {
+			return c.bin, c.args, true
 		}
+	}
+	return "", nil, false
+}
+
+// detectCookieTool checks for available cookie extraction tools in preference order.
+// pycookiecheat is skipped on Windows because upstream raises
+// `OSError("This script only works on MacOS or Linux.")` regardless of whether
+// the import probe succeeds.
+func detectCookieTool() (string, error) {
+	if runtime.GOOS != "windows" {
+		if bin, args, ok := resolvePythonBinary(); ok {
+			probeArgs := append(append([]string{}, args...), "-c", "import pycookiecheat")
+			if err := exec.Command(bin, probeArgs...).Run(); err == nil {
+				return "pycookiecheat", nil
+			}
+		}
+	}
+	if err := exec.Command("cookies", "--help").Run(); err == nil {
+		return "cookies", nil
+	}
+	if err := exec.Command("cookie-scoop", "--help").Run(); err == nil {
+		return "cookie-scoop", nil
+	}
+	if runtime.GOOS == "windows" {
+		return "", fmt.Errorf("no cookie extraction tool found; pycookiecheat does not support Windows. Use `auth login --browser` (live Chrome via CDP) or install cookie-scoop-cli")
 	}
 	return "", fmt.Errorf("no cookie extraction tool found; install one: pip install pycookiecheat")
 }
@@ -1194,8 +1228,12 @@ func extractViaPycookiecheat(domain, profileDir string) (string, error) {
 		)
 	}
 
+	bin, args, ok := resolvePythonBinary()
+	if !ok {
+		return "", fmt.Errorf("python interpreter not found on PATH (tried python3, python, py)")
+	}
 	var out bytes.Buffer
-	cmd := exec.Command("python3", "-c", script)
+	cmd := exec.Command(bin, append(append([]string{}, args...), "-c", script)...)
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

The generated `auth login --chrome` flow had two stacked Windows blockers in `internal/generator/templates/auth_browser.go.tmpl` (issue #1101):

1. **Hardcoded `python3`**: pycookiecheat detection and extraction both shelled out to `python3`. Windows ships `python.exe` or the `py` launcher — `python3` is not on PATH — so detection always reported "no cookie tool found" even when pycookiecheat was importable.
2. **pycookiecheat platform support**: even with a working Python binary, pycookiecheat raises `OSError("This script only works on MacOS or Linux.")` on Windows. Working around blocker 1 just exposes blocker 2.

This change makes every cookie-auth CLI emitted by the press usable on Windows out of the box (for the discoverable subset — see scope below).

## What changed

`internal/generator/templates/auth_browser.go.tmpl`:

- New `resolvePythonBinary` helper tries `python3`, `python`, `py -3` in order via `exec.LookPath` and returns the resolved binary plus any leading args. Used by both the import probe and the extraction call.
- `detectCookieTool` now skips the pycookiecheat probe entirely when `runtime.GOOS == "windows"` (since pycookiecheat will crash at runtime regardless). It still tries `cookies` and `cookie-scoop` as cross-platform fallbacks. When everything fails on Windows, the error message points at `auth login --browser` (live Chrome via CDP) and `cookie-scoop-cli`.
- The user-facing "Install one of:" hint emitted when no tool is found is platform-aware: Windows users get the working workaround (`auth login --browser`) instead of being told to install pycookiecheat.

`internal/generator/generator_test.go`:

- New `TestGenerate_CookieAuthWindowsCompatibility` regression test asserts the generated `auth.go` contains the Python resolver, the Windows skip, the resolved-binary `exec.Command` call, and the Windows-specific fallback prose.

## Scope

This is the **machine** fix per AGENTS.md ("Default to machine changes") — the template change affects every cookie-auth CLI on next regen.

Out of scope (left for follow-up if it surfaces): a Windows-native cookie reader against Chrome's DPAPI + app-bound encryption (the issue's optional "bigger fix"). The minimum the issue asked for — a discoverable Windows path that does not silently fail — is what this PR delivers.

## Test plan

- [x] `go build -o ./printing-press ./cmd/printing-press`
- [x] `go vet ./...`
- [x] `go test ./...` (4057 tests, all pass)
- [x] `go fmt ./...` (clean)
- [x] `golangci-lint run ./...` (clean)
- [x] `scripts/golden.sh verify` (18/18 pass, no golden churn)
- [x] New `TestGenerate_CookieAuthWindowsCompatibility` passes
- [x] Existing `TestGenerate_CookieAuthUsesBrowserTemplate` still passes

Closes #1101