### PR TITLE
fix(cli): drop // PATCH marker instruction from generated AGENTS.md

### DIFF
--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -37,35 +37,29 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader.
+If you modify this CLI beyond what the generator produced, record each customization in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader.
 
-1. **Mark every changed site** in source with a comment summarizing the deviation:
+Minimum shape:
 
-    ```
-    // PATCH: <one-line summary>
-    ```
-
-    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#<issue>): ...`). `grep -rn 'PATCH' .` from this directory then surfaces every customization.
-
-2. **Catalog the change** in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`). Minimum shape:
-
-    ```json
+```json
+{
+  "schema_version": 1,
+  "applied_at": "YYYY-MM-DD",
+  "base_run_id": "<copy from .printing-press.json>",
+  "base_printing_press_version": "<copy from .printing-press.json>",
+  "patches": [
     {
-      "schema_version": 1,
-      "applied_at": "YYYY-MM-DD",
-      "base_run_id": "<copy from .printing-press.json>",
-      "base_printing_press_version": "<copy from .printing-press.json>",
-      "patches": [
-        {
-          "id": "short-identifier",
-          "summary": "What changed (one sentence).",
-          "reason": "Why this customization was needed (one or two sentences).",
-          "files": ["internal/cli/foo.go"],
-          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-        }
-      ]
+      "id": "short-identifier",
+      "summary": "What changed (one sentence).",
+      "reason": "Why this customization was needed (one or two sentences).",
+      "files": ["internal/cli/foo.go"],
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
     }
-    ```
+  ]
+}
+```
 
-This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the source comment or commit message, not here.
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the manifest is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
+
+Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -37,35 +37,29 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader.
+If you modify this CLI beyond what the generator produced, record each customization in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader.
 
-1. **Mark every changed site** in source with a comment summarizing the deviation:
+Minimum shape:
 
-    ```
-    // PATCH: <one-line summary>
-    ```
-
-    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#<issue>): ...`). `grep -rn 'PATCH' .` from this directory then surfaces every customization.
-
-2. **Catalog the change** in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`). Minimum shape:
-
-    ```json
+```json
+{
+  "schema_version": 1,
+  "applied_at": "YYYY-MM-DD",
+  "base_run_id": "<copy from .printing-press.json>",
+  "base_printing_press_version": "<copy from .printing-press.json>",
+  "patches": [
     {
-      "schema_version": 1,
-      "applied_at": "YYYY-MM-DD",
-      "base_run_id": "<copy from .printing-press.json>",
-      "base_printing_press_version": "<copy from .printing-press.json>",
-      "patches": [
-        {
-          "id": "short-identifier",
-          "summary": "What changed (one sentence).",
-          "reason": "Why this customization was needed (one or two sentences).",
-          "files": ["internal/cli/foo.go"],
-          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-        }
-      ]
+      "id": "short-identifier",
+      "summary": "What changed (one sentence).",
+      "reason": "Why this customization was needed (one or two sentences).",
+      "files": ["internal/cli/foo.go"],
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
     }
-    ```
+  ]
+}
+```
 
-This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the source comment or commit message, not here.
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the manifest is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
+
+Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -37,35 +37,29 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization so it isn't lost on the next regen and is visible to the next reader.
+If you modify this CLI beyond what the generator produced, record each customization in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader.
 
-1. **Mark every changed site** in source with a comment summarizing the deviation:
+Minimum shape:
 
-    ```
-    // PATCH: <one-line summary>
-    ```
-
-    Include an upstream reference inline when there is one (e.g. `// PATCH(upstream cli-printing-press#<issue>): ...`). `grep -rn 'PATCH' .` from this directory then surfaces every customization.
-
-2. **Catalog the change** in a `.printing-press-patches.json` at this CLI's root (parallel to `.printing-press.json`). Minimum shape:
-
-    ```json
+```json
+{
+  "schema_version": 1,
+  "applied_at": "YYYY-MM-DD",
+  "base_run_id": "<copy from .printing-press.json>",
+  "base_printing_press_version": "<copy from .printing-press.json>",
+  "patches": [
     {
-      "schema_version": 1,
-      "applied_at": "YYYY-MM-DD",
-      "base_run_id": "<copy from .printing-press.json>",
-      "base_printing_press_version": "<copy from .printing-press.json>",
-      "patches": [
-        {
-          "id": "short-identifier",
-          "summary": "What changed (one sentence).",
-          "reason": "Why this customization was needed (one or two sentences).",
-          "files": ["internal/cli/foo.go"],
-          "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-          "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-        }
-      ]
+      "id": "short-identifier",
+      "summary": "What changed (one sentence).",
+      "reason": "Why this customization was needed (one or two sentences).",
+      "files": ["internal/cli/foo.go"],
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
     }
-    ```
+  ]
+}
+```
 
-This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; code lives in the source files; the inline `// PATCH:` comment carries the local semantics. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the source comment or commit message, not here.
+This file is an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the manifest is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
+
+Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.


### PR DESCRIPTION
## Summary

Drops the `// PATCH:` source-marker instruction from `internal/generator/templates/agents.md.tmpl` so every newly printed CLI's `AGENTS.md` describes a single customization-recording step: catalog the change in `.printing-press-patches.json`. Pairs with [printing-press-library#644](https://github.com/mvanhorn/printing-press-library/pull/644), which drops the verifier check enforcing bidirectional pairing.

## Why

The template currently tells the agent to do two things for any in-session customization:

1. Add a `// PATCH <id>:` comment in source
2. Add a matching entry to `.printing-press-patches.json`

The library CI then enforced both directions (markers without a manifest entry → error; manifest entry pointing at a `.go` file without a matching marker → error). The pairing doubled the commit count on every customization PR without surfacing a class of bug `git history` + the manifest itself didn't already cover. Library PR #644 relaxes the verifier; this PR aligns the template so newly printed CLIs don't carry the old instruction.

## What changes

- **`internal/generator/templates/agents.md.tmpl`** — `## Local Customizations` section collapses from two steps (mark + catalog) to one (catalog). A closing note calls out that inline `// PATCH:` comments are now optional navigation aids if an agent wants them, but CI no longer requires them.
- **Golden expected fixtures** for `generate-golden-api` and `generate-golden-api-rich-auth` — these are the two golden cases whose expected `AGENTS.md` covers the customizations section. Regenerated via `scripts/golden.sh update`.

Existing printed CLIs (already in `~/printing-press/library/` or in the public library) keep their old `AGENTS.md` until they regen. No retrofit is needed because the library verifier (post-#644) doesn't check the markers either way.

## Test plan

- [x] `go test ./internal/generator/...` — 20+ tests pass including `TestGeneratedAgentsGuideRendersPortableAgentContract` (the ASCII-only check that initially caught an em-dash I introduced and have since fixed)
- [x] `scripts/golden.sh verify` — 20/20 golden cases pass after the expected-fixture update
- [x] `go fmt ./...` clean, `go vet ./...` clean
- [x] Manual: confirmed the new template renders cleanly in both fixture outputs

## Sequencing

Land library PR #644 first (the verifier relaxation). Then this PR. The reverse order is also safe — the template change is non-breaking on its own (newly printed CLIs just stop *telling* their agent to add markers; the library CI keeps enforcing them) — but the friction is fully removed only when both PRs land.
