### PR TITLE
fix(ci): require all review threads resolved before queue + merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,12 @@ queue_rules:
     # timing out waiting for Greptile.
     queue_conditions:
       - base = main
+      # All Greptile/human inline review threads must be resolved before
+      # the PR enters the queue. Greptile Review's check_run going green
+      # only reflects the confidence score, not whether inline findings
+      # are addressed; without this condition a PR with unresolved P0/P1
+      # findings would auto-merge as soon as `ready-to-merge` is applied.
+      - "#review-threads-unresolved = 0"
       - check-success = build-and-test
       - check-success = generated-test
       - check-success = go-lint
@@ -58,6 +64,10 @@ merge_protections:
         - and:
           - head = release-please--branches--main
           - "title ~= ^chore\\(main\\): release"
+      # Mirrors the queue_conditions rule. Belt-and-suspenders so a queued
+      # PR that picks up new Greptile findings during the queue's CI re-run
+      # is held until those threads are resolved.
+      - "#review-threads-unresolved = 0"
       - check-success = build-and-test
       - check-success = generated-test
       - check-success = go-lint


### PR DESCRIPTION
## Problem

Mergify's `queue_conditions` and `success_conditions` both gate on `Greptile Review` being `success`/`neutral`/`skipped`. But that check_run only reflects the **confidence score** — it does not track whether Greptile's inline P0/P1 findings have actually been resolved.

So today a PR can:

1. Pass all 6 CI checks (build-and-test, generated-test, go-lint, golden, pr-title, test)
2. Pass Greptile Review (score ≥ threshold)
3. Get labeled `ready-to-merge`
4. **Auto-merge via Mergify with the inline findings still open**

**PR #1514 is the canonical example as of today:** `mergeStateStatus=CLEAN` with 1 unresolved Greptile thread. Apply `ready-to-merge` and Mergify will merge it with the finding intact.

The downstream library repo had the same gap. We closed it there via a ruleset rule + a visibility check_run (see mvanhorn/printing-press-library#620, #621). This repo uses Mergify rather than rulesets, so the equivalent fix is a **Mergify-native condition**.

## Fix

Add `#review-threads-unresolved = 0` to both `queue_conditions` and `success_conditions`. With both in place:

- Mergify won't queue a PR that has unresolved threads
- Mergify won't merge a queued PR that picks up new findings during the in-place queue re-run
- Mergify's status comments explicitly cite the unresolved threads as the blocker, so authors see what to fix in the same place they look for everything else Mergify says

## Release-please compatibility

Release-please PRs are bot-generated and reliably have zero review threads, so `#review-threads-unresolved = 0` passes them through transparently. The existing release-please branch-pattern exemption for Greptile Review (which silent-skips those PRs) does **not** need to be duplicated for this rule.

## Test plan

- [ ] Merge this PR
- [ ] On PR #1514 (the canonical case), verify Mergify's status comment now cites unresolved review threads as a missing condition
- [ ] Apply `ready-to-merge` to a clean test PR with no unresolved threads, verify it still queues and merges normally
- [ ] Verify the next release-please PR auto-merges without intervention

## Followup (separate PR)

Port `conversation-resolution-check.yml` from the library repo to give authors a visible `check_run` for the same gate state. Independent of this PR; Mergify's enforcement here is the source of truth, the workflow is the visibility layer.