### PR TITLE
fix(cli): handle setlist retro generator gaps

### DIFF
--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -12,7 +12,7 @@ import (
 )
 
 var leadingMarkdownHeadingRE = regexp.MustCompile(`^#{1,6}\s+(.+)$`)
-var htmlTagRE = regexp.MustCompile(`<[^>]+>`)
+var htmlTagRE = regexp.MustCompile(`</?\s*(?:a|abbr|address|article|aside|blockquote|br|button|code|dd|del|details|div|dl|dt|em|figcaption|figure|footer|h[1-6]|header|hr|img|li|main|mark|nav|ol|p|pre|samp|section|small|span|strong|sub|summary|sup|table|tbody|td|tfoot|th|thead|tr|u|ul)(?:\s+[^<>]*)?\s*/?>`)
 
 // ASCIIFold transliterates Unicode to ASCII via Unidecode tables (the
 // same ones Django's slugify and Rails use). Apply at every chokepoint

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -12,6 +12,7 @@ import (
 )
 
 var leadingMarkdownHeadingRE = regexp.MustCompile(`^#{1,6}\s+(.+)$`)
+var htmlTagRE = regexp.MustCompile(`<[^>]+>`)
 
 // ASCIIFold transliterates Unicode to ASCII via Unidecode tables (the
 // same ones Django's slugify and Rails use). Apply at every chokepoint
@@ -196,7 +197,7 @@ func OneLine(s string) string {
 // that's already curated for length (MCP tool descriptions, agent-authored
 // overrides) where truncating would defeat the purpose.
 func OneLineNormalize(s string) string {
-	s = stripLeadingMarkdownHeading(s)
+	s = stripDescriptionMarkup(stripLeadingMarkdownHeading(s))
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
@@ -213,7 +214,7 @@ func OneLineNormalize(s string) string {
 // quotes and backslashes because callers are responsible for escaping in their
 // target format.
 func CompactDescription(s string) string {
-	s = stripLeadingMarkdownHeading(s)
+	s = stripDescriptionMarkup(stripLeadingMarkdownHeading(s))
 	s = collapseWhitespace(s)
 	return truncateOneLine(s)
 }
@@ -223,8 +224,12 @@ func CompactDescription(s string) string {
 // truncation, since this value becomes the canonical description in generated
 // manifests.
 func CatalogDescription(s string) string {
-	s = stripLeadingMarkdownHeading(s)
+	s = stripDescriptionMarkup(stripLeadingMarkdownHeading(s))
 	return collapseWhitespace(s)
+}
+
+func stripDescriptionMarkup(s string) string {
+	return htmlTagRE.ReplaceAllString(s, " ")
 }
 
 func HasLiteralEllipsisSuffix(s string) bool {

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -162,7 +162,9 @@ func TestOneLine(t *testing.T) {
 		"  spaces  ":         "spaces",
 		"# Introduction\nAeroAPI delivers flight data.":       "AeroAPI delivers flight data.",
 		"<p>Search for <strong>artists</strong> by name.</p>": "Search for artists by name.",
-		"## Overview": "Overview",
+		"latency < 10ms > 1ms":                                "latency < 10ms > 1ms",
+		"formula A<B>C":                                       "formula A<B>C",
+		"## Overview":                                         "Overview",
 	}
 
 	for input, want := range tests {

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -160,7 +160,8 @@ func TestOneLine(t *testing.T) {
 		"too  many   spaces": "too many spaces",
 		`say "hello"`:        "say 'hello'",
 		"  spaces  ":         "spaces",
-		"# Introduction\nAeroAPI delivers flight data.": "AeroAPI delivers flight data.",
+		"# Introduction\nAeroAPI delivers flight data.":       "AeroAPI delivers flight data.",
+		"<p>Search for <strong>artists</strong> by name.</p>": "Search for artists by name.",
 		"## Overview": "Overview",
 	}
 
@@ -180,6 +181,17 @@ func TestCompactDescriptionPreservesHumanText(t *testing.T) {
 	want := `An "agent-native" CLI with C:\tmp paths.`
 	if got := CompactDescription(input); got != want {
 		t.Fatalf("CompactDescription(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestCompactDescriptionsStripHTMLTags(t *testing.T) {
+	input := "<p>Search for <strong>artists</strong> by name.</p>"
+	want := "Search for artists by name."
+	if got := CompactDescription(input); got != want {
+		t.Fatalf("CompactDescription(%q) = %q, want %q", input, got, want)
+	}
+	if got := CatalogDescription(input); got != want {
+		t.Fatalf("CatalogDescription(%q) = %q, want %q", input, got, want)
 	}
 }
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode"
 
@@ -4587,10 +4586,9 @@ func isVersionSegment(segment string) bool {
 		return false
 	}
 	if segment[0] == 'v' && len(segment) >= 2 {
-		return versionSegmentPattern.MatchString(segment)
+		return versionSegmentPattern.MatchString(segment) || isVersionToken(segment)
 	}
-	_, err := strconv.Atoi(segment)
-	return err == nil
+	return isVersionToken(segment)
 }
 
 func isPathParamSegment(segment string) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -1677,6 +1677,8 @@ func TestPathSegmentsStripsGenericAPIPrefix(t *testing.T) {
 		{"strips api then version", "/api/v2/pokemon", "", "pokemon"},
 		{"strips version then api then version", "/v2/api/v1/pokemon", "", "pokemon"},
 		{"strips api then numeric version", "/api/0/organizations", "", "organizations"},
+		{"strips dotted numeric version", "/1.0/search/artists", "", "search"},
+		{"strips dotted v-prefixed version", "/v1.0/search/artists", "", "search"},
 		{"strips beta version", "/v1beta2/{parent}/repositories", "", "{parent}"},
 		{"strips alpha version", "/v1alpha1/{parent}/services", "", "{parent}"},
 		{"strips p beta version", "/v1p1beta1/{parent}/sessions", "", "{parent}"},
@@ -1684,9 +1686,8 @@ func TestPathSegmentsStripsGenericAPIPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			segments := pathSegmentsAfterBase(tt.path, tt.basePath)
-			if len(segments) > 0 {
-				assert.Equal(t, tt.wantFirst, segments[0])
-			}
+			require.NotEmpty(t, segments)
+			assert.Equal(t, tt.wantFirst, segments[0])
 		})
 	}
 }

--- a/internal/openapi/swagger2_test.go
+++ b/internal/openapi/swagger2_test.go
@@ -210,3 +210,29 @@ func TestParseSwagger2BasicEndpointShape(t *testing.T) {
 	endpoint := findParsedEndpointByPath(t, parsed, "GET", "/users")
 	require.NotNil(t, endpoint)
 }
+
+func TestParseSwagger2HostBasePathDefaultsToHTTPS(t *testing.T) {
+	t.Parallel()
+
+	swagger2 := []byte(`{
+  "swagger": "2.0",
+  "info": {"title": "Host Demo", "version": "1.0.0"},
+  "host": "api.setlist.fm",
+  "basePath": "/rest",
+  "paths": {
+    "/1.0/search/artists": {
+      "get": {
+        "operationId": "searchArtists",
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  }
+}`)
+
+	parsed, err := Parse(swagger2)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.Equal(t, "https://api.setlist.fm/rest", parsed.BaseURL)
+	assert.Contains(t, parsed.Resources, "host-demo-search")
+	assert.NotContains(t, parsed.Resources, "1_0")
+}

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1982,6 +1982,9 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 	if envNeedle != "" && strings.Contains(strings.ToUpper(configContent), envNeedle) {
 		envMatched = true
 	}
+	if !envMatched && configReadsAPIKeyEnvForScheme(configContent, scheme) {
+		envMatched = true
+	}
 	// Browser cookie auth (composed or cookie type) uses Chrome cookie extraction
 	// instead of env vars. Credit envMatched if the auth code has cookie tooling.
 	if !envMatched && (strings.Contains(authContent, "detectCookieTool") ||
@@ -2112,8 +2115,38 @@ func scoreComposedHeaderScheme(clientContent string, scheme openAPISecuritySchem
 }
 
 func headerAssignmentPresent(clientContent, headerName string) bool {
-	return strings.Contains(clientContent, `Header.Set("`+headerName+`"`) ||
-		strings.Contains(clientContent, `Header.Add("`+headerName+`"`)
+	clientContent = strings.ToLower(clientContent)
+	headerName = strings.ToLower(headerName)
+	return strings.Contains(clientContent, `header.set("`+headerName+`"`) ||
+		strings.Contains(clientContent, `header.add("`+headerName+`"`)
+}
+
+var getenvCallRe = regexp.MustCompile(`os\.Getenv\("([A-Z][A-Z0-9_]*)"\)`)
+
+func configReadsAPIKeyEnvForScheme(configContent string, scheme openAPISecurityScheme) bool {
+	if !strings.EqualFold(scheme.Type, "apikey") || !isGenericAPIKeyScheme(scheme) {
+		return false
+	}
+	for _, match := range getenvCallRe.FindAllStringSubmatch(configContent, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		env := match[1]
+		if env == "API_KEY" || strings.HasSuffix(env, "_API_KEY") {
+			return true
+		}
+	}
+	return false
+}
+
+func isGenericAPIKeyScheme(scheme openAPISecurityScheme) bool {
+	for _, name := range []string{scheme.Key, scheme.HeaderName} {
+		needle := strings.ReplaceAll(sanitizeEnvName(name), "_", "")
+		if strings.Contains(needle, "APIKEY") {
+			return true
+		}
+	}
+	return false
 }
 
 // refreshTokenFieldRe word-anchors RefreshToken so cosmetic names like

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2121,18 +2121,27 @@ func headerAssignmentPresent(clientContent, headerName string) bool {
 		strings.Contains(clientContent, `header.add("`+headerName+`"`)
 }
 
-var getenvCallRe = regexp.MustCompile(`os\.Getenv\("([A-Z][A-Z0-9_]*)"\)`)
+var (
+	genericAPIKeyEnvCallRe             = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*:=\s*os\.Getenv\("(?:[A-Z][A-Z0-9_]*_)?API_KEY"\)`)
+	directGenericAPIKeyEnvAssignmentRe = regexp.MustCompile(`\.\s*APIKey\s*=\s*os\.Getenv\("(?:[A-Z][A-Z0-9_]*_)?API_KEY"\)`)
+)
 
 func configReadsAPIKeyEnvForScheme(configContent string, scheme openAPISecurityScheme) bool {
 	if !strings.EqualFold(scheme.Type, "apikey") || !isGenericAPIKeyScheme(scheme) {
 		return false
 	}
-	for _, match := range getenvCallRe.FindAllStringSubmatch(configContent, -1) {
-		if len(match) < 2 {
+	if directGenericAPIKeyEnvAssignmentRe.MatchString(configContent) {
+		return true
+	}
+	for _, match := range genericAPIKeyEnvCallRe.FindAllStringSubmatchIndex(configContent, -1) {
+		if len(match) < 4 {
 			continue
 		}
-		env := match[1]
-		if env == "API_KEY" || strings.HasSuffix(env, "_API_KEY") {
+		envVarName := configContent[match[2]:match[3]]
+		tailStart := match[1]
+		tailEnd := min(len(configContent), tailStart+240)
+		fieldAssignmentRe := regexp.MustCompile(`\.\s*APIKey\s*=\s*` + regexp.QuoteMeta(envVarName) + `\b`)
+		if fieldAssignmentRe.MatchString(configContent[tailStart:tailEnd]) {
 			return true
 		}
 	}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2015,6 +2015,76 @@ func (c *Client) do() {
 	})
 }
 
+func TestScoreAuthScheme_APIKeyHeaderUsesCaseInsensitiveHeaderAndGenericAPIKeyEnv(t *testing.T) {
+	clientContent := `package client
+func (c *Client) do(req *http.Request) {
+	req.Header.Set("X-API-Key", cfg.APIKey)
+}`
+	configContent := `package config
+func Load() {
+	if v := os.Getenv("SETLIST_FM_API_KEY"); v != "" {
+		cfg.APIKey = v
+	}
+}`
+	scheme := openAPISecurityScheme{
+		Key:        "x-api-key",
+		Type:       "apikey",
+		In:         "header",
+		HeaderName: "x-api-key",
+	}
+
+	score, scoreable := scoreAuthScheme(clientContent, configContent, "", false, scheme)
+	assert.True(t, scoreable)
+	assert.Equal(t, 10, score)
+
+	unrelatedScheme := openAPISecurityScheme{
+		Key:        "account-id",
+		Type:       "apikey",
+		In:         "header",
+		HeaderName: "X-Account-ID",
+	}
+	unrelatedScore, unrelatedScoreable := scoreAuthScheme(clientContent, configContent, "", false, unrelatedScheme)
+	assert.True(t, unrelatedScoreable)
+	assert.Equal(t, 0, unrelatedScore)
+}
+
+func TestRunScorecard_APIKeyHeaderUsesCaseInsensitiveHeaderAndGenericAPIKeyEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, "internal/client/client.go", `package client
+func (c *Client) do(req *http.Request) {
+	req.Header.Set("X-API-Key", cfg.APIKey)
+}`)
+	writeScorecardFixture(t, dir, "internal/config/config.go", `package config
+func Load() {
+	if v := os.Getenv("SETLIST_FM_API_KEY"); v != "" {
+		cfg.APIKey = v
+	}
+}`)
+	specPath := filepath.Join(dir, "spec.json")
+	writeScorecardFixture(t, dir, "spec.json", `{
+  "openapi": "3.0.3",
+  "info": {"title": "Setlist", "version": "1.0.0"},
+  "paths": {
+    "/1.0/search/artists": {
+      "get": {
+        "security": [{"x-api-key": []}],
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "x-api-key": {"type": "apiKey", "in": "header", "name": "x-api-key"}
+    }
+  }
+}`)
+
+	sc, err := RunScorecard(dir, t.TempDir(), specPath, nil)
+	assert.NoError(t, err)
+	assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+	assert.Equal(t, 10, sc.Steinberger.AuthProtocol)
+}
+
 func TestLoadOpenAPISpec_Swagger20SecurityDefinitions(t *testing.T) {
 	t.Run("swagger 2.0 apiKey in header with Authorization maps to bearer", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2037,6 +2037,17 @@ func Load() {
 	assert.True(t, scoreable)
 	assert.Equal(t, 10, score)
 
+	partnerOnlyConfig := `package config
+func Load() {
+	if v := os.Getenv("PARTNER_SERVICE_API_KEY"); v != "" {
+		cfg.PartnerAPIKey = v
+	}
+}`
+	assert.False(t, configReadsAPIKeyEnvForScheme(partnerOnlyConfig, scheme))
+	partnerOnlyScore, partnerOnlyScoreable := scoreAuthScheme(clientContent, partnerOnlyConfig, "", false, scheme)
+	assert.True(t, partnerOnlyScoreable)
+	assert.Equal(t, 8, partnerOnlyScore)
+
 	unrelatedScheme := openAPISecurityScheme{
 		Key:        "account-id",
 		Type:       "apikey",


### PR DESCRIPTION
## Summary

Setlist-shaped Swagger specs now generate cleaner future CLIs: dotted version path prefixes no longer become resource commands, HTML tags are removed from compact generated descriptions, and `x-api-key` header auth gets scorecard credit when the generated client and config prove the auth path is wired.

This also adds regression coverage for Swagger 2.0 `host` + `basePath` resolution without an explicit `schemes` block. Existing golden fixtures did not change; the deterministic contracts are covered by focused parser, naming, and scorecard tests.

## Validation

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1719
