### PR TITLE
fix(skills): capture Request object browser-sniff bodies

### DIFF
--- a/internal/browsersniff/capture_reference_test.go
+++ b/internal/browsersniff/capture_reference_test.go
@@ -1,0 +1,171 @@
+package browsersniff
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserSniffReferenceGraphQLInterceptorCapturesRequestBodies(t *testing.T) {
+	t.Parallel()
+
+	snippet := extractBrowserUseGraphQLSnippet(t)
+	runNodeSnippet(t, snippet+`
+await window.fetch(new Request('https://example.com/graphql', {
+  method: 'POST',
+  body: JSON.stringify({operationName: 'RequestObjectOp', variables: {prompt: 'x'}}),
+  headers: {'content-type': 'application/json'}
+}));
+await window.fetch('https://example.com/graphql', {
+  method: 'POST',
+  body: JSON.stringify({operationName: 'LegacyOptionsOp', variables: {page: 1}})
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+window.__gqlOps.sort((a, b) => a.op.localeCompare(b.op));
+assertEqual(window.__gqlOps, [
+  {op: 'LegacyOptionsOp', vars: ['page']},
+  {op: 'RequestObjectOp', vars: ['prompt']}
+]);
+`)
+}
+
+func TestBrowserSniffReferencePrimaryInterceptorCapturesRequestBodies(t *testing.T) {
+	t.Parallel()
+
+	snippet := extractBrowserUsePrimaryCaptureSnippet(t)
+	runNodeSnippet(t, snippet+`
+await window.fetch(new Request('https://example.com/api', {
+  method: 'POST',
+  body: JSON.stringify({prompt: 'request object'}),
+  headers: {'content-type': 'application/json'}
+}));
+await window.fetch('https://example.com/legacy', {
+  method: 'POST',
+  body: JSON.stringify({prompt: 'legacy options'})
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+assertEqual(window.__capture_bodies['POST https://example.com/api'].request_body, '{"prompt":"request object"}');
+assertEqual(window.__capture_bodies['POST https://example.com/api'].response_body, '{"ok":true}');
+assertEqual(window.__capture_bodies['POST https://example.com/api'].response_status, 200);
+assertEqual(window.__capture_bodies['POST https://example.com/api'].response_content_type, 'application/json');
+assertEqual(window.__capture_bodies['POST https://example.com/legacy'].request_body, '{"prompt":"legacy options"}');
+assertEqual(window.__capture_bodies['POST https://example.com/legacy'].response_body, '{"ok":true}');
+`)
+}
+
+func TestBrowserSniffReferenceChromeMCPInterceptorCapturesRequestBodies(t *testing.T) {
+	t.Parallel()
+
+	snippet := extractChromeMCPFetchSnippet(t)
+	runNodeSnippet(t, snippet+`
+await window.fetch(new Request('https://example.com/api', {
+  method: 'POST',
+  body: JSON.stringify({prompt: 'request object'}),
+  headers: {'content-type': 'application/json'}
+}));
+await window.fetch('https://example.com/legacy', {
+  method: 'POST',
+  body: JSON.stringify({prompt: 'legacy options'})
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+assertEqual(window.__capture_bodies['POST https://example.com/api'].request_body, '{"prompt":"request object"}');
+assertEqual(window.__capture_bodies['POST https://example.com/api'].response_body, '{"ok":true}');
+assertEqual(window.__capture_bodies['POST https://example.com/legacy'].request_body, '{"prompt":"legacy options"}');
+assertEqual(window.__capture_bodies['POST https://example.com/legacy'].response_body, '{"ok":true}');
+`)
+}
+
+func extractBrowserUsePrimaryCaptureSnippet(t *testing.T) string {
+	t.Helper()
+
+	content := readBrowserSniffReference(t)
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, `browser-use eval "window.__capture_bodies={};`) {
+			continue
+		}
+		snippet, err := strconv.Unquote(strings.TrimPrefix(line, "browser-use eval "))
+		require.NoError(t, err)
+		return snippet
+	}
+
+	t.Fatal("browser-use primary body capture snippet not found")
+	return ""
+}
+
+func extractBrowserUseGraphQLSnippet(t *testing.T) string {
+	t.Helper()
+
+	content := readBrowserSniffReference(t)
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, `browser-use eval "window.__gqlOps=[];`) {
+			continue
+		}
+		snippet, err := strconv.Unquote(strings.TrimPrefix(line, "browser-use eval "))
+		require.NoError(t, err)
+		return snippet
+	}
+
+	t.Fatal("browser-use GraphQL interceptor snippet not found")
+	return ""
+}
+
+func extractChromeMCPFetchSnippet(t *testing.T) string {
+	t.Helper()
+
+	content := readBrowserSniffReference(t)
+	marker := "// Run via mcp__claude-in-chrome__javascript_tool after navigating to <site>"
+	markerIndex := strings.Index(content, marker)
+	require.NotEqual(t, -1, markerIndex, "chrome-MCP interceptor snippet marker not found")
+
+	codeStart := strings.LastIndex(content[:markerIndex], "```javascript")
+	require.NotEqual(t, -1, codeStart, "chrome-MCP javascript fence start not found")
+	codeStart += len("```javascript")
+	codeEnd := strings.Index(content[markerIndex:], "```")
+	require.NotEqual(t, -1, codeEnd, "chrome-MCP javascript fence end not found")
+
+	return strings.TrimSpace(content[codeStart : markerIndex+codeEnd])
+}
+
+func readBrowserSniffReference(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "skills", "printing-press", "references", "browser-sniff-capture.md")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func runNodeSnippet(t *testing.T, snippet string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required to execute browser-sniff reference snippets")
+	}
+
+	script := `
+globalThis.window = globalThis;
+window.fetch = async function() {
+  return new Response('{"ok":true}', {status: 200, headers: {'content-type': 'application/json'}});
+};
+function assertEqual(actual, expected) {
+  const actualJSON = JSON.stringify(actual);
+  const expectedJSON = JSON.stringify(expected);
+  if (actualJSON !== expectedJSON) {
+    throw new Error("expected " + expectedJSON + ", got " + actualJSON);
+  }
+}
+` + snippet
+
+	cmd := exec.Command("node", "--input-type=module", "-e", script)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.NotContains(t, string(out), "Error")
+}

--- a/internal/browsersniff/capture_reference_test.go
+++ b/internal/browsersniff/capture_reference_test.go
@@ -85,6 +85,7 @@ func extractBrowserUsePrimaryCaptureSnippet(t *testing.T) string {
 	t.Helper()
 
 	content := readBrowserSniffReference(t)
+	var matches []string
 	for line := range strings.SplitSeq(content, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, `browser-use eval "window.__capture_bodies={};`) {
@@ -92,11 +93,11 @@ func extractBrowserUsePrimaryCaptureSnippet(t *testing.T) string {
 		}
 		snippet, err := strconv.Unquote(strings.TrimPrefix(line, "browser-use eval "))
 		require.NoError(t, err)
-		return snippet
+		matches = append(matches, snippet)
 	}
 
-	t.Fatal("browser-use primary body capture snippet not found")
-	return ""
+	require.Len(t, matches, 1, "browser-use primary body capture snippet should have one canonical copy")
+	return matches[0]
 }
 
 func extractBrowserUseGraphQLSnippet(t *testing.T) string {
@@ -128,7 +129,7 @@ func extractChromeMCPFetchSnippet(t *testing.T) string {
 	codeStart := strings.LastIndex(content[:markerIndex], "```javascript")
 	require.NotEqual(t, -1, codeStart, "chrome-MCP javascript fence start not found")
 	codeStart += len("```javascript")
-	codeEnd := strings.Index(content[markerIndex:], "```")
+	codeEnd := strings.Index(content[markerIndex:], "\n```")
 	require.NotEqual(t, -1, codeEnd, "chrome-MCP javascript fence end not found")
 
 	return strings.TrimSpace(content[codeStart : markerIndex+codeEnd])

--- a/internal/browsersniff/parser_test.go
+++ b/internal/browsersniff/parser_test.go
@@ -76,6 +76,47 @@ func TestParseCapture(t *testing.T) {
 	}
 }
 
+func TestParseCaptureHARUsesRequestPostDataText(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "capture.har")
+	err := os.WriteFile(path, []byte(`{
+		"log": {
+			"entries": [
+				{
+					"request": {
+						"method": "POST",
+						"url": "https://api.example.com/generate",
+						"headers": [{"name": "content-type", "value": "application/json"}],
+						"postData": {
+							"mimeType": "application/json",
+							"text": "{\"prompt\":\"donkey love\",\"gpt_description_prompt\":\"make a song\"}"
+						}
+					},
+					"response": {
+						"status": 200,
+						"headers": [{"name": "content-type", "value": "application/json"}],
+						"content": {
+							"mimeType": "application/json",
+							"text": "{\"metadata\":{\"prompt\":\"response-only shape\"}}"
+						}
+					}
+				}
+			]
+		}
+	}`), 0o600)
+	require.NoError(t, err)
+
+	entries, targetURL, err := ParseCapture(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, "https://api.example.com/generate", targetURL)
+	assert.Equal(t, "POST", entries[0].Method)
+	assert.JSONEq(t, `{"prompt":"donkey love","gpt_description_prompt":"make a song"}`, entries[0].RequestBody)
+	assert.JSONEq(t, `{"metadata":{"prompt":"response-only shape"}}`, entries[0].ResponseBody)
+}
+
 func TestParseHAR_EdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -566,8 +566,8 @@ SNIFF_URLS="$DISCOVERY_DIR/sniff-urls.txt"
 browser-use open "<target-page-url>"
 sleep 4  # Wait for initial page load API calls to complete
 
-# Install request/response body capture for interaction-triggered API calls
-browser-use eval "window.__capture_bodies={};const _f=window.fetch;async function __ppReadFetchRequestBody(args){try{if(args[1]&&args[1].body)return typeof args[1].body==='string'?args[1].body:'[non-string]';if(args[0]&&typeof args[0]==='object'&&args[0].clone)return await args[0].clone().text()}catch(e){}return ''}window.fetch=async function(...args){const url=typeof args[0]==='string'?args[0]:(args[0]&&args[0].url)||'';const method=(args[1]&&args[1].method)||(args[0]&&args[0].method)||'GET';const requestBodyPromise=__ppReadFetchRequestBody(args);const r=await _f.apply(this,args);const c=r.clone();Promise.all([requestBodyPromise,c.text()]).then(([requestBody,responseBody])=>{window.__capture_bodies[method+' '+url]={request_body:requestBody,response_body:responseBody,response_status:r.status,response_content_type:r.headers.get('content-type')||''}}).catch(()=>{});return r}"
+# Install request/response body capture for interaction-triggered API calls:
+# run the "Primary request-body capture" browser-use eval command above here.
 
 # Early interactive-challenge check. If this finds Cloudflare/Vercel/WAF
 # challenge assets or a challenge title/body, stop the capture attempt and

--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -524,7 +524,7 @@ When the user confirmed a logged-in session (AUTH_SESSION_AVAILABLE=true from Ph
 
 **SPA interaction rule:** On each page/state, take a snapshot first. Look for interactive elements (buttons, forms, dropdowns, tabs). Click through them. SPAs fire API calls on interaction, not on page load. If you load a page and see no XHR activity, that means you need to interact with the page, not that there is nothing to find.
 
-**SPA navigation rule:** After installing fetch/XHR interceptors, do NOT use `browser-use open` to navigate between pages — it triggers a full page reload which destroys the interceptors. Instead, navigate by clicking links:
+**SPA navigation rule:** After installing fetch/XHR interceptors, do NOT use `browser-use open` to navigate between pages unless you immediately reinstall the interceptor before further interactions. A full page reload destroys page-scoped interceptors. Prefer navigating by clicking links after the interceptor is installed:
 ```bash
 # Good: SPA navigation preserves interceptors
 browser-use eval "document.querySelector('a[href*=\"/orders\"]').click()"
@@ -535,6 +535,22 @@ browser-use click "Orders"
 browser-use open "https://site.com/orders"
 ```
 Only use `browser-use open` for the initial page load (before interceptors exist) or when you intentionally want to re-install interceptors on a fresh page.
+
+**Primary request-body capture.** After each `browser-use open` and before walking interactions on that page, install a Request-aware fetch body interceptor. The Performance API gives broad URL coverage, but it does not expose POST bodies. This interceptor preserves bodies for both `fetch(new Request(...))` and legacy `fetch(url, {body})` calls so the enriched capture can use the real request shape instead of inferring it from responses.
+
+```bash
+browser-use eval "window.__capture_bodies={};const _f=window.fetch;async function __ppReadFetchRequestBody(args){try{if(args[1]&&args[1].body)return typeof args[1].body==='string'?args[1].body:'[non-string]';if(args[0]&&typeof args[0]==='object'&&args[0].clone)return await args[0].clone().text()}catch(e){}return ''}window.fetch=async function(...args){const url=typeof args[0]==='string'?args[0]:(args[0]&&args[0].url)||'';const method=(args[1]&&args[1].method)||(args[0]&&args[0].method)||'GET';const requestBodyPromise=__ppReadFetchRequestBody(args);const r=await _f.apply(this,args);const c=r.clone();Promise.all([requestBodyPromise,c.text()]).then(([requestBody,responseBody])=>{window.__capture_bodies[method+' '+url]={request_body:requestBody,response_body:responseBody,response_status:r.status,response_content_type:r.headers.get('content-type')||''}}).catch(()=>{});return r}"
+```
+
+After browsing, collect these bodies:
+
+```bash
+browser-use eval "JSON.stringify(window.__capture_bodies)"
+```
+
+When building `$DISCOVERY_DIR/browser-sniff-capture.json`, merge the matching `request_body`, `response_body`, `response_status`, and `response_content_type` from `window.__capture_bodies` into each API entry. If a body is missing, fall back to the Step 2b enrichment loop or HAR metadata rather than guessing from the response shape.
+
+Because browser-use installs this interceptor inside the current page, it cannot capture API calls that fired before installation during the initial page load. For page-load POST bodies, use an agent-browser/manual HAR path and prefer HAR `request.postData.text`; do not infer request shape from the response body.
 
 **Step 2a.2: Collect API URLs**
 
@@ -549,6 +565,9 @@ SNIFF_URLS="$DISCOVERY_DIR/sniff-urls.txt"
 # For EACH target page (run this loop in foreground — do NOT use run_in_background):
 browser-use open "<target-page-url>"
 sleep 4  # Wait for initial page load API calls to complete
+
+# Install request/response body capture for interaction-triggered API calls
+browser-use eval "window.__capture_bodies={};const _f=window.fetch;async function __ppReadFetchRequestBody(args){try{if(args[1]&&args[1].body)return typeof args[1].body==='string'?args[1].body:'[non-string]';if(args[0]&&typeof args[0]==='object'&&args[0].clone)return await args[0].clone().text()}catch(e){}return ''}window.fetch=async function(...args){const url=typeof args[0]==='string'?args[0]:(args[0]&&args[0].url)||'';const method=(args[1]&&args[1].method)||(args[0]&&args[0].method)||'GET';const requestBodyPromise=__ppReadFetchRequestBody(args);const r=await _f.apply(this,args);const c=r.clone();Promise.all([requestBodyPromise,c.text()]).then(([requestBody,responseBody])=>{window.__capture_bodies[method+' '+url]={request_body:requestBody,response_body:responseBody,response_status:r.status,response_content_type:r.headers.get('content-type')||''}}).catch(()=>{});return r}"
 
 # Early interactive-challenge check. If this finds Cloudflare/Vercel/WAF
 # challenge assets or a challenge title/body, stop the capture attempt and
@@ -594,7 +613,7 @@ After collecting URLs, check whether the site uses a GraphQL BFF pattern. This i
 
    For browser-use: inject a fetch interceptor BEFORE browsing auth/interaction pages. This captures POST bodies that the Performance API misses:
    ```bash
-   browser-use eval "window.__gqlOps=[];const _f=window.fetch;window.fetch=async function(){const r=await _f.apply(this,arguments);try{if(arguments[0]&&arguments[0].toString().includes('graphql')&&arguments[1]&&arguments[1].body){const b=JSON.parse(arguments[1].body);if(b.operationName)window.__gqlOps.push({op:b.operationName,vars:Object.keys(b.variables||{})})}}catch(e){}return r}"
+   browser-use eval "window.__gqlOps=[];const _f=window.fetch;async function __ppReadFetchRequestBody(args){try{if(args[1]&&args[1].body)return typeof args[1].body==='string'?args[1].body:'[non-string]';if(args[0]&&typeof args[0]==='object'&&args[0].clone)return await args[0].clone().text()}catch(e){}return ''}window.fetch=async function(...args){const bodyPromise=__ppReadFetchRequestBody(args);const url=typeof args[0]==='string'?args[0]:(args[0]&&args[0].url)||'';const r=await _f.apply(this,args);bodyPromise.then(body=>{try{if(url.includes('graphql')&&body&&body!=='[non-string]'){const b=JSON.parse(body);if(b.operationName)window.__gqlOps.push({op:b.operationName,vars:Object.keys(b.variables||{})})}}catch(e){}});return r}"
    ```
    After browsing, collect:
    ```bash
@@ -762,35 +781,52 @@ Always create a fresh capture tab via `mcp__claude-in-chrome__tabs_create_mcp`, 
 
 Two viable approaches:
 
-1. **Recommended: in-page interceptor installed before navigation.** Use `mcp__claude-in-chrome__javascript_tool` to install a `fetch` and `XMLHttpRequest` interceptor in the new tab BEFORE navigating to `<site>`. The interceptor pushes each completed request's body into `window.__capture_bodies` keyed by URL+method. After capture, `javascript_tool` reads `window.__capture_bodies` back. This avoids re-firing requests against a wary WAF.
+1. **Recommended: in-page interceptor installed before interactions.** Use `mcp__claude-in-chrome__javascript_tool` to install a `fetch` and `XMLHttpRequest` interceptor in the fresh capture tab after navigating to `<site>` and before performing the user-flow interactions. The interceptor pushes each completed call's request and response bodies into `window.__capture_bodies` keyed by URL+method. After capture, `javascript_tool` reads `window.__capture_bodies` back. This avoids re-firing requests against a wary WAF.
 
 2. **Fallback: `javascript_tool` re-fetches each captured URL after the fact.** Mirrors the `agent-browser network request <id> --json` enrichment loop in Step 2b. Use this only when option 1 fails (e.g., the page wraps `fetch` itself and the interceptor can't shadow it). Re-fetching may trip rate limits — apply the pacing rules below.
 
 The interceptor sketch (illustrative, adapt to the page's actual fetch shape):
 
 ```javascript
-// Run via mcp__claude-in-chrome__javascript_tool BEFORE mcp__claude-in-chrome__navigate
+// Run via mcp__claude-in-chrome__javascript_tool after navigating to <site>
+// and before performing interaction-triggered capture steps.
 window.__capture_bodies = {};
 const _origFetch = window.fetch;
+async function __ppReadFetchRequestBody(args) {
+  try {
+    if (args[1] && args[1].body) {
+      return typeof args[1].body === 'string' ? args[1].body : '[non-string]';
+    }
+    if (args[0] && typeof args[0] === 'object' && args[0].clone) {
+      return await args[0].clone().text();
+    }
+  } catch (e) {}
+  return '';
+}
 window.fetch = async function(...args) {
+  const url = typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url) || '';
+  const method = (args[1] && args[1].method) || (args[0] && args[0].method) || 'GET';
+  const requestBodyPromise = __ppReadFetchRequestBody(args);
   const resp = await _origFetch.apply(this, args);
   const cloned = resp.clone();
-  const url = typeof args[0] === 'string' ? args[0] : args[0].url;
-  const method = (args[1] && args[1].method) || 'GET';
-  cloned.text().then(body => {
-    window.__capture_bodies[`${method} ${url}`] = body;
+  Promise.all([requestBodyPromise, cloned.text()]).then(([requestBody, body]) => {
+    window.__capture_bodies[`${method} ${url}`] = {request_body: requestBody, response_body: body};
   }).catch(() => {});
   return resp;
 };
 // XHR interceptor analogous; install both
 ```
 
+When merging `window.__capture_bodies` with network metadata, copy the stored `request_body` and `response_body` fields separately into the enriched capture entry.
+
+This page-scoped interceptor cannot capture API calls that fired before installation during the initial navigation. If a page-load POST body matters, use manual DevTools HAR export or another HAR-producing path and prefer HAR `request.postData.text`.
+
 **Capture flow (full sequence).**
 
 1. `mcp__claude-in-chrome__tabs_context_mcp` — awareness only; confirm extension is connected
 2. `mcp__claude-in-chrome__tabs_create_mcp` — fresh capture tab
-3. `mcp__claude-in-chrome__javascript_tool` — install fetch + XHR body interceptor in the new tab
-4. `mcp__claude-in-chrome__navigate` — open the discovery target URL
+3. `mcp__claude-in-chrome__navigate` — open the discovery target URL
+4. `mcp__claude-in-chrome__javascript_tool` — install fetch + XHR body interceptor in the current page
 5. Interaction loop (per the same "click + scroll + interact" guidance the browser-use flow uses):
    - `mcp__claude-in-chrome__read_page` to find interactive elements
    - `mcp__claude-in-chrome__find` + `mcp__claude-in-chrome__left_click` (or `form_input` for forms) to interact


### PR DESCRIPTION
## Summary

Browser-sniff guidance now preserves real request bodies for `fetch(new Request(...))` calls. The primary browser-use flow, GraphQL helper, and chrome-MCP fallback all document Request-aware capture, and the parser-side HAR behavior is pinned so `request.postData.text` remains the request-body source when interceptor data is missing.

Closes #1418

## Verification

- `go fmt ./...`
- `go test ./internal/browsersniff -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`
