### PR TITLE
fix(cli): filter auth login --chrome cookies by spec auth.cookies allowlist

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6583,6 +6583,52 @@ func TestGenerate_CookieAuthFiltersAllowlistOnLogin(t *testing.T) {
 		assert.NotContains(t, content, "requiredCookies := []string{")
 		assert.NotContains(t, content, `cookies = strings.Join(kept, "; ")`)
 	})
+
+	t.Run("refresh path also filters by allowlist", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := &spec.APISpec{
+			Name:    "refreshfilterapp",
+			Version: "0.1.0",
+			BaseURL: "https://app.example.com",
+			Auth: spec.AuthConfig{
+				Type:                           "cookie",
+				Header:                         "Cookie",
+				In:                             "cookie",
+				CookieDomain:                   ".example.com",
+				Cookies:                        []string{"session_id"},
+				EnvVars:                        []string{"REFRESHFILTERAPP_COOKIES"},
+				RequiresBrowserSession:         true,
+				BrowserSessionValidationPath:   "/api/items",
+				BrowserSessionValidationMethod: "GET",
+			},
+			Config: spec.ConfigSpec{Format: "toml"},
+			Resources: map[string]spec.Resource{
+				"items": {
+					Description: "Manage items",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/api/items", Description: "List items"},
+					},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "refreshfilterapp-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		auth, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+		require.NoError(t, err)
+		content := string(auth)
+
+		require.Contains(t, content, "func refreshStoredBrowserCookies")
+		_, refresh, _ := strings.Cut(content, "func refreshStoredBrowserCookies")
+		// Without the fix, the refresh body has SaveTokens(cookies) with no
+		// prior filter — the second SaveTokens call would then sit before any
+		// allowlist parsing in the function.
+		assert.Contains(t, refresh, `requiredCookies := []string{"session_id"}`)
+		assert.Contains(t, refresh, `cookies = strings.Join(kept, "; ")`)
+
+		runGoCommand(t, outputDir, "build", "./...")
+	})
 }
 
 func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6502,6 +6502,89 @@ func TestGenerate_CookieAuthWindowsCompatibility(t *testing.T) {
 	assert.Contains(t, content, "cookie-scoop-cli")
 }
 
+// TestGenerate_CookieAuthFiltersAllowlistOnLogin pins that `auth login --chrome`
+// stores only the cookies named in spec.auth.cookies when an allowlist is
+// declared, and falls back to the unfiltered blob when the allowlist is
+// empty (legacy specs).
+func TestGenerate_CookieAuthFiltersAllowlistOnLogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allowlist declared filters extracted cookies", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := &spec.APISpec{
+			Name:    "filterapp",
+			Version: "0.1.0",
+			BaseURL: "https://app.example.com",
+			Auth: spec.AuthConfig{
+				Type:         "cookie",
+				Header:       "Cookie",
+				In:           "cookie",
+				CookieDomain: ".example.com",
+				Cookies:      []string{"session_id"},
+				EnvVars:      []string{"FILTERAPP_COOKIES"},
+			},
+			Config: spec.ConfigSpec{Format: "toml"},
+			Resources: map[string]spec.Resource{
+				"items": {
+					Description: "Manage items",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/api/items", Description: "List items"},
+					},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "filterapp-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		auth, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+		require.NoError(t, err)
+		content := string(auth)
+
+		assert.Contains(t, content, `requiredCookies := []string{"session_id"}`)
+		assert.Contains(t, content, "cookieMap := parseCookieString(cookies)")
+		assert.Contains(t, content, `cookies = strings.Join(kept, "; ")`)
+		assert.Contains(t, content, `cookie %q not found for %s`)
+
+		runGoCommand(t, outputDir, "build", "./...")
+	})
+
+	t.Run("empty allowlist preserves legacy behavior", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := &spec.APISpec{
+			Name:    "legacycookieapp",
+			Version: "0.1.0",
+			BaseURL: "https://app.example.com",
+			Auth: spec.AuthConfig{
+				Type:         "cookie",
+				Header:       "Cookie",
+				In:           "cookie",
+				CookieDomain: ".example.com",
+				EnvVars:      []string{"LEGACYCOOKIEAPP_COOKIES"},
+			},
+			Config: spec.ConfigSpec{Format: "toml"},
+			Resources: map[string]spec.Resource{
+				"items": {
+					Description: "Manage items",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/api/items", Description: "List items"},
+					},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "legacycookieapp-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		auth, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+		require.NoError(t, err)
+		content := string(auth)
+
+		assert.NotContains(t, content, "requiredCookies := []string{")
+		assert.NotContains(t, content, `cookies = strings.Join(kept, "; ")`)
+	})
+}
+
 func TestGenerate_UserAgentOverrideGatedByBrowserTransport(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -270,7 +270,32 @@ profile by name when the installed backend supports it.`,
 			fmt.Fprintf(w, "Session saved to %s\n", cfg.Path)
 			return nil
 {{- else}}
-			// Step 4: Save to config
+{{- if .Auth.Cookies}}
+			// Unfiltered, the persisted blob carries every cookie the target
+			// domain has set (CSRF, WAF, anti-bot fingerprints, etc.) into the
+			// Cookie header on every request, which routinely trips upstream
+			// WAFs and shadows the real credential.
+			cookieMap := parseCookieString(cookies)
+			requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+			kept := make([]string, 0, len(requiredCookies))
+			for _, name := range requiredCookies {
+				v, ok := cookieMap[name]
+				if !ok {
+					loginURL := "https://" + strings.TrimPrefix(domain, ".")
+					fmt.Fprintf(w, "\n%s Cookie %q not found for %s.\n", red("ERROR"), name, domain)
+					fmt.Fprintln(w, "")
+					fmt.Fprintln(w, "Log in to your account:")
+					fmt.Fprintf(w, "\n  %s\n\n", loginURL)
+					fmt.Fprintln(w, "Then run this command again:")
+					fmt.Fprintf(w, "\n  {{.Name}}-pp-cli auth login --chrome\n")
+					return authErr(fmt.Errorf("cookie %q not found for %s", name, domain))
+				}
+				kept = append(kept, name+"="+v)
+			}
+			cookies = strings.Join(kept, "; ")
+{{- end}}
+
+			// Step 5: Save to config
 			cfg, err := config.Load(flags.configPath)
 			if err != nil {
 				return configErr(err)

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -620,6 +620,22 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	}
 	fmt.Fprintf(w, "Updated stored browser auth from %d cookies.\n", len(requiredCookies))
 {{- else}}
+{{- if .Auth.Cookies}}
+	// Refresh runs unattended, so silently saving the raw blob here would
+	// overwrite the filtered token that login just persisted. Apply the same
+	// allowlist filter as newAuthLoginCmd's non-composed branch.
+	cookieMap := parseCookieString(cookies)
+	requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+	kept := make([]string, 0, len(requiredCookies))
+	for _, name := range requiredCookies {
+		v, ok := cookieMap[name]
+		if !ok {
+			return fmt.Errorf("cookie %q not found for %s", name, domain)
+		}
+		kept = append(kept, name+"="+v)
+	}
+	cookies = strings.Join(kept, "; ")
+{{- end}}
 	if err := cfg.SaveTokens("", "", cookies, "", time.Time{}); err != nil {
 		return configErr(fmt.Errorf("saving cookies: %w", err))
 	}


### PR DESCRIPTION
## Intent

Issue: Closes #1292

When a spec declares `auth.cookies: [name]`, `auth login --chrome` was saving every cookie the target domain had set into `access_token`. The runtime then sent the whole blob on every authenticated request (CSRF, WAF, anti-bot fingerprints alongside the real credential), routinely tripping upstream WAFs and shadowing the credential in the Cookie header.

## Approach

Apply the allowlist filter the composed-auth branch already uses to the non-composed cookie-auth branch in `auth_browser.go.tmpl`. After `extractCookies` returns the raw blob: parse, keep only the names declared in `spec.auth.cookies`, and rejoin before `SaveTokens`. A missing required cookie aborts login with a re-login prompt instead of silently saving a bad blob.

Specs that declare no allowlist (legacy cookie-auth CLIs) keep their current behavior unchanged; the filter block is gated on `{{- if .Auth.Cookies}}`.

## Scope

Primary area: generator (`internal/generator/templates/auth_browser.go.tmpl`).

Why this belongs in this repo: machine fix. The bug is in the template emitted into every cookie-auth printed CLI; fixing it here propagates the fix to every future print and to every regen of an existing CLI.

The runtime header-vs-cookie placement (currently sends as `Authorization` instead of `Cookie`) is tracked separately by #981 and not changed here.

## Risk

- Legacy specs (`Auth.Cookies: nil`) hit the existing code path; generated output is byte-for-byte unchanged. Confirmed by the second subtest of `TestGenerate_CookieAuthFiltersAllowlistOnLogin` and by the golden harness (no fixture exercises a non-empty `Auth.Cookies` cookie-auth CLI).
- Composed-auth branch is untouched.
- A user whose Chrome session is missing the required cookie now hits a clear error at login time instead of authenticating with a corrupted blob and 4xx-ing later.

## Output Contract

For cookie-auth CLIs with `auth.cookies` declared, the generated `internal/cli/auth.go` now emits a `requiredCookies := []string{...}` declaration plus a parse-filter-rejoin loop ahead of `SaveTokens`. Generated output for cookie-auth CLIs with empty `Auth.Cookies` is unchanged.

## Verification

- `go test ./...` — 4388 passed in 35 packages
- `scripts/golden.sh verify` — 20/20 passed
- `golangci-lint run ./...` — no issues
- `go build -o ./printing-press ./cmd/printing-press` — clean
- New test `TestGenerate_CookieAuthFiltersAllowlistOnLogin` covers both the allowlisted and legacy branches; the allowlisted subtest also runs `go build ./...` against the generated CLI to catch template compile errors.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission