### PR TITLE
fix(cli): allow first force generation without go.mod snapshot

### DIFF
--- a/internal/pipeline/regenmerge/classify_test.go
+++ b/internal/pipeline/regenmerge/classify_test.go
@@ -183,6 +183,20 @@ func TestClassifyOutsideCwdRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "outside the current working directory")
 }
 
+func TestClassifyAllowsFreshGoModWithoutPublishedGoMod(t *testing.T) {
+	t.Parallel()
+
+	pubDir := t.TempDir()
+	freshDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(freshDir, "go.mod"),
+		[]byte("module fresh-cli\n\ngo 1.23\n"), 0o644))
+
+	report, err := Classify(pubDir, freshDir, Options{Force: true})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.Nil(t, report.GoMod, "empty first-generation snapshots have no prior go.mod to merge")
+}
+
 // TestClassifySpecYamlPropagates pins the contract that spec.yaml at the CLI
 // root is classified (and therefore overwritten by Apply) so source-spec
 // changes propagate into the library copy. Without this, downstream tools

--- a/internal/pipeline/regenmerge/classify_test.go
+++ b/internal/pipeline/regenmerge/classify_test.go
@@ -188,8 +188,8 @@ func TestClassifyAllowsFreshGoModWithoutPublishedGoMod(t *testing.T) {
 
 	pubDir := t.TempDir()
 	freshDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(freshDir, "go.mod"),
-		[]byte("module fresh-cli\n\ngo 1.23\n"), 0o644))
+	require.NoError(t, writeFileAtomic(filepath.Join(freshDir, "go.mod"),
+		[]byte("module fresh-cli\n\ngo 1.23\n")))
 
 	report, err := Classify(pubDir, freshDir, Options{Force: true})
 	require.NoError(t, err)

--- a/internal/pipeline/regenmerge/gomod.go
+++ b/internal/pipeline/regenmerge/gomod.go
@@ -15,21 +15,32 @@ import (
 // replaces from published win over fresh; version-replaces from fresh win
 // over published when both have a target for the same path).
 //
-// Returns nil GoModMerge if neither tree has a go.mod (trivially nothing to
-// merge).
+// Returns nil GoModMerge if either tree lacks a go.mod, after validating any
+// present go.mod parses. A merge plan exists only when both sides have module
+// files.
 func planGoModMerge(publishedDir, freshDir string) (*GoModMerge, error) {
 	pubPath := filepath.Join(publishedDir, "go.mod")
 	freshPath := filepath.Join(freshDir, "go.mod")
 	pubData, pubErr := os.ReadFile(pubPath)
 	freshData, freshErr := os.ReadFile(freshPath)
-	if pubErr != nil && freshErr != nil {
+	if pubErr != nil || freshErr != nil {
+		if pubErr != nil && !os.IsNotExist(pubErr) {
+			return nil, fmt.Errorf("reading published go.mod: %w", pubErr)
+		}
+		if freshErr != nil && !os.IsNotExist(freshErr) {
+			return nil, fmt.Errorf("reading fresh go.mod: %w", freshErr)
+		}
+		if pubErr == nil {
+			if _, err := modfile.Parse(pubPath, pubData, nil); err != nil {
+				return nil, fmt.Errorf("parsing published go.mod: %w", err)
+			}
+		}
+		if freshErr == nil {
+			if _, err := modfile.Parse(freshPath, freshData, nil); err != nil {
+				return nil, fmt.Errorf("parsing fresh go.mod: %w", err)
+			}
+		}
 		return nil, nil
-	}
-	if pubErr != nil {
-		return nil, fmt.Errorf("reading published go.mod: %w", pubErr)
-	}
-	if freshErr != nil {
-		return nil, fmt.Errorf("reading fresh go.mod: %w", freshErr)
 	}
 
 	pubMF, err := modfile.Parse(pubPath, pubData, nil)

--- a/internal/pipeline/regenmerge/gomod_test.go
+++ b/internal/pipeline/regenmerge/gomod_test.go
@@ -26,6 +26,83 @@ func TestPlanGoModMergePostmanExplore(t *testing.T) {
 		plan.PreservedModulePath)
 }
 
+func TestPlanGoModMergeTreatsMissingPublishedGoModAsFreshGeneration(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	pubDir := filepath.Join(tmp, "pub")
+	freshDir := filepath.Join(tmp, "fresh")
+	require.NoError(t, os.MkdirAll(pubDir, 0o755))
+	require.NoError(t, os.MkdirAll(freshDir, 0o755))
+	require.NoError(t, writeFileAtomic(filepath.Join(freshDir, "go.mod"), []byte(`module foo-pp-cli
+
+go 1.23.0
+`)))
+
+	plan, err := planGoModMerge(pubDir, freshDir)
+	require.NoError(t, err)
+	assert.Nil(t, plan, "first-time generation has no published go.mod to merge")
+}
+
+func TestPlanGoModMergeStillValidatesPresentGoModWhenOtherSideIsMissing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		writePub    bool
+		pubGoMod    string
+		writeFresh  bool
+		freshGoMod  string
+		wantErrPart string
+	}{
+		{
+			name:        "fresh malformed when published missing",
+			writeFresh:  true,
+			freshGoMod:  "not a module file\n",
+			wantErrPart: "parsing fresh go.mod",
+		},
+		{
+			name:        "published malformed when fresh missing",
+			writePub:    true,
+			pubGoMod:    "not a module file\n",
+			wantErrPart: "parsing published go.mod",
+		},
+		{
+			name:     "published valid when fresh missing",
+			writePub: true,
+			pubGoMod: "module published-cli\n\ngo 1.23\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp := t.TempDir()
+			pubDir := filepath.Join(tmp, "pub")
+			freshDir := filepath.Join(tmp, "fresh")
+			require.NoError(t, os.MkdirAll(pubDir, 0o755))
+			require.NoError(t, os.MkdirAll(freshDir, 0o755))
+			if tt.writePub {
+				require.NoError(t, writeFileAtomic(filepath.Join(pubDir, "go.mod"), []byte(tt.pubGoMod)))
+			}
+			if tt.writeFresh {
+				require.NoError(t, writeFileAtomic(filepath.Join(freshDir, "go.mod"), []byte(tt.freshGoMod)))
+			}
+
+			plan, err := planGoModMerge(pubDir, freshDir)
+			if tt.wantErrPart != "" {
+				require.Error(t, err)
+				assert.Nil(t, plan)
+				assert.Contains(t, err.Error(), tt.wantErrPart)
+				return
+			}
+			require.NoError(t, err)
+			assert.Nil(t, plan)
+		})
+	}
+}
+
 // TestRenderMergedGoModPreservesPublishedModule confirms the rendered bytes
 // have the published module line, the fresh require versions, and parse
 // cleanly.


### PR DESCRIPTION
## Summary

First-time `printing-press generate --force` runs can now finish when the preserved snapshot has no prior `go.mod`. The regen-merge planner treats that as a fresh generation instead of trying to merge a file that never existed, while still parsing whichever side is present so malformed `go.mod` files do not get hidden.

Closes #1706

## Validation

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
