### PR TITLE
feat(cli): add Supercut Platform catalog entry

### DIFF
--- a/catalog/supercut.yaml
+++ b/catalog/supercut.yaml
@@ -14,7 +14,7 @@ homepage: https://supercut.ai
 auth_key_url: https://supercut.ai/settings/api-tokens
 auth_instructions: "Open Settings -> API tokens and choose a token type. Workspace API tokens are available on all plans and unlock the item-scoped read endpoints (transcript, frame, reactions, comments). Personal API tokens require a paid workspace plan and additionally unlock the listing endpoints (/recordings/, /stacks/, /stacks/{id})."
 auth_env_vars:
-  - SUPERCUT_PLATFORM_BEARER_AUTH  # canonical: matches the securitySchemes key emitted by the vendor OpenAPI
+  - SUPERCUT_PLATFORM_BEARER_AUTH  # canonical: explicit Supercut platform bearer token
   - SUPERCUT_API_KEY               # common alias
 notes: >
   Each endpoint description in the vendor OpenAPI carries an inline HTML

--- a/catalog/supercut.yaml
+++ b/catalog/supercut.yaml
@@ -6,25 +6,22 @@ spec_url: https://api.supercut.ai/api/platform/v1/openapi.json
 spec_format: json
 openapi_version: "3.0"
 tier: official
-spec_source: official
 auth_required: true
 client_pattern: rest
 http_transport: standard
 verified_date: "2026-05-21"
-homepage: https://api.supercut.ai/api/platform/v1/docs/
-auth_key_url: https://supercut.ai/settings/clips/personal-api-tokens
-auth_instructions: "Supercut issues two token types: personal API tokens (user-scoped, list and detail endpoints) and workspace API tokens (item-scoped read endpoints — transcript, frame, reactions, comments). Personal tokens require a paid workspace plan; workspace tokens are available on all plans."
+homepage: https://supercut.ai
+auth_key_url: https://supercut.ai/settings/api-tokens
+auth_instructions: "Open Settings -> API tokens and choose a token type. Workspace API tokens are available on all plans and unlock the item-scoped read endpoints (transcript, frame, reactions, comments). Personal API tokens require a paid workspace plan and additionally unlock the listing endpoints (/recordings/, /stacks/, /stacks/{id})."
 auth_env_vars:
   - SUPERCUT_PLATFORM_BEARER_AUTH  # canonical: matches the securitySchemes key emitted by the vendor OpenAPI
   - SUPERCUT_API_KEY               # common alias
 notes: >
-  Supercut Platform API (api.supercut.ai/v1). Bearer auth via Authorization header.
-  Vendor publishes a versioned OpenAPI 3.0.2 document at /api/platform/v1/openapi.json.
-  9 paths across 2 resource groups: recordings and stacks. Each endpoint description
-  includes an HTML access-pill marking which token type it accepts (personal,
-  workspace, or both). Listing endpoints (/recordings/, /stacks/, /stacks/{id})
-  are personal-token only; item read endpoints (transcript, frame, reactions,
-  comments) accept both. All endpoints are read-only GETs in this version.
+  Each endpoint description in the vendor OpenAPI carries an inline HTML
+  access-pill marking which token type(s) it accepts (personal, workspace,
+  or both). Generated CLI help text surfaces these pills verbatim, so the
+  personal-vs-workspace gate is visible at the command level. All endpoints
+  in this version are read-only GETs.
 known_alternatives:
   - name: supercut-mcp
     url: https://mcp.supercut.ai/mcp

--- a/catalog/supercut.yaml
+++ b/catalog/supercut.yaml
@@ -1,0 +1,31 @@
+name: supercut
+display_name: Supercut
+description: AI video recording and clipping platform API for recordings, stacks, transcripts, frames, comments, and reactions
+category: media-and-entertainment
+spec_url: https://api.supercut.ai/api/platform/v1/openapi.json
+spec_format: json
+openapi_version: "3.0"
+tier: official
+spec_source: official
+auth_required: true
+client_pattern: rest
+http_transport: standard
+verified_date: "2026-05-21"
+homepage: https://api.supercut.ai/api/platform/v1/docs/
+auth_key_url: https://supercut.ai/settings/clips/personal-api-tokens
+auth_instructions: "Supercut issues two token types: personal API tokens (user-scoped, list and detail endpoints) and workspace API tokens (item-scoped read endpoints — transcript, frame, reactions, comments). Personal tokens require a paid workspace plan; workspace tokens are available on all plans."
+auth_env_vars:
+  - SUPERCUT_PLATFORM_BEARER_AUTH  # canonical: matches the securitySchemes key emitted by the vendor OpenAPI
+  - SUPERCUT_API_KEY               # common alias
+notes: >
+  Supercut Platform API (api.supercut.ai/v1). Bearer auth via Authorization header.
+  Vendor publishes a versioned OpenAPI 3.0.2 document at /api/platform/v1/openapi.json.
+  9 paths across 2 resource groups: recordings and stacks. Each endpoint description
+  includes an HTML access-pill marking which token type it accepts (personal,
+  workspace, or both). Listing endpoints (/recordings/, /stacks/, /stacks/{id})
+  are personal-token only; item read endpoints (transcript, frame, reactions,
+  comments) accept both. All endpoints are read-only GETs in this version.
+known_alternatives:
+  - name: supercut-mcp
+    url: https://mcp.supercut.ai/mcp
+    language: hosted

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -22,6 +22,9 @@ maps:
 marketing:
   producthunt          Find, monitor, and export Product Hunt launches for launch research, scouting, and competitive tracking without requiring a Product Hunt API application.
 
+media-and-entertainment:
+  supercut             AI video recording and clipping platform API for recordings, stacks, transcripts, frames, comments, and reactions
+
 monitoring:
   sentry               Error tracking and performance monitoring - projects, issues, events, releases
 


### PR DESCRIPTION
## Intent

Add an `official`-tier catalog entry for Supercut (AI video recording and clipping platform) so the Printing Press can generate a printed CLI for the Supercut Platform API.

Issue: N/A.

## Approach

One change, YAML-only, no generator code: `catalog/supercut.yaml`.

Supercut publishes a versioned vendor OpenAPI 3.0.2 document at `https://api.supercut.ai/api/platform/v1/openapi.json`, so the entry points `spec_url` directly at the vendor URL (matching the stripe / github / digitalocean pattern) rather than snapshotting a curated spec in-repo (the kayak / quo pattern).

Auth: Bearer token via the `Authorization` header. The vendor OpenAPI exposes a `BearerAuth` HTTP bearer security scheme; the catalog declares `SUPERCUT_PLATFORM_BEARER_AUTH` as the explicit Supercut platform bearer env var, with `SUPERCUT_API_KEY` listed as a common alias.

Token-type nuance worth flagging for reviewers: Supercut issues two token types. **Personal API tokens** (user-scoped, paid-plan only) unlock listing endpoints (`/recordings/`, `/stacks/`, `/stacks/{id}`). **Workspace API tokens** (available on all plans) unlock the item-scoped read endpoints (`transcript`, `frame`, `reactions`, `comments`). Each path in the vendor OpenAPI carries an inline HTML access-pill in its description marking which token type(s) it accepts, so the requirement surfaces verbatim in generated CLI help text at the command level.

## Scope

Primary area: `catalog` (machine — adding an entry to the embedded `catalog/` package; rebuilding the binary picks it up via `catalog.FS`).

Why this belongs in this repo: Catalog entries live in the machine. A new printed CLI for Supercut cannot be generated unless the entry exists here.

## Risk

- No generator code, template, scorer, MCP, or pipeline code changes — only one YAML file in `catalog/` plus the corresponding `catalog-list` golden text bump.
- `catalog.FS` rebuilds pick up the new entry. The `catalog list` golden gains a 3-line `media-and-entertainment` block (updated in this PR).
- `catalog show supercut` renders the new entry; not covered by any golden fixture today, same as other entries.
- All endpoints in the vendor spec are `GET`s, so the printed CLI is read-only and there is no destructive surface to worry about.

## Output Contract

Touches one golden fixture: `testdata/golden/expected/catalog-list/stdout.txt` — adds the `media-and-entertainment` category row for supercut. No other generated artifact or command output is affected. No template, MCP schema, scorecard, manifest, or pipeline fixture changes.

## Verification

Run from the repo root on `feat/supercut-catalog`:

- `go build -o ./printing-press ./cmd/printing-press` — clean build.
- `go test ./...` — all packages pass (including `internal/catalog`).
- `go fmt ./...` — no diff (no Go files touched).
- `scripts/golden.sh verify` — **Golden verify passed: 20 case(s)** after updating the `catalog-list` fixture.
- Manual: `./printing-press catalog show supercut` renders the full entry; `./printing-press catalog list` shows the new `media-and-entertainment` row.
- Live smoke test against `api.supercut.ai/v1` with a workspace bearer token: `printing-press generate` produced a printed CLI that hit 8/8 quality gates (`go mod tidy`, `govulncheck`, `go vet`, `go build`, binary build, `--help`, `version`, `doctor`). `doctor` reports `Auth: configured`, `API: reachable`, `Credentials: ok (auth accepted)`. Personal-token endpoints correctly return `403 "This endpoint requires a personal API token"` with a workspace token, as the spec describes.

Not run locally:
- `golangci-lint run ./...` — `golangci-lint` is not installed in this dev environment. CI runs the same config on PR, and this PR changes no Go files, so the lint result should match `main`.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change


