### PR TITLE
fix(cli): force sync concurrency=1 under PRINTING_PRESS_VERIFY to avoid SQLITE_BUSY

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7523,9 +7523,12 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 
 // assertVerifyEnvConcurrencyPin pins the verify-mode worker-pool override
 // in generated sync.go: cliutil import present, IsVerifyEnv() guard pins
-// concurrency to 1, and the guard sits AFTER the default-resolution block
-// (otherwise `if concurrency < 1 { concurrency = 4 }` would reset the pin
-// on every call).
+// concurrency to 1, and the guard sits after the default-resolution block.
+// Ordering is not load-bearing for correctness today (the default block's
+// `if concurrency < 1 { concurrency = 4 }` is a no-op when concurrency is
+// already 1), but pinning it as a defensive guard prevents future template
+// churn from drifting the placement and obscuring the worker-pool comment
+// block this override controls.
 func assertVerifyEnvConcurrencyPin(t *testing.T, syncContent, cliutilImportPath, label string) {
 	t.Helper()
 	assert.Contains(t, syncContent, `"`+cliutilImportPath+`"`,
@@ -7542,7 +7545,7 @@ func assertVerifyEnvConcurrencyPin(t *testing.T, syncContent, cliutilImportPath,
 	require.NotEqual(t, -1, defaultIdx, label+": default-resolution block must be present")
 	require.NotEqual(t, -1, verifyIdx, label+": verify-env block must be present")
 	assert.Less(t, defaultIdx, verifyIdx,
-		label+": verify-env override must sit AFTER the default-resolution block")
+		label+": verify-env override must sit after the default-resolution block (as shipped)")
 }
 
 // TestGeneratedSyncForcesSingleWorkerUnderVerifyEnv pins the verify-mode

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7521,6 +7521,103 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// assertVerifyEnvConcurrencyPin pins the verify-mode worker-pool override
+// in generated sync.go: cliutil import present, IsVerifyEnv() guard pins
+// concurrency to 1, and the guard sits AFTER the default-resolution block
+// (otherwise `if concurrency < 1 { concurrency = 4 }` would reset the pin
+// on every call).
+func assertVerifyEnvConcurrencyPin(t *testing.T, syncContent, cliutilImportPath, label string) {
+	t.Helper()
+	assert.Contains(t, syncContent, `"`+cliutilImportPath+`"`,
+		label+": sync.go must import internal/cliutil to call IsVerifyEnv")
+	assert.Contains(t, syncContent, "if cliutil.IsVerifyEnv() {",
+		label+": sync.go must consult cliutil.IsVerifyEnv() before starting the worker pool")
+	assert.Regexp(t,
+		`if cliutil\.IsVerifyEnv\(\) \{\s*concurrency = 1\s*\}`,
+		syncContent,
+		label+": verify-env block must pin concurrency to 1")
+
+	defaultIdx := strings.Index(syncContent, "concurrency = 4")
+	verifyIdx := strings.Index(syncContent, "cliutil.IsVerifyEnv()")
+	require.NotEqual(t, -1, defaultIdx, label+": default-resolution block must be present")
+	require.NotEqual(t, -1, verifyIdx, label+": verify-env block must be present")
+	assert.Less(t, defaultIdx, verifyIdx,
+		label+": verify-env override must sit AFTER the default-resolution block")
+}
+
+// TestGeneratedSyncForcesSingleWorkerUnderVerifyEnv pins the verify-mode
+// override in the REST sync template. Without it, the worker pool races on
+// SQLite writes once network latency disappears, tripping SQLITE_BUSY
+// despite _busy_timeout — which fails validate-narrative --full-examples
+// for any quickstart or recipe that exercises sync.
+func TestGeneratedSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "verifysync",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"VERIFYSYNC_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/verifysync-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"channels": {
+				Description: "Manage channels",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/channels",
+						Description: "List channels",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	assertVerifyEnvConcurrencyPin(t, string(syncGo), naming.CLI(apiSpec.Name)+"/internal/cliutil", "REST sync.go")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
+// TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv pins the same
+// override in the GraphQL sync template. graphql_sync.go.tmpl drives
+// sync.go when isGraphQLSpec selects it; the race-on-SQLite problem under
+// PRINTING_PRESS_VERIFY=1 applies the same way.
+func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
+	t.Parallel()
+
+	gqlSpec, err := graphql.ParseSDL(filepath.Join("..", "..", "testdata", "graphql", "test.graphql"))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	gen := New(gqlSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	assertVerifyEnvConcurrencyPin(t, string(syncGo), naming.CLI(gqlSpec.Name)+"/internal/cliutil", "GraphQL sync.go")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 // TestGeneratedSyncGatesSinceParamPerResource pins the fix for issue #900:
 // generators must only inject the incremental-cursor query parameter on
 // resources whose list endpoint actually declares it. Resources that don't

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"{{modulePath}}/internal/client"
+	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -125,6 +126,13 @@ Exit codes & warnings:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
+			// reach SQLite without the natural serialization that network
+			// latency provides in real syncs, so the worker pool races on
+			// the writer and trips SQLITE_BUSY despite _busy_timeout.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -21,6 +21,7 @@ import (
 {{- if .HasTierRouting}}
 	"{{modulePath}}/internal/client"
 {{- end}}
+	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -219,6 +220,13 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
+			// reach SQLite without the natural serialization that network
+			// latency provides in real syncs, so the worker pool races on
+			// the writer and trips SQLITE_BUSY despite _busy_timeout.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"net/url"
 	"os"
+	"printing-press-golden-pp-cli/internal/cliutil"
 	"printing-press-golden-pp-cli/internal/store"
 	"regexp"
 	"strconv"
@@ -184,6 +185,13 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
+			// reach SQLite without the natural serialization that network
+			// latency provides in real syncs, so the worker pool races on
+			// the writer and trips SQLITE_BUSY despite _busy_timeout.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync-walker-golden-pp-cli/internal/cliutil"
 	"sync-walker-golden-pp-cli/internal/store"
 	"sync/atomic"
 	"time"
@@ -184,6 +185,13 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
+			// reach SQLite without the natural serialization that network
+			// latency provides in real syncs, so the worker pool races on
+			// the writer and trips SQLITE_BUSY despite _busy_timeout.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"tier-routing-golden-pp-cli/internal/client"
+	"tier-routing-golden-pp-cli/internal/cliutil"
 	"tier-routing-golden-pp-cli/internal/store"
 	"time"
 )
@@ -182,6 +183,13 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
+			// reach SQLite without the natural serialization that network
+			// latency provides in real syncs, so the worker pool races on
+			// the writer and trips SQLITE_BUSY despite _busy_timeout.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()


### PR DESCRIPTION
## Intent

Under `PRINTING_PRESS_VERIFY=1` (mock / dry-run), the generated `sync` command's worker pool used to race on SQLite writes once network latency disappeared, tripping `SQLITE_BUSY` despite `_busy_timeout`. `validate-narrative --full-examples` failed any quickstart or recipe that exercised `sync` on a CLI with more than a handful of resources.

Issue: Closes #1205

## Approach

Force `concurrency = 1` immediately after the default-resolution block when `cliutil.IsVerifyEnv()` is true. Real-world (non-verify) sync keeps the parallel worker pool unchanged — the override only applies to the verifier's mock-mode subprocess. Mirrors the existing `cliutil.IsVerifyEnv()` short-circuit pattern used by `auth.go.tmpl`, `auth_simple.go.tmpl`, and `auth_client_credentials.go.tmpl`.

The override lands *after* the `if concurrency < 1 { concurrency = 4 }` default block — otherwise `concurrency = 1` would get clobbered back to 4. The new regression tests pin that ordering with an `assert.Less(defaultIdx, verifyIdx)` index check.

## Scope

Primary area: `internal/generator/templates/sync.go.tmpl` + `internal/generator/templates/graphql_sync.go.tmpl` (both templates power the `sync` command in printed CLIs; the GraphQL variant is selected by `isGraphQLSpec`).

Why this belongs in this repo: machine change — every future regen picks up the fix. The Datadog retro that surfaced this confirmed it would reproduce on any CLI with >5 resources whose narrative mentions `sync`.

## Risk

Low. The `cliutil.IsVerifyEnv()` call gates a single integer assignment; non-verify runs are byte-identical apart from the new (no-op) conditional. The `work` channel is still sized to `len(resources)`, so unused buffer slots sit idle but waste no work. Three sync.go golden fixtures refresh to absorb the import + 7-line block; no other generated artifact changes.

## Output Contract

Generated `sync.go` gains one import (`"<module>/internal/cliutil"`) and a 7-line block immediately after `if concurrency < 1 { concurrency = 4 }`. Three golden fixtures (`generate-golden-api`, `generate-sync-walker-api`, `generate-tier-routing-api`) refresh deterministically — no other deltas.

## Verification

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — 4193 passed in 34 packages
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 19/19 PASS (after the 3 expected sync.go refreshes)
- New tests: `TestGeneratedSyncForcesSingleWorkerUnderVerifyEnv` and `TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv` (both build the generated CLI to catch template-syntax / import errors that substring assertions miss)
