### PR TITLE
fix(ci): cancel-in-progress=false so cancelled check_runs don't pile up

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -62,11 +62,20 @@ jobs:
     if: github.event.pull_request == null || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Coalesce bursts (a push + Greptile review + several thread resolves can
-    # fire within seconds). Latest run wins; older runs are cancelled.
+    # Serialize concurrent triggers via the concurrency group, but do NOT
+    # cancel in-progress runs. Cancellation freezes the auto-created
+    # check_run in `cancelled` state forever (we can't PATCH it post-Feb
+    # 2025), and a single push commonly fires 3-5 events in seconds
+    # (synchronize + Greptile's review.submitted + multiple
+    # review_comment.created), which left a row of `cancelled` check_runs
+    # making the PR look "partially failed" even when the real result
+    # was success. With cancel-in-progress: false, queued runs execute
+    # serially, each completes with a terminal success/failure, and the
+    # required-check rollup uses the latest by completed_at. UI shows
+    # N consistent entries instead of cancelled noise.
     concurrency:
       group: conversation-resolution-${{ github.event.pull_request.number || inputs.pr || github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
## Problem

Mirrors mvanhorn/printing-press-library#625. With `cancel-in-progress: true`, a single push routinely fires multiple events in seconds — `pull_request_target.synchronize`, `pull_request_review.submitted` when Greptile reviews, and `pull_request_review_comment.created` for each inline comment. Cancellation freezes the auto-created check_run in `cancelled` state forever (we can't PATCH it away post-Feb 2025), making the merge widget look "partially failed" even when the real evaluation is success.

## Fix

Flip `cancel-in-progress: false`. Queued runs execute serially. Each completes with a terminal `success`/`failure`. Required-check rollup picks the latest by completed_at. UI shows N consistent entries instead of mixed cancelled noise.

## Tradeoff

3-5 workflow runs per push burst instead of 1, serial = ~100s total. Negligible for this repo's volume.

## Cross-repo

Mirror PR: mvanhorn/printing-press-library#625. Both repos should land their copies in either order.