### PR TITLE
chore(cli): deprecate v1 module path and retract v1.0.0-v1.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,15 @@
+// Deprecated: the module path moved to github.com/mvanhorn/cli-printing-press/v4
+// after the v4 release. Install the current binary with:
+//   go install github.com/mvanhorn/cli-printing-press/v4/cmd/printing-press@latest
 module github.com/mvanhorn/cli-printing-press
 
 go 1.26.1
+
+// Retract every release on the legacy v1 module path. `go install ...@latest`
+// against the unversioned path silently resolves here and installs a year-old
+// binary - the deprecation notice above plus these retractions make Go warn
+// loudly and steer users to the /v4 path.
+retract [v1.0.0, v1.3.2]
 
 require (
 	github.com/getkin/kin-openapi v0.133.0


### PR DESCRIPTION
## What this does

Adds two things to the `go.mod` shipped on the legacy v1 module path:

1. A module-level `// Deprecated:` comment pointing at `github.com/mvanhorn/cli-printing-press/v4`.
2. A `retract [v1.0.0, v1.3.2]` directive covering every published v1.x tag.

Diff is 9 lines in `go.mod`, no code changes.

## Why

`go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest` (no `/v4` suffix) silently resolves to v1.3.2 - a year-old binary - because Go treats the v1 and v4 module paths as separate modules. Anyone who guesses the install path (or copies it from one of the stale `/v3` references in `launch-video/SCRIPT.md`, `docs/plans/*`, etc.) gets the wrong binary with no warning. Already happened once locally today.

The README at HEAD says `/v4`, but Go's tooling itself doesn't tell users they're on a dead path. With these directives, once `v1.3.3` is tagged:

- `go install .../cmd/printing-press@latest` against the unversioned path will resolve to v1.3.3 (the only non-retracted v1 release) and print the **deprecation notice** steering users to `/v4`. No retraction warning fires on `@latest` because v1.3.3 is not in the retracted range.
- `go install .../cmd/printing-press@v1.3.2` (or any explicit version in `[v1.0.0, v1.3.2]`) will print the **retraction warning**.
- `go list -m -u github.com/mvanhorn/cli-printing-press` shows the deprecation.
- Anyone pinned to v1.x explicitly still gets that exact version (retract is advisory; it warns but does not block).

## Deploy mechanism

This PR is a review surface, not the deploy. The actual fix lands when a `v1.3.3` tag is cut from this branch's tip. Don't merge into `main` - the v1 and v4 module paths are separate, and main is on v4 with a different `go.mod`. The base branch `v1-base` is just a stable pointer at the v1.3.2 commit so the diff is clean.

## Test plan

- [ ] Inspect `go.mod` diff
- [ ] After tagging v1.3.3, run `go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@latest` from a clean module cache - confirm the **deprecation notice** surfaces (the install resolves to v1.3.3, which is not retracted, so no retraction warning fires)
- [ ] After tagging v1.3.3, run `go install github.com/mvanhorn/cli-printing-press/cmd/printing-press@v1.3.2` from a clean module cache - confirm the **retraction warning** surfaces
- [ ] `go list -m -u -retracted github.com/mvanhorn/cli-printing-press` lists the retraction
