### PR TITLE
fix(ci): switch queue update_method to merge so fork PRs can queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,7 +25,14 @@ queue_rules:
           - head = release-please--branches--main
           - "title ~= ^chore\\(main\\): release"
     merge_method: squash
-    update_method: rebase
+    # `update_method: merge` instead of `rebase` so the queue can update
+    # fork PRs without `update_bot_account`. Mergify deprecated the
+    # `rebase` + `update_bot_account` combination for fork PRs on
+    # 2026-04-21 (removal 2026-07-01); the published migration path is
+    # update_method=merge. The PR branch picks up a merge commit while
+    # in the queue, but `merge_method: squash` collapses it on the way
+    # to main, so the on-main history is unchanged.
+    update_method: merge
     # OSS plan: batch_size and max_parallel_checks must both be 1.
     batch_size: 1
     checks_timeout: 60m


### PR DESCRIPTION
## Summary

Fork PRs sit BLOCKED in this repo despite green CI because Mergify's default bot account can't push rebase commits to a fork branch in a way that triggers GitHub Actions. `@mergifyio queue` exposes this with "GitHub permissions prevent queueing" (live example: PRs #865, #1361).

The historical workaround was `update_bot_account: <maintainer>` so the rebase ran as a real user, but Mergify [deprecated the `update_method=rebase` + `update_bot_account` combination for fork PRs on 2026-04-21](https://docs.mergify.com/changelog/2026-04-21-merge-queue-rebase-with-update-bot-account-on-fork-pull-requests/) (removal 2026-07-01). The published migration path is `update_method=merge`.

## Behavior change

With `update_method: merge`, Mergify merges `main` INTO the PR branch (creating a merge commit) instead of rebasing the PR onto `main`. `mergify[bot]` can do this on fork branches without impersonation, and the resulting commit triggers workflows.

`merge_method: squash` is unchanged, so the final commit on `main` is still a single squashed commit — on-main history is identical to the rebase-based flow. The only visible difference is that a queued PR's branch carries an intermediate merge commit during processing, which is squashed away on landing.

## Test plan

- [ ] After merge, watch one of the stuck fork PRs (#865 or #1361) — Mergify should now queue when the `ready-to-merge` label is present and all checks are green.
- [ ] Confirm an in-repo PR (any `mvanhorn/...` head branch) still queues and merges normally with the new update method.

## Why this isn't `feat`

This is a fix for a stuck queueing path that's been silently broken for fork PRs; no new user-facing capability is added.