### PR TITLE
fix(skills): drop cli-skills mirror regen from publish flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,9 +199,9 @@ Generated artifacts live under `~/printing-press/`, not in this repo: `library/<
 
 ## Publishing to the Public Library
 The only supported path for **publishing a generated CLI** (adding or updating an entry under `library/<category>/<api-slug>/` in [mvanhorn/printing-press-library](https://github.com/mvanhorn/printing-press-library)) is to invoke the `/printing-press-publish` skill. The skill runs the required `gh`/`git` commands itself; do not reproduce them by hand.
-- Invoke `/printing-press-publish` and let it drive the fork, branch, manifest checks, `cli-skills/pp-<api-slug>/SKILL.md` regen, push, and PR creation. Following its prompts is the supported flow.
+- Invoke `/printing-press-publish` and let it drive the fork, branch, manifest checks, push, and PR creation. Following its prompts is the supported flow.
 - Do not skip the skill and improvise the same steps from scratch (manual `gh repo fork` / `cp -r` into a library clone / `gh pr create --repo mvanhorn/printing-press-library …` / branch push to a fork without the skill driving it). The commands look similar; the difference is the preflight checks and conventions the skill enforces before they run.
-- Do not edit `registry.json` or README catalog cells in a publish PR — the public library refreshes those post-merge from `.printing-press.json` / `manifest.json`.
+- Do not edit `registry.json`, README catalog cells, or `cli-skills/pp-<api-slug>/SKILL.md` in a publish PR — the public library refreshes those post-merge (registry and READMEs from `.printing-press.json` / `manifest.json`; the cli-skills mirror via the library's `generate-skills.yml` workflow). The library's `Guard against hand-edits to cli-skills mirror` check rejects any fork PR whose commits touch the mirror, so committing it pre-rejects the publish before review.
 
 Why this matters: the publish skill enforces preflight checks (printer sentinel validation, manifest shape, vendor-spec PII scope, govulncheck scoped to the changed module) and mirrors the public library's own `AGENTS.md` requirements. An agent operating in this repo's CWD never loads the public library's `AGENTS.md`, so those rules are invisible unless the skill is the entry point.
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -151,22 +151,21 @@ func TestPublishSkillTracksCanonicalUpstreamAndOverwriteFlow(t *testing.T) {
 	assert.Contains(t, skill, "git push --force-with-lease")
 }
 
-func TestPublishSkillUsesLibraryTreeForCliSkillsMirror(t *testing.T) {
+func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 
-	assert.Contains(t, skill, "Do not\nedit `registry.json`")
-	assert.Contains(t, skill, "fix the\nlibrary mirror generator to discover from `library/`")
-	assert.Contains(t, skill, "# Regenerate the flat cli-skills mirror from the library tree")
-	assert.Contains(t, skill, "git add library/ cli-skills/")
+	assert.Contains(t, skill, "Do not\nedit `registry.json`, README catalog cells, or `cli-skills/pp-<api-slug>/SKILL.md`")
+	assert.Contains(t, skill, "Guard against hand-edits to cli-skills mirror")
+	assert.Contains(t, skill, "Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` here")
+	assert.Contains(t, skill, "git add library/\ngit commit")
+	assert.NotContains(t, skill, "git add library/ cli-skills/")
 	assert.NotContains(t, skill, "git add library/ cli-skills/ registry.json")
 	assert.NotContains(t, skill, "REGISTRY_HAS_ENTRY")
 	assert.NotContains(t, skill, "seed one registry")
+	assert.NotContains(t, skill, "go run ./tools/generate-skills/main.go")
 
 	copyIntoLibrary := strings.Index(skill, `cp -r "$STAGING_DIR/library/<category>/<api-slug>"`)
-	mirrorRun := strings.Index(skill, "go run ./tools/generate-skills/main.go")
 	require.NotEqual(t, -1, copyIntoLibrary)
-	require.NotEqual(t, -1, mirrorRun)
-	assert.Less(t, copyIntoLibrary, mirrorRun)
 }
 
 func TestPolishSkillHardGatesPublishValidate(t *testing.T) {

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -25,13 +25,11 @@ Publish a generated CLI from your local library to the [printing-press-library](
 
 The public library treats `library/<category>/<api-slug>/.printing-press.json`
 and `manifest.json` as the source of truth for registry-display fields. Do not
-edit `registry.json` or README catalog cells in publish PRs; the library's
-post-merge workflow refreshes them from the CLI tree. Do regenerate and commit
-the `cli-skills/pp-<api-slug>/SKILL.md` mirror from
-`library/<category>/<api-slug>/SKILL.md` because PR CI verifies mirror parity.
-If a brand-new CLI's mirror is pruned because `registry.json` is behind, fix the
-library mirror generator to discover from `library/`; do not add a registry
-entry solely to satisfy mirror parity.
+edit `registry.json`, README catalog cells, or `cli-skills/pp-<api-slug>/SKILL.md`
+in publish PRs; all three are bot-regenerated post-merge by the library's own
+workflows. The library's `Guard against hand-edits to cli-skills mirror` check
+rejects any fork PR whose commits touch the mirror, so a publish that includes
+the mirror is pre-rejected before review.
 
 ## Setup
 
@@ -460,10 +458,16 @@ if [ -z "$PRINTER_NAME" ]; then
   exit 1
 fi
 
-# Regenerate the flat cli-skills mirror from the library tree so library PR CI passes mirror parity.
-if [ -f "$PUBLISH_REPO_DIR/tools/generate-skills/main.go" ]; then
-  (cd "$PUBLISH_REPO_DIR" && go run ./tools/generate-skills/main.go)
-fi
+# Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` here. The
+# mirror is auto-regenerated post-merge by the library's `generate-skills.yml`
+# workflow via a `[skip ci]` bot commit. Including the mirror in a fork PR is
+# pre-rejected by the library's `Guard against hand-edits to cli-skills mirror`
+# check, which fails on any non-bot commit touching the mirror. Same-repo PRs
+# are auto-handled by the library's `Commit generated convention fixes` step,
+# which is gated on `head.repo.full_name == github.repository`. Do not
+# re-introduce a mirror-regenerator invocation here without first resolving
+# the Guard check on the library side (tracked at
+# https://github.com/mvanhorn/printing-press-library/issues/590).
 
 # Verify this changed/new CLI builds and has no reachable Go vulnerabilities from the publish repo
 cd "$PUBLISH_REPO_DIR/library/<category>/<api-slug>" \
@@ -732,7 +736,7 @@ git checkout -B feat/<api-slug>
 
 ```bash
 cd "$PUBLISH_REPO_DIR"
-git add library/ cli-skills/
+git add library/
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 
@@ -785,7 +789,7 @@ Build the PR description from:
 
 Read `novel_features` from
 `$PUBLISH_REPO_DIR/library/<category>/<api-slug>/.printing-press.json` after
-packaging and mirror regeneration. Preserve the manifest order. Do not derive
+packaging. Preserve the manifest order. Do not derive
 this section from README prose, SKILL prose, root help, or memory of the run:
 those surfaces may be summarized or hand-edited, while the packaged manifest is
 the publish-time source of truth. For each entry, include the command, name, and

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -465,9 +465,8 @@ fi
 # check, which fails on any non-bot commit touching the mirror. Same-repo PRs
 # are auto-handled by the library's `Commit generated convention fixes` step,
 # which is gated on `head.repo.full_name == github.repository`. Do not
-# re-introduce a mirror-regenerator invocation here without first resolving
-# the Guard check on the library side (tracked at
-# https://github.com/mvanhorn/printing-press-library/issues/590).
+# re-introduce a mirror-regenerator invocation here unless the library's
+# Guard check has been loosened to accept publish-flow commits.
 
 # Verify this changed/new CLI builds and has no reachable Go vulnerabilities from the publish repo
 cd "$PUBLISH_REPO_DIR/library/<category>/<api-slug>" \


### PR DESCRIPTION
## Intent

Issue: Closes #1474

Publish flow regenerates the `cli-skills/pp-<api-slug>/SKILL.md` mirror in Step 6 and commits it. The library's `Guard against hand-edits to cli-skills mirror` workflow rejects any fork PR whose commits touch the mirror, so the publish skill produces guaranteed-rejected fork PRs. The library's auto-fix that would normally rewrite the mirror via the bot is gated on `head.repo.full_name == github.repository`, so fork PRs have no path that satisfies both Guard and the drift check.

## Approach

- Remove the `go run ./tools/generate-skills/main.go` call from Step 6 of `skills/printing-press-publish/SKILL.md`.
- Drop `cli-skills/` from the staging `git add` so a stray edit can't sneak in.
- Flip the preamble to forbid touching the mirror in publish PRs (parallel to the existing `registry.json` rule).
- Replace the regen lines with a guard comment naming the upstream Guard check and pointing at [printing-press-library#590](https://github.com/mvanhorn/printing-press-library/issues/590) so the regen isn't reintroduced without first addressing the library side.
- Update the contract test (`TestPublishSkillUsesLibraryTreeForCliSkillsMirror` -> `TestPublishSkillSkipsCliSkillsMirrorRegen`) to assert the new shape.

## Scope

Primary area: `skills/printing-press-publish`

Why this belongs in this repo: The publish skill is shipped from this repo. The contract it produces (a fork PR shape that the library will accept) is a generator-side concern.

Out of scope: the secondary pre-push commit-shape sanity-check additions proposed in [issue #1474 comment](https://github.com/mvanhorn/cli-printing-press/issues/1474#issuecomment-4462116054). Kept separate so this PR stays narrow and easy to revert if the library-side fix in printing-press-library#590 lands and the mirror commit becomes required again.

## Risk

Fork-only contributors: their next publish PR will have an empty `cli-skills/` diff. They may still trip the library's `Fail on cli-skills drift from fork` check until [printing-press-library#590](https://github.com/mvanhorn/printing-press-library/issues/590) lands -- but that is strictly better than the current "PR pre-rejected by Guard" state and surfaces as a clean library-side fix.

Push-access publishers (same-repo PRs): no behavior change. The library's `Commit generated convention fixes` step already auto-handles the mirror for `head.repo.full_name == github.repository` PRs.

## Output Contract

N/A. Skill text only; no generator template, manifest, or artifact shape changes.

## Verification

- `go test ./...` -- 4352 passed
- `go vet ./...` -- clean
- `golangci-lint run ./...` -- clean
- `grep "tools/generate-skills" skills/printing-press-publish/SKILL.md` -- 0 matches (matches issue acceptance criterion)
- Contract test `TestPublishSkillSkipsCliSkillsMirrorRegen` enforces the new shape (no regen call, no `cli-skills/` in `git add`, guard comment present, preamble flipped).