### PR TITLE
fix(cli): query generic resources_fts from search empty-type branch

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10203,8 +10203,11 @@ func TestSearchTemplateEmptyTypeQueriesGenericFTS(t *testing.T) {
 	caseEmptyIdx := strings.Index(body, `case "":`)
 	require.GreaterOrEqual(t, caseEmptyIdx, 0, "search.go.tmpl must have a case \"\": branch")
 
-	defaultIdx := strings.Index(body[caseEmptyIdx:], "default:")
-	require.GreaterOrEqual(t, defaultIdx, 0, "search.go.tmpl must have a default: after case \"\":")
+	// Anchor on the column-zero `default:` that closes the empty-type
+	// branch, so a stray "default:" inside a comment can't shift the
+	// slice boundary.
+	defaultIdx := strings.Index(body[caseEmptyIdx:], "\n\t\t\tdefault:")
+	require.GreaterOrEqual(t, defaultIdx, 0, "search.go.tmpl must have a tab-indented default: after case \"\":")
 	emptyBranch := body[caseEmptyIdx : caseEmptyIdx+defaultIdx]
 
 	assert.Contains(t, emptyBranch, "db.Search(query, limit)",

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10189,6 +10189,30 @@ func TestProjectManagementWorkflowsEmitReadOnlyAnnotations(t *testing.T) {
 	}
 }
 
+// TestSearchTemplateEmptyTypeQueriesGenericFTS pins #1390 — the
+// no-type branch must include a generic db.Search(query, limit) call
+// alongside the per-table typed Search<Resource> loop. Rows indexed
+// only in resources_fts (not in any typed FTS table) otherwise return
+// zero on the default search path.
+func TestSearchTemplateEmptyTypeQueriesGenericFTS(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("templates", "search.go.tmpl"))
+	require.NoError(t, err)
+	body := string(data)
+
+	caseEmptyIdx := strings.Index(body, `case "":`)
+	require.GreaterOrEqual(t, caseEmptyIdx, 0, "search.go.tmpl must have a case \"\": branch")
+
+	defaultIdx := strings.Index(body[caseEmptyIdx:], "default:")
+	require.GreaterOrEqual(t, defaultIdx, 0, "search.go.tmpl must have a default: after case \"\":")
+	emptyBranch := body[caseEmptyIdx : caseEmptyIdx+defaultIdx]
+
+	assert.Contains(t, emptyBranch, "db.Search(query, limit)",
+		"case \"\": must call db.Search(query, limit) so rows indexed only in resources_fts (not in a typed FTS table) are returned")
+	assert.Contains(t, emptyBranch, `"search resources_fts failed:`,
+		"the generic-search error path must mention resources_fts so the failure is debuggable")
+}
+
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the
 // generated `search` command in --json (or piped) mode must always emit
 // a valid JSON envelope, including on no matches. Agents pipe stdout

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -176,7 +176,12 @@ In local mode: searches locally synced data only.`,
 {{- end}}
 {{- end}}
 			case "":
-				// Search all FTS-enabled tables individually to avoid duplicates.
+				// Search every FTS-enabled source — typed per-resource tables
+				// AND the generic resources_fts — and dedup by raw JSON so a
+				// row indexed in multiple FTS sources appears once. Without
+				// the generic-search call, rows that landed in resources_fts
+				// but not in any typed FTS table (e.g., a resource whose sync
+				// populated only the generic index) silently return zero.
 				seen := make(map[string]bool)
 				_ = seen // prevent unused error when no FTS tables exist
 {{- range .Tables}}
@@ -196,6 +201,19 @@ In local mode: searches locally synced data only.`,
 				}
 {{- end}}
 {{- end}}
+				{
+					partial, searchErr := db.Search(query, limit)
+					if searchErr != nil {
+						return fmt.Errorf("search resources_fts failed: %w", searchErr)
+					}
+					for _, r := range partial {
+						key := string(r)
+						if !seen[key] {
+							seen[key] = true
+							results = append(results, r)
+						}
+					}
+				}
 			default:
 				// Unrecognized type — fall back to generic search
 				results, err = db.Search(query, limit)


### PR DESCRIPTION
## Summary

Fixes #1390. The generated \`internal/cli/search.go\`'s \`case \"\":\` branch iterated only the typed \`Search<Resource>\` helpers, so rows indexed in \`resources_fts\` (the generic FTS table) but not in any typed FTS table silently returned zero from \`<cli> search \"<query>\"\` without \`--type\`. Confirmed on Asana CLI where direct \`SELECT FROM resources_fts MATCH ...\` returned 249 hits but \`search \"<term>\"\` reported zero.

## Changes

- \`internal/generator/templates/search.go.tmpl\`: append a \`db.Search(query, limit)\` call to the existing seen-map dedup loop in the \`case \"\":\` branch. The generic resources_fts is now queried alongside the typed helpers, and dedup-by-raw-JSON keeps rows that are indexed in multiple FTS sources from appearing twice.
- \`internal/generator/generator_test.go\`: \`TestSearchTemplateEmptyTypeQueriesGenericFTS\` pins the call site and the contextual error message inside the empty-type branch.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/generator/... -run TestSearchTemplate\` (2 pass)
- [x] \`go vet ./...\` clean
- [x] \`go fmt ./...\` no changes
- [x] \`scripts/golden.sh verify\` (19 cases pass; no goldens cover search.go output)
- [x] \`golangci-lint run ./internal/generator/...\` (0 issues)

Closes #1390