### PR TITLE
fix(cli): short-circuit sync on dry-run sentinel response

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10318,9 +10318,9 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 		"pm_stale.go.tmpl must bind a numeric cutoff alongside the RFC 3339 cutoff for integer-typed timestamps")
 }
 
-// TestSyncTemplateShortCircuitsOnDryRunSentinel pins #1382: client.dryRun
-// returns `{"dry_run": true}` instead of a real response, and the sync
-// loop must detect this with isDryRunResponse and emit a synthetic
+// TestSyncTemplateShortCircuitsOnDryRunSentinel: client.dryRun returns
+// `{"dry_run": true}` instead of a real response, and the sync loop
+// must detect this with isDryRunResponse and emit a synthetic
 // sync_dryrun event before falling through to upsertSingleObject —
 // otherwise validate-narrative --full-examples (which auto-appends
 // --dry-run) blocks shipcheck on a spurious "missing id for <resource>"

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10318,6 +10318,35 @@ func TestStaleTemplateCoversCommonTimestampFields(t *testing.T) {
 		"pm_stale.go.tmpl must bind a numeric cutoff alongside the RFC 3339 cutoff for integer-typed timestamps")
 }
 
+// TestSyncTemplateShortCircuitsOnDryRunSentinel pins #1382: client.dryRun
+// returns `{"dry_run": true}` instead of a real response, and the sync
+// loop must detect this with isDryRunResponse and emit a synthetic
+// sync_dryrun event before falling through to upsertSingleObject —
+// otherwise validate-narrative --full-examples (which auto-appends
+// --dry-run) blocks shipcheck on a spurious "missing id for <resource>"
+// error.
+func TestSyncTemplateShortCircuitsOnDryRunSentinel(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("templates", "sync.go.tmpl"))
+	require.NoError(t, err)
+	body := string(data)
+
+	assert.Contains(t, body, "func isDryRunResponse(data json.RawMessage) bool",
+		"sync.go.tmpl must define isDryRunResponse helper that detects the client.dryRun sentinel")
+	assert.Contains(t, body, `"sync_dryrun"`,
+		"sync.go.tmpl must emit a sync_dryrun event on the short-circuit path so validate-narrative sees a structured success")
+
+	// Ordering pin: the dry-run check must run BEFORE upsertSingleObject,
+	// otherwise the sentinel reaches the upsert path and triggers a spurious
+	// "missing id for <resource>" error.
+	dryRunCheckIdx := strings.Index(body, "if isDryRunResponse(data)")
+	upsertSingleIdx := strings.Index(body, "if err := upsertSingleObject(db, resource, data)")
+	require.GreaterOrEqual(t, dryRunCheckIdx, 0, "sync.go.tmpl must call isDryRunResponse on the response")
+	require.GreaterOrEqual(t, upsertSingleIdx, 0, "sync.go.tmpl must still call upsertSingleObject for live single-object responses")
+	assert.Less(t, dryRunCheckIdx, upsertSingleIdx,
+		"isDryRunResponse check must run before upsertSingleObject so the dry-run sentinel doesn't fall through to the missing-id error")
+}
+
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the
 // generated `search` command in --json (or piped) mode must always emit
 // a valid JSON envelope, including on no matches. Agents pipe stdout

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -808,12 +808,24 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 // client.dryRun returns instead of a real API response. The sync loop
 // uses this to short-circuit before the upsert path, which would
 // otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id.
+// that has no items and no id. The check requires exactly one key
+// (dry_run) so a live API response that happens to include a top-level
+// dry_run field alongside real data isn't misclassified as the
+// sentinel and silently zero out the sync count.
 func isDryRunResponse(data json.RawMessage) bool {
-	var probe struct {
-		DryRun bool `json:"dry_run"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
 	}
-	return json.Unmarshal(data, &probe) == nil && probe.DryRun
+	if len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -536,6 +536,19 @@ func syncResource(c interface {
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
+		// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+		// of a real response when --dry-run is set. The upsert path below
+		// would otherwise fail with "missing id for <resource>" because the
+		// sentinel has no items and no id; emit a synthetic success event so
+		// validate-narrative --full-examples (which auto-appends --dry-run)
+		// sees a clean exit.
+		if isDryRunResponse(data) {
+			if !humanFriendly {
+				fmt.Fprintf(os.Stdout, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
+			}
+			return syncResult{Resource: resource, Count: 0, Duration: time.Since(started)}
+		}
+
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -789,6 +802,18 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	}
 
 	return nil, "", false
+}
+
+// isDryRunResponse detects the `{"dry_run": true}` sentinel that
+// client.dryRun returns instead of a real API response. The sync loop
+// uses this to short-circuit before the upsert path, which would
+// otherwise fail with "missing id for <resource>" against a sentinel
+// that has no items and no id.
+func isDryRunResponse(data json.RawMessage) bool {
+	var probe struct {
+		DryRun bool `json:"dry_run"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.DryRun
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -475,6 +475,19 @@ func syncResource(c interface {
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
+		// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+		// of a real response when --dry-run is set. The upsert path below
+		// would otherwise fail with "missing id for <resource>" because the
+		// sentinel has no items and no id; emit a synthetic success event so
+		// validate-narrative --full-examples (which auto-appends --dry-run)
+		// sees a clean exit.
+		if isDryRunResponse(data) {
+			if !humanFriendly {
+				fmt.Fprintf(os.Stdout, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
+			}
+			return syncResult{Resource: resource, Count: 0, Duration: time.Since(started)}
+		}
+
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -709,6 +722,18 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	}
 
 	return nil, "", false
+}
+
+// isDryRunResponse detects the `{"dry_run": true}` sentinel that
+// client.dryRun returns instead of a real API response. The sync loop
+// uses this to short-circuit before the upsert path, which would
+// otherwise fail with "missing id for <resource>" against a sentinel
+// that has no items and no id.
+func isDryRunResponse(data json.RawMessage) bool {
+	var probe struct {
+		DryRun bool `json:"dry_run"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.DryRun
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -728,12 +728,24 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 // client.dryRun returns instead of a real API response. The sync loop
 // uses this to short-circuit before the upsert path, which would
 // otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id.
+// that has no items and no id. The check requires exactly one key
+// (dry_run) so a live API response that happens to include a top-level
+// dry_run field alongside real data isn't misclassified as the
+// sentinel and silently zero out the sync count.
 func isDryRunResponse(data json.RawMessage) bool {
-	var probe struct {
-		DryRun bool `json:"dry_run"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
 	}
-	return json.Unmarshal(data, &probe) == nil && probe.DryRun
+	if len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -475,6 +475,19 @@ func syncResource(c interface {
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
+		// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+		// of a real response when --dry-run is set. The upsert path below
+		// would otherwise fail with "missing id for <resource>" because the
+		// sentinel has no items and no id; emit a synthetic success event so
+		// validate-narrative --full-examples (which auto-appends --dry-run)
+		// sees a clean exit.
+		if isDryRunResponse(data) {
+			if !humanFriendly {
+				fmt.Fprintf(os.Stdout, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
+			}
+			return syncResult{Resource: resource, Count: 0, Duration: time.Since(started)}
+		}
+
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -709,6 +722,18 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	}
 
 	return nil, "", false
+}
+
+// isDryRunResponse detects the `{"dry_run": true}` sentinel that
+// client.dryRun returns instead of a real API response. The sync loop
+// uses this to short-circuit before the upsert path, which would
+// otherwise fail with "missing id for <resource>" against a sentinel
+// that has no items and no id.
+func isDryRunResponse(data json.RawMessage) bool {
+	var probe struct {
+		DryRun bool `json:"dry_run"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.DryRun
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -728,12 +728,24 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 // client.dryRun returns instead of a real API response. The sync loop
 // uses this to short-circuit before the upsert path, which would
 // otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id.
+// that has no items and no id. The check requires exactly one key
+// (dry_run) so a live API response that happens to include a top-level
+// dry_run field alongside real data isn't misclassified as the
+// sentinel and silently zero out the sync count.
 func isDryRunResponse(data json.RawMessage) bool {
-	var probe struct {
-		DryRun bool `json:"dry_run"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
 	}
-	return json.Unmarshal(data, &probe) == nil && probe.DryRun
+	if len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -449,6 +449,19 @@ func syncResource(c interface {
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
 		}
 
+		// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+		// of a real response when --dry-run is set. The upsert path below
+		// would otherwise fail with "missing id for <resource>" because the
+		// sentinel has no items and no id; emit a synthetic success event so
+		// validate-narrative --full-examples (which auto-appends --dry-run)
+		// sees a clean exit.
+		if isDryRunResponse(data) {
+			if !humanFriendly {
+				fmt.Fprintf(os.Stdout, `{"event":"sync_dryrun","resource":"%s"}`+"\n", resource)
+			}
+			return syncResult{Resource: resource, Count: 0, Duration: time.Since(started)}
+		}
+
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -683,6 +696,18 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	}
 
 	return nil, "", false
+}
+
+// isDryRunResponse detects the `{"dry_run": true}` sentinel that
+// client.dryRun returns instead of a real API response. The sync loop
+// uses this to short-circuit before the upsert path, which would
+// otherwise fail with "missing id for <resource>" against a sentinel
+// that has no items and no id.
+func isDryRunResponse(data json.RawMessage) bool {
+	var probe struct {
+		DryRun bool `json:"dry_run"`
+	}
+	return json.Unmarshal(data, &probe) == nil && probe.DryRun
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -702,12 +702,24 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 // client.dryRun returns instead of a real API response. The sync loop
 // uses this to short-circuit before the upsert path, which would
 // otherwise fail with "missing id for <resource>" against a sentinel
-// that has no items and no id.
+// that has no items and no id. The check requires exactly one key
+// (dry_run) so a live API response that happens to include a top-level
+// dry_run field alongside real data isn't misclassified as the
+// sentinel and silently zero out the sync count.
 func isDryRunResponse(data json.RawMessage) bool {
-	var probe struct {
-		DryRun bool `json:"dry_run"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false
 	}
-	return json.Unmarshal(data, &probe) == nil && probe.DryRun
+	if len(envelope) != 1 {
+		return false
+	}
+	raw, ok := envelope["dry_run"]
+	if !ok {
+		return false
+	}
+	var v bool
+	return json.Unmarshal(raw, &v) == nil && v
 }
 
 func isEmptyPageResponse(data json.RawMessage) bool {


### PR DESCRIPTION
## Summary

Fixes #1382. \`client.dryRun\` returns \`{\"dry_run\": true}\` instead of a real response when \`--dry-run\` is set. The sync template fell through to \`upsertSingleObject\` against this sentinel, failing with \`missing id for <resource>\` because the sentinel has no items and no id. Every CLI shipped with a \`sync\` quickstart blocked shipcheck because \`validate-narrative --full-examples\` auto-appends \`--dry-run\`.

## Changes

- \`internal/generator/templates/sync.go.tmpl\`: add \`isDryRunResponse(data)\` helper near \`isEmptyPageResponse\`. In \`syncResource\`, check the helper right after \`c.Get\` and emit a structured \`sync_dryrun\` event + zero-count syncResult on match, before any extract/upsert logic runs.
- Three golden fixtures regenerated for the new short-circuit (\`generate-golden-api\`, \`generate-sync-walker-api\`, \`generate-tier-routing-api\`).
- \`internal/generator/generator_test.go\`: \`TestSyncTemplateShortCircuitsOnDryRunSentinel\` pins (a) the helper definition, (b) the \`sync_dryrun\` event string, and (c) the ordering — \`isDryRunResponse\` check must run before \`upsertSingleObject\` or the bug recurs.

Scope: the dependent-resource sync path (\`syncDependent\`) is already safe — it breaks out cleanly on \`len(items) == 0\` without an upsert, so the sentinel hits no error.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/generator/... -run TestSyncTemplateShortCircuitsOnDryRunSentinel\` (pass)
- [x] \`go test ./...\` (full suite, no failures)
- [x] \`go vet ./...\` clean
- [x] \`go fmt ./...\` no changes
- [x] \`scripts/golden.sh verify\` (19 cases pass after intentional update)
- [x] \`golangci-lint run ./internal/generator/...\` (0 issues)

Closes #1382