### PR TITLE
fix(cli): redact shipcheck api key in json

### DIFF
--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -318,8 +318,7 @@ type shipcheckJSONEnvelope struct {
 }
 
 // renderShipcheckJSON marshals the envelope to w. Each leg's `command`
-// field shows the full argv as it would be invoked at the shell so an
-// operator can copy-paste-rerun a specific leg from the JSON output.
+// field shows the argv used for that leg with sensitive flag values redacted.
 func renderShipcheckJSON(w *os.File, binPath string, results []shipcheckLegResult, runStartedAt time.Time, runElapsed time.Duration) error {
 	env := shipcheckJSONEnvelope{
 		Passed:    shipcheckUmbrellaCode(results) == 0,
@@ -352,13 +351,10 @@ func redactShipcheckCommandArgv(argv []string) []string {
 	redacted := make([]string, len(argv))
 	copy(redacted, argv)
 	for i, arg := range redacted {
-		switch {
-		case arg == "--api-key":
+		if arg == "--api-key" {
 			if i+1 < len(redacted) {
 				redacted[i+1] = "<redacted>"
 			}
-		case strings.HasPrefix(arg, "--api-key="):
-			redacted[i] = "--api-key=<redacted>"
 		}
 	}
 	return redacted

--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -335,12 +335,33 @@ func renderShipcheckJSON(w *os.File, binPath string, results []shipcheckLegResul
 			Passed:    r.Passed(),
 			StartedAt: r.StartedAt.UTC().Format(time.RFC3339),
 			ElapsedMS: r.Elapsed.Milliseconds(),
-			Command:   strings.Join(append([]string{binPath}, r.Argv...), " "),
+			Command:   renderShipcheckCommand(binPath, r.Argv),
 		})
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(env)
+}
+
+func renderShipcheckCommand(binPath string, argv []string) string {
+	args := append([]string{binPath}, redactShipcheckCommandArgv(argv)...)
+	return strings.Join(args, " ")
+}
+
+func redactShipcheckCommandArgv(argv []string) []string {
+	redacted := make([]string, len(argv))
+	copy(redacted, argv)
+	for i, arg := range redacted {
+		switch {
+		case arg == "--api-key":
+			if i+1 < len(redacted) {
+				redacted[i+1] = "<redacted>"
+			}
+		case strings.HasPrefix(arg, "--api-key="):
+			redacted[i] = "--api-key=<redacted>"
+		}
+	}
+	return redacted
 }
 
 // validateShipcheckDir confirms --dir points at something that looks

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -474,6 +474,43 @@ func TestShipcheck_JSONEnvelope_AllPass(t *testing.T) {
 	}
 }
 
+func TestShipcheck_JSONEnvelope_RedactsAPIKeyFromCommands(t *testing.T) {
+	h := newShipcheckHarness(t)
+	const secret = "secret-token"
+
+	out := captureStdout(t, func() {
+		if err := runShipcheckCmd(t, "--dir", h.dir, "--json", "--api-key", secret); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var env shipcheckJSONEnvelope
+	if err := json.Unmarshal([]byte(extractFinalJSONObject(t, out)), &env); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+
+	var verifyCommand string
+	for _, leg := range env.Legs {
+		if strings.Contains(leg.Command, secret) {
+			t.Fatalf("leg %s command leaked API key: %q", leg.Name, leg.Command)
+		}
+		if leg.Name == "verify" {
+			verifyCommand = leg.Command
+		}
+	}
+	if verifyCommand == "" {
+		t.Fatal("envelope missing verify command")
+	}
+	if !strings.Contains(verifyCommand, "--api-key <redacted>") {
+		t.Fatalf("verify command should include redacted API key flag; got %q", verifyCommand)
+	}
+
+	verifyArgs := findInvocation(readStubLog(t, h.logFile), "verify")
+	if !argvHas(verifyArgs, secret) {
+		t.Fatalf("verify subprocess argv should still receive the raw API key; got %v", verifyArgs)
+	}
+}
+
 // TestShipcheck_JSONEnvelope_OneFailure: --json envelope reflects a
 // failing leg with passed=false at the leg and envelope level.
 func TestShipcheck_JSONEnvelope_OneFailure(t *testing.T) {


### PR DESCRIPTION
shipcheck `--json` no longer echoes raw `--api-key` values in each leg's `command` field. The subprocess invocation still receives the original credential, but the JSON envelope now renders both `--api-key value` and `--api-key=value` forms as `<redacted>` so logs and CI artifacts do not leak secrets.

Tested with `go test ./internal/cli` and `go test ./...`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
