### PR TITLE
fix(cli): detect path params in browser-sniff URL grouper

### DIFF
--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -561,7 +561,7 @@ func DeduplicateTrafficEndpoints(entries []EnrichedEntry) []EndpointGroup {
 		})
 	}
 
-	return groups
+	return collapseVariantGroups(groups)
 }
 
 func classifyInCaptureOrder(entries []EnrichedEntry, apiEntries []EnrichedEntry, noiseEntries []EnrichedEntry) []EnrichedEntry {

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -555,6 +555,7 @@ func DeduplicateTrafficEndpoints(entries []EnrichedEntry) []EndpointGroup {
 
 		indexByKey[key] = len(groups)
 		groups = append(groups, EndpointGroup{
+			Host:           host,
 			Method:         method,
 			NormalizedPath: normalizedPath,
 			Entries:        []EnrichedEntry{entry},

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -380,15 +380,28 @@ func normalizeEntryPath(rawURL string) string {
 // emit a second {resource_id} — instead it becomes {resource_id_2}. This keeps
 // downstream spec generation safe: OpenAPI rejects duplicate path-parameter
 // names within a single path template.
+//
+// The `used` map tracks every concrete placeholder string already emitted in
+// the current path (including suffixed variants). The walk advances the
+// counter as long as the candidate name collides, so chains like
+// {resource_id}/{resource_id_2}/{resource_id_3} stay unique even when the
+// variance pass populates `used` from a path the per-segment normalizer
+// already disambiguated.
 func disambiguatePlaceholder(placeholder string, used map[string]int) string {
-	used[placeholder]++
-	count := used[placeholder]
-	if count == 1 {
+	if used[placeholder] == 0 {
+		used[placeholder] = 1
 		return placeholder
 	}
-	// Strip the surrounding braces, append the counter, and re-wrap.
 	inner := strings.TrimSuffix(strings.TrimPrefix(placeholder, "{"), "}")
-	return "{" + inner + "_" + strconv.Itoa(count) + "}"
+	// Find the next free suffix. Start at 2 (the first collision becomes _2)
+	// and advance until the candidate isn't already in `used`.
+	for n := 2; ; n++ {
+		candidate := "{" + inner + "_" + strconv.Itoa(n) + "}"
+		if used[candidate] == 0 {
+			used[candidate] = 1
+			return candidate
+		}
+	}
 }
 
 // previousMeaningfulSegment walks backwards from index i looking for a segment

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -16,13 +17,30 @@ type EndpointGroup struct {
 }
 
 var (
-	uuidSegmentPattern  = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
-	hashSegmentPattern  = regexp.MustCompile(`(?i)^[0-9a-f]{32,}$`)
-	numericPattern      = regexp.MustCompile(`^\d+$`)
-	blocklistMu         sync.RWMutex
-	additionalBlocklist []string
-	includeListMu       sync.RWMutex
-	additionalInclude   []string
+	uuidSegmentPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	hashSegmentPattern = regexp.MustCompile(`(?i)^[0-9a-f]{32,}$`)
+	numericPattern     = regexp.MustCompile(`^\d+$`)
+	// prefixedIDPattern matches application-issued IDs that ship a short
+	// type-prefix and a long alphanumeric tail, such as Clay's t_/r_/c_, Stripe's
+	// cus_/sub_, or OpenAI's run_/asst_. The tail floor of 8 chars keeps short
+	// literal segments like "v1" or two-letter language codes from matching.
+	prefixedIDPattern = regexp.MustCompile(`^[a-z]{1,5}_[A-Za-z0-9]{8,}$`)
+	// longAlnumIDPattern matches opaque application IDs without separators that
+	// are long enough and mixed enough to be implausible as literal route names:
+	// nanoid (21 chars), ULID (26 chars), short base62 IDs like OpenArt's
+	// `Zu2uNCmGDnmNCel8gbFQ` (20 chars). The mixed-case-or-digit floor below
+	// rules out long lowercase words (e.g. "subscriptions", "notifications").
+	longAlnumIDPattern = regexp.MustCompile(`^[A-Za-z0-9]{20,}$`)
+	// colonCompositePattern matches IDs that carry an embedded type discriminator
+	// via colon segments, like OpenArt form_ids
+	// (`create-image:reference:gpt-image-2`) or Stripe price tier IDs. Requires
+	// at least two colons total so simple key:value or port-style values
+	// (e.g. `host:80`) don't get pulled in as composite IDs.
+	colonCompositePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+:[A-Za-z0-9._-]+:[A-Za-z0-9._:-]+$`)
+	blocklistMu           sync.RWMutex
+	additionalBlocklist   []string
+	includeListMu         sync.RWMutex
+	additionalInclude     []string
 )
 
 func ClassifyEntries(entries []EnrichedEntry) (api []EnrichedEntry, noise []EnrichedEntry) {
@@ -161,7 +179,7 @@ func DeduplicateEndpoints(entries []EnrichedEntry) []EndpointGroup {
 		})
 	}
 
-	return groups
+	return collapseVariantGroups(groups)
 }
 
 func scoreEntry(entry EnrichedEntry, blocklist []string, include []string) int {
@@ -309,13 +327,25 @@ func normalizeEntryPath(rawURL string) string {
 	path := extractPath(rawURL)
 	segments := strings.Split(path, "/")
 	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+		// Skip framing segments (api, /v1) so the placeholder name reflects the
+		// resource the ID belongs to, not the version prefix.
+		parent := previousMeaningfulSegment(segments, i)
 		switch {
 		case numericPattern.MatchString(segment):
-			segments[i] = "{id}"
+			segments[i] = idPlaceholder(parent, "id")
 		case uuidSegmentPattern.MatchString(segment):
-			segments[i] = "{uuid}"
+			segments[i] = idPlaceholder(parent, "uuid")
 		case hashSegmentPattern.MatchString(segment):
-			segments[i] = "{hash}"
+			segments[i] = idPlaceholder(parent, "hash")
+		case prefixedIDPattern.MatchString(segment):
+			segments[i] = idPlaceholder(parent, "id")
+		case colonCompositePattern.MatchString(segment) && hasNonTrivialToken(segment):
+			segments[i] = idPlaceholder(parent, "id")
+		case longAlnumIDPattern.MatchString(segment) && looksOpaqueID(segment):
+			segments[i] = idPlaceholder(parent, "id")
 		}
 	}
 
@@ -325,4 +355,288 @@ func normalizeEntryPath(rawURL string) string {
 	}
 
 	return normalized
+}
+
+// previousMeaningfulSegment walks backwards from index i looking for a segment
+// that isn't empty, a placeholder, or a routing framing segment (api, vN). The
+// placeholder name (table_id, widget_id) reflects the resource the ID belongs
+// to, not the version prefix it happens to live under.
+func previousMeaningfulSegment(segments []string, i int) string {
+	for j := i - 1; j >= 0; j-- {
+		s := segments[j]
+		if s == "" {
+			continue
+		}
+		if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+			continue
+		}
+		if s == "api" || isVersionSegment(s) {
+			continue
+		}
+		return s
+	}
+	return ""
+}
+
+// isVersionSegment is the local mirror of discovery.isVersionSegment kept here
+// to avoid a package import cycle through the discovery package's spec import.
+func isVersionSegment(segment string) bool {
+	if len(segment) < 2 || segment[0] != 'v' {
+		return false
+	}
+	for _, r := range segment[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// idPlaceholder returns "{parent_id}" when parent is a useful resource segment
+// (drops trailing 's', forces snake_case), falling back to "{fallback}" when
+// the parent is empty or not safely Go-identifier shaped.
+func idPlaceholder(parent string, fallback string) string {
+	name := placeholderNameFromParent(parent)
+	if name == "" {
+		return "{" + fallback + "}"
+	}
+	return "{" + name + "_id}"
+}
+
+func placeholderNameFromParent(parent string) string {
+	parent = strings.TrimSpace(parent)
+	if parent == "" {
+		return ""
+	}
+	// Normalize to snake_case so "user-groups" -> "user_group_id" and an
+	// already-singular parent like "user" stays "user_id". Reject parents that
+	// aren't safely shaped as a Go identifier root (e.g. all-digit, empty).
+	lower := strings.ToLower(parent)
+	lower = strings.ReplaceAll(lower, "-", "_")
+	for _, r := range lower {
+		if r == '_' {
+			continue
+		}
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		return ""
+	}
+	// Drop a trailing 's' on plurals; keep "status"/"address" intact via simple
+	// "ss" guard. Mirrors the conservative singularizer used elsewhere; complex
+	// irregulars (entries -> entry) are left to downstream tooling that owns
+	// command naming.
+	if strings.HasSuffix(lower, "ies") && len(lower) > 3 {
+		lower = lower[:len(lower)-3] + "y"
+	} else if strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") && len(lower) > 1 {
+		lower = lower[:len(lower)-1]
+	}
+	return lower
+}
+
+// hasNonTrivialToken guards colon-composite detection: at least one
+// colon-separated token must have 3+ chars so plain port-style values like
+// "host:80" aren't mistaken for composite IDs.
+func hasNonTrivialToken(segment string) bool {
+	for token := range strings.SplitSeq(segment, ":") {
+		if len(token) >= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeIDShape returns true when a segment matches any of the strong ID
+// heuristics (UUID, hex hash, numeric, prefixed application id, colon
+// composite, or long opaque alphanumeric). Used by the cross-entry variance
+// pass to gate parametrization: two route literals that just happen to differ
+// (e.g. /api/health vs /api/version) won't be flagged because neither
+// segment fits any of these shapes.
+func looksLikeIDShape(segment string) bool {
+	if numericPattern.MatchString(segment) {
+		return true
+	}
+	if uuidSegmentPattern.MatchString(segment) {
+		return true
+	}
+	if hashSegmentPattern.MatchString(segment) {
+		return true
+	}
+	if prefixedIDPattern.MatchString(segment) {
+		return true
+	}
+	if colonCompositePattern.MatchString(segment) && hasNonTrivialToken(segment) {
+		return true
+	}
+	if longAlnumIDPattern.MatchString(segment) && looksOpaqueID(segment) {
+		return true
+	}
+	return false
+}
+
+// looksOpaqueID applies the mixed-case-or-digit floor for the long-alphanumeric
+// shape so route literals like "subscriptions" (all-lowercase, no digits) aren't
+// flagged. A long segment carrying any digit, or mixing case, is treated as an
+// opaque application ID.
+func looksOpaqueID(segment string) bool {
+	hasDigit := false
+	hasUpper := false
+	hasLower := false
+	for _, r := range segment {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		}
+	}
+	return hasDigit || (hasUpper && hasLower)
+}
+
+// collapseVariantGroups folds endpoint groups whose paths differ in exactly
+// one segment into a single parameterized group. Two HAR captures of
+// /widgets/abc-a and /widgets/abc-b produce two raw groups; the variance pass
+// detects they share the same method and identical path prefix/suffix, and
+// merges them into /widgets/{widget_id}. Only runs when neither path already
+// carries a placeholder at the diverging segment (preserves explicit hits from
+// the per-segment normalizer).
+func collapseVariantGroups(groups []EndpointGroup) []EndpointGroup {
+	if len(groups) < 2 {
+		return groups
+	}
+
+	// Bucket by (method, segment count, positions of existing placeholders) so
+	// only same-shape paths can collapse together. Group all candidates that
+	// share the same skeleton and differ in literal positions; for each
+	// position with >=2 distinct literals across the bucket, promote it.
+	type skeletonKey struct {
+		method      string
+		length      int
+		placeholder string // bitmask of positions already holding placeholders
+	}
+	buckets := make(map[skeletonKey][]int)
+	skeletons := make(map[int][]string)
+	for idx, group := range groups {
+		segments := strings.Split(group.NormalizedPath, "/")
+		skeletons[idx] = segments
+		var placeholderMask strings.Builder
+		for _, s := range segments {
+			if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+				placeholderMask.WriteByte('1')
+			} else {
+				placeholderMask.WriteByte('0')
+			}
+		}
+		key := skeletonKey{
+			method:      group.Method,
+			length:      len(segments),
+			placeholder: placeholderMask.String(),
+		}
+		buckets[key] = append(buckets[key], idx)
+	}
+
+	// Map from group index to merge-target index. Targets stay; non-targets get
+	// merged into the target and dropped from output.
+	mergeInto := make(map[int]int)
+
+	for _, members := range buckets {
+		if len(members) < 2 {
+			continue
+		}
+		segLen := len(skeletons[members[0]])
+
+		// Find positions that vary across the bucket. We only promote one
+		// position per bucket pass; if multiple positions vary, the paths are
+		// genuinely different resources and shouldn't collapse.
+		varyingPositions := make([]int, 0)
+		for pos := range segLen {
+			seen := make(map[string]struct{})
+			for _, idx := range members {
+				seen[skeletons[idx][pos]] = struct{}{}
+				if len(seen) > 1 {
+					break
+				}
+			}
+			if len(seen) > 1 {
+				varyingPositions = append(varyingPositions, pos)
+			}
+		}
+		if len(varyingPositions) != 1 {
+			continue
+		}
+		pos := varyingPositions[0]
+
+		// The diverging segment must look like a parameter candidate at every
+		// member: not a placeholder (filtered already), not a routing keyword.
+		// Conservative: require at least one member's value to match one of the
+		// strong ID heuristics. Cross-entry variance alone (two literals at the
+		// same position) isn't enough to parametrize, because two distinct route
+		// names (e.g. /api/health vs /api/version) also vary without being IDs.
+		anyOpaque := false
+		for _, idx := range members {
+			s := skeletons[idx][pos]
+			if s == "" || s == "api" || isVersionSegment(s) {
+				continue
+			}
+			if looksLikeIDShape(s) {
+				anyOpaque = true
+				break
+			}
+		}
+		if !anyOpaque {
+			continue
+		}
+
+		// Pick the lowest-index member as the merge target and rewrite its
+		// path. Other members fold into it.
+		target := members[0]
+		for _, idx := range members[1:] {
+			if idx < target {
+				target = idx
+			}
+		}
+		parent := previousMeaningfulSegment(skeletons[target], pos)
+		placeholder := idPlaceholder(parent, "id")
+		newSegments := append([]string(nil), skeletons[target]...)
+		newSegments[pos] = placeholder
+		groups[target].NormalizedPath = strings.Join(newSegments, "/")
+
+		for _, idx := range members {
+			if idx == target {
+				continue
+			}
+			mergeInto[idx] = target
+		}
+	}
+
+	if len(mergeInto) == 0 {
+		return groups
+	}
+
+	// Two-pass to keep the merge order deterministic: first fold every merged
+	// group's Entries into its target in source-index order (map iteration is
+	// random and would scramble Entries between runs), then emit survivors in
+	// original order.
+	sourceIdxs := make([]int, 0, len(mergeInto))
+	for idx := range mergeInto {
+		sourceIdxs = append(sourceIdxs, idx)
+	}
+	sort.Ints(sourceIdxs)
+	for _, idx := range sourceIdxs {
+		target := mergeInto[idx]
+		groups[target].Entries = append(groups[target].Entries, groups[idx].Entries...)
+	}
+	out := make([]EndpointGroup, 0, len(groups)-len(mergeInto))
+	for idx := range groups {
+		if _, merged := mergeInto[idx]; merged {
+			continue
+		}
+		out = append(out, groups[idx])
+	}
+	return out
 }

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -12,6 +12,13 @@ import (
 )
 
 type EndpointGroup struct {
+	// Host is the originating URL host for this group (lowercased), set by
+	// host-aware dedup paths like DeduplicateTrafficEndpoints. Empty when the
+	// caller doesn't care about host separation (DeduplicateEndpoints flattens
+	// across hosts). The cross-entry variance pass keys on this field so two
+	// groups sharing method/path-shape but coming from different hosts stay
+	// separate.
+	Host           string
 	Method         string
 	NormalizedPath string
 	Entries        []EnrichedEntry
@@ -572,11 +579,13 @@ func collapseVariantGroups(groups []EndpointGroup) []EndpointGroup {
 		return groups
 	}
 
-	// Bucket by (method, segment count, positions of existing placeholders) so
-	// only same-shape paths can collapse together. Group all candidates that
-	// share the same skeleton and differ in literal positions; for each
-	// position with >=2 distinct literals across the bucket, promote it.
+	// Bucket by (host, method, segment count, positions of existing
+	// placeholders) so only same-shape paths from the same host can collapse
+	// together. Two groups from different hosts must stay separate even when
+	// their path shapes coincide — DeduplicateTrafficEndpoints keys by host
+	// upstream, and the variance pass must preserve that separation.
 	type skeletonKey struct {
+		host        string
 		method      string
 		length      int
 		placeholder string // bitmask of positions already holding placeholders
@@ -595,6 +604,7 @@ func collapseVariantGroups(groups []EndpointGroup) []EndpointGroup {
 			}
 		}
 		key := skeletonKey{
+			host:        group.Host,
 			method:      group.Method,
 			length:      len(segments),
 			placeholder: placeholderMask.String(),
@@ -672,7 +682,19 @@ func collapseVariantGroups(groups []EndpointGroup) []EndpointGroup {
 		parent := previousMeaningfulSegment(skeletons[target], pos)
 		placeholder := idPlaceholder(parent, "id")
 		newSegments := append([]string(nil), skeletons[target]...)
-		newSegments[pos] = placeholder
+		// Build the in-path placeholder use count from the existing segments so
+		// the variance-pass emission disambiguates against placeholders the
+		// per-segment normalizer already placed. Without this, a path like
+		// /resources/{resource_id}/AbcDef would have its variance position
+		// resolved by walking back through the existing {resource_id} to find
+		// `resources` again, producing a duplicate `{resource_id}`.
+		used := make(map[string]int)
+		for _, s := range newSegments {
+			if strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}") {
+				used[s]++
+			}
+		}
+		newSegments[pos] = disambiguatePlaceholder(placeholder, used)
 		groups[target].NormalizedPath = strings.Join(newSegments, "/")
 
 		for _, idx := range members {

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -513,35 +513,27 @@ func looksLikeIDShape(segment string) bool {
 // looksParameterizable is the weaker gate used by the cross-entry variance
 // pass. By construction, any segment that satisfies looksLikeIDShape would
 // already have been replaced by normalizeEntryPath, so gating on that shape
-// alone makes the variance pass unreachable. The pass exists to catch IDs the
-// per-segment patterns can't classify in isolation — short opaque tokens like
-// `abc123` or `xyz456` that only stand out as IDs when two entries land at the
-// same position with different literal values. A weaker "data-shaped" check
-// (digit present, or mixed case, or hyphen-with-digit, or underscore-with-
-// alnum) catches these without flagging legitimate route literals like
-// `health`, `version`, or `users`.
+// alone makes the variance pass unreachable. The pass exists to catch IDs
+// that the per-segment patterns can't classify in isolation — short opaque
+// tokens like `abc123` or `xyz456` that only stand out as IDs when two
+// entries land at the same position with different literal values.
+//
+// The widening is deliberately narrow: presence of a digit. Pure mixed-case
+// alone (`hasUpper && hasLower`) is not enough — PascalCase is a normal
+// shape for action-style REST routes (`/api/CreateDocument` vs
+// `/api/ListDocuments`, common in ASP.NET / gRPC-HTTP transcoding), and a
+// pure-letter mixed-case check would merge those into `/api/{id}`. The
+// short-opaque IDs the variance pass exists to catch all carry at least one
+// digit; the rare digit-free opaque ID is left for users to parametrize
+// manually rather than risk destroying real route names.
 func looksParameterizable(segment string) bool {
 	if looksLikeIDShape(segment) {
 		return true
 	}
-	hasDigit := false
-	hasUpper := false
-	hasLower := false
 	for _, r := range segment {
-		switch {
-		case r >= '0' && r <= '9':
-			hasDigit = true
-		case r >= 'A' && r <= 'Z':
-			hasUpper = true
-		case r >= 'a' && r <= 'z':
-			hasLower = true
+		if r >= '0' && r <= '9' {
+			return true
 		}
-	}
-	if hasDigit {
-		return true
-	}
-	if hasUpper && hasLower {
-		return true
 	}
 	return false
 }

--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -326,6 +327,10 @@ func extractPath(rawURL string) string {
 func normalizeEntryPath(rawURL string) string {
 	path := extractPath(rawURL)
 	segments := strings.Split(path, "/")
+	// Track per-path placeholder name use so consecutive IDs that resolve to
+	// the same parent (e.g. /resources/123/456) don't both emit
+	// {resource_id}; the second collision gets a counter suffix.
+	nameCounts := make(map[string]int)
 	for i, segment := range segments {
 		if segment == "" {
 			continue
@@ -333,20 +338,24 @@ func normalizeEntryPath(rawURL string) string {
 		// Skip framing segments (api, /v1) so the placeholder name reflects the
 		// resource the ID belongs to, not the version prefix.
 		parent := previousMeaningfulSegment(segments, i)
+		var placeholder string
 		switch {
 		case numericPattern.MatchString(segment):
-			segments[i] = idPlaceholder(parent, "id")
+			placeholder = idPlaceholder(parent, "id")
 		case uuidSegmentPattern.MatchString(segment):
-			segments[i] = idPlaceholder(parent, "uuid")
+			placeholder = idPlaceholder(parent, "uuid")
 		case hashSegmentPattern.MatchString(segment):
-			segments[i] = idPlaceholder(parent, "hash")
+			placeholder = idPlaceholder(parent, "hash")
 		case prefixedIDPattern.MatchString(segment):
-			segments[i] = idPlaceholder(parent, "id")
+			placeholder = idPlaceholder(parent, "id")
 		case colonCompositePattern.MatchString(segment) && hasNonTrivialToken(segment):
-			segments[i] = idPlaceholder(parent, "id")
+			placeholder = idPlaceholder(parent, "id")
 		case longAlnumIDPattern.MatchString(segment) && looksOpaqueID(segment):
-			segments[i] = idPlaceholder(parent, "id")
+			placeholder = idPlaceholder(parent, "id")
+		default:
+			continue
 		}
+		segments[i] = disambiguatePlaceholder(placeholder, nameCounts)
 	}
 
 	normalized := strings.Join(segments, "/")
@@ -355,6 +364,24 @@ func normalizeEntryPath(rawURL string) string {
 	}
 
 	return normalized
+}
+
+// disambiguatePlaceholder appends a counter suffix when the same placeholder
+// name has already appeared earlier in the current path. For
+// /resources/123/456 the first segment yields {resource_id}; the second walks
+// back past the freshly-emitted placeholder, sees `resources` again, and would
+// emit a second {resource_id} — instead it becomes {resource_id_2}. This keeps
+// downstream spec generation safe: OpenAPI rejects duplicate path-parameter
+// names within a single path template.
+func disambiguatePlaceholder(placeholder string, used map[string]int) string {
+	used[placeholder]++
+	count := used[placeholder]
+	if count == 1 {
+		return placeholder
+	}
+	// Strip the surrounding braces, append the counter, and re-wrap.
+	inner := strings.TrimSuffix(strings.TrimPrefix(placeholder, "{"), "}")
+	return "{" + inner + "_" + strconv.Itoa(count) + "}"
 }
 
 // previousMeaningfulSegment walks backwards from index i looking for a segment
@@ -451,10 +478,9 @@ func hasNonTrivialToken(segment string) bool {
 
 // looksLikeIDShape returns true when a segment matches any of the strong ID
 // heuristics (UUID, hex hash, numeric, prefixed application id, colon
-// composite, or long opaque alphanumeric). Used by the cross-entry variance
-// pass to gate parametrization: two route literals that just happen to differ
-// (e.g. /api/health vs /api/version) won't be flagged because neither
-// segment fits any of these shapes.
+// composite, or long opaque alphanumeric). These are the same shapes the
+// per-segment normalizer recognizes; kept as a named helper so future variance
+// callers can ask the question without inlining the regex list.
 func looksLikeIDShape(segment string) bool {
 	if numericPattern.MatchString(segment) {
 		return true
@@ -472,6 +498,42 @@ func looksLikeIDShape(segment string) bool {
 		return true
 	}
 	if longAlnumIDPattern.MatchString(segment) && looksOpaqueID(segment) {
+		return true
+	}
+	return false
+}
+
+// looksParameterizable is the weaker gate used by the cross-entry variance
+// pass. By construction, any segment that satisfies looksLikeIDShape would
+// already have been replaced by normalizeEntryPath, so gating on that shape
+// alone makes the variance pass unreachable. The pass exists to catch IDs the
+// per-segment patterns can't classify in isolation — short opaque tokens like
+// `abc123` or `xyz456` that only stand out as IDs when two entries land at the
+// same position with different literal values. A weaker "data-shaped" check
+// (digit present, or mixed case, or hyphen-with-digit, or underscore-with-
+// alnum) catches these without flagging legitimate route literals like
+// `health`, `version`, or `users`.
+func looksParameterizable(segment string) bool {
+	if looksLikeIDShape(segment) {
+		return true
+	}
+	hasDigit := false
+	hasUpper := false
+	hasLower := false
+	for _, r := range segment {
+		switch {
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		}
+	}
+	if hasDigit {
+		return true
+	}
+	if hasUpper && hasLower {
 		return true
 	}
 	return false
@@ -573,22 +635,29 @@ func collapseVariantGroups(groups []EndpointGroup) []EndpointGroup {
 
 		// The diverging segment must look like a parameter candidate at every
 		// member: not a placeholder (filtered already), not a routing keyword.
-		// Conservative: require at least one member's value to match one of the
-		// strong ID heuristics. Cross-entry variance alone (two literals at the
-		// same position) isn't enough to parametrize, because two distinct route
-		// names (e.g. /api/health vs /api/version) also vary without being IDs.
-		anyOpaque := false
+		// Use the weaker looksParameterizable check (digit present, mixed case,
+		// or strong-ID shape) rather than looksLikeIDShape — by construction
+		// any strong-ID-shaped segment was already replaced by
+		// normalizeEntryPath, so gating on that alone makes the pass
+		// unreachable. The looksParameterizable widening catches short opaque
+		// tokens (`abc123` vs `xyz456`) that only stand out as IDs once two
+		// entries land at the same position with different values, while still
+		// rejecting plain route literals like `health`/`version`.
+		anyParameterizable := false
+		allParameterizable := true
 		for _, idx := range members {
 			s := skeletons[idx][pos]
 			if s == "" || s == "api" || isVersionSegment(s) {
+				allParameterizable = false
 				continue
 			}
-			if looksLikeIDShape(s) {
-				anyOpaque = true
-				break
+			if looksParameterizable(s) {
+				anyParameterizable = true
+			} else {
+				allParameterizable = false
 			}
 		}
-		if !anyOpaque {
+		if !anyParameterizable || !allParameterizable {
 			continue
 		}
 

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -281,6 +281,22 @@ func TestDeduplicateEndpoints(t *testing.T) {
 			wantNormalizedPaths: []string{"/api/CreateDocument", "/api/ListDocuments"},
 			wantGroupSizes:      []int{1, 1},
 		},
+		{
+			// Three consecutive same-parent IDs: per-segment normalization
+			// produces /resources/{resource_id}/{resource_id_2}/abc123. The
+			// variance pass then promotes position 4. Naive counter-only
+			// disambiguation would re-emit {resource_id_2} (already in the
+			// path); the implementation must keep advancing the counter past
+			// every existing suffix and land on {resource_id_3}.
+			name: "triple consecutive ids disambiguate to _3",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/resources/123/456/abc123"},
+				{Method: "GET", URL: "https://example.com/resources/789/012/xyz456"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/resources/{resource_id}/{resource_id_2}/{resource_id_3}"},
+			wantGroupSizes:      []int{2},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClassifyEntries(t *testing.T) {
@@ -157,24 +158,64 @@ func TestDeduplicateEndpoints(t *testing.T) {
 		wantGroupSizes      []int
 	}{
 		{
-			name: "numeric ids normalize to id placeholder",
+			name: "numeric ids normalize to parent-derived id placeholder",
 			entries: []EnrichedEntry{
 				{Method: "GET", URL: "https://example.com/users/123?expand=true"},
 				{Method: "GET", URL: "https://example.com/users/456"},
 			},
 			wantMethods:         []string{"GET"},
-			wantNormalizedPaths: []string{"/users/{id}"},
+			wantNormalizedPaths: []string{"/users/{user_id}"},
 			wantGroupSizes:      []int{2},
 		},
 		{
-			name: "uuid segment normalizes to uuid placeholder",
+			name: "uuid segment normalizes to parent-derived id placeholder",
 			entries: []EnrichedEntry{
 				{Method: "GET", URL: "https://example.com/orders/550e8400-e29b-41d4-a716-446655440000"},
 				{Method: "GET", URL: "https://example.com/orders/123e4567-e89b-12d3-a456-426614174000?include=items"},
 			},
 			wantMethods:         []string{"GET"},
-			wantNormalizedPaths: []string{"/orders/{uuid}"},
+			wantNormalizedPaths: []string{"/orders/{order_id}"},
 			wantGroupSizes:      []int{2},
+		},
+		{
+			name: "prefixed application ids normalize to parent-derived placeholder",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/api/v1/tables/t_0t3vswhpKogASf2XZpW"},
+				{Method: "GET", URL: "https://example.com/api/v1/tables/t_zzAAbbCC11223344"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/api/v1/tables/{table_id}"},
+			wantGroupSizes:      []int{2},
+		},
+		{
+			name: "colon-composite form ids collapse to parent-derived placeholder",
+			entries: []EnrichedEntry{
+				{Method: "POST", URL: "https://example.com/suite/api/forms/creations/create-image:reference:gpt-image-2"},
+				{Method: "POST", URL: "https://example.com/suite/api/forms/creations/create-image:reference:gpt-image-3"},
+			},
+			wantMethods:         []string{"POST"},
+			wantNormalizedPaths: []string{"/suite/api/forms/creations/{creation_id}"},
+			wantGroupSizes:      []int{2},
+		},
+		{
+			name: "long opaque application ids normalize via cross-entry variance",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/suite/api/history/Zu2uNCmGDnmNCel8gbFQ"},
+				{Method: "GET", URL: "https://example.com/suite/api/history/AbcDefGhi1234567890X"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/suite/api/history/{history_id}"},
+			wantGroupSizes:      []int{2},
+		},
+		{
+			name: "static endpoints with distinct literal segments stay separate",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/api/health"},
+				{Method: "GET", URL: "https://example.com/api/version"},
+			},
+			wantMethods:         []string{"GET", "GET"},
+			wantNormalizedPaths: []string{"/api/health", "/api/version"},
+			wantGroupSizes:      []int{1, 1},
 		},
 	}
 
@@ -187,6 +228,38 @@ func TestDeduplicateEndpoints(t *testing.T) {
 			assert.Equal(t, tt.wantMethods, groupMethods(groups))
 			assert.Equal(t, tt.wantNormalizedPaths, groupPaths(groups))
 			assert.Equal(t, tt.wantGroupSizes, groupSizes(groups))
+		})
+	}
+}
+
+// TestDeduplicateEndpoints_SingleEntryHeuristics covers the per-segment ID
+// shapes that must parametrize even when only one HAR entry is available, so
+// the cross-entry variance pass has nothing to compare against.
+func TestDeduplicateEndpoints_SingleEntryHeuristics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		wantPath string
+	}{
+		{"uuid v4", "https://example.com/widgets/550e8400-e29b-41d4-a716-446655440000", "/widgets/{widget_id}"},
+		{"long hex hash", "https://example.com/blobs/0123456789abcdef0123456789abcdef", "/blobs/{blob_id}"},
+		{"numeric id under resource", "https://example.com/workspaces/125600", "/workspaces/{workspace_id}"},
+		{"prefixed application id under resource", "https://example.com/records/r_0tf32xmAhEgGSh3TDWR", "/records/{record_id}"},
+		{"colon-composite under resource", "https://example.com/forms/creations/create-image:reference:gpt-image-2", "/forms/creations/{creation_id}"},
+		{"long base62 id under resource", "https://example.com/history/Zu2uNCmGDnmNCel8gbFQ", "/history/{history_id}"},
+		{"literal short segments remain literal", "https://example.com/api/health", "/api/health"},
+		{"version segment retains literal v1 framing", "https://example.com/api/v1/users", "/api/v1/users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			groups := DeduplicateEndpoints([]EnrichedEntry{{Method: "GET", URL: tt.url}})
+			require.Len(t, groups, 1)
+			assert.Equal(t, tt.wantPath, groups[0].NormalizedPath)
 		})
 	}
 }

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -248,6 +248,24 @@ func TestDeduplicateEndpoints(t *testing.T) {
 			wantNormalizedPaths: []string{"/resources/{resource_id}/{resource_id_2}"},
 			wantGroupSizes:      []int{2},
 		},
+		{
+			// Variance pass must disambiguate against placeholders the
+			// per-segment normalizer already placed. Position 2 (`123`/`456`)
+			// becomes `{resource_id}` in per-segment normalization; position
+			// 3 (`AbcDef`/`XyzUvw`) lacks per-segment ID shape but is
+			// promoted by the variance pass. The walker for position 3
+			// would find `resources` again — placeholder emission must see
+			// the existing `{resource_id}` and disambiguate to
+			// `{resource_id_2}` rather than emit a duplicate.
+			name: "variance pass disambiguates against per-segment placeholder",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/resources/123/AbcDef"},
+				{Method: "GET", URL: "https://example.com/resources/456/XyzUvw"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/resources/{resource_id}/{resource_id_2}"},
+			wantGroupSizes:      []int{2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -294,6 +312,33 @@ func TestDeduplicateEndpoints_SingleEntryHeuristics(t *testing.T) {
 			assert.Equal(t, tt.wantPath, groups[0].NormalizedPath)
 		})
 	}
+}
+
+// TestDeduplicateTrafficEndpoints_VariancePassRespectsHost verifies that the
+// cross-entry variance pass cannot merge groups from different hosts. The
+// upstream host-aware key keeps them separate at dedup time, but
+// collapseVariantGroups originally bucketed only by (method, length, mask) and
+// would collapse them into a single mixed-host group. The skeleton key now
+// includes Host so this no longer happens.
+func TestDeduplicateTrafficEndpoints_VariancePassRespectsHost(t *testing.T) {
+	t.Parallel()
+
+	entries := []EnrichedEntry{
+		{Method: "GET", URL: "https://api.service1.com/orders/ORD123"},
+		{Method: "GET", URL: "https://api.service2.com/orders/SHP456"},
+	}
+
+	groups := DeduplicateTrafficEndpoints(entries)
+
+	require.Len(t, groups, 2, "different hosts must stay in separate groups")
+	hosts := map[string]struct{}{}
+	for _, g := range groups {
+		hosts[g.Host] = struct{}{}
+	}
+	assert.Equal(t, map[string]struct{}{
+		"api.service1.com": {},
+		"api.service2.com": {},
+	}, hosts)
 }
 
 func entryURLs(entries []EnrichedEntry) []string {

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -252,19 +252,34 @@ func TestDeduplicateEndpoints(t *testing.T) {
 			// Variance pass must disambiguate against placeholders the
 			// per-segment normalizer already placed. Position 2 (`123`/`456`)
 			// becomes `{resource_id}` in per-segment normalization; position
-			// 3 (`AbcDef`/`XyzUvw`) lacks per-segment ID shape but is
-			// promoted by the variance pass. The walker for position 3
-			// would find `resources` again — placeholder emission must see
-			// the existing `{resource_id}` and disambiguate to
-			// `{resource_id_2}` rather than emit a duplicate.
+			// 3 (`abc123`/`xyz456`) is short-opaque-with-digit, not a strong
+			// per-segment ID shape but promoted by the variance pass. The
+			// walker for position 3 would find `resources` again — placeholder
+			// emission must see the existing `{resource_id}` and disambiguate
+			// to `{resource_id_2}` rather than emit a duplicate.
 			name: "variance pass disambiguates against per-segment placeholder",
 			entries: []EnrichedEntry{
-				{Method: "GET", URL: "https://example.com/resources/123/AbcDef"},
-				{Method: "GET", URL: "https://example.com/resources/456/XyzUvw"},
+				{Method: "GET", URL: "https://example.com/resources/123/abc123"},
+				{Method: "GET", URL: "https://example.com/resources/456/xyz456"},
 			},
 			wantMethods:         []string{"GET"},
 			wantNormalizedPaths: []string{"/resources/{resource_id}/{resource_id_2}"},
 			wantGroupSizes:      []int{2},
+		},
+		{
+			// PascalCase route literals (common in ASP.NET, gRPC-HTTP
+			// transcoding) must NOT collapse via the variance pass.
+			// `CreateDocument` and `ListDocuments` are distinct action-style
+			// endpoints, both digit-free; the parameterizability check
+			// requires a digit specifically to avoid this false positive.
+			name: "pascal-case route literals stay separate",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/api/CreateDocument"},
+				{Method: "GET", URL: "https://example.com/api/ListDocuments"},
+			},
+			wantMethods:         []string{"GET", "GET"},
+			wantNormalizedPaths: []string{"/api/CreateDocument", "/api/ListDocuments"},
+			wantGroupSizes:      []int{1, 1},
 		},
 	}
 

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -217,6 +217,37 @@ func TestDeduplicateEndpoints(t *testing.T) {
 			wantNormalizedPaths: []string{"/api/health", "/api/version"},
 			wantGroupSizes:      []int{1, 1},
 		},
+		{
+			// Short opaque IDs (`abc123`, `xyz456`) fail every per-segment ID
+			// regex in isolation — they're too short for the long-alnum or
+			// hash patterns and have no type prefix. The cross-entry variance
+			// pass is the only thing that can identify them, because their
+			// id-ness becomes obvious only when two entries land at the same
+			// position with different data-shaped values.
+			name: "short opaque ids parametrize via cross-entry variance",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/api/messages/abc123"},
+				{Method: "GET", URL: "https://example.com/api/messages/xyz456"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/api/messages/{message_id}"},
+			wantGroupSizes:      []int{2},
+		},
+		{
+			// Consecutive numeric ID segments share the same parent
+			// (`resources` for both). Without disambiguation the resulting
+			// path would carry two `{resource_id}` placeholders, which breaks
+			// downstream OpenAPI generation (duplicate path-parameter names
+			// within a single path template are rejected).
+			name: "consecutive ids under same parent get disambiguated names",
+			entries: []EnrichedEntry{
+				{Method: "GET", URL: "https://example.com/resources/123/456"},
+				{Method: "GET", URL: "https://example.com/resources/789/012"},
+			},
+			wantMethods:         []string{"GET"},
+			wantNormalizedPaths: []string{"/resources/{resource_id}/{resource_id_2}"},
+			wantGroupSizes:      []int{2},
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,6 +282,7 @@ func TestDeduplicateEndpoints_SingleEntryHeuristics(t *testing.T) {
 		{"long base62 id under resource", "https://example.com/history/Zu2uNCmGDnmNCel8gbFQ", "/history/{history_id}"},
 		{"literal short segments remain literal", "https://example.com/api/health", "/api/health"},
 		{"version segment retains literal v1 framing", "https://example.com/api/v1/users", "/api/v1/users"},
+		{"consecutive ids under same parent disambiguate", "https://example.com/resources/123/456", "/resources/{resource_id}/{resource_id_2}"},
 	}
 
 	for _, tt := range tests {

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -689,7 +689,7 @@ func TestWriteSamples_WritesOneFilePerEndpointGroup(t *testing.T) {
 		switch sample.Method {
 		case "GET":
 			foundGET = true
-			assert.Equal(t, "GET /v1/items/{id}", sample.Endpoint)
+			assert.Equal(t, "GET /v1/items/{item_id}", sample.Endpoint)
 			assert.Equal(t, 200, sample.Status)
 			assert.True(t, sample.ResponseBodyKnown)
 			assert.Equal(t, RedactedSentinel, sample.RequestHeaders["Authorization"])


### PR DESCRIPTION
## Intent

Browser-sniffed specs collapsed variable URL path segments into literal endpoint names because the URL grouper in `internal/browsersniff` only recognized UUID v4, lowercase hex hashes, and pure-numeric segments. Application IDs that ship a short type prefix (`t_xxx`, `cus_xxx`), long opaque base62 / ULID / nanoid tails, or colon-composite discriminators (`create-image:reference:gpt-image-2`) all landed in the spec as literals, producing per-ID command files that worked only for the exact rows captured during the HAR session.

Issue: Closes #1386

## Approach

Extend the per-segment normalizer in `normalizeEntryPath` with three new heuristics, then add a cross-entry variance post-pass on the dedup output.

- Per-segment heuristics:
  - `prefixedIDPattern` (`^[a-z]{1,5}_[A-Za-z0-9]{8,}$`) covers Stripe/Clay/OpenAI-style typed IDs.
  - `longAlnumIDPattern` (`^[A-Za-z0-9]{20,}$`) gated by a mixed-case-or-digit floor (`looksOpaqueID`) covers nanoid/ULID/short base62 IDs while rejecting all-lowercase route literals like `subscriptions`.
  - `colonCompositePattern` (two-colon minimum) gated by `hasNonTrivialToken` covers OpenArt form_ids while rejecting `host:80`.
- Placeholder name derives from the parent segment via a conservative snake-case + trailing-`s` singularizer, so `tables/t_xxx` becomes `tables/{table_id}` instead of `tables/{id}`. `{id}` / `{uuid}` / `{hash}` remain the fallback when the parent isn't a usable identifier root.
- `collapseVariantGroups` runs after dedup and folds groups whose paths differ in exactly one segment when at least one member's value matches a strong ID shape. Two distinct route literals (`/api/health` vs `/api/version`) won't collapse because neither matches the ID gate.

## Scope

Primary area: `internal/browsersniff` URL grouper and dedup pass.

Why this belongs in this repo: this is a generator-machine change. The bug is in how the browser-sniff path normalizer reconstructs structural information that the HAR capture format inherently loses. Every future browser-sniffed spec inherits the fix; no printed-CLI fix would address it.

## Risk

- Placeholder names changed for existing single-segment matches: `/users/{id}` -> `/users/{user_id}`, `/orders/{uuid}` -> `/orders/{order_id}`. Downstream `inferURLParams` reads the placeholder name as the param name, so this surfaces more meaningful param names in sniffed specs. Existing tests asserting `{id}` / `{uuid}` were updated to the parent-derived names.
- New segment heuristics are gated by length floors and shape filters; the negative cases (`/api/health` vs `/api/version`, `subscriptions`, `host:80`) are covered by dedicated tests.
- `crowdsniff` has structurally similar normalization but applies to already-typed framework parameters (`:id`, `<id>`, `$id`) and is out of scope for this issue.

## Output Contract

Browser-sniffed `spec.yaml` files now emit parent-derived path-param placeholder names (`{widget_id}`) where they previously emitted literal IDs or generic `{id}`/`{uuid}` placeholders. The browser-sniff golden case (`browser-sniff-sample`) is unaffected because its target API (`httpbin.org`) has flat URLs.

## Verification

- `go test ./...` (4559 passed)
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `scripts/golden.sh verify` (20 cases pass)
- `go fmt ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change