### PR TITLE
feat(cli): add obsidian wrapper-only catalog entry

### DIFF
--- a/catalog/obsidian.yaml
+++ b/catalog/obsidian.yaml
@@ -46,4 +46,3 @@ wrapper_libraries:
       CLI does not embed the vault parser itself.
 
 auth_env_vars: []
-auth_instructions: "No auth — operates on the locally-mounted vault. The Obsidian desktop app must be running for write and live-search commands."

--- a/catalog/obsidian.yaml
+++ b/catalog/obsidian.yaml
@@ -1,0 +1,49 @@
+name: obsidian
+display_name: Obsidian
+description: Note-taking knowledge base reached through the official Obsidian CLI shipped in the desktop app (v1.12+). Vault is local; no public network API.
+category: productivity
+tier: official
+verified_date: "2026-05-19"
+homepage: https://obsidian.md
+notes: |
+  Obsidian 1.12+ ships an official command-line interface bundled with the desktop
+  app. The CLI is symlinked at /usr/local/bin/obsidian when "Settings → General →
+  Command line interface" is toggled on. It exposes ~95 commands covering file
+  operations, search, frontmatter properties, backlinks, orphans, deadends,
+  unresolved links, tasks, bases, daily notes, sync, history, plugins, themes,
+  workspaces, and a developer surface (dev:cdp, dev:console, eval).
+
+  No HTTP API; integration is subprocess. The CLI requires Obsidian to be running
+  for write and live-search commands (the CLI dials the running desktop process).
+  Read commands that only consult the local vault filesystem can proceed without
+  Obsidian running when the printed CLI mirrors vault state into a local SQLite
+  store — this is the design path the Printing Press generator should take.
+
+  Known limitation: the underlying markdown-patch path used by Obsidian's write
+  commands has corruption modes when content contains certain edge-case markdown
+  shapes (verified 2026-05 against v1.12.7). Printed CLIs should default to
+  read-only Tier-3 flows (sync, health, stale, decay) and treat Tier-1 write
+  pass-through (append, prepend, create, move, delete, property:set) as a
+  known-limited surface pending upstream fix.
+
+wrapper_libraries:
+  - name: obsidian-official-cli
+    url: https://obsidian.md
+    language: native-app
+    license: proprietary
+    integration_mode: subprocess
+    notes: |
+      Bundled with the Obsidian desktop app v1.12+ and symlinked at
+      /usr/local/bin/obsidian when the in-app Command-Line Interface toggle is on.
+      All commands take ARG=value pairs (not POSIX flags). `file=<name>` resolves
+      wikilink-style; `path=<rel>` is exact. Many commands accept
+      `format=json|tsv|csv` for machine-friendly output. Output defaults to text
+      or TSV depending on the command; JSON is opt-in per command.
+
+      The CLI dials the running Obsidian desktop process for write operations and
+      live search. Read-only commands that consult the local vault filesystem
+      (file metadata, basic listings) also need the running process because the
+      CLI does not embed the vault parser itself.
+
+auth_env_vars: []
+auth_instructions: "No auth — operates on the locally-mounted vault. The Obsidian desktop app must be running for write and live-search commands."

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -33,6 +33,9 @@ payments:
   plaid                Banking API for account linking, transactions, identity verification, and income
   stripe               Payment processing and financial infrastructure API
 
+productivity:
+  obsidian             Note-taking knowledge base reached through the official Obsidian CLI shipped in the desktop app (v1.12+). Vault is local; no public network API.
+
 project-management:
   asana                Work management and project tracking API
   jira                 Issue tracking and project management API for Jira Cloud


### PR DESCRIPTION
## Intent

Adds catalog metadata for the official Obsidian CLI shipped in Obsidian desktop v1.12+. The entry serves as a discovery aid for future Printing Press work targeting Obsidian; the factory has no direct generation path from a wrapper-only entry today, but landing the catalog record now lets `printing-press catalog show obsidian` resolve and gives the next contributor a place to anchor the build conversation.

Issue: N/A (catalog addition; provenance documented below per `AGENTS.md` "Adding Catalog Entries").

## Approach

Modeled strictly on the existing wrapper-only precedents (`catalog/google-flights.yaml`, `catalog/kayak.yaml`):

- `tier: official` — the CLI is bundled with Obsidian's official desktop app.
- `wrapper_libraries[0].integration_mode: subprocess` — the upstream is the bundled `obsidian` binary (symlinked at `/usr/local/bin/obsidian` when the in-app Command-Line Interface toggle is on). All commands take `ARG=value` pairs, not POSIX flags; many accept `format=json|tsv|csv`.
- `auth_env_vars: []`, `auth_instructions` — no credentials; the only runtime prerequisite is "Obsidian desktop must be running" for write and live-search commands.
- `notes` document the known-limitation context: the underlying markdown-patch path used by Obsidian's write commands has corruption modes against certain edge-case markdown shapes (verified 2026-05 against v1.12.7). The note steers future Printing Press build work toward read-only Tier-3 flows (sync, health, stale, decay) until upstream is fixed.

## Scope

Primary area: catalog (`catalog/obsidian.yaml`)

Why this belongs in this repo: the embedded `catalog/` directory is the Printing Press's discovery surface for known target CLIs. The Obsidian official CLI is a real subprocess-mode target with a stable, named surface (~95 commands); adding it here lets future build sessions resolve `printing-press catalog show obsidian` and reason about wrapper-library shape via the same path the existing wrapper-only entries use.

### Provenance (per AGENTS.md "Adding Catalog Entries")

- **Source URL:** https://obsidian.md (the CLI ships bundled with the desktop app; there is currently no public deep-link doc page — `https://help.obsidian.md/command-line` and `https://obsidian.md/help/Obsidian+CLI` both 404 as of 2026-05-19).
- **Source type:** wrapper-only (subprocess integration mode); the wrapper is the official `obsidian` binary itself.
- **Live smoke evidence:** `obsidian version` → `1.12.7 (installer 1.12.7)` (2026-05-19, macOS arm64). `obsidian help` enumerates ~95 commands across files, search, frontmatter properties, backlinks/orphans/deadends/unresolved, tasks, bases, daily notes, sync, history, plugins, themes, workspaces, and a developer surface (dev:cdp, dev:console, eval).
- **Auth requirements:** none — operates on the locally-mounted vault. The desktop app must be running for write and live-search commands (the CLI dials the running process).
- **Out of scope for this catalog entry:**
  - No `spec_url` — wrapper-only entries do not drive `printing-press generate` directly (per `skills/printing-press/SKILL.md`).
  - No `base_url` — Obsidian has no public HTTP API surface.
  - Multi-vault and Windows/Linux behavior is intentionally not encoded; V1 build work is expected to target single-vault macOS.

## Risk

Low / additive:

- Generator behavior: `printing-press generate obsidian` will fail with `catalog entry "obsidian" does not define spec_url - try providing a URL with --spec`. This is the documented wrapper-only behavior in `skills/printing-press/SKILL.md`; not a regression.
- Other surfaces: `catalog list`, `catalog show obsidian`, `catalog search obsidian` all resolve cleanly.
- No template, generator, scorer, verifier, or publish-flow changes.

## Output Contract

`testdata/golden/expected/catalog-list/stdout.txt` updated: adds a new `productivity:` section header and the single `obsidian` entry. Diff is exactly the additive 3-line block from `./scripts/golden.sh verify` against the rebuilt binary.

## Verification

Commands run:

- `go test ./internal/catalog/...` → PASS
- `./scripts/golden.sh verify` → PASS (after the intentional `catalog-list` fixture update)
- `go build -o ./printing-press ./cmd/printing-press` → succeeds
- `./printing-press catalog show obsidian` → renders the entry (Mode: wrapper-only)
- `./printing-press catalog list | grep obsidian` → entry appears under the productivity category

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change