### PR TITLE
fix(cli): stop generated main.go from printing every error twice

### DIFF
--- a/internal/generator/main_no_double_print_test.go
+++ b/internal/generator/main_no_double_print_test.go
@@ -9,14 +9,11 @@ import (
 )
 
 // TestMainNoDoublePrintErrors asserts the generated cmd/<cli>/main.go does
-// not print err.Error() to stderr, since root.go.tmpl leaves Cobra's
-// default error printing on (SilenceUsage:true but no SilenceErrors). A
-// second main.go-side print causes every failing command to emit the
-// error message twice — once with Cobra's "Error:" prefix and once as
-// the raw message — which is what schoology/epic-myhealth shipped before
-// this fix.
-//
-// We pin the structural shape: no `fmt` import in main.go, no
+// not print err.Error() to stderr. root.go.tmpl leaves Cobra's default
+// error printing on (SilenceUsage:true but no SilenceErrors), so a
+// second main.go-side print would emit every failing command's message
+// twice — once with Cobra's "Error:" prefix and once as the raw text.
+// Pin the structural shape here: no `fmt` import in main.go, no
 // `fmt.Fprintln(os.Stderr, err.Error())` call. Behavior is covered
 // by the emitted root.go's own tests (root_test.go.tmpl).
 func TestMainNoDoublePrintErrors(t *testing.T) {

--- a/internal/generator/main_no_double_print_test.go
+++ b/internal/generator/main_no_double_print_test.go
@@ -1,0 +1,71 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMainNoDoublePrintErrors asserts the generated cmd/<cli>/main.go does
+// not print err.Error() to stderr, since root.go.tmpl leaves Cobra's
+// default error printing on (SilenceUsage:true but no SilenceErrors). A
+// second main.go-side print causes every failing command to emit the
+// error message twice — once with Cobra's "Error:" prefix and once as
+// the raw message — which is what schoology/epic-myhealth shipped before
+// this fix.
+//
+// We pin the structural shape: no `fmt` import in main.go, no
+// `fmt.Fprintln(os.Stderr, err.Error())` call. Behavior is covered
+// by the emitted root.go's own tests (root_test.go.tmpl).
+func TestMainNoDoublePrintErrors(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("nodbl-canary")
+	outputDir := filepath.Join(t.TempDir(), "nodbl-canary-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	mainPath := filepath.Join(outputDir, "cmd", "nodbl-canary-pp-cli", "main.go")
+	mainSrc, err := os.ReadFile(mainPath)
+	require.NoError(t, err, "main.go must be emitted")
+	src := string(mainSrc)
+
+	require.NotContains(t, src, `"fmt"`,
+		`main.go must not import "fmt" — the only prior use was the double-print line`)
+	require.NotContains(t, src, "fmt.Fprintln(os.Stderr, err.Error())",
+		"main.go must not print err.Error(); Cobra prints it once via SilenceUsage=true/SilenceErrors=false")
+	require.NotContains(t, src, "fmt.Fprint(os.Stderr, err.Error())",
+		"main.go must not print err.Error() via Fprint either")
+
+	// Exit-code propagation must still flow through cli.ExitCode so
+	// usageErr → 2, configErr → 10, authErr → 5 stay intact.
+	require.Contains(t, src, "os.Exit(cli.ExitCode(err))",
+		"main.go must still propagate the typed exit code")
+}
+
+// TestRootEmitsUnknownFlagHintToStderr asserts root.go.tmpl emits an
+// explicit stderr write of the suggestion alongside the err wrap. Before
+// this fix, the hint was only ever visible because main.go re-printed
+// err.Error(); now that main.go is silent, Cobra prints `Error: unknown
+// flag: --foob` (without the hint, since Cobra prints before the wrap
+// happens), and root.go owns surfacing the hint.
+func TestRootEmitsUnknownFlagHintToStderr(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("hint-canary")
+	outputDir := filepath.Join(t.TempDir(), "hint-canary-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err, "root.go must be emitted")
+	src := string(rootSrc)
+
+	require.Contains(t, src, `fmt.Fprintf(os.Stderr, "hint: did you mean --%s?\n", suggestion)`,
+		"root.go must print the unknown-flag hint to stderr directly; main.go no longer does")
+	// And the wrap still has to happen so the err.Error() chain carries
+	// the hint for downstream consumers and isCobraUsageError keeps its
+	// classification (covered by TestUsageErrorExitCode_EmittedInRoot).
+	require.Contains(t, src, `err = fmt.Errorf("%w\nhint: did you mean --%s?", err, suggestion)`,
+		"root.go must still wrap err with the hint for downstream consumers")
+}

--- a/internal/generator/templates/main.go.tmpl
+++ b/internal/generator/templates/main.go.tmpl
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"{{modulePath}}/internal/cli"
@@ -12,7 +11,6 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(cli.ExitCode(err))
 	}
 }

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -71,6 +71,13 @@ func Execute() error {
 		if idx := strings.Index(msg, "unknown flag: "); idx >= 0 {
 			flagStr := strings.TrimSpace(msg[idx+len("unknown flag: "):])
 			if suggestion := suggestFlag(flagStr, rootCmd); suggestion != "" {
+				// Cobra already printed `Error: unknown flag: --foob` before
+				// returning; the wrap below attaches the hint to err.Error()
+				// for downstream consumers and exit-code classification, but
+				// would never reach stderr now that main.go no longer prints
+				// err. Emit the hint explicitly so the suggestion still
+				// shows up under Cobra's error line.
+				fmt.Fprintf(os.Stderr, "hint: did you mean --%s?\n", suggestion)
 				err = fmt.Errorf("%w\nhint: did you mean --%s?", err, suggestion)
 			}
 		}

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-cli/main.go
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-cli/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"cafe-bistro-pp-cli/internal/cli"
@@ -12,7 +11,6 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(cli.ExitCode(err))
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-cli/main.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-cli/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"printing-press-golden-pp-cli/internal/cli"
@@ -12,7 +11,6 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(cli.ExitCode(err))
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -65,6 +65,13 @@ func Execute() error {
 		if idx := strings.Index(msg, "unknown flag: "); idx >= 0 {
 			flagStr := strings.TrimSpace(msg[idx+len("unknown flag: "):])
 			if suggestion := suggestFlag(flagStr, rootCmd); suggestion != "" {
+				// Cobra already printed `Error: unknown flag: --foob` before
+				// returning; the wrap below attaches the hint to err.Error()
+				// for downstream consumers and exit-code classification, but
+				// would never reach stderr now that main.go no longer prints
+				// err. Emit the hint explicitly so the suggestion still
+				// shows up under Cobra's error line.
+				fmt.Fprintf(os.Stderr, "hint: did you mean --%s?\n", suggestion)
 				err = fmt.Errorf("%w\nhint: did you mean --%s?", err, suggestion)
 			}
 		}


### PR DESCRIPTION
## What changed

`main.go.tmpl` dropped the redundant `fmt.Fprintln(os.Stderr, err.Error())` (and now-unused `fmt` import). `root.go.tmpl` already set `SilenceUsage: true` but not `SilenceErrors`, so Cobra was printing the error once with its `Error:` prefix and `main.go` was printing the raw message a second time. Now Cobra prints once.

## Why the root.go change

The unknown-flag suggestion path in `Execute()` wraps the error with `\nhint: did you mean --foo?` for downstream consumers and `usageErr` classification. Cobra prints `err.Error()` _before_ that wrap attaches the hint, so before this PR the hint only ever reached stderr via `main.go`'s second print. Now that `main.go` is silent, the hint would disappear — so `root.go.tmpl` emits it to stderr explicitly when the suggestion is found. The existing `fmt.Errorf` wrap stays intact for `isCobraUsageError` (test pinned by `internal/generator/usage_error_exit_test.go`).

## Verification

Built petstore from the worktree and confirmed:
- `./petstore-pp-cli --foob 2>&1 | grep -c '^Error:'` → `1` (was `1` for the `Error:` line plus a duplicate raw line)
- `./petstore-pp-cli --idempoten` prints `Error: unknown flag: --idempoten` followed by `hint: did you mean --idempotent?` — hint preserved
- Exit code via `cli.ExitCode(err)` still propagates (`os.Exit(cli.ExitCode(err))` retained in main.go.tmpl)

Other gates: `go build`, `go vet`, `go test ./...` (4101 pass), `golangci-lint run ./...`, `scripts/golden.sh verify` (18 pass after the 3 expected updates).

## Closes

Closes #1407