### PR TITLE
fix(cli): harden manifest-gen remote spec loader against hangs and silent truncation

### DIFF
--- a/cmd/manifest-gen/main.go
+++ b/cmd/manifest-gen/main.go
@@ -30,8 +30,9 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
-// Tunables for remote spec fetches; var (not const) so tests can override.
-var (
+// Tunables for remote spec fetches. Production callers pass these to loadSpec
+// explicitly; tests pass their own values so no package-level state is mutated.
+const (
 	maxRemoteSpecBytes int64         = 50 * 1024 * 1024
 	remoteSpecTimeout  time.Duration = 60 * time.Second
 )
@@ -48,7 +49,7 @@ func main() {
 	}
 
 	// Load spec data.
-	data, err := loadSpec(*specFlag)
+	data, err := loadSpec(*specFlag, maxRemoteSpecBytes, remoteSpecTimeout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error loading spec: %v\n", err)
 		os.Exit(1)
@@ -118,9 +119,9 @@ func main() {
 	fmt.Fprintf(os.Stderr, "Spec format: %s\n", format)
 }
 
-func loadSpec(source string) ([]byte, error) {
+func loadSpec(source string, maxBytes int64, timeout time.Duration) ([]byte, error) {
 	if openapi.IsRemoteSpecSource(source) {
-		ctx, cancel := context.WithTimeout(context.Background(), remoteSpecTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
 		if err != nil {
@@ -135,12 +136,12 @@ func loadSpec(source string) ([]byte, error) {
 			return nil, fmt.Errorf("fetching %s: HTTP %d", source, resp.StatusCode)
 		}
 		// Read limit+1 bytes so we can distinguish "exactly at limit" from "exceeds limit".
-		data, err := io.ReadAll(io.LimitReader(resp.Body, maxRemoteSpecBytes+1))
+		data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
 		if err != nil {
 			return nil, fmt.Errorf("fetching %s: %w", source, err)
 		}
-		if int64(len(data)) > maxRemoteSpecBytes {
-			return nil, fmt.Errorf("fetching %s: spec exceeds %d bytes", source, maxRemoteSpecBytes)
+		if int64(len(data)) > maxBytes {
+			return nil, fmt.Errorf("fetching %s: spec exceeds %d bytes", source, maxBytes)
 		}
 		return data, nil
 	}

--- a/cmd/manifest-gen/main.go
+++ b/cmd/manifest-gen/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -21,11 +22,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/graphql"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+// Tunables for remote spec fetches; var (not const) so tests can override.
+var (
+	maxRemoteSpecBytes int64         = 50 * 1024 * 1024
+	remoteSpecTimeout  time.Duration = 60 * time.Second
 )
 
 func main() {
@@ -112,7 +120,13 @@ func main() {
 
 func loadSpec(source string) ([]byte, error) {
 	if openapi.IsRemoteSpecSource(source) {
-		resp, err := http.Get(source)
+		ctx, cancel := context.WithTimeout(context.Background(), remoteSpecTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+		if err != nil {
+			return nil, fmt.Errorf("fetching %s: %w", source, err)
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("fetching %s: %w", source, err)
 		}
@@ -120,7 +134,15 @@ func loadSpec(source string) ([]byte, error) {
 		if resp.StatusCode != 200 {
 			return nil, fmt.Errorf("fetching %s: HTTP %d", source, resp.StatusCode)
 		}
-		return io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+		// Read limit+1 bytes so we can distinguish "exactly at limit" from "exceeds limit".
+		data, err := io.ReadAll(io.LimitReader(resp.Body, maxRemoteSpecBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("fetching %s: %w", source, err)
+		}
+		if int64(len(data)) > maxRemoteSpecBytes {
+			return nil, fmt.Errorf("fetching %s: spec exceeds %d bytes", source, maxRemoteSpecBytes)
+		}
+		return data, nil
 	}
 	return os.ReadFile(source)
 }

--- a/cmd/manifest-gen/main_test.go
+++ b/cmd/manifest-gen/main_test.go
@@ -12,22 +12,6 @@ import (
 	"time"
 )
 
-// withTimeout temporarily swaps remoteSpecTimeout for the duration of the test.
-func withTimeout(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := remoteSpecTimeout
-	remoteSpecTimeout = d
-	t.Cleanup(func() { remoteSpecTimeout = prev })
-}
-
-// withMaxBytes temporarily swaps maxRemoteSpecBytes for the duration of the test.
-func withMaxBytes(t *testing.T, n int64) {
-	t.Helper()
-	prev := maxRemoteSpecBytes
-	maxRemoteSpecBytes = n
-	t.Cleanup(func() { maxRemoteSpecBytes = prev })
-}
-
 func TestLoadSpec_HappyPath(t *testing.T) {
 	body := "openapi: 3.0.0\ninfo:\n  title: tiny\n"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +20,7 @@ func TestLoadSpec_HappyPath(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	got, err := loadSpec(srv.URL)
+	got, err := loadSpec(srv.URL, maxRemoteSpecBytes, remoteSpecTimeout)
 	if err != nil {
 		t.Fatalf("loadSpec returned error: %v", err)
 	}
@@ -53,7 +37,7 @@ func TestLoadSpec_LocalFile(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	got, err := loadSpec(path)
+	got, err := loadSpec(path, maxRemoteSpecBytes, remoteSpecTimeout)
 	if err != nil {
 		t.Fatalf("loadSpec returned error: %v", err)
 	}
@@ -68,7 +52,7 @@ func TestLoadSpec_Non200(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := loadSpec(srv.URL)
+	_, err := loadSpec(srv.URL, maxRemoteSpecBytes, remoteSpecTimeout)
 	if err == nil {
 		t.Fatalf("loadSpec returned nil error for 500 response")
 	}
@@ -80,7 +64,7 @@ func TestLoadSpec_Non200(t *testing.T) {
 // TestLoadSpec_StalledServer verifies the request times out instead of hanging
 // forever when the server flushes headers but never sends the body.
 func TestLoadSpec_StalledServer(t *testing.T) {
-	withTimeout(t, 200*time.Millisecond)
+	shortTimeout := 200 * time.Millisecond
 
 	released := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -101,36 +85,36 @@ func TestLoadSpec_StalledServer(t *testing.T) {
 	})
 
 	start := time.Now()
-	_, err := loadSpec(srv.URL)
+	_, err := loadSpec(srv.URL, maxRemoteSpecBytes, shortTimeout)
 	elapsed := time.Since(start)
 
 	if err == nil {
 		t.Fatalf("loadSpec returned nil error for stalled server")
 	}
 	// Allow generous slack (~3x the configured timeout) for scheduler jitter.
-	if elapsed > 3*remoteSpecTimeout+500*time.Millisecond {
-		t.Fatalf("loadSpec took %v, expected to error within ~3x timeout (%v)", elapsed, remoteSpecTimeout)
+	if elapsed > 3*shortTimeout+500*time.Millisecond {
+		t.Fatalf("loadSpec took %v, expected to error within ~3x timeout (%v)", elapsed, shortTimeout)
 	}
 }
 
-// TestLoadSpec_Oversized verifies that responses larger than maxRemoteSpecBytes
+// TestLoadSpec_Oversized verifies that responses larger than the byte limit
 // produce an explicit oversized-spec error instead of silently truncating.
 func TestLoadSpec_Oversized(t *testing.T) {
-	withMaxBytes(t, 1024)
+	const smallLimit int64 = 1024
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/yaml")
-		// Stream maxRemoteSpecBytes + 1 bytes so the read sees one byte past the limit.
-		buf := bytes.Repeat([]byte{'a'}, int(maxRemoteSpecBytes)+1)
+		// Stream smallLimit + 1 bytes so the read sees one byte past the limit.
+		buf := bytes.Repeat([]byte{'a'}, int(smallLimit)+1)
 		_, _ = w.Write(buf)
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := loadSpec(srv.URL)
+	_, err := loadSpec(srv.URL, smallLimit, remoteSpecTimeout)
 	if err == nil {
 		t.Fatalf("loadSpec returned nil error for oversized response")
 	}
-	want := fmt.Sprintf("%d bytes", maxRemoteSpecBytes)
+	want := fmt.Sprintf("%d bytes", smallLimit)
 	if !strings.Contains(err.Error(), want) {
 		t.Fatalf("error %q does not mention byte limit %q", err.Error(), want)
 	}
@@ -141,20 +125,20 @@ func TestLoadSpec_Oversized(t *testing.T) {
 
 // TestLoadSpec_AtLimit verifies a response exactly at the byte limit succeeds.
 func TestLoadSpec_AtLimit(t *testing.T) {
-	withMaxBytes(t, 1024)
+	const smallLimit int64 = 1024
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/yaml")
-		buf := bytes.Repeat([]byte{'a'}, int(maxRemoteSpecBytes))
+		buf := bytes.Repeat([]byte{'a'}, int(smallLimit))
 		_, _ = w.Write(buf)
 	}))
 	t.Cleanup(srv.Close)
 
-	got, err := loadSpec(srv.URL)
+	got, err := loadSpec(srv.URL, smallLimit, remoteSpecTimeout)
 	if err != nil {
 		t.Fatalf("loadSpec returned error for at-limit response: %v", err)
 	}
-	if int64(len(got)) != maxRemoteSpecBytes {
-		t.Fatalf("loadSpec returned %d bytes, want %d", len(got), maxRemoteSpecBytes)
+	if int64(len(got)) != smallLimit {
+		t.Fatalf("loadSpec returned %d bytes, want %d", len(got), smallLimit)
 	}
 }

--- a/cmd/manifest-gen/main_test.go
+++ b/cmd/manifest-gen/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withTimeout temporarily swaps remoteSpecTimeout for the duration of the test.
+func withTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := remoteSpecTimeout
+	remoteSpecTimeout = d
+	t.Cleanup(func() { remoteSpecTimeout = prev })
+}
+
+// withMaxBytes temporarily swaps maxRemoteSpecBytes for the duration of the test.
+func withMaxBytes(t *testing.T, n int64) {
+	t.Helper()
+	prev := maxRemoteSpecBytes
+	maxRemoteSpecBytes = n
+	t.Cleanup(func() { maxRemoteSpecBytes = prev })
+}
+
+func TestLoadSpec_HappyPath(t *testing.T) {
+	body := "openapi: 3.0.0\ninfo:\n  title: tiny\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := loadSpec(srv.URL)
+	if err != nil {
+		t.Fatalf("loadSpec returned error: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("loadSpec returned %q, want %q", string(got), body)
+	}
+}
+
+func TestLoadSpec_LocalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.yaml")
+	body := []byte("base_url: https://example.com\nresources: {}\n")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got, err := loadSpec(path)
+	if err != nil {
+		t.Fatalf("loadSpec returned error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("loadSpec returned %q, want %q", string(got), string(body))
+	}
+}
+
+func TestLoadSpec_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := loadSpec(srv.URL)
+	if err == nil {
+		t.Fatalf("loadSpec returned nil error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("error %q does not mention HTTP 500", err.Error())
+	}
+}
+
+// TestLoadSpec_StalledServer verifies the request times out instead of hanging
+// forever when the server flushes headers but never sends the body.
+func TestLoadSpec_StalledServer(t *testing.T) {
+	withTimeout(t, 200*time.Millisecond)
+
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Block until the test ends so the body never arrives.
+		select {
+		case <-released:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(released)
+		srv.Close()
+	})
+
+	start := time.Now()
+	_, err := loadSpec(srv.URL)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("loadSpec returned nil error for stalled server")
+	}
+	// Allow generous slack (~3x the configured timeout) for scheduler jitter.
+	if elapsed > 3*remoteSpecTimeout+500*time.Millisecond {
+		t.Fatalf("loadSpec took %v, expected to error within ~3x timeout (%v)", elapsed, remoteSpecTimeout)
+	}
+}
+
+// TestLoadSpec_Oversized verifies that responses larger than maxRemoteSpecBytes
+// produce an explicit oversized-spec error instead of silently truncating.
+func TestLoadSpec_Oversized(t *testing.T) {
+	withMaxBytes(t, 1024)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		// Stream maxRemoteSpecBytes + 1 bytes so the read sees one byte past the limit.
+		buf := bytes.Repeat([]byte{'a'}, int(maxRemoteSpecBytes)+1)
+		_, _ = w.Write(buf)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := loadSpec(srv.URL)
+	if err == nil {
+		t.Fatalf("loadSpec returned nil error for oversized response")
+	}
+	want := fmt.Sprintf("%d bytes", maxRemoteSpecBytes)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error %q does not mention byte limit %q", err.Error(), want)
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error %q does not mention 'exceeds'", err.Error())
+	}
+}
+
+// TestLoadSpec_AtLimit verifies a response exactly at the byte limit succeeds.
+func TestLoadSpec_AtLimit(t *testing.T) {
+	withMaxBytes(t, 1024)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		buf := bytes.Repeat([]byte{'a'}, int(maxRemoteSpecBytes))
+		_, _ = w.Write(buf)
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := loadSpec(srv.URL)
+	if err != nil {
+		t.Fatalf("loadSpec returned error for at-limit response: %v", err)
+	}
+	if int64(len(got)) != maxRemoteSpecBytes {
+		t.Fatalf("loadSpec returned %d bytes, want %d", len(got), maxRemoteSpecBytes)
+	}
+}


### PR DESCRIPTION
## Summary

`cmd/manifest-gen/main.go` `loadSpec()` had two real defects when fetching remote specs:

- **No request timeout.** `http.Get` (default client) has no overall timeout, so a remote host that flushed headers and stalled on the body would hang `manifest-gen` indefinitely. Now routes through `http.NewRequestWithContext` with a 60s timeout (`remoteSpecTimeout`).
- **Silent truncation.** `io.LimitReader(body, 50*1024*1024)` + `io.ReadAll` returned the first 50 MiB of any oversized response with no error, so the caller could not distinguish a real 49 MiB spec from a multi-gigabyte stream truncated mid-document. Now reads `limit+1` bytes and returns an explicit `spec exceeds <N> bytes` error when the response is over the limit. The 50 MiB cap is preserved (`maxRemoteSpecBytes`).
- Timeout and limit are package-level `var`s so tests can override them; no new dependencies.

## Test plan

- [x] `go build ./cmd/manifest-gen`
- [x] `go test ./cmd/manifest-gen/...` (6 cases pass)
- [x] `golangci-lint run ./cmd/manifest-gen/...` (no issues)
- [x] New `cmd/manifest-gen/main_test.go` covers: happy path, local file, non-200, stalled server (with short timeout override; finishes well under a second), oversized response (returns explicit error mentioning the byte limit), and exactly-at-limit response (succeeds).
- [ ] Manual repro of the original bug: point a stalled local netcat at `-spec http://localhost:PORT/x` on `main` (hangs) vs this branch (errors within 60s).

Clawpatch finding: fnd_sig-feat-cli-command-4b5c230b57-_798522070f