### PR TITLE
fix(cli): refresh auth on redirects via CheckRedirect

### DIFF
--- a/internal/generator/client_redirect_auth_test.go
+++ b/internal/generator/client_redirect_auth_test.go
@@ -1,0 +1,100 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #1410: the generated client.go must wire CheckRedirect on
+// the http.Client so nonce-bound auth (OAuth 1.0a PLAINTEXT, SigV4, Hawk)
+// gets a fresh authHeader on each redirect hop instead of replaying the
+// original Authorization header. Go's default replays headers verbatim,
+// which trips replay-detection on the second hop (Schoology 303 -> 401).
+func TestClientCheckRedirectReappliesAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bearer in Authorization header re-sets Authorization", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-bearer")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:    "bearer_token",
+			EnvVars: []string{"REDIRECT_BEARER_TOKEN"},
+		}
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, "if len(via) >= 10 {",
+			"CheckRedirect must cap depth at 10 to match Go's default policy")
+		require.Contains(t, closure, "return http.ErrUseLastResponse",
+			"depth cap must return ErrUseLastResponse to surface the last hop's response")
+		require.Contains(t, closure, `c.authHeader()`,
+			"CheckRedirect must call c.authHeader() so nonce-bound schemes get a fresh signature")
+		require.Contains(t, closure, `req.Header.Set("Authorization", h)`,
+			"bearer auth must re-set Authorization on redirect to refresh nonce-bound headers")
+	})
+
+	t.Run("api_key in custom header re-sets that header, not Authorization", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-apikey-header")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "X-API-Key",
+			EnvVars: []string{"REDIRECT_APIKEY_HEADER_TOKEN"},
+		}
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, `req.Header.Set("X-API-Key", h)`,
+			"api_key in custom header must re-set that header on redirect, not Authorization")
+		require.NotContains(t, closure, `req.Header.Set("Authorization", h)`,
+			"must not also stamp Authorization when the spec uses a custom header")
+	})
+
+	t.Run("api_key in query parameter skips header re-set", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-apikey-query")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:    "api_key",
+			In:      "query",
+			Header:  "api_key",
+			EnvVars: []string{"REDIRECT_APIKEY_QUERY_TOKEN"},
+		}
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, "if len(via) >= 10 {",
+			"CheckRedirect must still cap redirect depth for query-param auth")
+		require.NotContains(t, closure, `c.authHeader()`,
+			"query-param auth must not re-derive a header inside the closure; Go preserves the URL query on redirects")
+		require.NotContains(t, closure, "req.Header.Set(",
+			"query-param auth must not stamp any auth header on redirect")
+	})
+}
+
+// checkRedirectClosureBody extracts the body of the CheckRedirect closure
+// from the generated New() function so substring assertions don't match the
+// docstring above the closure (which mentions c.authHeader for context).
+func checkRedirectClosureBody(t *testing.T, content string) string {
+	t.Helper()
+	marker := "httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {"
+	start := strings.Index(content, marker)
+	require.NotEqual(t, -1, start, "CheckRedirect closure must be emitted in New()")
+	body := content[start+len(marker):]
+	end := strings.Index(body, "\n\t}\n")
+	require.NotEqual(t, -1, end, "CheckRedirect closure must be properly closed")
+	return body[:end]
+}
+
+func generateClientSource(t *testing.T, apiSpec *spec.APISpec) string {
+	t.Helper()
+	outputDir := filepath.Join(t.TempDir(), apiSpec.Name+"-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	return string(src)
+}

--- a/internal/generator/client_redirect_auth_test.go
+++ b/internal/generator/client_redirect_auth_test.go
@@ -36,6 +36,8 @@ func TestClientCheckRedirectReappliesAuth(t *testing.T) {
 			"CheckRedirect must call c.authHeader() so nonce-bound schemes get a fresh signature")
 		require.Contains(t, closure, `req.Header.Set("Authorization", h)`,
 			"bearer auth must re-set Authorization on redirect to refresh nonce-bound headers")
+		require.Contains(t, closure, "req.URL.Host == via[0].URL.Host",
+			"auth re-stamp must be gated on same-host so a cross-domain 3xx (open redirect or partner handoff) does not leak the credential — Go's automatic Authorization stripping has already run by the time CheckRedirect is called, and any header set here is sent verbatim")
 	})
 
 	t.Run("api_key in custom header re-sets that header, not Authorization", func(t *testing.T) {
@@ -53,6 +55,8 @@ func TestClientCheckRedirectReappliesAuth(t *testing.T) {
 			"api_key in custom header must re-set that header on redirect, not Authorization")
 		require.NotContains(t, closure, `req.Header.Set("Authorization", h)`,
 			"must not also stamp Authorization when the spec uses a custom header")
+		require.Contains(t, closure, "req.URL.Host == via[0].URL.Host",
+			"custom-header auth must also be same-host gated to avoid leaking credentials across domains")
 	})
 
 	t.Run("api_key in query parameter skips header re-set", func(t *testing.T) {

--- a/internal/generator/client_redirect_auth_test.go
+++ b/internal/generator/client_redirect_auth_test.go
@@ -30,8 +30,8 @@ func TestClientCheckRedirectReappliesAuth(t *testing.T) {
 
 		require.Contains(t, closure, "if len(via) >= 10 {",
 			"CheckRedirect must cap depth at 10 to match Go's default policy")
-		require.Contains(t, closure, "return http.ErrUseLastResponse",
-			"depth cap must return ErrUseLastResponse to surface the last hop's response")
+		require.Contains(t, closure, `return errors.New("stopped after 10 redirects")`,
+			"depth cap must return a plain error so Do() propagates it; ErrUseLastResponse would silently surface the 3xx body as a successful response")
 		require.Contains(t, closure, `c.authHeader()`,
 			"CheckRedirect must call c.authHeader() so nonce-bound schemes get a fresh signature")
 		require.Contains(t, closure, `req.Header.Set("Authorization", h)`,

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -324,7 +324,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	sess := newSessionManager(timeout)
 	httpClient := newHTTPClient(timeout, sess.CookieJar())
 	sess.AttachTo(httpClient)
-	return &Client{
+	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 {{- if .BasePath}}
 		BasePath:   normalizeBasePath(cfg.BasePath),
@@ -350,7 +350,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	}
 {{- else}}
 	httpClient := newHTTPClient(timeout, nil)
-	return &Client{
+	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 {{- if .BasePath}}
 		BasePath:   normalizeBasePath(cfg.BasePath),
@@ -374,6 +374,38 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- end}}
 	}
 {{- end}}
+	// CheckRedirect re-derives auth on each hop. Go's default replays the
+	// original Authorization header verbatim, which breaks nonce-bound
+	// schemes (OAuth 1.0a PLAINTEXT, SigV4, Hawk): the duplicate nonce
+	// trips the server's replay detector with a 401. c.authHeader()
+	// returns a fresh value for those schemes and the same static value
+	// for Bearer/api_key, so post-redirect headers are byte-identical for
+	// static auth and freshly-signed for nonce-bound auth.
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+{{- if .HasTierRouting}}
+		// Tier routing picks header vs query at runtime via authForRequest;
+		// re-deriving here would duplicate that selection logic. Cap depth
+		// only and let Go's default header replay handle static credentials.
+{{- else if eq .Auth.Type "session_handshake"}}
+{{- if eq .Auth.TokenParamIn "header"}}
+		if h, err := c.authHeader(); err == nil && h != "" {
+			req.Header.Set("{{.Auth.TokenParamName}}", h)
+		}
+{{- end}}
+{{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
+		// Auth lives on URL query; Go preserves the query on relative
+		// redirects, so nothing to re-derive.
+{{- else}}
+		if h, err := c.authHeader(); err == nil && h != "" {
+			req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
+		}
+{{- end}}
+		return nil
+	}
+	return c
 }
 
 // RateLimit returns the current effective rate limit in req/s. Returns 0 if disabled.

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -397,16 +397,28 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// only and let Go's default header replay handle static credentials.
 {{- else if eq .Auth.Type "session_handshake"}}
 {{- if eq .Auth.TokenParamIn "header"}}
-		if h, err := c.authHeader(); err == nil && h != "" {
-			req.Header.Set("{{.Auth.TokenParamName}}", h)
+		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
+		// cross-domain 3xx (open redirect or partner handoff) must not
+		// receive the auth credential, even though we are inside
+		// CheckRedirect where Go's automatic stripping has already run.
+		if req.URL.Host == via[0].URL.Host {
+			if h, err := c.authHeader(); err == nil && h != "" {
+				req.Header.Set("{{.Auth.TokenParamName}}", h)
+			}
 		}
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
 		// Auth lives on URL query; Go preserves the query on relative
 		// redirects, so nothing to re-derive.
 {{- else}}
-		if h, err := c.authHeader(); err == nil && h != "" {
-			req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
+		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
+		// cross-domain 3xx (open redirect or partner handoff) must not
+		// receive the auth credential, even though we are inside
+		// CheckRedirect where Go's automatic stripping has already run.
+		if req.URL.Host == via[0].URL.Host {
+			if h, err := c.authHeader(); err == nil && h != "" {
+				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
+			}
 		}
 {{- end}}
 		return nil

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -383,7 +384,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// static auth and freshly-signed for nonce-bound auth.
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return http.ErrUseLastResponse
+			// Match Go's defaultCheckRedirect: a plain error so Client.Do
+			// returns it through do()'s err != nil branch. ErrUseLastResponse
+			// would cause Do to return the 3xx with nil error, which do()
+			// would then classify as a successful response and hand the HTML
+			// "Moved Permanently" body back to the caller.
+			return errors.New("stopped after 10 redirects")
 		}
 {{- if .HasTierRouting}}
 		// Tier routing picks header vs query at runtime via authForRequest;

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -59,7 +59,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
 	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-oauth2-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
-	return &Client{
+	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 		Config:     cfg,
 		HTTPClient: httpClient,
@@ -67,6 +67,23 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		limiter:    cliutil.NewAdaptiveLimiter(rateLimit),
 		ccMu:       &sync.Mutex{},
 	}
+	// CheckRedirect re-derives auth on each hop. Go's default replays the
+	// original Authorization header verbatim, which breaks nonce-bound
+	// schemes (OAuth 1.0a PLAINTEXT, SigV4, Hawk): the duplicate nonce
+	// trips the server's replay detector with a 401. c.authHeader()
+	// returns a fresh value for those schemes and the same static value
+	// for Bearer/api_key, so post-redirect headers are byte-identical for
+	// static auth and freshly-signed for nonce-bound auth.
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		if h, err := c.authHeader(); err == nil && h != "" {
+			req.Header.Set("Authorization", h)
+		}
+		return nil
+	}
+	return c
 }
 
 // RateLimit returns the current effective rate limit in req/s. Returns 0 if disabled.

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -76,7 +77,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// static auth and freshly-signed for nonce-bound auth.
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return http.ErrUseLastResponse
+			// Match Go's defaultCheckRedirect: a plain error so Client.Do
+			// returns it through do()'s err != nil branch. ErrUseLastResponse
+			// would cause Do to return the 3xx with nil error, which do()
+			// would then classify as a successful response and hand the HTML
+			// "Moved Permanently" body back to the caller.
+			return errors.New("stopped after 10 redirects")
 		}
 		if h, err := c.authHeader(); err == nil && h != "" {
 			req.Header.Set("Authorization", h)

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -84,8 +84,14 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
-		if h, err := c.authHeader(); err == nil && h != "" {
-			req.Header.Set("Authorization", h)
+		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
+		// cross-domain 3xx (open redirect or partner handoff) must not
+		// receive the auth credential, even though we are inside
+		// CheckRedirect where Go's automatic stripping has already run.
+		if req.URL.Host == via[0].URL.Host {
+			if h, err := c.authHeader(); err == nil && h != "" {
+				req.Header.Set("Authorization", h)
+			}
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -70,7 +71,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// static auth and freshly-signed for nonce-bound auth.
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return http.ErrUseLastResponse
+			// Match Go's defaultCheckRedirect: a plain error so Client.Do
+			// returns it through do()'s err != nil branch. ErrUseLastResponse
+			// would cause Do to return the 3xx with nil error, which do()
+			// would then classify as a successful response and hand the HTML
+			// "Moved Permanently" body back to the caller.
+			return errors.New("stopped after 10 redirects")
 		}
 		if h, err := c.authHeader(); err == nil && h != "" {
 			req.Header.Set("X-API-Key", h)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -54,13 +54,30 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
 	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
-	return &Client{
+	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 		Config:     cfg,
 		HTTPClient: httpClient,
 		cacheDir:   cacheDir,
 		limiter:    cliutil.NewAdaptiveLimiter(rateLimit),
 	}
+	// CheckRedirect re-derives auth on each hop. Go's default replays the
+	// original Authorization header verbatim, which breaks nonce-bound
+	// schemes (OAuth 1.0a PLAINTEXT, SigV4, Hawk): the duplicate nonce
+	// trips the server's replay detector with a 401. c.authHeader()
+	// returns a fresh value for those schemes and the same static value
+	// for Bearer/api_key, so post-redirect headers are byte-identical for
+	// static auth and freshly-signed for nonce-bound auth.
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		if h, err := c.authHeader(); err == nil && h != "" {
+			req.Header.Set("X-API-Key", h)
+		}
+		return nil
+	}
+	return c
 }
 
 // RateLimit returns the current effective rate limit in req/s. Returns 0 if disabled.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -78,8 +78,14 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			// "Moved Permanently" body back to the caller.
 			return errors.New("stopped after 10 redirects")
 		}
-		if h, err := c.authHeader(); err == nil && h != "" {
-			req.Header.Set("X-API-Key", h)
+		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
+		// cross-domain 3xx (open redirect or partner handoff) must not
+		// receive the auth credential, even though we are inside
+		// CheckRedirect where Go's automatic stripping has already run.
+		if req.URL.Host == via[0].URL.Host {
+			if h, err := c.authHeader(); err == nil && h != "" {
+				req.Header.Set("X-API-Key", h)
+			}
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -147,7 +147,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	homeDir, _ := os.UserHomeDir()
 	cacheDir := filepath.Join(homeDir, ".cache", "tier-routing-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
-	return &Client{
+	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 		Config:     cfg,
 		HTTPClient: httpClient,
@@ -155,6 +155,23 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		limiter:    cliutil.NewAdaptiveLimiter(rateLimit),
 		limiters:   newTierLimiters(rateLimit),
 	}
+	// CheckRedirect re-derives auth on each hop. Go's default replays the
+	// original Authorization header verbatim, which breaks nonce-bound
+	// schemes (OAuth 1.0a PLAINTEXT, SigV4, Hawk): the duplicate nonce
+	// trips the server's replay detector with a 401. c.authHeader()
+	// returns a fresh value for those schemes and the same static value
+	// for Bearer/api_key, so post-redirect headers are byte-identical for
+	// static auth and freshly-signed for nonce-bound auth.
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return http.ErrUseLastResponse
+		}
+		// Tier routing picks header vs query at runtime via authForRequest;
+		// re-deriving here would duplicate that selection logic. Cap depth
+		// only and let Go's default header replay handle static credentials.
+		return nil
+	}
+	return c
 }
 
 // RateLimit returns the current effective rate limit in req/s. Returns 0 if disabled.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -164,7 +165,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	// static auth and freshly-signed for nonce-bound auth.
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
-			return http.ErrUseLastResponse
+			// Match Go's defaultCheckRedirect: a plain error so Client.Do
+			// returns it through do()'s err != nil branch. ErrUseLastResponse
+			// would cause Do to return the 3xx with nil error, which do()
+			// would then classify as a successful response and hand the HTML
+			// "Moved Permanently" body back to the caller.
+			return errors.New("stopped after 10 redirects")
 		}
 		// Tier routing picks header vs query at runtime via authForRequest;
 		// re-deriving here would duplicate that selection logic. Cap depth


### PR DESCRIPTION
## Intent

Generated client.go does not set `CheckRedirect`, so Go follows redirects with the original `Authorization` header replayed verbatim. Nonce-bound auth (OAuth 1.0a PLAINTEXT, SigV4, Hawk) breaks on the second hop because the server's replay detector rejects the duplicate nonce. Schoology reproduced this with a 303 redirect on `/users/me` returning 401 \"Duplicate timestamp/nonce combination\".

Issue: Closes #1410

## Approach

Wire `CheckRedirect` on `httpClient` inside `New()` after the `*Client` is allocated, so the closure can call `c.authHeader()` on each redirect hop. The closure caps depth at 10 (Go's default) and re-stamps the auth header.

Template branches keep the closure narrow:

- Default header auth (Bearer, api_key in header): re-set `Auth.Header` (or `Authorization`) from `c.authHeader()`. Byte-identical for static schemes; freshly-derived for nonce-bound schemes.
- `session_handshake` with `TokenParamIn: header`: re-set `TokenParamName` from `c.authHeader()`.
- Query-param auth or session_handshake-query: cap depth only. Go's URL resolution preserves the query on relative redirects, so no header to re-stamp.
- Tier routing: cap depth only. The runtime `authForRequest` selection (header vs query, tier-specific limiter) lives on the request path; duplicating it inside the redirect closure was rejected as the scope grew faster than its value.

## Scope

Primary area: generator template `internal/generator/templates/client.go.tmpl`.

Why this belongs in this repo: every printed CLI that hits a 3xx-returning endpoint is affected. The fix lives in the generator so all future regens inherit it; published CLIs pick it up on next reprint.

## Risk

- Bearer / api_key-in-header CLIs: byte-identical post-redirect headers. New `CheckRedirect` closure is wired but its result matches Go's default replay behavior for static auth.
- Tier-routing and query-param CLIs: closure caps depth but does not re-stamp any header. Behavior unchanged.
- session_handshake header-mode: the closure calls `c.authHeader()`, which returns the cached config token. On session_handshake `c.authHeader()` typically returns empty (the live token lives on `c.Session`), so the re-set is a no-op and the original Go-replayed header stands — same as before for that path.
- OAuth2 client_credentials: `c.authHeader()` invokes the cached-token fast path under the existing mutex; an expired token would mint synchronously, but in practice the parent request just minted before issuing the original call, so the redirect path returns the cached token without a fresh network round trip.

## Output Contract

Three golden client.go fixtures updated: `generate-golden-api` (api_key in custom header re-sets `X-API-Key`), `generate-golden-api-oauth2-cc` (oauth2 re-sets `Authorization`), `generate-tier-routing-api` (cap-only branch).

## Verification

- ``go fmt ./...``
- ``go vet ./...``
- ``go test ./...``  (4323 passed, 35 packages)
- ``golangci-lint run ./...``  (no issues)
- ``scripts/golden.sh verify``  (20 passing after intentional updates to 3 client.go fixtures)
- New regression test ``internal/generator/client_redirect_auth_test.go`` asserts CheckRedirect emission across bearer, custom-header api_key, and query-param api_key configurations.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change