### PR TITLE
fix(cli): use Chrome User-Agent for synthetic/cookie/composed/session_handshake CLIs

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10237,24 +10237,32 @@ func TestSearchTemplateEmptyTypeQueriesGenericFTS(t *testing.T) {
 		"the generic-search error path must mention resources_fts so the failure is debuggable")
 }
 
-// TestClientTemplateBrowserLikeUserAgent pins that the client template
-// branches User-Agent emission on UsesBrowserLikeUserAgent so that
-// cookie/composed/session_handshake auth and Kind: synthetic ship a
-// Chrome-shaped UA instead of the script-flavored `<cli>-pp-cli/<ver>`.
-// Otherwise WAFs (Wordfence, Imperva, Akamai bot-mode, DataDome,
-// Cloudflare bot-fight) bucket every CLI request as bot traffic.
-func TestClientTemplateBrowserLikeUserAgent(t *testing.T) {
+// TestBrowserLikeUserAgentTemplates pins that BOTH the client.go.tmpl
+// and auth_browser.go.tmpl branch User-Agent emission on
+// UsesBrowserLikeUserAgent so that cookie/composed/session_handshake
+// auth and Kind: synthetic ship a Chrome-shaped UA instead of the
+// script-flavored `<cli>-pp-cli/<ver>`. Otherwise WAFs (Wordfence,
+// Imperva, Akamai bot-mode, DataDome, Cloudflare bot-fight) bucket
+// every CLI request as bot traffic — including the auth-verify call,
+// which must clear the same bar or the user can't bootstrap session
+// state.
+func TestBrowserLikeUserAgentTemplates(t *testing.T) {
 	t.Parallel()
-	data, err := os.ReadFile(filepath.Join("templates", "client.go.tmpl"))
-	require.NoError(t, err)
-	body := string(data)
+	for _, tmpl := range []string{"client.go.tmpl", "auth_browser.go.tmpl"} {
+		t.Run(tmpl, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(filepath.Join("templates", tmpl))
+			require.NoError(t, err)
+			body := string(data)
 
-	assert.Contains(t, body, "{{- if .UsesBrowserLikeUserAgent}}",
-		"client.go.tmpl must branch UA emission on UsesBrowserLikeUserAgent")
-	assert.Contains(t, body, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
-		"client.go.tmpl must emit a Chrome UA string on the browser-like branch")
-	assert.Contains(t, body, `"{{.Name}}-pp-cli/{{.Version}}"`,
-		"client.go.tmpl must keep the script-flavored UA on the default branch so documented APIs stay identifiable")
+			assert.Contains(t, body, "{{- if .UsesBrowserLikeUserAgent}}",
+				"%s must branch UA emission on UsesBrowserLikeUserAgent", tmpl)
+			assert.Contains(t, body, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
+				"%s must emit a Chrome UA string on the browser-like branch", tmpl)
+			assert.Contains(t, body, `"{{.Name}}-pp-cli/{{.Version}}"`,
+				"%s must keep the script-flavored UA on the default branch so documented APIs stay identifiable", tmpl)
+		})
+	}
 }
 
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10237,6 +10237,26 @@ func TestSearchTemplateEmptyTypeQueriesGenericFTS(t *testing.T) {
 		"the generic-search error path must mention resources_fts so the failure is debuggable")
 }
 
+// TestClientTemplateBrowserLikeUserAgent pins that the client template
+// branches User-Agent emission on UsesBrowserLikeUserAgent so that
+// cookie/composed/session_handshake auth and Kind: synthetic ship a
+// Chrome-shaped UA instead of the script-flavored `<cli>-pp-cli/<ver>`.
+// Otherwise WAFs (Wordfence, Imperva, Akamai bot-mode, DataDome,
+// Cloudflare bot-fight) bucket every CLI request as bot traffic.
+func TestClientTemplateBrowserLikeUserAgent(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("templates", "client.go.tmpl"))
+	require.NoError(t, err)
+	body := string(data)
+
+	assert.Contains(t, body, "{{- if .UsesBrowserLikeUserAgent}}",
+		"client.go.tmpl must branch UA emission on UsesBrowserLikeUserAgent")
+	assert.Contains(t, body, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
+		"client.go.tmpl must emit a Chrome UA string on the browser-like branch")
+	assert.Contains(t, body, `"{{.Name}}-pp-cli/{{.Version}}"`,
+		"client.go.tmpl must keep the script-flavored UA on the default branch so documented APIs stay identifiable")
+}
+
 // TestSearchTemplateEmitsEmptyJSONEnvelope pins the contract: the
 // generated `search` command in --json (or piped) mode must always emit
 // a valid JSON envelope, including on no matches. Agents pipe stdout

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -1328,7 +1328,14 @@ func validateComposedAuth(authHeader string) error {
 {{- end}}
 {{- if not .UsesBrowserManagedUserAgent}}
 	if req.Header.Get("User-Agent") == "" {
+{{- if .UsesBrowserLikeUserAgent}}
+		// Browser-shaped UA matches the main client default; WAF fingerprint
+		// checks on the auth-verify call have to clear the same bar as the
+		// per-resource calls or the user can't log in to begin with.
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36")
+{{- else}}
 		req.Header.Set("User-Agent", "{{.Name}}-pp-cli/{{.Version}}")
+{{- end}}
 	}
 {{- end}}
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -994,7 +994,19 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 		}
 {{- if not .UsesBrowserManagedUserAgent}}
 		if req.Header.Get("User-Agent") == "" {
+{{- if .UsesBrowserLikeUserAgent}}
+			// Browser-shaped UA: synthetic specs and cookie/composed/
+			// session_handshake auth almost always target website-itself
+			// origins whose WAFs (Wordfence, Imperva, Akamai bot-mode,
+			// DataDome, Cloudflare bot-fight) bucket the script-shaped
+			// `<cli>-pp-cli/<version>` string as a bot and answer with
+			// empty 5xx or a challenge. RequiredHeaders or per-endpoint
+			// headerOverrides still win, and any caller that wants the
+			// CLI-flavored UA can set it on the request explicitly.
+			req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36")
+{{- else}}
 			req.Header.Set("User-Agent", "{{.Name}}-pp-cli/{{.Version}}")
+{{- end}}
 		}
 		// Go's net/http omits Accept by default; browsers, curl, and other
 		// stdlibs always send it. Fingerprint-checking WAFs (Imperva, Akamai,

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -420,6 +420,35 @@ func (s *APISpec) UsesBrowserManagedUserAgent() bool {
 	}
 }
 
+// UsesBrowserLikeUserAgent reports whether the generated CLI should
+// default to a browser-shaped User-Agent rather than the
+// `<cli>-pp-cli/<version>` script identifier. Triggered by:
+//   - Kind: synthetic — browser-sniffed specs typically talk to
+//     origins whose WAFs (Wordfence, Imperva, Akamai bot-mode,
+//     DataDome, Cloudflare bot-fight) flag the script-shaped UA as a
+//     bot and answer with 5xx, 403, or a challenge redirect.
+//   - Auth.Type in {cookie, composed, session_handshake} — same
+//     bot-detection surface; these CLIs are almost always speaking to
+//     a website-itself rather than a public API.
+//
+// The browser-managed transports (chrome, chrome-h3) handle their own
+// UA already — UsesBrowserManagedUserAgent short-circuits the template
+// emission entirely there. This method only matters for the standard
+// Go HTTP client path.
+func (s *APISpec) UsesBrowserLikeUserAgent() bool {
+	if s == nil {
+		return false
+	}
+	if s.Kind == KindSynthetic {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Auth.Type)) {
+	case "cookie", "composed", "session_handshake":
+		return true
+	}
+	return false
+}
+
 func (s *APISpec) HasRequiredHeader(name string) bool {
 	if s == nil {
 		return false

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -2750,6 +2750,88 @@ func TestHTTPTransportValidationAndDefaults(t *testing.T) {
 	require.ErrorContains(t, invalid.Validate(), "http_transport must be one of")
 }
 
+func TestUsesBrowserLikeUserAgent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		spec APISpec
+		want bool
+	}{
+		{
+			name: "documented JSON API stays script-shaped",
+			spec: APISpec{
+				Name:    "stripe",
+				BaseURL: "https://api.stripe.com",
+				Auth:    AuthConfig{Type: "bearer"},
+			},
+			want: false,
+		},
+		{
+			name: "kind: synthetic flips to browser-shaped",
+			spec: APISpec{
+				Name:    "bbquality",
+				BaseURL: "https://bbquality.nl",
+				Kind:    KindSynthetic,
+				Auth:    AuthConfig{Type: "bearer"},
+			},
+			want: true,
+		},
+		{
+			name: "cookie auth flips to browser-shaped",
+			spec: APISpec{
+				Name:    "marktplaats",
+				BaseURL: "https://www.marktplaats.nl",
+				Auth:    AuthConfig{Type: "cookie"},
+			},
+			want: true,
+		},
+		{
+			name: "composed auth flips to browser-shaped",
+			spec: APISpec{
+				Name:    "picnic",
+				BaseURL: "https://storefront-prod.nl.picnicinternational.com",
+				Auth:    AuthConfig{Type: "composed"},
+			},
+			want: true,
+		},
+		{
+			name: "session_handshake auth flips to browser-shaped",
+			spec: APISpec{
+				Name:    "openart",
+				BaseURL: "https://openart.ai",
+				Auth:    AuthConfig{Type: "session_handshake"},
+			},
+			want: true,
+		},
+		{
+			name: "auth.type casing is normalized",
+			spec: APISpec{
+				Name:    "cookieUpper",
+				BaseURL: "https://example.com",
+				Auth:    AuthConfig{Type: "  Cookie  "},
+			},
+			want: true,
+		},
+		{
+			name: "nil spec is safe and returns false",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got bool
+			if tc.name == "nil spec is safe and returns false" {
+				var s *APISpec
+				got = s.UsesBrowserLikeUserAgent()
+			} else {
+				got = tc.spec.UsesBrowserLikeUserAgent()
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestHTMLResponseExtractionValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -2755,12 +2755,12 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 
 	cases := []struct {
 		name string
-		spec APISpec
+		spec *APISpec
 		want bool
 	}{
 		{
 			name: "documented JSON API stays script-shaped",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "stripe",
 				BaseURL: "https://api.stripe.com",
 				Auth:    AuthConfig{Type: "bearer"},
@@ -2769,7 +2769,7 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 		},
 		{
 			name: "kind: synthetic flips to browser-shaped",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "bbquality",
 				BaseURL: "https://bbquality.nl",
 				Kind:    KindSynthetic,
@@ -2779,7 +2779,7 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 		},
 		{
 			name: "cookie auth flips to browser-shaped",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "marktplaats",
 				BaseURL: "https://www.marktplaats.nl",
 				Auth:    AuthConfig{Type: "cookie"},
@@ -2788,7 +2788,7 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 		},
 		{
 			name: "composed auth flips to browser-shaped",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "picnic",
 				BaseURL: "https://storefront-prod.nl.picnicinternational.com",
 				Auth:    AuthConfig{Type: "composed"},
@@ -2797,7 +2797,7 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 		},
 		{
 			name: "session_handshake auth flips to browser-shaped",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "openart",
 				BaseURL: "https://openart.ai",
 				Auth:    AuthConfig{Type: "session_handshake"},
@@ -2806,7 +2806,7 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 		},
 		{
 			name: "auth.type casing is normalized",
-			spec: APISpec{
+			spec: &APISpec{
 				Name:    "cookieUpper",
 				BaseURL: "https://example.com",
 				Auth:    AuthConfig{Type: "  Cookie  "},
@@ -2814,20 +2814,18 @@ func TestUsesBrowserLikeUserAgent(t *testing.T) {
 			want: true,
 		},
 		{
+			// Nil spec must reach the nil-receiver guard; dispatching via
+			// a typed pointer (not a name-string comparison) ensures the
+			// guard stays under test even if the case name is renamed.
 			name: "nil spec is safe and returns false",
+			spec: nil,
+			want: false,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			var got bool
-			if tc.name == "nil spec is safe and returns false" {
-				var s *APISpec
-				got = s.UsesBrowserLikeUserAgent()
-			} else {
-				got = tc.spec.UsesBrowserLikeUserAgent()
-			}
-			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.want, tc.spec.UsesBrowserLikeUserAgent())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1293. Generated CLIs default to \`<cli>-pp-cli/<version>\` for User-Agent. For documented JSON APIs that's fine, but for browser-sniffed (Kind: synthetic) CLIs and any auth.type in {cookie, composed, session_handshake}, the script-shaped UA is exactly what WAFs (Wordfence, Imperva, Akamai bot-mode, DataDome, Cloudflare bot-fight) bucket as bot traffic and reject with 5xx, 403, or a challenge. The issue cites a bbquality.nl/Wordfence confirmation and notes that picnic-pp-cli already carries a hand-fixed UA workaround.

## Changes

- \`internal/spec/spec.go\`: add \`(s *APISpec) UsesBrowserLikeUserAgent() bool\` — returns true for \`Kind: synthetic\` or auth.type in {cookie, composed, session_handshake}. Nil-safe; ToLower+TrimSpace on auth.type for casing tolerance.
- \`internal/generator/templates/client.go.tmpl\`: branch the default-UA emission on \`.UsesBrowserLikeUserAgent\`. Browser-like path emits \`Mozilla/5.0 ... Chrome/148.0.0.0 Safari/537.36\`; default path keeps \`<cli>-pp-cli/<version>\`.
- \`internal/generator/templates/auth_browser.go.tmpl\`: same branch for the auth-verify call. The WAF gate must clear at login time too or the user can't bootstrap session state.
- \`internal/spec/spec_test.go\`: 7 table-driven cases for \`UsesBrowserLikeUserAgent\` covering bearer (false), synthetic (true), cookie (true), composed (true), session_handshake (true), casing-normalize, nil-safe.
- \`internal/generator/generator_test.go\`: \`TestClientTemplateBrowserLikeUserAgent\` pins the template branch + both UA strings (positive and negative).

Scope: just the UA header. Doctor's auth-verify path and session_handshake's bootstrap UA are left for a follow-up — they have their own explicit UA contexts. The \`--user-agent\` override flag suggested in the issue is also follow-up; existing \`RequiredHeaders\` and per-endpoint \`headerOverrides\` already let callers override.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/spec/... -run TestUsesBrowserLikeUserAgent\` (7 cases pass)
- [x] \`go test ./internal/generator/... -run TestClientTemplateBrowserLikeUserAgent\` (pass)
- [x] \`go test ./...\` (full suite, no failures)
- [x] \`go vet ./...\` clean
- [x] \`go fmt ./...\` no changes
- [x] \`scripts/golden.sh verify\` (19 cases pass; no goldens cover synthetic-kind CLIs so no fixture diffs)
- [x] \`golangci-lint run ./internal/spec/... ./internal/generator/...\` (0 issues)

Closes #1293