### PR TITLE
fix(cli): archive merged spec for multi-spec generate runs

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1017,6 +1017,172 @@ resources:
 
 }
 
+// TestGenerateArchivesMergedSpecForMultiSpec asserts that a generate run
+// with multiple --spec inputs archives the merged in-memory APISpec — with
+// the merged title and the union of resources — rather than just the first
+// input's raw bytes.
+func TestGenerateArchivesMergedSpecForMultiSpec(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	coreSpecPath := filepath.Join(dir, "core.yaml")
+	wikiSpecPath := filepath.Join(dir, "wiki.yaml")
+	outputDir := filepath.Join(dir, "combo")
+	require.NoError(t, os.WriteFile(coreSpecPath, []byte(`name: core
+description: Core API
+version: 0.1.0
+base_url: https://tenant.example.com
+auth:
+  type: none
+resources:
+  projects:
+    description: Projects
+    endpoints:
+      list:
+        method: GET
+        path: /projects
+        description: List projects
+`), 0o644))
+	require.NoError(t, os.WriteFile(wikiSpecPath, []byte(`name: wiki
+description: Wiki API
+version: 0.1.0
+base_url: https://tenant.example.com/wiki/api/v2
+auth:
+  type: none
+resources:
+  pages:
+    description: Pages
+    endpoints:
+      list:
+        method: GET
+        path: /pages
+        description: List pages
+`), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", coreSpecPath,
+		"--spec", wikiSpecPath,
+		"--name", "combo",
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	// Multi-spec must archive as spec.json (canonical JSON of merged APISpec),
+	// not spec.yaml (which would be the first input verbatim).
+	assert.NoFileExists(t, filepath.Join(outputDir, "spec.yaml"))
+	archived, err := os.ReadFile(filepath.Join(outputDir, "spec.json"))
+	require.NoError(t, err)
+
+	parsed, err := spec.ParseBytes(archived)
+	require.NoError(t, err, "archived merged spec must round-trip through spec.ParseBytes")
+
+	// The merged title is the --name, not "core" (the first input).
+	assert.Equal(t, "combo", parsed.Name)
+
+	// The merged BaseURL pins the archive to the merged struct rather than to
+	// either input alone — both inputs share https://tenant.example.com as the
+	// host, and that is what mergeSpecs resolves to.
+	assert.Equal(t, "https://tenant.example.com", parsed.BaseURL, "archived merged spec carries the merged BaseURL")
+
+	// Both inputs' resources are present in the archived snapshot.
+	assert.Contains(t, parsed.Resources, "projects", "first-input resource preserved")
+	assert.Contains(t, parsed.Resources, "pages", "second-input resource present in merged archive")
+}
+
+// TestArchiveSpecBytesBranches covers each branch of archiveSpecBytes
+// directly, including the json-input single-spec arm that the integration
+// tests above don't exercise (their fixtures are YAML).
+func TestArchiveSpecBytesBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multi-spec marshals merged APISpec as JSON", func(t *testing.T) {
+		merged := &spec.APISpec{
+			Name:      "combo",
+			Version:   "0.1.0",
+			BaseURL:   "https://example.com",
+			Resources: map[string]spec.Resource{"things": {Description: "Things"}},
+		}
+		specs := []*spec.APISpec{
+			{Name: "a", Resources: map[string]spec.Resource{}},
+			{Name: "b", Resources: map[string]spec.Resource{}},
+		}
+		data, name, ok := archiveSpecBytes(merged, specs, [][]byte{[]byte("a"), []byte("b")})
+		require.True(t, ok)
+		assert.Equal(t, "spec.json", name)
+		assert.True(t, json.Valid(data), "multi-spec archive must be valid JSON")
+		assert.Contains(t, string(data), `"name": "combo"`)
+	})
+
+	t.Run("single-spec JSON input returns raw bytes as spec.json", func(t *testing.T) {
+		jsonInput := []byte(`{"name":"solo","resources":{}}`)
+		data, name, ok := archiveSpecBytes(nil, []*spec.APISpec{{Name: "solo"}}, [][]byte{jsonInput})
+		require.True(t, ok)
+		assert.Equal(t, "spec.json", name)
+		assert.Equal(t, jsonInput, data, "single-spec JSON archive is byte-identical to input")
+	})
+
+	t.Run("single-spec YAML input returns raw bytes as spec.yaml", func(t *testing.T) {
+		yamlInput := []byte("name: solo\nresources: {}\n")
+		data, name, ok := archiveSpecBytes(nil, []*spec.APISpec{{Name: "solo"}}, [][]byte{yamlInput})
+		require.True(t, ok)
+		assert.Equal(t, "spec.yaml", name)
+		assert.Equal(t, yamlInput, data, "single-spec YAML archive is byte-identical to input")
+	})
+
+	t.Run("no inputs returns ok=false", func(t *testing.T) {
+		_, _, ok := archiveSpecBytes(nil, nil, nil)
+		assert.False(t, ok)
+	})
+}
+
+// TestGenerateArchivesRawSpecForSingleSpec asserts that single-spec runs
+// archive the user's original input bytes verbatim (post-redaction), the
+// negative case complementing the multi-spec merged-archive behavior.
+func TestGenerateArchivesRawSpecForSingleSpec(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "solo")
+	input := []byte(`name: solo
+description: Solo API
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  things:
+    description: Things
+    endpoints:
+      list:
+        method: GET
+        path: /things
+        description: List things
+`)
+	require.NoError(t, os.WriteFile(specPath, input, 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	// YAML input archives as spec.yaml (not spec.json).
+	assert.NoFileExists(t, filepath.Join(outputDir, "spec.json"))
+	archived, err := os.ReadFile(filepath.Join(outputDir, "spec.yaml"))
+	require.NoError(t, err)
+
+	// Single-spec archive is byte-identical to the input (this spec contains
+	// no secrets, so redaction is a no-op).
+	assert.Equal(t, input, archived, "single-spec archive must preserve original bytes")
+}
+
 func TestMergeSpecsPrefersReplayableBrowserTransportOverUnshippablePageContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1136,6 +1136,15 @@ func TestArchiveSpecBytesBranches(t *testing.T) {
 		_, _, ok := archiveSpecBytes(nil, nil, nil)
 		assert.False(t, ok)
 	})
+
+	t.Run("multi-spec with nil apiSpec returns ok=false", func(t *testing.T) {
+		specs := []*spec.APISpec{
+			{Name: "a"},
+			{Name: "b"},
+		}
+		_, _, ok := archiveSpecBytes(nil, specs, [][]byte{[]byte("a"), []byte("b")})
+		assert.False(t, ok, "nil apiSpec must not silently archive the literal 'null'")
+	})
 }
 
 // TestGenerateArchivesRawSpecForSingleSpec asserts that single-spec runs

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -719,6 +719,12 @@ func parseOpenAPISpec(specFile string, data []byte, lenient bool) (*spec.APISpec
 // transient archive failure does not abort generation.
 func archiveSpecBytes(apiSpec *spec.APISpec, specs []*spec.APISpec, specRawBytes [][]byte) ([]byte, string, bool) {
 	if len(specs) > 1 {
+		// json.MarshalIndent on a nil pointer succeeds with the literal
+		// "null" bytes, which would write a syntactically-valid but
+		// useless snapshot. Surface the precondition explicitly.
+		if apiSpec == nil {
+			return nil, "", false
+		}
 		data, err := json.MarshalIndent(apiSpec, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not marshal merged spec for archive: %v\n", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -383,15 +383,10 @@ func newGenerateCmd() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 			}
 
-			// Archive the input spec alongside the CLI for reproducibility.
-			// The spec_url may change or disappear; this local copy is the
-			// only guaranteed way to regenerate from the exact same input.
-			if len(specRawBytes) > 0 {
-				archiveName := "spec.yaml"
-				if json.Valid(specRawBytes[0]) {
-					archiveName = "spec.json"
-				}
-				data := artifacts.RedactArchivedSpecSecrets(specRawBytes[0])
+			// Archive a snapshot of the spec alongside the CLI; multi-spec
+			// runs use the merged form (see archiveSpecBytes for why).
+			if archiveBytes, archiveName, ok := archiveSpecBytes(apiSpec, specs, specRawBytes); ok {
+				data := artifacts.RedactArchivedSpecSecrets(archiveBytes)
 				if err := os.WriteFile(filepath.Join(absOut, archiveName), data, 0o644); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: could not archive spec: %v\n", err)
 				}
@@ -708,6 +703,37 @@ func parseOpenAPISpec(specFile string, data []byte, lenient bool) (*spec.APISpec
 		return openapi.ParseWithPathLenient(data, specFile)
 	}
 	return openapi.ParseWithPath(data, specFile)
+}
+
+// archiveSpecBytes picks the bytes and filename for the spec snapshot that
+// generate writes alongside the CLI. Single-spec runs preserve the user's
+// original input (post-redaction at the call site) so audit/replay round-trip
+// against the same bytes the parser saw. Multi-spec runs serialize the merged
+// APISpec — its union of paths, merged title, and merged x-mcp config — so
+// downstream consumers that re-read this snapshot operate on the surface the
+// generator actually emitted rather than on whichever input happened to be
+// passed first.
+//
+// Returns ok=false when there is nothing to archive (no inputs) or when
+// marshalling the merged spec failed; the call site logs and continues so a
+// transient archive failure does not abort generation.
+func archiveSpecBytes(apiSpec *spec.APISpec, specs []*spec.APISpec, specRawBytes [][]byte) ([]byte, string, bool) {
+	if len(specs) > 1 {
+		data, err := json.MarshalIndent(apiSpec, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not marshal merged spec for archive: %v\n", err)
+			return nil, "", false
+		}
+		return data, "spec.json", true
+	}
+	if len(specRawBytes) == 0 {
+		return nil, "", false
+	}
+	raw := specRawBytes[0]
+	if json.Valid(raw) {
+		return raw, "spec.json", true
+	}
+	return raw, "spec.yaml", true
 }
 
 func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {


### PR DESCRIPTION
## Summary

`printing-press generate --spec A --spec B ...` writes a snapshot of the spec alongside the generated CLI. Today that snapshot is the **first input's raw bytes** (`specRawBytes[0]`), so every downstream tool that re-reads `<output>/spec.json` — `mcp-sync`, `dogfood`, `validate-narrative` — operates on one input instead of the merged surface.

The HubSpot retro that filed #1195 saw the concrete fallout: a 20-spec merge with 167 paths landed a 9-path `spec.json`, `mcp-sync` derived the binary slug from the first input's `info.title` (`hubspot-associations-pp-mcp` instead of `hubspot-pp-mcp`), `manifest.json` / `tools-manifest.json` recorded the wrong identity, dogfood path-validity scored 0/10, and polish had to manually rewrite the snapshot before the run could ship.

This PR fixes the archive step: single-spec runs continue to preserve the user's original input verbatim (post-redaction) for audit/replay parity; multi-spec runs serialize the merged in-memory `APISpec` as canonical JSON so the snapshot reflects what the generator actually emitted.

- Extract `archiveSpecBytes(apiSpec, specs, specRawBytes) ([]byte, string, bool)` to centralize the choice. `ok=false` logs and skips the write so a transient marshal failure does not abort generation.
- Multi-spec archive is loaded back via `spec.ParseBytes` by `loadArchivedSpec` (`internal/pipeline/mcpsync/sync.go:212`). The round-trip is safe because `expandOperations`, `enrichPathParams`, and `promoteParamsToBodyForWriteEndpoints` are idempotent.
- Out of scope: emitting a sibling `spec.inputs/` directory for true reproducibility of the input set; that is the follow-on the retro flagged.

Closes #1195.

## Test plan

- [x] `go build ./... && go test ./...` — 4182 tests pass (was 4177; +5 new sub-tests)
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `scripts/golden.sh verify` — 18/18 cases pass (no generator-output regression)
- [x] New unit tests in `internal/cli/generate_test.go`:
  - `TestGenerateArchivesMergedSpecForMultiSpec` — multi-spec snapshot has merged title, merged BaseURL, and the union of resources from both inputs; round-trips through `spec.ParseBytes`.
  - `TestGenerateArchivesRawSpecForSingleSpec` — single-spec snapshot is byte-identical to the user's input (no regression).
  - `TestArchiveSpecBytesBranches` — direct unit test covering each branch (multi-spec, single-spec JSON, single-spec YAML, no inputs).