### PR TITLE
fix(cli): match both singular and plural required-flag cobra outputs

### DIFF
--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -114,9 +114,17 @@ func Execute() error {
 //   - "unknown flag: --foo"                            (pflag)
 //   - "unknown shorthand flag: 'x' in -x"              (pflag)
 //   - "unknown command \"foo\" for ..."                (Cobra)
-//   - "required flag(s) \"foo\" not set"               (Cobra MarkFlagRequired)
+//   - "required flag \"foo\" not set"                  (Cobra, single missing)
+//   - "required flag(s) \"foo\" not set"               (Cobra, multiple missing)
 //   - "flag needs an argument: --foo"                  (pflag, missing value)
 //   - "invalid argument \"x\" for \"--y\" flag: ..."   (pflag, parse failure)
+//
+// Cobra emits the singular form ("required flag") when exactly one
+// MarkFlagRequired flag is missing, and the plural form ("required
+// flag(s)") only when multiple are missing on the same command. Both
+// shapes must be anchored to avoid matching app-level errors that
+// happen to mention "required flag" as prose; the trailing space + quote
+// (`required flag "`) is the literal punctuation cobra emits.
 //
 // Returns false for nil err.
 func isCobraUsageError(err error) bool {
@@ -127,6 +135,7 @@ func isCobraUsageError(err error) bool {
 	return strings.HasPrefix(msg, "unknown flag") ||
 		strings.HasPrefix(msg, "unknown shorthand flag") ||
 		strings.HasPrefix(msg, "unknown command") ||
+		strings.HasPrefix(msg, `required flag "`) ||
 		strings.HasPrefix(msg, `required flag(s) "`) ||
 		strings.HasPrefix(msg, "flag needs an argument:") ||
 		strings.HasPrefix(msg, `invalid argument "`)

--- a/internal/generator/templates/root_test.go.tmpl
+++ b/internal/generator/templates/root_test.go.tmpl
@@ -24,7 +24,8 @@ func TestIsCobraUsageError(t *testing.T) {
 		{"unknown flag", errors.New("unknown flag: --foob"), true},
 		{"unknown shorthand flag", errors.New("unknown shorthand flag: 'x' in -x"), true},
 		{"unknown command", errors.New("unknown command \"foo\" for \"cli\""), true},
-		{"required flag", errors.New("required flag(s) \"query\" not set"), true},
+		{"required flag (singular)", errors.New("required flag \"query\" not set"), true},
+		{"required flag(s) (plural)", errors.New("required flag(s) \"query\", \"vault\" not set"), true},
 		{"flag needs argument", errors.New("flag needs an argument: --query"), true},
 		{"invalid argument", errors.New("invalid argument \"abc\" for \"--limit\" flag: strconv.ParseInt: parsing \"abc\": invalid syntax"), true},
 		// Non-usage errors must NOT be flagged — they should retain their

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/root_test.go
@@ -24,7 +24,8 @@ func TestIsCobraUsageError(t *testing.T) {
 		{"unknown flag", errors.New("unknown flag: --foob"), true},
 		{"unknown shorthand flag", errors.New("unknown shorthand flag: 'x' in -x"), true},
 		{"unknown command", errors.New("unknown command \"foo\" for \"cli\""), true},
-		{"required flag", errors.New("required flag(s) \"query\" not set"), true},
+		{"required flag (singular)", errors.New("required flag \"query\" not set"), true},
+		{"required flag(s) (plural)", errors.New("required flag(s) \"query\", \"vault\" not set"), true},
 		{"flag needs argument", errors.New("flag needs an argument: --query"), true},
 		{"invalid argument", errors.New("invalid argument \"abc\" for \"--limit\" flag: strconv.ParseInt: parsing \"abc\": invalid syntax"), true},
 		// Non-usage errors must NOT be flagged — they should retain their

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -108,9 +108,17 @@ func Execute() error {
 //   - "unknown flag: --foo"                            (pflag)
 //   - "unknown shorthand flag: 'x' in -x"              (pflag)
 //   - "unknown command \"foo\" for ..."                (Cobra)
-//   - "required flag(s) \"foo\" not set"               (Cobra MarkFlagRequired)
+//   - "required flag \"foo\" not set"                  (Cobra, single missing)
+//   - "required flag(s) \"foo\" not set"               (Cobra, multiple missing)
 //   - "flag needs an argument: --foo"                  (pflag, missing value)
 //   - "invalid argument \"x\" for \"--y\" flag: ..."   (pflag, parse failure)
+//
+// Cobra emits the singular form ("required flag") when exactly one
+// MarkFlagRequired flag is missing, and the plural form ("required
+// flag(s)") only when multiple are missing on the same command. Both
+// shapes must be anchored to avoid matching app-level errors that
+// happen to mention "required flag" as prose; the trailing space + quote
+// (`required flag "`) is the literal punctuation cobra emits.
 //
 // Returns false for nil err.
 func isCobraUsageError(err error) bool {
@@ -121,6 +129,7 @@ func isCobraUsageError(err error) bool {
 	return strings.HasPrefix(msg, "unknown flag") ||
 		strings.HasPrefix(msg, "unknown shorthand flag") ||
 		strings.HasPrefix(msg, "unknown command") ||
+		strings.HasPrefix(msg, `required flag "`) ||
 		strings.HasPrefix(msg, `required flag(s) "`) ||
 		strings.HasPrefix(msg, "flag needs an argument:") ||
 		strings.HasPrefix(msg, `invalid argument "`)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root_test.go
@@ -24,7 +24,8 @@ func TestIsCobraUsageError(t *testing.T) {
 		{"unknown flag", errors.New("unknown flag: --foob"), true},
 		{"unknown shorthand flag", errors.New("unknown shorthand flag: 'x' in -x"), true},
 		{"unknown command", errors.New("unknown command \"foo\" for \"cli\""), true},
-		{"required flag", errors.New("required flag(s) \"query\" not set"), true},
+		{"required flag (singular)", errors.New("required flag \"query\" not set"), true},
+		{"required flag(s) (plural)", errors.New("required flag(s) \"query\", \"vault\" not set"), true},
 		{"flag needs argument", errors.New("flag needs an argument: --query"), true},
 		{"invalid argument", errors.New("invalid argument \"abc\" for \"--limit\" flag: strconv.ParseInt: parsing \"abc\": invalid syntax"), true},
 		// Non-usage errors must NOT be flagged — they should retain their


### PR DESCRIPTION
## Intent

Follow-up to #1194. \`isCobraUsageError\` matched only Cobra's plural \`required flag(s) \"foo\" not set\` form. Cobra actually emits the **singular** form \`required flag \"foo\" not set\` (no parens) when exactly one MarkFlagRequired flag is missing — by far the more common case in practice. The plural form only fires when multiple required flags are missing on the same command.

Result before this fix: any CLI with a single required flag, invoked without it, exits 1 instead of the documented exit-2 usage convention from #1194. The other paths from #1194 (unknown-flag, unknown-command, flag-needs-argument) all work correctly; only this edge case falls through.

Issue: N/A (downstream finding from regenerating rok-brain-cli against v4.6.1)

## Approach

Add the singular pattern alongside the existing plural one. Both stay anchored to the literal trailing-space-quote (\`required flag \"\`), so application RunE errors mentioning \"required flag\" as prose continue to classify as non-usage (the prose-as-non-usage negative test from #1194's Greptile fixup still passes).

## Scope

Primary area: \`cli\` (generator template — every printed CLI's emitted root.go)

Why this belongs in this repo: the bug is in \`isCobraUsageError\` which is emitted from \`root.go.tmpl\` into every printed CLI. A printed-CLI hand-edit would be lost on next regen; the fix has to land at the template.

## Risk

Low. Strict superset of #1194's coverage:

- Adds one prefix (\`HasPrefix(\"required flag \\\"\")\`) — exactly anchored to cobra's singular punctuation.
- Existing plural pattern unchanged.
- Existing negative test (\"app msg containing 'required flag' as prose\" → \`false\`) continues to pass — that string starts with \"the required flag\" / similar, not \`required flag \"\`.

## Output Contract

Template change to \`root.go.tmpl\` and \`root_test.go.tmpl\`. Every regenerated CLI's \`isCobraUsageError\` gains the singular pattern + corresponding test case. Golden fixtures for \`generate-golden-api\` and \`generate-golden-api-rich-auth\` updated.

## Verification

- \`go test ./...\` — full upstream suite green (29 packages, 0 fails)
- New emitted test case \`required flag (singular)\` passes alongside the existing \`required flag(s) (plural)\` case in the emitted test
- \`scripts/golden.sh verify\` — 18 cases pass after \`GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update\`
- End-to-end verified on a freshly generated CLI: invoking a command with one missing required flag now exits 2 (was 1)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

## Discovery Context

Regenerating rok-brain-cli against v4.6.1 today (post-#1194 + post-#1212 + post-#1379 merge). Brain's \`query\` command has exactly one MarkFlagRequired flag (\`--query\`). Invoking \`./rok-brain-pp-cli query\` produced:

\`\`\`
$ ./rok-brain-pp-cli query
Error: required flag \"query\" not set
required flag \"query\" not set
exit=1   (expected 2 per the convention #1194 ships)
\`\`\`

Confirmed via grep on cobra's source that the singular form is what cobra emits when exactly one required flag is missing — my #1194 pattern was overly narrow. Three other usage-error paths from #1194 (unknown flag, unknown command, flag needs argument) all correctly exit 2; this is the last edge case.