### PR TITLE
fix(cli): preserve required global query params

### DIFF
--- a/docs/solutions/logic-errors/preserve-required-params-during-prevalence-filtering-2026-05-21.md
+++ b/docs/solutions/logic-errors/preserve-required-params-during-prevalence-filtering-2026-05-21.md
@@ -1,0 +1,62 @@
+---
+title: Preserve Required Params During Prevalence Filtering
+date: 2026-05-21
+category: docs/solutions/logic-errors
+module: internal/openapi
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "A query parameter marked required: true vanished from every generated command when it appeared on every endpoint"
+  - Generated CLIs could call the API but could not request the response shape the API required
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [openapi, generator, query-params, required-params, prevalence-filter]
+---
+
+# Preserve Required Params During Prevalence Filtering
+
+## Problem
+
+The OpenAPI parser's global query-param filter removed parameters that appeared on more than 80% of endpoints. On narrow specs, this stripped required API selectors such as YouTube-style `part` parameters from every generated command.
+
+## Symptoms
+
+- Generation warned that a global query param was filtered because it appeared on all endpoints.
+- The generated CLI still sent valid HTTP requests, but the user had no flag for a spec-required selector that controlled the response shape.
+- Optional boilerplate params and required semantic params were treated identically by the prevalence filter.
+
+## What Didn't Work
+
+- Treating this as a printed-CLI problem would only restore one missing flag. The bug was in the generator path that decides which OpenAPI params remain reachable for every future CLI.
+- Allowlisting vendor-specific names such as `part` would fix one API family while leaving the same required-vs-prevalent conflict in other specs.
+
+## Solution
+
+Keep the prevalence filter, but narrow its candidate predicate:
+
+```go
+func isGlobalFilterCandidate(param spec.Param) bool {
+	return !isPathSubstitutionParam(param) && !param.Required
+}
+```
+
+Use that predicate both when counting prevalent params and when removing them from endpoints. This keeps optional cross-cutting noise filterable while preserving parameters whose `required: true` flag is part of the API contract.
+
+Add regression coverage with a narrow OpenAPI fixture where `part` is required on every endpoint and `prettyPrint` is optional on every endpoint. The required param must survive with its default and endpoint-specific enum values, while the optional prevalent param must still be filtered.
+
+## Why This Works
+
+Prevalence is a useful signal for boilerplate params, but `required: true` is a stronger semantic signal from the spec. A parameter can be present everywhere because it is noise, or because every operation genuinely needs it. The filter must only act on the former class.
+
+Sharing one predicate between counting and removal prevents future drift where a parameter is excluded from one phase but still removed in the other.
+
+## Prevention
+
+- When adding generator filters, separate "candidate for filtering" from "matches the filter threshold" so semantic exemptions live in one named predicate.
+- Regression fixtures for broad filters should include both a positive survivor and a negative removal case in the same fixture.
+- Avoid vendor-name allowlists when the spec already carries a portable signal such as `required`.
+
+## Related Issues
+
+- GitHub issue: https://github.com/mvanhorn/cli-printing-press/issues/1456

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2724,7 +2724,7 @@ func filterGlobalParams(resources map[string]spec.Resource) {
 
 		seen := map[string]struct{}{}
 		for _, param := range endpoint.Params {
-			if isPathSubstitutionParam(param) {
+			if !isGlobalFilterCandidate(param) {
 				continue
 			}
 			if _, ok := seen[param.Name]; ok {
@@ -2761,7 +2761,7 @@ func filterGlobalParams(resources map[string]spec.Resource) {
 	walkResourceEndpoints(resources, func(endpoint *spec.Endpoint) {
 		filtered := endpoint.Params[:0]
 		for _, param := range endpoint.Params {
-			if !isPathSubstitutionParam(param) {
+			if isGlobalFilterCandidate(param) {
 				if _, ok := globalParams[param.Name]; ok {
 					continue
 				}
@@ -2784,6 +2784,10 @@ func filterGlobalParams(resources map[string]spec.Resource) {
 
 func isPathSubstitutionParam(param spec.Param) bool {
 	return param.Positional || param.PathParam
+}
+
+func isGlobalFilterCandidate(param spec.Param) bool {
+	return !isPathSubstitutionParam(param) && !param.Required
 }
 
 func walkResourceEndpoints(resources map[string]spec.Resource, fn func(endpoint *spec.Endpoint)) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2142,6 +2142,112 @@ paths:
 	}
 }
 
+func TestParsePreservesRequiredQueryParamsDuringGlobalFilter(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+openapi: 3.0.0
+info:
+  title: Narrow Required Query API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /search:
+    get:
+      operationId: searchList
+      parameters:
+        - in: query
+          name: part
+          required: true
+          schema:
+            type: string
+            default: snippet
+            enum: [snippet, id]
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: q
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+  /videos:
+    get:
+      operationId: videosList
+      parameters:
+        - in: query
+          name: part
+          required: true
+          schema:
+            type: string
+            default: snippet
+            enum: [snippet, statistics]
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+  /channels:
+    get:
+      operationId: channelsList
+      parameters:
+        - in: query
+          name: part
+          required: true
+          schema:
+            type: string
+            default: snippet
+            enum: [snippet, contentDetails]
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+
+	wantEnums := map[string][]string{
+		"/search":   {"snippet", "id"},
+		"/videos":   {"snippet", "statistics"},
+		"/channels": {"snippet", "contentDetails"},
+	}
+	for _, path := range []string{"/search", "/videos", "/channels"} {
+		endpoint := findEndpoint(t, parsed, path)
+		var part *spec.Param
+		for i := range endpoint.Params {
+			switch endpoint.Params[i].Name {
+			case "part":
+				part = &endpoint.Params[i]
+			case "prettyPrint":
+				t.Fatalf("%s should filter optional prevalent query param prettyPrint", path)
+			}
+		}
+		if assert.NotNil(t, part, "%s should preserve required prevalent query param part", path) {
+			assert.True(t, part.Required)
+			assert.Equal(t, "snippet", part.Default)
+			assert.Equal(t, wantEnums[path], part.Enum)
+		}
+	}
+}
+
 // Real-world OpenAPI specs (Tally, others) frequently include {placeholder}
 // tokens in a path template without declaring the corresponding parameter at
 // either the operation or path-item level. The path template is then the only


### PR DESCRIPTION
## Summary

- Preserve OpenAPI query params marked `required: true` when the global query-param prevalence filter runs, so generated commands keep required selectors even on narrow specs.
- Keep optional prevalent params filterable through the same candidate predicate.
- Add regression coverage for a narrow spec where required `part` survives with defaults/enums while optional `prettyPrint` is still filtered.

Closes #1456

## Verification

- `go test ./internal/openapi -run TestParsePreservesRequiredQueryParamsDuringGlobalFilter -count=1`
- `go test ./internal/openapi -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`

## Compounded learnings

- File: `docs/solutions/logic-errors/preserve-required-params-during-prevalence-filtering-2026-05-21.md`
- Track: bug
- Category: logic-errors
- Overlap: low
- Instruction-file edit: none needed
- Refresh recommendation: none
