### PR TITLE
fix(skills): require codex completion marker before treating delegation as success

### DIFF
--- a/skills/printing-press/references/codex-delegation.md
+++ b/skills/printing-press/references/codex-delegation.md
@@ -32,16 +32,19 @@ When `CODEX_MODE` is true, delegate code-writing tasks to Codex CLI. Claude stil
      -
    ```
 
-   e. **Validate** — Check the completion marker first, then the build:
+   e. **Validate** — Check the completion marker first (self-describing on failure), then the build:
    ```bash
-   cd "$PRESS_LIBRARY/<api>-pp-cli" && \
-     [ -f _codex-result.json ] && \
-     [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" = "complete" ] && \
+   cd "$PRESS_LIBRARY/<api>-pp-cli"
+   if [ ! -f _codex-result.json ] || [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" != "complete" ]; then
+     echo "codex output marker missing — partial work may be present in $PWD; review before continuing" >&2
+     false
+   else
      go build ./... && go vet ./...
+   fi
    ```
    Also verify `git diff --stat` shows a non-empty diff.
 
-   If `_codex-result.json` is missing or `status != "complete"`, Codex exited before finishing the prompt (sandbox abort, OOM, SIGINT, internal toolchain crash). Surface `codex output marker missing — partial work may be present in <dir>; review before continuing` and fall through to step (g) as a failure. Do NOT proceed to the next priority task with whatever Codex managed to write before bailing.
+   A missing or non-complete marker means Codex exited before finishing the prompt (sandbox abort, OOM, SIGINT, internal toolchain crash); the `if` branch prints the diagnostic itself so the agent does not have to second-guess which arm failed. Fall through to step (g) as a failure. Do NOT proceed to the next priority task with whatever Codex managed to write before bailing.
 
    f. **On success** — Discard the restore point and reset the failure counter:
    ```bash
@@ -238,14 +241,17 @@ When `CODEX_MODE` is true, delegate each bug fix to Codex. The shipcheck tools t
      -
    ```
 
-5. **Validate** — same as Phase 3: check the completion marker first, then build and vet:
+5. **Validate** — same as Phase 3: check the completion marker first (self-describing on failure), then build and vet:
    ```bash
-   cd "$PRESS_LIBRARY/<api>-pp-cli" && \
-     [ -f _codex-result.json ] && \
-     [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" = "complete" ] && \
+   cd "$PRESS_LIBRARY/<api>-pp-cli"
+   if [ ! -f _codex-result.json ] || [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" != "complete" ]; then
+     echo "codex output marker missing — partial work may be present in $PWD; review before continuing" >&2
+     false
+   else
      go build ./... && go vet ./...
+   fi
    ```
-   Also verify `git diff --stat` shows a non-empty diff. Missing marker or `status != "complete"` is a Codex failure — surface `codex output marker missing — partial work may be present in <dir>; review before continuing` and fall through to step 7.
+   Also verify `git diff --stat` shows a non-empty diff. The `if` branch prints the diagnostic itself before exiting non-zero, so the agent does not have to second-guess which arm failed; fall through to step 7.
 
 6. **On success** — `git stash drop`, reset `CODEX_CONSECUTIVE_FAILURES=0`.
 

--- a/skills/printing-press/references/codex-delegation.md
+++ b/skills/printing-press/references/codex-delegation.md
@@ -24,19 +24,24 @@ When `CODEX_MODE` is true, delegate code-writing tasks to Codex CLI. Claude stil
 
    c. **Assemble prompt** — Build a CODEX_PROMPT using the appropriate task type template (see below).
 
-   d. **Delegate** — Pipe to Codex:
+   d. **Delegate** — Remove any stale completion marker from a prior task, then pipe to Codex:
    ```bash
    # Model and reasoning effort inherit from ~/.codex/config.toml. Do not pin -m / -c here.
-   cd "$PRESS_LIBRARY/<api>-pp-cli" && echo "$CODEX_PROMPT" | codex exec \
+   cd "$PRESS_LIBRARY/<api>-pp-cli" && rm -f _codex-result.json && echo "$CODEX_PROMPT" | codex exec \
      --yolo \
      -
    ```
 
-   e. **Validate** — Check the result:
+   e. **Validate** — Check the completion marker first, then the build:
    ```bash
-   cd "$PRESS_LIBRARY/<api>-pp-cli" && go build ./... && go vet ./...
+   cd "$PRESS_LIBRARY/<api>-pp-cli" && \
+     [ -f _codex-result.json ] && \
+     [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" = "complete" ] && \
+     go build ./... && go vet ./...
    ```
    Also verify `git diff --stat` shows a non-empty diff.
+
+   If `_codex-result.json` is missing or `status != "complete"`, Codex exited before finishing the prompt (sandbox abort, OOM, SIGINT, internal toolchain crash). Surface `codex output marker missing — partial work may be present in <dir>; review before continuing` and fall through to step (g) as a failure. Do NOT proceed to the next priority task with whatever Codex managed to write before bailing.
 
    f. **On success** — Discard the restore point and reset the failure counter:
    ```bash
@@ -92,6 +97,10 @@ CONSTRAINTS:
 
 VERIFY: After making changes, run:
   cd . && go build ./... && go vet ./...
+
+COMPLETION MARKER: After VERIFY succeeds (build green, vet clean), and only then, write a JSON object to _codex-result.json in the cwd:
+  {"status":"complete","files_written":["internal/store/store.go"],"timestamp":"<ISO 8601 UTC, e.g. 2026-05-16T12:00:00Z>"}
+If you bail, hit a fatal error, or VERIFY fails, do NOT write this file. The parent skill uses its presence and "status":"complete" as the only signal that the prompt ran end-to-end; missing marker is treated as a partial-completion failure regardless of process exit code.
 ```
 
 **Workflow command task:**
@@ -129,6 +138,10 @@ CONSTRAINTS:
 
 VERIFY: After making changes, run:
   cd . && go build ./... && go vet ./...
+
+COMPLETION MARKER: After VERIFY succeeds (build green, vet clean), and only then, write a JSON object to _codex-result.json in the cwd:
+  {"status":"complete","files_written":["internal/cli/<command>.go","internal/cli/root.go"],"timestamp":"<ISO 8601 UTC>"}
+If you bail, hit a fatal error, or VERIFY fails, do NOT write this file. The parent skill uses its presence and "status":"complete" as the only signal that the prompt ran end-to-end; missing marker is treated as a partial-completion failure regardless of process exit code.
 ```
 
 **Transcendence command task:**
@@ -164,6 +177,10 @@ CONSTRAINTS:
 
 VERIFY: After making changes, run:
   cd . && go build ./... && go vet ./...
+
+COMPLETION MARKER: After VERIFY succeeds (build green, vet clean), and only then, write a JSON object to _codex-result.json in the cwd:
+  {"status":"complete","files_written":["internal/cli/<command>.go","internal/cli/root.go"],"timestamp":"<ISO 8601 UTC>"}
+If you bail, hit a fatal error, or VERIFY fails, do NOT write this file. The parent skill uses its presence and "status":"complete" as the only signal that the prompt ran end-to-end; missing marker is treated as a partial-completion failure regardless of process exit code.
 ```
 
 ## Phase 4: Codex Delegation (Fixes)
@@ -208,16 +225,27 @@ When `CODEX_MODE` is true, delegate each bug fix to Codex. The shipcheck tools t
 
    VERIFY: After making changes, run:
      cd . && go build ./... && go vet ./...
+
+   COMPLETION MARKER: After VERIFY succeeds (build green, vet clean), and only then, write a JSON object to _codex-result.json in the cwd:
+     {"status":"complete","files_written":["<exact file path>"],"timestamp":"<ISO 8601 UTC>"}
+   If you bail, hit a fatal error, or VERIFY fails, do NOT write this file. The parent skill uses its presence and "status":"complete" as the only signal that the prompt ran end-to-end; missing marker is treated as a partial-completion failure regardless of process exit code.
    ```
 
    ```bash
    # Model and reasoning effort inherit from ~/.codex/config.toml. Do not pin -m / -c here.
-   cd "$PRESS_LIBRARY/<api>-pp-cli" && echo "$CODEX_PROMPT" | codex exec \
+   cd "$PRESS_LIBRARY/<api>-pp-cli" && rm -f _codex-result.json && echo "$CODEX_PROMPT" | codex exec \
      --yolo \
      -
    ```
 
-5. **Validate** — same as Phase 3: `go build`, `go vet`, non-empty diff.
+5. **Validate** — same as Phase 3: check the completion marker first, then build and vet:
+   ```bash
+   cd "$PRESS_LIBRARY/<api>-pp-cli" && \
+     [ -f _codex-result.json ] && \
+     [ "$(jq -r '.status // empty' _codex-result.json 2>/dev/null)" = "complete" ] && \
+     go build ./... && go vet ./...
+   ```
+   Also verify `git diff --stat` shows a non-empty diff. Missing marker or `status != "complete"` is a Codex failure — surface `codex output marker missing — partial work may be present in <dir>; review before continuing` and fall through to step 7.
 
 6. **On success** — `git stash drop`, reset `CODEX_CONSECUTIVE_FAILURES=0`.
 


### PR DESCRIPTION
## Problem

Per #1288, `codex exec` can exit non-zero or be killed mid-prompt (sandbox abort, OOM, SIGINT, internal toolchain crash) and leave partial work in tree. The existing post-codex validate step in `skills/printing-press/references/codex-delegation.md` only checks `go build && go vet` and a non-empty `git diff`, both of which can pass against partial output — so the parent skill silently treats partial completion as success and proceeds to the next priority task with the partial files committed to the workspace. The reporter hit this on a partitaiva24 generation (codex wrote ~80% of files, exited 127, the SKILL didn't notice).

## Fix

Direction A from the issue (completion marker file). Adds a self-describing `COMPLETION MARKER` section to each of the four prompt templates (3 Phase 3 task types + 1 Phase 4 fix template) instructing Codex to write `_codex-result.json` with `{status, files_written, timestamp}` only after its own VERIFY step succeeds. Adds two surrounding hooks:

- **Delegate step**: `rm -f _codex-result.json` before invoking codex, so a marker from a prior task can't fool the next one.
- **Validate step**: check that `_codex-result.json` exists and `status == \"complete\"` before running `go build && go vet`. Missing or non-complete marker is surfaced as `codex output marker missing — partial work may be present in <dir>; review before continuing` and falls through to the existing revert + Claude-fallback path, which also increments the existing 3-strike `CODEX_CONSECUTIVE_FAILURES` circuit breaker.

The error-message wording matches the spec in the issue verbatim.

## Scope boundary

- Does NOT change Codex itself, retry logic, or any non-codex generation path. Non-codex runs hit none of these code paths.
- The adjacent `nohup`-wrapped exit-code guardrail mentioned in the issue is out of scope: no current template in this file uses `nohup`, and the marker check is the primary defense regardless of how exit codes get wrapped downstream.
- Skill prose only — no generator code, templates, or fixtures touched. Golden suite skip is justified per the AGENTS.md rubric.

## Acceptance criteria (from issue)

- **positive**: A successful codex run writes `_codex-result.json` with `status: \"complete\"` at the end of the prompt. The SKILL reads the marker and proceeds. Subsequent build/test passes. ✔ Each template's COMPLETION MARKER section produces this; Validate step gates on it.
- **negative**: A codex run that exits before writing the marker (sandbox abort, 127, 137, network drop) is detected. The SKILL surfaces an explicit \"codex output marker missing — partial work may be present in `<dir>`; review before continuing\" message and does NOT proceed to verify/dogfood/promote as if generation succeeded. ✔ Validate-step branch covers this.
- **regression**: The marker convention does not require changes to any non-codex code path. ✔ All edits are inside Phase 3 and Phase 4 codex-mode blocks; non-codex paths untouched.

## Testing

- `go build ./cmd/printing-press` ✔
- `go test ./...` — 4416 passed in 35 packages
- `go vet ./...` — clean
- `go fmt ./...` — no diffs
- `golangci-lint run ./...` — no issues

Closes #1288