### PR TITLE
fix(skills): canonicalize auth env var when slug-derived differs

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1649,34 +1649,58 @@ slug-derivation rule (security-scheme slug uppercased plus `_TOKEN` /
 `_API_KEY` / `_OAUTH2` per type) rarely matches the canonical name for
 established APIs. Common shapes:
 
-- Stripe: canonical `STRIPE_SECRET_KEY`, not `STRIPE_OAUTH2`
-- HubSpot: canonical `HUBSPOT_PRIVATE_APP_TOKEN`, not `HUBSPOT_API_KEY`
-- Twilio: canonical `TWILIO_AUTH_TOKEN`, not `TWILIO_API_KEY`
-- Keap: canonical `KEAP_SERVICE_ACCOUNT_KEY`, not `KEAP_OAUTH2`
+- Stripe (bearer): canonical `STRIPE_SECRET_KEY`, not slug-derived `STRIPE_OAUTH2`
+- HubSpot (bearer): canonical `HUBSPOT_PRIVATE_APP_TOKEN`, not slug-derived `HUBSPOT_API_KEY`
+- Twilio (HTTP Basic, two-var pair): canonical `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN`, not slug-derived `TWILIO_USERNAME` + `TWILIO_PASSWORD`
+- Keap (OAuth2 authorization-code): canonical `KEAP_SERVICE_ACCOUNT_KEY`, not slug-derived `KEAP_OAUTH2`
 
 Walk through:
 
 1. Compute the slug-derived env var the generator will pick (security-scheme
-   slug, uppercased, plus the type-suffix above).
+   slug, uppercased, plus the type-suffix above; HTTP Basic produces a
+   `_USERNAME` + `_PASSWORD` pair; OAuth2 `client_credentials` produces a
+   `_CLIENT_ID` + `_CLIENT_SECRET` pair).
 2. Check Phase 1 research, Phase 1.5a MCP source code analysis, and community
    wrapper READMEs for a canonical env var name documented by the vendor or
    in widespread use.
 3. If they differ, add `x-auth-env-vars` on the selected security scheme
    (OpenAPI) or set `auth.env_vars` to the canonical name (internal YAML).
    Use only the canonical name; do not retain the slug-derived form as an
-   alias.
+   alias. For HTTP Basic, supply the full two-entry canonical pair
+   (username position first, password position second). For OAuth2
+   `client_credentials`, the parser silently re-applies the
+   `CLIENT_ID`/`CLIENT_SECRET` default when `x-auth-env-vars` has fewer
+   than two entries (see `applyAuthEnvVarDefaults` in
+   `internal/openapi/parser.go`); if the canonical secret is a single
+   service-account token for a `client_credentials` flow, use
+   `x-auth-vars` instead (next section) so the override is preserved.
 4. If research surfaces no canonical name distinct from the slug-derived
    form, do nothing. The slug-derived name is fine, and a spurious
    `x-auth-env-vars` would just shadow it with the same value.
 
 ```yaml
+# Bearer / API-key single-token case (Stripe, HubSpot, Keap on
+# authorization-code grant, most apiKey schemes).
 components:
   securitySchemes:
     keapOAuth2:
       type: oauth2
-      flows: ...
+      flows:
+        authorizationCode: { ... }
       x-auth-env-vars:
         - KEAP_SERVICE_ACCOUNT_KEY
+```
+
+```yaml
+# HTTP Basic two-var canonical pair (Twilio).
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      x-auth-env-vars:
+        - TWILIO_ACCOUNT_SID
+        - TWILIO_AUTH_TOKEN
 ```
 
 Skipping this step pushes the agent into hand-patching

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1642,6 +1642,48 @@ name in `env_vars`; do not add guessed slug-based aliases. For OpenAPI specs,
 prefer `x-auth-env-vars` on the selected security scheme when the wrapper slug
 differs from the underlying API brand.
 
+**If auth IS present** in the spec but Phase 1 evidence shows the slug-derived
+env var will differ from the canonical name users have already set for this
+API, enrich the spec with the canonical name before generation. The
+slug-derivation rule (security-scheme slug uppercased plus `_TOKEN` /
+`_API_KEY` / `_OAUTH2` per type) rarely matches the canonical name for
+established APIs. Common shapes:
+
+- Stripe: canonical `STRIPE_SECRET_KEY`, not `STRIPE_OAUTH2`
+- HubSpot: canonical `HUBSPOT_PRIVATE_APP_TOKEN`, not `HUBSPOT_API_KEY`
+- Twilio: canonical `TWILIO_AUTH_TOKEN`, not `TWILIO_API_KEY`
+- Keap: canonical `KEAP_SERVICE_ACCOUNT_KEY`, not `KEAP_OAUTH2`
+
+Walk through:
+
+1. Compute the slug-derived env var the generator will pick (security-scheme
+   slug, uppercased, plus the type-suffix above).
+2. Check Phase 1 research, Phase 1.5a MCP source code analysis, and community
+   wrapper READMEs for a canonical env var name documented by the vendor or
+   in widespread use.
+3. If they differ, add `x-auth-env-vars` on the selected security scheme
+   (OpenAPI) or set `auth.env_vars` to the canonical name (internal YAML).
+   Use only the canonical name; do not retain the slug-derived form as an
+   alias.
+4. If research surfaces no canonical name distinct from the slug-derived
+   form, do nothing. The slug-derived name is fine, and a spurious
+   `x-auth-env-vars` would just shadow it with the same value.
+
+```yaml
+components:
+  securitySchemes:
+    keapOAuth2:
+      type: oauth2
+      flows: ...
+      x-auth-env-vars:
+        - KEAP_SERVICE_ACCOUNT_KEY
+```
+
+Skipping this step pushes the agent into hand-patching
+`internal/config/config.go` Load and `internal/cli/doctor.go` env-var
+checks after a `doctor` FAIL against the operator's real environment.
+Enriching the spec avoids that round-trip.
+
 For OpenAPI specs that need richer env-var metadata (kind classification,
 optional credentials, OR-group relationships), use `x-auth-vars` on the
 security scheme. See `docs/SPEC-EXTENSIONS.md` for the canonical schema.


### PR DESCRIPTION
## Summary

Extends the Pre-Generation Auth Enrichment section of `skills/printing-press/SKILL.md` so the canonical-env-var check also fires when auth IS present in the spec, not only when `auth.type: none` or auth is missing.

Today the section only walks the agent through adding `x-auth-env-vars` when mechanical auth detection has failed. For established APIs where auth detection succeeds but the slug-derived env var (e.g. `KEAP_OAUTH2`, `STRIPE_OAUTH2`, `HUBSPOT_API_KEY`) doesn't match the canonical name vendors actually document (`KEAP_SERVICE_ACCOUNT_KEY`, `STRIPE_SECRET_KEY`, `HUBSPOT_PRIVATE_APP_TOKEN`), the agent has to discover the mismatch by running `doctor` against a real environment and then hand-patch `internal/config/config.go` and `internal/cli/doctor.go`.

After this change the skill explicitly tells the agent to:

1. Compute the slug-derived env var the generator will pick.
2. Check Phase 1 research, Phase 1.5a MCP source analysis, and community wrapper READMEs for a canonical env var name.
3. If they differ, add `x-auth-env-vars` on the security scheme (or `auth.env_vars` for internal YAML) using only the canonical name.
4. If research surfaces no distinct canonical name, do nothing -- the slug-derived form is fine.

`x-auth-env-vars` parsing already exists in `internal/openapi/parser.go`, so this is a pure skill-instruction change with no generator-code or template change.

The recurrence comment on #1157 raised a separate render-time canonicalization concern (narrative prose disagreeing with the spec-derived env var name in README/SKILL templates). That's a template-side fix and out of scope for this PR; the canonical pre-generation enrichment handled here is the durable upstream fix for the original retro finding.

## Test plan

- [x] `go build -o ./printing-press ./cmd/printing-press`
- [x] `go vet ./...`
- [x] `go test ./...` (4168 passed in 34 packages)
- [x] `golangci-lint run ./...` (0 issues)
- [x] No generator-output or template files touched; golden harness not applicable.

Closes #1157