### PR TITLE
fix(cli): preserve OpenAPI param casing in detected pagination

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5034,25 +5034,28 @@ func selectDescription(summary, description string) string {
 }
 
 func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Pagination {
-	paramNames := map[string]struct{}{}
+	// Map lowercase parameter name back to the spec's original casing so
+	// the detected LimitParam/CursorParam preserves whatever the API
+	// expects (e.g. Google APIs reject `pagesize` but accept `pageSize`).
+	originalCase := map[string]string{}
 	for _, p := range params {
-		paramNames[strings.ToLower(p.Name)] = struct{}{}
+		originalCase[strings.ToLower(p.Name)] = p.Name
 	}
 
 	var pag spec.Pagination
 
 	// Detect limit param
 	for _, name := range []string{"limit", "maxresults", "pagesize", "page_size", "max_results", "per_page", "page[size]"} {
-		if _, ok := paramNames[name]; ok {
-			pag.LimitParam = name
+		if orig, ok := originalCase[name]; ok {
+			pag.LimitParam = orig
 			break
 		}
 	}
 
 	// Detect cursor param and pagination type
 	for _, name := range []string{"pagetoken", "page_token"} {
-		if _, ok := paramNames[name]; ok {
-			pag.CursorParam = name
+		if orig, ok := originalCase[name]; ok {
+			pag.CursorParam = orig
 			pag.Type = "page_token"
 			pag.NextCursorPath = "nextPageToken"
 			break
@@ -5060,8 +5063,8 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	}
 	if pag.Type == "" {
 		for _, name := range []string{"after", "cursor", "page[cursor]"} {
-			if _, ok := paramNames[name]; ok {
-				pag.CursorParam = name
+			if orig, ok := originalCase[name]; ok {
+				pag.CursorParam = orig
 				pag.Type = "cursor"
 				break
 			}
@@ -5069,8 +5072,8 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	}
 	if pag.Type == "" {
 		for _, name := range []string{"offset"} {
-			if _, ok := paramNames[name]; ok {
-				pag.CursorParam = name
+			if orig, ok := originalCase[name]; ok {
+				pag.CursorParam = orig
 				pag.Type = "offset"
 				break
 			}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -6113,3 +6113,55 @@ paths:
 			"default captured verbatim; generator must use %q to escape at emit time")
 	})
 }
+
+// TestDetectPaginationPreservesParameterCase guards #1353 — Google APIs
+// declare `pageSize` (camelCase) and reject the lowercased `pagesize`
+// the detector previously stored. The detector matches case-insensitively
+// but must store the parameter name as it appears in the spec.
+func TestDetectPaginationPreservesParameterCase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		paramName string
+		wantLimit string
+	}{
+		{"google camelCase pageSize", "pageSize", "pageSize"},
+		{"snake_case page_size", "page_size", "page_size"},
+		{"plain lowercase limit", "limit", "limit"},
+		{"mixed-case maxResults", "maxResults", "maxResults"},
+		{"per_page", "per_page", "per_page"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pag := detectPagination([]spec.Param{{Name: tc.paramName}}, nil)
+			require.NotNil(t, pag, "detector should classify %q as a paginator", tc.paramName)
+			assert.Equal(t, tc.wantLimit, pag.LimitParam)
+		})
+	}
+}
+
+func TestDetectPaginationPreservesCursorParamCase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		paramName string
+		wantParam string
+		wantType  string
+	}{
+		{"google camelCase pageToken", "pageToken", "pageToken", "page_token"},
+		{"snake_case page_token", "page_token", "page_token", "page_token"},
+		{"plain after", "after", "after", "cursor"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pag := detectPagination([]spec.Param{{Name: tc.paramName}}, nil)
+			require.NotNil(t, pag, "detector should classify %q as a cursor paginator", tc.paramName)
+			assert.Equal(t, tc.wantParam, pag.CursorParam)
+			assert.Equal(t, tc.wantType, pag.Type)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1353. \`detectPagination\` in \`internal/openapi/parser.go\` matched param names case-insensitively but stored the candidate lookup key (always lowercase) as \`Pagination.LimitParam\` and \`Pagination.CursorParam\`. Generated CLIs that synced against Google APIs ended up sending \`pagesize=100\` instead of \`pageSize=100\`, and Firebase / Cloud Resource Manager / GMail all reject the lowercased form with HTTP 400 \`"Unknown name 'pagesize'"\`.

## Changes

- \`internal/openapi/parser.go\`: replace \`paramNames map[string]struct{}\` with \`originalCase map[string]string\` mapping the lowercased lookup name to the spec's original parameter name. Both \`LimitParam\` and \`CursorParam\` now store the original casing.
- \`internal/openapi/parser_test.go\`: new \`TestDetectPaginationPreservesParameterCase\` (limit-side: pageSize, page_size, limit, maxResults, per_page) and \`TestDetectPaginationPreservesCursorParamCase\` (cursor-side: pageToken, page_token, after).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/openapi/... -run TestDetectPagination\` (10 pass)
- [x] \`go test ./...\` (full suite, no failures)
- [x] \`go vet ./...\` clean
- [x] \`go fmt ./...\` no changes
- [x] \`scripts/golden.sh verify\` (19 cases pass; no goldens cover Google-shape pagination casing yet, but generate-* fixtures cover the lowercase happy path)
- [x] \`golangci-lint run ./internal/openapi/...\` (0 issues)

Closes #1353