### PR TITLE
fix(cli): populate printer + run_id in generated .printing-press.json

### DIFF
--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -423,10 +423,20 @@ func readManifestPrinter(outputDir string) string {
 	return readManifestField(outputDir, "printer")
 }
 
-// resolvePrinterForNew returns "" instead of a sentinel when github.user is unset.
+// resolvePrinterForNew returns the printer @handle for a brand-new print.
+// Tries `git config github.user`, then `gh api user --jq .login` so a
+// logged-in `gh` covers machines without `git config github.user`. Returns
+// "" instead of a sentinel when both are unset.
 func resolvePrinterForNew() string {
-	if out, err := exec.Command("git", "config", "github.user").Output(); err == nil && len(out) > 0 {
-		return strings.TrimSpace(string(out))
+	if out, err := exec.Command("git", "config", "github.user").Output(); err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			return v
+		}
+	}
+	if out, err := exec.Command("gh", "api", "user", "--jq", ".login").Output(); err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			return v
+		}
 	}
 	return ""
 }

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -434,7 +434,10 @@ func resolvePrinterForNew() string {
 		}
 	}
 	if out, err := exec.Command("gh", "api", "user", "--jq", ".login").Output(); err == nil {
-		if v := strings.TrimSpace(string(out)); v != "" {
+		// jq emits the literal string "null" when .login is absent or JSON null;
+		// filter that explicitly so it doesn't survive into the printer field
+		// and re-fail publish-validate the way an empty printer would.
+		if v := strings.TrimSpace(string(out)); v != "" && v != "null" {
 			return v
 		}
 	}

--- a/internal/generator/printer_test.go
+++ b/internal/generator/printer_test.go
@@ -3,11 +3,32 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubBinaryDir creates a temp dir with fake `git` and `gh` shell scripts and
+// replaces PATH entirely with it. ghScript is the body emitted by the `gh`
+// stub (must include a shebang); pass an empty string to omit gh so
+// exec.LookPath fails. Note: replacing PATH (rather than prepending) means
+// any other binary called transitively from the code under test will also
+// fail to resolve — keep scope to functions that only exec git/gh.
+func stubBinaryDir(t *testing.T, gitScript, ghScript string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell scripts are Unix-only")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(gitScript), 0o755))
+	if ghScript != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "gh"), []byte(ghScript), 0o755))
+	}
+	t.Setenv("PATH", dir)
+	return dir
+}
 
 // TestResolvePrinterForExistingManifestWins pins the regen-preservation tier.
 func TestResolvePrinterForExistingManifestWins(t *testing.T) {
@@ -84,9 +105,14 @@ func TestReadManifestPrinterNameHandlesMissingFile(t *testing.T) {
 
 // TestGenerateLeavesPrinterEmptyWhenGitHandleUnset prevents owner-slug false positives.
 func TestGenerateLeavesPrinterEmptyWhenGitHandleUnset(t *testing.T) {
-	t.Setenv("GIT_CONFIG_COUNT", "1")
-	t.Setenv("GIT_CONFIG_KEY_0", "github.user")
-	t.Setenv("GIT_CONFIG_VALUE_0", "")
+	// Stub both git (returns empty for `git config github.user`) and gh
+	// (exits non-zero — simulates unauthenticated/missing gh) so resolution
+	// falls through to "". Without the gh stub a logged-in test runner
+	// would now pick up the gh fallback and flip the assertion.
+	stubBinaryDir(t,
+		"#!/bin/sh\nexit 0\n",
+		"#!/bin/sh\necho 'not authenticated' >&2\nexit 1\n",
+	)
 
 	apiSpec := minimalSpec("self-owned")
 	outputDir := filepath.Join(t.TempDir(), "self-owned-pp-cli")
@@ -94,4 +120,34 @@ func TestGenerateLeavesPrinterEmptyWhenGitHandleUnset(t *testing.T) {
 	require.NoError(t, gen.Generate())
 
 	assert.Empty(t, gen.Spec.Printer)
+}
+
+// TestResolvePrinterForNewFallsBackToGhWhenGitUnset pins the gh fallback.
+// Covers the common case where `git config github.user` is unset but `gh`
+// is logged in — without this fallback, every fresh print on such a machine
+// emits an empty printer and fails publish-validate's manifest contract.
+func TestResolvePrinterForNewFallsBackToGhWhenGitUnset(t *testing.T) {
+	stubBinaryDir(t,
+		"#!/bin/sh\nexit 0\n",
+		"#!/bin/sh\necho ghfallback-user\n",
+	)
+	assert.Equal(t, "ghfallback-user", resolvePrinterForNew())
+}
+
+// TestResolvePrinterForNewPrefersGitConfigOverGh pins resolution order.
+func TestResolvePrinterForNewPrefersGitConfigOverGh(t *testing.T) {
+	stubBinaryDir(t,
+		"#!/bin/sh\necho git-handle\n",
+		"#!/bin/sh\necho gh-handle\n",
+	)
+	assert.Equal(t, "git-handle", resolvePrinterForNew())
+}
+
+// TestResolvePrinterForNewReturnsEmptyWhenBothUnset pins the empty fallthrough.
+func TestResolvePrinterForNewReturnsEmptyWhenBothUnset(t *testing.T) {
+	stubBinaryDir(t,
+		"#!/bin/sh\nexit 1\n",
+		"#!/bin/sh\nexit 1\n",
+	)
+	assert.Empty(t, resolvePrinterForNew())
 }

--- a/internal/generator/printer_test.go
+++ b/internal/generator/printer_test.go
@@ -11,11 +11,9 @@ import (
 )
 
 // stubBinaryDir creates a temp dir with fake `git` and `gh` shell scripts and
-// replaces PATH entirely with it. ghScript is the body emitted by the `gh`
-// stub (must include a shebang); pass an empty string to omit gh so
-// exec.LookPath fails. Note: replacing PATH (rather than prepending) means
-// any other binary called transitively from the code under test will also
-// fail to resolve — keep scope to functions that only exec git/gh.
+// prepends it to PATH so the stubs shadow real binaries but other binaries
+// remain reachable. ghScript is the body emitted by the `gh` stub (must
+// include a shebang); pass an empty string to omit gh so exec.LookPath fails.
 func stubBinaryDir(t *testing.T, gitScript, ghScript string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -26,7 +24,7 @@ func stubBinaryDir(t *testing.T, gitScript, ghScript string) string {
 	if ghScript != "" {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "gh"), []byte(ghScript), 0o755))
 	}
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return dir
 }
 
@@ -148,6 +146,17 @@ func TestResolvePrinterForNewReturnsEmptyWhenBothUnset(t *testing.T) {
 	stubBinaryDir(t,
 		"#!/bin/sh\nexit 1\n",
 		"#!/bin/sh\nexit 1\n",
+	)
+	assert.Empty(t, resolvePrinterForNew())
+}
+
+// TestResolvePrinterForNewRejectsGhNullOutput guards against jq emitting the
+// literal string "null" when the API response lacks `.login` — accepting it
+// would set printer to "null" and still fail publish-validate downstream.
+func TestResolvePrinterForNewRejectsGhNullOutput(t *testing.T) {
+	stubBinaryDir(t,
+		"#!/bin/sh\nexit 0\n",
+		"#!/bin/sh\necho null\n",
 	)
 	assert.Empty(t, resolvePrinterForNew())
 }

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -540,6 +540,10 @@ type GenerateManifestParams struct {
 // a real run_id; otherwise fall back to empty (and warn at the call site).
 var runIDPattern = regexp.MustCompile(`^\d{8}-\d{6}$`)
 
+// runIDTimeFormat is the canonical YYYYMMDD-HHMMSS layout matched by
+// runIDPattern. Kept as a const so the format and pattern can't drift.
+const runIDTimeFormat = "20060102-150405"
+
 // DeriveRunIDFromResearchDir extracts a canonical run_id from a research-dir
 // path, or returns "" when no valid run_id can be derived. The standalone
 // generate command does not load a PipelineState, so it cannot reach
@@ -559,14 +563,24 @@ func DeriveRunIDFromResearchDir(researchDir string) string {
 // WriteManifestForGenerate writes a .printing-press.json manifest into the
 // generated CLI directory. This is the generate-command counterpart of
 // writeCLIManifestForPublish (which operates on PipelineState).
+//
+// An empty p.RunID is auto-filled with a fresh timestamp so the emitted
+// manifest satisfies publish-validate's required-run_id contract. Phase 5
+// dogfood acceptance still needs the original research-dir-derived run_id,
+// and the root.go --research-dir warning informs phase5 callers of that gap.
 func WriteManifestForGenerate(p GenerateManifestParams) error {
+	now := time.Now().UTC()
+	runID := p.RunID
+	if runID == "" {
+		runID = now.Format(runIDTimeFormat)
+	}
 	m := CLIManifest{
 		SchemaVersion:        CurrentCLIManifestSchemaVersion,
-		GeneratedAt:          time.Now().UTC(),
+		GeneratedAt:          now,
 		PrintingPressVersion: version.Version,
 		APIName:              p.APIName,
 		CLIName:              naming.CLI(p.APIName),
-		RunID:                p.RunID,
+		RunID:                runID,
 		Owner:                p.Owner,
 		Printer:              p.Printer,
 		PrinterName:          p.PrinterName,

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -596,7 +596,7 @@ func TestWriteManifestForGenerateStampsRunID(t *testing.T) {
 	assert.Equal(t, "20260504-190931", got.RunID)
 }
 
-func TestWriteManifestForGenerateOmitsEmptyRunID(t *testing.T) {
+func TestWriteManifestForGenerateAutoFillsEmptyRunID(t *testing.T) {
 	dir := t.TempDir()
 
 	err := WriteManifestForGenerate(GenerateManifestParams{
@@ -607,8 +607,12 @@ func TestWriteManifestForGenerateOmitsEmptyRunID(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
 	require.NoError(t, err)
-	// run_id has the omitempty tag; empty value must not appear in serialized JSON.
-	assert.NotContains(t, string(data), `"run_id"`)
+	// publish-validate requires run_id to be non-empty. When the caller has no
+	// research-dir-derived run_id, the emitter falls back to a fresh
+	// YYYYMMDD-HHMMSS so the manifest contract still holds.
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Regexp(t, `^\d{8}-\d{6}$`, got.RunID)
 }
 
 func TestDeriveRunIDFromResearchDir(t *testing.T) {

--- a/scripts/golden.sh
+++ b/scripts/golden.sh
@@ -41,9 +41,14 @@ normalize_json() {
 
   case "$file" in
     */.printing-press.json)
+      # run_id is auto-filled from time.Now() when the caller doesn't supply
+      # one (the standalone `generate` path the golden harness exercises).
+      # Normalize alongside generated_at / printing_press_version so the
+      # golden doesn't drift on every run.
       jq -S '
         .generated_at = "<GENERATED_AT>"
         | .printing_press_version = "<PRINTING_PRESS_VERSION>"
+        | (if has("run_id") then .run_id = "<RUN_ID>" else . end)
       ' "$file" | normalize_text
       ;;
     */manifest.json)

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -15,6 +15,7 @@
   "printer": "printing-press-golden",
   "printer_name": "printing-press-golden",
   "printing_press_version": "<PRINTING_PRESS_VERSION>",
+  "run_id": "<RUN_ID>",
   "schema_version": 1,
   "spec_checksum": "sha256:8cfba131c384836e8dde461511c9fd63cf2cbab7793553067765d515f2007aa1",
   "spec_format": "openapi3",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -16,6 +16,7 @@
   "printer": "printing-press-golden",
   "printer_name": "printing-press-golden",
   "printing_press_version": "<PRINTING_PRESS_VERSION>",
+  "run_id": "<RUN_ID>",
   "schema_version": 1,
   "spec_checksum": "sha256:2ea5c937580b3011c022fa9fcbbd19cba6be4a38a5303c66905cb9bb736991fb",
   "spec_format": "openapi3",

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -15,6 +15,7 @@
   "printer": "printing-press-golden",
   "printer_name": "printing-press-golden",
   "printing_press_version": "<PRINTING_PRESS_VERSION>",
+  "run_id": "<RUN_ID>",
   "schema_version": 1,
   "spec_checksum": "sha256:46c60ba489f2e138ffe6ab01531f2ed550369299820342a7f0093b94d0fc17b4",
   "spec_format": "openapi3",

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
@@ -15,6 +15,7 @@
   "printer": "printing-press-golden",
   "printer_name": "printing-press-golden",
   "printing_press_version": "<PRINTING_PRESS_VERSION>",
+  "run_id": "<RUN_ID>",
   "schema_version": 1,
   "spec_checksum": "sha256:2aa39c064cd068cb090102e22a446f9542fa06f75453d52e4fa9db5c21f27809",
   "spec_format": "internal",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
@@ -18,6 +18,7 @@
   "printer": "printing-press-golden",
   "printer_name": "printing-press-golden",
   "printing_press_version": "<PRINTING_PRESS_VERSION>",
+  "run_id": "<RUN_ID>",
   "schema_version": 1,
   "spec_checksum": "sha256:a059b4da997e0e835f0cdcd911ef5894fc048b50506bdcd90260a7478efb2958",
   "spec_format": "internal",


### PR DESCRIPTION
## Intent

Issue: Closes #1348

Every freshly-generated CLI shipped `.printing-press.json` with `printer: null` (omitted) and the `run_id` field missing. `printing-press publish-validate --strict` failed on the manifest contract for every printed CLI in the public library until polish hand-patched it; the retro doc on #1348 listed six concrete CLIs hitting the same gap.

## Approach

Two small generator changes plus a golden-harness normalization:

- `resolvePrinterForNew` in `internal/generator/plan_generate.go` now falls back to `gh api user --jq .login` when `git config github.user` is unset. This covers machines where the user has authenticated `gh` without ever setting the git config. When both are unset, the function still returns `""` and the existing `WARNING: spec.Printer is empty` log fires.
- `WriteManifestForGenerate` in `internal/pipeline/climanifest.go` auto-fills an empty `RunID` with a fresh `YYYYMMDD-HHMMSS` timestamp via a new `runIDTimeFormat` const that pairs with the existing `runIDPattern` regex. Phase 5 dogfood acceptance still needs the original research-dir-derived ID — the `root.go` `--research-dir` warning is preserved so phase5 callers still see the gap.
- `scripts/golden.sh` normalizes `run_id` alongside `generated_at` and `printing_press_version` for `.printing-press.json` fixtures so the goldens don't drift on every run. Five existing fixtures regain a stable shape (one new line each: `"run_id": "<RUN_ID>"`).

## Scope

Primary area: generator + manifest emitter.

Why this belongs in this repo: machine change — every printed CLI ships `.printing-press.json`, so this fixes the contract once instead of patching each library entry. Generalizes across APIs and auth patterns; doesn't hardcode anything specific.

## Risk

- Generator output: every `printing-press generate` run now emits `printer` (when git/gh provide one) and `run_id` (always) in `.printing-press.json`. Existing CLIs gain these fields on next regen; nothing is removed.
- Publish flow: closes the polish-hand-patch loop. Existing `publish-validate` thresholds unchanged.
- Phase 5 dogfood: still requires `--research-dir`. A synthetic run_id won't point at real proofs; that path keeps failing the same way, and the warning is preserved.
- Goldens: regenerated for `.printing-press.json` only — diff is a single new `run_id` line per fixture.

## Test Plan

- [x] `go test ./...` (4194 passed)
- [x] `go vet ./...`, `go fmt ./...`, `golangci-lint run`
- [x] `scripts/golden.sh verify` (19 cases pass after the regen)
- [x] Unit tests for the gh fallback (`TestResolvePrinterForNewFallsBackToGhWhenGitUnset`, `…PrefersGitConfigOverGh`, `…ReturnsEmptyWhenBothUnset`) and the run_id auto-fill (`TestWriteManifestForGenerateAutoFillsEmptyRunID`).