### PR TITLE
fix(cli): surface unsafe paginated all truncation

### DIFF
--- a/docs/solutions/logic-errors/paginated-all-needs-advanceable-signal-2026-05-21.md
+++ b/docs/solutions/logic-errors/paginated-all-needs-advanceable-signal-2026-05-21.md
@@ -1,0 +1,75 @@
+---
+title: "Paginated --all needs an advanceable response signal"
+date: 2026-05-21
+category: logic-errors
+module: internal/openapi
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Generated CLI --all fetches page 1, emits a normal complete event, and exits 0"
+  - "Numeric response cursors such as meta.nextPage do not advance pagination"
+  - "has_more-only pagination can repeat the same request without a cursor update"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - internal/generator
+  - generated-cli-runtime
+tags:
+  - pagination
+  - openapi-parser
+  - generated-cli
+  - truncation-warning
+  - agent-native
+---
+
+# Paginated --all needs an advanceable response signal
+
+## Problem
+
+Generated read commands can expose `--all` even when the Printing Press has not wired a response signal that lets the runtime advance beyond page 1. In issue #1688, a generated command fetched 100 records from a 3,204-record collection, emitted `{"event":"complete","total":100,"pages":1}`, and exited 0. That is dangerous for agent workflows because downstream analysis treats the truncated data set as complete.
+
+## Symptoms
+
+- `--all --json` prints one `page_fetch` event, then a normal `complete` event.
+- The reported `total` is the number of fetched records, not the upstream total available.
+- Response metadata includes a next-page signal such as `meta.nextPage`, but generated command code passes an empty `nextCursorPath`.
+- When a response signal is numeric, string-only cursor extraction silently fails and the loop stops.
+- When a response has `has_more: true` but no extracted cursor, the loop can re-fetch the same page because the request params never change.
+
+## What Didn't Work
+
+- **Relying on a pagination block with only a limit param.** That makes `--all` available but does not prove the runtime can advance.
+- **String-only cursor extraction.** Some APIs return page numbers or numeric IDs as cursors. Treating only JSON strings as cursors recreates page-1 truncation.
+- **Continuing on `has_more` alone.** A has-more flag says more data exists; it does not say how to request it. Continuing without mutating the cursor param repeats the same request.
+- **Only testing `paginatedGet` with manually supplied paths.** That verifies runtime behavior but misses the generator-facing failure where the OpenAPI parser never populated `NextCursorPath`.
+
+## Solution
+
+Keep parser detection and runtime pagination aligned around advanceable signals:
+
+1. Detect nested response metadata such as `meta.nextPage`, `pagination.next_page`, and `response_metadata.next_cursor` when the request declares a real cursor or page parameter.
+2. Do not wire a response-side next cursor when `CursorParam` is empty. A cursor value with no query key cannot advance the request safely.
+3. Convert numeric cursor values to strings in `paginatedGet` so page-number cursors like `2` can flow back through `map[string]string` request params.
+4. When `--all` has no declared `nextCursorPath` or `hasMoreField`, emit an explicit structured truncation event instead of a normal-looking page-1 completion.
+5. When `hasMoreField` is true but no cursor was extracted, emit a structured truncation event and stop instead of looping.
+
+The important invariant is: `--all` may only continue when the next request will be observably different from the previous request. If the runtime cannot prove that, it should return the pages it has and emit an agent-readable truncation warning.
+
+## Why This Works
+
+The fix separates "more pages exist" from "the runtime can advance." `NextCursorPath` plus a non-empty `CursorParam` is advanceable. A numeric cursor is advanceable after string conversion. A bare has-more flag is not advanceable, so it becomes an explicit truncation signal rather than a loop trigger.
+
+The parser-side regression test starts from an OpenAPI response schema with `meta.nextPage` and verifies the generated command passes `"meta.nextPage"` into `resolvePaginatedRead`. The runtime regression tests cover numeric cursor advance, non-`--all` numeric truncation warnings, missing-signal `--all` warnings, and has-more-without-cursor warnings.
+
+## Prevention
+
+- Add parser-level and generated-runtime tests for pagination changes. A direct helper test is not enough for generator-owned behavior.
+- Treat any pagination signal as incomplete unless the request side has a known parameter to carry it.
+- Include negative tests for loop progress: if a branch can `continue`, assert the request params changed first.
+- Run `scripts/golden.sh verify` after template changes, and update fixtures only when emitted generated CLI behavior intentionally changes.
+
+## Related Issues
+
+- GitHub issue #1688
+- docs/solutions/logic-errors/openapi-parser-missing-x-mcp-extension-support-2026-05-08.md

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -237,6 +237,9 @@ func TestPaginatedGetWarnsWhenHasMoreCannotAdvance(t *testing.T) {
 	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"pagination_cursor_missing"` + "`" + `) {
 		t.Fatalf("stderr missing has-more truncation warning: %s", stderr)
 	}
+	if strings.Contains(stderr, ` + "`" + `"next_cursor_path":""` + "`" + `) {
+		t.Fatalf("stderr should omit an empty next_cursor_path: %s", stderr)
+	}
 }
 
 func containsAll(s string, needles ...string) bool {

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -3,8 +3,10 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -48,4 +50,246 @@ func TestPaginatedGetEmitsTruncationWarning(t *testing.T) {
 		"paginatedGet should call emitTruncationWarning on the single-page path")
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("paginate-edge")
+	apiSpec.Resources = map[string]spec.Resource{
+		"orders": {
+			Description: "Manage orders",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/orders",
+					Description: "List orders",
+					Pagination: &spec.Pagination{
+						Type:           "page",
+						CursorParam:    "page",
+						LimitParam:     "limit",
+						NextCursorPath: "meta.nextPage",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Order"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "paginate-edge-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	behaviorTest := `package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+type paginatedTestClient struct {
+	responses []json.RawMessage
+	params    []map[string]string
+}
+
+func (c *paginatedTestClient) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	copied := map[string]string{}
+	for k, v := range params {
+		copied[k] = v
+	}
+	c.params = append(c.params, copied)
+	if len(c.responses) == 0 {
+		return json.RawMessage(` + "`" + `[]` + "`" + `), nil
+	}
+	next := c.responses[0]
+	c.responses = c.responses[1:]
+	return next, nil
+}
+
+func capturePaginatedStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldErr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = oldErr }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(out)
+}
+
+func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"meta":{}}` + "`" + `),
+	}}
+	data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2; data=%s", len(got), data)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if client.params[1]["page"] != "2" {
+		t.Fatalf("second request page = %q, want 2", client.params[1]["page"])
+	}
+}
+
+func TestPaginatedGetWarnsForSinglePageNumericNextCursor(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		_, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "meta.nextPage", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+	})
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"hint":"pass --all to fetch every page"` + "`" + `) {
+		t.Fatalf("stderr missing numeric-cursor truncation warning: %s", stderr)
+	}
+}
+
+func TestPaginatedGetWarnsWhenAllHasNoAdvanceSignal(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `[{"id":"one"}]` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1", len(got))
+		}
+	})
+	if len(client.params) != 1 {
+		t.Fatalf("got %d requests, want 1", len(client.params))
+	}
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+		t.Fatalf("stderr missing structured truncation warning: %s", stderr)
+	}
+}
+
+func TestPaginatedGetWarnsWhenHasMoreCannotAdvance(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "meta.has_more")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1", len(got))
+		}
+	})
+	if len(client.params) != 1 {
+		t.Fatalf("got %d requests, want 1", len(client.params))
+	}
+	if !containsAll(stderr, ` + "`" + `"event":"truncated"` + "`" + `, ` + "`" + `"reason":"pagination_cursor_missing"` + "`" + `) {
+		t.Fatalf("stderr missing has-more truncation warning: %s", stderr)
+	}
+}
+
+func containsAll(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if !strings.Contains(s, needle) {
+			return false
+		}
+	}
+	return true
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "paginated_get_issue1688_test.go"), []byte(behaviorTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestPaginatedGet")
+}
+
+func TestOpenAPINestedNextPageGeneratesPaginatedCommandSignal(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Nested Page API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /opportunities/search:
+    get:
+      operationId: searchOpportunities
+      parameters:
+        - name: page
+          in: query
+          schema: {type: integer}
+        - name: limit
+          in: query
+          schema: {type: integer}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                  meta:
+                    type: object
+                    properties:
+                      nextPage:
+                        type: integer
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "nested-page-api-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+	entries, err := os.ReadDir(cliDir)
+	require.NoError(t, err)
+	var commandSrc strings.Builder
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(cliDir, entry.Name()))
+		require.NoError(t, err)
+		commandSrc.Write(src)
+		commandSrc.WriteByte('\n')
+	}
+	require.Contains(t, commandSrc.String(), `flagAll, "page", "meta.nextPage", ""`,
+		"generated command must pass parser-detected nested nextPage to resolvePaginatedRead")
 }

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -154,6 +154,26 @@ func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
 	}
 }
 
+func TestPaginatedGetStopsAtNumericZeroNextCursor(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":0}}` + "`" + `),
+	}}
+	data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d items, want 1; data=%s", len(got), data)
+	}
+	if len(client.params) != 1 {
+		t.Fatalf("got %d requests, want 1; params=%v", len(client.params), client.params)
+	}
+}
+
 func TestPaginatedGetWarnsForSinglePageNumericNextCursor(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -877,8 +877,10 @@ func emitMissingPaginationSignalWarning() {
 func emitMissingPaginationCursorWarning(nextCursorPath string) {
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
-	} else {
+	} else if nextCursorPath != "" {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n")
 	}
 }
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -782,20 +782,21 @@ func paginatedGet(c interface {
 				// Check for next cursor
 				if nextCursorPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-						var token string
-						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
+						if token := paginationCursorToken(tokenRaw); token != "" {
 							clean[cursorParam] = token
 							continue
 						}
 					}
 				}
 
-				// Check has_more
+				// Check has_more. A has-more flag without an extracted cursor
+				// proves truncation but cannot advance the request safely.
 				if hasMoreField != "" {
 					if moreRaw, ok := rawAtPath(obj, hasMoreField); ok {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil && more {
-							continue
+							emitMissingPaginationCursorWarning(nextCursorPath)
+							break
 						}
 					}
 				}
@@ -808,6 +809,9 @@ func paginatedGet(c interface {
 		break
 	}
 
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+		emitMissingPaginationSignalWarning()
+	}
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "fetched %d items across %d pages\n", len(allItems), page)
 	} else {
@@ -831,7 +835,7 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	var nextCursor string
 	if nextCursorPath != "" {
 		if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-			_ = json.Unmarshal(tokenRaw, &nextCursor)
+			nextCursor = paginationCursorToken(tokenRaw)
 		}
 	}
 	var hasMore bool
@@ -860,6 +864,34 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated"}`+"\n")
 	}
+}
+
+func emitMissingPaginationSignalWarning() {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but this endpoint does not declare a next cursor or has-more field; returning page 1 only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_signal_missing","message":"--all requested but this endpoint does not declare a next cursor or has-more field; returning page 1 only"}`+"\n")
+	}
+}
+
+func emitMissingPaginationCursorWarning(nextCursorPath string) {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	}
+}
+
+func paginationCursorToken(raw json.RawMessage) string {
+	var token string
+	if json.Unmarshal(raw, &token) == nil && token != "" {
+		return token
+	}
+	var number json.Number
+	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
+		return number.String()
+	}
+	return ""
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -888,8 +888,10 @@ func paginationCursorToken(raw json.RawMessage) string {
 		return token
 	}
 	var number json.Number
-	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
-		return number.String()
+	if json.Unmarshal(raw, &number) == nil {
+		if n, err := number.Int64(); err == nil && n > 0 {
+			return number.String()
+		}
 	}
 	return ""
 }

--- a/internal/openapi/embedded_paged_test.go
+++ b/internal/openapi/embedded_paged_test.go
@@ -263,6 +263,24 @@ paths:
                     properties:
                       data: { type: array, items: { type: object } }
                       next_page_token: { type: string }
+  /page-shape/{id}:
+    get:
+      operationId: getPageShape
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  revisions:
+                    type: object
+                    properties:
+                      data: { type: array, items: { type: object } }
+                      next_page: { type: integer }
 `)
 	parsed, err := Parse(doc)
 	require.NoError(t, err)
@@ -287,6 +305,14 @@ paths:
 	assert.False(t, tokenEP.EmbeddedPagedSubresources[0].NextIsURL,
 		"`next_page_token` is opaque; same constraint as next_cursor")
 	assert.False(t, tokenEP.EmbeddedPagedSubresources[0].NextIsBoolean)
+
+	pageEP, ok := findGetEndpoint(parsed, "/page-shape/{id}")
+	require.True(t, ok)
+	require.Len(t, pageEP.EmbeddedPagedSubresources, 1)
+	assert.Equal(t, "next_page", pageEP.EmbeddedPagedSubresources[0].NextField)
+	assert.False(t, pageEP.EmbeddedPagedSubresources[0].NextIsURL,
+		"`next_page` is a page-number signal, not a direct URL")
+	assert.False(t, pageEP.EmbeddedPagedSubresources[0].NextIsBoolean)
 }
 
 // TestEmbeddedPagedSubresources_CaseInsensitive guards the detector

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5700,6 +5700,11 @@ func findNextField(lowered map[string]string) (string, nextFieldKind) {
 			return actual, nextKindCursor
 		}
 	}
+	for _, candidate := range nextFieldPageNumberNames {
+		if actual, ok := lowered[candidate]; ok {
+			return actual, nextKindCursor
+		}
+	}
 	for _, candidate := range nextFieldCursorNames {
 		if actual, ok := lowered[candidate]; ok {
 			return actual, nextKindCursor

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5459,21 +5459,7 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 		if success != nil && success.Value != nil {
 			schemaRef := selectResponseSchema(success.Value)
 			if schemaRef != nil && schemaRef.Value != nil {
-				for propName := range schemaRef.Value.Properties {
-					lower := strings.ToLower(propName)
-					if lower == "nextpagetoken" || lower == "next_page_token" {
-						pag.NextCursorPath = propName
-						if pag.Type == "" {
-							pag.Type = "page_token"
-						}
-					}
-					if lower == "has_more" || lower == "hasmore" {
-						pag.HasMoreField = propName
-						if pag.Type == "" {
-							pag.Type = "cursor"
-						}
-					}
-				}
+				detectPaginationResponseFields(schemaRef.Value, "", &pag)
 			}
 		}
 	}
@@ -5489,6 +5475,66 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	return &pag
 }
 
+func detectPaginationResponseFields(schema *openapi3.Schema, prefix string, pag *spec.Pagination) {
+	if schema == nil {
+		return
+	}
+	for propName, propRef := range schema.Properties {
+		if pag.NextCursorPath != "" && pag.HasMoreField != "" {
+			return
+		}
+		path := propName
+		if prefix != "" {
+			path = prefix + "." + propName
+		}
+		lower := strings.ToLower(propName)
+		switch {
+		case stringInSlice(lower, nextFieldPageTokenNames):
+			if pag.NextCursorPath == "" && pag.CursorParam != "" {
+				pag.NextCursorPath = path
+			}
+			if pag.Type == "" {
+				pag.Type = "page_token"
+			}
+		case stringInSlice(lower, nextFieldPageNumberNames):
+			if pag.NextCursorPath == "" && pag.CursorParam != "" {
+				pag.NextCursorPath = path
+			}
+			if pag.Type == "" {
+				pag.Type = "page"
+			}
+		case stringInSlice(lower, nextFieldCursorNames):
+			if pag.NextCursorPath == "" && pag.CursorParam != "" {
+				pag.NextCursorPath = path
+			}
+			if pag.Type == "" {
+				pag.Type = "cursor"
+			}
+		case stringInSlice(lower, nextFieldBoolNames):
+			if pag.HasMoreField == "" {
+				pag.HasMoreField = path
+			}
+			if pag.Type == "" {
+				pag.Type = "cursor"
+			}
+		}
+
+		if prefix != "" || !isPaginationWrapperField(lower) || propRef == nil || propRef.Value == nil {
+			continue
+		}
+		detectPaginationResponseFields(propRef.Value, path, pag)
+	}
+}
+
+func isPaginationWrapperField(lower string) bool {
+	switch lower {
+	case "meta", "metadata", "pagination", "paging", "response_metadata":
+		return true
+	default:
+		return false
+	}
+}
+
 // itemsFieldNames lists JSON property names that, when typed as an array,
 // signal "this object is a paged envelope" — matches the runtime
 // extractPaginatedItems helper in templates/helpers.go.tmpl so detect-time
@@ -5500,6 +5546,15 @@ var itemsFieldNames = []string{"data", "items", "results", "messages", "members"
 // follows these without API-specific cursor arithmetic.
 var nextFieldURLNames = []string{"next", "next_url", "nexturl"}
 
+// nextFieldPageNumberNames lists numeric fields that carry the next page
+// number. Unlike opaque cursors, these can be fed back to page-style
+// pagination params as strings.
+var nextFieldPageNumberNames = []string{"next_page", "nextpage"}
+
+// nextFieldPageTokenNames lists cursor fields that conventionally pair with
+// page-token request params.
+var nextFieldPageTokenNames = []string{"next_page_token", "nextpagetoken"}
+
 // nextFieldCursorNames lists string properties that carry an opaque
 // cursor token (e.g. next_page_token, next_cursor). These cannot be
 // followed without knowing which query parameter to set on the next
@@ -5507,7 +5562,7 @@ var nextFieldURLNames = []string{"next", "next_url", "nexturl"}
 // runtime helper treats their presence the same way it treats
 // has_more=true: fetch page 1, then emit a truncation event so callers
 // know data is incomplete.
-var nextFieldCursorNames = []string{"next_cursor", "nextcursor", "next_page_token", "nextpagetoken", "cursor"}
+var nextFieldCursorNames = append([]string{"next_cursor", "nextcursor", "cursor"}, nextFieldPageTokenNames...)
 
 // nextFieldBoolNames lists boolean-typed "more pages" flags.
 var nextFieldBoolNames = []string{"has_more", "hasmore"}
@@ -5646,6 +5701,10 @@ func findNextField(lowered map[string]string) (string, nextFieldKind) {
 		}
 	}
 	return "", nextKindNone
+}
+
+func stringInSlice(s string, values []string) bool {
+	return slices.Contains(values, s)
 }
 
 // joinChildPath returns parentPath + "/" + property — the conventional

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5479,7 +5479,14 @@ func detectPaginationResponseFields(schema *openapi3.Schema, prefix string, pag 
 	if schema == nil {
 		return
 	}
-	for propName, propRef := range schema.Properties {
+	propNames := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+
+	for _, propName := range propNames {
+		propRef := schema.Properties[propName]
 		if pag.NextCursorPath != "" && pag.HasMoreField != "" {
 			return
 		}
@@ -5555,14 +5562,12 @@ var nextFieldPageNumberNames = []string{"next_page", "nextpage"}
 // page-token request params.
 var nextFieldPageTokenNames = []string{"next_page_token", "nextpagetoken"}
 
-// nextFieldCursorNames lists string properties that carry an opaque
-// cursor token (e.g. next_page_token, next_cursor). These cannot be
-// followed without knowing which query parameter to set on the next
-// request — metadata the embedded envelope does not provide — so the
-// runtime helper treats their presence the same way it treats
-// has_more=true: fetch page 1, then emit a truncation event so callers
-// know data is incomplete.
-var nextFieldCursorNames = append([]string{"next_cursor", "nextcursor", "cursor"}, nextFieldPageTokenNames...)
+// nextFieldCursorNames lists opaque cursor fields. Unlike page-token
+// names (handled by nextFieldPageTokenNames), these carry unstructured
+// strings that cannot advance pagination without a known query parameter.
+// The runtime treats their presence as a truncation signal when no cursor
+// param is configured.
+var nextFieldCursorNames = []string{"next_cursor", "nextcursor", "cursor"}
 
 // nextFieldBoolNames lists boolean-typed "more pages" flags.
 var nextFieldBoolNames = []string{"has_more", "hasmore"}
@@ -5688,6 +5693,11 @@ func findNextField(lowered map[string]string) (string, nextFieldKind) {
 	for _, candidate := range nextFieldURLNames {
 		if actual, ok := lowered[candidate]; ok {
 			return actual, nextKindURL
+		}
+	}
+	for _, candidate := range nextFieldPageTokenNames {
+		if actual, ok := lowered[candidate]; ok {
+			return actual, nextKindCursor
 		}
 	}
 	for _, candidate := range nextFieldCursorNames {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -6747,6 +6747,79 @@ func TestDetectPaginationRecognizesPageIntCursor(t *testing.T) {
 	}
 }
 
+func TestDetectPaginationRecognizesNestedNumericNextPage(t *testing.T) {
+	t.Parallel()
+
+	description := "OK"
+	responses := openapi3.NewResponses()
+	responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+		Description: &description,
+		Content: openapi3.Content{
+			"application/json": &openapi3.MediaType{
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"items": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type:  &openapi3.Types{"array"},
+							Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+						}},
+						"meta": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type: &openapi3.Types{"object"},
+							Properties: openapi3.Schemas{
+								"nextPage": &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}})
+	op := &openapi3.Operation{Responses: responses}
+
+	pag := detectPagination([]spec.Param{{Name: "page"}, {Name: "limit"}}, op)
+	require.NotNil(t, pag)
+	assert.Equal(t, "page", pag.CursorParam)
+	assert.Equal(t, "page", pag.Type)
+	assert.Equal(t, "limit", pag.LimitParam)
+	assert.Equal(t, "meta.nextPage", pag.NextCursorPath)
+}
+
+func TestDetectPaginationDoesNotWireNestedNextPageWithoutRequestCursor(t *testing.T) {
+	t.Parallel()
+
+	description := "OK"
+	responses := openapi3.NewResponses()
+	responses.Set("200", &openapi3.ResponseRef{Value: &openapi3.Response{
+		Description: &description,
+		Content: openapi3.Content{
+			"application/json": &openapi3.MediaType{
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"items": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type:  &openapi3.Types{"array"},
+							Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+						}},
+						"meta": &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type: &openapi3.Types{"object"},
+							Properties: openapi3.Schemas{
+								"nextPage": &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+							},
+						}},
+					},
+				}},
+			},
+		},
+	}})
+	op := &openapi3.Operation{Responses: responses}
+
+	pag := detectPagination([]spec.Param{{Name: "limit"}}, op)
+	require.NotNil(t, pag)
+	assert.Equal(t, "limit", pag.LimitParam)
+	assert.Empty(t, pag.CursorParam)
+	assert.Empty(t, pag.NextCursorPath)
+}
+
 // TestDetectPaginationCursorBeatsPage guards mixed-form specs: when an
 // API declares both `cursor` and `page` (rare but real), cursor must
 // win so existing cursor-based sync loops stay on the body-cursor

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -584,20 +584,21 @@ func paginatedGet(c interface {
 				// Check for next cursor
 				if nextCursorPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-						var token string
-						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
+						if token := paginationCursorToken(tokenRaw); token != "" {
 							clean[cursorParam] = token
 							continue
 						}
 					}
 				}
 
-				// Check has_more
+				// Check has_more. A has-more flag without an extracted cursor
+				// proves truncation but cannot advance the request safely.
 				if hasMoreField != "" {
 					if moreRaw, ok := rawAtPath(obj, hasMoreField); ok {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil && more {
-							continue
+							emitMissingPaginationCursorWarning(nextCursorPath)
+							break
 						}
 					}
 				}
@@ -610,6 +611,9 @@ func paginatedGet(c interface {
 		break
 	}
 
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+		emitMissingPaginationSignalWarning()
+	}
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "fetched %d items across %d pages\n", len(allItems), page)
 	} else {
@@ -633,7 +637,7 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	var nextCursor string
 	if nextCursorPath != "" {
 		if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-			_ = json.Unmarshal(tokenRaw, &nextCursor)
+			nextCursor = paginationCursorToken(tokenRaw)
 		}
 	}
 	var hasMore bool
@@ -662,6 +666,34 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated"}`+"\n")
 	}
+}
+
+func emitMissingPaginationSignalWarning() {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but this endpoint does not declare a next cursor or has-more field; returning page 1 only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_signal_missing","message":"--all requested but this endpoint does not declare a next cursor or has-more field; returning page 1 only"}`+"\n")
+	}
+}
+
+func emitMissingPaginationCursorWarning(nextCursorPath string) {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	}
+}
+
+func paginationCursorToken(raw json.RawMessage) string {
+	var token string
+	if json.Unmarshal(raw, &token) == nil && token != "" {
+		return token
+	}
+	var number json.Number
+	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
+		return number.String()
+	}
+	return ""
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -690,8 +690,10 @@ func paginationCursorToken(raw json.RawMessage) string {
 		return token
 	}
 	var number json.Number
-	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
-		return number.String()
+	if json.Unmarshal(raw, &number) == nil {
+		if n, err := number.Int64(); err == nil && n > 0 {
+			return number.String()
+		}
 	}
 	return ""
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -679,8 +679,10 @@ func emitMissingPaginationSignalWarning() {
 func emitMissingPaginationCursorWarning(nextCursorPath string) {
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
-	} else {
+	} else if nextCursorPath != "" {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n")
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -683,8 +683,10 @@ func paginationCursorToken(raw json.RawMessage) string {
 		return token
 	}
 	var number json.Number
-	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
-		return number.String()
+	if json.Unmarshal(raw, &number) == nil {
+		if n, err := number.Int64(); err == nil && n > 0 {
+			return number.String()
+		}
 	}
 	return ""
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -672,8 +672,10 @@ func emitMissingPaginationSignalWarning() {
 func emitMissingPaginationCursorWarning(nextCursorPath string) {
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
-	} else {
+	} else if nextCursorPath != "" {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n")
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -577,20 +577,21 @@ func paginatedGet(c interface {
 				// Check for next cursor
 				if nextCursorPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-						var token string
-						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
+						if token := paginationCursorToken(tokenRaw); token != "" {
 							clean[cursorParam] = token
 							continue
 						}
 					}
 				}
 
-				// Check has_more
+				// Check has_more. A has-more flag without an extracted cursor
+				// proves truncation but cannot advance the request safely.
 				if hasMoreField != "" {
 					if moreRaw, ok := rawAtPath(obj, hasMoreField); ok {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil && more {
-							continue
+							emitMissingPaginationCursorWarning(nextCursorPath)
+							break
 						}
 					}
 				}
@@ -603,6 +604,9 @@ func paginatedGet(c interface {
 		break
 	}
 
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+		emitMissingPaginationSignalWarning()
+	}
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "fetched %d items across %d pages\n", len(allItems), page)
 	} else {
@@ -626,7 +630,7 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	var nextCursor string
 	if nextCursorPath != "" {
 		if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-			_ = json.Unmarshal(tokenRaw, &nextCursor)
+			nextCursor = paginationCursorToken(tokenRaw)
 		}
 	}
 	var hasMore bool
@@ -655,6 +659,34 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated"}`+"\n")
 	}
+}
+
+func emitMissingPaginationSignalWarning() {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but this endpoint does not declare a next cursor or has-more field; returning page 1 only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_signal_missing","message":"--all requested but this endpoint does not declare a next cursor or has-more field; returning page 1 only"}`+"\n")
+	}
+}
+
+func emitMissingPaginationCursorWarning(nextCursorPath string) {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	}
+}
+
+func paginationCursorToken(raw json.RawMessage) string {
+	var token string
+	if json.Unmarshal(raw, &token) == nil && token != "" {
+		return token
+	}
+	var number json.Number
+	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
+		return number.String()
+	}
+	return ""
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 62
+    "total": 65
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -584,20 +584,21 @@ func paginatedGet(c interface {
 				// Check for next cursor
 				if nextCursorPath != "" {
 					if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-						var token string
-						if json.Unmarshal(tokenRaw, &token) == nil && token != "" {
+						if token := paginationCursorToken(tokenRaw); token != "" {
 							clean[cursorParam] = token
 							continue
 						}
 					}
 				}
 
-				// Check has_more
+				// Check has_more. A has-more flag without an extracted cursor
+				// proves truncation but cannot advance the request safely.
 				if hasMoreField != "" {
 					if moreRaw, ok := rawAtPath(obj, hasMoreField); ok {
 						var more bool
 						if json.Unmarshal(moreRaw, &more) == nil && more {
-							continue
+							emitMissingPaginationCursorWarning(nextCursorPath)
+							break
 						}
 					}
 				}
@@ -610,6 +611,9 @@ func paginatedGet(c interface {
 		break
 	}
 
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+		emitMissingPaginationSignalWarning()
+	}
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "fetched %d items across %d pages\n", len(allItems), page)
 	} else {
@@ -633,7 +637,7 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	var nextCursor string
 	if nextCursorPath != "" {
 		if tokenRaw, ok := rawAtPath(obj, nextCursorPath); ok {
-			_ = json.Unmarshal(tokenRaw, &nextCursor)
+			nextCursor = paginationCursorToken(tokenRaw)
 		}
 	}
 	var hasMore bool
@@ -662,6 +666,34 @@ func emitTruncationWarning(data json.RawMessage, nextCursorPath, hasMoreField st
 	} else {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated"}`+"\n")
 	}
+}
+
+func emitMissingPaginationSignalWarning() {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but this endpoint does not declare a next cursor or has-more field; returning page 1 only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_signal_missing","message":"--all requested but this endpoint does not declare a next cursor or has-more field; returning page 1 only"}`+"\n")
+	}
+}
+
+func emitMissingPaginationCursorWarning(nextCursorPath string) {
+	if humanFriendly {
+		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	}
+}
+
+func paginationCursorToken(raw json.RawMessage) string {
+	var token string
+	if json.Unmarshal(raw, &token) == nil && token != "" {
+		return token
+	}
+	var number json.Number
+	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
+		return number.String()
+	}
+	return ""
 }
 
 func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -690,8 +690,10 @@ func paginationCursorToken(raw json.RawMessage) string {
 		return token
 	}
 	var number json.Number
-	if json.Unmarshal(raw, &number) == nil && number.String() != "" {
-		return number.String()
+	if json.Unmarshal(raw, &number) == nil {
+		if n, err := number.Int64(); err == nil && n > 0 {
+			return number.String()
+		}
 	}
 	return ""
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -679,8 +679,10 @@ func emitMissingPaginationSignalWarning() {
 func emitMissingPaginationCursorWarning(nextCursorPath string) {
 	if humanFriendly {
 		fmt.Fprintf(os.Stderr, "warning: --all requested, but the response indicated more pages without a usable next cursor; returning fetched pages only.\n")
-	} else {
+	} else if nextCursorPath != "" {
 		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","next_cursor_path":%q,"message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n", nextCursorPath)
+	} else {
+		fmt.Fprintf(os.Stderr, `{"event":"truncated","reason":"pagination_cursor_missing","message":"--all requested but the response indicated more pages without a usable next cursor; returning fetched pages only"}`+"\n")
 	}
 }
 


### PR DESCRIPTION
## Summary

Generated CLIs now make `--all` pagination failures explicit instead of silently returning page 1 as a successful complete result. The OpenAPI parser detects nested response cursors such as `meta.nextPage` only when the request has a real cursor/page parameter to carry the next value, and generated runtime pagination accepts numeric cursor values.

The runtime now emits structured truncation events when `--all` cannot safely advance: no pagination signal is declared, or a has-more flag says more data exists but no usable cursor was extracted. This prevents both silent page-1 truncation and same-request pagination loops.

## What changed

- Detect nested pagination fields in response wrappers such as `meta`, `pagination`, `paging`, and `response_metadata`.
- Convert numeric cursor values to strings before feeding them back into query params.
- Guard `has_more`-only pagination so it warns and stops instead of re-fetching the same page.
- Add parser, generated-runtime, and golden coverage for the issue #1688 cases.
- Add a compounded learning doc for the `--all` advance-signal invariant.

## Verification

- `go test ./internal/openapi -run TestDetectPagination -count=1`
- `go test ./internal/generator -run 'TestPaginatedGetHandlesNumericCursorAndMissingAllSignal|TestOpenAPINestedNextPageGeneratesPaginatedCommandSignal' -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

## Compounded learnings

- File: `docs/solutions/logic-errors/paginated-all-needs-advanceable-signal-2026-05-21.md`
- Track: bug
- Category: logic-errors
- Overlap: low
- Instruction-file edit: none needed
- Refresh recommendation: none

Closes #1688
