### PR TITLE
fix(cli): move extra_commands SKILL.md block to its own top-level section

### DIFF
--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -421,6 +421,15 @@ func TestSkillRendersExtraCommands(t *testing.T) {
 		assert.NotContains(t, afterHeading, name,
 			"extra command %q must not appear under Command Reference; the unknown-command walker would flag it", name)
 	}
+
+	// Markdown nests every `###` under the most recent `##`. Placing
+	// `## Hand-written Extensions` BEFORE `### Finding the right command`
+	// would silently reparent that subsection. Assert the ordering so a
+	// future template edit doesn't regress the structure.
+	findingIdx := strings.Index(content, "### Finding the right command")
+	require.NotEqual(t, -1, findingIdx, "Finding the right command subsection should exist")
+	require.Greater(t, extIdx, findingIdx,
+		"Hand-written Extensions must come after ### Finding the right command so it doesn't reparent that subsection")
 }
 
 // TestSkillFrontmatterMetadataIsClawHubCompliantNestedYAML asserts that the

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -358,11 +359,11 @@ func TestSkillRendersAuthBranchPerType(t *testing.T) {
 }
 
 // TestSkillRendersExtraCommands asserts that hand-written commands declared
-// in spec.ExtraCommands appear in the generated SKILL.md Command Reference,
-// after the spec-driven resources, with binary prefix and optional args.
-// This closes the drift class where SKILL.md silently omitted hand-written
-// commands like `today`, `streak`, `rivals` because the template only iterated
-// .Resources.
+// in spec.ExtraCommands appear in their own `## Hand-written Extensions`
+// section (NOT inside `## Command Reference`), with binary prefix and optional
+// args. The separate section keeps verify-skill's unknown-command walker
+// (scoped to ## Command Reference) from treating extra_commands as canonical
+// Cobra paths — that drift was the root cause of #1451.
 func TestSkillRendersExtraCommands(t *testing.T) {
 	t.Parallel()
 
@@ -380,16 +381,46 @@ func TestSkillRendersExtraCommands(t *testing.T) {
 	require.NoError(t, err)
 	content := string(skill)
 
-	assert.Contains(t, content, "**Hand-written commands**",
-		"Command Reference should include a Hand-written commands subsection when ExtraCommands present")
+	assert.Contains(t, content, "## Hand-written Extensions",
+		"ExtraCommands should be surfaced in their own top-level section, not under ## Command Reference")
 	assert.Contains(t, content, "`sports-pp-cli trending`",
-		"extra command without args should render as just binary + name")
+		"extra command without args should render as binary + name in the Extensions section")
 	assert.Contains(t, content, "`sports-pp-cli boxscore <event_id>`",
 		"extra command with args should render args after the name")
 	assert.Contains(t, content, "Most-followed athletes and teams across all leagues",
 		"extra command description should appear in the rendered output")
 	assert.Contains(t, content, "`sports-pp-cli h2h <team1> <team2>`",
 		"extra command with multi-arg signature should render verbatim")
+
+	// Regression guard for #1451: the Extensions section must live OUTSIDE
+	// the Command Reference section so verify-skill's _extract_inline_commands
+	// walker (scoped to ## Command Reference) does not flag these as
+	// unknown-command findings. Asserted by locating each section's offset
+	// and confirming Extensions starts after Reference ends.
+	cmdRefIdx := strings.Index(content, "## Command Reference")
+	require.NotEqual(t, -1, cmdRefIdx, "Command Reference section is expected to exist")
+	extIdx := strings.Index(content, "## Hand-written Extensions")
+	require.NotEqual(t, -1, extIdx)
+	require.Greater(t, extIdx, cmdRefIdx,
+		"Hand-written Extensions must be a sibling section after Command Reference, not nested inside it")
+
+	// Belt-and-suspenders: confirm the Command Reference section body
+	// (everything between its heading and the next top-level heading)
+	// does NOT contain any extra_commands path. Mirrors the Python
+	// walker's scoping (regex in scripts/verify-skill/verify_skill.py:74)
+	// without lookahead, which Go's RE2 doesn't support.
+	cmdRefHeadingRE := regexp.MustCompile(`(?m)^##\s+Command\s+Reference\s*$`)
+	nextSectionRE := regexp.MustCompile(`(?m)^##\s+`)
+	loc := cmdRefHeadingRE.FindStringIndex(content)
+	require.NotNil(t, loc, "Command Reference section heading should match the walker's regex")
+	afterHeading := content[loc[1]:]
+	if next := nextSectionRE.FindStringIndex(afterHeading); next != nil {
+		afterHeading = afterHeading[:next[0]]
+	}
+	for _, name := range []string{"sports-pp-cli trending", "sports-pp-cli boxscore", "sports-pp-cli h2h"} {
+		assert.NotContains(t, afterHeading, name,
+			"extra command %q must not appear under Command Reference; the unknown-command walker would flag it", name)
+	}
 }
 
 // TestSkillFrontmatterMetadataIsClawHubCompliantNestedYAML asserts that the

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -144,15 +144,6 @@ This CLI was generated with browser-observed traffic context.
 {{- end}}
 {{- end}}
 {{end}}
-{{- if .ExtraCommands}}
-
-## Hand-written Extensions
-
-These commands are declared by the spec author and require separate hand-written wiring; the generator does not emit Cobra registration for them. They are listed here for discoverability and are intentionally outside `## Command Reference` so the verify-skill unknown-command check does not treat them as generator-owned paths.
-{{range .ExtraCommands}}
-- `{{$.Name}}-pp-cli {{.Name}}{{if .Args}} {{.Args}}{{end}}` — {{oneline .Description}}
-{{- end}}
-{{end}}
 {{- if and .HasDataLayer .Cache.Enabled}}
 
 ## Freshness Contract
@@ -178,6 +169,15 @@ When you know what you want to do but not which command does it, ask the CLI dir
 ```
 
 `which` resolves a natural-language capability query to the best matching command from this CLI's curated feature index. Exit code `0` means at least one match; exit code `2` means no confident match — fall back to `--help` or use a narrower query.
+{{- if .ExtraCommands}}
+
+## Hand-written Extensions
+
+These commands are declared by the spec author and require separate hand-written wiring; the generator does not emit Cobra registration for them. They are listed here for discoverability and are intentionally outside `## Command Reference` so the verify-skill unknown-command check does not treat them as generator-owned paths.
+{{range .ExtraCommands}}
+- `{{$.Name}}-pp-cli {{.Name}}{{if .Args}} {{.Args}}{{end}}` — {{oneline .Description}}
+{{- end}}
+{{- end}}
 {{- if and .Narrative .Narrative.Recipes}}
 
 ## Recipes

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -146,7 +146,9 @@ This CLI was generated with browser-observed traffic context.
 {{end}}
 {{- if .ExtraCommands}}
 
-**Hand-written commands**
+## Hand-written Extensions
+
+These commands are declared by the spec author and require separate hand-written wiring; the generator does not emit Cobra registration for them. They are listed here for discoverability and are intentionally outside `## Command Reference` so the verify-skill unknown-command check does not treat them as generator-owned paths.
 {{range .ExtraCommands}}
 - `{{$.Name}}-pp-cli {{.Name}}{{if .Args}} {{.Args}}{{end}}` — {{oneline .Description}}
 {{- end}}


### PR DESCRIPTION
## Intent

\`extra_commands\` declared in internal-YAML specs render under a \`**Hand-written commands**\` subsection nested inside \`## Command Reference\`. The Cobra emitter never reads the field, so those rows are promises the generator does not back. \`verify-skill\` walks \`## Command Reference\` for inline backticks shaped like \`<binary> <cmd>\` and (correctly) fails the unknown-command check on every entry. End-to-end repro from the issue: generating \`catalog/specs/producthunt-spec.yaml\` and running \`printing-press verify-skill --dir <out>\` exits 1 with \`unknown-command\` errors for \`today\`, \`recent\`, and \`search\`.

Issue: Closes #1451

## Approach

Option (a) from the issue. Lift the conditional \`**Hand-written commands**\` block out of \`## Command Reference\` into its own sibling \`## Hand-written Extensions\` top-level section, with an explainer paragraph stating these need separate hand-written wiring. The verify-skill walker's \`_extract_inline_commands\` is scoped to the Command Reference body (regex in \`scripts/verify-skill/verify_skill.py:74\`), so a sibling section is invisible to the unknown-command check.

Kept the binary-prefixed backtick rendering inside the new section so humans still see the canonical invocation; the section heading change alone is what defangs the walker.

## Scope

Primary area: \`comp:generator\` (skill.md.tmpl).

Why this belongs in this repo: every CLI generated from a spec with \`extra_commands\` (shopify, producthunt, future internal-YAML specs that declare hand-written extensions) regenerates with the fix on the next print. The runtime branch is conditional on \`{{- if .ExtraCommands}}\` so CLIs without any extras emit a byte-identical SKILL.md.

## Risk

**Published-library drift.** Two already-published CLIs (\`commerce/shopify\`, \`marketing/producthunt\`) ship the old SKILL.md shape. Filed [mvanhorn/printing-press-library#616](https://github.com/mvanhorn/printing-press-library/issues/616) for the sweep tool to retrofit; anchors and idempotency tests called out in the issue body. Until the sweep runs, fresh prints diverge from existing entries for those two CLIs only.

**Test churn.** \`TestSkillRendersExtraCommands\` is updated to assert the new section heading; \`TestSkillNoExtraCommandsIsBackwardCompatible\` is unchanged (the absent-state still renders nothing). Added a belt-and-suspenders regression that mirrors the Python walker's scoping in Go and asserts no extra_commands path is reachable from inside Command Reference.

## Output Contract

No golden fixture diffs — no golden case declares \`extra_commands\`, so the conditional branch is unreached. Output contract for CLIs with \`extra_commands\`: SKILL.md gains a top-level \`## Hand-written Extensions\` section after \`## Command Reference\` (and before \`## Freshness Contract\` when present).

## Verification

- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./...\` — 4429 passed, 35 packages
- \`golangci-lint run ./...\` — no issues
- \`scripts/golden.sh verify\` — 20 cases pass
- End-to-end: \`./printing-press generate --spec catalog/specs/producthunt-spec.yaml --output /tmp/ph_repro --force --validate\` followed by \`./printing-press verify-skill --dir /tmp/ph_repro\` exits 0 (\"All checks passed\"). Issue reproduces on \`main\` before the patch.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change