### PR TITLE
fix(cli): align publish-skill contract tests with api-slug staged path

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -162,7 +162,7 @@ func TestPublishSkillUsesLibraryTreeForCliSkillsMirror(t *testing.T) {
 	assert.NotContains(t, skill, "REGISTRY_HAS_ENTRY")
 	assert.NotContains(t, skill, "seed one registry")
 
-	copyIntoLibrary := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<cli-name>"`)
+	copyIntoLibrary := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<api-slug>"`)
 	mirrorRun := strings.Index(skill, "go run ./tools/generate-skills/main.go")
 	require.NotEqual(t, -1, copyIntoLibrary)
 	require.NotEqual(t, -1, mirrorRun)
@@ -183,7 +183,7 @@ func TestPublishSkillPRBodyIncludesStableNovelCommands(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 
 	snapshotState := strings.Index(skill, "PREEXISTING_MERGED_PATHS=$(ls")
-	packageCopy := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<cli-name>"`)
+	packageCopy := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<api-slug>"`)
 	require.NotEqual(t, -1, snapshotState)
 	require.NotEqual(t, -1, packageCopy)
 	assert.Less(t, snapshotState, packageCopy)


### PR DESCRIPTION
## Summary

Unblocks the merge queue. PR #1444 changed `skills/printing-press-publish/SKILL.md` line 437 from `<cli-name>` to `<api-slug>` (correct — matches the publish package's actual staged_dir keying), but did not update the companion contract tests in `internal/pipeline/contracts_test.go`. That violation of the AGENTS.md "Update dependent verifiers in the same change" rule slipped past #1444's own CI because the path filter only ran `test-changes` on the SKILL-only diff; the `test (pipeline)` matrix shard was SKIPPED so the broken assertion was never exercised.

## Why this affects every ready-to-merge PR

Mergify's in-place mode rebases queued PRs onto current `main`. Any open PR with Go-file changes triggers the full test matrix, the rebased branch picks up the broken `contracts_test.go` from `main`, `test (pipeline)` fails on `TestPublishSkillUsesLibraryTreeForCliSkillsMirror` and `TestPublishSkillPRBodyIncludesStableNovelCommands`, the `test` / `build-and-test` rollup checks go FAILURE, and Mergify dequeues. The sticky-dequeue behavior then traps each PR behind the `dequeued` label until it gets a new commit or `@mergifyio queue` comment.

Confirmed against PRs #1449, #1447, #1445, #1443, #1442, #1441, #1307 — same two `Waiting for: check-success = build-and-test`, `check-success = test` rows in every Mergify "Left the queue" comment.

## Changes

Two `strings.Index(...)` substrings in `internal/pipeline/contracts_test.go` (lines 165 and 186) updated from `<cli-name>` to `<api-slug>` to match SKILL.md as it stands at `ce3aeb4a`.

## Test plan

- [x] `go test ./internal/pipeline/ -run "TestPublishSkillUsesLibraryTreeForCliSkillsMirror |TestPublishSkillPRBodyIncludesStableNovelCommands" -count=1 -v` → both pass
- [x] `go test ./internal/pipeline/... -count=1` → 1284 passed
- [x] `go fmt ./internal/pipeline/...` → no changes

## Follow-up

After this lands, the stuck PRs need either a new commit or `@mergifyio queue` to clear their `dequeued` label.