### PR TITLE
fix(cli): preserve generated catalog descriptions

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	catalogfs "github.com/mvanhorn/cli-printing-press/v4/catalog"
@@ -1990,6 +1991,35 @@ func TestEnrichSpecFromCatalogMatchesSpecURLWhenSlugDiffers(t *testing.T) {
 	assert.False(t, apiSpec.DisplayNameDerivedFromTitle)
 	assert.Equal(t, "cloud", apiSpec.Category)
 	assert.Equal(t, "https://cloud.google.com/run/docs/reference/rest", apiSpec.WebsiteURL)
+}
+
+func TestRunGenerateProjectUsesCatalogDescription(t *testing.T) {
+	t.Parallel()
+
+	entry, err := catalog.LookupFS(catalogfs.FS, "asana")
+	require.NoError(t, err)
+	apiSpec := &spec.APISpec{
+		Name:        "asana",
+		Description: "Weak source-spec fallback copy.",
+		Version:     "1.0",
+		BaseURL:     "https://api.example.com",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "asana")
+
+	got, err := runGenerateProject(apiSpec, outputDir, generateProjectOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, entry.Description, got.CatalogDescription)
+	assert.False(t, strings.HasSuffix(got.CatalogDescription, "..."))
 }
 
 func TestEnrichSpecFromCatalogReplacesTitleDerivedDisplayName(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -181,7 +181,7 @@ func newGenerateCmd() *cobra.Command {
 					return err
 				}
 
-				novelFeatures, polished, err := runGenerateProject(parsed, absOut, generateProjectOptions{validate: validate, polish: polish, researchDir: researchDir, trafficAnalysisPath: trafficAnalysisPath})
+				generateResult, err := runGenerateProject(parsed, absOut, generateProjectOptions{validate: validate, polish: polish, researchDir: researchDir, trafficAnalysisPath: trafficAnalysisPath})
 				if err != nil {
 					return err
 				}
@@ -200,12 +200,13 @@ func newGenerateCmd() *cobra.Command {
 					APIName:       parsed.Name,
 					DocsURL:       docsURL,
 					OutputDir:     absOut,
+					Description:   generateResult.CatalogDescription,
 					Owner:         parsed.Owner,
 					Printer:       parsed.Printer,
 					PrinterName:   parsed.PrinterName,
 					RunID:         runID,
 					Spec:          parsed,
-					NovelFeatures: novelFeatures,
+					NovelFeatures: generateResult.NovelFeatures,
 				}); err != nil {
 					fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 				}
@@ -218,7 +219,7 @@ func newGenerateCmd() *cobra.Command {
 						"output_dir": absOut,
 						"spec_files": specFiles,
 						"validated":  validate,
-						"polished":   polished,
+						"polished":   generateResult.Polished,
 					}); err != nil {
 						return fmt.Errorf("encoding JSON: %w", err)
 					}
@@ -359,7 +360,7 @@ func newGenerateCmd() *cobra.Command {
 				return printDryRun(apiSpec, absOut, specFiles)
 			}
 
-			novelFeatures, polished, err := runGenerateProject(apiSpec, absOut, generateProjectOptions{validate: validate, polish: polish, researchDir: researchDir, trafficAnalysisPath: trafficAnalysisPath, specFiles: specFiles, specURL: specURL, rejectUnshippablePageContextTraffic: true})
+			generateResult, err := runGenerateProject(apiSpec, absOut, generateProjectOptions{validate: validate, polish: polish, researchDir: researchDir, trafficAnalysisPath: trafficAnalysisPath, specFiles: specFiles, specURL: specURL, rejectUnshippablePageContextTraffic: true})
 			if err != nil {
 				return err
 			}
@@ -405,12 +406,13 @@ func newGenerateCmd() *cobra.Command {
 				SpecSrcs:      specFiles,
 				SpecURL:       specURL,
 				OutputDir:     absOut,
+				Description:   generateResult.CatalogDescription,
 				Owner:         apiSpec.Owner,
 				Printer:       apiSpec.Printer,
 				PrinterName:   apiSpec.PrinterName,
 				RunID:         runID,
 				Spec:          apiSpec,
-				NovelFeatures: novelFeatures,
+				NovelFeatures: generateResult.NovelFeatures,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 			}
@@ -432,7 +434,7 @@ func newGenerateCmd() *cobra.Command {
 					"output_dir": absOut,
 					"spec_files": specFiles,
 					"validated":  validate,
-					"polished":   polished,
+					"polished":   generateResult.Polished,
 				}); err != nil {
 					return fmt.Errorf("encoding JSON: %w", err)
 				}
@@ -501,16 +503,29 @@ type generateProjectOptions struct {
 	rejectUnshippablePageContextTraffic bool
 }
 
-func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProjectOptions) ([]pipeline.NovelFeatureManifest, bool, error) {
-	enrichSpecFromCatalog(apiSpec, catalogSpecLookupRefs(opts.specFiles, opts.specURL)...)
+type generateProjectResult struct {
+	NovelFeatures      []pipeline.NovelFeatureManifest
+	CatalogDescription string
+	Polished           bool
+}
+
+func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProjectOptions) (generateProjectResult, error) {
+	var catalogEntry *catalog.Entry
+	if apiSpec != nil {
+		catalogEntry = lookupCatalogEntryForGenerateSpec(apiSpec.Name, catalogSpecLookupRefs(opts.specFiles, opts.specURL))
+		enrichSpecFromCatalogEntry(apiSpec, catalogEntry)
+	}
 	gen := generator.New(apiSpec, absOut)
+	if catalogEntry != nil {
+		gen.CatalogEntryDescription = catalogEntry.Description
+	}
 	novelFeatures := loadResearchSources(gen, opts.researchDir)
 	trafficAnalysis, err := loadTrafficAnalysisForGenerate(opts.trafficAnalysisPath, opts.specFiles, apiSpec.SpecSource)
 	if err != nil {
-		return nil, false, &ExitError{Code: ExitInputError, Err: err}
+		return generateProjectResult{}, &ExitError{Code: ExitInputError, Err: err}
 	}
 	if opts.rejectUnshippablePageContextTraffic && trafficAnalysisRequiresUnshippablePageContext(trafficAnalysis) {
-		return nil, false, &ExitError{Code: ExitInputError, Err: fmt.Errorf("traffic analysis says this target requires live browser page-context execution; persistent browser transport is not a shippable printed CLI runtime. Re-run discovery for a Surf/direct/browser-clearance replayable surface instead")}
+		return generateProjectResult{}, &ExitError{Code: ExitInputError, Err: fmt.Errorf("traffic analysis says this target requires live browser page-context execution; persistent browser transport is not a shippable printed CLI runtime. Re-run discovery for a Surf/direct/browser-clearance replayable surface instead")}
 	}
 	// ApplyReachabilityDefaults runs first so its HAR-driven HTTP-version
 	// mapping wins for browser_http / browser_clearance_http modes.
@@ -525,14 +540,18 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	applyHTTPTransportDefault(apiSpec, trafficAnalysis)
 	gen.TrafficAnalysis = trafficAnalysis
 	if err := gen.Generate(); err != nil {
-		return nil, false, &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("generating project: %w", err)}
+		return generateProjectResult{}, &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("generating project: %w", err)}
 	}
 	if opts.validate {
 		if err := gen.Validate(); err != nil {
-			return nil, false, &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("validating generated project: %w", err)}
+			return generateProjectResult{}, &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("validating generated project: %w", err)}
 		}
 	}
-	return novelFeatures, runGeneratePolishPass(opts.polish, apiSpec.Name, absOut), nil
+	return generateProjectResult{
+		NovelFeatures:      novelFeatures,
+		CatalogDescription: gen.CatalogDescription(),
+		Polished:           runGeneratePolishPass(opts.polish, apiSpec.Name, absOut),
+	}, nil
 }
 
 func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource, clientPattern, httpTransport, owner string) error {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -128,11 +128,15 @@ type Generator struct {
 	VisionSet       VisionTemplateSet
 	FixtureSet      *browsersniff.FixtureSet
 	TrafficAnalysis *browsersniff.TrafficAnalysis
-	Sources         []ReadmeSource          // Ecosystem tools to credit in README
-	DiscoveryPages  []string                // Pages visited during browser-sniff discovery
-	NovelFeatures   []NovelFeature          // Transcendence features for README/SKILL
-	Narrative       *ReadmeNarrative        // LLM-authored prose for README/SKILL; optional
-	AsyncJobs       map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
+	Sources         []ReadmeSource   // Ecosystem tools to credit in README
+	DiscoveryPages  []string         // Pages visited during browser-sniff discovery
+	NovelFeatures   []NovelFeature   // Transcendence features for README/SKILL
+	Narrative       *ReadmeNarrative // LLM-authored prose for README/SKILL; optional
+	// CatalogEntryDescription carries curated catalog copy into durable
+	// generated metadata without making compact Homebrew/SKILL surfaces depend
+	// on it.
+	CatalogEntryDescription string
+	AsyncJobs               map[string]AsyncJobInfo // Detected async-job endpoints, keyed by "<resource>/<endpoint>"
 
 	// ModulePath overrides the Go module import path emitted by templates that
 	// reference internal packages (`{{modulePath}}/internal/client`, etc.).
@@ -834,6 +838,32 @@ func (g *Generator) compactDescription() string {
 	}
 	for _, candidate := range candidates {
 		if desc := naming.CompactDescription(candidate); desc != "" {
+			return desc
+		}
+	}
+	return fmt.Sprintf("Printing Press CLI for %s.", g.proseName())
+}
+
+// CatalogDescription returns the best generated user-facing description for
+// durable catalog metadata.
+func (g *Generator) CatalogDescription() string {
+	candidates := []string{}
+	if g.Narrative != nil {
+		candidates = append(candidates, g.Narrative.Headline)
+	}
+	candidates = append(candidates, g.CatalogEntryDescription)
+	if g.Spec != nil {
+		candidates = append(candidates, g.Spec.CLIDescription)
+	}
+	for _, candidate := range candidates {
+		if desc := naming.CatalogDescription(candidate); desc != "" {
+			if !naming.HasLiteralEllipsisSuffix(desc) {
+				return desc
+			}
+		}
+	}
+	if g.Spec != nil {
+		if desc := naming.CompactDescription(g.Spec.Description); desc != "" {
 			return desc
 		}
 	}

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -320,6 +320,28 @@ func TestCompactDescriptionPrefersCLIShapedCopy(t *testing.T) {
 	assert.NotContains(t, string(goreleaser), "# Introduction")
 }
 
+func TestCatalogDescriptionPreservesCompleteLongCopy(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("longcopy")
+	apiSpec.CLIDescription = "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+	outputDir := filepath.Join(t.TempDir(), "longcopy-pp-cli")
+	gen := New(apiSpec, outputDir)
+
+	assert.Equal(t, apiSpec.CLIDescription, gen.CatalogDescription())
+}
+
+func TestCatalogDescriptionSkipsLiteralEllipsisCandidates(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("longcopy")
+	apiSpec.CLIDescription = "Truncated CLI-shaped copy..."
+	apiSpec.Description = "Complete fallback sentence."
+	gen := New(apiSpec, filepath.Join(t.TempDir(), "longcopy-pp-cli"))
+
+	assert.Equal(t, "Complete fallback sentence.", gen.CatalogDescription())
+}
+
 // TestSkillRendersAuthBranchPerType asserts the deterministic Auth Setup
 // block branches correctly on .Auth.Type when no narrative auth is provided.
 func TestSkillRendersAuthBranchPerType(t *testing.T) {

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/mozillazg/go-unidecode"
 	"golang.org/x/text/cases"
@@ -217,6 +218,19 @@ func CompactDescription(s string) string {
 	return truncateOneLine(s)
 }
 
+// CatalogDescription produces single-line prose for durable catalog metadata.
+// It normalizes markdown and whitespace without applying compact-surface
+// truncation, since this value becomes the canonical description in generated
+// manifests.
+func CatalogDescription(s string) string {
+	s = stripLeadingMarkdownHeading(s)
+	return collapseWhitespace(s)
+}
+
+func HasLiteralEllipsisSuffix(s string) bool {
+	return strings.HasSuffix(strings.TrimSpace(s), "...")
+}
+
 func collapseWhitespace(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
@@ -228,15 +242,62 @@ func collapseWhitespace(s string) string {
 }
 
 func truncateOneLine(s string) string {
-	if len(s) > 120 {
-		cut := s[:117]
-		if idx := strings.LastIndex(cut, " "); idx > 60 {
-			s = cut[:idx] + "..."
-		} else {
-			s = cut + "..."
-		}
+	if utf8.RuneCountInString(s) <= 120 {
+		return s
 	}
-	return s
+	if sentence := lastSentenceBoundaryUnder(s, 120); sentence != "" {
+		return sentence
+	}
+	if clause := firstCompleteClauseUnder(s, 120); clause != "" {
+		return clause
+	}
+	return hardTruncateOneLine(s, 120)
+}
+
+func lastSentenceBoundaryUnder(s string, limit int) string {
+	best := ""
+	for idx, r := range s {
+		if r != '.' && r != '!' && r != '?' {
+			continue
+		}
+		candidate := strings.TrimSpace(s[:idx+len(string(r))])
+		if candidate == "" || utf8.RuneCountInString(candidate) > limit {
+			continue
+		}
+		best = candidate
+	}
+	return best
+}
+
+func hardTruncateOneLine(s string, limit int) string {
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	cut := string(runes[:limit])
+	if idx := strings.LastIndex(cut, " "); idx > 60 {
+		return strings.TrimRight(cut[:idx], " ,;:")
+	}
+	return strings.TrimRight(cut, " ,;:")
+}
+
+func firstCompleteClauseUnder(s string, limit int) string {
+	best := ""
+	for idx, r := range s {
+		if r != ';' && r != ':' && r != ',' && r != ')' {
+			continue
+		}
+		end := idx
+		if r == ')' {
+			end += len(string(r))
+		}
+		candidate := strings.TrimSpace(s[:end])
+		if candidate == "" || utf8.RuneCountInString(candidate) > limit {
+			continue
+		}
+		best = strings.TrimRight(candidate, " ,;:")
+	}
+	return best
 }
 
 func stripLeadingMarkdownHeading(s string) string {

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -183,6 +183,49 @@ func TestCompactDescriptionPreservesHumanText(t *testing.T) {
 	}
 }
 
+func TestCompactDescriptionDoesNotEmitLiteralEllipsis(t *testing.T) {
+	input := "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks). Includes offline FTS search and agent-friendly JSON output."
+	got := CompactDescription(input)
+	if strings.HasSuffix(got, "...") {
+		t.Fatalf("CompactDescription(%q) ended with literal ellipsis: %q", input, got)
+	}
+	if got != "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks)." {
+		t.Fatalf("CompactDescription(%q) = %q, want first complete sentence", input, got)
+	}
+	if len(got) > 120 {
+		t.Fatalf("CompactDescription(%q) = %q, want compact copy", input, got)
+	}
+}
+
+func TestCompactDescriptionAvoidsIncompleteFragments(t *testing.T) {
+	input := "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+	got := CompactDescription(input)
+	if got != "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks)" {
+		t.Fatalf("CompactDescription(%q) = %q, want complete clause", input, got)
+	}
+}
+
+func TestCompactDescriptionFallsBackToNonEmptyHardTruncation(t *testing.T) {
+	input := "Local first CLI for the Roam HQ API chat On Air events transcripts SCIM webhooks offline search agent friendly JSON output without punctuation until the end."
+	got := CompactDescription(input)
+	if got == "" {
+		t.Fatalf("CompactDescription(%q) returned empty string", input)
+	}
+	if strings.HasSuffix(got, "...") {
+		t.Fatalf("CompactDescription(%q) ended with literal ellipsis: %q", input, got)
+	}
+	if len([]rune(got)) > 120 {
+		t.Fatalf("CompactDescription(%q) = %q, want compact copy", input, got)
+	}
+}
+
+func TestCatalogDescriptionPreservesCompleteLongCopy(t *testing.T) {
+	input := "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+	if got := CatalogDescription(input); got != input {
+		t.Fatalf("CatalogDescription(%q) = %q, want complete source sentence", input, got)
+	}
+}
+
 func TestMCPDescription(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -196,7 +196,11 @@ func RefreshCLIManifestFromSpec(dir string, parsed *spec.APISpec) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return fmt.Errorf("parsing CLI manifest for refresh: %w", err)
 	}
+	existingDescription := m.Description
 	populateMCPMetadata(&m, parsed)
+	if preserveExistingDescription(existingDescription) {
+		m.Description = existingDescription
+	}
 	return WriteCLIManifest(dir, m)
 }
 
@@ -586,6 +590,7 @@ type GenerateManifestParams struct {
 	SpecURL       string   // --spec-url: explicit provenance URL (when --spec is a local downloaded file)
 	DocsURL       string   // --docs URL, if used
 	OutputDir     string
+	Description   string                 // best generated user-facing catalog description
 	Owner         string                 // resolved owner attribution (manifest preserve > copyright parse > git config)
 	Printer       string                 // resolved printer @handle (manifest preserve > git config github.user > empty)
 	PrinterName   string                 // resolved printer display name (manifest preserve > git config user.name > empty)
@@ -658,6 +663,10 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	runID := p.RunID
 	if runID == "" {
 		runID = now.Format(runIDTimeFormat)
+	}
+	var existingDescription string
+	if existing, err := ReadCLIManifest(p.OutputDir); err == nil {
+		existingDescription = existing.Description
 	}
 	m := CLIManifest{
 		SchemaVersion:        CurrentCLIManifestSchemaVersion,
@@ -742,6 +751,15 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if p.Spec != nil {
 		populateMCPMetadata(&m, p.Spec)
 	}
+	if description := strings.TrimSpace(p.Description); description != "" {
+		m.Description = description
+	}
+	// A durable manifest description may be hand-edited after generation.
+	// Operators can delete or replace the field when they want changed spec
+	// prose to become canonical on a later generate run.
+	if preserveExistingDescription(existingDescription) {
+		m.Description = existingDescription
+	}
 	if len(p.NovelFeatures) > 0 {
 		m.NovelFeatures = p.NovelFeatures
 	}
@@ -759,6 +777,11 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	// Emit MCPB manifest.json next to .printing-press.json. Pass the
 	// in-memory struct so we don't re-read the file we just wrote.
 	return WriteMCPBManifestFromStruct(p.OutputDir, m)
+}
+
+func preserveExistingDescription(description string) bool {
+	description = strings.TrimSpace(description)
+	return description != "" && !naming.HasLiteralEllipsisSuffix(description)
 }
 
 func lookupCatalogEntryForGenerate(apiName, specURL string) *catalogpkg.Entry {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1299,10 +1300,10 @@ func TestWriteMCPBManifestPreservesExistingDisplayName(t *testing.T) {
 	}
 }
 
-func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
+func TestWriteMCPBManifestDescription(t *testing.T) {
 	t.Run("hand-edited description preserved over canonical", func(t *testing.T) {
 		dir := t.TempDir()
-		handEdit := "Find the best version of any recipe across 37 trusted sites — trust-aware ranking weights real reader signal."
+		handEdit := "Find the best version of any recipe across 37 trusted sites with trust-aware ranking weights real reader signal."
 		writeMCPBManifest(t, dir, MCPBManifest{
 			ManifestVersion: MCPBManifestVersion,
 			Name:            "recipe-goat-pp-mcp",
@@ -1319,6 +1320,26 @@ func TestWriteMCPBManifestPreservesExistingDescription(t *testing.T) {
 
 		require.NoError(t, WriteMCPBManifest(dir))
 		assert.Equal(t, handEdit, readMCPBManifest(t, dir).Description)
+	})
+
+	t.Run("literal ellipsis description refreshed from canonical", func(t *testing.T) {
+		dir := t.TempDir()
+		writeMCPBManifest(t, dir, MCPBManifest{
+			ManifestVersion: MCPBManifestVersion,
+			Name:            "recipe-goat-pp-mcp",
+			DisplayName:     "Recipe Goat",
+			Description:     "Recipe GOAT aggregates recipes from...",
+		})
+		writeManifest(t, dir, CLIManifest{
+			APIName:     "recipe-goat",
+			DisplayName: "Recipe Goat",
+			MCPBinary:   "recipe-goat-pp-mcp",
+			MCPReady:    "full",
+			Description: "Recipe GOAT aggregates recipes from canonical-description-source.json",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		assert.Equal(t, "Recipe GOAT aggregates recipes from canonical-description-source.json", readMCPBManifest(t, dir).Description)
 	})
 
 	t.Run("derived-default existing description refreshed from canonical", func(t *testing.T) {
@@ -1687,6 +1708,113 @@ func TestPopulateMCPMetadataCLIDescription(t *testing.T) {
 		})
 		assert.Equal(t, "Catalog description.", m.Description)
 	})
+}
+
+func TestRefreshCLIManifestFromSpecPreservesDurableDescription(t *testing.T) {
+	dir := t.TempDir()
+	existing := "Curated manifest description."
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "asana",
+		Description: existing,
+	})
+
+	err := RefreshCLIManifestFromSpec(dir, &spec.APISpec{
+		Name:           "asana",
+		CLIDescription: "Parsed spec fallback.",
+		Auth:           spec.AuthConfig{Type: "none"},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, existing, got.Description)
+}
+
+func TestRefreshCLIManifestFromSpecReplacesLiteralEllipsisDescription(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "asana",
+		Description: "Legacy truncated manifest description...",
+	})
+
+	err := RefreshCLIManifestFromSpec(dir, &spec.APISpec{
+		Name:           "asana",
+		CLIDescription: "Parsed spec fallback.",
+		Auth:           spec.AuthConfig{Type: "none"},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "Parsed spec fallback.", got.Description)
+}
+
+func TestWriteManifestForGenerateUsesExplicitCatalogDescription(t *testing.T) {
+	dir := t.TempDir()
+	rich := "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		// asana is in the embedded catalog; this proves the generate-time
+		// description from the rendered project wins over catalog fallback
+		// and the source spec's CLI-shaped copy.
+		APIName:     "asana",
+		OutputDir:   dir,
+		Description: rich,
+		Spec: &spec.APISpec{
+			Name:           "asana",
+			CLIDescription: "Manage Asana workspaces from the terminal.",
+			Auth:           spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, rich, got.Description)
+	assert.False(t, strings.HasSuffix(got.Description, "..."))
+}
+
+func TestWriteManifestForGeneratePreservesExistingDurableDescription(t *testing.T) {
+	dir := t.TempDir()
+	existing := "Curated CLI description that should survive force regeneration."
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "asana",
+		Description: existing,
+	})
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:     "asana",
+		OutputDir:   dir,
+		Description: "Fresh generated fallback copy.",
+		Spec: &spec.APISpec{
+			Name: "asana",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, existing, got.Description)
+}
+
+func TestWriteManifestForGenerateReplacesLiteralEllipsisDescription(t *testing.T) {
+	dir := t.TempDir()
+	fresh := "Curated catalog description without a truncation marker."
+	writeManifest(t, dir, CLIManifest{
+		APIName:     "asana",
+		Description: "Legacy truncated catalog copy...",
+	})
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:     "asana",
+		OutputDir:   dir,
+		Description: fresh,
+		Spec: &spec.APISpec{
+			Name: "asana",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, fresh, got.Description)
 }
 
 // TestWriteManifestForGeneratePopulatesCategoryFromSpec pins the fallback

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
 )
@@ -238,18 +239,16 @@ func bundleVersion(m CLIManifest) string {
 	return "0.0.0"
 }
 
-// manifestDescription returns the existing hand-edited description over
-// the canonical one from .printing-press.json. The existing snapshot's
-// description is only treated as "hand-edited" when it differs from
-// every form the generator would have emitted — current and prior — so
-// a manifest written before the displayNameForConcat trim still gets
-// recognized as derived and refreshed from canonical.
+// manifestDescription preserves hand-edited bundle descriptions while letting
+// canonical manifest descriptions refresh known generated defaults and legacy
+// literal-ellipsis truncations.
 func manifestDescription(existing *existingMCPBManifest, m CLIManifest, displayName string) string {
 	derivedDefault := displayNameForConcat(displayName) + " API surface as MCP tools."
 	priorDerivedDefault := displayName + " API surface as MCP tools."
 	if existing != nil && existing.Description != "" &&
 		existing.Description != derivedDefault &&
-		existing.Description != priorDerivedDefault {
+		existing.Description != priorDerivedDefault &&
+		!naming.HasLiteralEllipsisSuffix(existing.Description) {
 		return existing.Description
 	}
 	if m.Description != "" {

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -185,9 +185,6 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	if err := gen.GenerateMCPSurface(); err != nil {
 		return Result{}, fmt.Errorf("rendering MCP surface: %w", err)
 	}
-	if err := pipeline.WriteToolsManifest(cliDir, parsed); err != nil {
-		return Result{}, fmt.Errorf("regenerating tools-manifest.json: %w", err)
-	}
 	// Refresh .printing-press.json's spec-derived fields before regenerating
 	// manifest.json. WriteMCPBManifest reads provenance from disk, so
 	// without this step spec.yaml updates to auth.key_url, auth.optional,
@@ -197,6 +194,13 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// when auth.optional was added (Required label didn't drop).
 	if err := pipeline.RefreshCLIManifestFromSpec(cliDir, parsed); err != nil {
 		return Result{}, fmt.Errorf("refreshing CLI manifest from spec: %w", err)
+	}
+	var manifestDescription string
+	if m, err := pipeline.ReadCLIManifest(cliDir); err == nil {
+		manifestDescription = m.Description
+	}
+	if err := pipeline.WriteToolsManifestWithDescription(cliDir, parsed, manifestDescription); err != nil {
+		return Result{}, fmt.Errorf("regenerating tools-manifest.json: %w", err)
 	}
 	// Regenerate the MCPB manifest too. The schema can drift between
 	// generator releases (most recently: cli_binary was removed because

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
+	"gopkg.in/yaml.v3"
 )
 
 type RunManifest struct {
@@ -203,6 +204,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		SpecPath:             specPath,
 		RunID:                state.RunID,
 	}
+	var existingDescription string
 
 	// Carry forward metadata from the generated manifest when publish-time
 	// parsing is unavailable or lossy for the original spec format. NovelFeatures
@@ -234,8 +236,9 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 			if existing.Category != "" {
 				m.Category = existing.Category
 			}
-			if existing.Description != "" {
+			if preserveExistingDescription(existing.Description) {
 				m.Description = existing.Description
+				existingDescription = existing.Description
 			}
 			if existing.APIVersion != "" {
 				m.APIVersion = existing.APIVersion
@@ -264,7 +267,9 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	if entry, err := catalogpkg.LookupFS(catalog.FS, state.APIName); err == nil {
 		m.CatalogEntry = entry.Name
 		m.Category = entry.Category
-		m.Description = entry.Description
+		if m.Description == "" {
+			m.Description = entry.Description
+		}
 		if entry.DisplayName != "" {
 			m.DisplayName = entry.DisplayName
 		}
@@ -298,6 +303,15 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		if parseErr == nil {
 			applyPublishCatalogMetadata(parsed, state.APIName)
 			populateMCPMetadata(&m, parsed)
+			if m.Description == "" {
+				m.Description = naming.CompactDescription(parsed.Description)
+			}
+			if preserveExistingDescription(existingDescription) {
+				m.Description = existingDescription
+			}
+		}
+		if m.Description == "" {
+			m.Description = archivedSpecDescription(data)
 		}
 
 		// Fall back to spec.Category for synthetic CLIs not in the embedded
@@ -314,7 +328,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		// (auth-doctor, mcp-audit). Non-blocking: log warning on error
 		// but don't fail the publish.
 		if parsed != nil {
-			if tmErr := WriteToolsManifest(dir, parsed); tmErr != nil {
+			if tmErr := WriteToolsManifestWithDescription(dir, parsed, m.Description); tmErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write tools manifest: %v\n", tmErr)
 			}
 		}
@@ -373,6 +387,16 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	}
 
 	return WriteCLIManifest(dir, m)
+}
+
+func archivedSpecDescription(data []byte) string {
+	var probe struct {
+		Description string `yaml:"description" json:"description"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return ""
+	}
+	return naming.CompactDescription(probe.Description)
 }
 
 func applyPublishCatalogMetadata(parsed *spec.APISpec, apiName string) {

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/catalog"
+	catalogpkg "github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -267,6 +270,104 @@ paths: {}
 
 	m := readPublishedManifest(t, state.WorkingDir)
 	assert.Equal(t, "Product Hunt", m.DisplayName)
+}
+
+func TestWriteCLIManifestForPublishPreservesGeneratedDescription(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	rich := "Local-first CLI for the Roam HQ API (chat, On-Air events, transcripts, SCIM, webhooks) with offline FTS search and agent-friendly JSON output."
+	state := NewStateWithRun("asana", filepath.Join(tmp, "working", "asana-pp-cli"), "20260521-description", "test-scope")
+	require.NoError(t, os.MkdirAll(state.WorkingDir, 0o755))
+	writeManifest(t, state.WorkingDir, CLIManifest{
+		APIName:     "asana",
+		Description: rich,
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, "spec.yaml"), []byte(`
+name: asana
+description: API-shaped fallback copy.
+cli_description: Spec CLI copy that should not replace generated catalog copy during publish.
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+resources: {}
+`), 0o644))
+
+	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+
+	m := readPublishedManifest(t, state.WorkingDir)
+	assert.Equal(t, rich, m.Description)
+	assert.False(t, strings.HasSuffix(m.Description, "..."))
+}
+
+func TestWriteCLIManifestForPublishReplacesLiteralEllipsisDescription(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	state := NewStateWithRun("asana", filepath.Join(tmp, "working", "asana-pp-cli"), "20260521-description", "test-scope")
+	require.NoError(t, os.MkdirAll(state.WorkingDir, 0o755))
+	writeManifest(t, state.WorkingDir, CLIManifest{
+		APIName:     "asana",
+		Description: "Legacy generated description...",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, "spec.yaml"), []byte(`
+name: asana
+description: API-shaped fallback copy.
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  items:
+    description: Items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+`), 0o644))
+
+	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+
+	entry, err := catalogpkg.LookupFS(catalog.FS, "asana")
+	require.NoError(t, err)
+	m := readPublishedManifest(t, state.WorkingDir)
+	assert.Equal(t, entry.Description, m.Description)
+	assert.False(t, strings.HasSuffix(m.Description, "..."))
+}
+
+func TestWriteCLIManifestForPublishReplacesLiteralEllipsisDescriptionFromSyntheticSpec(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	state := NewStateWithRun("synthetic-local", filepath.Join(tmp, "working", "synthetic-local-pp-cli"), "20260521-description", "test-scope")
+	require.NoError(t, os.MkdirAll(state.WorkingDir, 0o755))
+	writeManifest(t, state.WorkingDir, CLIManifest{
+		APIName:     "synthetic-local",
+		Description: "Legacy generated description...",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, "spec.yaml"), []byte(`
+name: synthetic-local
+description: Synthetic local command line interface description without early punctuation so publish still emits usable metadata after rejecting legacy ellipsis descriptions
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+resources: {}
+`), 0o644))
+
+	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+
+	m := readPublishedManifest(t, state.WorkingDir)
+	assert.NotEmpty(t, m.Description)
+	assert.False(t, strings.HasSuffix(m.Description, "..."))
 }
 
 func TestWriteCLIManifestForPublishAppliesCatalogMetadataAfterNameOverride(t *testing.T) {

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -148,6 +148,13 @@ func ReadToolsManifest(dir string) (*ToolsManifest, error) {
 // It iterates Resources/SubResources/Endpoints in sorted key order (matching
 // the MCP template's RegisterTools pattern) and writes deterministic JSON.
 func WriteToolsManifest(dir string, parsed *spec.APISpec) error {
+	return WriteToolsManifestWithDescription(dir, parsed, "")
+}
+
+// WriteToolsManifestWithDescription generates a tools-manifest.json using the
+// supplied manifestDescription when available. The parsed spec remains the
+// source for tools and auth metadata; .printing-press.json owns durable prose.
+func WriteToolsManifestWithDescription(dir string, parsed *spec.APISpec, manifestDescription string) error {
 	if parsed == nil {
 		return fmt.Errorf("parsed spec is nil")
 	}
@@ -167,6 +174,9 @@ func WriteToolsManifest(dir string, parsed *spec.APISpec) error {
 		Auth:            manifestAuth(parsed.Auth),
 		RequiredHeaders: make([]ManifestHeader, 0, len(parsed.RequiredHeaders)),
 		Tools:           make([]ManifestTool, 0),
+	}
+	if description := strings.TrimSpace(manifestDescription); description != "" {
+		manifest.Description = description
 	}
 	if parsed.HasTierRouting() {
 		manifest.TierRouting = buildManifestTiers(parsed.TierRouting)

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -123,6 +123,33 @@ func TestWriteToolsManifest_MultipleResources(t *testing.T) {
 	assert.Equal(t, "/store/inventory", got.Tools[3].Path)
 }
 
+func TestWriteToolsManifestWithDescriptionUsesCanonicalManifestDescription(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:        "petstore",
+		Description: "Weak source-spec fallback copy.",
+		BaseURL:     "https://petstore.example.com/v3",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"Pets": {
+				Description: "Pet operations",
+				Endpoints: map[string]spec.Endpoint{
+					"List": {Method: "GET", Path: "/pets", Description: "List all pets"},
+				},
+			},
+		},
+	}
+	canonical := "Curated catalog description for the generated CLI."
+
+	require.NoError(t, WriteToolsManifestWithDescription(dir, parsed, canonical))
+
+	data, err := os.ReadFile(filepath.Join(dir, ToolsManifestFilename))
+	require.NoError(t, err)
+	var got ToolsManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, canonical, got.Description)
+}
+
 func TestWriteToolsManifest_SubResources(t *testing.T) {
 	dir := t.TempDir()
 	parsed := &spec.APISpec{

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -6,6 +6,7 @@
   ],
   "auth_type": "api_key",
   "cli_name": "cafe-bistro-pp-cli",
+  "description": "Purpose-built fixture for the Unicode-to-ASCII slug contract.",
   "display_name": "Café Bistro",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "cafe-bistro-pp-mcp",

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/manifest.json
@@ -10,7 +10,7 @@
       "win32"
     ]
   },
-  "description": "Café Bistro API surface as MCP tools.",
+  "description": "Purpose-built fixture for the Unicode-to-ASCII slug contract.",
   "display_name": "Café Bistro",
   "license": "Apache-2.0",
   "manifest_version": "0.3",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -6,6 +6,7 @@
   ],
   "auth_type": "api_key",
   "cli_name": "printing-press-golden-pp-cli",
+  "description": "Purpose-built fixture for golden generation coverage.",
   "display_name": "Printing Press Studio",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "printing-press-golden-pp-mcp",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/manifest.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/manifest.json
@@ -10,7 +10,7 @@
       "win32"
     ]
   },
-  "description": "Printing Press Studio API surface as MCP tools.",
+  "description": "Purpose-built fixture for golden generation coverage.",
   "display_name": "Printing Press Studio",
   "license": "Apache-2.0",
   "manifest_version": "0.3",

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -6,6 +6,7 @@
   ],
   "auth_type": "api_key",
   "cli_name": "mcp-cloudflare-pp-cli",
+  "description": "Golden fixture exercising x-mcp on an OpenAPI spec.",
   "display_name": "Mcp Cloudflare",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "mcp-cloudflare-pp-mcp",

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
@@ -6,6 +6,7 @@
   ],
   "auth_type": "bearer_token",
   "cli_name": "sync-walker-golden-pp-cli",
+  "description": "Golden fixture for the Tier 2 spec-declared walker mechanism.",
   "display_name": "Sync Walker Golden",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "sync-walker-golden-pp-mcp",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
@@ -8,6 +8,7 @@
   ],
   "auth_type": "bearer_token",
   "cli_name": "tier-routing-golden-pp-cli",
+  "description": "Golden fixture for tier-routed generated clients.",
   "display_name": "Tier Routing Golden",
   "generated_at": "<GENERATED_AT>",
   "mcp_binary": "tier-routing-golden-pp-mcp",

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/manifest.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/manifest.json
@@ -10,7 +10,7 @@
       "win32"
     ]
   },
-  "description": "Tier Routing Golden API surface as MCP tools.",
+  "description": "Golden fixture for tier-routed generated clients.",
   "display_name": "Tier Routing Golden",
   "license": "Apache-2.0",
   "manifest_version": "0.3",


### PR DESCRIPTION
## Summary
- Preserve curated generated/catalog descriptions in .printing-press.json, MCP bundle manifests, and tools-manifest.json.
- Keep compact descriptions sentence-aware and avoid emitting literal ... truncation markers.
- Preserve hand-edited MCP bundle descriptions while refreshing generated defaults and legacy ellipsis descriptions.

## Tests
- go test ./...
- scripts/golden.sh verify
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- go vet ./...
- golangci-lint run ./...

Closes #1666