### PR TITLE
fix(cli): expand pm_stale timestamp-field list for non-updated_at APIs

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10280,6 +10280,7 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 	for _, field := range []string{
 		"updatedAt",
 		"updated_at",
+		"updatedDate",
 		"modifiedAt",
 		"modified_at",
 		"lastModified",
@@ -10299,6 +10300,13 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 	// must update one place, not three.
 	assert.Contains(t, body, "buildStaleTimestampPredicate()",
 		"pm_stale.go.tmpl should build SQL from staleTimestampFields instead of hardcoding columns")
+
+	// Pin the COALESCE-based ORDER BY so a future refactor doesn't
+	// regress to a multi-column sort, which SQLite's NULL-first ASC
+	// ordering would corrupt for rows from APIs that don't populate the
+	// leading field.
+	assert.Contains(t, body, `"COALESCE(" + strings.Join(coalesceArgs, ", ") + ") ASC"`,
+		"pm_stale.go.tmpl ORDER BY must COALESCE across staleTimestampFields, not sort multi-column")
 }
 
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10265,6 +10265,42 @@ func TestBrowserLikeUserAgentTemplates(t *testing.T) {
 	}
 }
 
+// TestStaleTemplateCoversCommonTimestampFields pins the timestamp-key
+// list in pm_stale.go.tmpl so APIs that use modified_at (Asana),
+// last_edited_time (Notion), updated (Stripe), and similar variants
+// don't silently return zero stale items. The WHERE/ORDER BY/scan
+// loop all read from the same constant, so testing the constant is
+// the cheap-and-correct way to guard the bug.
+func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("templates", "workflows", "pm_stale.go.tmpl"))
+	require.NoError(t, err)
+	body := string(data)
+
+	for _, field := range []string{
+		"updatedAt",
+		"updated_at",
+		"modifiedAt",
+		"modified_at",
+		"lastModified",
+		"last_modified",
+		"lastEditedTime",
+		"last_edited_time",
+		"updated",
+		"last_updated",
+	} {
+		assert.Contains(t, body, `"`+field+`"`,
+			"pm_stale.go.tmpl must list %q as a stale-timestamp field; %s users return zero results otherwise",
+			field, field)
+	}
+
+	// Pin the dynamic-build approach so the WHERE/ORDER BY/scan stay in
+	// lockstep with the field list — a future maintainer adding a field
+	// must update one place, not three.
+	assert.Contains(t, body, "buildStaleTimestampPredicate()",
+		"pm_stale.go.tmpl should build SQL from staleTimestampFields instead of hardcoding columns")
+}
+
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the
 // generated `search` command in --json (or piped) mode must always emit
 // a valid JSON envelope, including on no matches. Agents pipe stdout

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10307,6 +10307,15 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 	// leading field.
 	assert.Contains(t, body, `"COALESCE(" + strings.Join(coalesceArgs, ", ") + ") ASC"`,
 		"pm_stale.go.tmpl ORDER BY must COALESCE across staleTimestampFields, not sort multi-column")
+
+	// Pin the typeof-gated WHERE so integer-typed timestamps (Stripe's
+	// `updated`) compare against an epoch cutoff rather than the
+	// RFC 3339 cutoff. Without the gate SQLite's type-class ordering
+	// makes every numeric row unconditionally match the predicate.
+	assert.Contains(t, body, "typeof(",
+		"pm_stale.go.tmpl WHERE must gate string/numeric comparisons with typeof()")
+	assert.Contains(t, body, "cutoffEpoch",
+		"pm_stale.go.tmpl must bind a numeric cutoff alongside the RFC 3339 cutoff for integer-typed timestamps")
 }
 
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -37,17 +37,24 @@ var staleTimestampFields = []string{
 
 // buildStaleTimestampPredicate emits SQL clauses (with the same `?`
 // placeholder consumed for every field) that match a row whose
-// modification timestamp is older than cutoff or sort by the earliest
-// such timestamp. Centralising the field list keeps WHERE / ORDER BY /
-// in-Go scan in lockstep.
+// modification timestamp is older than cutoff and sort rows by the
+// earliest non-null timestamp the row exposes. The ORDER BY uses
+// COALESCE rather than a multi-column sort because SQLite places NULLs
+// first under ASC, so a multi-column list would float rows from APIs
+// that don't populate the leading field above rows that do, breaking
+// the oldest-first guarantee in any mixed-API store.
+// Centralising the field list keeps WHERE / ORDER BY / in-Go scan in
+// lockstep.
 func buildStaleTimestampPredicate() (whereClause, orderClause string, placeholders int) {
 	whereParts := make([]string, 0, len(staleTimestampFields))
-	orderParts := make([]string, 0, len(staleTimestampFields))
+	coalesceArgs := make([]string, 0, len(staleTimestampFields))
 	for _, f := range staleTimestampFields {
 		whereParts = append(whereParts, fmt.Sprintf("json_extract(data, '$.%s') < ?", f))
-		orderParts = append(orderParts, fmt.Sprintf("json_extract(data, '$.%s') ASC", f))
+		coalesceArgs = append(coalesceArgs, fmt.Sprintf("json_extract(data, '$.%s')", f))
 	}
-	return strings.Join(whereParts, " OR "), strings.Join(orderParts, ", "), len(whereParts)
+	return strings.Join(whereParts, " OR "),
+		"COALESCE(" + strings.Join(coalesceArgs, ", ") + ") ASC",
+		len(whereParts)
 }
 
 func newStaleCmd(flags *rootFlags) *cobra.Command {

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -6,11 +6,49 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
 )
+
+// staleTimestampFields lists every JSON key the press considers a
+// modification timestamp when looking for stale items. Order matters:
+// the WHERE/ORDER BY and the Go-side scan iterate this list in order,
+// so the first key present on a row wins. Includes the historical
+// updatedAt/updated_at pair plus variants commonly seen in mainstream
+// APIs (Asana modified_at, Notion last_edited_time, Stripe updated, etc.)
+// so a `stale` query against any of them returns real data instead of
+// silently empty results.
+var staleTimestampFields = []string{
+	"updatedAt",
+	"updated_at",
+	"updatedDate",
+	"modifiedAt",
+	"modified_at",
+	"lastModified",
+	"last_modified",
+	"lastEditedTime",
+	"last_edited_time",
+	"updated",
+	"last_updated",
+}
+
+// buildStaleTimestampPredicate emits SQL clauses (with the same `?`
+// placeholder consumed for every field) that match a row whose
+// modification timestamp is older than cutoff or sort by the earliest
+// such timestamp. Centralising the field list keeps WHERE / ORDER BY /
+// in-Go scan in lockstep.
+func buildStaleTimestampPredicate() (whereClause, orderClause string, placeholders int) {
+	whereParts := make([]string, 0, len(staleTimestampFields))
+	orderParts := make([]string, 0, len(staleTimestampFields))
+	for _, f := range staleTimestampFields {
+		whereParts = append(whereParts, fmt.Sprintf("json_extract(data, '$.%s') < ?", f))
+		orderParts = append(orderParts, fmt.Sprintf("json_extract(data, '$.%s') ASC", f))
+	}
+	return strings.Join(whereParts, " OR "), strings.Join(orderParts, ", "), len(whereParts)
+}
 
 func newStaleCmd(flags *rootFlags) *cobra.Command {
 	var days int
@@ -48,18 +86,19 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 
 			cutoff := time.Now().AddDate(0, 0, -days).Format(time.RFC3339)
 
-			// Query resources table for items not updated since cutoff
-			query := `SELECT id, resource_type, data FROM resources
-				WHERE json_extract(data, '$.updatedAt') < ?
-				   OR json_extract(data, '$.updated_at') < ?`
-			qArgs := []any{cutoff, cutoff}
+			whereClause, orderClause, n := buildStaleTimestampPredicate()
+			query := "SELECT id, resource_type, data FROM resources WHERE (" + whereClause + ")"
+			qArgs := make([]any, 0, n+4)
+			for i := 0; i < n; i++ {
+				qArgs = append(qArgs, cutoff)
+			}
 
 			if team != "" {
 				query += ` AND (json_extract(data, '$.teamId') = ? OR json_extract(data, '$.team_id') = ? OR json_extract(data, '$.team') = ?)`
 				qArgs = append(qArgs, team, team, team)
 			}
 
-			query += ` ORDER BY json_extract(data, '$.updatedAt') ASC, json_extract(data, '$.updated_at') ASC`
+			query += " ORDER BY " + orderClause
 
 			// Get total count first
 			countQuery := "SELECT COUNT(*) FROM (" + query + ")"
@@ -112,7 +151,7 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 
 				updatedAt := ""
 				daysSince := days
-				for _, key := range []string{"updatedAt", "updated_at", "updatedDate"} {
+				for _, key := range staleTimestampFields {
 					if v, ok := obj[key]; ok {
 						updatedAt = fmt.Sprintf("%v", v)
 						if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -35,22 +35,38 @@ var staleTimestampFields = []string{
 	"last_updated",
 }
 
-// buildStaleTimestampPredicate emits SQL clauses (with the same `?`
-// placeholder consumed for every field) that match a row whose
+// buildStaleTimestampPredicate emits SQL clauses that match a row whose
 // modification timestamp is older than cutoff and sort rows by the
-// earliest non-null timestamp the row exposes. The ORDER BY uses
-// COALESCE rather than a multi-column sort because SQLite places NULLs
-// first under ASC, so a multi-column list would float rows from APIs
-// that don't populate the leading field above rows that do, breaking
-// the oldest-first guarantee in any mixed-API store.
+// earliest non-null timestamp the row exposes.
+//
+// Each field needs two placeholders because the JSON value can be a
+// text RFC 3339 string (most APIs: Asana modified_at, Notion
+// last_edited_time, etc.) or a numeric Unix epoch (Stripe `updated`).
+// SQLite's type-class ordering puts numbers unconditionally below text,
+// so without a typeof gate a numeric `updated` would always satisfy
+// `... < <text-cutoff>` and every Stripe row would falsely show stale.
+// The caller binds (cutoffStr, cutoffEpoch) per field in order.
+//
+// The ORDER BY uses COALESCE rather than a multi-column sort because
+// SQLite places NULLs first under ASC, so a multi-column list would
+// float rows from APIs that don't populate the leading field above
+// rows that do, breaking the oldest-first guarantee in any mixed-API
+// store. Within a single API the value type is consistent, so COALESCE
+// produces stable per-API chronological ordering; mixed-type stores
+// still group by type-class but stay deterministic.
+//
 // Centralising the field list keeps WHERE / ORDER BY / in-Go scan in
 // lockstep.
-func buildStaleTimestampPredicate() (whereClause, orderClause string, placeholders int) {
+func buildStaleTimestampPredicate() (whereClause, orderClause string, placeholderPairs int) {
 	whereParts := make([]string, 0, len(staleTimestampFields))
 	coalesceArgs := make([]string, 0, len(staleTimestampFields))
 	for _, f := range staleTimestampFields {
-		whereParts = append(whereParts, fmt.Sprintf("json_extract(data, '$.%s') < ?", f))
-		coalesceArgs = append(coalesceArgs, fmt.Sprintf("json_extract(data, '$.%s')", f))
+		extract := fmt.Sprintf("json_extract(data, '$.%s')", f)
+		whereParts = append(whereParts, fmt.Sprintf(
+			"((typeof(%s) = 'text' AND %s < ?) OR (typeof(%s) IN ('integer','real') AND %s < ?))",
+			extract, extract, extract, extract,
+		))
+		coalesceArgs = append(coalesceArgs, extract)
 	}
 	return strings.Join(whereParts, " OR "),
 		"COALESCE(" + strings.Join(coalesceArgs, ", ") + ") ASC",
@@ -91,13 +107,15 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 			}
 			defer db.Close()
 
-			cutoff := time.Now().AddDate(0, 0, -days).Format(time.RFC3339)
+			cutoffTime := time.Now().AddDate(0, 0, -days)
+			cutoffStr := cutoffTime.Format(time.RFC3339)
+			cutoffEpoch := cutoffTime.Unix()
 
 			whereClause, orderClause, n := buildStaleTimestampPredicate()
 			query := "SELECT id, resource_type, data FROM resources WHERE (" + whereClause + ")"
-			qArgs := make([]any, 0, n+4)
+			qArgs := make([]any, 0, n*2+4)
 			for i := 0; i < n; i++ {
-				qArgs = append(qArgs, cutoff)
+				qArgs = append(qArgs, cutoffStr, cutoffEpoch)
 			}
 
 			if team != "" {
@@ -161,8 +179,14 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 				for _, key := range staleTimestampFields {
 					if v, ok := obj[key]; ok {
 						updatedAt = fmt.Sprintf("%v", v)
-						if t, err := time.Parse(time.RFC3339, updatedAt); err == nil {
-							daysSince = int(now.Sub(t).Hours() / 24)
+						switch ts := v.(type) {
+						case string:
+							if t, err := time.Parse(time.RFC3339, ts); err == nil {
+								daysSince = int(now.Sub(t).Hours() / 24)
+							}
+						case float64:
+							// JSON numbers decode to float64 (Stripe-style Unix epoch seconds).
+							daysSince = int(now.Sub(time.Unix(int64(ts), 0)).Hours() / 24)
 						}
 						break
 					}


### PR DESCRIPTION
## Summary

Fixes #1391. The generated \`pm_stale\` command queried \`COALESCE($.updatedAt, $.updated_at)\` only, so APIs that use a different modification-timestamp field returned \`total_count: 0\` even when the local store had thousands of stale rows. Confirmed on Asana (\`modified_at\`); the issue lists Notion (\`last_edited_time\`), Stripe (\`updated\`), and similar variants as cross-API evidence.

## Changes

- \`internal/generator/templates/workflows/pm_stale.go.tmpl\`: introduce a single \`staleTimestampFields\` constant and a \`buildStaleTimestampPredicate\` helper that emits the WHERE / ORDER BY SQL fragments from it. The Go-side scan loop now iterates the same constant. Adding a new variant updates one place.
- \`internal/generator/generator_test.go\`: \`TestStaleTemplateCoversCommonTimestampFields\` pins the field list (\`updatedAt\`, \`updated_at\`, \`modifiedAt\`, \`modified_at\`, \`lastModified\`, \`last_modified\`, \`lastEditedTime\`, \`last_edited_time\`, \`updated\`, \`last_updated\`) and the build-from-constant approach.

This is the cheap-fix layer of the issue. The deeper spec-introspection layer (per-resource timestamp detection at template-emit time) is out of scope here — the broad COALESCE list is a strict superset of what spec-introspection would emit, so the durable layer can land later without breaking this guarantee.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/generator/... -run TestStaleTemplate\` (pass)
- [x] \`go test ./...\` (full suite, no failures)
- [x] \`go vet ./...\` clean
- [x] \`go fmt ./...\` no changes
- [x] \`scripts/golden.sh verify\` (19 cases pass)
- [x] \`golangci-lint run ./internal/generator/...\` (0 issues)
- [x] Inspected emitted \`pm_stale.go\` from the golden actual tree to confirm the generated Go compiles and \`staleTimestampFields\` is in lockstep with the WHERE / ORDER BY / scan.

Closes #1391