### PR TITLE
fix(cli): clear every emitted credential field in ClearTokens

### DIFF
--- a/internal/generator/cleartokens_test.go
+++ b/internal/generator/cleartokens_test.go
@@ -35,6 +35,33 @@ func TestClearTokensClearsEmittedCredentialFields(t *testing.T) {
 	assert.Contains(t, body, "c.PrintingPressApikey = \"\"", "env-var-derived API key field should be cleared")
 }
 
+// TestClearTokensClearsOAuth2ClientCredentials pins that ClientID and
+// ClientSecret are zeroed on logout. SaveTokens (called from the
+// oauth2 auth-code and client_credentials flows) persists them to disk,
+// so leaving them after `auth logout` would let `auth login` re-mint a
+// new access token unattended — not a true logout.
+func TestClearTokensClearsOAuth2ClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-cc-logout")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		TokenURL:    "https://api.example.com/oauth/token",
+		OAuth2Grant: "client_credentials",
+		EnvVars:     []string{"OAUTH2_CC_LOGOUT_CLIENT_ID", "OAUTH2_CC_LOGOUT_CLIENT_SECRET"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth2-cc-logout-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	body := extractClearTokensBody(t, configSrc)
+
+	assert.Contains(t, body, "c.ClientID = \"\"", "ClientID must be cleared so auth login can't re-mint headlessly")
+	assert.Contains(t, body, "c.ClientSecret = \"\"", "ClientSecret must be cleared so auth login can't re-mint headlessly")
+}
+
 // TestClearTokensSkipsBuiltinCollisions pins that env vars whose
 // placeholder collides with a builtin Config tag (e.g. *_ACCESS_TOKEN
 // resolves to AccessToken) don't produce a duplicate clear: the OAuth-trio

--- a/internal/generator/cleartokens_test.go
+++ b/internal/generator/cleartokens_test.go
@@ -1,0 +1,76 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClearTokensClearsEmittedCredentialFields pins that the generated
+// (*Config).ClearTokens body zeroes every credential-bearing field the
+// template emits for an api_key CLI, not only the OAuth trio. AuthHeader()
+// falls back to the env-var-derived field for api_key auth, so leaving
+// it set after logout would silently re-authenticate the next command.
+func TestClearTokensClearsEmittedCredentialFields(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("clear-tokens")
+	apiSpec.Auth.EnvVars = []string{"PRINTING_PRESS_APIKEY"}
+
+	outputDir := filepath.Join(t.TempDir(), "clear-tokens-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	body := extractClearTokensBody(t, configSrc)
+
+	assert.Contains(t, body, "c.AccessToken = \"\"", "AccessToken should be cleared")
+	assert.Contains(t, body, "c.RefreshToken = \"\"", "RefreshToken should be cleared")
+	assert.Contains(t, body, "c.TokenExpiry = time.Time{}", "TokenExpiry should be cleared")
+	assert.Contains(t, body, "c.AuthHeaderVal = \"\"", "AuthHeaderVal should be cleared (cached header could re-authenticate)")
+	assert.Contains(t, body, "c.PrintingPressApikey = \"\"", "env-var-derived API key field should be cleared")
+}
+
+// TestClearTokensSkipsBuiltinCollisions pins that env vars whose
+// placeholder collides with a builtin Config tag (e.g. *_ACCESS_TOKEN
+// resolves to AccessToken) don't produce a duplicate clear: the OAuth-trio
+// line already covers them and a second `c.AccessToken = ""` would be
+// dead-code duplication.
+func TestClearTokensSkipsBuiltinCollisions(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("builtin-collision")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		Format:  "Bearer {token}",
+		EnvVars: []string{"PRINTING_PRESS_ACCESS_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "builtin-collision-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	body := extractClearTokensBody(t, configSrc)
+
+	count := strings.Count(body, "c.AccessToken = \"\"")
+	assert.Equal(t, 1, count, "AccessToken should be cleared exactly once; env-var loop must skip the builtin collision")
+}
+
+func extractClearTokensBody(t *testing.T, src string) string {
+	t.Helper()
+	const decl = "func (c *Config) ClearTokens() error {"
+	start := strings.Index(src, decl)
+	require.GreaterOrEqual(t, start, 0, "ClearTokens declaration not found in generated config.go")
+	body := src[start+len(decl):]
+	end := strings.Index(body, "\nfunc ")
+	if end < 0 {
+		end = len(body)
+	}
+	return body[:end]
+}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -526,10 +526,15 @@ func (c *Config) ClearTokens() error {
 	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
 	// and AccessToken are empty, so dropping the working credential requires
 	// zeroing every emitted credential field, not just the OAuth trio.
+	// ClientID/ClientSecret persist to disk via SaveTokens for the oauth2
+	// and oauth2-cc flows, so logout must wipe them too; otherwise
+	// `auth login` can re-mint a new access token unattended.
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.ClientID = ""
+	c.ClientSecret = ""
 {{- if .BearerRefresh.Enabled}}
 	c.BearerTokenRefreshedAt = time.Time{}
 {{- end}}
@@ -540,6 +545,7 @@ func (c *Config) ClearTokens() error {
 {{- end}}
 {{- end}}
 {{- else if .Auth.EnvVars}}
+	// fallback to legacy EnvVars when EnvVarSpecs is empty
 {{- range .Auth.EnvVars}}
 {{- if not (envVarIsBuiltinField .)}}
 	c.{{envVarField .}} = ""

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -523,11 +523,33 @@ func (c *Config) SaveBearerToken(accessToken string, refreshedAt time.Time) erro
 {{- end}}
 
 func (c *Config) ClearTokens() error {
+	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
+	// and AccessToken are empty, so dropping the working credential requires
+	// zeroing every emitted credential field, not just the OAuth trio.
+	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
 {{- if .BearerRefresh.Enabled}}
 	c.BearerTokenRefreshedAt = time.Time{}
+{{- end}}
+{{- if .Auth.EnvVarSpecs}}
+{{- range .Auth.EnvVarSpecs}}
+{{- if not (envVarIsBuiltinField .Name)}}
+	c.{{envVarField .Name}} = ""
+{{- end}}
+{{- end}}
+{{- else if .Auth.EnvVars}}
+{{- range .Auth.EnvVars}}
+{{- if not (envVarIsBuiltinField .)}}
+	c.{{envVarField .}} = ""
+{{- end}}
+{{- end}}
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if not (envVarIsBuiltinField .EnvVar.Name)}}
+	c.{{envVarField .EnvVar.Name}} = ""
+{{- end}}
 {{- end}}
 	return c.save()
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -135,10 +135,15 @@ func (c *Config) ClearTokens() error {
 	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
 	// and AccessToken are empty, so dropping the working credential requires
 	// zeroing every emitted credential field, not just the OAuth trio.
+	// ClientID/ClientSecret persist to disk via SaveTokens for the oauth2
+	// and oauth2-cc flows, so logout must wipe them too; otherwise
+	// `auth login` can re-mint a new access token unattended.
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.ClientID = ""
+	c.ClientSecret = ""
 	c.PrintingPressOauth2ClientId = ""
 	c.PrintingPressOauth2ClientSecret = ""
 	return c.save()

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -132,9 +132,15 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 }
 
 func (c *Config) ClearTokens() error {
+	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
+	// and AccessToken are empty, so dropping the working credential requires
+	// zeroing every emitted credential field, not just the OAuth trio.
+	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.PrintingPressOauth2ClientId = ""
+	c.PrintingPressOauth2ClientSecret = ""
 	return c.save()
 }
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -182,10 +182,15 @@ func (c *Config) ClearTokens() error {
 	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
 	// and AccessToken are empty, so dropping the working credential requires
 	// zeroing every emitted credential field, not just the OAuth trio.
+	// ClientID/ClientSecret persist to disk via SaveTokens for the oauth2
+	// and oauth2-cc flows, so logout must wipe them too; otherwise
+	// `auth login` can re-mint a new access token unattended.
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.ClientID = ""
+	c.ClientSecret = ""
 	c.RichAuthApiKey = ""
 	c.RichAuthClientId = ""
 	c.RichAuthClientSecret = ""

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -179,9 +179,20 @@ func (c *Config) SaveCredential(token string) error {
 }
 
 func (c *Config) ClearTokens() error {
+	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
+	// and AccessToken are empty, so dropping the working credential requires
+	// zeroing every emitted credential field, not just the OAuth trio.
+	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.RichAuthApiKey = ""
+	c.RichAuthClientId = ""
+	c.RichAuthClientSecret = ""
+	c.RichAuthSessionCookie = ""
+	c.RichAuthOptionalToken = ""
+	c.RichAuthBotToken = ""
+	c.RichAuthUserToken = ""
 	return c.save()
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -131,9 +131,14 @@ func (c *Config) SaveCredential(token string) error {
 }
 
 func (c *Config) ClearTokens() error {
+	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
+	// and AccessToken are empty, so dropping the working credential requires
+	// zeroing every emitted credential field, not just the OAuth trio.
+	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.PrintingPressGoldenApiKey = ""
 	return c.save()
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -134,10 +134,15 @@ func (c *Config) ClearTokens() error {
 	// AuthHeader() falls back to the env-var-derived fields when AuthHeaderVal
 	// and AccessToken are empty, so dropping the working credential requires
 	// zeroing every emitted credential field, not just the OAuth trio.
+	// ClientID/ClientSecret persist to disk via SaveTokens for the oauth2
+	// and oauth2-cc flows, so logout must wipe them too; otherwise
+	// `auth login` can re-mint a new access token unattended.
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+	c.ClientID = ""
+	c.ClientSecret = ""
 	c.PrintingPressGoldenApiKey = ""
 	return c.save()
 }


### PR DESCRIPTION
## Summary

- The config-template's `(*Config).ClearTokens()` only zeroed the OAuth trio (`AccessToken` / `RefreshToken` / `TokenExpiry`), so `auth logout` succeeded but the working credential persisted on disk for any CLI whose `AuthHeader()` falls back to an env-var-derived field. Every api_key-auth CLI inherited the bug — Greptile P1 on the freshservice publish PR ([printing-press-library#533](https://github.com/mvanhorn/printing-press-library/pull/533)) caught it; spot-check found 15 published CLIs ship the same gap today (openrouter, render, fedex, ahrefs, klaviyo, fireflies, granola, opensnow, roam, ticketmaster, steam-web, openalex, recipe-goat, movie-goat, amazon-seller).
- Expand `ClearTokens` to also zero `AuthHeaderVal` (the cached header that short-circuits `AuthHeader()`), every non-builtin `EnvVarSpecs` / `EnvVars` field, and every non-builtin `AdditionalHeaders` sibling-scheme field. Mirrors the credential-clearing block already in `SaveBearerToken` directly above it.
- The `envVarIsBuiltinField` guard reuses the same skip-builtins helper used elsewhere in the template, so env vars whose placeholder collides with an OAuth-trio tag (e.g. `*_ACCESS_TOKEN` resolving to `AccessToken`) don't emit duplicate clears.

## Scope

- Machine change in `internal/generator/templates/config.go.tmpl`, not a per-CLI patch — fixes the bug at the source so every regen (and future first-print) ships a working `auth logout`.
- Goldens for the three fixtures that have `HasAuthCommand` + env-var-derived fields (`golden-api`, `oauth2-cc`, `rich-auth`) regenerate with the new lines; the 15 other golden cases (no auth command or no env-var fields) are byte-identical and untouched.
- OAuth-only auth-code CLIs (no env-var-derived credentials, like Notion / Slack) gain only the `AuthHeaderVal = ""` line — a no-op in normal flows since neither `SaveTokens` nor any other code path persists a non-empty `AuthHeaderVal` for that auth shape.

## Test plan

- [x] `go fmt ./... && go vet ./...` clean
- [x] `go test ./...` — 4177 passed in 34 packages, including the two new tests:
  - `TestClearTokensClearsEmittedCredentialFields` — api_key CLI's `ClearTokens` zeroes the env-var-derived field plus `AuthHeaderVal`
  - `TestClearTokensSkipsBuiltinCollisions` — env vars whose placeholder is a builtin Config tag don't produce duplicate clears
- [x] `golangci-lint run ./...` clean
- [x] `scripts/golden.sh verify` — 18 cases pass after the targeted regeneration

Closes #1328