### PR TITLE
fix(cli): propagate PRINTING_PRESS_VERIFY=1 to browser-session-proof probe

### DIFF
--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -540,7 +540,15 @@ func runBrowserSessionProofTest(binary string, auth apispec.AuthConfig) CommandR
 		return result
 	}
 
-	output, err := runCLIWithOutput(binary, []string{"doctor", "--json"}, subprocessEnv(), 20*time.Second)
+	// cliutil.IsVerifyEnv() drives doctor's synthetic browser-session
+	// proof short-circuit. Without PRINTING_PRESS_VERIFY=1 the probe
+	// asks the CLI to validate against a real session, which a clean
+	// shipcheck environment doesn't have — every cookie-auth CLI then
+	// scores 0 even when the synthetic proof would have passed. Match
+	// the env-augmentation buildEnv() uses for the other mock-mode
+	// probes so this probe is self-contained.
+	env := append(subprocessEnv(), "PRINTING_PRESS_VERIFY=1")
+	output, err := runCLIWithOutput(binary, []string{"doctor", "--json"}, env, 20*time.Second)
 	if err != nil {
 		result.Error = fmt.Sprintf("doctor --json failed: %v", err)
 		result.Score = 0

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -128,6 +128,28 @@ func TestRunBrowserSessionProofTestPassesValidDoctorProof(t *testing.T) {
 	assert.Empty(t, result.Error)
 }
 
+// TestRunBrowserSessionProofTestPropagatesVerifyEnv guards the fix for
+// shipcheck FAIL-ing on cookie-auth CLIs: doctor must see
+// PRINTING_PRESS_VERIFY=1 so its synthetic browser-session proof
+// short-circuit fires. The stub binary returns a valid proof only when
+// the env var is set; without the probe's env augmentation it would
+// score 0.
+func TestRunBrowserSessionProofTestPropagatesVerifyEnv(t *testing.T) {
+	binary := buildVerifyEnvDoctorBinary(t)
+	// Ensure the env var isn't already set in the test process; the
+	// probe must add it itself.
+	t.Setenv("PRINTING_PRESS_VERIFY", "")
+
+	result := runBrowserSessionProofTest(binary, apispec.AuthConfig{
+		RequiresBrowserSession:       true,
+		BrowserSessionValidationPath: "/api/items",
+	})
+
+	assert.Equal(t, 3, result.Score)
+	assert.True(t, result.Execute)
+	assert.Empty(t, result.Error)
+}
+
 func TestRunCommandTestsExecutesMockReadCommands(t *testing.T) {
 	binary := buildCommandProbeBinary(t)
 	cmd := discoveredCommand{Name: "items", Kind: "read"}
@@ -136,6 +158,41 @@ func TestRunCommandTestsExecutesMockReadCommands(t *testing.T) {
 	assert.True(t, result.Help)
 	assert.True(t, result.DryRun)
 	assert.False(t, result.Execute)
+}
+
+// buildVerifyEnvDoctorBinary builds a stub printed-CLI binary whose
+// `doctor --json` returns a valid browser-session proof only when its
+// process sees PRINTING_PRESS_VERIFY=1; otherwise it reports the proof
+// as missing. Used to verify env propagation from the verify probe.
+func buildVerifyEnvDoctorBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "doctor" && os.Args[2] == "--json" {
+		if os.Getenv("PRINTING_PRESS_VERIFY") == "1" {
+			fmt.Println(`+"`"+`{"browser_session_proof":"valid","browser_session_proof_detail":"synthetic"}`+"`"+`)
+			return
+		}
+		fmt.Println(`+"`"+`{"browser_session_proof":"missing","browser_session_proof_detail":"PRINTING_PRESS_VERIFY not set"}`+"`"+`)
+		return
+	}
+	os.Exit(1)
+}
+`)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
 }
 
 func buildDoctorJSONBinary(t *testing.T, payload string) string {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -136,9 +136,17 @@ func TestRunBrowserSessionProofTestPassesValidDoctorProof(t *testing.T) {
 // score 0.
 func TestRunBrowserSessionProofTestPropagatesVerifyEnv(t *testing.T) {
 	binary := buildVerifyEnvDoctorBinary(t)
-	// Ensure the env var isn't already set in the test process; the
-	// probe must add it itself.
-	t.Setenv("PRINTING_PRESS_VERIFY", "")
+	// Fully unset PRINTING_PRESS_VERIFY for the duration of the test
+	// rather than t.Setenv(key, ""), which would leave PRINTING_PRESS_VERIFY=
+	// in os.Environ() and let it shadow the probe's later "=1" entry on
+	// platforms where the first env occurrence wins.
+	prev, had := os.LookupEnv("PRINTING_PRESS_VERIFY")
+	require.NoError(t, os.Unsetenv("PRINTING_PRESS_VERIFY"))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("PRINTING_PRESS_VERIFY", prev)
+		}
+	})
 
 	result := runBrowserSessionProofTest(binary, apispec.AuthConfig{
 		RequiresBrowserSession:       true,


### PR DESCRIPTION
## Summary

Fixes #1389. \`runBrowserSessionProofTest\` spawned \`doctor --json\` with \`subprocessEnv()\` alone, so \`PRINTING_PRESS_VERIFY\` wasn't set, \`cliutil.IsVerifyEnv()\` read false, and doctor's synthetic browser-session-proof short-circuit didn't fire. Every cookie/composed-auth CLI scored 0 on the probe and shipcheck returned a FAIL verdict that the polish skill correctly flagged as \"environmental\".

## Changes

- \`internal/pipeline/runtime.go\`: append \`PRINTING_PRESS_VERIFY=1\` to the probe's subprocess env before invoking \`doctor --json\`. Mirrors the env-augmentation \`buildEnv()\` uses for the other mock-mode probes.
- \`internal/pipeline/runtime_test.go\`: new \`TestRunBrowserSessionProofTestPropagatesVerifyEnv\` builds a stub doctor that returns a valid proof **only** when \`PRINTING_PRESS_VERIFY=1\` is set, with the test's own env cleared via \`t.Setenv\`. The test fails on main; passes with the fix.

## Test plan

- [x] \`go build -o ./printing-press ./cmd/printing-press\`
- [x] \`go test ./internal/pipeline/... -run TestRunBrowserSessionProofTest\` (3 cases pass, including the new propagation test)
- [x] \`go test ./...\` (full suite, no failures)
- [x] \`go vet ./...\` clean, \`go fmt ./...\` no changes after running
- [x] \`golangci-lint run ./internal/pipeline/...\` (0 issues)
- [x] \`scripts/golden.sh verify\` (19 cases pass)

Closes #1389