### PR TITLE
fix(cli): writeThroughCache caches single-object responses keyed by non-id PKs

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3742,12 +3742,62 @@ func TestWriteThroughCacheCachesObjectWithNullWrapperFieldName(t *testing.T) {
 		t.Fatalf("certs count after null-wrapper-field response = %d, want 1 (JSON null is not an empty array)", count)
 	}
 }
+
+// TestWriteThroughCacheCachesObjectWithEmptyListWrapperAndOtherFields
+// covers the multi-key case Greptile flagged in round 3: a detail object
+// with real per-row fields PLUS a wrapper-named field that happens to be
+// an empty array. The skip branch must only fire when EVERY top-level
+// key is a list wrapper or known pagination metadata.
+func TestWriteThroughCacheCachesObjectWithEmptyListWrapperAndOtherFields(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"CertNo":"88888","items":[],"Grade":"PR69"}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs WHERE id = '88888'` + "`" + `).Scan(&count); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("certs count after detail-with-empty-wrapper-field response = %d, want 1 (envelope has real per-row fields and must be cached)", count)
+	}
+}
+
+// TestWriteThroughCacheSkipsListEnvelopeWithPaginationMetadata guards the
+// flip side: a real list envelope with pagination metadata fields
+// (next_cursor, has_more, etc.) plus an empty array must still skip
+// the single-object upsert path. The metadata allowlist is what keeps
+// these envelopes recognized as lists.
+func TestWriteThroughCacheSkipsListEnvelopeWithPaginationMetadata(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"items":[],"next_cursor":"","has_more":false}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs` + "`" + `).Scan(&count); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("certs count after list-envelope-with-metadata response = %d, want 0 (no real per-row data, must skip)", count)
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "write_through_cache_non_id_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope|TestWriteThroughCacheCachesObjectWithListWrapperFieldName|TestWriteThroughCacheCachesObjectWithNullWrapperFieldName", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope|TestWriteThroughCacheCachesObjectWithListWrapperFieldName|TestWriteThroughCacheCachesObjectWithNullWrapperFieldName|TestWriteThroughCacheCachesObjectWithEmptyListWrapperAndOtherFields|TestWriteThroughCacheSkipsListEnvelopeWithPaginationMetadata", "./internal/cli")
 }
 
 func TestSyncDiscriminatorDispatchRoutesMixedItemsToTypedTables(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3573,6 +3573,129 @@ func TestWriteThroughCachePopulatesTypedTable(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCachePopulatesTypedTable", "./internal/cli")
 }
 
+// TestWriteThroughCacheNonIDPrimaryKeyResponse guards #1439: the previous
+// `envelope["id"]` guard silently dropped single-object detail responses
+// whose primary key field was named anything other than "id" (PCGS uses
+// CertNo, Stripe uses object ids prefixed with their type, many ERP APIs
+// use sku / invoiceId / etc.). After the fix the row reaches UpsertBatch
+// and the existing resourceIDFieldOverrides path resolves the PK.
+func TestLiveFetchWriteThroughCacheNonIDPrimaryKeyResponse(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "pcgs",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/pcgs-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"certs": {
+				Description: "Look up coin certs by CertNo",
+				Endpoints: map[string]spec.Endpoint{
+					// list endpoint triggers typed-table emission (UpsertBatch
+					// dispatches to it); lookup endpoint is the single-object
+					// detail path the bug fires on at runtime.
+					"list": {
+						Method:      "GET",
+						Path:        "/certs",
+						Description: "List recent certs",
+						IDField:     "CertNo",
+						Response:    spec.ResponseDef{Type: "array", Item: "Cert"},
+					},
+					"lookup": {
+						Method:      "GET",
+						Path:        "/certs/{cert_no}",
+						Description: "Fetch a single cert by CertNo",
+						IDField:     "CertNo",
+						Response:    spec.ResponseDef{Type: "object", Item: "Cert"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Cert": {
+				Fields: []spec.TypeField{
+					{Name: "CertNo", Type: "string"},
+					{Name: "PCGSNo", Type: "string"},
+					{Name: "Grade", Type: "string"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+func TestWriteThroughCacheNonIDPrimaryKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Single-object detail response keyed by CertNo (not "id"). Before
+	// #1439, the envelope["id"] guard caused writeThroughCache to drop
+	// this on the floor. After the fix the row reaches UpsertBatch and
+	// the resourceIDFieldOverrides mechanism resolves the PK.
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"CertNo":"12345678","PCGSNo":"7280","Grade":"MS65"}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var typedCount int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs WHERE id = '12345678'` + "`" + `).Scan(&typedCount); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if typedCount != 1 {
+		t.Fatalf("typed certs count = %d, want 1 (non-id primary key was dropped)", typedCount)
+	}
+}
+
+// TestWriteThroughCacheSkipsEmptyListEnvelope guards the tighter
+// single-object branch from misfiring on list responses whose array
+// happened to be empty. {"items": []} must NOT write a row keyed by
+// the entire envelope; the existing wrapper-key loop already handled
+// this implicitly and the relaxed guard must preserve the invariant.
+func TestWriteThroughCacheSkipsEmptyListEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"items": []}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs` + "`" + `).Scan(&count); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("certs count after empty-list envelope = %d, want 0 (envelope must not be upserted as a single object)", count)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "write_through_cache_non_id_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope", "./internal/cli")
+}
+
 func TestSyncDiscriminatorDispatchRoutesMixedItemsToTypedTables(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3688,12 +3688,41 @@ func TestWriteThroughCacheSkipsEmptyListEnvelope(t *testing.T) {
 		t.Fatalf("certs count after empty-list envelope = %d, want 0 (envelope must not be upserted as a single object)", count)
 	}
 }
+
+// TestWriteThroughCacheCachesObjectWithListWrapperFieldName guards the
+// list-envelope guard from a field-name collision: a detail object whose
+// own field happens to be named "data" / "results" / "items" with a
+// scalar value (not an array) is a regular response, not an empty list
+// envelope, and must still be cached. Skipping it would be a regression
+// from the prior envelope["id"] path.
+func TestWriteThroughCacheCachesObjectWithListWrapperFieldName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// "data" key is present but holds a string. Old code would have written
+	// this via the id guard; new guard must still write it because the
+	// wrapper key isn't a list.
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"CertNo":"55555","data":"opaque-token","Grade":"AU58"}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs WHERE id = '55555'` + "`" + `).Scan(&count); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("certs count after field-name-collision response = %d, want 1 (scalar-valued wrapper-named field must not trip the list-envelope skip)", count)
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "write_through_cache_non_id_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope|TestWriteThroughCacheCachesObjectWithListWrapperFieldName", "./internal/cli")
 }
 
 func TestSyncDiscriminatorDispatchRoutesMixedItemsToTypedTables(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3717,12 +3717,37 @@ func TestWriteThroughCacheCachesObjectWithListWrapperFieldName(t *testing.T) {
 		t.Fatalf("certs count after field-name-collision response = %d, want 1 (scalar-valued wrapper-named field must not trip the list-envelope skip)", count)
 	}
 }
+
+// TestWriteThroughCacheCachesObjectWithNullWrapperFieldName guards the
+// specific JSON-null case Greptile flagged: json.Unmarshal("null", &arr)
+// succeeds with arr=nil, so without an explicit arr != nil check the
+// guard would misclassify {"CertNo":"x","items":null} as an empty-list
+// envelope and silently drop the row.
+func TestWriteThroughCacheCachesObjectWithNullWrapperFieldName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	writeThroughCache(context.Background(), "certs", json.RawMessage(` + "`" + `{"CertNo":"77777","items":null,"Grade":"PR70"}` + "`" + `))
+
+	db, err := store.Open(defaultDBPath("pcgs-pp-cli"))
+	if err != nil {
+		t.Fatalf("open cache store: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.DB().QueryRow(` + "`" + `SELECT COUNT(*) FROM certs WHERE id = '77777'` + "`" + `).Scan(&count); err != nil {
+		t.Fatalf("query certs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("certs count after null-wrapper-field response = %d, want 1 (JSON null is not an empty array)", count)
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "write_through_cache_non_id_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope|TestWriteThroughCacheCachesObjectWithListWrapperFieldName", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestWriteThroughCacheNonIDPrimaryKey|TestWriteThroughCacheSkipsEmptyListEnvelope|TestWriteThroughCacheCachesObjectWithListWrapperFieldName|TestWriteThroughCacheCachesObjectWithNullWrapperFieldName", "./internal/cli")
 }
 
 func TestSyncDiscriminatorDispatchRoutesMixedItemsToTypedTables(t *testing.T) {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -191,13 +191,21 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 			// resourceIDFieldOverrides mechanism resolve the primary key.
 			// Guarding on envelope["id"] dropped any API whose PK is named
 			// CertNo / sku / invoiceId / etc. on the floor (#1439). Skip
-			// when the envelope carries a known list-wrapper key — that's
-			// a list response whose array happened to be empty, not a
-			// detail object — and when the envelope is empty (malformed).
+			// only when the envelope carries a list-wrapper KEY whose
+			// VALUE is an array — that's a list response whose array
+			// happened to be empty, not a detail object. A wrapper-named
+			// field whose value is a scalar/object/null is a regular
+			// field name collision (e.g. {"id":"x","data":"<base64>"})
+			// and the row still needs to be cached.
 			if items == nil && len(envelope) > 0 {
 				isEmptyListEnvelope := false
 				for _, key := range []string{"results", "data", "items"} {
-					if _, ok := envelope[key]; ok {
+					raw, ok := envelope[key]
+					if !ok {
+						continue
+					}
+					var arr []json.RawMessage
+					if json.Unmarshal(raw, &arr) == nil {
 						isEmptyListEnvelope = true
 						break
 					}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -187,9 +187,22 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 					}
 				}
 			}
-			// Single object with an id field (e.g., detail response)
-			if items == nil {
-				if _, ok := envelope["id"]; ok {
+			// Single object detail response: let UpsertBatch's existing
+			// resourceIDFieldOverrides mechanism resolve the primary key.
+			// Guarding on envelope["id"] dropped any API whose PK is named
+			// CertNo / sku / invoiceId / etc. on the floor (#1439). Skip
+			// when the envelope carries a known list-wrapper key — that's
+			// a list response whose array happened to be empty, not a
+			// detail object — and when the envelope is empty (malformed).
+			if items == nil && len(envelope) > 0 {
+				isEmptyListEnvelope := false
+				for _, key := range []string{"results", "data", "items"} {
+					if _, ok := envelope[key]; ok {
+						isEmptyListEnvelope = true
+						break
+					}
+				}
+				if !isEmptyListEnvelope {
 					_, _, _ = db.UpsertBatch(resourceType, []json.RawMessage{data})
 					return
 				}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -159,6 +159,36 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 	}
 }
 
+// listEnvelopeMetadataKeys are top-level keys that, when accompanying a
+// list-wrapper array, suggest the response is a paginated list envelope
+// rather than a detail object. Used by writeThroughCache to decide
+// whether to upsert a single-object body. Any envelope key NOT in this
+// set (and not a list wrapper itself) signals real per-row data, and
+// the envelope is treated as a detail object even when one of its
+// wrapper-named fields happens to be an empty array.
+var listEnvelopeMetadataKeys = map[string]bool{
+	// list wrappers themselves
+	"results": true, "data": true, "items": true,
+	// pagination cursors / tokens
+	"next_cursor": true, "nextCursor": true,
+	"next_page_token": true, "nextPageToken": true,
+	"page_token": true, "pageToken": true,
+	"end_cursor": true, "endCursor": true,
+	"start_cursor": true, "startCursor": true,
+	"cursor": true, "after": true, "before": true,
+	// has-more flags and page numbers
+	"has_more": true, "hasMore": true, "has_next": true, "hasNext": true,
+	"next_page": true, "previous_page": true,
+	"page": true, "page_size": true, "per_page": true,
+	// counts / totals
+	"total": true, "count": true, "size": true, "total_count": true, "totalCount": true,
+	// wrapper objects
+	"links": true, "meta": true, "pagination": true,
+	"response_metadata": true, "paging": true,
+	// links shape
+	"next": true, "prev": true, "previous": true, "first": true, "last": true,
+}
+
 // writeThroughCache upserts live API results into the local SQLite store so
 // FTS search covers everything the user has looked up — not just explicit syncs.
 // Best-effort: failures are silently ignored (the live result already succeeded).
@@ -190,32 +220,42 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 			// Single object detail response: let UpsertBatch's existing
 			// resourceIDFieldOverrides mechanism resolve the primary key.
 			// Guarding on envelope["id"] dropped any API whose PK is named
-			// CertNo / sku / invoiceId / etc. on the floor (#1439). Skip
-			// only when the envelope carries a list-wrapper KEY whose
-			// VALUE is an array — that's a list response whose array
-			// happened to be empty, not a detail object. A wrapper-named
-			// field whose value is a scalar/object/null is a regular
-			// field name collision (e.g. {"id":"x","data":"<base64>"})
-			// and the row still needs to be cached.
+			// CertNo / sku / invoiceId / etc. on the floor (#1439).
+			//
+			// Treat the envelope as a list-shaped response only when EVERY
+			// top-level key is either a list-wrapper (results/data/items)
+			// holding a real array, or a known pagination-metadata key.
+			// A detail object that happens to carry an empty wrapper-named
+			// field alongside real data (e.g. {"id":"order","items":[],
+			// "status":"pending"}) must still cache as a single row.
 			if items == nil && len(envelope) > 0 {
-				isEmptyListEnvelope := false
+				looksLikeListEnvelope := false
+				hasListWrapperArray := false
 				for _, key := range []string{"results", "data", "items"} {
 					raw, ok := envelope[key]
 					if !ok {
 						continue
 					}
 					// json.Unmarshal("null", &arr) succeeds with arr=nil,
-					// so the unmarshal check alone misclassifies null-valued
-					// fields as list envelopes. Requiring arr != nil keeps
-					// true empty arrays [] in the skip branch while leaving
-					// scalar/null/object values as regular field collisions.
+					// so require arr != nil to keep true empty arrays in
+					// the skip branch while letting scalar/null values fall
+					// through as regular field-name collisions.
 					var arr []json.RawMessage
 					if json.Unmarshal(raw, &arr) == nil && arr != nil {
-						isEmptyListEnvelope = true
+						hasListWrapperArray = true
 						break
 					}
 				}
-				if !isEmptyListEnvelope {
+				if hasListWrapperArray {
+					looksLikeListEnvelope = true
+					for k := range envelope {
+						if !listEnvelopeMetadataKeys[k] {
+							looksLikeListEnvelope = false
+							break
+						}
+					}
+				}
+				if !looksLikeListEnvelope {
 					_, _, _ = db.UpsertBatch(resourceType, []json.RawMessage{data})
 					return
 				}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -204,8 +204,13 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 					if !ok {
 						continue
 					}
+					// json.Unmarshal("null", &arr) succeeds with arr=nil,
+					// so the unmarshal check alone misclassifies null-valued
+					// fields as list envelopes. Requiring arr != nil keeps
+					// true empty arrays [] in the skip branch while leaving
+					// scalar/null/object values as regular field collisions.
 					var arr []json.RawMessage
-					if json.Unmarshal(raw, &arr) == nil {
+					if json.Unmarshal(raw, &arr) == nil && arr != nil {
 						isEmptyListEnvelope = true
 						break
 					}


### PR DESCRIPTION
## Intent

\`writeThroughCache\` in the generated \`data_source.go\` guards single-object cache writes with \`if _, ok := envelope[\"id\"]; ok\`. APIs whose primary key is named anything other than \`id\` (\`CertNo\`, \`sku\`, \`invoiceId\`, etc.) never match — every lookup returns HTTP 200 with correct stdout while the local SQLite store stays empty. Every downstream feature that reads from the cache (smart presets, holdings analysis, offline search) silently gets no data.

Issue: Closes #1439

## Approach

Two changes in the same template branch:

1. **Drop the hardcoded \`\"id\"\` guard.** Delegate primary-key resolution to \`UpsertBatch\`'s existing \`resourceIDFieldOverrides\` mechanism, which the parser already populates from \`x-resource-id\` and the response-schema inference chain. Matches the reporter's validated fix.
2. **Tighten the single-object branch.** Skip envelopes whose only meaningful content is a known list-wrapper key (\`results\`, \`data\`, \`items\`) with an empty array — \`{\"items\": []}\` must not write a row keyed by the entire envelope. The existing wrapper-array loop above handles non-empty list responses; this guard preserves that invariant for the empty case.

## Scope

Primary area: \`comp:generator\` (\`internal/generator/templates/data_source.go.tmpl\`).

Why this belongs in this repo: every printed CLI that exposes a lookup-style detail endpoint regenerates with the fix on the next print. No spec changes required — the existing \`IDField\` plumbing handles all variants.

## Risk

**False positive avoided.** The first fix attempt triggered \`TestClientBasePathLiveRequest\` (\`{\"items\": []}\` was being upserted as a single object → \"no extractable ID field\" warning). The list-wrapper skip handles that and is locked in by \`TestWriteThroughCacheSkipsEmptyListEnvelope\`.

**Existing \`id\`-keyed APIs unchanged.** The \`UpsertBatch\` path already handled them; this PR removes a hardcoded shortcut that bypassed it for the common case. \`TestWriteThroughCachePopulatesTypedTable\` continues to pass.

## Output Contract

No golden fixture diffs — no golden case exercises a non-id-PK single-object response. Output contract for CLIs whose detail endpoints carry non-\`id\` PKs: \`writeThroughCache\` now upserts the row into the typed table using the spec-declared \`IDField\`. Cache-dependent features (smart presets, offline search) work after first lookup instead of silently returning empty.

## Verification

- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./...\` — 4455 passed, 35 packages
- \`golangci-lint run ./...\` — no issues
- \`scripts/golden.sh verify\` — 20 cases pass
- Inline runtime tests: \`TestWriteThroughCacheNonIDPrimaryKey\` (asserts the CertNo-shaped response lands in the typed table), \`TestWriteThroughCacheSkipsEmptyListEnvelope\` (asserts the empty-list shape never reaches UpsertBatch)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change