### PR TITLE
chore(ci): add CODEOWNERS for workflows and CODEOWNERS itself

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,13 @@
 # A malicious PR that modifies these paths could exfiltrate secrets at workflow
 # runtime or weaken the merge-gate; require an explicit maintainer review.
 # See: docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Coverage rationale: anything a workflow can `run:` is effectively part of
+# the workflow's trust boundary. That includes workflow YAML, scripts checked
+# into the repo that workflows invoke, and CODEOWNERS itself (so a malicious
+# PR cannot strip the gate before exploiting it).
 
 .github/workflows/  @tmchow @mvanhorn
+.github/scripts/    @tmchow @mvanhorn
+scripts/            @tmchow @mvanhorn
 .github/CODEOWNERS  @tmchow @mvanhorn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for security-sensitive paths.
+# A malicious PR that modifies these paths could exfiltrate secrets at workflow
+# runtime or weaken the merge-gate; require an explicit maintainer review.
+# See: docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+.github/workflows/  @tmchow @mvanhorn
+.github/CODEOWNERS  @tmchow @mvanhorn


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` listing `@tmchow` and `@mvanhorn` as required reviewers for:

- `.github/workflows/` — workflow files have access to repo secrets at runtime
- `.github/CODEOWNERS` itself — so a future malicious PR can't strip the gating rule

Pairs with the org-level setting change earlier today flipping "Fork pull request workflows from outside collaborators" from *Require approval for first-time contributors* to *Require approval for first-time contributors who are new to GitHub*. The runtime gate now only catches throwaway accounts; CODEOWNERS catches the merge-time path so an established-but-malicious contributor still can't quietly land a workflow edit.

Two owners listed so bus factor is 2 — either of us can satisfy the gate.

## Test plan

- [x] CODEOWNERS file parses (no syntax errors; GitHub validates on PR open and surfaces issues in the Files tab if any)
- [ ] After merge: confirm a PR touching `.github/workflows/` requires a review from a code owner (will verify on next workflow-touching PR)
- [ ] After merge: branch protection on `main` should include "Require review from Code Owners" — separate config change, not in this PR