### PR TITLE
feat(cli): add auth_env_vars catalog field for canonical SDK env vars

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -15,6 +15,11 @@ import (
 
 var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
+// authEnvVarPattern matches the same shape the OpenAPI parser accepts for
+// x-auth-env-vars entries: uppercase letters, digits, and underscores, with a
+// non-digit leading character.
+var authEnvVarPattern = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+
 // Public categories first, alphabetized. "other" and "example" are explicitly
 // special (catch-all / test-only) and kept at the end.
 var validCategories = map[string]struct{}{
@@ -142,6 +147,19 @@ type Entry struct {
 	// rather than a deep link to the keys UI. Overrides any spec-supplied
 	// x-auth-instructions value.
 	AuthInstructions string `yaml:"auth_instructions,omitempty"`
+	// AuthEnvVars lists the canonical environment variable names the printed
+	// CLI should read credentials from, in priority order. First entry wins
+	// when multiple are set. Catalog-mode workflows feed the spec straight
+	// into generate without the SKILL's pre-generation enrichment step, so
+	// this field is the structured replacement for that manual edit: declare
+	// each API's well-known SDK env var here (STRIPE_SECRET_KEY,
+	// GITHUB_TOKEN, DISCORD_BOT_TOKEN, ...) so the printed config.go reads
+	// them instead of the mechanical <API>_BEARER_AUTH default. Overrides any
+	// names supplied by the spec's x-auth-env-vars extension or parser
+	// inference. Names must be uppercase, may contain digits and underscores,
+	// and cannot start with a digit -- matching the spec parser's
+	// isUpperEnvVarName rule for x-auth-env-vars.
+	AuthEnvVars []string `yaml:"auth_env_vars,omitempty"`
 	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
 	// Values: rest, proxy-envelope, graphql.
 	ClientPattern string `yaml:"client_pattern,omitempty"`
@@ -320,6 +338,11 @@ func (e *Entry) Validate() error {
 	}
 	if e.AuthKeyURL != "" && !strings.HasPrefix(e.AuthKeyURL, "https://") {
 		return fmt.Errorf(`auth_key_url must start with "https://"`)
+	}
+	for i, envVar := range e.AuthEnvVars {
+		if !authEnvVarPattern.MatchString(envVar) {
+			return fmt.Errorf("auth_env_vars[%d] %q must be uppercase letters, digits, and underscores (non-digit first character)", i, envVar)
+		}
 	}
 
 	return nil

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -183,6 +183,20 @@ func TestValidateEntry(t *testing.T) {
 			},
 			wantErr: `auth_key_url must start with "https://"`,
 		},
+		{
+			name: "auth_env_vars lowercase rejected",
+			mutate: func(e *Entry) {
+				e.AuthEnvVars = []string{"stripe_secret_key"}
+			},
+			wantErr: "auth_env_vars[0]",
+		},
+		{
+			name: "auth_env_vars leading digit rejected",
+			mutate: func(e *Entry) {
+				e.AuthEnvVars = []string{"VALID_TOKEN", "1BAD"}
+			},
+			wantErr: "auth_env_vars[1]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -320,6 +334,24 @@ func TestOptionalFieldsOmittedValid(t *testing.T) {
 	assert.Empty(t, entry.ClientPattern)
 	assert.Empty(t, entry.HTTPTransport)
 	assert.Empty(t, entry.BearerRefresh.BundleURL)
+}
+
+func TestAuthEnvVarsParse(t *testing.T) {
+	data := []byte(`
+name: stripe
+display_name: Stripe
+description: Payments and subscriptions
+category: payments
+spec_url: https://example.com/stripe.json
+spec_format: json
+tier: official
+auth_env_vars:
+  - STRIPE_SECRET_KEY
+  - STRIPE_API_KEY
+`)
+	entry, err := ParseEntry(data)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"STRIPE_SECRET_KEY", "STRIPE_API_KEY"}, entry.AuthEnvVars)
 }
 
 func TestBearerRefreshValid(t *testing.T) {

--- a/internal/catalogmeta/catalogmeta.go
+++ b/internal/catalogmeta/catalogmeta.go
@@ -56,6 +56,9 @@ func ApplyRuntimeMetadata(apiSpec *spec.APISpec, entry *catalog.Entry) {
 	if entry.AuthInstructions != "" {
 		apiSpec.Auth.Instructions = entry.AuthInstructions
 	}
+	if len(entry.AuthEnvVars) > 0 {
+		apiSpec.Auth.OverrideEnvVars(entry.AuthEnvVars)
+	}
 	if entry.ClientPattern != "" {
 		apiSpec.ClientPattern = entry.ClientPattern
 	}

--- a/internal/catalogmeta/catalogmeta_test.go
+++ b/internal/catalogmeta/catalogmeta_test.go
@@ -1,0 +1,51 @@
+package catalogmeta
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRuntimeMetadataAuthEnvVarsOverridesSpec(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Auth: spec.AuthConfig{
+			Type:    "bearer_token",
+			Header:  "Authorization",
+			EnvVars: []string{"STRIPE_BEARER_AUTH"},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "STRIPE_BEARER_AUTH", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+			},
+		},
+	}
+	entry := &catalog.Entry{
+		Name:        "stripe",
+		AuthEnvVars: []string{"STRIPE_SECRET_KEY", "STRIPE_API_KEY"},
+	}
+
+	ApplyRuntimeMetadata(apiSpec, entry)
+
+	assert.Equal(t, []string{"STRIPE_SECRET_KEY", "STRIPE_API_KEY"}, apiSpec.Auth.EnvVars)
+	assert.Empty(t, apiSpec.Auth.EnvVarSpecs, "EnvVarSpecs should be cleared so NormalizeEnvVarSpecs rebuilds from the new EnvVars")
+
+	apiSpec.Auth.NormalizeEnvVarSpecs("")
+	require.Len(t, apiSpec.Auth.EnvVarSpecs, 2)
+	assert.Equal(t, "STRIPE_SECRET_KEY", apiSpec.Auth.EnvVarSpecs[0].Name)
+	assert.Equal(t, "STRIPE_API_KEY", apiSpec.Auth.EnvVarSpecs[1].Name)
+	assert.True(t, apiSpec.Auth.EnvVarSpecs[0].Inferred)
+}
+
+func TestApplyRuntimeMetadataAuthEnvVarsEmptyLeavesSpecUntouched(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Auth: spec.AuthConfig{
+			EnvVars: []string{"FOO_BEARER_AUTH"},
+		},
+	}
+	entry := &catalog.Entry{Name: "foo"}
+
+	ApplyRuntimeMetadata(apiSpec, entry)
+
+	assert.Equal(t, []string{"FOO_BEARER_AUTH"}, apiSpec.Auth.EnvVars)
+}

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/catalogmeta"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -400,6 +402,59 @@ func TestTierRouting_BearerPrefix(t *testing.T) {
 		"per-tier bearer auth must honor configured prefix")
 	assert.NotContains(t, content, `value := "Bearer " + tierValue0`,
 		"default Bearer literal must not leak when tier prefix is overridden")
+}
+
+// TestAuthHeader_CatalogAuthEnvVarsReachConfig pins the end-to-end contract
+// for the catalog auth_env_vars field: ApplyRuntimeMetadata sets EnvVars on
+// the spec, the generator emits config.go with the catalog-supplied names in
+// priority order, and the slug-derived <API>_BEARER_AUTH default never lands
+// in the generated config. Without this, the unit tests for ApplyRuntimeMetadata
+// and OverrideEnvVars could pass while the generator quietly read the wrong
+// EnvVarSpecs source and the printed CLI still asked for the mechanical
+// default.
+func TestAuthHeader_CatalogAuthEnvVarsReachConfig(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("catalog-auth")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		EnvVars: []string{"CATALOG_AUTH_BEARER_AUTH"},
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "CATALOG_AUTH_BEARER_AUTH", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+		},
+	}
+	entry := &catalog.Entry{
+		Name:        "catalog-auth",
+		AuthEnvVars: []string{"CATALOG_AUTH_SECRET_KEY", "CATALOG_AUTH_API_KEY"},
+	}
+
+	catalogmeta.ApplyRuntimeMetadata(apiSpec, entry)
+
+	outputDir := filepath.Join(t.TempDir(), "catalog-auth-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	content := string(cfgSrc)
+
+	canonicalField := resolveEnvVarField("CATALOG_AUTH_SECRET_KEY")
+	aliasField := resolveEnvVarField("CATALOG_AUTH_API_KEY")
+	defaultField := resolveEnvVarField("CATALOG_AUTH_BEARER_AUTH")
+
+	canonicalIdx := strings.Index(content, `os.Getenv("CATALOG_AUTH_SECRET_KEY")`)
+	aliasIdx := strings.Index(content, `os.Getenv("CATALOG_AUTH_API_KEY")`)
+	require.NotEqual(t, -1, canonicalIdx, "config.go must read the canonical catalog env var")
+	require.NotEqual(t, -1, aliasIdx, "config.go must also read the alias catalog env var")
+	assert.Less(t, canonicalIdx, aliasIdx, "canonical env var must be read before the alias")
+
+	assert.NotContains(t, content, `os.Getenv("CATALOG_AUTH_BEARER_AUTH")`,
+		"slug-derived default must not survive the catalog override")
+	assert.NotContains(t, content, "c."+defaultField,
+		"Config struct field for the slug-derived default must not be emitted")
+
+	assert.Contains(t, content, "c."+canonicalField)
+	assert.Contains(t, content, "c."+aliasField)
 }
 
 // authHeaderBody slices out just the AuthHeader function body so precedence

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -875,10 +875,10 @@ func applyAuthOverrideExtensions(auth *spec.AuthConfig, extensions map[string]an
 		return
 	}
 	if envVars := stringListExtension(extensions, extensionAuthEnvVars); len(envVars) > 0 {
-		applyAuthEnvVars(auth, envVars)
+		auth.OverrideEnvVars(envVars)
 	} else if len(auth.EnvVars) == 1 {
 		if envVar := envVarExtension(extensions, extensionSpeakeasyExample); envVar != "" {
-			applyAuthEnvVars(auth, []string{envVar})
+			auth.OverrideEnvVars([]string{envVar})
 		}
 	}
 	if optional, ok := boolExtension(extensions, extensionAuthOptional); ok {
@@ -1089,25 +1089,6 @@ func requiredStringField(m map[string]any, name string) (string, bool) {
 		return "", false
 	}
 	return s, true
-}
-
-func applyAuthEnvVars(auth *spec.AuthConfig, envVars []string) {
-	oldEnvVars := append([]string(nil), auth.EnvVars...)
-	auth.EnvVars = envVars
-	remapAuthFormatForEnvOverride(auth, oldEnvVars, envVars)
-}
-
-func remapAuthFormatForEnvOverride(auth *spec.AuthConfig, oldEnvVars, newEnvVars []string) {
-	if auth.Format == "" || len(oldEnvVars) != 1 || len(newEnvVars) != 1 {
-		return
-	}
-	oldPlaceholder := naming.EnvVarPlaceholder(oldEnvVars[0])
-	newPlaceholder := naming.EnvVarPlaceholder(newEnvVars[0])
-	if oldPlaceholder == "" || newPlaceholder == "" {
-		return
-	}
-	auth.Format = strings.ReplaceAll(auth.Format, "{"+oldPlaceholder+"}", "{"+newPlaceholder+"}")
-	auth.Format = strings.ReplaceAll(auth.Format, "{"+oldEnvVars[0]+"}", "{"+newPlaceholder+"}")
 }
 
 func envVarExtension(extensions map[string]any, name string) string {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -773,7 +773,15 @@ func (c *AuthConfig) OverrideEnvVars(envVars []string) {
 }
 
 func remapAuthFormatForEnvOverride(auth *AuthConfig, oldEnvVars, newEnvVars []string) {
-	if auth.Format == "" || len(oldEnvVars) != 1 || len(newEnvVars) != 1 {
+	// Format strings interpolate exactly one env var by placeholder. The remap
+	// only makes sense when the old list named one placeholder; the new list
+	// may carry several priority-ordered names, in which case the first entry
+	// is the canonical placeholder for the format string. Without this, a
+	// 1->N override (catalog-mode shape: canonical + aliases) would leave
+	// auth.Format referencing a placeholder absent from the new env-var map,
+	// and applyAuthFormat would emit the literal {placeholder} into the
+	// Authorization header.
+	if auth.Format == "" || len(oldEnvVars) != 1 || len(newEnvVars) == 0 {
 		return
 	}
 	oldPlaceholder := naming.EnvVarPlaceholder(oldEnvVars[0])

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -756,6 +756,35 @@ func (c AuthConfig) HeaderPrefix() string {
 	return "Bearer"
 }
 
+// OverrideEnvVars replaces the env-var list from an authoritative outer source
+// (catalog metadata, x-auth-env-vars extension). It clones the input slice,
+// resets EnvVarSpecs so NormalizeEnvVarSpecs rebuilds them from the new names,
+// and remaps any single-token placeholder embedded in auth.Format. Safe to
+// call before EnvVarSpecs has been populated -- the reset is a no-op then.
+func (c *AuthConfig) OverrideEnvVars(envVars []string) {
+	if c == nil || len(envVars) == 0 {
+		return
+	}
+	oldEnvVars := append([]string(nil), c.EnvVars...)
+	next := append([]string(nil), envVars...)
+	c.EnvVars = next
+	c.EnvVarSpecs = nil
+	remapAuthFormatForEnvOverride(c, oldEnvVars, next)
+}
+
+func remapAuthFormatForEnvOverride(auth *AuthConfig, oldEnvVars, newEnvVars []string) {
+	if auth.Format == "" || len(oldEnvVars) != 1 || len(newEnvVars) != 1 {
+		return
+	}
+	oldPlaceholder := naming.EnvVarPlaceholder(oldEnvVars[0])
+	newPlaceholder := naming.EnvVarPlaceholder(newEnvVars[0])
+	if oldPlaceholder == "" || newPlaceholder == "" {
+		return
+	}
+	auth.Format = strings.ReplaceAll(auth.Format, "{"+oldPlaceholder+"}", "{"+newPlaceholder+"}")
+	auth.Format = strings.ReplaceAll(auth.Format, "{"+oldEnvVars[0]+"}", "{"+newPlaceholder+"}")
+}
+
 // CanonicalEnvVar returns the deterministic canonical entry for human-prose surfaces.
 func (c *AuthConfig) CanonicalEnvVar() *AuthEnvVar {
 	if c == nil {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4358,13 +4358,27 @@ func TestAuthConfigOverrideEnvVars(t *testing.T) {
 		assert.Equal(t, "Token {secret_key}", auth.Format)
 	})
 
-	t.Run("remap is no-op for multi-element overrides", func(t *testing.T) {
+	t.Run("1->N override remaps placeholder to the new canonical (first) entry", func(t *testing.T) {
+		// Catalog-mode shape: catalog declares a priority-ordered list of
+		// canonical + alias env vars. The format string can only reference
+		// one placeholder; the first new entry wins.
 		auth := &AuthConfig{
 			Format:  "Token {bearer_auth}",
 			EnvVars: []string{"FOO_BEARER_AUTH"},
 		}
 
 		auth.OverrideEnvVars([]string{"FOO_SECRET_KEY", "FOO_API_KEY"})
+
+		assert.Equal(t, "Token {secret_key}", auth.Format)
+	})
+
+	t.Run("N->1 override leaves Format untouched (no unambiguous source placeholder)", func(t *testing.T) {
+		auth := &AuthConfig{
+			Format:  "Token {bearer_auth}",
+			EnvVars: []string{"FOO_BEARER_AUTH", "FOO_API_KEY"},
+		}
+
+		auth.OverrideEnvVars([]string{"FOO_SECRET_KEY"})
 
 		assert.Equal(t, "Token {bearer_auth}", auth.Format)
 	})

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4328,3 +4328,53 @@ resources:
 		assert.Equal(t, "title", ep.Body[0].Name)
 	})
 }
+
+func TestAuthConfigOverrideEnvVars(t *testing.T) {
+	t.Run("replaces env vars and clears already-built specs", func(t *testing.T) {
+		auth := &AuthConfig{
+			EnvVars: []string{"FOO_BEARER_AUTH"},
+			EnvVarSpecs: []AuthEnvVar{
+				{Name: "FOO_BEARER_AUTH", Kind: AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+			},
+		}
+
+		auth.OverrideEnvVars([]string{"FOO_API_TOKEN", "FOO_LEGACY_TOKEN"})
+
+		assert.Equal(t, []string{"FOO_API_TOKEN", "FOO_LEGACY_TOKEN"}, auth.EnvVars)
+		assert.Empty(t, auth.EnvVarSpecs)
+	})
+
+	t.Run("remaps single placeholder in auth.Format", func(t *testing.T) {
+		// Format strings reference env vars by placeholder form
+		// (naming.EnvVarPlaceholder strips the leading prefix segment and
+		// lowercases the rest, so FOO_BEARER_AUTH becomes {bearer_auth}).
+		auth := &AuthConfig{
+			Format:  "Token {bearer_auth}",
+			EnvVars: []string{"FOO_BEARER_AUTH"},
+		}
+
+		auth.OverrideEnvVars([]string{"FOO_SECRET_KEY"})
+
+		assert.Equal(t, "Token {secret_key}", auth.Format)
+	})
+
+	t.Run("remap is no-op for multi-element overrides", func(t *testing.T) {
+		auth := &AuthConfig{
+			Format:  "Token {bearer_auth}",
+			EnvVars: []string{"FOO_BEARER_AUTH"},
+		}
+
+		auth.OverrideEnvVars([]string{"FOO_SECRET_KEY", "FOO_API_KEY"})
+
+		assert.Equal(t, "Token {bearer_auth}", auth.Format)
+	})
+
+	t.Run("nil receiver and empty list are no-ops", func(t *testing.T) {
+		var nilAuth *AuthConfig
+		nilAuth.OverrideEnvVars([]string{"FOO_TOKEN"})
+
+		auth := &AuthConfig{EnvVars: []string{"FOO_BEARER_AUTH"}}
+		auth.OverrideEnvVars(nil)
+		assert.Equal(t, []string{"FOO_BEARER_AUTH"}, auth.EnvVars)
+	})
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1712,6 +1712,14 @@ Skipping this step pushes the agent into hand-patching
 checks after a `doctor` FAIL against the operator's real environment.
 Enriching the spec avoids that round-trip.
 
+**Catalog-mode shortcut:** When the run is `printing-press generate <catalog-name>`
+and the catalog entry declares `auth_env_vars: [...]`, the catalog field
+takes precedence over both parser inference and spec extensions. No spec
+edit is needed -- catalog metadata is the right place to record the
+canonical env var per API once, and printers reuse it on every regen.
+Spec-level `x-auth-env-vars` enrichment is still the path for ad-hoc
+specs and for entries the catalog doesn't yet cover.
+
 For OpenAPI specs that need richer env-var metadata (kind classification,
 optional credentials, OR-group relationships), use `x-auth-vars` on the
 security scheme. See `docs/SPEC-EXTENSIONS.md` for the canonical schema.


### PR DESCRIPTION
## Intent

Catalog entries declared `AuthKeyURL` and `AuthInstructions` but had no structured field for the env-var names a printed CLI should read credentials from, so the generator fell back to `<API>_BEARER_AUTH` even when the API has a well-known canonical env var (`STRIPE_SECRET_KEY`, `GITHUB_TOKEN`, `DISCORD_BOT_TOKEN`, `SENTRY_AUTH_TOKEN`, `STYTCH_PROJECT_ID` + `STYTCH_SECRET`). The SKILL's Pre-Generation Auth Enrichment step covered this for spec-edit workflows via `x-auth-env-vars`, but catalog-mode workflows (`printing-press generate <catalog-name>`) feed the spec straight to generate and bypass that step entirely. The result was a per-print patch of `config.go` to make `STRIPE_SECRET_KEY` win.

Issue: Closes #1482

## Approach

Add an opt-in `auth_env_vars: [...]` field to `catalog/*.yaml` as the structured replacement for the manual spec edit. The new field is plumbed through `catalogmeta.ApplyRuntimeMetadata` into `spec.Auth` via a new `AuthConfig.OverrideEnvVars` method that:

- replaces the env-var list with the catalog-supplied names,
- clears `EnvVarSpecs` so the downstream `NormalizeEnvVarSpecs` rebuild picks up the new names (this is required because parser-inferred specs would otherwise win at the manifest layer),
- remaps `{placeholder}` tokens in `auth.Format` on single-element overrides.

The OpenAPI parser's `x-auth-env-vars` path now routes through the same method, collapsing two near-duplicate codepaths and giving catalog mode and spec-extension mode a single source of truth for env-var overrides.

A short addendum in `skills/printing-press/SKILL.md` under Pre-Generation Auth Enrichment notes that catalog-mode runs should reach for `auth_env_vars` on the catalog entry instead of editing `x-auth-env-vars` into the spec. Spec-level enrichment stays the path for ad-hoc specs and entries the catalog doesn't yet cover.

## Scope

Primary area: catalog schema (`internal/catalog`), runtime metadata overlay (`internal/catalogmeta`), the shared spec helper (`internal/spec`), and the Pre-Generation Auth Enrichment skill section.

Why this belongs in this repo: machine-level fix. Every catalog entry with auth currently ships with the mechanical `<API>_BEARER_AUTH` default; this raises the floor on all future prints from those entries and on regenerations. Existing catalog entries continue to behave as today until a curator opts in by adding `auth_env_vars`.

## Risk

- The catalog field is purely additive. Entries without `auth_env_vars` continue to produce the existing `<API>_BEARER_AUTH`-only behavior.
- `AuthConfig.OverrideEnvVars` is the same logic the OpenAPI parser was already running (`applyAuthEnvVars` + `remapAuthFormatForEnvOverride`) plus an `EnvVarSpecs = nil` reset. Clearing pre-build (parser path) is a no-op because `applyAuthEnvVarDefaults` rebuilds the specs immediately after. Post-build (catalog path), the reset is what makes `NormalizeEnvVarSpecs` re-derive specs from the new names instead of warning that they disagree.
- Validator rejects names that fail the parser's existing `isUpperEnvVarName` shape, so authoring mistakes surface at catalog load rather than at template emission.

## Output Contract

No generator template changes. A catalog entry that opts in to `auth_env_vars` produces:

- `internal/config/config.go` reads each declared env var in order, then falls back to `<API>_BEARER_AUTH` only when none are set (existing `EnvVars` -> config emission contract, unchanged).
- `.printing-press.json` `auth_env_vars` lists the declared names (existing manifest contract: `populateMCPMetadata` reads `spec.Auth.EnvVars`).
- SKILL.md auth section names the canonical env var instead of `<API>_BEARER_AUTH` (existing SKILL template reads `spec.Auth` fields).

Golden harness passes unchanged (no fixture currently exercises catalog -> generator end-to-end auth override).

## Verification

- `go fmt ./...`
- `go vet ./...`
- `go test ./...` — 4366 passed across 35 packages
- `golangci-lint run ./...` — clean
- `scripts/golden.sh verify` — 20 cases pass
- New tests:
  - `TestAuthEnvVarsParse` and validation cases for lowercase / leading-digit names in `internal/catalog/catalog_test.go`
  - `TestApplyRuntimeMetadataAuthEnvVarsOverridesSpec` and an empty-list no-op test in `internal/catalogmeta/catalogmeta_test.go`
  - `TestAuthConfigOverrideEnvVars` covering the EnvVarSpecs reset, single-placeholder format remap, multi-element no-op, and nil receiver in `internal/spec/spec_test.go`
- OpenAPI parser tests for `x-auth-env-vars` (`TestOpenAPIAuthVarsCanConsolidateLegacyMultipleEnvVars` and adjacent cases) still pass after the parser was repointed at the shared method.

## AI / Automation Disclosure

- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission