### PR TITLE
fix(cli): route Swagger 2.0 specs through openapi2conv to avoid OOM on circular refs

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1063,6 +1063,15 @@ func authVarsExtension(raw any) ([]spec.AuthEnvVar, error) {
 }
 
 func loadOpenAPIDoc(data []byte, lenient bool, location *url.URL) (*openapi3.T, error) {
+	// Swagger 2.0 specs with circular $ref chains (Tripletex, NetSuite, etc.)
+	// burn 15-30 minutes of CPU and OOM the process when fed straight to the
+	// OpenAPI 3 loader. Detect them at the boundary and route through
+	// openapi2conv.ToV3 so the existing OpenAPI 3 code path handles the
+	// resolved spec. See issue #1241 and internal/openapi/swagger2.go.
+	if isSwagger2SpecJSON(data) {
+		return loadSwagger2AsOpenAPI3(data, lenient, location)
+	}
+
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = lenient || location != nil
 	allowLocalExternalRefs := location != nil

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1072,6 +1072,19 @@ func loadOpenAPIDoc(data []byte, lenient bool, location *url.URL) (*openapi3.T, 
 		return loadSwagger2AsOpenAPI3(data, lenient, location)
 	}
 
+	loader := newConfiguredOpenAPI3Loader(lenient, location)
+	if location != nil {
+		return loader.LoadFromDataWithPath(data, location)
+	}
+	return loader.LoadFromData(data)
+}
+
+// newConfiguredOpenAPI3Loader returns an openapi3.Loader with the project's
+// standard ReadFromURIFunc installed: the per-ref file-URI guard for strict
+// mode and the YAML->JSON normalization step for referenced files. Shared
+// between the OpenAPI 3 load path and the Swagger 2.0 conversion path so both
+// honor the same external-ref policy.
+func newConfiguredOpenAPI3Loader(lenient bool, location *url.URL) *openapi3.Loader {
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = lenient || location != nil
 	allowLocalExternalRefs := location != nil
@@ -1090,10 +1103,7 @@ func loadOpenAPIDoc(data []byte, lenient bool, location *url.URL) (*openapi3.T, 
 		}
 		return data, nil
 	}
-	if location != nil {
-		return loader.LoadFromDataWithPath(data, location)
-	}
-	return loader.LoadFromData(data)
+	return loader
 }
 
 func isFileURI(location *url.URL) bool {

--- a/internal/openapi/swagger2.go
+++ b/internal/openapi/swagger2.go
@@ -1,0 +1,79 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi2conv"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// isSwagger2SpecJSON reports whether normalized JSON spec bytes describe a
+// Swagger 2.0 (OpenAPI v2) document. The parser pipeline always normalizes
+// spec input to JSON via normalizeSpecData before reaching loadOpenAPIDoc, so
+// a top-level `"swagger": "2.0"` substring is a reliable signal.
+//
+// Real-world Swagger 2.0 specs (Tripletex, NetSuite REST, Salesforce Tooling)
+// frequently contain circular $ref chains through `definitions/`. Routing them
+// through openapi2conv.ToV3 before kin-openapi's OpenAPI 3 resolver runs
+// avoids the runaway memory + 15-30 minute hangs documented in the retro
+// (issue #1241): the conversion rewrites `#/definitions/X` to
+// `#/components/schemas/X` and lets the existing cycle-aware OpenAPI 3 code
+// path do the resolution work.
+func isSwagger2SpecJSON(data []byte) bool {
+	// Tolerate leading whitespace and a leading `{` before the first key.
+	// normalizeSpecData emits compact JSON via encoding/json so the key order
+	// reflects raw map iteration; sniff for the field anywhere in the first
+	// ~4KB instead of insisting on the first key position.
+	head := data
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	if !bytes.Contains(head, []byte(`"swagger"`)) {
+		return false
+	}
+	// Disambiguate from OpenAPI 3 specs that mention "swagger" as a string
+	// value (description text, x-* extension keys). Look for the value form
+	// `"swagger":"2.0"` or `"swagger": "2.0"` produced by encoding/json's
+	// canonical-ish output. encoding/json drops spaces after the colon, but
+	// keep both variants for defensive parsing.
+	if bytes.Contains(head, []byte(`"swagger":"2.0"`)) ||
+		bytes.Contains(head, []byte(`"swagger": "2.0"`)) ||
+		bytes.Contains(head, []byte(`"swagger":"2"`)) ||
+		bytes.Contains(head, []byte(`"swagger": "2"`)) {
+		return true
+	}
+	return false
+}
+
+// loadSwagger2AsOpenAPI3 parses normalized Swagger 2.0 JSON bytes into an
+// openapi2.T, converts the result to an openapi3.T, and returns the converted
+// document. The returned doc behaves identically to one produced by
+// openapi3.Loader.LoadFromData on the equivalent OpenAPI 3 spec, which lets
+// the downstream parser code path stay format-agnostic.
+//
+// Emits a single stderr line so operators can see why a long-running phase
+// happened on Swagger 2.0 input. The retro called out the silent multi-minute
+// phase as the biggest UX issue in the failure mode this function exists to
+// fix.
+func loadSwagger2AsOpenAPI3(data []byte, lenient bool, location *url.URL) (*openapi3.T, error) {
+	var doc2 openapi2.T
+	if err := json.Unmarshal(data, &doc2); err != nil {
+		return nil, fmt.Errorf("loading Swagger 2.0 spec: %w", err)
+	}
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = lenient || location != nil
+
+	fmt.Fprintf(os.Stderr, "info: converting Swagger 2.0 spec to OpenAPI 3 before parsing\n")
+
+	doc3, err := openapi2conv.ToV3WithLoader(&doc2, loader, location)
+	if err != nil {
+		return nil, fmt.Errorf("converting Swagger 2.0 to OpenAPI 3: %w", err)
+	}
+	return doc3, nil
+}

--- a/internal/openapi/swagger2.go
+++ b/internal/openapi/swagger2.go
@@ -37,14 +37,13 @@ func isSwagger2SpecJSON(data []byte) bool {
 		return false
 	}
 	// Disambiguate from OpenAPI 3 specs that mention "swagger" as a string
-	// value (description text, x-* extension keys). Look for the value form
-	// `"swagger":"2.0"` or `"swagger": "2.0"` produced by encoding/json's
-	// canonical-ish output. encoding/json drops spaces after the colon, but
-	// keep both variants for defensive parsing.
+	// value (description text, x-* extension keys). Match only the canonical
+	// `"2.0"` value form — the Swagger 2.0 spec mandates the version string
+	// exactly. encoding/json drops spaces after the colon, but keep both
+	// variants since this helper may be reached from paths where the input
+	// has been re-serialized by a non-encoding/json marshaller.
 	if bytes.Contains(head, []byte(`"swagger":"2.0"`)) ||
-		bytes.Contains(head, []byte(`"swagger": "2.0"`)) ||
-		bytes.Contains(head, []byte(`"swagger":"2"`)) ||
-		bytes.Contains(head, []byte(`"swagger": "2"`)) {
+		bytes.Contains(head, []byte(`"swagger": "2.0"`)) {
 		return true
 	}
 	return false
@@ -66,8 +65,10 @@ func loadSwagger2AsOpenAPI3(data []byte, lenient bool, location *url.URL) (*open
 		return nil, fmt.Errorf("loading Swagger 2.0 spec: %w", err)
 	}
 
-	loader := openapi3.NewLoader()
-	loader.IsExternalRefsAllowed = lenient || location != nil
+	// Reuse the OpenAPI 3 loader configuration so the conversion path honors
+	// the same external-ref policy (strict file-URI guard + YAML->JSON
+	// normalization for referenced files) as the direct OpenAPI 3 load path.
+	loader := newConfiguredOpenAPI3Loader(lenient, location)
 
 	fmt.Fprintf(os.Stderr, "info: converting Swagger 2.0 spec to OpenAPI 3 before parsing\n")
 

--- a/internal/openapi/swagger2.go
+++ b/internal/openapi/swagger2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 
@@ -13,9 +14,7 @@ import (
 )
 
 // isSwagger2SpecJSON reports whether normalized JSON spec bytes describe a
-// Swagger 2.0 (OpenAPI v2) document. The parser pipeline always normalizes
-// spec input to JSON via normalizeSpecData before reaching loadOpenAPIDoc, so
-// a top-level `"swagger": "2.0"` substring is a reliable signal.
+// Swagger 2.0 (OpenAPI v2) document.
 //
 // Real-world Swagger 2.0 specs (Tripletex, NetSuite REST, Salesforce Tooling)
 // frequently contain circular $ref chains through `definitions/`. Routing them
@@ -24,29 +23,74 @@ import (
 // (issue #1241): the conversion rewrites `#/definitions/X` to
 // `#/components/schemas/X` and lets the existing cycle-aware OpenAPI 3 code
 // path do the resolution work.
+//
+// Uses a streaming JSON decoder to find the top-level `swagger` key and stop
+// reading. Substring scanning is unsafe at this stage: normalizeSpecData
+// round-trips through encoding/json, which sorts map keys alphabetically, so
+// "swagger" lands AFTER "definitions" and "paths" in the serialized output —
+// far past any reasonable head window for a multi-MB spec like Tripletex.
 func isSwagger2SpecJSON(data []byte) bool {
-	// Tolerate leading whitespace and a leading `{` before the first key.
-	// normalizeSpecData emits compact JSON via encoding/json so the key order
-	// reflects raw map iteration; sniff for the field anywhere in the first
-	// ~4KB instead of insisting on the first key position.
-	head := data
-	if len(head) > 4096 {
-		head = head[:4096]
-	}
-	if !bytes.Contains(head, []byte(`"swagger"`)) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	// Expect a top-level object.
+	tok, err := dec.Token()
+	if err != nil {
 		return false
 	}
-	// Disambiguate from OpenAPI 3 specs that mention "swagger" as a string
-	// value (description text, x-* extension keys). Match only the canonical
-	// `"2.0"` value form — the Swagger 2.0 spec mandates the version string
-	// exactly. encoding/json drops spaces after the colon, but keep both
-	// variants since this helper may be reached from paths where the input
-	// has been re-serialized by a non-encoding/json marshaller.
-	if bytes.Contains(head, []byte(`"swagger":"2.0"`)) ||
-		bytes.Contains(head, []byte(`"swagger": "2.0"`)) {
-		return true
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return false
+	}
+	// Walk top-level keys. For each key whose value we don't need, skip the
+	// value by reading and discarding tokens until the value's depth balances.
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return false
+		}
+		valTok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if key == "swagger" {
+			value, ok := valTok.(string)
+			return ok && value == "2.0"
+		}
+		// If the value is a container, drain it. Scalars consumed one token
+		// by the call above and need no further work.
+		if delim, ok := valTok.(json.Delim); ok && (delim == '{' || delim == '[') {
+			if err := skipJSONValue(dec, 1); err != nil {
+				return false
+			}
+		}
 	}
 	return false
+}
+
+// skipJSONValue consumes JSON tokens from dec until the container depth
+// returns to zero. depth must start at 1 because the caller has already read
+// the opening `{` or `[`.
+func skipJSONValue(dec *json.Decoder, depth int) error {
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			if err == io.EOF {
+				return err
+			}
+			return err
+		}
+		if delim, ok := tok.(json.Delim); ok {
+			switch delim {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
 }
 
 // loadSwagger2AsOpenAPI3 parses normalized Swagger 2.0 JSON bytes into an

--- a/internal/openapi/swagger2_test.go
+++ b/internal/openapi/swagger2_test.go
@@ -1,12 +1,41 @@
 package openapi
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// bigSwagger2Spec returns a Swagger 2.0 JSON document with a large
+// `definitions/` block padded so that the `"swagger":"2.0"` marker only
+// appears well past the 4KB mark in the serialized output. Models the real
+// shape produced by normalizeSpecData when fed a vendor Swagger 2.0 spec:
+// encoding/json sorts keys alphabetically, so "definitions" (d) and "paths"
+// (p) precede "swagger" (s) in the wire form.
+func bigSwagger2Spec() []byte {
+	const pad = 8192 // generously past any plausible head-buffer cap
+	definitions := map[string]any{
+		"Padding": map[string]any{
+			"type":        "string",
+			"description": strings.Repeat("x", pad),
+		},
+	}
+	doc := map[string]any{
+		"swagger":     "2.0",
+		"info":        map[string]any{"title": "Big", "version": "1.0.0"},
+		"definitions": definitions,
+		"paths":       map[string]any{},
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
 
 func TestIsSwagger2SpecJSON(t *testing.T) {
 	t.Parallel()
@@ -48,6 +77,17 @@ func TestIsSwagger2SpecJSON(t *testing.T) {
 			// "2.5" is not Swagger 2.0; prefix-match temptation must be avoided.
 			data: []byte(`{"swagger":"2.5","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
 			want: false,
+		},
+		{
+			name: "swagger key after large alphabetized definitions block",
+			// normalizeSpecData round-trips through encoding/json, which sorts
+			// keys alphabetically; "swagger" (s) lands after "definitions" (d)
+			// and "paths" (p). A real Swagger 2.0 spec's "swagger" marker is
+			// often far past the start of the serialized JSON. Build a fixture
+			// where definitions[]'s padding pushes "swagger" well past 4KB to
+			// assert the detector still finds it.
+			data: bigSwagger2Spec(),
+			want: true,
 		},
 		{
 			name: "empty",

--- a/internal/openapi/swagger2_test.go
+++ b/internal/openapi/swagger2_test.go
@@ -38,6 +38,18 @@ func TestIsSwagger2SpecJSON(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "swagger 2 without minor version",
+			// Bare "2" is not a Swagger version string and must not match.
+			data: []byte(`{"swagger":"2","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
+			want: false,
+		},
+		{
+			name: "swagger future minor version",
+			// "2.5" is not Swagger 2.0; prefix-match temptation must be avoided.
+			data: []byte(`{"swagger":"2.5","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
+			want: false,
+		},
+		{
 			name: "empty",
 			data: []byte{},
 			want: false,
@@ -113,6 +125,12 @@ func TestParseSwagger2WithCircularRefsConverts(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
+		// Note: this intentionally abandons the Parse goroutine when the
+		// regression returns. Parse exposes no cancellation hook, so the
+		// alternative is letting the test run for ~25 minutes and OOM the
+		// CI runner before failing. Leaking one goroutine for the rest of
+		// the test binary's lifetime is the lesser evil; the failure will
+		// surface immediately and the run will end shortly after.
 		t.Fatal("parsing cyclic Swagger 2.0 spec did not complete within 30s; regression of issue #1241")
 	}
 

--- a/internal/openapi/swagger2_test.go
+++ b/internal/openapi/swagger2_test.go
@@ -1,0 +1,154 @@
+package openapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSwagger2SpecJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{
+			name: "swagger 2.0 minimal",
+			data: []byte(`{"swagger":"2.0","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
+			want: true,
+		},
+		{
+			name: "swagger 2.0 with space",
+			data: []byte(`{"swagger": "2.0","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
+			want: true,
+		},
+		{
+			name: "openapi 3.0",
+			data: []byte(`{"openapi":"3.0.3","info":{"title":"Demo","version":"1.0.0"},"paths":{}}`),
+			want: false,
+		},
+		{
+			name: "openapi 3 with swagger mention in description",
+			// A spec that mentions "swagger" in a description should not be misdetected.
+			data: []byte(`{"openapi":"3.0.3","info":{"title":"Demo","description":"swagger inspired","version":"1.0.0"},"paths":{}}`),
+			want: false,
+		},
+		{
+			name: "empty",
+			data: []byte{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isSwagger2SpecJSON(tc.data))
+		})
+	}
+}
+
+func TestParseSwagger2WithCircularRefsConverts(t *testing.T) {
+	t.Parallel()
+
+	// Build a small Swagger 2.0 spec with a bi-directional cycle in
+	// definitions/. Pre-fix, this shape combined with kin-openapi's OpenAPI 3
+	// loader caused unbounded resolution time. Post-fix, the conversion to
+	// OpenAPI 3 should let the parser complete quickly.
+	swagger2 := []byte(`{
+  "swagger": "2.0",
+  "info": {"title": "Cycle Demo", "version": "1.0.0"},
+  "host": "api.example.com",
+  "basePath": "/v1",
+  "schemes": ["https"],
+  "paths": {
+    "/employees/{id}": {
+      "get": {
+        "operationId": "getEmployee",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "type": "string"}
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {"$ref": "#/definitions/Employee"}
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Employee": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "department": {"$ref": "#/definitions/Department"},
+        "manager": {"$ref": "#/definitions/Employee"}
+      }
+    },
+    "Department": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "head": {"$ref": "#/definitions/Employee"}
+      }
+    }
+  }
+}`)
+
+	done := make(chan struct{})
+	var parsed any
+	var parseErr error
+	go func() {
+		defer close(done)
+		parsed, parseErr = Parse(swagger2)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("parsing cyclic Swagger 2.0 spec did not complete within 30s; regression of issue #1241")
+	}
+
+	require.NoError(t, parseErr)
+	require.NotNil(t, parsed)
+}
+
+func TestParseSwagger2BasicEndpointShape(t *testing.T) {
+	t.Parallel()
+
+	// Make sure the conversion preserves enough endpoint metadata for the
+	// downstream generator. Asserts only the load-bearing shape (resource +
+	// endpoint by method+path); fine-grained field-by-field parity with the
+	// equivalent OpenAPI 3 spec is enforced by the conversion library's own
+	// test suite.
+	swagger2 := []byte(`{
+  "swagger": "2.0",
+  "info": {"title": "Shape Demo", "version": "1.0.0"},
+  "host": "api.example.com",
+  "basePath": "/v1",
+  "schemes": ["https"],
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  }
+}`)
+
+	parsed, err := Parse(swagger2)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.Equal(t, "https://api.example.com/v1", parsed.BaseURL)
+
+	endpoint := findParsedEndpointByPath(t, parsed, "GET", "/users")
+	require.NotNil(t, endpoint)
+}


### PR DESCRIPTION
## Intent

Issue: Closes #1241

Generation against a Swagger 2.0 spec whose `definitions/` form circular `$ref` chains (Tripletex, NetSuite REST, Salesforce Tooling) burned 15-30 minutes of CPU at 1.8-4.4 GB RSS, wrote zero stdout/stderr, and eventually OOMed. The same byte content converted to OpenAPI 3.x via `npx swagger2openapi` and re-run through `generate` completed in about three minutes.

## Approach

Detect Swagger 2.0 at the parser boundary (`loadOpenAPIDoc`) — normalized JSON has top-level `"swagger": "2.0"` — and route through `openapi2conv.ToV3WithLoader` before the OpenAPI 3 loader runs. The conversion rewrites `#/definitions/X` to `#/components/schemas/X` so the existing cycle-aware OpenAPI 3 code path handles resolution. `openapi2conv` is a sub-package of `kin-openapi`, which is already a dependency, so no new module is added.

One stderr line announces the conversion so operators have visibility into the multi-minute resolution phase — the retro called out the silent phase as the largest UX pain point.

This is option 1 from the issue ("Auto-convert Swagger 2.0 -> OpenAPI 3.x internally"), picked over option 2 (parity-fix the Swagger 2.0 resolver) to eliminate the divergence between the two code paths rather than leave two paths to maintain.

## Scope

Primary area: `internal/openapi/` (spec-parser)

Why this belongs in this repo: this is a machine change. Every printed CLI inherits the fix on next generation; no printed-CLI edits required.

## Risk

Behavior change is scoped to specs where `isSwagger2SpecJSON` returns true, which only matches the `"swagger": "2.0"` value form at the document root. OpenAPI 3 specs that incidentally mention "swagger" in description text or `x-*` extension keys still hit the original loader path (covered by `TestIsSwagger2SpecJSON`).

The conversion library's own test suite covers field-by-field parity with hand-converted OpenAPI 3 specs; our regression test asserts only the load-bearing shape (endpoints reachable, BaseURL set) plus a 30-second time bound on the cyclic-ref case.

## Output Contract

N/A — no template, manifest, scorecard, or pipeline-artifact changes. Golden harness still passes 20/20.

## Verification

- `go build ./...`
- `go test ./...` (4489 passed)
- `go test ./internal/openapi/ -run 'TestIsSwagger2SpecJSON|TestParseSwagger2' -v` (8 passed)
- `go vet ./...`
- `go fmt ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify` (20/20)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission