### PR TITLE
fix(cli): apply Bearer prefix in composed and cookie AuthHeader paths

### DIFF
--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -445,20 +445,20 @@ func (c *Config) AuthHeader() string {
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		c.AuthSource = "env:{{.Name}}"
-		return c.{{resolveEnvVarField .Name}}
+		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
 	{{- with $canonicalEnvVar}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		c.AuthSource = "env:{{.Name}}"
-		return c.{{resolveEnvVarField .Name}}
+		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
 	if c.AccessToken != "" {
 		c.AuthSource = "browser"
-		return c.AccessToken
+		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
 	}
 	return ""
 {{- else if eq .Auth.Type "composed"}}
@@ -467,20 +467,20 @@ func (c *Config) AuthHeader() string {
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		c.AuthSource = "env:{{.Name}}"
-		return c.{{resolveEnvVarField .Name}}
+		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
 	{{- with $canonicalEnvVar}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		c.AuthSource = "env:{{.Name}}"
-		return c.{{resolveEnvVarField .Name}}
+		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
 	if c.AccessToken != "" {
 		c.AuthSource = "chrome-composed"
-		return c.AccessToken
+		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
 	}
 	return ""
 {{- else}}
@@ -500,6 +500,27 @@ func applyAuthFormat(format string, replacements map[string]string) string {
 	}
 	return format
 }
+
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+
+// ensureAuthScheme returns "<scheme> <token>" but skips the prefix when the
+// token already carries it case-insensitively, so a user who exports the
+// env var with the scheme already attached doesn't end up double-prefixed.
+// Empty scheme returns the token as-is.
+func ensureAuthScheme(scheme, token string) string {
+	if token == "" {
+		return ""
+	}
+	if scheme == "" {
+		return token
+	}
+	schemeWithSpace := scheme + " "
+	if len(token) >= len(schemeWithSpace) && strings.EqualFold(token[:len(schemeWithSpace)], schemeWithSpace) {
+		return token
+	}
+	return schemeWithSpace + token
+}
+{{- end}}
 
 {{- if .HasAuthCommand}}
 

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -289,7 +289,6 @@ func TestAuthHeaderComposedAndCookieApplySchemePrefix(t *testing.T) {
 			apiSpec.Auth = spec.AuthConfig{
 				Type:    tt.authType,
 				Header:  "Authorization",
-				Format:  "Bearer {token}",
 				EnvVars: []string{tt.envVar},
 			}
 
@@ -300,21 +299,21 @@ func TestAuthHeaderComposedAndCookieApplySchemePrefix(t *testing.T) {
 			require.NoError(t, err)
 			content := string(configSrc)
 
-			// Env-var branch must apply the Bearer prefix, not return the raw token.
-			envCheck := `if c.` + tt.envField + ` != ""`
-			envIdx := strings.Index(content, envCheck)
-			require.NotEqual(t, -1, envIdx, "AuthHeader should contain env-var branch:\n%s", content)
-			afterEnv := content[envIdx:]
-			rawReturn := `return c.` + tt.envField
-			require.NotContains(t, afterEnv[:findReturnEnd(afterEnv)], rawReturn,
+			// The raw-return literal must appear nowhere in the emitted config — every
+			// composed/cookie return path now flows through ensureAuthScheme. Whole-file
+			// NotContains avoids depending on a fragile slice boundary.
+			require.NotContains(t, content, "return c."+tt.envField+"\n",
 				"%s auth must not return raw env-var token without scheme prefix:\n%s", tt.authType, content)
-
-			// AccessToken branch must apply the Bearer prefix, not return the raw access token.
-			atIdx := strings.Index(content, `if c.AccessToken != ""`)
-			require.NotEqual(t, -1, atIdx, "AuthHeader should contain AccessToken branch:\n%s", content)
-			afterAT := content[atIdx:]
-			require.NotContains(t, afterAT[:findReturnEnd(afterAT)], "return c.AccessToken\n",
+			require.NotContains(t, content, "return c.AccessToken\n",
 				"%s auth must not return raw AccessToken without scheme prefix:\n%s", tt.authType, content)
+
+			// The replacement ensureAuthScheme call must be the wrapper for both paths.
+			require.Contains(t, content,
+				`return ensureAuthScheme("Bearer", c.`+tt.envField+")",
+				"%s auth env-var path should wrap return in ensureAuthScheme:\n%s", tt.authType, content)
+			require.Contains(t, content,
+				`return ensureAuthScheme("Bearer", c.AccessToken)`,
+				"%s auth AccessToken path should wrap return in ensureAuthScheme:\n%s", tt.authType, content)
 
 			// Confirm AuthSource label preserved (no behavior regression on which branch we took).
 			require.Contains(t, content, `c.AuthSource = "`+tt.authSource+`"`)
@@ -323,20 +322,6 @@ func TestAuthHeaderComposedAndCookieApplySchemePrefix(t *testing.T) {
 			runGoCommand(t, outputDir, "test", "./internal/config")
 		})
 	}
-}
-
-// findReturnEnd returns the index just past the first "return" line in s,
-// scoped to the first branch the caller is inspecting.
-func findReturnEnd(s string) int {
-	i := strings.Index(s, "return ")
-	if i == -1 {
-		return len(s)
-	}
-	end := strings.Index(s[i:], "\n")
-	if end == -1 {
-		return len(s)
-	}
-	return i + end + 1
 }
 
 // TestAuthHeaderSchemeHelperHandlesPreprefixedTokens compiles a composed-auth

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -339,38 +339,54 @@ func findReturnEnd(s string) int {
 	return i + end + 1
 }
 
-// TestAuthHeaderComposedSchemeHelperHandlesPreprefixedTokens compiles a
-// composed-auth CLI and exercises the emitted ensureAuthScheme helper through
-// AuthHeader() to confirm the positive (Bearer prefix applied) and negative
-// (no double prefix when the user pre-prefixes the env var) cases.
-func TestAuthHeaderComposedSchemeHelperHandlesPreprefixedTokens(t *testing.T) {
+// TestAuthHeaderSchemeHelperHandlesPreprefixedTokens compiles a composed-auth
+// and a cookie-auth CLI and exercises the emitted ensureAuthScheme helper
+// through AuthHeader() to confirm the positive (Bearer prefix applied) and
+// negative (no double prefix when the user pre-prefixes the env var) cases
+// for both auth types. The Bearer prefix here comes from HeaderPrefix()'s
+// default (the composed and cookie branches do not consult Auth.Format), so
+// the test specs intentionally omit Format.
+func TestAuthHeaderSchemeHelperHandlesPreprefixedTokens(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("composed-auth-runtime")
-	apiSpec.Auth = spec.AuthConfig{
-		Type:    "composed",
-		Header:  "Authorization",
-		Format:  "Bearer {token}",
-		EnvVars: []string{"FOO_TOKEN"},
+	tests := []struct {
+		name     string
+		authType string
+		envVar   string
+		envField string
+	}{
+		{name: "composed", authType: "composed", envVar: "FOO_TOKEN", envField: "FooToken"},
+		{name: "cookie", authType: "cookie", envVar: "BAR_TOKEN", envField: "BarToken"},
 	}
 
-	outputDir := filepath.Join(t.TempDir(), "composed-auth-runtime-pp-cli")
-	require.NoError(t, New(apiSpec, outputDir).Generate())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	testFile := filepath.Join(outputDir, "internal", "config", "auth_scheme_runtime_test.go")
-	require.NoError(t, os.WriteFile(testFile, []byte(`package config
+			apiSpec := minimalSpec(tt.name + "-auth-runtime")
+			apiSpec.Auth = spec.AuthConfig{
+				Type:    tt.authType,
+				Header:  "Authorization",
+				EnvVars: []string{tt.envVar},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), tt.name+"-auth-runtime-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			testFile := filepath.Join(outputDir, "internal", "config", "auth_scheme_runtime_test.go")
+			testSrc := `package config
 
 import "testing"
 
 func TestEnsureAuthSchemeAppliesBearerPrefix(t *testing.T) {
-	c := &Config{FooToken: "eyJxxx"}
+	c := &Config{` + tt.envField + `: "eyJxxx"}
 	if got := c.AuthHeader(); got != "Bearer eyJxxx" {
 		t.Fatalf("expected Bearer-prefixed header, got %q", got)
 	}
 }
 
 func TestEnsureAuthSchemeDoesNotDoublePrefix(t *testing.T) {
-	c := &Config{FooToken: "Bearer eyJxxx"}
+	c := &Config{` + tt.envField + `: "Bearer eyJxxx"}
 	if got := c.AuthHeader(); got != "Bearer eyJxxx" {
 		t.Fatalf("expected single Bearer prefix, got %q", got)
 	}
@@ -382,7 +398,9 @@ func TestEnsureAuthSchemeBlankReturnsEmpty(t *testing.T) {
 		t.Fatalf("expected empty header for blank config, got %q", got)
 	}
 }
-`), 0o644))
-
-	runGoCommand(t, outputDir, "test", "./internal/config")
+`
+			require.NoError(t, os.WriteFile(testFile, []byte(testSrc), 0o644))
+			runGoCommand(t, outputDir, "test", "./internal/config")
+		})
+	}
 }

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -249,3 +249,140 @@ func TestAuthHeaderTokenEnvVarsDoNotEmitDuplicateMapKeys(t *testing.T) {
 		})
 	}
 }
+
+// TestAuthHeaderComposedAndCookieApplySchemePrefix pins the fix for #1419:
+// composed and cookie auth types must apply the spec's HeaderPrefix (defaulting
+// to "Bearer ") when emitting AuthHeader(), so env-var and chrome-composed
+// token paths don't return raw tokens that the upstream API will reject as
+// "Authorization: <raw>" instead of "Authorization: Bearer <raw>".
+func TestAuthHeaderComposedAndCookieApplySchemePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		authType   string
+		envVar     string
+		envField   string
+		authSource string
+	}{
+		{
+			name:       "composed-single-env-var",
+			authType:   "composed",
+			envVar:     "SUNO_TOKEN",
+			envField:   "SunoToken",
+			authSource: "chrome-composed",
+		},
+		{
+			name:       "cookie-single-env-var",
+			authType:   "cookie",
+			envVar:     "NOTION_TOKEN",
+			envField:   "NotionToken",
+			authSource: "browser",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec(tt.name)
+			apiSpec.Auth = spec.AuthConfig{
+				Type:    tt.authType,
+				Header:  "Authorization",
+				Format:  "Bearer {token}",
+				EnvVars: []string{tt.envVar},
+			}
+
+			outputDir := filepath.Join(t.TempDir(), tt.name+"-pp-cli")
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+			require.NoError(t, err)
+			content := string(configSrc)
+
+			// Env-var branch must apply the Bearer prefix, not return the raw token.
+			envCheck := `if c.` + tt.envField + ` != ""`
+			envIdx := strings.Index(content, envCheck)
+			require.NotEqual(t, -1, envIdx, "AuthHeader should contain env-var branch:\n%s", content)
+			afterEnv := content[envIdx:]
+			rawReturn := `return c.` + tt.envField
+			require.NotContains(t, afterEnv[:findReturnEnd(afterEnv)], rawReturn,
+				"%s auth must not return raw env-var token without scheme prefix:\n%s", tt.authType, content)
+
+			// AccessToken branch must apply the Bearer prefix, not return the raw access token.
+			atIdx := strings.Index(content, `if c.AccessToken != ""`)
+			require.NotEqual(t, -1, atIdx, "AuthHeader should contain AccessToken branch:\n%s", content)
+			afterAT := content[atIdx:]
+			require.NotContains(t, afterAT[:findReturnEnd(afterAT)], "return c.AccessToken\n",
+				"%s auth must not return raw AccessToken without scheme prefix:\n%s", tt.authType, content)
+
+			// Confirm AuthSource label preserved (no behavior regression on which branch we took).
+			require.Contains(t, content, `c.AuthSource = "`+tt.authSource+`"`)
+
+			// Generated config must compile and pass its own tests.
+			runGoCommand(t, outputDir, "test", "./internal/config")
+		})
+	}
+}
+
+// findReturnEnd returns the index just past the first "return" line in s,
+// scoped to the first branch the caller is inspecting.
+func findReturnEnd(s string) int {
+	i := strings.Index(s, "return ")
+	if i == -1 {
+		return len(s)
+	}
+	end := strings.Index(s[i:], "\n")
+	if end == -1 {
+		return len(s)
+	}
+	return i + end + 1
+}
+
+// TestAuthHeaderComposedSchemeHelperHandlesPreprefixedTokens compiles a
+// composed-auth CLI and exercises the emitted ensureAuthScheme helper through
+// AuthHeader() to confirm the positive (Bearer prefix applied) and negative
+// (no double prefix when the user pre-prefixes the env var) cases.
+func TestAuthHeaderComposedSchemeHelperHandlesPreprefixedTokens(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("composed-auth-runtime")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "composed",
+		Header:  "Authorization",
+		Format:  "Bearer {token}",
+		EnvVars: []string{"FOO_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "composed-auth-runtime-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testFile := filepath.Join(outputDir, "internal", "config", "auth_scheme_runtime_test.go")
+	require.NoError(t, os.WriteFile(testFile, []byte(`package config
+
+import "testing"
+
+func TestEnsureAuthSchemeAppliesBearerPrefix(t *testing.T) {
+	c := &Config{FooToken: "eyJxxx"}
+	if got := c.AuthHeader(); got != "Bearer eyJxxx" {
+		t.Fatalf("expected Bearer-prefixed header, got %q", got)
+	}
+}
+
+func TestEnsureAuthSchemeDoesNotDoublePrefix(t *testing.T) {
+	c := &Config{FooToken: "Bearer eyJxxx"}
+	if got := c.AuthHeader(); got != "Bearer eyJxxx" {
+		t.Fatalf("expected single Bearer prefix, got %q", got)
+	}
+}
+
+func TestEnsureAuthSchemeBlankReturnsEmpty(t *testing.T) {
+	c := &Config{}
+	if got := c.AuthHeader(); got != "" {
+		t.Fatalf("expected empty header for blank config, got %q", got)
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/config")
+}


### PR DESCRIPTION
## Intent

The generator's `composed` and `cookie` auth branches in `AuthHeader()` returned the raw env-var token (or chrome-imported `AccessToken`) without applying the spec's `HeaderPrefix`. Any CLI relying on the documented env-var fallback hit 401 on every call: `Authorization: <raw>` instead of `Authorization: Bearer <raw>`. The `auth login --chrome` path masked the bug because the token exchange already carried the prefix.

Issue: Closes #1419

## Approach

Wrapped the env-var and `AccessToken` returns in the `composed` and `cookie` branches of `config.go.tmpl`'s `AuthHeader()` with a new generator-emitted `ensureAuthScheme(scheme, token)` helper. The helper applies `Auth.HeaderPrefix` (default `"Bearer"`) and skips prefixing when the token already starts with the scheme case-insensitively, so users who pre-prefixed their env var to work around the original bug don't end up with `Bearer Bearer <token>`.

Stuck to the pragmatic option from the issue (apply scheme directly) over the faithful option (plumb `auth.format` placeholders through the parser) — the dominant composed/cookie shape across catalog and sniffed CLIs is Bearer, and `Auth.HeaderPrefix` already exposes the per-spec override.

## Scope

Primary area: generator template `internal/generator/templates/config.go.tmpl`

Why this belongs in this repo: machine-level fix. Every CLI generated from a `composed` or `cookie` auth spec carries the bug; the fix raises the floor on all future prints and on regenerations of existing ones. `bearer_token`, `api_key`, and `oauth2` branches are untouched.

## Risk

- Generated `AuthHeader()` for `composed`/`cookie` auth now emits a helper call and a per-CLI helper function. The helper is gated to those two auth types only, so other CLIs see no diff.
- The runtime helper is case-insensitive on the scheme prefix to match what real-world users typed (`"Bearer "` vs `"bearer "`); no other policy change.
- No behavioral change to `bearer_token`/`api_key`/`oauth2` paths — verified via existing AuthHeader tests.

## Output Contract

Generator emits a new `ensureAuthScheme` helper in the generated `internal/config/config.go` for CLIs with `auth.type: composed` or `auth.type: cookie`. The `AuthHeader()` body wraps env-var and `AccessToken` returns with `ensureAuthScheme("<prefix>", c.Field)`. Golden harness covers `composed`-shaped specs via `generate-golden-api-rich-auth` and `generate-tier-routing-api`; both pass unchanged.

## Verification

- `go fmt ./...`
- `go vet ./...`
- `go test ./...` — 4328 passed across 35 packages
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 20 cases pass
- New tests: `TestAuthHeaderComposedAndCookieApplySchemePrefix` (template emission check for both auth types), `TestAuthHeaderComposedSchemeHelperHandlesPreprefixedTokens` (runtime exercise of the helper through a compiled CLI — positive, negative double-prefix, empty token).

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change