### PR TITLE
fix(cli): seed narrative template env placeholders

### DIFF
--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -18,9 +18,12 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
 // Section names the narrative section a command lives in. Matches the
@@ -106,6 +109,10 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 	if err != nil {
 		return nil, err
 	}
+	var templateVarEnv []string
+	if opts.FullExamples {
+		templateVarEnv = missingTemplateVarEnvAssignments(discoverTemplateVarEnv(binaryPath))
+	}
 
 	report := &Report{
 		Results:       make([]Result, 0, len(commands)),
@@ -113,7 +120,7 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 		ResearchEmpty: len(commands) == 0,
 	}
 	for _, sc := range commands {
-		r := classify(ctx, binaryPath, sc.Section, sc.Command, opts)
+		r := classify(ctx, binaryPath, sc.Section, sc.Command, opts, templateVarEnv)
 		switch r.Status {
 		case StatusOK:
 			report.Walked++
@@ -185,7 +192,7 @@ func loadCommands(researchPath string) ([]sectionCommand, error) {
 // binary name, keep words until the first flag (starts with `-`) or
 // non-identifier character. Hyphens stay because Cobra subcommands use
 // them (`list-projects`).
-func classify(ctx context.Context, binaryPath string, section Section, command string, opts Options) Result {
+func classify(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarEnv []string) Result {
 	segments, err := splitShellChain(command)
 	if err != nil {
 		return Result{
@@ -237,7 +244,7 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 
 	var last Result
 	for i, seg := range runnable {
-		sub := classifySegment(ctx, binaryPath, section, seg.cleaned, opts)
+		sub := classifySegment(ctx, binaryPath, section, seg.cleaned, opts, templateVarEnv)
 		if sub.Status != StatusOK {
 			if len(runnable) > 1 {
 				sub.Error = fmt.Sprintf("segment %d (%q): %s", i+1, seg.cleaned, sub.Error)
@@ -249,7 +256,7 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 	return finish(last)
 }
 
-func classifySegment(ctx context.Context, binaryPath string, section Section, command string, opts Options) Result {
+func classifySegment(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarEnv []string) Result {
 	words := extractSubcommandWords(command)
 	r := Result{Section: section, Command: command, Words: strings.Join(words, " ")}
 
@@ -277,10 +284,10 @@ func classifySegment(ctx context.Context, binaryPath string, section Section, co
 		r.Error = fmt.Sprintf("%s %s --help failed: %v", binaryPath, r.Words, err)
 		return r
 	}
-	return classifyFullExample(ctx, binaryPath, command, helpOut, r)
+	return classifyFullExample(ctx, binaryPath, command, helpOut, r, templateVarEnv)
 }
 
-func classifyFullExample(ctx context.Context, binaryPath, command string, helpOut []byte, r Result) Result {
+func classifyFullExample(ctx context.Context, binaryPath, command string, helpOut []byte, r Result, templateVarEnv []string) Result {
 	tokens, err := shellargs.Split(command)
 	if err != nil {
 		r.Status = StatusExampleFailed
@@ -315,6 +322,7 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 	// transport-layer mutating-verb gate doesn't collapse narrative
 	// full-example assertions to a synthetic envelope.
 	cmd.Env = append(os.Environ(), "PRINTING_PRESS_VERIFY=1", "PRINTING_PRESS_VERIFY_LIVE_HTTP=1")
+	cmd.Env = append(cmd.Env, templateVarEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		r.Status = StatusExampleFailed
@@ -329,6 +337,54 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 
 	r.Status = StatusOK
 	return r
+}
+
+type templateVarEnv struct {
+	Name  string
+	Value string
+}
+
+func discoverTemplateVarEnv(binaryPath string) []templateVarEnv {
+	manifest, err := pipeline.ReadCLIManifest(filepath.Dir(binaryPath))
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var envs []templateVarEnv
+	for _, templateVar := range manifest.EndpointTemplateVars {
+		templateVar = strings.TrimSpace(templateVar)
+		if templateVar == "" {
+			continue
+		}
+		envName := strings.TrimSpace(manifest.EndpointTemplateEnvOverrides[templateVar])
+		if envName == "" {
+			apiName := strings.TrimSpace(manifest.APIName)
+			if apiName == "" {
+				continue
+			}
+			envName = spec.DefaultEndpointTemplateEnvName(apiName, templateVar)
+		}
+		if seen[envName] {
+			continue
+		}
+		seen[envName] = true
+		envs = append(envs, templateVarEnv{
+			Name:  envName,
+			Value: templateVar + "_placeholder",
+		})
+	}
+	return envs
+}
+
+func missingTemplateVarEnvAssignments(templateVars []templateVarEnv) []string {
+	var env []string
+	for _, templateVar := range templateVars {
+		if strings.TrimSpace(os.Getenv(templateVar.Name)) != "" {
+			continue
+		}
+		env = append(env, templateVar.Name+"="+templateVar.Value)
+	}
+	return env
 }
 
 func isSideEffectfulNarrativeExample(args []string) bool {

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -109,9 +109,9 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 	if err != nil {
 		return nil, err
 	}
-	var templateVarEnv []string
+	var templateVarAssignments []string
 	if opts.FullExamples {
-		templateVarEnv = missingTemplateVarEnvAssignments(discoverTemplateVarEnv(binaryPath))
+		templateVarAssignments = missingTemplateVarEnvAssignments(discoverTemplateVarEnv(binaryPath))
 	}
 
 	report := &Report{
@@ -120,7 +120,7 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 		ResearchEmpty: len(commands) == 0,
 	}
 	for _, sc := range commands {
-		r := classify(ctx, binaryPath, sc.Section, sc.Command, opts, templateVarEnv)
+		r := classify(ctx, binaryPath, sc.Section, sc.Command, opts, templateVarAssignments)
 		switch r.Status {
 		case StatusOK:
 			report.Walked++
@@ -192,7 +192,7 @@ func loadCommands(researchPath string) ([]sectionCommand, error) {
 // binary name, keep words until the first flag (starts with `-`) or
 // non-identifier character. Hyphens stay because Cobra subcommands use
 // them (`list-projects`).
-func classify(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarEnv []string) Result {
+func classify(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarAssignments []string) Result {
 	segments, err := splitShellChain(command)
 	if err != nil {
 		return Result{
@@ -244,7 +244,7 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 
 	var last Result
 	for i, seg := range runnable {
-		sub := classifySegment(ctx, binaryPath, section, seg.cleaned, opts, templateVarEnv)
+		sub := classifySegment(ctx, binaryPath, section, seg.cleaned, opts, templateVarAssignments)
 		if sub.Status != StatusOK {
 			if len(runnable) > 1 {
 				sub.Error = fmt.Sprintf("segment %d (%q): %s", i+1, seg.cleaned, sub.Error)
@@ -256,7 +256,7 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 	return finish(last)
 }
 
-func classifySegment(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarEnv []string) Result {
+func classifySegment(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarAssignments []string) Result {
 	words := extractSubcommandWords(command)
 	r := Result{Section: section, Command: command, Words: strings.Join(words, " ")}
 
@@ -284,10 +284,10 @@ func classifySegment(ctx context.Context, binaryPath string, section Section, co
 		r.Error = fmt.Sprintf("%s %s --help failed: %v", binaryPath, r.Words, err)
 		return r
 	}
-	return classifyFullExample(ctx, binaryPath, command, helpOut, r, templateVarEnv)
+	return classifyFullExample(ctx, binaryPath, command, helpOut, r, templateVarAssignments)
 }
 
-func classifyFullExample(ctx context.Context, binaryPath, command string, helpOut []byte, r Result, templateVarEnv []string) Result {
+func classifyFullExample(ctx context.Context, binaryPath, command string, helpOut []byte, r Result, templateVarAssignments []string) Result {
 	tokens, err := shellargs.Split(command)
 	if err != nil {
 		r.Status = StatusExampleFailed
@@ -322,7 +322,7 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 	// transport-layer mutating-verb gate doesn't collapse narrative
 	// full-example assertions to a synthetic envelope.
 	cmd.Env = append(os.Environ(), "PRINTING_PRESS_VERIFY=1", "PRINTING_PRESS_VERIFY_LIVE_HTTP=1")
-	cmd.Env = append(cmd.Env, templateVarEnv...)
+	cmd.Env = append(cmd.Env, templateVarAssignments...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		r.Status = StatusExampleFailed
@@ -339,18 +339,18 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 	return r
 }
 
-type templateVarEnv struct {
+type templateVarEnvEntry struct {
 	Name  string
 	Value string
 }
 
-func discoverTemplateVarEnv(binaryPath string) []templateVarEnv {
+func discoverTemplateVarEnv(binaryPath string) []templateVarEnvEntry {
 	manifest, err := pipeline.ReadCLIManifest(filepath.Dir(binaryPath))
 	if err != nil {
 		return nil
 	}
 	seen := map[string]bool{}
-	var envs []templateVarEnv
+	var envs []templateVarEnvEntry
 	for _, templateVar := range manifest.EndpointTemplateVars {
 		templateVar = strings.TrimSpace(templateVar)
 		if templateVar == "" {
@@ -368,7 +368,7 @@ func discoverTemplateVarEnv(binaryPath string) []templateVarEnv {
 			continue
 		}
 		seen[envName] = true
-		envs = append(envs, templateVarEnv{
+		envs = append(envs, templateVarEnvEntry{
 			Name:  envName,
 			Value: templateVar + "_placeholder",
 		})
@@ -376,7 +376,7 @@ func discoverTemplateVarEnv(binaryPath string) []templateVarEnv {
 	return envs
 }
 
-func missingTemplateVarEnvAssignments(templateVars []templateVarEnv) []string {
+func missingTemplateVarEnvAssignments(templateVars []templateVarEnvEntry) []string {
 	var env []string
 	for _, templateVar := range templateVars {
 		if strings.TrimSpace(os.Getenv(templateVar.Name)) != "" {

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -850,7 +851,13 @@ func buildTemplateVarOverrideStubBinary(t *testing.T) string {
 
 func renderEnvChecks(want map[string]string) string {
 	var b strings.Builder
-	for envName, envValue := range want {
+	keys := make([]string, 0, len(want))
+	for envName := range want {
+		keys = append(keys, envName)
+	}
+	sort.Strings(keys)
+	for _, envName := range keys {
+		envValue := want[envName]
 		fmt.Fprintf(&b, "\t\tif got := os.Getenv(%q); got != %q {\n", envName, envValue)
 		fmt.Fprintf(&b, "\t\t\tfmt.Fprintf(os.Stderr, %q, got)\n", envName+" = %q\\n")
 		b.WriteString("\t\t\tmissing = true\n")

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -216,6 +216,95 @@ func TestValidateWithOptions_FullExamplesCatchesInvalidFlag(t *testing.T) {
 	}
 }
 
+func TestValidateWithOptions_FullExamplesSeedsTemplateVarEnv(t *testing.T) {
+	unsetEnv(t, "SHOPIFY_SHOP")
+	unsetEnv(t, "SHOPIFY_API_VERSION")
+
+	binary := buildTemplateVarStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub sync --full"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.HasFailures() {
+		t.Fatalf("full example should pass with manifest-declared template var placeholders, got %+v", report)
+	}
+	if report.Walked != 1 {
+		t.Errorf("Walked = %d, want 1", report.Walked)
+	}
+}
+
+func TestValidateWithOptions_FullExamplesSeedsTemplateVarEnvWhenParentEnvEmpty(t *testing.T) {
+	t.Setenv("SHOPIFY_SHOP", "")
+	t.Setenv("SHOPIFY_API_VERSION", " ")
+
+	binary := buildTemplateVarStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub sync --full"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.HasFailures() {
+		t.Fatalf("full example should replace blank inherited template env vars with placeholders, got %+v", report)
+	}
+}
+
+func TestValidateWithOptions_FullExamplesPreservesTemplateVarParentEnv(t *testing.T) {
+	t.Setenv("SHOPIFY_SHOP", "custom-shop")
+	t.Setenv("SHOPIFY_API_VERSION", "2026-01")
+
+	binary := buildTemplateVarStubBinary(t, map[string]string{
+		"SHOPIFY_SHOP":        "custom-shop",
+		"SHOPIFY_API_VERSION": "2026-01",
+	})
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub sync --full"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.HasFailures() {
+		t.Fatalf("full example should preserve non-empty inherited template env vars, got %+v", report)
+	}
+}
+
+func TestValidateWithOptions_FullExamplesUsesTemplateVarEnvOverrides(t *testing.T) {
+	unsetEnv(t, "ST_TENANT_ID")
+
+	binary := buildTemplateVarOverrideStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub sync --full"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.HasFailures() {
+		t.Fatalf("full example should seed manifest override env names, got %+v", report)
+	}
+}
+
 func TestClassifyFullExample_ReportsUnsupportedWhenDryRunUnavailable(t *testing.T) {
 	t.Parallel()
 
@@ -225,6 +314,7 @@ func TestClassifyFullExample_ReportsUnsupportedWhenDryRunUnavailable(t *testing.
 		"stub widgets list",
 		[]byte("Usage: stub widgets list"),
 		Result{Section: SectionQuickstart, Command: "stub widgets list", Words: "widgets list"},
+		nil,
 	)
 	if got.Status != StatusUnsupported {
 		t.Fatalf("Status = %q, want %q", got.Status, StatusUnsupported)
@@ -243,6 +333,7 @@ func TestRunFullExample_SkipsAuthSetToken(t *testing.T) {
 		"stub auth set-token YOUR_TOKEN_HERE",
 		[]byte("      --dry-run   Show request without sending"),
 		Result{Section: SectionQuickstart, Command: "stub auth set-token YOUR_TOKEN_HERE", Words: "auth set-token YOUR_TOKEN_HERE"},
+		nil,
 	)
 	if got.Status != StatusUnsupported {
 		t.Fatalf("Status = %q, want %q", got.Status, StatusUnsupported)
@@ -261,6 +352,7 @@ func TestRunFullExample_SkipsAuthLogout(t *testing.T) {
 		"stub auth logout",
 		[]byte("      --dry-run   Show request without sending"),
 		Result{Section: SectionRecipes, Command: "stub auth logout", Words: "auth logout"},
+		nil,
 	)
 	if got.Status != StatusUnsupported {
 		t.Fatalf("Status = %q, want %q", got.Status, StatusUnsupported)
@@ -588,6 +680,21 @@ func writeFile(t *testing.T, content string) string {
 	return path
 }
 
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	old, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, old)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
+
 // buildStubBinary compiles a small Go program that simulates a printed
 // CLI: it accepts `widgets list --help`, `widgets show <id> --help`,
 // and exits non-zero for anything else. The stub is the most direct
@@ -663,6 +770,93 @@ func main() {
 		t.Fatal(stubErr)
 	}
 	return stubPath
+}
+
+func buildTemplateVarStubBinary(t *testing.T, wantEnv ...map[string]string) string {
+	t.Helper()
+	want := map[string]string{
+		"SHOPIFY_SHOP":        "shop_placeholder",
+		"SHOPIFY_API_VERSION": "api_version_placeholder",
+	}
+	if len(wantEnv) > 0 {
+		want = wantEnv[0]
+	}
+	wantChecks := renderEnvChecks(want)
+	src := `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	joined := strings.Join(args, " ")
+	if len(args) >= 2 && args[0] == "sync" && args[1] == "--help" {
+		fmt.Println("usage stub: sync")
+		fmt.Println("      --dry-run   Show request without sending")
+		return
+	}
+	if joined == "sync --full --dry-run" {
+		missing := false
+` + wantChecks + `
+		if missing {
+			os.Exit(1)
+		}
+		fmt.Println("dry run ok")
+		return
+	}
+	fmt.Fprintln(os.Stderr, "unknown command:", joined)
+	os.Exit(1)
+}
+`
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "stub.go")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binaryPath := filepath.Join(dir, "stub")
+	if out, err := exec.Command("go", "build", "-o", binaryPath, srcPath).CombinedOutput(); err != nil {
+		t.Fatalf("building template-var stub: %v\n%s", err, out)
+	}
+	manifest := `{
+		"api_name": "shopify",
+		"cli_name": "shopify-pp-cli",
+		"endpoint_template_vars": ["shop", "api_version"]
+	}`
+	if err := os.WriteFile(filepath.Join(dir, ".printing-press.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return binaryPath
+}
+
+func buildTemplateVarOverrideStubBinary(t *testing.T) string {
+	t.Helper()
+	binaryPath := buildTemplateVarStubBinary(t, map[string]string{
+		"ST_TENANT_ID": "tenant_placeholder",
+	})
+	manifest := `{
+		"api_name": "servicetitan",
+		"cli_name": "servicetitan-pp-cli",
+		"endpoint_template_vars": ["tenant"],
+		"endpoint_template_env_overrides": {"tenant": "ST_TENANT_ID"}
+	}`
+	if err := os.WriteFile(filepath.Join(filepath.Dir(binaryPath), ".printing-press.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return binaryPath
+}
+
+func renderEnvChecks(want map[string]string) string {
+	var b strings.Builder
+	for envName, envValue := range want {
+		fmt.Fprintf(&b, "\t\tif got := os.Getenv(%q); got != %q {\n", envName, envValue)
+		fmt.Fprintf(&b, "\t\t\tfmt.Fprintf(os.Stderr, %q, got)\n", envName+" = %q\\n")
+		b.WriteString("\t\t\tmissing = true\n")
+		b.WriteString("\t\t}\n")
+	}
+	return b.String()
 }
 
 func TestStripRedirects(t *testing.T) {


### PR DESCRIPTION
## Intent

Closes #1452.

`validate-narrative --full-examples` can now exercise dry-run examples for generated CLIs whose URLs contain endpoint template variables. Shopify-style CLIs no longer fail before dry-run just because `SHOPIFY_SHOP` or `SHOPIFY_API_VERSION` is unset in the parent shell.

## Approach

The full-example runner reads the printed CLI manifest next to the binary, derives the env names for `endpoint_template_vars` including manifest overrides, and adds deterministic `<var>_placeholder` values only when the parent env value is missing or blank. Non-empty operator-provided values are preserved.

## Scope

Primary area: narrative validation/scorer subprocess setup.

Why this belongs in this repo: this is a Printing Press validator behavior gap that affects any printed CLI with templated base URLs or endpoint paths, not a one-off printed CLI fix.

## Risk

Low. The new env seeding only runs for `--full-examples`, only for manifest-declared endpoint template vars, and does not change CLIs with no template vars.

## Output Contract

The `validate-narrative --full-examples` probe environment now includes placeholder values for manifest-declared endpoint template vars when the parent process does not provide non-blank values.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/narrativecheck -count=1`
- `go test ./internal/cli ./internal/narrativecheck -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
