### PR TITLE
fix(cli): resolve shipcheck CLI binary name from .printing-press.json

### DIFF
--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/spf13/cobra"
 )
@@ -156,12 +157,22 @@ func shipcheckResearchPath(o *shipcheckOpts) string {
 	return filepath.Join(dir, "research.json")
 }
 
+// shipcheckBinaryName resolves the CLI binary name for a generated CLI directory.
+// Prefers .printing-press.json's cli_name (the canonical "<api-slug>-pp-cli" form)
+// and falls back to the directory's basename for legacy/manifest-less dirs.
+func shipcheckBinaryName(dir string) string {
+	if name := pipeline.ReadCLIBinaryName(dir); name != "" {
+		return name
+	}
+	return filepath.Base(dir)
+}
+
 func shipcheckCLIPath(o *shipcheckOpts) string {
-	return platform.ExecutablePath(filepath.Join(o.dir, filepath.Base(o.dir)))
+	return platform.ExecutablePath(filepath.Join(o.dir, shipcheckBinaryName(o.dir)))
 }
 
 func shipcheckCLIPathForGOOS(o *shipcheckOpts, goos string) string {
-	return platform.ExecutablePathForGOOS(filepath.Join(o.dir, filepath.Base(o.dir)), goos)
+	return platform.ExecutablePathForGOOS(filepath.Join(o.dir, shipcheckBinaryName(o.dir)), goos)
 }
 
 // shipcheckLegResult is the per-leg outcome of one umbrella run.

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -108,6 +108,32 @@ func TestShipcheckCLIPath_FallsBackToBasename(t *testing.T) {
 	}
 }
 
+// TestShipcheckCLIPath_FallsBackOnUnparseableManifest pins the
+// unparseable-error branch of pipeline.ReadCLIBinaryName: a
+// .printing-press.json that exists but contains malformed JSON must
+// fall back to the directory basename rather than propagating a parse
+// error or producing an empty binary name.
+func TestShipcheckCLIPath_FallsBackOnUnparseableManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "notion")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating slug dir: %v", err)
+	}
+	// Truncated JSON: opening brace, key, colon, no value, no close.
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(`{"cli_name":`), 0o644); err != nil {
+		t.Fatalf("writing malformed manifest: %v", err)
+	}
+	opts := &shipcheckOpts{dir: dir}
+
+	if got, want := shipcheckCLIPathForGOOS(opts, "linux"), filepath.Join(dir, "notion"); got != want {
+		t.Fatalf("linux path = %q, want %q", got, want)
+	}
+	if got, want := shipcheckCLIPathForGOOS(opts, "windows"), filepath.Join(dir, "notion.exe"); got != want {
+		t.Fatalf("windows path = %q, want %q", got, want)
+	}
+}
+
 type shipcheckHarness struct {
 	dir     string
 	logFile string

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -64,6 +64,50 @@ func TestShipcheckCLIPathForGOOS(t *testing.T) {
 	}
 }
 
+// TestShipcheckCLIPath_ManifestOverridesBasename covers the slug-keyed
+// library layout: dir basename ("notion") differs from the actual binary
+// name ("notion-pp-cli"), so the binary path must be resolved from
+// .printing-press.json's cli_name rather than the directory's basename.
+func TestShipcheckCLIPath_ManifestOverridesBasename(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "notion")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating slug dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(`{"cli_name":"notion-pp-cli"}`), 0o644); err != nil {
+		t.Fatalf("writing manifest: %v", err)
+	}
+	opts := &shipcheckOpts{dir: dir}
+
+	if got, want := shipcheckCLIPathForGOOS(opts, "linux"), filepath.Join(dir, "notion-pp-cli"); got != want {
+		t.Fatalf("linux path = %q, want %q", got, want)
+	}
+	if got, want := shipcheckCLIPathForGOOS(opts, "windows"), filepath.Join(dir, "notion-pp-cli.exe"); got != want {
+		t.Fatalf("windows path = %q, want %q", got, want)
+	}
+}
+
+// TestShipcheckCLIPath_FallsBackToBasename covers the manifest-less case:
+// when .printing-press.json is missing or unparseable, the binary name
+// falls back to the directory basename (preserves legacy behavior).
+func TestShipcheckCLIPath_FallsBackToBasename(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "sample-cli")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating dir: %v", err)
+	}
+	opts := &shipcheckOpts{dir: dir}
+
+	if got, want := shipcheckCLIPathForGOOS(opts, "linux"), filepath.Join(dir, "sample-cli"); got != want {
+		t.Fatalf("linux path = %q, want %q", got, want)
+	}
+	if got, want := shipcheckCLIPathForGOOS(opts, "windows"), filepath.Join(dir, "sample-cli.exe"); got != want {
+		t.Fatalf("windows path = %q, want %q", got, want)
+	}
+}
+
 type shipcheckHarness struct {
 	dir     string
 	logFile string


### PR DESCRIPTION
## Summary

- `shipcheckCLIPath` / `shipcheckCLIPathForGOOS` derived the binary name from `filepath.Base(o.dir)`, which is wrong for slug-keyed library dirs (`~/printing-press/library/notion` -> basename `notion`, but the binary is `notion-pp-cli`).
- The fallout: `validate-narrative` (and any other leg using these helpers) was invoked with a binary path that does not exist, so shipcheck fails on every slug-keyed CLI.
- Fix: resolve the binary name from `.printing-press.json`'s `cli_name` via `pipeline.ReadCLIBinaryName`, falling back to `filepath.Base(dir)` when the manifest is absent or unparseable (preserves legacy behavior).

## Test plan

- New `TestShipcheckCLIPath_ManifestOverridesBasename`: tempdir named `notion` with `.printing-press.json` containing `{"cli_name":"notion-pp-cli"}` -> result ends in `notion-pp-cli` (and `.exe` on Windows).
- New `TestShipcheckCLIPath_FallsBackToBasename`: tempdir with no manifest -> result ends in `filepath.Base(dir)` (legacy behavior).
- `go test ./internal/cli/...` -> 434 passed.
- `golangci-lint run ./internal/cli/...` -> clean.
- Manual repro: `printing-press shipcheck --dir ~/printing-press/library/notion --spec ./openapi.yaml` now resolves the binary to `notion-pp-cli` before invoking `validate-narrative`.

Clawpatch finding: fnd_sig-feat-cli-command-e17f734225-_8ca7979519