### PR TITLE
fix(cli): route promoted-command file stem through safeResourceFileStem

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2602,7 +2602,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			IsReadOnly:      endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
 			APISpec:         g.Spec,
 		}
-		promotedPath := filepath.Join("internal", "cli", "promoted_"+pc.PromotedName+".go")
+		promotedPath := filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+pc.PromotedName)+".go")
 		if err := g.renderTemplate("command_promoted.go.tmpl", promotedPath, promotedData); err != nil {
 			return fmt.Errorf("rendering promoted command %s: %w", pc.PromotedName, err)
 		}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5509,6 +5509,41 @@ func TestGeneratedOutput_PromotedCommandCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// A resource named `test` produces `promoted_test.go`; Go treats *_test.go as a
+// test file and excludes it from the normal package build, so root.go's
+// reference to newTestPromotedCmd fails to compile. Mirrors the safe-stem fix
+// that #1021 applied to `<resource>_<verb>.go`.
+func TestGeneratedOutput_PromotedCommand_TestResourceCompiles(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "promotedtest",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "api_key", Header: "X-Api-Key", EnvVars: []string{"PT_API_KEY"}},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/promotedtest-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"test": {
+				Description: "Single-endpoint resource whose name collides with Go's *_test.go convention",
+				Endpoints: map[string]spec.Endpoint{
+					"generate": {Method: "POST", Path: "/test/generate", Description: "Generate a test"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promotedtest-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	assert.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_test.go"),
+		"promoted_test.go is excluded from go build; safeResourceFileStem must rewrite to promoted_test_cmd.go")
+	assert.FileExists(t, filepath.Join(outputDir, "internal", "cli", "promoted_test_cmd.go"))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 func TestGeneratedOutput_ResourceParentsHiddenWhenAPIBrowserGenerated(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #1489.

## What

#1021 fixed `safeResourceFileStem` to rename trailing GOOS/GOARCH/`test` tokens to `_cmd`, but only for the `<resource>_<verb>.go` emit path. The promoted-command emitter at [`internal/generator/generator.go:2605`](https://github.com/mvanhorn/cli-printing-press/blob/main/internal/generator/generator.go#L2605) built its path as `"promoted_" + pc.PromotedName + ".go"` without the safe-stem wrapper, so an OpenAPI resource named `test` produces `internal/cli/promoted_test.go`. Go treats `*_test.go` as a test file and excludes it from the normal package build, leaving `root.go`'s `newTestPromotedCmd` reference undefined.

Wrap the stem in `safeResourceFileStem`. The function's existing `_test`/GOOS/GOARCH trailing-token rules now cover both emit paths.

## Repro (from the issue)

OpenAPI spec exposes `POST /test/generate` -> resource `test` -> file `internal/cli/promoted_test.go`:

```
FAIL govulncheck ./...
.../internal/cli/root.go:241:21: undefined: newTestPromotedCmd
```

After fix: emits `internal/cli/promoted_test_cmd.go`; package builds.

## Fix

```diff
- promotedPath := filepath.Join("internal", "cli", "promoted_"+pc.PromotedName+".go")
+ promotedPath := filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+pc.PromotedName)+".go")
```

The function already handles `promoted_test` -> `promoted_test_cmd` (covered by the existing `webhook_test` -> `webhook_test_cmd` case in `safe_filename_test.go`); the bug was a missed call site.

## Tests

- New: `TestGeneratedOutput_PromotedCommand_TestResourceCompiles` builds an APISpec with a single-endpoint resource named `test`, asserts emission as `promoted_test_cmd.go` (not `promoted_test.go`), and runs `go build ./...` to catch the silent-exclusion regression.
- Pre-existing `TestSafeResourceFileStem` already covers the function-level behavior.

## Test plan

- [x] `go test ./internal/generator/ -run TestGeneratedOutput_PromotedCommand_TestResourceCompiles -v` passes
- [x] `go test ./internal/generator/...` clean (923/923)
- [x] `go vet ./...` / `go fmt ./...` clean
- [x] `golangci-lint run ./...` no issues
- [x] `scripts/golden.sh verify` passes (20/20)