### PR TITLE
fix(cli): classify captcha prechecks as auth context

### DIFF
--- a/docs/solutions/logic-errors/captcha-precheck-challenge-classification-2026-05-21.md
+++ b/docs/solutions/logic-errors/captcha-precheck-challenge-classification-2026-05-21.md
@@ -1,0 +1,65 @@
+---
+title: Distinguish CAPTCHA precheck decisions from challenge evidence
+date: 2026-05-21
+category: logic-errors
+module: browsersniff
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Small 2xx JSON CAPTCHA precheck responses were classified as full CAPTCHA challenges"
+  - "`traffic-analysis.json` set reachability.mode to browser_required for replayable API captures"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [browser-sniff, traffic-analysis, captcha, reachability]
+---
+
+# Distinguish CAPTCHA precheck decisions from challenge evidence
+
+## Problem
+
+Browser-sniff traffic analysis treated CAPTCHA-related substrings in any response body as challenge evidence. That collapsed benign preflight endpoints such as `/api/c/check` into the same `protections[].label: "captcha"` bucket as real challenge pages, which made `reachability.mode` become `browser_required` and blocked generation for otherwise replayable APIs.
+
+## Symptoms
+
+- A `POST /api/c/check` response with `200 application/json` and a tiny body such as `{"present":false}` produced a `captcha` protection.
+- `deriveGenerationHints` emitted `requires_page_context` because the false protection drove `browser_required`.
+- Agents were pushed toward abandoning generation even though the capture contained normal authenticated API traffic.
+
+## What Didn't Work
+
+- Checking only response paths was too broad because many SaaS APIs expose CAPTCHA eligibility endpoints before sensitive operations.
+- Checking only provider tokens such as `turnstile`, `hcaptcha`, or `recaptcha` was still too broad because negative precheck JSON can mention those provider names.
+- Suppressing all 2xx JSON CAPTCHA text was too narrow because some APIs return real positive challenge decisions as JSON.
+
+## Solution
+
+Make the classifier decision-shaped:
+
+- Known preflight paths with successful JSON responses are recorded as `auth.captcha_preflight`.
+- The same preflight response is classified as a `captcha` protection only when parsed JSON contains an explicit positive decision such as `captcha_required: true` or a message saying a CAPTCHA is required.
+- Non-preflight successful JSON responses are parsed for explicit positive CAPTCHA decisions before falling back to text heuristics.
+- Provider-name-only mentions in successful JSON, such as `turnstile_enabled: false`, remain informational.
+
+The regression coverage should include both directions:
+
+- Negative preflight decisions stay `standard_http` and emit `auth_supports_captcha_preflight`.
+- Positive preflight decisions and non-preflight JSON challenge decisions still emit `captcha` and promote reachability.
+
+## Why This Works
+
+CAPTCHA preflight endpoints answer "is a challenge required?" They are auth context, not challenge evidence by themselves. The classifier must preserve that distinction before the reachability gate consumes `protections`, because `captcha` is load-bearing and intentionally promotes to `browser_required`.
+
+Parsing small JSON decisions keeps the machine general across reCAPTCHA, hCaptcha, Turnstile, and custom eligibility endpoints without hardcoding one API's path. It also prevents the inverse regression where a real JSON challenge decision is hidden just because the response status is 200.
+
+## Prevention
+
+- Treat protection labels as challenge evidence only after response status, content type, and body semantics agree.
+- When adding a new traffic-analysis field, update `schema traffic-analysis`, golden output, and loader/unmarshal tests in the same change.
+- For browser-sniff reachability fixes, write paired regressions for false positives and false negatives.
+
+## Related Issues
+
+- GitHub issue #1420
+- `docs/plans/2026-04-21-001-feat-browser-sniff-traffic-analysis-plan.md`
+- `docs/plans/2026-04-27-001-feat-printing-press-food52-retro-fixes-plan.md`

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -929,7 +929,11 @@ func hasCaptchaChallengeMarker(entry EnrichedEntry, lowerBody string) bool {
 		entry.ResponseStatus < 300 &&
 		strings.Contains(strings.ToLower(entry.ResponseContentType), "json")
 	if isSuccessfulJSON {
-		if captchaPreflightRequiresChallenge(entry.ResponseBody) {
+		hasCaptchaKeyword := strings.Contains(lowerBody, "captcha") ||
+			strings.Contains(lowerBody, "recaptcha") ||
+			strings.Contains(lowerBody, "hcaptcha") ||
+			strings.Contains(lowerBody, "turnstile")
+		if hasCaptchaKeyword && captchaPreflightRequiresChallenge(entry.ResponseBody) {
 			return true
 		}
 		return captchaChallengeText(lowerBody)

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -17,6 +17,7 @@ import (
 )
 
 const trafficAnalysisVersion = "1"
+const maxCaptchaPreflightJSONBytes = 4096
 
 type TrafficAnalysis struct {
 	Version           string                  `json:"version"`
@@ -224,7 +225,8 @@ type ProtocolObservation struct {
 }
 
 type AuthAnalysis struct {
-	Candidates []AuthCandidate `json:"candidates,omitempty"`
+	Candidates       []AuthCandidate `json:"candidates,omitempty"`
+	CaptchaPreflight bool            `json:"captcha_preflight,omitempty"`
 
 	// Auth0SPAInMemory is true when an /oauth/token response carried an
 	// `access_token` in the JSON body without a JWT-shaped Set-Cookie on the
@@ -245,12 +247,14 @@ func (a *AuthAnalysis) UnmarshalJSON(data []byte) error {
 	var legacy struct {
 		Candidates       []AuthCandidate `json:"candidates,omitempty"`
 		CandidateTypes   []string        `json:"candidate_types,omitempty"`
+		CaptchaPreflight bool            `json:"captcha_preflight,omitempty"`
 		Auth0SPAInMemory bool            `json:"auth0_spa_in_memory,omitempty"`
 	}
 	if err := json.Unmarshal(data, &legacy); err != nil {
 		return err
 	}
 	a.Candidates = legacy.Candidates
+	a.CaptchaPreflight = legacy.CaptchaPreflight
 	a.Auth0SPAInMemory = legacy.Auth0SPAInMemory
 	if len(a.Candidates) == 0 && len(legacy.CandidateTypes) > 0 {
 		a.Candidates = make([]AuthCandidate, 0, len(legacy.CandidateTypes))
@@ -755,6 +759,7 @@ func detectTrafficAuth(capture *EnrichedCapture, entries []EnrichedEntry) AuthAn
 		candidate AuthCandidate
 	}
 	candidates := map[string]*accumulator{}
+	captchaPreflight := false
 	add := func(key string, candidate AuthCandidate) {
 		existing := candidates[key]
 		if existing == nil {
@@ -804,6 +809,9 @@ func detectTrafficAuth(capture *EnrichedCapture, entries []EnrichedEntry) AuthAn
 				}
 			}
 		}
+		if !captchaPreflight && isCaptchaPreflightCandidate(entry) {
+			captchaPreflight = true
+		}
 	}
 
 	out := make([]AuthCandidate, 0, len(candidates))
@@ -822,6 +830,7 @@ func detectTrafficAuth(capture *EnrichedCapture, entries []EnrichedEntry) AuthAn
 	})
 	return AuthAnalysis{
 		Candidates:       out,
+		CaptchaPreflight: captchaPreflight,
 		Auth0SPAInMemory: detectAuth0SPAInMemory(entries),
 	}
 }
@@ -866,7 +875,7 @@ func detectProtections(entries []EnrichedEntry) []ProtectionObservation {
 			add("perimeterx", 0.8, entry, index, "PerimeterX marker")
 		}
 
-		if strings.Contains(body, "recaptcha") || strings.Contains(body, "hcaptcha") || strings.Contains(body, "captcha") {
+		if hasCaptchaChallengeMarker(entry, body) {
 			add("captcha", 0.85, entry, index, "CAPTCHA marker")
 		}
 		if entry.ResponseStatus == 403 || entry.ResponseStatus == 429 {
@@ -893,6 +902,122 @@ func detectProtections(entries []EnrichedEntry) []ProtectionObservation {
 		return out[i].Confidence > out[j].Confidence
 	})
 	return out
+}
+
+func isCaptchaPreflightCandidate(entry EnrichedEntry) bool {
+	if entry.ResponseStatus < 200 || entry.ResponseStatus >= 300 {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(entry.ResponseContentType), "json") {
+		return false
+	}
+	if len(strings.TrimSpace(entry.ResponseBody)) > maxCaptchaPreflightJSONBytes {
+		return false
+	}
+	path := strings.ToLower(extractPath(entry.URL))
+	return strings.Contains(path, "/c/check") ||
+		strings.Contains(path, "check_captcha") ||
+		strings.Contains(path, "captcha/required") ||
+		strings.Contains(path, "turnstile/check")
+}
+
+func hasCaptchaChallengeMarker(entry EnrichedEntry, lowerBody string) bool {
+	if isCaptchaPreflightCandidate(entry) {
+		return captchaPreflightRequiresChallenge(entry.ResponseBody)
+	}
+	isSuccessfulJSON := entry.ResponseStatus >= 200 &&
+		entry.ResponseStatus < 300 &&
+		strings.Contains(strings.ToLower(entry.ResponseContentType), "json")
+	if isSuccessfulJSON {
+		if captchaPreflightRequiresChallenge(entry.ResponseBody) {
+			return true
+		}
+		return captchaChallengeText(lowerBody)
+	}
+	if strings.Contains(lowerBody, "recaptcha") ||
+		strings.Contains(lowerBody, "hcaptcha") ||
+		strings.Contains(lowerBody, "turnstile") ||
+		strings.Contains(lowerBody, "cf_chl") {
+		return true
+	}
+	if !strings.Contains(lowerBody, "captcha") {
+		return false
+	}
+	if captchaChallengeText(lowerBody) {
+		return true
+	}
+	if entry.ResponseStatus < 200 || entry.ResponseStatus >= 300 {
+		return true
+	}
+	return strings.Contains(strings.ToLower(entry.ResponseContentType), "html")
+}
+
+func captchaChallengeText(lowerBody string) bool {
+	return (strings.Contains(lowerBody, "captcha") ||
+		strings.Contains(lowerBody, "recaptcha") ||
+		strings.Contains(lowerBody, "hcaptcha") ||
+		strings.Contains(lowerBody, "turnstile")) &&
+		(strings.Contains(lowerBody, "required") ||
+			strings.Contains(lowerBody, "challenge"))
+}
+
+func captchaPreflightRequiresChallenge(body string) bool {
+	var value any
+	if err := json.Unmarshal([]byte(body), &value); err != nil {
+		return false
+	}
+	return hasPositiveCaptchaDecision("", value)
+}
+
+func hasPositiveCaptchaDecision(key string, value any) bool {
+	switch v := value.(type) {
+	case map[string]any:
+		for childKey, childValue := range v {
+			if hasPositiveCaptchaDecision(childKey, childValue) {
+				return true
+			}
+		}
+	case []any:
+		for _, childValue := range v {
+			if hasPositiveCaptchaDecision(key, childValue) {
+				return true
+			}
+		}
+	case bool:
+		return v && captchaDecisionKey(key)
+	case string:
+		lowerValue := strings.ToLower(v)
+		if captchaDecisionKey(key) {
+			return lowerValue == "true" ||
+				lowerValue == "yes" ||
+				strings.Contains(lowerValue, "required") ||
+				strings.Contains(lowerValue, "challenge")
+		}
+		return captchaMessageKey(key) && captchaChallengeText(lowerValue)
+	case float64:
+		return v != 0 && captchaDecisionKey(key)
+	}
+	return false
+}
+
+func captchaDecisionKey(key string) bool {
+	lowerKey := strings.ToLower(key)
+	return strings.Contains(lowerKey, "captcha") ||
+		strings.Contains(lowerKey, "recaptcha") ||
+		strings.Contains(lowerKey, "hcaptcha") ||
+		strings.Contains(lowerKey, "turnstile") ||
+		strings.Contains(lowerKey, "challenge") ||
+		strings.Contains(lowerKey, "required") ||
+		strings.Contains(lowerKey, "present")
+}
+
+func captchaMessageKey(key string) bool {
+	lowerKey := strings.ToLower(key)
+	return lowerKey == "error" ||
+		lowerKey == "message" ||
+		lowerKey == "detail" ||
+		lowerKey == "reason" ||
+		lowerKey == "status"
 }
 
 func classifyReachability(analysis *TrafficAnalysis, entries []EnrichedEntry) *ReachabilityAnalysis {
@@ -1435,6 +1560,9 @@ func deriveGenerationHints(analysis *TrafficAnalysis) []string {
 	}
 	if analysis.Auth.Auth0SPAInMemory {
 		hints["auth0_spa_in_memory"] = true
+	}
+	if analysis.Auth.CaptchaPreflight {
+		hints["auth_supports_captcha_preflight"] = true
 	}
 	for _, warning := range analysis.Warnings {
 		if warning.Type == "weak_schema_evidence" || warning.Type == "raw_protocol_envelope" {

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -933,8 +933,10 @@ func hasCaptchaChallengeMarker(entry EnrichedEntry, lowerBody string) bool {
 			strings.Contains(lowerBody, "recaptcha") ||
 			strings.Contains(lowerBody, "hcaptcha") ||
 			strings.Contains(lowerBody, "turnstile")
-		if hasCaptchaKeyword && captchaPreflightRequiresChallenge(entry.ResponseBody) {
-			return true
+		if hasCaptchaKeyword {
+			if requiresChallenge, parsed := captchaPreflightChallengeDecision(entry.ResponseBody); parsed {
+				return requiresChallenge
+			}
 		}
 		return captchaChallengeText(lowerBody)
 	}
@@ -966,11 +968,16 @@ func captchaChallengeText(lowerBody string) bool {
 }
 
 func captchaPreflightRequiresChallenge(body string) bool {
+	requiresChallenge, _ := captchaPreflightChallengeDecision(body)
+	return requiresChallenge
+}
+
+func captchaPreflightChallengeDecision(body string) (bool, bool) {
 	var value any
 	if err := json.Unmarshal([]byte(body), &value); err != nil {
-		return false
+		return false, false
 	}
-	return hasPositiveCaptchaDecision("", value)
+	return hasPositiveCaptchaDecision("", value), true
 }
 
 func hasPositiveCaptchaDecision(key string, value any) bool {

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -934,10 +934,14 @@ func hasCaptchaChallengeMarker(entry EnrichedEntry, lowerBody string) bool {
 			strings.Contains(lowerBody, "recaptcha") ||
 			strings.Contains(lowerBody, "hcaptcha") ||
 			strings.Contains(lowerBody, "turnstile")
-		if hasCaptchaKeyword && len(strings.TrimSpace(entry.ResponseBody)) <= maxCaptchaChallengeJSONBytes {
-			if requiresChallenge, parsed := captchaPreflightChallengeDecision(entry.ResponseBody); parsed {
-				return requiresChallenge
-			}
+		if !hasCaptchaKeyword {
+			return false
+		}
+		if len(strings.TrimSpace(entry.ResponseBody)) > maxCaptchaChallengeJSONBytes {
+			return false
+		}
+		if requiresChallenge, parsed := captchaPreflightChallengeDecision(entry.ResponseBody); parsed {
+			return requiresChallenge
 		}
 		return captchaChallengeText(lowerBody)
 	}

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -18,6 +18,7 @@ import (
 
 const trafficAnalysisVersion = "1"
 const maxCaptchaPreflightJSONBytes = 4096
+const maxCaptchaChallengeJSONBytes = maxCaptchaPreflightJSONBytes * 16
 
 type TrafficAnalysis struct {
 	Version           string                  `json:"version"`
@@ -933,7 +934,7 @@ func hasCaptchaChallengeMarker(entry EnrichedEntry, lowerBody string) bool {
 			strings.Contains(lowerBody, "recaptcha") ||
 			strings.Contains(lowerBody, "hcaptcha") ||
 			strings.Contains(lowerBody, "turnstile")
-		if hasCaptchaKeyword {
+		if hasCaptchaKeyword && len(strings.TrimSpace(entry.ResponseBody)) <= maxCaptchaChallengeJSONBytes {
 			if requiresChallenge, parsed := captchaPreflightChallengeDecision(entry.ResponseBody); parsed {
 				return requiresChallenge
 			}

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -600,7 +600,7 @@ func TestAnalyzeTraffic_ClassifiesCaptchaPrecheckDecisions(t *testing.T) {
 		{
 			name:         "large non-precheck turnstile body is ordinary JSON",
 			url:          "https://studio-api.example.com/api/songs",
-			body:         `{"songs":[{"title":"turnstile","description":"` + strings.Repeat("x", maxCaptchaChallengeJSONBytes) + `"}]}`,
+			body:         `{"turnstile":{"enabled":false},"fields":[{"name":"email","required":true}],"description":"` + strings.Repeat("x", maxCaptchaChallengeJSONBytes) + `"}`,
 			expectedMode: "standard_http",
 		},
 	}

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -597,6 +597,12 @@ func TestAnalyzeTraffic_ClassifiesCaptchaPrecheckDecisions(t *testing.T) {
 			body:         `{"fields":[{"name":"email","required":true}]}`,
 			expectedMode: "standard_http",
 		},
+		{
+			name:         "large non-precheck turnstile body is ordinary JSON",
+			url:          "https://studio-api.example.com/api/songs",
+			body:         `{"songs":[{"title":"turnstile","description":"` + strings.Repeat("x", maxCaptchaChallengeJSONBytes) + `"}]}`,
+			expectedMode: "standard_http",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -580,6 +580,12 @@ func TestAnalyzeTraffic_ClassifiesCaptchaPrecheckDecisions(t *testing.T) {
 			expectedMode: "standard_http",
 		},
 		{
+			name:         "non-precheck negative captcha decision is informational",
+			url:          "https://studio-api.example.com/api/login",
+			body:         `{"captcha_required":false}`,
+			expectedMode: "standard_http",
+		},
+		{
 			name:         "non-precheck present field is ordinary JSON",
 			url:          "https://studio-api.example.com/api/settings",
 			body:         `{"subscription_present":true}`,

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -579,6 +579,18 @@ func TestAnalyzeTraffic_ClassifiesCaptchaPrecheckDecisions(t *testing.T) {
 			body:         `{"turnstile_enabled":false}`,
 			expectedMode: "standard_http",
 		},
+		{
+			name:         "non-precheck present field is ordinary JSON",
+			url:          "https://studio-api.example.com/api/settings",
+			body:         `{"subscription_present":true}`,
+			expectedMode: "standard_http",
+		},
+		{
+			name:         "non-precheck required field is ordinary JSON",
+			url:          "https://studio-api.example.com/api/forms",
+			body:         `{"fields":[{"name":"email","required":true}]}`,
+			expectedMode: "standard_http",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -475,6 +475,143 @@ func TestAnalyzeTraffic_ClassifiesBrowserClearanceReachability(t *testing.T) {
 	assert.Contains(t, analysis.GenerationHints, "requires_browser_auth")
 }
 
+func TestAnalyzeTraffic_TreatsCaptchaPrecheckAsInformational(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "https://app.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "POST",
+				URL:                 "https://studio-api.example.com/api/c/check",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"present":false,"captcha":false}`,
+				RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://studio-api.example.com/api/songs",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"songs":[]}`,
+			},
+		},
+	}
+
+	analysis, err := AnalyzeTraffic(capture)
+	require.NoError(t, err)
+	require.NotNil(t, analysis.Reachability)
+
+	assert.NotContains(t, protectionLabels(analysis.Protections), "captcha")
+	assert.Equal(t, "standard_http", analysis.Reachability.Mode)
+	assert.NotContains(t, analysis.GenerationHints, "requires_page_context")
+	assert.NotContains(t, analysis.GenerationHints, "requires_protected_client")
+	assert.Contains(t, analysis.GenerationHints, "auth_supports_captcha_preflight")
+	assert.True(t, analysis.Auth.CaptchaPreflight)
+}
+
+func TestAnalyzeTraffic_ClassifiesCaptchaPrecheckDecisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		url           string
+		body          string
+		expectedMode  string
+		wantCaptcha   bool
+		wantPreflight bool
+	}{
+		{
+			name:          "turnstile precheck says no challenge",
+			url:           "https://studio-api.example.com/turnstile/check",
+			body:          `{"turnstile":false}`,
+			expectedMode:  "standard_http",
+			wantPreflight: true,
+		},
+		{
+			name:          "hcaptcha precheck says no challenge",
+			url:           "https://studio-api.example.com/check_captcha",
+			body:          `{"hcaptcha_required":false}`,
+			expectedMode:  "standard_http",
+			wantPreflight: true,
+		},
+		{
+			name:          "precheck says challenge required",
+			url:           "https://studio-api.example.com/captcha/required",
+			body:          `{"captcha_required":true}`,
+			expectedMode:  "browser_required",
+			wantCaptcha:   true,
+			wantPreflight: true,
+		},
+		{
+			name:          "precheck reports required challenge in error field",
+			url:           "https://studio-api.example.com/api/c/check",
+			body:          `{"error":"captcha required"}`,
+			expectedMode:  "browser_required",
+			wantCaptcha:   true,
+			wantPreflight: true,
+		},
+		{
+			name:          "larger turnstile precheck says no challenge",
+			url:           "https://studio-api.example.com/turnstile/check",
+			body:          `{"turnstile":false,"captcha_required":false,"site_key":"` + strings.Repeat("x", 240) + `"}`,
+			expectedMode:  "standard_http",
+			wantPreflight: true,
+		},
+		{
+			name:         "non-precheck captcha required response",
+			url:          "https://studio-api.example.com/api/login",
+			body:         `{"error":"captcha required"}`,
+			expectedMode: "browser_required",
+			wantCaptcha:  true,
+		},
+		{
+			name:         "non-precheck positive captcha decision",
+			url:          "https://studio-api.example.com/api/login",
+			body:         `{"captcha":true}`,
+			expectedMode: "browser_required",
+			wantCaptcha:  true,
+		},
+		{
+			name:         "non-precheck captcha config is informational",
+			url:          "https://studio-api.example.com/api/settings",
+			body:         `{"turnstile_enabled":false}`,
+			expectedMode: "standard_http",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := &EnrichedCapture{
+				TargetURL: "https://app.example.com",
+				Entries: []EnrichedEntry{{
+					Method:              "POST",
+					URL:                 tt.url,
+					ResponseStatus:      200,
+					ResponseContentType: "application/json",
+					ResponseBody:        tt.body,
+				}},
+			}
+
+			analysis, err := AnalyzeTraffic(capture)
+			require.NoError(t, err)
+			require.NotNil(t, analysis.Reachability)
+
+			assert.Equal(t, tt.expectedMode, analysis.Reachability.Mode)
+			assert.Equal(t, tt.wantPreflight, analysis.Auth.CaptchaPreflight)
+			if tt.wantPreflight {
+				assert.Contains(t, analysis.GenerationHints, "auth_supports_captcha_preflight")
+			}
+			if tt.wantCaptcha {
+				assert.Contains(t, protectionLabels(analysis.Protections), "captcha")
+			} else {
+				assert.NotContains(t, protectionLabels(analysis.Protections), "captcha")
+			}
+		})
+	}
+}
+
 func TestAnalyzeTraffic_DoesNotRequirePageContextForSPADocumentNoise(t *testing.T) {
 	t.Parallel()
 

--- a/internal/browsersniff/analysis_v2_compat_test.go
+++ b/internal/browsersniff/analysis_v2_compat_test.go
@@ -137,6 +137,12 @@ func TestAuthAnalysis_CandidateTypesV2Compat(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(`{}`), &a))
 		assert.Empty(t, a.Candidates)
 	})
+
+	t.Run("captcha preflight field preserved", func(t *testing.T) {
+		var a AuthAnalysis
+		require.NoError(t, json.Unmarshal([]byte(`{"captcha_preflight":true}`), &a))
+		assert.True(t, a.CaptchaPreflight)
+	})
 }
 
 // TestTrafficAnalysis_GenerationHintsMapCompat covers `generation_hints` shape

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -46,7 +46,8 @@ const trafficAnalysisSchemaJSON = `{
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "candidates": {"type": "array", "items": {"$ref": "#/$defs/auth_candidate"}}
+        "candidates": {"type": "array", "items": {"$ref": "#/$defs/auth_candidate"}},
+        "captcha_preflight": {"type": "boolean"}
       }
     },
     "protections": {"type": "array", "items": {"$ref": "#/$defs/protection_observation"}},

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -18,7 +18,12 @@ func TestSchemaTrafficAnalysisPrintsJSONSchema(t *testing.T) {
 	var schema map[string]any
 	require.NoError(t, json.Unmarshal([]byte(output), &schema))
 	assert.Equal(t, "CLI Printing Press traffic-analysis.json", schema["title"])
+	properties := schema["properties"].(map[string]any)
+	auth := properties["auth"].(map[string]any)
+	authProperties := auth["properties"].(map[string]any)
+	captchaPreflight := authProperties["captcha_preflight"].(map[string]any)
 	assert.Contains(t, output, `"confidence": {"type": "number"`)
+	assert.Equal(t, "boolean", captchaPreflight["type"])
 	assert.Contains(t, output, `"endpoint_clusters"`)
 }
 

--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -1010,7 +1010,7 @@ The report must contain these sections:
    - Auth signals (candidate types, header/query/cookie names only -- never values)
    - Parameter-name evidence from forms, input labels, placeholder text, SDK/source names, and request context. Preserve enough detail to justify any later `flag_name` enrichment.
    - Protection signals (Cloudflare/CAPTCHA/login redirects/protected-web hints)
-   - Generation hints (e.g., `requires_browser_auth`, `requires_js_rendering`, `requires_protected_client`, `has_rpc_envelope`)
+   - Generation hints (e.g., `requires_browser_auth`, `requires_js_rendering`, `requires_protected_client`, `has_rpc_envelope`). Treat `auth_supports_captcha_preflight` as informational auth context, not as proof that the runtime needs browser page context.
    - Candidate commands worth considering
    - Warnings such as raw protocol envelopes, GraphQL error-only responses, HTML challenge pages, empty payloads, or weak schema evidence
    Treat warnings as discovery evidence, not publish blockers.

--- a/testdata/golden/expected/schema-traffic-analysis/stdout.txt
+++ b/testdata/golden/expected/schema-traffic-analysis/stdout.txt
@@ -38,7 +38,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "candidates": {"type": "array", "items": {"$ref": "#/$defs/auth_candidate"}}
+        "candidates": {"type": "array", "items": {"$ref": "#/$defs/auth_candidate"}},
+        "captcha_preflight": {"type": "boolean"}
       }
     },
     "protections": {"type": "array", "items": {"$ref": "#/$defs/protection_observation"}},


### PR DESCRIPTION
## Summary

Browser-sniff can now tell the difference between a CAPTCHA eligibility precheck and a real CAPTCHA challenge. Small successful JSON decision endpoints such as `/api/c/check`, `/check_captcha`, and `/turnstile/check` are recorded as auth context instead of forcing `browser_required`, while positive challenge decisions still promote reachability.

The traffic-analysis schema now includes `auth.captcha_preflight`, and generated discovery guidance documents the `auth_supports_captcha_preflight` hint as informational rather than page-context evidence.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## Compounded learnings

- File: `docs/solutions/logic-errors/captcha-precheck-challenge-classification-2026-05-21.md`
- Track: bug
- Category: logic-errors
- Overlap: low, new doc created
- Instruction-file edit: none needed
- Refresh recommendation: none

Closes #1420

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
