### PR TITLE
fix(cli): drop MCP code-orch handler pre-marshal that base64-encoded mutating bodies

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10056,6 +10056,69 @@ func TestMCPHandlerPassesBodyArgsMap(t *testing.T) {
 		"PATCH branch must forward bodyArgs directly to the client")
 }
 
+// TestMCPCodeOrchPassesParamsMap pins the same body-passthrough contract for
+// the code-orchestration handler template (mcp_code_orch.go.tmpl). Sibling of
+// TestMCPHandlerPassesBodyArgsMap: an earlier pre-marshal stored []byte in the
+// body slot, which client.do() then json.Marshaled into a base64-encoded
+// string that strict APIs reject.
+func TestMCPCodeOrchPassesParamsMap(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-orch-body-passthrough")
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code", EndpointTools: "hidden"}
+	apiSpec.Resources["widgets"] = spec.Resource{
+		Description: "Widgets",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/widgets",
+				Description: "Create a widget",
+				Body: []spec.Param{
+					{Name: "label", Type: "string", Required: true, Description: "Widget label"},
+				},
+			},
+			"replace": {
+				Method:      "PUT",
+				Path:        "/widgets/{id}",
+				Description: "Replace a widget",
+				Params: []spec.Param{
+					{Name: "id", Type: "string", Required: true, Description: "Widget id"},
+				},
+				Body: []spec.Param{
+					{Name: "label", Type: "string", Required: true, Description: "Widget label"},
+				},
+			},
+			"update": {
+				Method:      "PATCH",
+				Path:        "/widgets/{id}",
+				Description: "Update a widget",
+				Params: []spec.Param{
+					{Name: "id", Type: "string", Required: true, Description: "Widget id"},
+				},
+				Body: []spec.Param{
+					{Name: "label", Type: "string", Required: true, Description: "Widget label"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	mcpSource := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+
+	assert.NotContains(t, mcpSource, "json.Marshal(params)",
+		"code-orch handler must not pre-marshal params: client.do() json.Marshals what it receives, "+
+			"so a []byte arrives base64-encoded on the wire and strict APIs reject the payload")
+
+	assert.Contains(t, mcpSource, "c.Post(path, params)",
+		"POST branch must forward params directly to the client")
+	assert.Contains(t, mcpSource, "c.Put(path, params)",
+		"PUT branch must forward params directly to the client")
+	assert.Contains(t, mcpSource, "c.Patch(path, params)",
+		"PATCH branch must forward params directly to the client")
+}
+
 // TestMCPBindingNumericTypesAcrossSpecShapes pins template wiring: both
 // OpenAPI-parsed shapes ("int", "bool") and internal-spec literals
 // ("integer", "boolean") flow through mcpBindingFunc to WithNumber /

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -249,21 +249,14 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		data, err = c.Get(path, query)
 	case "DELETE":
 		data, _, err = c.DeleteWithParams(path, query)
+	case "POST":
+		data, _, err = c.Post(path, params)
+	case "PUT":
+		data, _, err = c.Put(path, params)
+	case "PATCH":
+		data, _, err = c.Patch(path, params)
 	default:
-		body, mErr := json.Marshal(params)
-		if mErr != nil {
-			return mcplib.NewToolResultError(fmt.Sprintf("marshaling body: %v", mErr)), nil
-		}
-		switch ep.Method {
-		case "POST":
-			data, _, err = c.Post(path, body)
-		case "PUT":
-			data, _, err = c.Put(path, body)
-		case "PATCH":
-			data, _, err = c.Patch(path, body)
-		default:
-			return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil
-		}
+		return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil
 	}
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -219,21 +219,14 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		data, err = c.Get(path, query)
 	case "DELETE":
 		data, _, err = c.DeleteWithParams(path, query)
+	case "POST":
+		data, _, err = c.Post(path, params)
+	case "PUT":
+		data, _, err = c.Put(path, params)
+	case "PATCH":
+		data, _, err = c.Patch(path, params)
 	default:
-		body, mErr := json.Marshal(params)
-		if mErr != nil {
-			return mcplib.NewToolResultError(fmt.Sprintf("marshaling body: %v", mErr)), nil
-		}
-		switch ep.Method {
-		case "POST":
-			data, _, err = c.Post(path, body)
-		case "PUT":
-			data, _, err = c.Put(path, body)
-		case "PATCH":
-			data, _, err = c.Patch(path, body)
-		default:
-			return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil
-		}
+		return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil
 	}
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil


### PR DESCRIPTION
## Intent

Issue: Closes #1426

The code-orchestration MCP handler template (`mcp_code_orch.go.tmpl`) had the same defect #1357 fixed in the endpoint-mirror template. `POST/PUT/PATCH` branches pre-marshaled `params` into a `[]byte` and handed it to `c.Post/Put/Patch`; the generated `client.do()` then `json.Marshal`ed the `[]byte` again, which `encoding/json` base64-encodes into a quoted JSON string. Strict APIs reject with `Request data must be a JSON object, not a string`.

## Approach

Drop the intermediate `json.Marshal(params)` step in the orchestrator template and pass `params` (`map[string]any`) directly to `c.Post/Put/Patch`. `client.do()` already does the single marshal pass and wraps marshal errors with the same `"marshaling body"` prefix, so error UX is preserved.

Add `TestMCPCodeOrchPassesParamsMap` mirroring `TestMCPHandlerPassesBodyArgsMap` to pin orchestrator emission: no `json.Marshal(params)` intermediate, plus the literal `c.Post(path, params)` / `c.Put(path, params)` / `c.Patch(path, params)` forms.

## Scope

Primary area: generator template (`internal/generator/templates/mcp_code_orch.go.tmpl`).

This is a generator fix; every printed CLI in code-orchestration mode inherits the bug today.

## Risk

Generated `code_orch.go` regenerates with three POST/PUT/PATCH lines collapsed under the outer `switch` and no helper marshal block. Behavior change is the bugfix itself: mutating MCP `<api>_execute` calls now send JSON objects on the wire instead of base64 strings. Golden fixture `mcp-cloudflare/internal/mcp/code_orch.go` updated in lockstep.

## Output Contract

Template change reshapes the orchestrator's switch and removes the inner marshal block. Golden updated; `scripts/golden.sh verify` passes.

## Verification

- `go fmt ./... && go vet ./...` — clean
- `go test ./...` — 4417 passed in 35 packages
- `go test ./internal/generator/ -run 'TestMCPHandlerPassesBodyArgsMap|TestMCPCodeOrchPassesParamsMap'` — both pass
- `golangci-lint run ./...` — no issues
- `scripts/golden.sh verify` — 20 cases pass

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission