### PR TITLE
feat(cli): add catalog and planning artifacts

### DIFF
--- a/catalog/capcut.yaml
+++ b/catalog/capcut.yaml
@@ -1,0 +1,30 @@
+name: capcut
+display_name: CapCut
+description: Local CapCut and JianYing draft editing by reading and writing project JSON files. No public API.
+category: media-and-entertainment
+tier: community
+verified_date: "2026-05-12"
+homepage: https://www.capcut.com
+notes: |
+  CapCut does not publish a public project-editing API for this workflow. The
+  viable surface is the local desktop draft format: draft_content.json on
+  Windows and draft_info.json on macOS.
+
+  Treat this as local-file implementation backing, not an endpoint-backed API
+  wrapper. Generated or hand-authored commands should preserve user project
+  files carefully: close the project in CapCut before edits, create backups
+  before writes, preserve JSON formatting where possible, and default to
+  machine-readable output for agent use.
+wrapper_libraries:
+  - name: renezander030/capcut-cli
+    url: https://github.com/renezander030/capcut-cli
+    language: typescript
+    license: MIT
+    integration_mode: subprocess
+    notes: |
+      Node CLI published as capcut-cli. It edits CapCut and JianYing project
+      drafts directly, supports JSON output by default, and covers project
+      inspection, subtitles, timing, media insertion, templates, long-form
+      cuts, and JSONL batch edits. A Printing Press-backed CLI can either
+      shell out to this package for parity or port the draft schema handling
+      natively to Go for a single-binary distribution.

--- a/catalog/kit.yaml
+++ b/catalog/kit.yaml
@@ -1,0 +1,15 @@
+name: kit
+display_name: Kit
+description: Email marketing for creators (formerly ConvertKit) — subscribers, broadcasts, sequences, tags
+category: marketing
+spec_url: https://developers.kit.com/api-reference/v4.json
+spec_format: json
+openapi_version: "3.0"
+tier: official
+verified_date: "2026-05-19"
+homepage: https://developers.kit.com
+auth_key_url: https://app.kit.com/account_settings/developer_settings
+auth_instructions: "Generate a v4 API key in Account Settings → Developer."
+auth_preference: API Key
+auth_env_vars:
+  - KIT_API_KEY

--- a/catalog/specs/google-photos.yaml
+++ b/catalog/specs/google-photos.yaml
@@ -1,0 +1,453 @@
+name: google-photos
+display_name: Google Photos
+description: Google Photos Library and Picker APIs for app-created media, albums, uploads, and user-selected media.
+cli_description: Manage Google Photos app-created albums and media, upload files, and work with Picker sessions from the terminal.
+version: "0.1.0"
+spec_source: official
+category: media-and-entertainment
+website_url: https://developers.google.com/photos
+base_url: https://photoslibrary.googleapis.com
+http_transport: standard
+
+auth:
+  type: oauth2
+  header: Authorization
+  format: Bearer {token}
+  env_vars:
+    - GOOGLE_PHOTOS_TOKEN
+  authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+  token_url: https://oauth2.googleapis.com/token
+  scopes:
+    - https://www.googleapis.com/auth/photoslibrary.appendonly
+    - https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata
+    - https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata
+    - https://www.googleapis.com/auth/photospicker.mediaitems.readonly
+  key_url: https://console.cloud.google.com/apis/credentials
+  verify_path: /v1/albums?pageSize=1
+
+config:
+  format: toml
+  path: ~/.config/google-photos-pp-cli/config.toml
+
+mcp:
+  transport:
+    - stdio
+    - http
+
+extra_commands:
+  - name: upload file
+    description: Upload raw photo or video bytes and print the upload token for media-items batch-create.
+    args: "<path>"
+  - name: picker wait
+    description: Poll a Picker session until selected media items are ready.
+    args: "<session-id>"
+
+resources:
+  albums:
+    description: Manage app-created Google Photos albums.
+    endpoints:
+      create:
+        method: POST
+        path: /v1/albums
+        description: Create an album in the user's Google Photos library.
+        body:
+          - name: album
+            type: object
+            required: true
+            description: Album JSON object, for example '{"title":"Trip"}'.
+        response:
+          type: object
+          item: Album
+      get:
+        method: GET
+        path: /v1/albums/{albumId}
+        description: Get an app-created album by ID.
+        params:
+          - name: albumId
+            type: string
+            required: true
+            positional: true
+            description: Album ID.
+        response:
+          type: object
+          item: Album
+        meta:
+          mcp:read-only: "true"
+      list:
+        method: GET
+        path: /v1/albums
+        description: List albums created by this app.
+        params:
+          - name: pageSize
+            type: int
+            default: 20
+            description: Maximum albums to return, up to 50.
+          - name: pageToken
+            type: string
+            description: Continuation token from nextPageToken.
+        response:
+          type: array
+          item: Album
+        response_path: albums
+        pagination:
+          type: page_token
+          cursor_param: pageToken
+          next_cursor_path: nextPageToken
+        meta:
+          mcp:read-only: "true"
+      patch:
+        method: PATCH
+        path: /v1/albums/{id}
+        description: Update title or cover photo on an app-created album.
+        params:
+          - name: id
+            type: string
+            required: true
+            positional: true
+            description: Album ID.
+          - name: updateMask
+            type: string
+            required: true
+            description: Comma-separated fields to update, such as title or coverPhotoMediaItemId.
+        body:
+          - name: title
+            type: string
+            description: New album title.
+          - name: coverPhotoMediaItemId
+            type: string
+            description: Media item ID to use as the album cover.
+        response:
+          type: object
+          item: Album
+      add_enrichment:
+        method: POST
+        path: /v1/albums/{albumId}:addEnrichment
+        description: Add text, location, or map enrichment to an app-created album.
+        params:
+          - name: albumId
+            type: string
+            required: true
+            positional: true
+            description: Album ID.
+        body:
+          - name: newEnrichmentItem
+            type: object
+            required: true
+            description: Enrichment JSON object.
+          - name: albumPosition
+            type: object
+            required: true
+            description: Album position JSON object.
+        response:
+          type: object
+          item: AddEnrichmentToAlbumResponse
+      batch_add_media_items:
+        method: POST
+        path: /v1/albums/{albumId}:batchAddMediaItems
+        description: Add app-created media items to an app-created album.
+        params:
+          - name: albumId
+            type: string
+            required: true
+            positional: true
+            description: Album ID.
+        body:
+          - name: mediaItemIds
+            type: array
+            required: true
+            description: JSON array of media item IDs.
+        response:
+          type: object
+          item: BatchAddMediaItemsToAlbumResponse
+      batch_remove_media_items:
+        method: POST
+        path: /v1/albums/{albumId}:batchRemoveMediaItems
+        description: Remove app-created media items from an app-created album.
+        params:
+          - name: albumId
+            type: string
+            required: true
+            positional: true
+            description: Album ID.
+        body:
+          - name: mediaItemIds
+            type: array
+            required: true
+            description: JSON array of media item IDs.
+        response:
+          type: object
+          item: BatchRemoveMediaItemsFromAlbumResponse
+
+  media_items:
+    description: Manage app-created Google Photos media items.
+    endpoints:
+      batch_create:
+        method: POST
+        path: /v1/mediaItems:batchCreate
+        description: Create media items from upload tokens.
+        body:
+          - name: albumId
+            type: string
+            description: Optional app-created album ID to add items to.
+          - name: newMediaItems
+            type: array
+            required: true
+            description: JSON array of new media items containing uploadToken and simpleMediaItem.
+          - name: albumPosition
+            type: object
+            description: Optional album position JSON object.
+        response:
+          type: object
+          item: BatchCreateMediaItemsResponse
+      batch_get:
+        method: GET
+        path: /v1/mediaItems:batchGet
+        description: Get multiple app-created media items by ID.
+        params:
+          - name: mediaItemIds
+            type: string
+            required: true
+            description: Media item IDs. Repeat with comma-separated IDs when using shell wrappers.
+        response:
+          type: array
+          item: MediaItemResult
+        response_path: mediaItemResults
+        meta:
+          mcp:read-only: "true"
+      get:
+        method: GET
+        path: /v1/mediaItems/{mediaItemId}
+        description: Get an app-created media item by ID.
+        params:
+          - name: mediaItemId
+            type: string
+            required: true
+            positional: true
+            description: Media item ID.
+        response:
+          type: object
+          item: MediaItem
+        meta:
+          mcp:read-only: "true"
+      list:
+        method: GET
+        path: /v1/mediaItems
+        description: List media items created by this app.
+        params:
+          - name: pageSize
+            type: int
+            default: 25
+            description: Maximum media items to return.
+          - name: pageToken
+            type: string
+            description: Continuation token from nextPageToken.
+        response:
+          type: array
+          item: MediaItem
+        response_path: mediaItems
+        pagination:
+          type: page_token
+          cursor_param: pageToken
+          next_cursor_path: nextPageToken
+        meta:
+          mcp:read-only: "true"
+      patch:
+        method: PATCH
+        path: /v1/mediaItems/{id}
+        description: Update the description on an app-created media item.
+        params:
+          - name: id
+            type: string
+            required: true
+            positional: true
+            description: Media item ID.
+          - name: updateMask
+            type: string
+            required: true
+            default: description
+            description: Fields to update. Google Photos currently supports description.
+        body:
+          - name: description
+            type: string
+            required: true
+            description: New media item description.
+        response:
+          type: object
+          item: MediaItem
+      search:
+        method: POST
+        path: /v1/mediaItems:search
+        description: Search app-created media items by album or filters.
+        body:
+          - name: albumId
+            type: string
+            description: Optional app-created album ID.
+          - name: filters
+            type: object
+            description: Filters JSON object.
+          - name: orderBy
+            type: string
+            description: Sort expression.
+          - name: pageSize
+            type: int
+            default: 25
+            description: Maximum media items to return.
+          - name: pageToken
+            type: string
+            description: Continuation token from nextPageToken.
+        response:
+          type: array
+          item: MediaItem
+        response_path: mediaItems
+        meta:
+          mcp:read-only: "true"
+
+  picker:
+    description: Create, poll, clean up, and read Google Photos Picker sessions.
+    base_url: https://photospicker.googleapis.com
+    endpoints:
+      create_session:
+        method: POST
+        path: /v1/sessions
+        description: Create a Picker session and return the picker URI.
+        body:
+          - name: pickingConfig
+            type: object
+            description: Optional picking configuration JSON object.
+        response:
+          type: object
+          item: PickingSession
+      get_session:
+        method: GET
+        path: /v1/sessions/{sessionId}
+        description: Get Picker session status.
+        params:
+          - name: sessionId
+            type: string
+            required: true
+            positional: true
+            description: Picker session ID.
+        response:
+          type: object
+          item: PickingSession
+        meta:
+          mcp:read-only: "true"
+      delete_session:
+        method: DELETE
+        path: /v1/sessions/{sessionId}
+        description: Delete a Picker session after selected media bytes have been retrieved.
+        params:
+          - name: sessionId
+            type: string
+            required: true
+            positional: true
+            description: Picker session ID.
+        response:
+          type: object
+          item: Empty
+      list_media_items:
+        method: GET
+        path: /v1/mediaItems
+        description: List media items picked by the user during a Picker session.
+        params:
+          - name: sessionId
+            type: string
+            required: true
+            description: Picker session ID.
+          - name: pageSize
+            type: int
+            default: 25
+            description: Maximum selected media items to return.
+          - name: pageToken
+            type: string
+            description: Continuation token from nextPageToken.
+        response:
+          type: array
+          item: PickedMediaItem
+        response_path: mediaItems
+        pagination:
+          type: page_token
+          cursor_param: pageToken
+          next_cursor_path: nextPageToken
+        meta:
+          mcp:read-only: "true"
+
+types:
+  Empty:
+    fields: []
+  Album:
+    fields:
+      - name: id
+        type: string
+      - name: title
+        type: string
+      - name: productUrl
+        type: string
+      - name: mediaItemsCount
+        type: string
+      - name: coverPhotoBaseUrl
+        type: string
+      - name: coverPhotoMediaItemId
+        type: string
+      - name: isWriteable
+        type: bool
+  MediaItem:
+    fields:
+      - name: id
+        type: string
+      - name: description
+        type: string
+      - name: productUrl
+        type: string
+      - name: baseUrl
+        type: string
+      - name: mimeType
+        type: string
+      - name: filename
+        type: string
+      - name: mediaMetadata
+        type: object
+      - name: contributorInfo
+        type: object
+  MediaItemResult:
+    fields:
+      - name: status
+        type: object
+      - name: mediaItem
+        type: object
+  BatchCreateMediaItemsResponse:
+    fields:
+      - name: newMediaItemResults
+        type: array
+  BatchAddMediaItemsToAlbumResponse:
+    fields: []
+  BatchRemoveMediaItemsFromAlbumResponse:
+    fields: []
+  AddEnrichmentToAlbumResponse:
+    fields:
+      - name: enrichmentItem
+        type: object
+  PickingSession:
+    fields:
+      - name: id
+        type: string
+      - name: pickerUri
+        type: string
+      - name: pollingConfig
+        type: object
+      - name: expireTime
+        type: string
+      - name: pickingConfig
+        type: object
+      - name: mediaItemsSet
+        type: bool
+  PickedMediaItem:
+    fields:
+      - name: id
+        type: string
+      - name: createTime
+        type: string
+      - name: type
+        type: string
+      - name: mediaFile
+        type: object

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CLI Printing Press — Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: #f5f5f5;
+      color: #2d3142;
+      font-family: 'Geist', sans-serif;
+      padding: 48px 32px 64px;
+    }
+
+    .page { max-width: 840px; margin: 0 auto; }
+
+    .eyebrow {
+      font-family: 'Geist Mono', monospace;
+      font-size: 8px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: #4f5d75;
+      margin-bottom: 12px;
+    }
+
+    h1 {
+      font-family: 'Instrument Serif', serif;
+      font-size: 40px;
+      font-weight: 400;
+      color: #2d3142;
+      line-height: 1.1;
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      font-size: 16px;
+      color: #4f5d75;
+      margin-bottom: 40px;
+    }
+
+    .diagram { width: 100%; margin-bottom: 40px; overflow-x: auto; }
+    .diagram svg { width: 100%; height: auto; display: block; }
+
+    .cards {
+      display: grid;
+      grid-template-columns: 1.1fr 1fr 0.9fr;
+      gap: 16px;
+      margin-bottom: 48px;
+    }
+
+    .card {
+      background: #ffffff;
+      border: 1px solid rgba(45,49,66,0.12);
+      border-radius: 6px;
+      padding: 20px;
+    }
+
+    .card .eyebrow { margin-bottom: 8px; }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .card-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+    .card-dot.coral { background: #eb6c36; }
+    .card-dot.ink   { background: #2d3142; }
+    .card-dot.muted { background: #4f5d75; }
+
+    .card h3 {
+      font-family: 'Geist', sans-serif;
+      font-size: 12px;
+      font-weight: 600;
+      color: #2d3142;
+    }
+
+    .card ul { list-style: none; }
+
+    .card li {
+      font-size: 12px;
+      color: #4f5d75;
+      padding: 3px 0 3px 12px;
+      position: relative;
+    }
+
+    .card li::before {
+      content: '—';
+      position: absolute;
+      left: 0;
+      color: #7a8399;
+      font-size: 10px;
+    }
+
+    .mono { font-family: 'Geist Mono', monospace; font-size: 11px; }
+
+    .explainer {
+      background: #ffffff;
+      border: 1px solid rgba(45,49,66,0.12);
+      border-radius: 6px;
+      padding: 24px 28px;
+      margin-bottom: 40px;
+    }
+
+    .explainer h2 {
+      font-family: 'Instrument Serif', serif;
+      font-size: 22px;
+      font-weight: 400;
+      color: #2d3142;
+      margin-bottom: 8px;
+    }
+
+    .explainer p {
+      font-size: 14px;
+      color: #4f5d75;
+      line-height: 1.6;
+      margin-bottom: 0;
+    }
+
+    .explainer p + p { margin-top: 12px; }
+
+    .compare {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-bottom: 48px;
+    }
+
+    .compare-col {
+      border: 1px solid rgba(45,49,66,0.12);
+      border-radius: 6px;
+      padding: 20px;
+    }
+
+    .compare-col.official { background: #ffffff; }
+
+    .compare-col.press {
+      background: #ffffff;
+      border-color: #eb6c36;
+    }
+
+    .compare-col .eyebrow { margin-bottom: 8px; }
+
+    .compare-col h3 {
+      font-family: 'Geist', sans-serif;
+      font-size: 13px;
+      font-weight: 600;
+      color: #2d3142;
+      margin-bottom: 12px;
+    }
+
+    .compare-col ul { list-style: none; }
+
+    .compare-col li {
+      font-size: 12px;
+      color: #4f5d75;
+      padding: 4px 0 4px 16px;
+      position: relative;
+    }
+
+    .compare-col.official li::before {
+      content: '✗';
+      position: absolute;
+      left: 0;
+      color: #bfc0c0;
+      font-size: 11px;
+    }
+
+    .compare-col.press li::before {
+      content: '✓';
+      position: absolute;
+      left: 0;
+      color: #eb6c36;
+      font-size: 11px;
+    }
+
+    footer {
+      border-top: 1px solid rgba(45,49,66,0.12);
+      padding-top: 16px;
+      font-family: 'Geist Mono', monospace;
+      font-size: 8px;
+      letter-spacing: 0.14em;
+      color: #7a8399;
+      text-transform: uppercase;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <p class="eyebrow">Architecture</p>
+      <h1>CLI Printing Press</h1>
+      <p class="subtitle">Feed it a spec. Get back an agent-native CLI.</p>
+    </header>
+
+    <div class="diagram">
+      <svg viewBox="0 0 720 548" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#4f5d75"/>
+          </marker>
+          <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+            <polygon points="0 0, 8 3, 0 6" fill="#eb6c36"/>
+          </marker>
+        </defs>
+
+        <!-- Background -->
+        <rect width="100%" height="100%" fill="#f5f5f5"/>
+
+        <!-- ═══ ARROWS (drawn before boxes) ═══ -->
+
+        <!-- API spec → THE PRESS -->
+        <path d="M 112 84 L 112 120 L 216 120 L 216 156"
+              fill="none" stroke="#4f5d75" stroke-width="1" marker-end="url(#arrow)"/>
+
+        <!-- browser sniff → THE PRESS (straight) -->
+        <path d="M 360 84 L 360 156"
+              fill="none" stroke="#4f5d75" stroke-width="1" marker-end="url(#arrow)"/>
+
+        <!-- crowd sniff → THE PRESS -->
+        <path d="M 608 84 L 608 120 L 504 120 L 504 156"
+              fill="none" stroke="#4f5d75" stroke-width="1" marker-end="url(#arrow)"/>
+
+        <!-- THE PRESS → PRINTED CLI (accent — the key transform) -->
+        <path d="M 360 236 L 360 300"
+              fill="none" stroke="#eb6c36" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+        <rect x="328" y="260" width="64" height="12" rx="2" fill="#f5f5f5"/>
+        <text x="360" y="269" fill="#7a8399" font-size="8" font-family="'Geist Mono', monospace"
+              text-anchor="middle" letter-spacing="0.06em">GENERATE</text>
+
+        <!-- PRINTED CLI → two surfaces (parallel lines, not exclusive Y-split) -->
+        <path d="M 260 364 L 260 392 L 132 392 L 132 432"
+              fill="none" stroke="#4f5d75" stroke-width="1" marker-end="url(#arrow)"/>
+        <path d="M 460 364 L 460 392 L 588 392 L 588 432"
+              fill="none" stroke="#4f5d75" stroke-width="1" marker-end="url(#arrow)"/>
+
+        <!-- Mirrors dashed connection between the two surfaces -->
+        <path d="M 212 458 L 508 458"
+              fill="none" stroke="#bfc0c0" stroke-width="0.8" stroke-dasharray="4,3"/>
+        <rect x="328" y="452" width="64" height="12" rx="2" fill="#f5f5f5"/>
+        <text x="360" y="461" fill="#bfc0c0" font-size="8" font-family="'Geist Mono', monospace"
+              text-anchor="middle" letter-spacing="0.06em">MIRRORS</text>
+
+        <!-- ═══ BOXES ═══ -->
+
+        <!-- Floating labels above input boxes -->
+        <text x="112" y="30" fill="#7a8399" font-size="7" font-family="'Geist Mono', monospace"
+              text-anchor="middle" letter-spacing="0.14em">OFFICIAL</text>
+        <text x="360" y="30" fill="#7a8399" font-size="7" font-family="'Geist Mono', monospace"
+              text-anchor="middle" letter-spacing="0.14em">DISCOVER</text>
+        <text x="608" y="30" fill="#7a8399" font-size="7" font-family="'Geist Mono', monospace"
+              text-anchor="middle" letter-spacing="0.14em">DISCOVER</text>
+
+        <!-- Official spec (input) -->
+        <rect x="40" y="36" width="144" height="48" rx="6" fill="#f5f5f5"/>
+        <rect x="40" y="36" width="144" height="48" rx="6"
+              fill="rgba(79,93,117,0.10)" stroke="#7a8399" stroke-width="1"/>
+        <text x="112" y="60" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">API Spec</text>
+        <text x="112" y="74" fill="#7a8399" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle">OpenAPI · GraphQL</text>
+
+        <!-- Browser sniff (discovered input) -->
+        <rect x="288" y="36" width="144" height="48" rx="6" fill="#f5f5f5"/>
+        <rect x="288" y="36" width="144" height="48" rx="6"
+              fill="rgba(79,93,117,0.10)" stroke="#7a8399" stroke-width="1"/>
+        <text x="360" y="60" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">Browser Sniff</text>
+        <text x="360" y="74" fill="#7a8399" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle">unofficial APIs</text>
+
+        <!-- Crowd sniff (discovered input) -->
+        <rect x="536" y="36" width="144" height="48" rx="6" fill="#f5f5f5"/>
+        <rect x="536" y="36" width="144" height="48" rx="6"
+              fill="rgba(79,93,117,0.10)" stroke="#7a8399" stroke-width="1"/>
+        <text x="608" y="60" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">Crowd Sniff</text>
+        <text x="608" y="74" fill="#7a8399" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle">community patterns</text>
+
+        <!-- THE PRESS (focal) -->
+        <rect x="160" y="156" width="400" height="80" rx="6" fill="#f5f5f5"/>
+        <rect x="160" y="156" width="400" height="80" rx="6"
+              fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="1.2"/>
+        <rect x="168" y="164" width="40" height="12" rx="2"
+              fill="transparent" stroke="rgba(235,108,54,0.40)" stroke-width="0.8"/>
+        <text x="188" y="173" fill="rgba(235,108,54,0.8)" font-size="7"
+              font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">PRESS</text>
+        <text x="360" y="200" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">The Press</text>
+        <text x="360" y="216" fill="#7a8399" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle">parser · generator · 9-phase pipeline</text>
+
+        <!-- PRINTED CLI (output) -->
+        <rect x="180" y="300" width="360" height="64" rx="6" fill="#f5f5f5"/>
+        <rect x="180" y="300" width="360" height="64" rx="6"
+              fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+        <rect x="188" y="308" width="24" height="12" rx="2"
+              fill="transparent" stroke="rgba(45,49,66,0.40)" stroke-width="0.8"/>
+        <text x="200" y="317" fill="rgba(45,49,66,0.8)" font-size="7"
+              font-family="'Geist Mono', monospace" text-anchor="middle" letter-spacing="0.08em">CLI</text>
+        <text x="360" y="336" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">Printed CLI</text>
+        <text x="360" y="352" fill="#7a8399" font-size="9"
+              font-family="'Geist Mono', monospace" text-anchor="middle">go binary · cobra · mcp server · sqlite store</text>
+
+        <!-- CLI surface -->
+        <rect x="52" y="432" width="160" height="52" rx="6" fill="#f5f5f5"/>
+        <rect x="52" y="432" width="160" height="52" rx="6"
+              fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+        <text x="132" y="462" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">CLI</text>
+
+        <!-- MCP surface -->
+        <rect x="508" y="432" width="160" height="52" rx="6" fill="#f5f5f5"/>
+        <rect x="508" y="432" width="160" height="52" rx="6"
+              fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+        <text x="588" y="462" fill="#2d3142" font-size="12" font-weight="600"
+              font-family="'Geist', sans-serif" text-anchor="middle">MCP</text>
+
+        <!-- Legend -->
+        <line x1="32" y1="508" x2="688" y2="508" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+        <text x="32" y="524" fill="#4f5d75" font-size="8"
+              font-family="'Geist Mono', monospace" letter-spacing="0.14em">LEGEND</text>
+
+        <rect x="96" y="516" width="16" height="12" rx="2"
+              fill="rgba(79,93,117,0.10)" stroke="#7a8399" stroke-width="0.8"/>
+        <text x="120" y="525" fill="#4f5d75" font-size="8"
+              font-family="'Geist Mono', monospace">spec / discovered input</text>
+
+        <rect x="256" y="516" width="16" height="12" rx="2"
+              fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="0.8"/>
+        <text x="280" y="525" fill="#4f5d75" font-size="8"
+              font-family="'Geist Mono', monospace">the press (focal)</text>
+
+        <rect x="444" y="516" width="16" height="12" rx="2"
+              fill="#ffffff" stroke="#2d3142" stroke-width="0.8"/>
+        <text x="468" y="525" fill="#4f5d75" font-size="8"
+              font-family="'Geist Mono', monospace">generated output</text>
+
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <p class="eyebrow">The Machine</p>
+        <div class="card-header">
+          <span class="card-dot coral"></span>
+          <h3>THE PRESS</h3>
+        </div>
+        <ul>
+          <li>Reads official specs (OpenAPI 3.0+, GraphQL) — or discovers them itself via browser sniffing and crowd sniffing for APIs with no public spec</li>
+          <li>Derives endpoints, types, auth patterns, and pagination automatically</li>
+          <li>Runs 9 phases: preflight → research → scaffold → enrich → regenerate → review → readiness → ship</li>
+          <li>Enforces quality gates at every phase: <span class="mono">go build</span>, <span class="mono">go vet</span>, <span class="mono">--help</span>, <span class="mono">doctor</span></li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <p class="eyebrow">The Output</p>
+        <div class="card-header">
+          <span class="card-dot ink"></span>
+          <h3>Printed CLI</h3>
+        </div>
+        <ul>
+          <li>A Go binary named <span class="mono">api-slug-pp-cli</span></li>
+          <li>CLI surface (cobra) — operator-first, also usable by agents via shell-out</li>
+          <li>MCP surface — agent-optimized, mirrors every CLI command automatically</li>
+          <li>SQLite store for offline reads and fast sync — no repeated API calls</li>
+          <li>Skills, README, and install section included</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <p class="eyebrow">The Principle</p>
+        <div class="card-header">
+          <span class="card-dot muted"></span>
+          <h3>Machine Before CLI</h3>
+        </div>
+        <ul>
+          <li>Every fix to the Press improves all future CLIs at once</li>
+          <li>Commands call real APIs — no fake stubs or canned responses</li>
+          <li>Any action a human can take, an agent can too</li>
+          <li>Golden fixtures catch regressions across all generated output</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="explainer">
+      <p class="eyebrow">Plain English</p>
+      <h2>What is a CLI, and why does it matter for AI?</h2>
+      <p>A CLI — Command Line Interface — is a text-based tool you use by typing commands in a terminal. Instead of clicking buttons in an app, you type things like <span class="mono">stripe customers list</span> or <span class="mono">github issues create</span>. Every major API ships one so developers can explore and automate without writing code against the API directly.</p>
+      <p>When AI agents need to interact with an external service, they reach for the same tools a developer would. The problem: most official CLIs weren't built with agents in mind. They output text formatted for human eyes — colors, ASCII tables, prose error messages — that agents have to parse, guess at, and burn tokens on. They require interactive auth flows. They hit the network every time, even for data the agent already fetched. They don't expose an MCP surface at all.</p>
+      <p>Token efficiency is the hidden cost. Every time an agent calls an official CLI, it reads back a wall of human-formatted text, figures out which line has the value it needs, then decides what to do next. A Printing Press CLI returns structured output, reads from a local SQLite store when possible, and exposes typed MCP tools where the agent just calls <span class="mono">list_customers(limit: 10)</span> and gets back clean JSON — no parsing, no wasted context.</p>
+    </div>
+
+    <div class="compare">
+      <div class="compare-col official">
+        <p class="eyebrow">Without Printing Press</p>
+        <h3>Most APIs weren't built for agents</h3>
+        <ul>
+          <li>Official CLIs output text for humans — agents parse walls of colored ASCII to extract one value</li>
+          <li>APIs with no CLI require agents to write raw HTTP calls and manage auth from scratch every time</li>
+          <li>APIs with no public spec are completely out of reach — browser-only workflows stay locked</li>
+          <li>No local store — every query hits the network and burns rate limits</li>
+          <li>Auth designed for interactive browser login — breaks headless, in CI, or inside another agent</li>
+          <li>Pagination manual — agents track cursors, loop, and lose state on failure</li>
+          <li>No agent context — agents must reverse-engineer each API individually</li>
+        </ul>
+      </div>
+
+      <div class="compare-col press">
+        <p class="eyebrow">Printing Press CLIs</p>
+        <h3>Token-efficient, agent-native, still great for humans</h3>
+        <ul>
+          <li>MCP surface mirrors every CLI command — agents call typed tools, get clean JSON back, no parsing</li>
+          <li>SQLite store synced locally — most reads never hit the network or rate limits</li>
+          <li>Auth via env vars — works headless, in CI, inside another agent's subprocess</li>
+          <li>Typed exit codes agents branch on without reading stdout</li>
+          <li>Pagination handled internally — agents get the full result in one call</li>
+          <li>Works for unofficial APIs too — browser sniffing builds specs where none exist</li>
+          <li>Skills and context built in — agents start productive immediately</li>
+        </ul>
+      </div>
+    </div>
+
+    <footer>CLI Printing Press · Machine before printed CLI</footer>
+  </div>
+</body>
+</html>

--- a/docs/plans/2026-05-01-002-feat-shopify-wrapper-spec-plan.md
+++ b/docs/plans/2026-05-01-002-feat-shopify-wrapper-spec-plan.md
@@ -1,0 +1,411 @@
+---
+title: "feat: Curated Shopify wrapper spec and baseline scaffold"
+type: feat
+status: active
+date: 2026-05-01
+---
+
+# feat: Curated Shopify wrapper spec and baseline scaffold
+
+## Summary
+
+The next step for Shopify is not "generate the CLI from the raw SDL" and it is not yet the full hand-finished `shopify-pp-cli` from PR-4. The correct intermediate deliverable is a curated Shopify wrapper spec that uses the fetched Admin GraphQL SDL as source-of-truth for field validation, but does not ask the Printing Press to infer a useful CLI surface from the full SDL automatically.
+
+The raw SDL fetch succeeded and is now stored at [catalog/specs/shopify-2026-04.graphql](/Users/cathrynlavery/Developer/mvanhorn/cli-printing-press/catalog/specs/shopify-2026-04.graphql). However, a dry run plus scratch generation proved that direct SDL parsing is not sufficient:
+
+- the generated config defaulted to `BaseURL: "https://shopify.dev"` instead of the required per-shop endpoint
+- the generator derived only 4 low-value resources from the full schema
+- the generated README and command surface were not usable as a Shopify operator CLI
+
+So the next part needs its own spec: define a small, intentional Shopify wrapper spec that encodes the real endpoint, auth, throttling, and the initial operator-facing resource/query surface. Use that wrapper spec to generate the baseline scaffold that PR-4 can then hand-finish with Bulk Ops and the 4 GOAT commands.
+
+---
+
+## Problem Frame
+
+The Printing Press now has the machine primitives Shopify needed:
+
+- endpoint path modeling
+- runtime endpoint template substitution
+- Shopify-shaped cost throttling
+
+But those machine fixes do not solve the Shopify spec-shape problem.
+
+Shopify Admin GraphQL is a giant schema-first API with thousands of types and many internal or low-value nodes. The current GraphQL parser can validate SDL and synthesize a technically valid CLI, but it cannot yet infer the specific business surface we want:
+
+- orders
+- products and variants
+- inventory items and inventory levels
+- customers
+- fulfillment orders
+- bulk operations
+
+The raw SDL is therefore the wrong direct generation input for PR-4. We need a curated wrapper spec that says:
+
+- which resources matter
+- which queries back them
+- which fields should populate the local store
+- which runtime settings the generated client must use
+
+Without that wrapper, PR-4 devolves into hand-editing a mostly useless scaffold instead of using the generator as intended.
+
+---
+
+## Goal
+
+Produce a minimal but real Shopify generation spec and baseline scaffold that:
+
+1. points at the real per-shop Admin GraphQL endpoint
+2. uses the correct auth header and env vars
+3. opts into the throttling primitive shipped in PR-3
+4. defines the initial syncable resource surface explicitly
+5. generates a scaffold that is recognizably the start of `shopify-pp-cli`
+6. gives PR-4 a clean base for Bulk Ops and GOAT command work
+
+This is the "PR-4A" slice. It is smaller than the full Shopify CLI but large enough to validate the architecture.
+
+---
+
+## Requirements
+
+- R1. Keep the fetched SDL in `cli-printing-press` as the schema source-of-truth for the 2026-04 Admin GraphQL API.
+- R2. Do not generate the baseline Shopify CLI directly from the raw SDL alone.
+- R3. Create a curated wrapper spec, checked in as YAML, that the generator can consume deterministically.
+- R4. The wrapper spec must set:
+  - `name: shopify`
+  - `display_name: Shopify`
+  - `base_url: https://{shop}`
+  - `graphql_endpoint_path: /admin/api/{api_version}/graphql.json`
+  - `endpoint_template_vars: [shop, api_version]`
+  - auth header `X-Shopify-Access-Token`
+  - env var `SHOPIFY_ACCESS_TOKEN`
+- R5. The wrapper spec must opt into cost throttling with `throttling: { enabled: true, shape: shopify }`.
+- R6. The wrapper spec must use the real runtime env vocabulary:
+  - `SHOPIFY_SHOP`
+  - `SHOPIFY_API_VERSION`
+  - `SHOPIFY_ACCESS_TOKEN`
+- R7. The initial resource set must be intentionally small and operator-relevant:
+  - `orders`
+  - `products`
+  - `inventory-items`
+  - `customers`
+  - `fulfillment-orders`
+  - `bulk-operations`
+- R8. The first baseline scaffold must build and pass the standard mechanical quality gates.
+- R9. The first baseline scaffold must emit a sensible config and README:
+  - no `https://shopify.dev` default
+  - mentions multi-store env vars
+  - mentions Admin GraphQL, not generic API-key copy
+- R10. The baseline scaffold may still be incomplete functionally; Bulk Ops and GOAT commands are explicitly follow-up work.
+- R11. The wrapper spec must be written so that future Shopify API version bumps are localized:
+  - SDL file changes
+  - wrapper spec field/query adjustments
+  - no hardcoded endpoint in generated code
+- R12. The work must preserve the "machine vs printed CLI" rule: only encode reusable Shopify generation structure in the machine repo; library-specific hand-finish work stays in `printing-press-library`.
+
+---
+
+## Non-Goals
+
+- Not implementing the 4 GOAT commands yet
+- Not implementing Bulk Operations orchestration yet
+- Not extracting the commerce archetype yet
+- Not teaching the generic SDL parser to infer a perfect Shopify CLI from arbitrary GraphQL schemas
+- Not finalizing scorecard support for Shopify bulk-query rules
+- Not validating production-scale data coverage yet
+
+---
+
+## Proposed Artifacts
+
+### In `cli-printing-press`
+
+- `catalog/specs/shopify-2026-04.graphql`
+  - already fetched
+  - remains the raw schema source
+
+- `catalog/specs/shopify-2026-04-wrapper.yaml` or similarly named curated spec
+  - new internal YAML wrapper spec for generation
+  - hand-authored but backed by the real SDL
+
+- optional `catalog/shopify.yaml`
+  - only if we want Shopify available as a first-class catalog entry immediately
+  - can be deferred until the wrapper spec is stable
+
+### In `printing-press-library`
+
+- `library/commerce/shopify/`
+  - first generated baseline scaffold from the curated wrapper spec
+  - baseline only, before Bulk Ops/GOAT hand-finishing
+
+---
+
+## Wrapper Spec Shape
+
+The wrapper spec should be a custom Printing Press YAML spec, not raw SDL.
+
+It should include:
+
+```yaml
+name: shopify
+display_name: Shopify
+description: Ecommerce orders, products, customers, inventory, fulfillment orders, and bulk operations via the Shopify Admin GraphQL API.
+cli_description: Operate a Shopify store from the terminal with local sync, analytics, and bulk exports.
+version: "2026-04"
+base_url: https://{shop}
+graphql_endpoint_path: /admin/api/{api_version}/graphql.json
+endpoint_template_vars:
+  - shop
+  - api_version
+auth:
+  type: api_key
+  header: X-Shopify-Access-Token
+  env_vars:
+    - SHOPIFY_ACCESS_TOKEN
+config:
+  format: toml
+  path: ~/.config/shopify-pp-cli/config.toml
+throttling:
+  enabled: true
+  shape: shopify
+resources:
+  ...
+types:
+  ...
+```
+
+Important detail: use `api_version`, not bare `version`, so the generated env name is `SHOPIFY_API_VERSION` rather than `SHOPIFY_VERSION`.
+
+---
+
+## Initial Resource Surface
+
+The baseline wrapper spec should not attempt to mirror the whole schema. It should define a small set of high-value resources and list/query paths.
+
+### `orders`
+
+Purpose:
+- foundational entity for sync
+- required for refund analysis, fulfillment lag, and customer cohorting later
+
+Initial fields:
+- `id`
+- `name`
+- `createdAt`
+- `processedAt`
+- `displayFinancialStatus`
+- `displayFulfillmentStatus`
+- `currencyCode`
+- `totalPriceSet.shopMoney.amount`
+- `totalRefundedSet.shopMoney.amount`
+- `customer.id`
+
+### `products`
+
+Purpose:
+- product and variant inventory analysis later
+
+Initial fields:
+- `id`
+- `title`
+- `handle`
+- `vendor`
+- `productType`
+- `status`
+- variants:
+  - `id`
+  - `sku`
+  - `price`
+  - `inventoryItem.id`
+
+### `inventory-items`
+
+Purpose:
+- inventory-level sync separate from products to avoid over-deep query shapes
+
+Initial fields:
+- `id`
+- `sku`
+- `tracked`
+- levels:
+  - `location.id`
+  - `location.name`
+  - `quantities(names: ["available"])`
+  - `updatedAt`
+
+### `customers`
+
+Purpose:
+- customer cohorting and lifetime-value analysis later
+
+Initial fields:
+- `id`
+- `email`
+- `firstName`
+- `lastName`
+- `numberOfOrders`
+- `amountSpent.amount`
+- `amountSpent.currencyCode`
+- `createdAt`
+- `updatedAt`
+
+### `fulfillment-orders`
+
+Purpose:
+- fulfillment lag and routing analysis later
+
+Initial fields:
+- `id`
+- `status`
+- `requestStatus`
+- `assignedLocation.location.id`
+- `assignedLocation.location.name`
+- `fulfillAt`
+- `createdAt`
+- `updatedAt`
+- `order.id`
+
+### `bulk-operations`
+
+Purpose:
+- future home for run/poll/download workflow
+
+Initial baseline:
+- may start as a thin generated resource or hand-authored command family later
+- should be explicitly reserved in the plan even if not fully generated in the first scaffold
+
+---
+
+## Generation Strategy
+
+Use a two-stage generation model:
+
+1. **Schema acquisition**
+   - fetch and pin the real Shopify SDL
+   - already complete for `2026-04`
+
+2. **Curated generation**
+   - generate the baseline scaffold from the wrapper spec, not the raw SDL
+
+This gives us:
+
+- real Shopify field names and query validation
+- deterministic scaffold generation
+- a manageable CLI surface
+
+It also avoids forcing the generic GraphQL parser to solve a problem it does not currently solve.
+
+---
+
+## Scope Split Between Repos
+
+### `cli-printing-press`
+
+Owns:
+- raw SDL
+- curated wrapper spec format and contents
+- optional catalog entry
+- any machine-level fixes discovered while generating the baseline
+
+Does not own:
+- the full hand-finished Shopify CLI
+- Bulk Ops implementation details specific to the first printed CLI
+
+### `printing-press-library`
+
+Owns:
+- generated baseline Shopify CLI directory
+- hand-finished Bulk Ops support
+- GOAT commands
+- verification against a real store
+
+This split keeps the machine reusable and the printed CLI specific.
+
+---
+
+## Acceptance Criteria
+
+This spec is complete when all of the following are true:
+
+- A curated Shopify wrapper spec exists and is checked in.
+- Generating from that wrapper spec produces a scaffold under a scratch dir or library dir.
+- The generated config uses:
+  - `https://{shop}`
+  - `/admin/api/{api_version}/graphql.json`
+  - `SHOPIFY_SHOP`
+  - `SHOPIFY_API_VERSION`
+  - `SHOPIFY_ACCESS_TOKEN`
+- The generated scaffold opts into Shopify-shaped throttling.
+- The generated scaffold builds and passes the mechanical gates.
+- The generated README and config are no longer generic nonsense.
+- The baseline resource surface is small but meaningful.
+
+---
+
+## Risks
+
+### Risk 1: wrapper spec drifts from SDL
+
+Mitigation:
+- every field/query added to the wrapper spec should be validated against the pinned SDL
+- treat the SDL as canonical and the wrapper as the curated projection
+
+### Risk 2: GraphQL custom-spec support is still too weak
+
+Mitigation:
+- keep the baseline resource set small
+- discover the next machine gap before writing hand-finished library code
+
+### Risk 3: overcommitting to generated endpoint resources
+
+Mitigation:
+- baseline scaffold is intentionally narrow
+- Bulk Ops and GOAT commands remain hand-finished follow-up work
+
+### Risk 4: store-scoped URL or auth still leaks generic defaults
+
+Mitigation:
+- acceptance criteria explicitly require inspection of generated config and README before promoting to the library repo
+
+---
+
+## Open Questions
+
+- Should the curated wrapper spec live in `catalog/specs/` or directly in the eventual library directory during iteration?
+  - default recommendation: `catalog/specs/` while the machine is still evolving
+
+- Should Shopify get a catalog entry immediately?
+  - recommendation: no, not until the wrapper spec generates a sensible baseline
+
+- Should `bulk-operations` be represented in the wrapper spec as a generated resource or reserved for hand-authored commands only?
+  - recommendation: reserve the command family in planning, but do not force it into the first generated baseline if that produces junk
+
+---
+
+## Implementation Order
+
+1. Author the curated wrapper spec from the pinned SDL.
+2. Generate a scratch Shopify scaffold from the wrapper spec.
+3. Inspect:
+   - config
+   - endpoint URL shape
+   - auth env vars
+   - README
+   - command surface
+4. Fix machine gaps only if they are clearly reusable.
+5. Once the baseline is acceptable, generate into `printing-press-library/library/commerce/shopify/`.
+6. Start the hand-finished PR-4 work on Bulk Ops and GOAT commands.
+
+---
+
+## Smallest Next Action
+
+Write the curated wrapper spec now and treat that as the next executable task.
+
+That is the highest-leverage move because:
+
+- the raw SDL fetch is complete
+- the machine primitives are already landed
+- the raw SDL generation path is proven insufficient
+- the wrapper spec is the smallest artifact that turns Shopify from research into a real baseline CLI
+

--- a/docs/plans/2026-05-01-003-feat-ahrefs-cli-plan.md
+++ b/docs/plans/2026-05-01-003-feat-ahrefs-cli-plan.md
@@ -1,0 +1,495 @@
+---
+title: "feat(cli): generate ahrefs-pp-cli from reconstructed internal spec"
+type: feat
+status: draft
+date: 2026-05-01
+---
+
+# feat(cli): generate ahrefs-pp-cli from reconstructed internal spec
+
+## Summary
+
+Generate a printed CLI (`ahrefs-pp-cli`) for Ahrefs API v3 from the official `ahrefs/ahrefs-python` SDK, scoped to the first 29 read endpoints. Do not reduce v1 below these 29 endpoints.
+
+Ahrefs does not publish a downloadable OpenAPI spec. The official Python SDK is generated from Ahrefs' internal API contract and currently ships:
+
+- `src/ahrefs/_search_index.json`
+- `src/ahrefs/_generated_methods.py`
+- `src/ahrefs/types/_generated.py`
+- transport helpers in `src/ahrefs/_base_client.py` and `src/ahrefs/_sync_client.py`
+
+This plan reconstructs a Printing Press internal YAML spec, not OpenAPI. The internal spec format supports the `mcp:` block that this CLI needs; the OpenAPI parser currently does not extract `mcp:` from OpenAPI documents.
+
+The current SDK master inspected during this plan review is `15022030974ffbd46f82dd3d6fb9d298d6b30bf9`. At that revision, `_search_index.json` contains 105 methods across 11 sections. The reconstruction script must emit a manifest proving total methods discovered, sections discovered, selected v1 methods, skipped methods, transport paths, HTTP verbs, and source file SHAs. The manifest is the count authority. If counts drift on re-run, the reconstruction command fails until the allowlist and plan are consciously updated.
+
+## Non-Negotiables
+
+- Keep v1 at 29 endpoints.
+- Do not invent generator, verifier, or catalog features.
+- Use local `--spec` generation during development. Do not depend on catalog lookup finding `catalog/specs/**`.
+- Keep the plan `status: draft` until Cathryn explicitly approves implementation.
+- The printed CLI must wrap real Ahrefs API endpoints. No hand-written response builders or endpoint stubs.
+
+## Repo Facts Confirmed
+
+These repo behaviors shape the plan:
+
+- OpenAPI parsing currently extracts `x-api-name`, `x-display-name`, `x-website`, and `x-proxy-routes`, but not an OpenAPI `mcp:` block (`internal/openapi/parser.go`).
+- Internal YAML specs support `mcp.transport`, `mcp.orchestration`, and `mcp.endpoint_tools` (`internal/spec/spec.go`).
+- Catalog embed only includes root `catalog/*.yaml`; `catalog/specs/**` is not embedded (`catalog/catalog.go`).
+- `generate` takes `--spec <path>` or `--plan <path>`, and `--dry-run` is a flag on `generate`.
+- `dogfood`, `verify`, `scorecard`, and `shipcheck` take `--dir`; `dogfood`, `verify`, `scorecard`, and `shipcheck` can also take `--spec`.
+- `publish` is a command group with `validate`, `package`, and `rename`; there is no `printing-press publish ahrefs`.
+- `verify` runs mock mode when no `--api-key` is supplied and live mode when `--api-key` is supplied. There is no `--mock`, `--live`, or `--probes-only`.
+- `shipcheck` runs `scorecard --live-check` by default; pass `--no-live-check` to avoid live scorecard sampling.
+- The generated doctor probes `auth.verify_path` when set, otherwise `/`.
+- Endpoint commands register normal Cobra flags. There is no `@file` expansion for flag values.
+- Generated endpoint commands can emit `mcp:read-only` annotations when `endpoint.meta["mcp:read-only"] == "true"` or the read heuristic classifies the command as read-only.
+- Dogfood can load internal YAML specs, but its path-validity reporting is skipped for internal YAML with detail `internal-yaml spec: paths validated at parse time`. Scorecard still converts internal YAML paths and should be treated as a real path-validity signal.
+
+## Goal
+
+Land an `ahrefs` catalog entry and a generated `ahrefs-pp-cli` that:
+
+1. Mirrors 29 v1 Ahrefs API endpoints across 7 sections.
+2. Uses Printing Press internal YAML as the source spec at `catalog/specs/ahrefs-v3.yaml`.
+3. Authenticates with `Authorization: Bearer <token>` from `AHREFS_API_KEY`.
+4. Emits stdio and HTTP MCP transport support while keeping endpoint tools visible for the 29-endpoint v1 surface.
+5. Avoids paid API-unit burn in routine shipcheck by running mock verification, omitting `scorecard --live-check`, and manually probing only known-free endpoints when live credentials are available.
+6. Produces a reconstruction manifest that proves SDK provenance, endpoint counts, selected endpoints, skipped endpoints, paths, verbs, request placement, and free-endpoint status.
+7. Marks the two public crawler endpoints as `no_auth: true` so generated MCP descriptions and `tools-manifest.json` reflect that those endpoints work without an Ahrefs key.
+
+## Requirements
+
+### Spec Reconstruction
+
+- **R1.** Write `scripts/reconstruct-ahrefs-spec.py` to consume pinned SDK artifacts and emit:
+  - `catalog/specs/ahrefs-v3.yaml`
+  - `catalog/specs/ahrefs-v3.manifest.json`
+- **R2.** Target Printing Press internal YAML, not OpenAPI.
+- **R3.** Pin the SDK commit SHA and source file blob SHAs in `catalog/specs/ahrefs-v3.manifest.json`. The internal spec parser has no supported top-level metadata field, so the manifest is the provenance authority; YAML comments in the spec are acceptable for human context only.
+- **R4.** Extract transport paths from `_generated_methods.py` `_request(api_section, endpoint, ...)` calls. Do not derive URLs from method names.
+- **R5.** Extract base URL and auth behavior from SDK transport helpers:
+  - base URL: `https://api.ahrefs.com/v3`
+  - header: `Authorization: Bearer <key>`
+  - SDK env var: `AHREFS_API_KEY`
+- **R6.** Extract request parameters from generated method signatures and request model classes. Request placement is query for GET. If a future selected endpoint uses `http_method="POST"` with read-only filter body, put body fields under `body:` and set `meta: {"mcp:read-only": "true"}` explicitly.
+- **R7.** Emit all response schema types needed by the 29 selected endpoints from `types/_generated.py`. If exact nested schema conversion is too expensive for v1, use object/array schemas conservatively but document the skipped fidelity in the manifest.
+- **R8.** Emit `auth.verify_path: /subscription-info/limits-and-usage`.
+- **R9.** Emit `mcp.transport: [stdio, http]`. Do not set `orchestration` or `endpoint_tools` in v1.
+- **R10.** Emit `meta: {"mcp:read-only": "true"}` for all 29 endpoints. They are read endpoints, and explicit metadata avoids relying on the generator's write/read heuristic.
+- **R10a.** Emit `http_transport: standard`. Current Printing Press defaults `spec_source: community` to browser-compatible transport, which is wrong for Ahrefs' normal API surface.
+- **R10b.** Emit `no_auth: true` for `public_crawler_ips` and `public_crawler_ip_ranges`. `free_probe` in the manifest is not enough; the internal spec field drives generated MCP/tool metadata.
+
+### Catalog
+
+- **R11.** Add `catalog/ahrefs.yaml` with `spec_source: community`. The SDK is official, but the reconstructed spec is produced by this repo and is not vendor-published.
+- **R12.** Use `tier: community` for v1. Revisit only if Ahrefs publishes a stable downloadable spec or explicitly blesses this reconstructed spec.
+- **R13.** During development, always generate with local `--spec catalog/specs/ahrefs-v3.yaml`.
+- **R14.** Set `spec_url` in `catalog/ahrefs.yaml` to the raw GitHub URL only after the spec file is committed in the same branch and expected to exist on `main` after merge. Do not rely on catalog lookup before merge.
+- **R15.** Do not assume `catalog/specs/**` is embedded. The catalog entry is for discovery and future remote fetch, not for local embedded spec lookup.
+
+### Auth and Doctor
+
+- **R16.** Use internal spec auth:
+
+```yaml
+auth:
+  type: api_key
+  in: header
+  header: Authorization
+  format: "Bearer {api_key}"
+  env_vars: [AHREFS_API_KEY]
+  verify_path: /subscription-info/limits-and-usage
+```
+
+This preserves the Ahrefs SDK's documented `AHREFS_API_KEY` env var while still sending a bearer token. The `{api_key}` placeholder is derived from `AHREFS_API_KEY` by the generator's env-var placeholder logic. Do not use OpenAPI `http` bearer auth unless accepting `AHREFS_TOKEN` is intentional.
+
+### Verification and Cost Control
+
+- **R17.** Routine verification must not pass `--api-key`; this keeps `verify` in mock mode.
+- **R18.** Routine `shipcheck` must pass `--no-live-check`; otherwise the umbrella invokes `scorecard --live-check` by default.
+- **R19.** There is no current verifier flag that live-tests only selected free endpoints. Live free-endpoint probing is manual for v1:
+  - build the printed CLI
+  - export `AHREFS_API_KEY`
+  - run only the three free endpoint commands directly
+- **R20.** Full live `verify --api-key "$AHREFS_API_KEY"` is explicitly out of routine v1 shipcheck because it may call all 29 endpoints and burn API units.
+- **R21.** Because internal YAML path validity is skipped by current dogfood, the reconstruction manifest must prove selected transport paths and the generated source must be inspected when dogfood reports the internal-YAML skip. Scorecard still evaluates internal-YAML paths and should be treated as a real path-validity signal.
+
+### Publishing
+
+- **R22.** Use concrete repo and GitHub commands, not `/printing-press-publish`, for public-library publication. The skill can be a convenience later, but this plan must be executable without it.
+- **R23.** Use `printing-press publish validate` and `printing-press publish package` for packaging. Then use `git`, `gh repo clone`, branch creation, copy, commit, push, and `gh pr create` against `mvanhorn/printing-press-library`.
+
+## V1 Endpoint Allowlist
+
+The selected v1 surface remains 29 endpoints. Paths below are from the SDK `_request(api_section, endpoint, ...)` call sites, not inferred from method names. At inspected SDK SHA `15022030974ffbd46f82dd3d6fb9d298d6b30bf9`, all selected endpoints are GET-shaped because the generated `_request` call does not pass `http_method`.
+
+| Method | HTTP | Path |
+|---|---:|---|
+| `public_crawler_ips` | GET | `/public/crawler-ips` |
+| `public_crawler_ip_ranges` | GET | `/public/crawler-ip-ranges` |
+| `subscription_info_limits_and_usage` | GET | `/subscription-info/limits-and-usage` |
+| `site_explorer_domain_rating` | GET | `/site-explorer/domain-rating` |
+| `site_explorer_domain_rating_history` | GET | `/site-explorer/domain-rating-history` |
+| `site_explorer_backlinks_stats` | GET | `/site-explorer/backlinks-stats` |
+| `site_explorer_refdomains_history` | GET | `/site-explorer/refdomains-history` |
+| `site_explorer_metrics` | GET | `/site-explorer/metrics` |
+| `site_explorer_all_backlinks` | GET | `/site-explorer/all-backlinks` |
+| `site_explorer_broken_backlinks` | GET | `/site-explorer/broken-backlinks` |
+| `site_explorer_organic_keywords` | GET | `/site-explorer/organic-keywords` |
+| `site_explorer_organic_competitors` | GET | `/site-explorer/organic-competitors` |
+| `site_explorer_top_pages` | GET | `/site-explorer/top-pages` |
+| `site_explorer_pages_by_traffic` | GET | `/site-explorer/pages-by-traffic` |
+| `site_explorer_metrics_by_country` | GET | `/site-explorer/metrics-by-country` |
+| `keywords_explorer_overview` | GET | `/keywords-explorer/overview` |
+| `keywords_explorer_matching_terms` | GET | `/keywords-explorer/matching-terms` |
+| `keywords_explorer_related_terms` | GET | `/keywords-explorer/related-terms` |
+| `keywords_explorer_search_suggestions` | GET | `/keywords-explorer/search-suggestions` |
+| `keywords_explorer_volume_history` | GET | `/keywords-explorer/volume-history` |
+| `keywords_explorer_volume_by_country` | GET | `/keywords-explorer/volume-by-country` |
+| `rank_tracker_overview` | GET | `/rank-tracker/overview` |
+| `rank_tracker_competitors_overview` | GET | `/rank-tracker/competitors-overview` |
+| `rank_tracker_serp_overview` | GET | `/rank-tracker/serp-overview` |
+| `site_audit_projects` | GET | `/site-audit/projects` |
+| `site_audit_issues` | GET | `/site-audit/issues` |
+| `site_audit_page_explorer` | GET | `/site-audit/page-explorer` |
+| `site_audit_page_content` | GET | `/site-audit/page-content` |
+| `serp_overview` | GET | `/serp-overview/serp-overview` |
+
+Notes:
+
+- The old plan name `site_explorer_backlinks` is replaced by the SDK method `site_explorer_all_backlinks`.
+- The three free live probes are `public_crawler_ips`, `public_crawler_ip_ranges`, and `subscription_info_limits_and_usage`.
+- The script must fail if any allowlisted method is missing from `_search_index.json` or `_generated_methods.py`.
+
+## Reconstruction Manifest Contract
+
+`catalog/specs/ahrefs-v3.manifest.json` must include:
+
+```json
+{
+  "sdk_repo": "https://github.com/ahrefs/ahrefs-python",
+  "sdk_commit": "15022030974ffbd46f82dd3d6fb9d298d6b30bf9",
+  "source_files": {
+    "src/ahrefs/_search_index.json": "<blob-sha>",
+    "src/ahrefs/_generated_methods.py": "<blob-sha>",
+    "src/ahrefs/types/_generated.py": "<blob-sha>",
+    "src/ahrefs/_base_client.py": "<blob-sha>",
+    "src/ahrefs/_sync_client.py": "<blob-sha>"
+  },
+  "total_methods_discovered": 105,
+  "sections_discovered": {
+    "batch-analysis": 1,
+    "brand-radar": 9,
+    "keywords-explorer": 6,
+    "management": 16,
+    "public": 2,
+    "rank-tracker": 5,
+    "serp-overview": 1,
+    "site-audit": 4,
+    "site-explorer": 26,
+    "subscription-info": 1,
+    "web-analytics": 34
+  },
+  "methods_selected": 29,
+  "methods_skipped": 76,
+  "selected": [
+    {
+      "method": "site_explorer_domain_rating",
+      "path": "/site-explorer/domain-rating",
+      "http_method": "GET",
+      "request_placement": "query",
+      "source_call": "self._request(\"site-explorer\", \"domain-rating\", ...)",
+      "no_auth": false,
+      "free_probe": false
+    }
+  ]
+}
+```
+
+The exact source SHAs come from the pinned SDK commit. The counts above reflect the inspected SDK master. If Ahrefs changes the SDK before implementation starts, update this manifest and this plan consciously rather than silently accepting drift.
+
+## Internal Spec Shape
+
+The reconstructed spec should use this shape:
+
+```yaml
+name: ahrefs
+display_name: Ahrefs
+description: SEO and competitive intelligence API for backlinks, keywords, rank tracking, site audit, and SERP data.
+base_url: https://api.ahrefs.com/v3
+http_transport: standard
+auth:
+  type: api_key
+  in: header
+  header: Authorization
+  format: "Bearer {api_key}"
+  env_vars: [AHREFS_API_KEY]
+  verify_path: /subscription-info/limits-and-usage
+mcp:
+  transport: [stdio, http]
+resources:
+  public:
+    description: Public Ahrefs crawler endpoints.
+    endpoints:
+      crawler_ips:
+        method: GET
+        path: /public/crawler-ips
+        no_auth: true
+        description: Ahrefs crawler IP addresses.
+        body: []
+        response: {type: object}
+        pagination: null
+        meta:
+          "mcp:read-only": "true"
+  site_explorer:
+    description: Site Explorer endpoints.
+    endpoints:
+      domain_rating:
+        method: GET
+        path: /site-explorer/domain-rating
+        description: Domain Rating.
+        params:
+          - name: target
+            type: string
+            required: true
+            positional: false
+            description: Domain, URL, or path target.
+          - name: protocol
+            type: string
+            required: false
+            positional: false
+            description: Target protocol mode.
+          - name: date
+            type: string
+            required: false
+            positional: false
+            format: date
+            description: Snapshot date.
+        body: []
+        response: {type: object, item: SiteExplorerDomainRatingResponse}
+        pagination: null
+        meta:
+          "mcp:read-only": "true"
+types:
+  SiteExplorerDomainRatingResponse:
+    fields:
+      - name: data
+        type: object
+```
+
+Parameter names and type details above are illustrative. The script must derive them from the SDK artifacts.
+
+## Catalog Entry Draft
+
+```yaml
+name: ahrefs
+display_name: Ahrefs
+description: SEO and competitive intelligence for backlinks, keywords, rank tracking, site audit, and SERP data
+category: marketing
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/ahrefs-v3.yaml
+spec_format: yaml
+spec_source: community
+http_transport: standard
+tier: community
+verified_date: "2026-05-01"
+homepage: https://docs.ahrefs.com/docs/api/reference/introduction
+notes: |
+  Internal Printing Press spec reconstructed from the official ahrefs/ahrefs-python SDK, filtered to 29 read endpoints.
+  Source SDK commit: 15022030974ffbd46f82dd3d6fb9d298d6b30bf9.
+  Manifest: catalog/specs/ahrefs-v3.manifest.json.
+  Use local --spec during development because catalog/specs/** is not embedded in catalog.FS.
+  API units are shared across direct API v3, Ahrefs MCP, and Ahrefs Connect. Routine shipcheck must use mock verify and --no-live-check.
+known_alternatives:
+  - name: ahrefs-python
+    url: https://github.com/ahrefs/ahrefs-python
+    language: python
+sandbox_endpoint: ""
+```
+
+Bootstrap order:
+
+1. Generate and review `catalog/specs/ahrefs-v3.yaml` and `catalog/specs/ahrefs-v3.manifest.json`.
+2. Add `catalog/ahrefs.yaml` pointing to the future raw GitHub URL.
+3. Rebuild `./printing-press` after adding `catalog/ahrefs.yaml`; root catalog YAML is embedded at build time and manifest/category enrichment reads the embedded catalog.
+4. During local development, run `generate --spec catalog/specs/ahrefs-v3.yaml`; do not run `generate ahrefs`.
+5. After merge to `main`, the catalog `spec_url` becomes fetchable for future runs.
+
+## Commands
+
+All commands assume repo root.
+
+### Build the printing-press binary
+
+```bash
+go build -o ./printing-press ./cmd/printing-press
+```
+
+Run this again after adding `catalog/ahrefs.yaml`, because catalog root YAML files are embedded in the binary.
+
+### Reconstruct the internal spec
+
+```bash
+python3 scripts/reconstruct-ahrefs-spec.py \
+  --sdk-repo https://github.com/ahrefs/ahrefs-python \
+  --sdk-ref 15022030974ffbd46f82dd3d6fb9d298d6b30bf9 \
+  --out catalog/specs/ahrefs-v3.yaml \
+  --manifest catalog/specs/ahrefs-v3.manifest.json
+```
+
+### Validate catalog entry and spec parse
+
+```bash
+go test ./internal/catalog/...
+./printing-press generate --spec catalog/specs/ahrefs-v3.yaml --spec-source community --transport standard --dry-run
+```
+
+### Generate the printed CLI
+
+```bash
+./printing-press generate \
+  --spec catalog/specs/ahrefs-v3.yaml \
+  --spec-source community \
+  --transport standard \
+  --output "$HOME/printing-press/library/ahrefs" \
+  --force
+```
+
+### Run routine verification without paid API-unit burn
+
+```bash
+CLI_DIR="$HOME/printing-press/library/ahrefs"
+
+./printing-press dogfood --dir "$CLI_DIR" --spec catalog/specs/ahrefs-v3.yaml
+./printing-press verify --dir "$CLI_DIR" --spec catalog/specs/ahrefs-v3.yaml --fix
+./printing-press workflow-verify --dir "$CLI_DIR"
+./printing-press verify-skill --dir "$CLI_DIR"
+./printing-press scorecard --dir "$CLI_DIR" --spec catalog/specs/ahrefs-v3.yaml
+./printing-press shipcheck --dir "$CLI_DIR" --spec catalog/specs/ahrefs-v3.yaml --no-live-check
+```
+
+Expected dogfood nuance: path validity is skipped for internal YAML. Treat dead flags, auth protocol, MCP surface parity, anti-reimplementation, workflow, skill verification, and scorecard as required checks. Path correctness is proven by the manifest, generated source inspection, and scorecard's internal-YAML path-validity signal.
+
+### Optional live free probes only
+
+There is no verifier allowlist for live probes. Run these printed CLI commands directly instead of `verify --api-key`:
+
+```bash
+export AHREFS_API_KEY="<redacted>"
+"$CLI_DIR/ahrefs-pp-cli" public crawler-ips --json
+"$CLI_DIR/ahrefs-pp-cli" public crawler-ip-ranges --json
+"$CLI_DIR/ahrefs-pp-cli" subscription-info --json
+```
+
+`subscription-info` is expected to be promoted because it is a single-endpoint resource. If these commands differ after generation, use the generated `--help` output and update this command list in the implementation PR.
+
+### Package for public-library PR
+
+```bash
+STAGE_DIR="$PWD/.gotmp/publish-ahrefs"
+PUBLIC_REPO_DIR="$PWD/.gotmp/printing-press-library"
+
+./printing-press publish validate --dir "$CLI_DIR" --json
+rm -rf "$STAGE_DIR"
+./printing-press publish package \
+  --dir "$CLI_DIR" \
+  --category marketing \
+  --target "$STAGE_DIR" \
+  --json
+
+gh repo clone mvanhorn/printing-press-library "$PUBLIC_REPO_DIR"
+cd "$PUBLIC_REPO_DIR"
+git checkout -b feat/ahrefs-cli
+cp -R "$STAGE_DIR"/library/marketing/ahrefs ./library/marketing/
+git status --short
+git add library/marketing/ahrefs
+git commit -m "feat(marketing): add ahrefs printed cli"
+git push -u origin feat/ahrefs-cli
+gh pr create --title "feat(marketing): add ahrefs printed cli" --body "Adds the Ahrefs printed CLI generated from the reconstructed internal spec."
+```
+
+The public-library repo is outside this repo. Do not run this packaging section while only revising this plan.
+
+## Pricing and Unit Notes
+
+Use USD in this plan. As of the referenced Ahrefs help docs reviewed during plan revision:
+
+| Plan | Monthly API integration units | Max rows per request |
+|---|---:|---:|
+| Lite | 25,000 | 10 |
+| Standard | 150,000 | 25 |
+| Advanced | 500,000 | 100 |
+| Enterprise | 2,000,000 | Unlimited |
+
+Each API call has a 50-unit minimum. API units are shared across direct API v3, Ahrefs MCP, and Ahrefs Connect. Enterprise is not unlimited for API units; it has 2,000,000 included units and can buy additional units. Currency and pricing amounts are region-dependent, so this plan tracks unit limits rather than plan prices.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| SDK surface drifts before implementation | Pin SDK commit and blob SHAs; manifest fails count or allowlist drift. |
+| Transport paths are guessed incorrectly | Extract from `_request(api_section, endpoint, ...)`; reject method-name-derived paths. |
+| Internal YAML skips dogfood path-validity scoring | Treat as known dogfood limitation; use manifest path proof, generated source inspection, and scorecard's internal-YAML path-validity signal. |
+| Routine shipcheck burns API units | Do not pass `--api-key`; pass `--no-live-check`; live-test free endpoints manually. |
+| `where` filter UX is weaker than desired | v1 accepts JSON/filter strings as ordinary flags only. `@file` expansion is out of scope until implemented as a machine feature. |
+| Reconstructed spec is not vendor-published | Use `spec_source: community` and `tier: community`; document official SDK provenance. |
+| Response schema conversion takes longer than expected | Budget 6-10 hours and allow conservative object schemas with manifest-documented fidelity gaps for v1. |
+
+## Out of Scope - Blocking Machine Work
+
+These are not part of v1 implementation. If needed, write separate plans before relying on them:
+
+1. **OpenAPI `mcp:` extraction.** Proposed plan path: `docs/plans/2026-05-XX-feat-openapi-mcp-extension-parser.md`. Files likely touched: `internal/openapi/parser.go`, `docs/SPEC-EXTENSIONS.md`, `internal/openapi/*_test.go`.
+2. **Verifier live endpoint allowlist.** Proposed plan path: `docs/plans/2026-05-XX-feat-verify-live-allowlist.md`. Files likely touched: `internal/cli/verify.go`, `internal/pipeline/runtime.go`, `internal/cli/shipcheck.go`, tests.
+3. **Dogfood internal-YAML path-validity reporting.** Proposed plan path: `docs/plans/2026-05-XX-feat-dogfood-internal-yaml-path-validity.md`. Files likely touched: `internal/pipeline/dogfood.go` and dogfood tests. Scorecard already converts internal YAML paths and remains in scope for v1 verification.
+4. **Cobra `@file` flag expansion for JSON filters.** Proposed plan path: `docs/plans/2026-05-XX-feat-json-flag-file-expansion.md`. Files likely touched: `internal/generator/templates/command_endpoint.go.tmpl`, helper templates, generator tests.
+5. **Golden snapshots for Ahrefs catalog generation.** Not needed for this catalog addition unless the implementation changes deterministic generator contracts. Use existing tests and shipcheck first.
+
+## Review Finding Resolution
+
+| # | Resolution |
+|---:|---|
+| 1 | Switched reconstruction target from OpenAPI to internal YAML because OpenAPI parser does not extract `mcp:`. |
+| 2 | Rewrote all phase commands to actual `generate --spec`, `generate --dry-run`, and `--dir` forms. |
+| 3 | Documented local `--spec` bootstrap and remote `spec_url` only after merge. |
+| 4 | Documented that `catalog/specs/**` is not embedded and catalog lookup must not read it locally. |
+| 5 | Set `spec_source: community` and `tier: community`. |
+| 6 | Chose internal spec `api_key` header auth with `AHREFS_API_KEY` and `Authorization: Bearer {api_key}`. |
+| 7 | Added `auth.verify_path: /subscription-info/limits-and-usage`. |
+| 8 | Removed `@file` support from v1 and made it separate machine work. |
+| 9 | Required path extraction from SDK `_request` call sites and listed the 29 SDK paths. |
+| 10 | Added explicit `meta: {"mcp:read-only": "true"}` for all v1 endpoints; selected endpoints are currently GET. |
+| 11 | Rewrote verification cost control around actual `verify`, `scorecard`, and `shipcheck` flags. |
+| 12 | Fixed Enterprise API units to 2,000,000 and avoided region-specific price claims. |
+| 13 | Added reconstruction manifest with counts, selected/skipped methods, sections, paths, and drift failure. |
+| 14 | Revised estimate to 6-10 hours. |
+| 15 | Dropped endpoint golden snapshots from v1 and listed them as unnecessary unless generator contracts change. |
+| 16 | Replaced `/printing-press-publish` with concrete `publish validate`, `publish package`, `git`, and `gh` steps. |
+
+## Estimate
+
+Minimum implementation time: 6-10 hours.
+
+Breakdown:
+
+- SDK artifact retrieval, SHA pinning, and manifest emission: 1 hour
+- Method and transport extraction from generated Python: 1.5-2 hours
+- Parameter, enum, request placement, and response type conversion: 2-3 hours
+- Internal spec validation and generator dry-run fixes: 1-2 hours
+- Generation, dogfood, verify, scorecard, manual free probes, and packaging: 1.5-2 hours
+
+## Deferred Expansion
+
+v2 can expand beyond 29 endpoints after v1 proves reconstruction and generation against the current machine. The likely expansion areas are Web Analytics, Brand Radar, Management write endpoints, remaining Rank Tracker endpoints, remaining Site Explorer endpoints, and Batch Analysis.
+
+When the surface grows past roughly 50 endpoints, switch the internal spec MCP block to:
+
+```yaml
+mcp:
+  transport: [stdio, http]
+  orchestration: code
+  endpoint_tools: hidden
+```
+
+Do not make that switch in v1.

--- a/docs/plans/2026-05-04-002-docs-consolidate-agents-md-plan.md
+++ b/docs/plans/2026-05-04-002-docs-consolidate-agents-md-plan.md
@@ -1,0 +1,304 @@
+---
+title: "docs(cli): consolidate AGENTS.md via progressive disclosure"
+type: docs
+status: active
+date: 2026-05-04
+---
+
+# docs(cli): consolidate AGENTS.md via progressive disclosure
+
+## Overview
+
+`AGENTS.md` has grown to 337 lines (~30KB) and is loaded into every agent's context for every turn in this repo (via `CLAUDE.md`'s `@AGENTS.md` include). The file mixes three distinct content kinds:
+
+1. **Write-time rules** that must fire at the moment an agent edits code (e.g. anti-reimplementation, code & comment hygiene, commit style).
+2. **Procedural runbooks** that fire only on specific operations (golden harness decision rubric, release-please flow, catalog entry validation).
+3. **Pure reference / glossary** material that agents look up on demand (the canonical-term table, local artifact layout, public library flow).
+
+This plan extracts the *body* of (2) and (3) into dedicated `docs/` files. It does **not** move the *load-bearing rules* that fire at the moment of an action — those stay inline. Every extracted section is replaced by a short, command-shaped inline rule that retains the prohibitions, file paths, and validation values an agent needs at write-time, plus a pointer to the new doc for the longer rubric/flow.
+
+This is a deliberate revision after a codex review (REQUEST CHANGES, 8 findings). Earlier draft would have weakened or moved write-time rules out of agents' line of sight; this revision keeps them inline.
+
+Target shape: `AGENTS.md` shrinks from 337 → ~210 lines, with no rule, file path, validation value, or prohibition removed from the inline file.
+
+---
+
+## Problem Frame
+
+Two forces are in tension:
+
+- **Context economy.** Every line of `AGENTS.md` is paid for on every turn. A 337-line preamble dilutes attention on the rules that matter most for the change in front of the agent. The glossary alone is ~57 lines of lookup material that fires when someone asks "what does *manuscript* mean?" — not when an agent is editing a template.
+- **Locality of rules.** `AGENTS.md` itself contains the rule *"Make rules applicable at the moment they fire."* A rule split into a separate file only works if the inline section retains everything the agent needs to *not act wrongly* — file paths, prohibitions, validation values — and the pointer leads to the longer flow/rubric. A vague "see `docs/...`" pointer is worse than the inline rule it replaced.
+
+The right consolidation keeps short, write-time-applicable rules inline (including their concrete file paths and prohibitions) and extracts long, situational, or lookup-shaped content — only when paired with a command-shaped inline rule.
+
+---
+
+## Requirements Trace
+
+- R1. No information present in `AGENTS.md` today is lost after the split. Every prohibition, file path, validation value, and pointer either stays inline or appears verbatim/tightened in its destination file. The PR description carries a paragraph-level mapping table from old `AGENTS.md` to (new `AGENTS.md` ∪ extracted files); a missing mapping blocks merge.
+- R2. Every extracted section is replaced inline by a **command-shaped rule**, not a bare pointer. A command-shaped rule names the trigger condition, the prohibition or required action, the concrete file paths or values involved, and ends with a pointer to the longer flow/rubric.
+- R3. Write-time-fire rules stay inline in full: Machine vs Printed CLI, Anti-reimplementation, Agent-Native Surface, Build/Test/Lint, Project Structure (with new pointers added to its bullet list), Commit Style, Testing, Quality Gates one-liner, Code & Comment Hygiene, Internal Skills install (short and one-time but stays inline because it's 6 lines and pulling it out doesn't save context worth the indirection cost).
+- R4. Long rubrics, flows, and rationales are extracted: Golden Output Harness decision rubric and fixture-author guide, release-please / goreleaser flow narrative, catalog validation rationale and `internal/catalog` cross-link, Local Artifacts + Public Library narrative, Glossary table.
+- R5. The following rules/values stay inline even when their owning section is otherwise extracted:
+  - **Golden:** the full enumerated trigger list ("CLI command output, catalog rendering, browser-sniff or crowd-sniff output, generated specs or generated printed CLI files, templates under `internal/generator/templates/`, naming, endpoint derivation, auth emission, manifest generation, scorecard output, or pipeline artifacts") and the rule "never update goldens just to make a failing check pass."
+  - **Versioning:** the prohibition "Never manually edit version numbers" and the **two** file paths that carry the plugin version (`.claude-plugin/plugin.json` → `version`, `internal/version/version.go` → `var Version` annotated `x-release-please-version`) and the test names (`TestVersionConsistencyAcrossFiles`, `TestMarketplaceJSONHasNoPluginVersion`). **`marketplace.json` does *not* carry a plugin version** — `TestMarketplaceJSONHasNoPluginVersion` (`internal/cli/release_test.go:81`) fails if a reviewer re-adds one. The current `AGENTS.md` text claiming three version files is stale; this plan corrects it inline rather than propagating the staleness.
+  - **Catalog:** the required-fields list, the wrapper-only carve-out, the HTTPS rule, the allowed `category` enum (the public categories from `internal/catalog/catalog.go:19`), the allowed `tier` enum, and the "rebuild the binary after editing" requirement. The validator additionally accepts `example` as a test-only catch-all category — the inline rule names it explicitly and instructs not to use it for real entries. The current `AGENTS.md` omits `example` and treats `spec_url`/`spec_format` as unconditional; the validator (`internal/catalog/catalog.go:219`) makes them conditional on the entry not being wrapper-only (`wrapper_libraries` set, `spec_url` empty). This plan corrects both omissions to match the validator.
+  - **Glossary:** the canonical-naming command — *"use canonical terms; in skills and user-facing output use 'the Printing Press' (never 'the machine'); ask before acting on ambiguous user phrasing"* — plus the four disambiguation defaults (library / publish / manifest / catalog).
+- R6. Internal cross-references in `AGENTS.md` (e.g., the "Editing AGENTS.md" section's reference to "Code & Comment Hygiene") continue to resolve correctly.
+- R7. Skills, code comments, and other docs that quote glossary terms or canonical names keep working without edits.
+- R8. The `CLAUDE.md` → `@AGENTS.md` include keeps working.
+- R9. Pointer-rot is prevented: when an extracted doc's applicability changes (a new fire condition added, a fire condition removed, a prohibition value changes), the inline trigger sentence in `AGENTS.md` is updated in the same PR. This rule lives in the new doc-authoring file (see U1).
+
+---
+
+## Scope Boundaries
+
+- In scope: reorganization of `AGENTS.md` and creation of new files under `docs/`.
+- In scope: updating cross-references inside `AGENTS.md` and adding command-shaped inline rules with pointer suffixes.
+- In scope: correcting factual staleness items in the current `AGENTS.md` while authoring the new inline specimens, **only where the corrected statement is enforced by code or tests in this repo**. Three corrections are in scope:
+  1. Versioning: "three files" → two files + "no version in `marketplace.json`" prohibition. Enforced by `internal/cli/release_test.go:57` (`TestVersionConsistencyAcrossFiles`) and `:81` (`TestMarketplaceJSONHasNoPluginVersion`).
+  2. Catalog enum: add `example` as test-only catch-all. Enforced by `internal/catalog/catalog.go:37`.
+  3. Catalog required fields: `spec_url` and `spec_format` are required only when `wrapper_libraries` is empty. Enforced by `internal/catalog/catalog.go:219`.
+- Out of scope: rewriting the substance of any rule. Tightening prose and aligning a stale fact with the code/test that already enforces it are allowed; changing what a rule *says* is not. Factual corrections that lack a code/test enforcer are also out of scope — they belong in a separate review pass, not this docs split.
+- Out of scope: changes to `CLAUDE.md` (which only contains `@AGENTS.md`), skills, templates, or generator code. Docs-only PR.
+- Out of scope: deleting glossary entries or pruning stale entries. A separate review can prune; this plan moves intact.
+- Out of scope: any audit or change inside `skills/`. Skill-file scanning is deferred to U4 follow-up so this PR does not need to read or rewrite skill content. Skill quotations of `AGENTS.md` prose, if any, remain valid because the inline rules they would have quoted remain inline.
+
+---
+
+## Context & Research
+
+### Current AGENTS.md sections and disposition (line ranges as of 5bc7390)
+
+| # | Section | Lines | Fires when | Disposition |
+|---|---|---|---|---|
+| 1 | Machine vs Printed CLI | 3–17 | every change | stay |
+| 1a | Anti-reimplementation | 19–38 | adding/touching novel commands | stay |
+| 2 | Agent-Native Surface | 40–78 | touching MCP / Cobra annotations | stay |
+| 3 | Build, Test & Lint | 80–93 | every change | stay |
+| 4 | Golden Output Harness | 95–125 | template/output changes | **split**: trigger list + "never update to make it pass" rule stay inline; rubric/fixtures/decision-tree → `docs/GOLDEN.md` |
+| 5 | Project Structure | 127–140 | quick reference | stay; bullet list extended with new doc paths |
+| 6 | Glossary | 142–198 | naming + ambiguous user phrasing | **split**: canonical-naming command + 4 disambiguation defaults stay inline; full term table → `docs/GLOSSARY.md` |
+| 7 | Commit Style | 200–226 | at commit / PR creation | stay |
+| 8 | Versioning & Release | 228–241 | release flow / version files | **split**: "never edit version numbers" + 2 version file paths + both test names + "no version in marketplace.json" prohibition stay inline; release-please flow → `docs/RELEASE.md` |
+| 9 | Adding Catalog Entries | 243–249 | adding `catalog/*.yaml` | **split**: required fields + HTTPS rule + category/tier enums + rebuild rule stay inline; longer narrative + validation rationale → `docs/CATALOG.md` |
+| 10 | Testing | 251–257 | every code change | stay |
+| 11 | Quality Gates | 259–261 | one-liner reference | stay |
+| 12 | Local Artifacts | 263–273 | discussions of file location | extract → `docs/ARTIFACTS.md` |
+| 13 | Public Library | 275–286 | publish-related work | extract → `docs/ARTIFACTS.md` |
+| 14 | Internal Skills | 288–298 | one-time skill install | **stay**: 6 lines, no extraction win |
+| 15 | Skill Authoring | 300–304 | when machine change touches a skill | stay (already a pointer) |
+| 16 | Code & Comment Hygiene | 306–324 | every code write + diff review | stay |
+| 17 | Editing AGENTS.md | 326–333 | editing this file | extract → `docs/DOCS.md` (NEW) |
+| 18 | Patterns | 335–337 | designing cross-cutting workflows | stay (already a pointer) |
+
+### Existing `docs/` files
+
+`docs/PIPELINE.md`, `docs/SPEC-EXTENSIONS.md`, `docs/SKILLS.md`, `docs/PATTERNS.md` are the prior art — each is a focused doc that `AGENTS.md` already points to with a one-liner. New files extend the same pattern.
+
+### Constraints already in AGENTS.md that this plan must respect
+
+- *"Make rules applicable at the moment they fire."* → write-time rules stay inline; only flows/rubrics/lookup material extract.
+- *"Don't defend the doc's structure inside the doc."* → `AGENTS.md` will not contain a "we split this because…" section. The plan itself is the justification.
+- *"Examples should be generic or anti-pattern-shaped."* → extracted files keep existing examples; we add no new incident-tied examples.
+- *"No dates, incidents, or ticket numbers in rules."* → applies to new files. Note: some current glossary entries already violate this ("introduced April 2026"); preserved as-is, flagged for U4 follow-up.
+
+---
+
+## Key Technical Decisions
+
+- **Inline keeps the *command*; extracted file keeps the *flow*.** This is the central revision after codex review. Examples:
+  - Golden: inline keeps the full list of fire conditions and the prohibition against updating goldens to mask a failure. Extracted keeps the decision rubric, fixture-add procedure, and verify-failure recovery.
+  - Versioning: inline keeps "never edit by hand," the **two** version file paths, both relevant test names, and the explicit prohibition on adding a `version` to `marketplace.json` plugin entries. Extracted keeps the release-please/goreleaser flow narrative. (Note: the current `AGENTS.md` says "three files" — that text is stale against `release_test.go:81`. The inline specimen above is the corrected version.)
+  - Catalog: inline keeps the required-fields list with the wrapper-only carve-out, HTTPS, the public `category` enum, the `tier` enum, the `example`-is-test-only carve-out, and the rebuild requirement. Extracted keeps validation rationale, the longer narrative on why these constraints exist, and the full wrapper-only entry shape.
+  - Glossary: inline keeps the naming command and the four disambiguation defaults. Extracted keeps the term table.
+- **`docs/DOCS.md` is a new file, not an append to `docs/SKILLS.md`.** Doc-authoring rules and skill-authoring rules have different audiences. Mixing them turns `docs/SKILLS.md` into a junk drawer. New `docs/DOCS.md` covers: editing-AGENTS.md rules + pointer-rot rule (R9).
+- **Internal Skills install stays inline.** Six lines. Pulling it out costs more in indirection than it saves in context. The previous draft moved it to `docs/SKILLS.md` mainly to share a destination with editing-AGENTS.md; with `docs/DOCS.md` taking the latter, internal-skills install no longer has a natural co-located destination, so it stays.
+- **Local Artifacts + Public Library merge into `docs/ARTIFACTS.md`.** Same conceptual axis (where do printed CLIs live, local vs. public). One file beats two for this content. Project Structure gets a one-line pointer.
+- **No skill audit in this PR.** The earlier draft's `grep -rn "AGENTS.md" skills/` step would have read skill content, which is out of scope. Skill-quote audit moves to U4 (optional human-driven follow-up). Skills should remain valid because the inline rules they could have quoted are still inline.
+- **No changes to extracted prose beyond tightening duplicated phrasing.** If two paragraphs say the same thing in slightly different words, the extracted file gets the clearer version. Substantive content stays.
+- **The mapping table is a merge gate.** R1 requires a paragraph-level mapping table in the PR description showing every chunk of the old `AGENTS.md` → its destination. No mapping = no merge. Audit is operationalized, not aspirational.
+
+---
+
+## Open Questions
+
+### Resolved during planning
+
+- **Q: Should the glossary stay fully inline because canonical naming fires constantly?** No. The naming *command* fires constantly (use "printed CLI" not "the CLI"; use "the Printing Press" in user-facing output) and stays inline. The lookup of unfamiliar terms (manuscript, regen-merge, side-effect command convention, etc.) fires rarely and moves to `docs/GLOSSARY.md`.
+- **Q: Should this be one combined `docs/AGENTS-EXTRAS.md` instead of multiple files?** No. One-purpose files match the prior art and let pointers be specific. Grab-bag forces vague pointers.
+- **Q: Should `docs/SKILLS.md` absorb editing-AGENTS rules and internal-skills install?** No. Different audiences. New `docs/DOCS.md` for doc-authoring; internal-skills install stays inline.
+- **Q: Should the U3 audit grep `skills/`?** No. Out of scope for this PR. U4 follow-up.
+- **Q: Does this risk breaking external links into `AGENTS.md` anchors?** Low risk inside this repo (a quick grep before merge confirms callers, scoped to non-skill paths). External pins to GitHub anchors are not a supported contract.
+- **Q: Should the inline catalog rule duplicate the values that live in `internal/catalog`'s validator?** Yes. Validation in code is the source of truth, but the inline rule is a write-time-applicable fence for an agent who hasn't read the validator yet. The `docs/CATALOG.md` cross-link to `internal/catalog` keeps them traceable.
+
+### Deferred to implementation
+
+- Exact wording of inline command-shaped rules. The plan specifies the structure (trigger / prohibition or action / concrete values / pointer); the implementing change picks phrasing.
+- Whether the inline glossary stub uses bullet form or paragraph form for the naming command. Picked at implementation time.
+- Whether `docs/ARTIFACTS.md` opens with Local Artifacts or Public Library first. Local → public is the flow direction; user-facing question is more often public → local. Implementer picks.
+
+---
+
+## High-Level Technical Design
+
+> *Directional guidance for review. The implementing agent should treat it as context, not exact prose to reproduce.*
+
+### Final AGENTS.md shape (target ~210 lines)
+
+```
+# CLI Printing Press - Development Conventions
+
+## Machine vs Printed CLI                     [stay]
+### Anti-reimplementation                     [stay]
+
+## Agent-Native Surface                       [stay]
+### Default: expose; skip rules are exceptions
+### Tool safety annotations
+### Typed exit-code verification
+
+## Build, Test & Lint                         [stay]
+
+## Generator output stability                 [NEW: ~6 lines — full trigger list + "never update to mask" rule + pointer to docs/GOLDEN.md]
+
+## Project Structure                          [stay; bullet list extended]
+- ... existing entries ...
+- docs/GLOSSARY.md   - Canonical terms, full disambiguation table
+- docs/GOLDEN.md     - Golden harness decision rubric and fixture conventions
+- docs/RELEASE.md    - release-please / goreleaser flow
+- docs/CATALOG.md    - Catalog entry validation rationale
+- docs/ARTIFACTS.md  - Local library, manuscripts, public library
+- docs/DOCS.md       - Doc-authoring rules (editing AGENTS.md, pointer-rot rule)
+
+## Naming and disambiguation                  [NEW: ~7 lines — naming command + 4 disambiguation defaults + pointer to docs/GLOSSARY.md]
+
+## Commit Style                               [stay]
+
+## Versioning                                 [NEW: ~6 lines — "never edit by hand" + 2 version file paths + both test names + "no version in marketplace.json" prohibition + pointer to docs/RELEASE.md]
+
+## Adding Catalog Entries                     [NEW: ~6 lines — required fields + HTTPS + category enum + tier enum + rebuild rule + pointer to docs/CATALOG.md]
+
+## Testing                                    [stay]
+
+## Quality Gates                              [stay; one-liner]
+
+## Local Artifacts                            [NEW: ~3 lines — paths only + pointer to docs/ARTIFACTS.md]
+
+## Internal Skills                            [stay; 6 lines]
+
+## Skill Authoring                            [stay; already a pointer]
+
+## Code & Comment Hygiene                     [stay]
+### Write-time defaults
+### Pre-commit: scan the diff
+
+## Editing AGENTS.md                          [REPLACED by 2-line pointer to docs/DOCS.md]
+
+## Patterns                                   [stay; already a pointer]
+```
+
+### New files
+
+- **`docs/GOLDEN.md`** — decision rubric (No-update / Update existing / Add or expand), how to add fixtures, fixture-quality guidance, verify-failure recovery, relationship to `go test` / lint / build. The list of fire conditions and the prohibition stay inline in `AGENTS.md`.
+- **`docs/GLOSSARY.md`** — full term table (lines 159–198 of current `AGENTS.md`) plus the longer naming-context paragraphs (lines 144–152). The naming command and four disambiguation defaults stay inline.
+- **`docs/RELEASE.md`** — release-please flow (3 numbered steps), goreleaser behavior, what merging the release PR triggers. The prohibition + 2 version file paths + both test names + "no version in marketplace.json" rule stay inline.
+- **`docs/CATALOG.md`** — validation rationale, the link to `internal/catalog`, narrative on why categories/tiers exist. The required fields, HTTPS rule, allowed enums, and rebuild rule stay inline.
+- **`docs/ARTIFACTS.md`** — Local Artifacts (lines 263–273) + Public Library (lines 275–286), in `local → public` narrative order. Inline keeps just the path skeleton.
+- **`docs/DOCS.md`** — NEW. Editing-AGENTS.md rules (current lines 326–333) + pointer-rot rule (R9): *"When an extracted doc's applicability changes — a new fire condition, a removed condition, a changed prohibition value — update the inline trigger in `AGENTS.md` in the same PR."*
+
+### Specimen inline rules (structure shown; final wording deferred)
+
+**Golden (~6 lines inline):**
+> Run `scripts/golden.sh verify` whenever a change may affect CLI command output, catalog rendering, browser-sniff or crowd-sniff output, generated specs or generated printed CLI files, templates under `internal/generator/templates/`, naming, endpoint derivation, auth emission, manifest generation, scorecard output, or pipeline artifacts. **Never update goldens just to make a failing check pass.** Run `scripts/golden.sh update` only when the behavior change is intentional, then explain the diff in your final response. See `docs/GOLDEN.md` for the decision rubric (No-update / Update / Add) and how to author fixtures.
+
+**Versioning (~6 lines inline):**
+> Releases are automated by release-please. **Never manually edit version numbers.** The plugin version lives in exactly **two** places and must stay in sync: `.claude-plugin/plugin.json` → `version`, and `internal/version/version.go` → `var Version` (annotated `x-release-please-version`; goreleaser injects via ldflags). `TestVersionConsistencyAcrossFiles` (`internal/cli/release_test.go`) fails if they drift. **Do not add a `version` field to `marketplace.json` plugin entries** — `TestMarketplaceJSONHasNoPluginVersion` fails on that. See `docs/RELEASE.md` for the merge-the-release-PR flow.
+
+**Catalog (~8 lines inline):**
+> When adding or editing `catalog/*.yaml`, the entry must pass `internal/catalog` validation. Required fields: name, display_name, description, category, tier — plus `spec_url` and `spec_format` *unless* the entry is wrapper-only (`wrapper_libraries` is set and `spec_url` is omitted). `spec_url` (when present) must use HTTPS. `category` must be one of: ai, auth, cloud, commerce, developer-tools, devices, food-and-dining, marketing, media-and-entertainment, monitoring, payments, productivity, project-management, sales-and-crm, social-and-messaging, travel, other. `tier` must be `official` or `community`. (The validator additionally accepts `example` as a test-only catch-all — do not use it for real catalog entries.) Rebuild the binary after editing — `catalog.FS` is a Go embed. See `docs/CATALOG.md` for validation rationale and the wrapper-only entry shape.
+
+**Glossary (~7 lines inline):**
+> Use canonical terms in your responses so intent stays unambiguous. In skills and user-facing output (GitHub issues, retro documents, confirmation prompts), use **"the Printing Press"** as the system name — never "the machine." Subsystem names (generator, scorer, skills, binary) are fine alongside it. When user phrasing is ambiguous and the distinction affects what action to take, ask before acting. Most-confused defaults: "library" → local library; "publish" → the publish step (pipeline) unless explicitly the public-library workflow; "manifest" → `tools-manifest.json`; "catalog" → embedded `catalog/`. See `docs/GLOSSARY.md` for the full term table and disambiguation cases.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[U1 Create extracted docs incl. docs/DOCS.md] --> U2[U2 Rewrite AGENTS.md with command-shaped rules]
+  U2 --> U3[U3 Mapping table + non-skill anchor audit]
+  U3 --> U4[U4 Optional follow-ups]
+```
+
+- **U1. Create the six extracted docs.**
+  - `docs/GOLDEN.md`, `docs/GLOSSARY.md`, `docs/RELEASE.md`, `docs/CATALOG.md`, `docs/ARTIFACTS.md`, `docs/DOCS.md`.
+  - `docs/DOCS.md` includes the pointer-rot rule (R9) explicitly.
+  - Each new file: short header, the moved content verbatim or tightened, no editorial restructuring.
+  - **Done when:** every paragraph extracted from `AGENTS.md` lines 95–125, 142–198, 228–249, 263–286, 326–333 has a home, and `docs/DOCS.md` includes the pointer-rot rule.
+
+- **U2. Rewrite AGENTS.md with command-shaped inline rules.**
+  - Replace each extracted section with a command-shaped rule per the specimens above.
+  - Each inline rule: trigger / prohibition or action / concrete values / pointer suffix.
+  - Extend Project Structure's bullet list with the six new doc paths.
+  - **Done when:** AGENTS.md is ≤220 lines, every extracted section has a command-shaped inline replacement (not a bare pointer), and every prohibition / file path / enum / test name listed in R5 appears inline.
+
+- **U3. Mapping table + non-skill anchor audit.**
+  - Produce a paragraph-level mapping table in the PR description: every paragraph of old `AGENTS.md` → its destination (new `AGENTS.md` section heading or extracted file path).
+  - Run `grep -rn "AGENTS.md#" docs/ catalog/ cmd/ internal/` (deliberately scoped to non-skill paths) to surface anchor-based links the rename might break.
+  - Run `grep -rn "in AGENTS.md" docs/ catalog/ cmd/ internal/` (same scoping) for prose references that should now point to a sub-doc.
+  - **Done when:** the mapping shows zero unaccounted paragraphs, no broken in-repo non-skill anchors, and the table is committed in the PR description.
+
+- **U4. Optional follow-ups (not in this PR).**
+  - Skill-quote audit: run `grep -rn "AGENTS.md\|the machine" skills/` once a human can decide which quotations to update; do this only if a real bug is reported.
+  - Tighten glossary entries that contain dates / incidents — currently violate the no-dates rule; flagged but out of scope here.
+  - Add a `docs/README.md` index of the developer-doc files.
+
+---
+
+## Risks and Mitigations
+
+- **Risk: pointer sentences drift toward generic "see docs/X" over time, defeating the locality goal.** Mitigation: `docs/DOCS.md` includes both the pointer-rot rule and a structural rule for command-shaped inline rules (trigger / prohibition / values / pointer). The Code & Comment Hygiene "diff-review" section already covers similar shapes for code; the doc-authoring rule mirrors it for docs.
+- **Risk: an extracted doc gains a new fire condition and the inline trigger in `AGENTS.md` doesn't get updated.** Mitigation: R9 + pointer-rot rule in `docs/DOCS.md` explicitly require same-PR updates. Reviewers enforce.
+- **Risk: glossary entries with embedded dates ("introduced April 2026") get moved verbatim and now violate the no-dates rule in their new home.** Mitigation: explicitly out of scope for this plan; flagged as U4 follow-up. The current `AGENTS.md` already has this issue; moving it doesn't make it worse.
+- **Risk: future agents quote "AGENTS.md says X" for X that now lives in `docs/`.** Mitigation: low-impact; the content is still in the repo and discoverable. The inline command-shaped rule in `AGENTS.md` retains the load-bearing parts most likely to be quoted.
+- **Risk: mapping table is treated as a formality and waved through.** Mitigation: R1 makes "missing mapping = merge blocked" explicit. Reviewer must verify each row.
+- **Risk: the split makes onboarding harder because newcomers must follow more pointers.** Mitigation: the inline file is shorter and more scannable; command-shaped rules name triggers so a reader knows whether to follow or skip; `docs/DOCS.md` lists the developer-doc files.
+
+---
+
+## Validation
+
+- After U2, `wc -l AGENTS.md` reports ≤220 lines.
+- After U2, a manual scan confirms each item in R5 (golden trigger list, version file paths/test, catalog enums/HTTPS/rebuild, glossary naming command + defaults) appears verbatim or tightened inline.
+- After U3, the mapping table in the PR description shows a 1-to-1 paragraph mapping from old AGENTS.md to (new AGENTS.md ∪ extracted files); zero unaccounted paragraphs.
+- The non-skill anchor audit grep returns no broken links into AGENTS.md anchors that pointed to extracted sections.
+- Manual read-through: open the new AGENTS.md and read top-to-bottom; every command-shaped inline rule lets a reader decide "do I need to follow this link right now?" without ambiguity.
+- No code, tests, or skills change. `go test ./...` and `scripts/golden.sh verify` are unaffected.
+
+---
+
+## Codex Review Disposition
+
+### First review (REQUEST CHANGES, 8 findings)
+
+1. **Golden trigger too narrow.** → R5 + specimen inline rule retains the full enumerated trigger list.
+2. **Version rule fires too late.** → R5 + specimen retains "never edit by hand" + version file paths + test name inline; only flow extracted.
+3. **Catalog trigger needs to be command-shaped.** → R5 + specimen retains required fields + HTTPS + enums + rebuild rule inline.
+4. **U3 violates skill-files boundary.** → U3 grep scoped to `docs/ catalog/ cmd/ internal/`; skill-quote audit deferred to U4 follow-up.
+5. **`docs/SKILLS.md` becoming a junk drawer.** → New `docs/DOCS.md` for doc-authoring; internal-skills install stays inline.
+6. **Glossary inline stub must preserve naming command.** → R5 + specimen retains the canonical-naming command alongside the 4 defaults.
+7. **"No content is dropped" not operationalized.** → R1 elevates the mapping table to a merge gate, not an informal U3 step.
+8. **Pointer-rot risk missed.** → R9 + pointer-rot rule lives in `docs/DOCS.md` (created in U1).
+
+### Second review (REQUEST CHANGES, 3 new findings — all addressed)
+
+1. **Version specimen is wrong against current tests.** Current `AGENTS.md` claims three version files including `marketplace.json → plugins[0].version`, but `internal/cli/release_test.go:81` (`TestMarketplaceJSONHasNoPluginVersion`) fails if any plugin entry declares `version`. Earlier draft would have copied the stale claim forward. → Scope expanded to permit aligning a stale fact with the test that already enforces it. R5 now specifies **two** files (plugin.json + version.go) and adds the explicit "do not add `version` to `marketplace.json`" prohibition, plus both relevant test names. Specimen rewritten.
+2. **Catalog enum specimen is imprecise.** `internal/catalog/catalog.go:37` accepts `example` as a test-only catch-all (used by `catalog/petstore.yaml`); current `AGENTS.md` omits it. → R5 now names the public categories from the validator and explicitly notes `example` as test-only-do-not-use. Specimen updated.
+3. **R4 vs R5 contradiction.** R4 said "category/tier value list" was extracted while R5 said allowed enums stay inline. → R4 reworded to "validation rationale and `internal/catalog` cross-link" — values stay inline, rationale extracted. No contradiction.
+
+### Third review (REQUEST CHANGES, 1 partial + 1 new finding — all addressed)
+
+1. **PARTIALLY RESOLVED: version specimen.** The actual specimen rule was correct (two files, both tests) but three internal plan references still said "3 file paths + test name" — disposition table, target shape sketch, new-file summary. → Updated all three sites to "2 version file paths + both test names + 'no version in marketplace.json' prohibition." Stale planning text was the exact failure mode codex first warned about.
+2. **NEW: catalog required-fields rule was still stale.** `internal/catalog/catalog.go:219` shows `spec_url` and `spec_format` are conditional on the entry not being wrapper-only (`wrapper_libraries` set, `spec_url` empty). Earlier specimen treated them as unconditional. → Specimen rewritten to make `spec_url`/`spec_format` conditional on the wrapper-only carve-out. R5 expanded. Scope-Boundaries section now lists three corrections (versioning, catalog enum, catalog required-fields), each with its enforcing test/code line, and explicitly states that factual corrections without a code/test enforcer are out of scope.

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -20,6 +20,7 @@ maps:
   openrouteservice     Open-source routing, geocoding, matrix, isochrones, and VRP optimization on OpenStreetMap data.
 
 marketing:
+  kit                  Email marketing for creators (formerly ConvertKit) — subscribers, broadcasts, sequences, tags
   producthunt          Find, monitor, and export Product Hunt launches for launch research, scouting, and competitive tracking without requiring a Product Hunt API application.
 
 monitoring:
@@ -49,4 +50,3 @@ social-and-messaging:
 
 travel:
   google-flights       Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers (krisukox in Go, fli in Python).
-

--- a/testdata/openapi/kit-3-endpoint-stub.json
+++ b/testdata/openapi/kit-3-endpoint-stub.json
@@ -1,0 +1,113 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Kit",
+    "version": "4.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.kit.com"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "API Key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Kit-Api-Key"
+      }
+    },
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "API Key": []
+    }
+  ],
+  "paths": {
+    "/v4/account": {
+      "get": {
+        "operationId": "getAccount",
+        "tags": ["Account"],
+        "responses": {
+          "200": {
+            "description": "The authenticated account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tags": {
+      "get": {
+        "operationId": "listTags",
+        "tags": ["Tags"],
+        "responses": {
+          "200": {
+            "description": "Tags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createTag",
+        "tags": ["Tags"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created tag",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add CapCut and Kit catalog artifacts
- add Google Photos OpenAPI fixture and Kit endpoint test fixture
- add planning/architecture docs already present in the worktree
- update catalog-list golden output for Kit

## Verification
- go test ./internal/catalog
- git diff --check

Note: direct push to main was rejected by branch protection, so this PR is the required path.