### PR TITLE
fix(cli): require documented flags in verify-skill

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -62,13 +62,10 @@ def read_utf8(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-COMMON_FLAGS = {
-    "help", "version", "json", "csv", "plain", "quiet", "agent",
-    "select", "compact", "dry-run", "no-cache", "yes", "no-input",
-    "no-color", "human-friendly", "config", "base-url", "rate-limit",
-    "timeout", "data-source", "stdin", "limit", "format", "output",
-    "no-prompt", "days",
-}
+# Cobra supplies these without explicit source-level flag declarations. Other
+# generated/global flags must still be discovered in source so command-scoped
+# copy-paste examples cannot hide missing flags behind this whitelist.
+COMMON_FLAGS = {"help", "version"}
 
 CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
 COMMAND_REFERENCE_SECTION_RE = re.compile(
@@ -746,10 +743,13 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
 def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
+        seen: set[tuple[str, str]] = set()
         for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+            path_str = " ".join(cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
-                if flag in COMMON_FLAGS:
+                key = (path_str, flag)
+                if flag in COMMON_FLAGS or key in seen:
                     continue
                 cmd_files, _, _ = find_command_source(cli_dir, cmd_path)
                 if cmd_files and flag_declared_in(cmd_files, flag):
@@ -758,7 +758,7 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
                     continue
                 if cmd_files and flag_declared_via_helper(cli_dir, cmd_files, flag):
                     continue
-                path_str = " ".join(cmd_path)
+                seen.add(key)
                 if flag_declared_in(all_files, flag):
                     report.findings.append(
                         Finding(

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -22,6 +22,7 @@ from verify_skill import (  # noqa: E402
     find_root_children,
     resolve_command_path,
     find_command_source,
+    run_checks,
     _extract_function_body,
 )
 
@@ -238,6 +239,60 @@ func newSearchCmd() *cobra.Command {
             # Legacy fallback returns the file; not empty
             self.assertEqual([f.name for f in files], ["search.go"])
             self.assertEqual(use, "search <query>")
+
+
+class TestFlagChecks(unittest.TestCase):
+    def test_missing_limit_flag_is_reported(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newSearchCmd())
+    return rootCmd.Execute()
+}
+''',
+                "search.go": '''package cli
+import "github.com/spf13/cobra"
+func newSearchCmd() *cobra.Command {
+    return &cobra.Command{Use: "search"}
+}
+''',
+            })
+            cli_binary = f"{cli_dir.name}-pp-cli"
+            (cli_dir / "SKILL.md").write_text(
+                f"""# Fixture
+
+```bash
+{cli_binary} search --limit 5
+{cli_binary} search --limit 10
+```
+""",
+                encoding="utf-8",
+            )
+
+            report = run_checks(cli_dir, {"flag-names", "flag-commands"})
+            details = {(f.check, f.detail) for f in report.findings}
+
+            self.assertIn(
+                ("flag-names", "--limit is referenced in SKILL.md but not declared in any internal/cli/*.go"),
+                details,
+            )
+            self.assertIn(
+                ("flag-commands", "--limit is not declared anywhere"),
+                details,
+            )
+            self.assertEqual(
+                1,
+                sum(
+                    1
+                    for f in report.findings
+                    if f.check == "flag-commands"
+                    and f.command == f"{cli_binary} search"
+                    and f.detail == "--limit is not declared anywhere"
+                ),
+            )
 
 
 class UTF8ReadTest(unittest.TestCase):

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -62,13 +62,10 @@ def read_utf8(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-COMMON_FLAGS = {
-    "help", "version", "json", "csv", "plain", "quiet", "agent",
-    "select", "compact", "dry-run", "no-cache", "yes", "no-input",
-    "no-color", "human-friendly", "config", "base-url", "rate-limit",
-    "timeout", "data-source", "stdin", "limit", "format", "output",
-    "no-prompt", "days",
-}
+# Cobra supplies these without explicit source-level flag declarations. Other
+# generated/global flags must still be discovered in source so command-scoped
+# copy-paste examples cannot hide missing flags behind this whitelist.
+COMMON_FLAGS = {"help", "version"}
 
 CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
 COMMAND_REFERENCE_SECTION_RE = re.compile(
@@ -746,10 +743,13 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
 def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
+        seen: set[tuple[str, str]] = set()
         for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+            path_str = " ".join(cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
-                if flag in COMMON_FLAGS:
+                key = (path_str, flag)
+                if flag in COMMON_FLAGS or key in seen:
                     continue
                 cmd_files, _, _ = find_command_source(cli_dir, cmd_path)
                 if cmd_files and flag_declared_in(cmd_files, flag):
@@ -758,7 +758,7 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
                     continue
                 if cmd_files and flag_declared_via_helper(cli_dir, cmd_files, flag):
                     continue
-                path_str = " ".join(cmd_path)
+                seen.add(key)
                 if flag_declared_in(all_files, flag):
                     report.findings.append(
                         Finding(


### PR DESCRIPTION
## Summary

The verify-skill checker now fails when generated CLI docs reference command flags that the command does not declare. Only Cobra-provided built-ins stay exempt, so examples like `search --limit 5` can no longer pass just because `limit` was in a broad static whitelist.

This also keeps the embedded verifier copy in sync and adds a regression fixture that proves missing documented flags are reported by both flag-name and flag-command checks.

Clawpatch finding: `fnd_sig-feat-library-2852349fd3-4c39_88860b71f0`

## Verification

- `python3 -m pytest scripts/verify-skill/test_resolve_command_path.py`
- `git diff --check`
- `go test ./...`
- `clawpatch revalidate --finding fnd_sig-feat-library-2852349fd3-4c39_88860b71f0 --json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
