### PR TITLE
fix(cli): handle single-quoted args in validate-narrative shell tokenizer

### DIFF
--- a/internal/shellargs/shellargs.go
+++ b/internal/shellargs/shellargs.go
@@ -6,14 +6,16 @@ import (
 )
 
 // Split tokenizes the simple command examples the Printing Press emits in
-// README/SKILL narrative. It preserves double-quoted tokens and backslash
-// escapes, but intentionally does not perform shell expansion.
+// README/SKILL narrative. It preserves double-quoted and single-quoted
+// tokens and backslash escapes (POSIX semantics: backslashes are literal
+// inside single quotes), but intentionally does not perform shell
+// expansion.
 func Split(s string) ([]string, error) {
 	s = joinLineContinuations(s)
 
 	var tokens []string
 	var current strings.Builder
-	inQuote := false
+	var quoteChar rune // 0 outside quotes; '"' or '\'' while inside.
 	tokenStarted := false
 	escaped := false
 
@@ -30,14 +32,27 @@ func Split(s string) ([]string, error) {
 			escaped = false
 			continue
 		}
+		// Single quotes: everything is literal until the closing quote.
+		// POSIX forbids backslash escapes inside single quotes, so the
+		// '\\' branch must be skipped while quoteChar is '\''.
+		if quoteChar == '\'' {
+			if r == '\'' {
+				quoteChar = 0
+				tokenStarted = true
+				continue
+			}
+			current.WriteRune(r)
+			tokenStarted = true
+			continue
+		}
 		if r == '\\' {
 			escaped = true
 			tokenStarted = true
 			continue
 		}
-		if inQuote {
+		if quoteChar == '"' {
 			if r == '"' {
-				inQuote = false
+				quoteChar = 0
 				tokenStarted = true
 				continue
 			}
@@ -46,8 +61,8 @@ func Split(s string) ([]string, error) {
 			continue
 		}
 		switch r {
-		case '"':
-			inQuote = true
+		case '"', '\'':
+			quoteChar = r
 			tokenStarted = true
 		case '#':
 			if !tokenStarted {
@@ -71,13 +86,20 @@ func Split(s string) ([]string, error) {
 	if escaped {
 		current.WriteRune('\\')
 	}
-	if inQuote {
-		return nil, fmt.Errorf("unclosed quote in %q", s)
+	if quoteChar != 0 {
+		return nil, fmt.Errorf("unclosed %s quote in %q", quoteName(quoteChar), s)
 	}
 	if tokenStarted {
 		flush()
 	}
 	return tokens, nil
+}
+
+func quoteName(r rune) string {
+	if r == '\'' {
+		return "single"
+	}
+	return "double"
 }
 
 func joinLineContinuations(s string) string {

--- a/internal/shellargs/shellargs_test.go
+++ b/internal/shellargs/shellargs_test.go
@@ -2,6 +2,7 @@ package shellargs
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -32,6 +33,24 @@ func TestSplit(t *testing.T) {
 		{`cli regex foo#bar`, []string{"cli", "regex", "foo#bar"}},
 		// Escaped '#' is a literal.
 		{`cli \#literal`, []string{"cli", "#literal"}},
+		// Single-quoted args: contents are literal, surrounding quotes
+		// are stripped so the consumer sees the value the author meant.
+		{`cli normalize-date '5/12/2026'`, []string{"cli", "normalize-date", "5/12/2026"}},
+		{`cli tag-find 'Autumn 2025 Cohort'`, []string{"cli", "tag-find", "Autumn 2025 Cohort"}},
+		// POSIX rule: backslashes are literal inside single quotes.
+		{`cli echo 'C:\path\to\file'`, []string{"cli", "echo", `C:\path\to\file`}},
+		// Single-quoted '#' is part of the value, not a comment, mirroring
+		// the existing double-quote case.
+		{`cli query '# not a comment'`, []string{"cli", "query", "# not a comment"}},
+		// Mixed quoting in one example: double for some args, single for
+		// others. Both sets get stripped, both preserve embedded spaces.
+		{`cli echo "double quoted" 'single quoted'`, []string{"cli", "echo", "double quoted", "single quoted"}},
+		// Adjacent quoted segments concatenate within the same token, the
+		// way bash joins "foo"'bar' into a single argument 'foobar'.
+		{`cli echo "foo"'bar'`, []string{"cli", "echo", "foobar"}},
+		// Single-quoted segments cannot contain a literal single quote;
+		// authors close, escape, and reopen — `foo'\''bar` -> foo'bar.
+		{`cli echo 'foo'\''bar'`, []string{"cli", "echo", "foo'bar"}},
 	}
 	for _, tc := range cases {
 		got, err := Split(tc.in)
@@ -45,8 +64,24 @@ func TestSplit(t *testing.T) {
 }
 
 func TestSplitUnclosedQuote(t *testing.T) {
-	if _, err := Split(`cli "unclosed`); err == nil {
-		t.Fatal("expected unclosed quote error")
+	cases := []struct {
+		in       string
+		wantSubs string
+	}{
+		// Per #1159 acceptance criteria: an unbalanced single quote must
+		// surface a clear, quote-type-specific error so authors don't
+		// chase a downstream argument-parse failure.
+		{`cli tag-find 'Autumn`, "unclosed single quote"},
+		{`cli "unclosed`, "unclosed double quote"},
+	}
+	for _, tc := range cases {
+		_, err := Split(tc.in)
+		if err == nil {
+			t.Fatalf("Split(%q): expected error, got nil", tc.in)
+		}
+		if !strings.Contains(err.Error(), tc.wantSubs) {
+			t.Fatalf("Split(%q) error = %q, want substring %q", tc.in, err, tc.wantSubs)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`shellargs.Split` only recognized double quotes, so any narrative recipe with single-quoted args (e.g. `tag-find 'Autumn 2025 Cohort'`, `normalize-date '5/12/2026'`) reached the underlying command with the quotes still attached. `validate-narrative --full-examples` then failed with downstream argument-parse errors, and authors silently scrubbed the quotes from `research.json` — which made the rendered README/SKILL recipes broken for any user pasting them into a real shell with whitespace-bearing args.

## Fix

Extend `Split` with single-quote handling (POSIX semantics): contents are literal, backslash escapes do NOT apply inside single quotes, and an unbalanced single quote produces a quote-type-specific error (`unclosed single quote in ...` vs `unclosed double quote in ...`) so authors can locate the problem rather than chase a downstream parse failure.

The fix is intentionally local to `internal/shellargs` — both call sites (`narrativecheck.classifyFullExample` and `pipeline.live_check`) consume the result transparently, so no changes are needed there.

## Acceptance criteria (from #1159)

- **Positive:** `cli foo 'bar baz' --json` validates — the consumer sees args `[foo, bar baz, --json]`, the embedded space is preserved, the quotes are stripped. Covered by the new `'5/12/2026'`, `'Autumn 2025 Cohort'`, mixed-quoting, and adjacent-quoted-segment cases in `TestSplit`.
- **Negative:** Recipe with unbalanced quotes fails with a clear quote-type-specific error. Covered by the rewritten `TestSplitUnclosedQuote` (asserts both `unclosed single quote` and `unclosed double quote` substrings).

## Verification

- `go test ./...` — 4168 pass.
- `scripts/golden.sh verify` — 18/18 pass.
- `golangci-lint run ./internal/shellargs/ ./internal/narrativecheck/` — clean.
- `go fmt ./...`, `go vet ./...` — clean.

Closes #1159