### PR TITLE
docs(cli): document sync --resources parent-keyed dependent cascade

### DIFF
--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -90,7 +90,17 @@ Exit codes & warnings:
   emit {"event":"sync_warning","reason":"exit_policy_default_changed",
   ...} so callers can detect that a partial failure was tolerated. Pass
   --strict to exit non-zero on any per-resource failure. Exit is always
-  non-zero when every selected resource failed, regardless of --strict.`,
+  non-zero when every selected resource failed, regardless of --strict.
+
+Resource scoping:
+  --resources runs the named flat resources, plus any parent-keyed
+  dependent whose own name is listed OR whose parent table is listed.
+  Naming a parent therefore cascades to its dependents (so "sync this
+  parent and its children" works without listing every nested resource
+  by hand). There is no flag today to suppress the cascade for a named
+  parent. To run a dependent without re-syncing its parent, list only
+  the dependent by name; the parent table must already be populated
+  from a prior sync.`,
 		Example: `  # Sync all resources
   {{.Name}}-pp-cli sync
 
@@ -345,7 +355,7 @@ Exit codes & warnings:
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync")
+	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -93,7 +93,7 @@ Exit codes & warnings:
   non-zero when every selected resource failed, regardless of --strict.
 
 Resource scoping:
-  --resources runs the named flat resources, plus any parent-keyed
+  --resources runs the named top-level resources, plus any parent-keyed
   dependent whose own name is listed OR whose parent table is listed.
   Naming a parent therefore cascades to its dependents (so "sync this
   parent and its children" works without listing every nested resource

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -70,7 +70,7 @@ Exit codes & warnings:
   non-zero when every selected resource failed, regardless of --strict.
 
 Resource scoping:
-  --resources runs the named flat resources, plus any parent-keyed
+  --resources runs the named top-level resources, plus any parent-keyed
   dependent whose own name is listed OR whose parent table is listed.
   Naming a parent therefore cascades to its dependents (so "sync this
   parent and its children" works without listing every nested resource

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -67,7 +67,17 @@ Exit codes & warnings:
   emit {"event":"sync_warning","reason":"exit_policy_default_changed",
   ...} so callers can detect that a partial failure was tolerated. Pass
   --strict to exit non-zero on any per-resource failure. Exit is always
-  non-zero when every selected resource failed, regardless of --strict.`,
+  non-zero when every selected resource failed, regardless of --strict.
+
+Resource scoping:
+  --resources runs the named flat resources, plus any parent-keyed
+  dependent whose own name is listed OR whose parent table is listed.
+  Naming a parent therefore cascades to its dependents (so "sync this
+  parent and its children" works without listing every nested resource
+  by hand). There is no flag today to suppress the cascade for a named
+  parent. To run a dependent without re-syncing its parent, list only
+  the dependent by name; the parent table must already be populated
+  from a prior sync.`,
 		Example: `  # Sync all resources
   printing-press-golden-pp-cli sync
 
@@ -307,7 +317,7 @@ Exit codes & warnings:
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync")
+	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -67,7 +67,17 @@ Exit codes & warnings:
   emit {"event":"sync_warning","reason":"exit_policy_default_changed",
   ...} so callers can detect that a partial failure was tolerated. Pass
   --strict to exit non-zero on any per-resource failure. Exit is always
-  non-zero when every selected resource failed, regardless of --strict.`,
+  non-zero when every selected resource failed, regardless of --strict.
+
+Resource scoping:
+  --resources runs the named flat resources, plus any parent-keyed
+  dependent whose own name is listed OR whose parent table is listed.
+  Naming a parent therefore cascades to its dependents (so "sync this
+  parent and its children" works without listing every nested resource
+  by hand). There is no flag today to suppress the cascade for a named
+  parent. To run a dependent without re-syncing its parent, list only
+  the dependent by name; the parent table must already be populated
+  from a prior sync.`,
 		Example: `  # Sync all resources
   sync-walker-golden-pp-cli sync
 
@@ -307,7 +317,7 @@ Exit codes & warnings:
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync")
+	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -70,7 +70,7 @@ Exit codes & warnings:
   non-zero when every selected resource failed, regardless of --strict.
 
 Resource scoping:
-  --resources runs the named flat resources, plus any parent-keyed
+  --resources runs the named top-level resources, plus any parent-keyed
   dependent whose own name is listed OR whose parent table is listed.
   Naming a parent therefore cascades to its dependents (so "sync this
   parent and its children" works without listing every nested resource

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -68,7 +68,17 @@ Exit codes & warnings:
   emit {"event":"sync_warning","reason":"exit_policy_default_changed",
   ...} so callers can detect that a partial failure was tolerated. Pass
   --strict to exit non-zero on any per-resource failure. Exit is always
-  non-zero when every selected resource failed, regardless of --strict.`,
+  non-zero when every selected resource failed, regardless of --strict.
+
+Resource scoping:
+  --resources runs the named flat resources, plus any parent-keyed
+  dependent whose own name is listed OR whose parent table is listed.
+  Naming a parent therefore cascades to its dependents (so "sync this
+  parent and its children" works without listing every nested resource
+  by hand). There is no flag today to suppress the cascade for a named
+  parent. To run a dependent without re-syncing its parent, list only
+  the dependent by name; the parent table must already be populated
+  from a prior sync.`,
 		Example: `  # Sync all resources
   tier-routing-golden-pp-cli sync
 
@@ -281,7 +291,7 @@ Exit codes & warnings:
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync")
+	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -71,7 +71,7 @@ Exit codes & warnings:
   non-zero when every selected resource failed, regardless of --strict.
 
 Resource scoping:
-  --resources runs the named flat resources, plus any parent-keyed
+  --resources runs the named top-level resources, plus any parent-keyed
   dependent whose own name is listed OR whose parent table is listed.
   Naming a parent therefore cascades to its dependents (so "sync this
   parent and its children" works without listing every nested resource


### PR DESCRIPTION
## Summary

- The `sync --resources <list>` flag silently cascades from named parents to their parent-keyed dependent resources, but the flag's short help only said "Comma-separated resource types to sync". Users hitting parent-cascade for the first time on a rate-limited API report syncs taking far longer than expected (#1141).
- Document the contract on both surfaces of the generated `sync` command: short flag description points to the Long help, and a new "Resource scoping:" section in the Long help explains the cascade rule and the current scoping options.
- Behavior is unchanged. The template fix matches what `syncDependentResources` already implements (`internal/generator/templates/sync.go.tmpl:1163` — a dependent runs when its parent table OR its own name is in `--resources`).

## Test plan

- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 4168 tests pass
- [x] `golangci-lint run ./...` clean
- [x] `scripts/golden.sh verify` — 18 cases pass after updating the three sync goldens (`generate-golden-api`, `generate-sync-walker-api`, `generate-tier-routing-api`) for the new help text. Diffs match the template change byte-for-byte.
- [x] Generated `sync-walker-golden-pp-cli sync --help` reads cleanly with the new "Resource scoping:" section appearing under "Exit codes & warnings".

## Scope notes

This is the issue's "at minimum, document" path. The author also suggested two larger options (`--no-children` flag or making `--resources` truly scoped); both are additional feature/breaking changes and are out of scope for this docs PR. If maintainers want the flag follow-up, happy to open a separate issue.

Closes #1141