### PR TITLE
fix(cli): strip root-level binaries from staged publish tree

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -361,6 +361,19 @@ func newPublishPackageCmd() *cobra.Command {
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping build dir: %w", err)}
 			}
 
+			// Strip root-level binaries that local `go build ./cmd/...` (or
+			// `make build` / `make build-mcp` without `-o bin/...`) drops at
+			// the CLI dir root. The skill cleanup line tries to catch these
+			// after the copy, but routinely misses `<api-slug>-pp-mcp`; this
+			// strip applies the same convention before the copy so the staged
+			// tree is binary-free regardless of which path the operator took.
+			for _, name := range stagedBinaryNames(cliName, dirName) {
+				if err := os.Remove(filepath.Join(outCLIDir, name)); err != nil && !os.IsNotExist(err) {
+					cleanupOnFailure()
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged binary %s: %w", name, err)}
+				}
+			}
+
 			// Rewrite go.mod module path if --module-path is set
 			if modulePath != "" {
 				oldModPath := cliName // generated CLIs use bare CLI name as module path
@@ -992,6 +1005,35 @@ func buildArtifactCandidates(dir, cliName string) []string {
 		filepath.Join(dir, cliName),
 		filepath.Join(dir, "cmd", cliName, cliName),
 	}
+}
+
+// stagedBinaryNames returns the root-level filenames that local builds
+// (`go build ./cmd/...`, `make build`, `make build-mcp` without `-o`)
+// drop alongside the source tree. The Makefile template emits
+// `<api-slug>-pp-cli` and `<api-slug>-pp-mcp` peers, and verifier paths
+// may also leave a bare `<api-slug>` artifact. The list is intentionally
+// a small, named superset rather than a glob so the strip step never
+// removes a tracked source file by accident.
+func stagedBinaryNames(cliName, apiSlug string) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	add := func(n string) {
+		if n == "" {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		names = append(names, n)
+	}
+	add(apiSlug)
+	add(cliName)
+	if apiSlug != "" {
+		add(apiSlug + "-pp-cli")
+		add(apiSlug + "-pp-mcp")
+	}
+	return names
 }
 
 type fileSnapshot struct {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -363,10 +363,11 @@ func newPublishPackageCmd() *cobra.Command {
 
 			// Strip root-level binaries that local `go build ./cmd/...` (or
 			// `make build` / `make build-mcp` without `-o bin/...`) drops at
-			// the CLI dir root. The skill cleanup line tries to catch these
-			// after the copy, but routinely misses `<api-slug>-pp-mcp`; this
-			// strip applies the same convention before the copy so the staged
-			// tree is binary-free regardless of which path the operator took.
+			// the CLI dir root. The skill's downstream `cp -r ... PUBLISH_REPO_DIR`
+			// has a parallel `rm -f` line that historically missed
+			// `<api-slug>-pp-mcp`; doing the strip here on the staged copy
+			// makes the publish path binary-free regardless of which downstream
+			// step (skill or other tooling) the operator runs next.
 			for _, name := range stagedBinaryNames(cliName, dirName) {
 				if err := os.Remove(filepath.Join(outCLIDir, name)); err != nil && !os.IsNotExist(err) {
 					cleanupOnFailure()

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -566,6 +566,63 @@ func TestPublishPackageStripsBuildDir(t *testing.T) {
 	assert.ErrorIs(t, stagedErr, os.ErrNotExist, "staged dir must not include build/")
 }
 
+func TestPublishPackageStripsRootBinaries(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	// Simulate an operator who ran `go build ./cmd/...` (or `make build` /
+	// `make build-mcp` without `-o bin/...`): binaries land at the CLI
+	// dir root, named per the generator convention. None of these should
+	// reach the staged tree, regardless of which one the publish skill's
+	// rm -f line happened to enumerate.
+	for _, name := range []string{
+		"test",        // phantom bare-slug binary
+		"test-pp-cli", // primary CLI binary
+		"test-pp-mcp", // MCP peer binary the skill cleanup currently misses
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, name), []byte("\x7fELF"), 0o755))
+	}
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	// Source binaries stay — we don't mutate the operator's working tree.
+	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp"} {
+		_, srcErr := os.Stat(filepath.Join(cliDir, name))
+		assert.NoError(t, srcErr, "package must not delete source-tree binary %s", name)
+	}
+
+	// Staged tree must have none of them.
+	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp"} {
+		_, stagedErr := os.Stat(filepath.Join(result.StagedDir, name))
+		assert.ErrorIs(t, stagedErr, os.ErrNotExist, "staged dir must not include root-level binary %s", name)
+	}
+}
+
+func TestStagedBinaryNamesDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	got := stagedBinaryNames("foo-pp-cli", "foo")
+	want := []string{"foo", "foo-pp-cli", "foo-pp-mcp"}
+	assert.Equal(t, want, got)
+
+	// Empty slug returns only the cliName (no -pp-cli/-pp-mcp suffix expansion).
+	got = stagedBinaryNames("custom-binary", "")
+	want = []string{"custom-binary"}
+	assert.Equal(t, want, got)
+
+	// Empty both is empty.
+	assert.Empty(t, stagedBinaryNames("", ""))
+}
+
 func TestPublishPackageFailsWhenManuscriptsCopyFails(t *testing.T) {
 	skipIfRootCannotSimulateUnreadable(t)
 	home := setLibraryTestEnv(t)

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -579,7 +579,7 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 	for _, name := range []string{
 		"test",        // phantom bare-slug binary
 		"test-pp-cli", // primary CLI binary
-		"test-pp-mcp", // MCP peer binary the skill cleanup currently misses
+		"test-pp-mcp", // MCP peer binary (now covered by both code-level strip and skill cleanup)
 	} {
 		require.NoError(t, os.WriteFile(filepath.Join(cliDir, name), []byte("\x7fELF"), 0o755))
 	}

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -436,8 +436,13 @@ rm -rf "$PUBLISH_REPO_DIR/library"/*/"<api-slug>"
 # Copy staged CLI into publish repo (slug-keyed directory)
 cp -r "$STAGING_DIR/library/<category>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>"
 
-# Remove binaries (should not be committed)
-rm -f "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>" "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<cli-name>"
+# Remove root-level binaries (should not be committed). publish package
+# already strips these before the copy; this rm -f is belt-and-suspenders
+# for the agent path. Cover all three names the Makefile/`go build ./cmd/...`
+# can drop: bare slug, CLI binary, MCP peer.
+rm -f "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>" \
+      "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<cli-name>" \
+      "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/<api-slug>-pp-mcp"
 
 # Defense-in-depth: validate printer attribution before README and registry surfaces.
 PRINTER=$(jq -r '.printer // ""' "$PUBLISH_REPO_DIR/library/<category>/<api-slug>/.printing-press.json")


### PR DESCRIPTION
## Summary

Fixes #1396. The publish skill's binary cleanup listed `<api-slug>` and `<cli-name>`, missing the `<api-slug>-pp-mcp` peer the generator emits for every MCP-enabled CLI. When the operator (or any preceding step) ran `go build ./cmd/...` at the CLI root, the 21MB MCP binary slipped into the staged publish tree.

## Changes

- `internal/cli/publish.go`: after `CopyDir(dir, outCLIDir)` and the existing `build/` strip, remove the named root-level binaries from the staged tree. New helper `stagedBinaryNames` returns the canonical set (bare slug, `<api-slug>-pp-cli`, `<cli-name>`, `<api-slug>-pp-mcp`).
- `skills/printing-press-publish/SKILL.md`: Step 6 cleanup line now also lists `<api-slug>-pp-mcp` so following the SKILL verbatim matches the code-level guarantee.
- New tests:
  - `TestPublishPackageStripsRootBinaries`: writes bare-slug + pp-cli + pp-mcp at the source root, packages, asserts the source binaries survive and the staged tree contains none of them.
  - `TestStagedBinaryNamesDeduplicates`: pins the helper's name list and dedup behavior.

## Test plan

- [x] `go build -o ./printing-press ./cmd/printing-press`
- [x] `go test ./internal/cli/... ./internal/pipeline/...` (1683 passed)
- [x] `go vet ./...` (clean)
- [x] `go fmt ./...` (no changes)
- [x] `golangci-lint run ./internal/cli/...` (0 issues)
- [x] `scripts/golden.sh verify` (19 cases, no goldens cover root-level binaries)

Closes #1396