### PR TITLE
fix(skills): use api-slug in publish Step 6 staged path

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -434,7 +434,7 @@ Then copy the staged CLI into the publish repo, replacing any existing version:
 rm -rf "$PUBLISH_REPO_DIR/library"/*/"<api-slug>"
 
 # Copy staged CLI into publish repo (slug-keyed directory)
-cp -r "$STAGING_DIR/library/<category>/<cli-name>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>"
+cp -r "$STAGING_DIR/library/<category>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>"
 
 # Remove binaries (should not be committed)
 rm -f "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<cli-name>"
@@ -479,7 +479,7 @@ directory:
 rm -rf "$STAGING_PARENT"
 ```
 
-Note: `staged_dir` uses the CLI name (e.g., `espn-pp-cli`) but the publish repo uses the API slug (e.g., `espn`). The copy step handles this rename.
+Note: `staged_dir` is keyed by the API slug (e.g., `espn`), matching the publish repo's directory layout. The copy step is a same-name copy, not a rename.
 
 ## Step 7: Collision Detection & Resolution
 


### PR DESCRIPTION
## Summary

Fixes the stale Step 6 example in \`skills/printing-press-publish/SKILL.md\`. The \`publish package\` code stages CLIs under \`library/<category>/<api-slug>/\` (see [internal/cli/publish.go:287-291,323](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/cli/publish.go#L287-L323)), and the test fixture explicitly asserts \`result.StagedDir == .../library/<category>/<api-slug>\` ([publish_test.go:831-833](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/cli/publish_test.go#L831-L833)). But the SKILL.md \`cp\` example used \`<cli-name>\`, and the trailing note claimed the copy step performs a rename. Agents following the skill verbatim got \`cp: .../library/<category>/<api-slug>-pp-cli: No such file or directory\`.

## Changes

- Update Step 6 \`cp\` example to use \`<api-slug>\` on both source and destination.
- Rewrite the trailing note to reflect the current truth: the staged tree is keyed by the API slug; the copy is a same-name copy, not a rename.

Scope strictly the two stale lines called out in #1233. Other \`<cli-name>\` references in the SKILL (line 440 \`rm -f\` binary cleanup, line 642 \`--old-name\` for content replacement, line 835 runtime help example) are intentional and unchanged.

## Test plan

- [x] \`go build -o ./printing-press ./cmd/printing-press\`
- [x] \`go test ./internal/cli/...\` (397 passed)
- [x] \`go vet ./...\`
- [x] \`go fmt ./...\` (no changes)
- [x] \`scripts/golden.sh verify\` (19 cases passed; no golden touches a SKILL.md)
- [x] Inspected diff: 2 lines changed, both inside Step 6 prose.

Closes #1233