### PR TITLE
fix(cli): tighten phone-us PII regex to NANP-valid first digits

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -109,9 +109,13 @@ var piiDetectors = []piiDetector{
 	{
 		kind: PIIKindPhoneUS,
 		// US-shaped 10-digit phone with optional +1 prefix and
-		// parens/separators. Word boundaries on each end. Catches
-		// "(415) 555-0123", "415-555-0123", "+1 415 555 0123".
-		pattern: regexp.MustCompile(`\b(?:\+?1[\s.\-]?)?\(?\d{3}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}\b`),
+		// parens/separators. NANP requires the area code and the
+		// exchange code to each start with 2-9 — leading 0 or 1 is
+		// not a real US phone. That constraint filters out 10-digit
+		// product UPCs (`0190074442`) and coordinate-shaped numerics
+		// (`106.0512973`) without rejecting any real phone shape.
+		// Catches "(415) 555-0123", "415-555-0123", "+1 415 555 0123".
+		pattern: regexp.MustCompile(`\b(?:\+?1[\s.\-]?)?\(?[2-9]\d{2}\)?[\s.\-]?[2-9]\d{2}[\s.\-]?\d{4}\b`),
 	},
 	{
 		kind: PIIKindZipPlus4,

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -72,6 +72,20 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "country-code", line: `"phone": "+1 415 555 0123"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "version-string", line: `"version": "1.2.3"`, expectKinds: nil},
 		{name: "ip-address", line: `"addr": "192.168.1.1"`, expectKinds: nil},
+		// NANP-shape filters — area code and exchange code must each
+		// start with 2-9. Regression for the dataforseo retro: 10-digit
+		// product UPCs and coordinate-shaped numerics false-positived.
+		{name: "no-product-upc-leading-zero", line: `"upc": "0190074442"`, expectKinds: nil},
+		{name: "no-coordinate-leading-one", line: `"lng": 106.0512973`, expectKinds: nil},
+		{name: "no-epoch-timestamp", line: `"updated_at": 1700000000`, expectKinds: nil},
+		// Boundary cases that prove the constraint is on the leading
+		// digit of each quadrant, not on the whole string.
+		{name: "no-area-code-leading-zero", line: `"phone": "015-555-0123"`, expectKinds: nil},
+		{name: "no-area-code-leading-one", line: `"phone": "115-555-0123"`, expectKinds: nil},
+		{name: "no-exchange-leading-zero", line: `"phone": "415-055-0123"`, expectKinds: nil},
+		{name: "no-exchange-leading-one", line: `"phone": "415-155-0123"`, expectKinds: nil},
+		{name: "area-code-200-valid", line: `"phone": "(212) 555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "area-code-900-valid", line: `"phone": "(900) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -84,7 +84,7 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "no-area-code-leading-one", line: `"phone": "115-555-0123"`, expectKinds: nil},
 		{name: "no-exchange-leading-zero", line: `"phone": "415-055-0123"`, expectKinds: nil},
 		{name: "no-exchange-leading-one", line: `"phone": "415-155-0123"`, expectKinds: nil},
-		{name: "area-code-200-valid", line: `"phone": "(212) 555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "area-code-212-valid", line: `"phone": "(212) 555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "area-code-900-valid", line: `"phone": "(900) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Constrains the `phone-us` PII detector to match only NANP-valid 10-digit phone shapes: area code and exchange code must each start with `[2-9]`.
- Filters out the two documented false-positive shapes the DataForSEO retro hit: 10-digit product UPCs starting with `0` (`0190074442`) and 3-digit-leading coordinate-shaped numerics (`106.0512973`).
- Extends `TestFindPII_PhoneUS` with both reported strings, an epoch-timestamp regression, and explicit boundary cases that prove the constraint is on the leading digit of each quadrant — not on the whole string.

## Why this approach

The issue proposes a two-layer fix: a provenance allowlist for upstream OpenAPI specs archived under `.manuscripts/`, and a tighter `phone-us` regex. The regex tightening alone closes both reported false positives and the entire leading-0/1 numeric class (epoch timestamps, ISBNs, latitudes 0-89, longitudes 0-179) while preserving every real US phone shape — NANP forbids 0 or 1 as the first digit of either an area code or an exchange code. It is also the smaller, more conservative change: it does not touch the existing design intent that captured content under `.manuscripts/` stays in scope for review.

If retros surface additional false positives after this lands (e.g., 10-digit account IDs whose first digit happens to be 2-9), the provenance-allowlist layer is a clean follow-up.

## Test plan
- [x] `go test ./internal/artifacts/...` — passes (101 cases)
- [x] `go test ./...` — full suite passes (4065 cases)
- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] No golden fixture covers PII output; PII gate runs at publish time and does not affect generator templates or printed CLI surfaces.

Closes #1149