### PR TITLE
fix(cli): polish press-auth output and make spec warnings testable

### DIFF
--- a/internal/pressauth/login.go
+++ b/internal/pressauth/login.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -52,7 +52,7 @@ JWT session you want press-auth to refresh lazily on expiry.`,
 			if domain == "" {
 				return &ExitError{Code: ExitUsageError, Err: fmt.Errorf("domain argument cannot be empty")}
 			}
-			return runLogin(cmd.Context(), domain, lf)
+			return runLogin(cmd.Context(), cmd.OutOrStdout(), domain, lf)
 		},
 	}
 
@@ -67,9 +67,10 @@ JWT session you want press-auth to refresh lazily on expiry.`,
 
 // runLogin runs the body of `press-auth login`: flag validation, an
 // existing-state precondition check, the chromedp capture, and the
-// Save call. The Cobra layer wraps any returned error in the standard
-// exit-code envelope.
-func runLogin(ctx context.Context, domain string, lf *LoginFlags) error {
+// Save call. Success output goes to out (the command's stdout) so the
+// body stays testable without capturing os.Stdout. The Cobra layer wraps
+// any returned error in the standard exit-code envelope.
+func runLogin(ctx context.Context, out io.Writer, domain string, lf *LoginFlags) error {
 	if lf.LoginURL == "" {
 		return &ExitError{Code: ExitUsageError, Err: fmt.Errorf("--login-url is required")}
 	}
@@ -119,7 +120,7 @@ func runLogin(ctx context.Context, domain string, lf *LoginFlags) error {
 	if carrier == "" {
 		carrier = "(none configured)"
 	}
-	fmt.Fprintf(os.Stdout, "captured %d cookies for %s; JWT carrier: %s (expiry will be set on first refresh)\n", len(state.Cookies), domain, carrier)
+	fmt.Fprintf(out, "captured %d cookies for %s; JWT carrier: %s (expiry will be set on first refresh)\n", len(state.Cookies), domain, carrier)
 	return nil
 }
 

--- a/internal/pressauth/refresh.go
+++ b/internal/pressauth/refresh.go
@@ -83,8 +83,15 @@ endpoint via --refresh-endpoint, otherwise this exits with code 6.`,
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Refreshed session for %s; JWT now expires at %s\n",
-				updated.Domain, updated.JWTExpiry.Format(time.RFC3339))
+			if updated.JWTExpiry.IsZero() {
+				// No JWT carrier configured (or no exp claim), so there is
+				// no expiry to report; printing a zero time would read as
+				// "expires 0001-01-01".
+				fmt.Fprintf(cmd.OutOrStdout(), "Refreshed session for %s\n", updated.Domain)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Refreshed session for %s; JWT now expires at %s\n",
+					updated.Domain, updated.JWTExpiry.Format(time.RFC3339))
+			}
 			return nil
 		},
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/netip"
 	"net/url"
 	"os"
@@ -14,6 +15,15 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"gopkg.in/yaml.v3"
 )
+
+// warnWriter is the destination for non-fatal spec-validation warnings.
+// Tests swap it for a buffer so warnings are assertable without reassigning
+// the process-wide os.Stderr. Mirrors the same sink in internal/openapi.
+var warnWriter io.Writer = os.Stderr
+
+func warnf(format string, args ...any) {
+	fmt.Fprintf(warnWriter, "warning: "+format+"\n", args...)
+}
 
 // Valid values for APISpec.Kind. A bare string with no const was the
 // established convention for sibling fields (SpecSource, ClientPattern), but
@@ -922,7 +932,7 @@ func (c *AuthConfig) NormalizeEnvVarSpecs(context string) {
 		if context == "" {
 			context = "auth"
 		}
-		fmt.Fprintf(os.Stderr, "warning: %s env_vars disagree with env_var_specs; using env_var_specs\n", context)
+		warnf("%s env_vars disagree with env_var_specs; using env_var_specs", context)
 		c.EnvVars = specNames
 		return
 	}
@@ -1003,7 +1013,7 @@ func validateAuthCompanion(c AuthConfig) error {
 			}
 		}
 		if !found {
-			fmt.Fprintf(os.Stderr, "warning: auth.jwt_carrier_cookie %q is not in auth.cookies %v; press-auth refresh will not be wired up\n", carrier, c.Cookies)
+			warnf("auth.jwt_carrier_cookie %q is not in auth.cookies %v; press-auth refresh will not be wired up", carrier, c.Cookies)
 		}
 	}
 	return nil

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3,7 +3,6 @@ package spec
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,24 +11,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func captureStderr(t *testing.T, fn func()) string {
+// captureWarnings runs fn with the package warning sink redirected to a
+// buffer and returns everything written to it. This replaces an older
+// approach that reassigned the process-wide os.Stderr, which was racy and
+// coupled the assertion to a global file handle.
+func captureWarnings(t *testing.T, fn func()) string {
 	t.Helper()
 
-	old := os.Stderr
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stderr = w
-	defer func() {
-		os.Stderr = old
-	}()
+	old := warnWriter
+	var buf bytes.Buffer
+	warnWriter = &buf
+	t.Cleanup(func() { warnWriter = old })
 
 	fn()
-	require.NoError(t, w.Close())
-
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(r)
-	require.NoError(t, err)
-	require.NoError(t, r.Close())
 	return buf.String()
 }
 
@@ -553,7 +547,7 @@ func TestAuthEnvVarSpecsNormalizeAndValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			candidate := baseSpec(tt.auth)
-			stderr := captureStderr(t, func() {
+			stderr := captureWarnings(t, func() {
 				require.NoError(t, candidate.Validate())
 			})
 
@@ -4289,7 +4283,7 @@ func TestAuthCompanionValidate(t *testing.T) {
 }
 
 // TestAuthCompanionJWTCarrierCookieNotInCookiesWarns asserts that a
-// jwt_carrier_cookie that isn't in the cookies list surfaces a stderr
+// jwt_carrier_cookie that isn't in the cookies list surfaces a non-fatal
 // warning, not a hard error. Plausible typo, surface it but don't block.
 func TestAuthCompanionJWTCarrierCookieNotInCookiesWarns(t *testing.T) {
 	auth := AuthConfig{
@@ -4297,7 +4291,7 @@ func TestAuthCompanionJWTCarrierCookieNotInCookiesWarns(t *testing.T) {
 		Cookies:          []string{"session", "csrf_token"},
 		JWTCarrierCookie: "guestsesion", // intentional typo
 	}
-	warnings := captureStderr(t, func() {
+	warnings := captureWarnings(t, func() {
 		err := validateAuthCompanion(auth)
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Follow-up to #1466. Addresses the three non-blocking nits Greptile left on that PR (it scored 5/5 / safe-to-merge; these were explicitly cosmetic and did not block).

## Changes

- **`internal/pressauth/login.go`** — thread an `io.Writer` through `runLogin` and write the success line to the command's stdout instead of `os.Stdout`. The login body is now testable without capturing the process stdout. (`os` import dropped.)
- **`internal/pressauth/refresh.go`** — when no JWT carrier is configured (zero `JWTExpiry`), print `Refreshed session for <domain>` instead of a bogus `... expires at 0001-01-01T00:00:00Z`.
- **`internal/spec/spec.go`** — route the two non-fatal validation warnings (`env_vars` disagreement and `jwt_carrier_cookie` mismatch) through a package `warnWriter` sink + `warnf`, mirroring the existing pattern in `internal/openapi`. The spec test helper now swaps the sink for a buffer instead of reassigning the process-wide `os.Stderr` (racy, global). Existing warning tests retargeted; warning text is byte-identical.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` clean.
- `go test ./internal/pressauth/ ./internal/spec/` pass (capture tests run against real Chrome locally).
- `scripts/golden.sh verify` — 20/20, no output drift (warning text unchanged).