### PR TITLE
fix(cli): serialize sync worker pool under PRINTING_PRESS_VERIFY=1

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2832,6 +2832,89 @@ func TestExtractPageItemsNoCursor(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "-run", "TestExtractPageItems", "./internal/cli")
 }
 
+// TestGeneratedSyncSerializesUnderVerifyEnv pins that the emitted sync
+// command clamps its worker pool to one goroutine when running under
+// PRINTING_PRESS_VERIFY=1. Without this clamp, the dry-run mock races
+// instantly against SQLite and trips SQLITE_BUSY before _busy_timeout
+// fires, breaking shipcheck legs that exercise `sync` examples.
+func TestGeneratedSyncSerializesUnderVerifyEnv(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "verify-sync",
+		Version: "0.1.0",
+		BaseURL: "https://verify-sync.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/verify-sync-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"things": {
+				Description: "Things",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/things",
+						Description: "List things",
+						Response:    spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{
+							{Name: "id", Type: "string"},
+							{Name: "name", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	src := string(syncSrc)
+
+	// Stripping comments first prevents false negatives from a refactor
+	// that removes the call sites but leaves the explanatory prose
+	// behind. The check would otherwise pass on comments alone.
+	codeOnly := stripGoComments(src)
+
+	assert.Contains(t, codeOnly, "cliutil.IsVerifyEnv()",
+		"sync.go must consult cliutil.IsVerifyEnv() so verify-mode runs short-circuit the worker pool")
+	// `\b` after the `1` rejects `concurrency = 10`/`= 100` survivals if a
+	// future refactor widens the literal while keeping the call-site shape.
+	assert.Regexp(t, `(?s)cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
+		"sync.go must clamp concurrency to 1 when IsVerifyEnv() is true so dry-run sync serializes SQLite writes")
+}
+
+// TestGeneratedGraphQLSyncSerializesUnderVerifyEnv is the GraphQL-spec
+// counterpart to TestGeneratedSyncSerializesUnderVerifyEnv. The generator
+// swaps sync.go.tmpl for graphql_sync.go.tmpl when isGraphQLSpec() is true,
+// so the verify-mode clamp must ship from both templates or GraphQL-backed
+// CLIs still race on SQLite under PRINTING_PRESS_VERIFY=1.
+func TestGeneratedGraphQLSyncSerializesUnderVerifyEnv(t *testing.T) {
+	t.Parallel()
+
+	gqlSpec, err := graphql.ParseSDL(filepath.Join("..", "..", "testdata", "graphql", "test.graphql"))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	gen := New(gqlSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	codeOnly := stripGoComments(string(syncSrc))
+
+	assert.Contains(t, codeOnly, "cliutil.IsVerifyEnv()",
+		"graphql_sync.go must consult cliutil.IsVerifyEnv() so verify-mode runs short-circuit the worker pool")
+	assert.Regexp(t, `(?s)cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
+		"graphql_sync.go must clamp concurrency to 1 when IsVerifyEnv() is true")
+}
+
 // TestGeneratedSyncHandlesPascalCaseDotNetShape verifies the generated sync +
 // store paths recognize .NET-shape PascalCase envelopes ("Items"), PKs ("Id"),
 // and field keys (LookupFieldValue PascalCase pass). Parser-side tier-5 PK

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2886,7 +2886,7 @@ func TestGeneratedSyncSerializesUnderVerifyEnv(t *testing.T) {
 		"sync.go must consult cliutil.IsVerifyEnv() so verify-mode runs short-circuit the worker pool")
 	// `\b` after the `1` rejects `concurrency = 10`/`= 100` survivals if a
 	// future refactor widens the literal while keeping the call-site shape.
-	assert.Regexp(t, `(?s)cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
+	assert.Regexp(t, `cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
 		"sync.go must clamp concurrency to 1 when IsVerifyEnv() is true so dry-run sync serializes SQLite writes")
 }
 
@@ -2911,7 +2911,7 @@ func TestGeneratedGraphQLSyncSerializesUnderVerifyEnv(t *testing.T) {
 
 	assert.Contains(t, codeOnly, "cliutil.IsVerifyEnv()",
 		"graphql_sync.go must consult cliutil.IsVerifyEnv() so verify-mode runs short-circuit the worker pool")
-	assert.Regexp(t, `(?s)cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
+	assert.Regexp(t, `cliutil\.IsVerifyEnv\(\)\s*\{[^}]*concurrency\s*=\s*1\b`, codeOnly,
 		"graphql_sync.go must clamp concurrency to 1 when IsVerifyEnv() is true")
 }
 

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"{{modulePath}}/internal/client"
+	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -125,6 +126,12 @@ Exit codes & warnings:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1, mock responses return instantly
+			// and the worker pool races on SQLite faster than _busy_timeout
+			// can absorb. Serialize writes to avoid SQLITE_BUSY in dry-run.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -21,6 +21,7 @@ import (
 {{- if .HasTierRouting}}
 	"{{modulePath}}/internal/client"
 {{- end}}
+	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -219,6 +220,12 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1, mock responses return instantly
+			// and the worker pool races on SQLite faster than _busy_timeout
+			// can absorb. Serialize writes to avoid SQLITE_BUSY in dry-run.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"net/url"
 	"os"
+	"printing-press-golden-pp-cli/internal/cliutil"
 	"printing-press-golden-pp-cli/internal/store"
 	"regexp"
 	"strconv"
@@ -184,6 +185,12 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1, mock responses return instantly
+			// and the worker pool races on SQLite faster than _busy_timeout
+			// can absorb. Serialize writes to avoid SQLITE_BUSY in dry-run.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync-walker-golden-pp-cli/internal/cliutil"
 	"sync-walker-golden-pp-cli/internal/store"
 	"sync/atomic"
 	"time"
@@ -184,6 +185,12 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1, mock responses return instantly
+			// and the worker pool races on SQLite faster than _busy_timeout
+			// can absorb. Serialize writes to avoid SQLITE_BUSY in dry-run.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"tier-routing-golden-pp-cli/internal/client"
+	"tier-routing-golden-pp-cli/internal/cliutil"
 	"tier-routing-golden-pp-cli/internal/store"
 	"time"
 )
@@ -182,6 +183,12 @@ Resource scoping:
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
 				concurrency = 4
+			}
+			// Under PRINTING_PRESS_VERIFY=1, mock responses return instantly
+			// and the worker pool races on SQLite faster than _busy_timeout
+			// can absorb. Serialize writes to avoid SQLITE_BUSY in dry-run.
+			if cliutil.IsVerifyEnv() {
+				concurrency = 1
 			}
 
 			started := time.Now()


### PR DESCRIPTION
## Intent

Issue: Closes #1205

Under `PRINTING_PRESS_VERIFY=1`, the generated `sync` command's worker pool races on SQLite faster than `_busy_timeout` can absorb, tripping `SQLITE_BUSY` across every resource. `printing-press shipcheck` invokes `validate-narrative --full-examples`, which runs every quickstart/recipe under verify + `--dry-run`, so every CLI with >5 resources whose narrative mentions `sync` fails the leg.

## Approach

After the existing `--concurrency` normalization in the sync template, clamp `concurrency = 1` when `cliutil.IsVerifyEnv()` is true. Real-world sync (no verify env) continues to use the concurrent pool unchanged.

Applied to both sync templates because the generator picks one based on `isGraphQLSpec()`:

- `internal/generator/templates/sync.go.tmpl` — REST/OpenAPI specs
- `internal/generator/templates/graphql_sync.go.tmpl` — GraphQL SDL specs (identical worker pool shape, would otherwise still race)

## Scope

Primary area: generator templates (`internal/generator/templates/{sync,graphql_sync}.go.tmpl`).

Why this belongs in this repo: The bug is in the emission, not in any one printed CLI. Both sync templates ship into every generated CLI with `VisionSet.Sync == true`, so the fix has to land in the generator. Fixing a printed CLI directly would not compound to future regens.

## Risk

- **Real-world performance:** No change. The clamp only fires under `PRINTING_PRESS_VERIFY=1`, an env var the verifier sets in mock-mode subprocesses.
- **Generated output:** Three existing golden fixtures (`generate-golden-api`, `generate-sync-walker-api`, `generate-tier-routing-api`) pick up the new clamp lines; refreshed via `scripts/golden.sh update`. No other goldens affected.
- **MCP / auth / catalog / publish / scorer:** N/A.

## Output Contract

The emitted `sync.go` gains a new `cliutil` import line and a 4-line `if cliutil.IsVerifyEnv() { concurrency = 1 }` block right after the existing concurrency normalization. Both REST and GraphQL sync emissions get the same shape. Documented by `TestGeneratedSyncSerializesUnderVerifyEnv` and `TestGeneratedGraphQLSyncSerializesUnderVerifyEnv`.

## Verification

- `go fmt ./...` and `go vet ./...` — clean
- `go test ./...` — 4193 passed in 34 packages
- `go test ./internal/generator/ -run TestGeneratedSyncSerializesUnderVerifyEnv -count=1` — pass
- `go test ./internal/generator/ -run TestGeneratedGraphQLSyncSerializesUnderVerifyEnv -count=1` — pass
- `scripts/golden.sh verify` — 19 cases pass; 3 sync.go fixtures intentionally updated

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change