### PR TITLE
test(cli): update TestPublishSkillSkipsCliSkillsMirrorRegen for new library gate name

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -156,8 +156,16 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 
 	assert.Contains(t, skill, "Do not\nedit `registry.json`, README catalog cells, or `cli-skills/pp-<api-slug>/SKILL.md`")
-	assert.Contains(t, skill, "Guard against hand-edits to cli-skills mirror")
-	assert.Contains(t, skill, "Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` here")
+	// Post mvanhorn/printing-press-library#659, the library's verify
+	// workflow replaced the Guard + auto-fix + fork-only drift trio
+	// with a single `Fail on changes to generated artifacts` check.
+	// The publish skill must reference the current gate name so an
+	// agent reading it knows what failure to expect, and must still
+	// tell the agent not to regenerate or commit either generated
+	// file (cli-skills/pp-*/SKILL.md or registry.json) — the library
+	// no longer has an in-PR auto-fix path for either.
+	assert.Contains(t, skill, "Fail on changes to generated artifacts")
+	assert.Contains(t, skill, "Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` or")
 	assert.Contains(t, skill, "git add library/\ngit commit")
 	assert.NotContains(t, skill, "git add library/ cli-skills/")
 	assert.NotContains(t, skill, "git add library/ cli-skills/ registry.json")


### PR DESCRIPTION
## Summary

Updates `TestPublishSkillSkipsCliSkillsMirrorRegen` to match the publish skill's new gate-name references, so release-please PRs (which run the full test matrix) don't fail on this contract test.

## Why

The release-please PR ([#1495](https://github.com/mvanhorn/cli-printing-press/pull/1495)) failed on \`test (pipeline)\`:

```
--- FAIL: TestPublishSkillSkipsCliSkillsMirrorRegen
```

Root cause: #1614 updated the publish skill's prose to reference the new \`Fail on changes to generated artifacts\` gate from [mvanhorn/printing-press-library#659](https://github.com/mvanhorn/printing-press-library/pull/659). The contract test in \`internal/pipeline/contracts_test.go\` still asserted the old gate-name strings:

- `"Guard against hand-edits to cli-skills mirror"` — gate retired
- `"Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` here"` — wording now extended to cover both cli-skills and registry.json

#1614's CI passed because change-scoped test selection didn't include the pipeline shard (#1614 only touched `skills/`, not `internal/pipeline/`). The full-suite matrix that runs on release-please PRs caught the divergence on the next release prep.

## What's preserved

The test's intent is unchanged:
- Verify the publish skill names the current rejection mechanism (now \`Fail on changes to generated artifacts\`).
- Verify it tells agents not to regenerate or commit either generated file (the new wording covers both cli-skills and registry.json in one phrase).

All other assertions (negative guards against `go run ./tools/generate-skills/main.go`, `REGISTRY_HAS_ENTRY`, `git add library/ cli-skills/`, etc.) still hold against the current skill text — verified locally.

## Test plan

- [x] `go test ./internal/pipeline/ -run TestPublishSkillSkipsCliSkillsMirrorRegen -v` — passes locally.
- [ ] After merge: release-please PR re-runs CI green.

## Related

- Surfaced by: [#1495](https://github.com/mvanhorn/cli-printing-press/pull/1495) (release-please)
- Caused by: [#1614](https://github.com/mvanhorn/cli-printing-press/pull/1614) (publish skill prose update)
- Library-side gate change: [mvanhorn/printing-press-library#659](https://github.com/mvanhorn/printing-press-library/pull/659)