### PR TITLE
fix(cli): choose freshest live-check binary

### DIFF
--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -253,15 +253,36 @@ func findResearchDir(cliDir string) string {
 // `<base>-pp-cli` naming convention and falls back to `<base>`.
 func resolveBinaryPath(cliDir, name string) (string, error) {
 	candidates := liveCheckBinaryCandidates(cliDir, name)
-	for _, path := range candidates {
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
+	var nonExecutablePath string
+	for _, candidate := range liveCheckBinaryNames(cliDir, name) {
+		var bestPath string
+		var bestModTime time.Time
+		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, runtime.GOOS) {
+			info, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			if !isLiveCheckExecutable(path, info.Mode()) {
+				if nonExecutablePath == "" {
+					nonExecutablePath = path
+				}
+				continue
+			}
+			if bestPath == "" || info.ModTime().After(bestModTime) {
+				bestPath = path
+				bestModTime = info.ModTime()
+			}
 		}
-		if !isLiveCheckExecutable(path, info.Mode()) {
-			return "", fmt.Errorf("binary %q is not executable", path)
+		if bestPath != "" {
+			absPath, err := filepath.Abs(bestPath)
+			if err != nil {
+				return "", fmt.Errorf("resolving binary path %q: %w", bestPath, err)
+			}
+			return absPath, nil
 		}
-		return path, nil
+	}
+	if nonExecutablePath != "" {
+		return "", fmt.Errorf("binary %q is not executable", nonExecutablePath)
 	}
 	return "", fmt.Errorf("no runnable binary found in %q (tried %v)", cliDir, candidates)
 }
@@ -282,31 +303,10 @@ func liveCheckBinaryCandidates(cliDir, name string) []string {
 }
 
 func liveCheckBinaryCandidatesForGOOS(cliDir, name, goos string) []string {
-	names := []string{name}
-	if name == "" {
-		base := filepath.Base(cliDir)
-		names = []string{base + "-pp-cli", base}
-	}
-	// Resolution order (per issue #1150):
-	//   1. <cliDir>/build/stage/bin/<name>           canonical Unix
-	//   2. <cliDir>/build/stage/bin/<name>.exe       canonical Windows
-	//   3. <cliDir>/<name>                           legacy fallback
-	//   4. <cliDir>/<name>.exe                       legacy Windows fallback
-	// The generator's --validate "build runnable binary" gate emits the
-	// binary under build/stage/bin/; older layouts left it at cliDir.
-	stagedDir := filepath.Join(cliDir, "build", "stage", "bin")
-	candidates := make([]string, 0, len(names)*4)
+	candidates := make([]string, 0)
 	seen := map[string]struct{}{}
-	for _, candidate := range names {
-		if candidate == "" {
-			continue
-		}
-		for _, path := range []string{
-			filepath.Join(stagedDir, candidate),
-			platform.ExecutablePathForGOOS(filepath.Join(stagedDir, candidate), goos),
-			filepath.Join(cliDir, candidate),
-			platform.ExecutablePathForGOOS(filepath.Join(cliDir, candidate), goos),
-		} {
+	for _, candidate := range liveCheckBinaryNames(cliDir, name) {
+		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos) {
 			if _, ok := seen[path]; ok {
 				continue
 			}
@@ -315,6 +315,41 @@ func liveCheckBinaryCandidatesForGOOS(cliDir, name, goos string) []string {
 		}
 	}
 	return candidates
+}
+
+func liveCheckBinaryNames(cliDir, name string) []string {
+	names := []string{name}
+	if name == "" {
+		base := filepath.Base(cliDir)
+		names = []string{base + "-pp-cli", base}
+	}
+	return names
+}
+
+func liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos string) []string {
+	// Candidate order breaks ties between equally fresh binaries:
+	//   1. <cliDir>/build/stage/bin/<name>           validate-stage Unix
+	//   2. <cliDir>/build/stage/bin/<name>.exe       validate-stage Windows
+	//   3. <cliDir>/bin/<name>                       Makefile Unix
+	//   4. <cliDir>/bin/<name>.exe                   Makefile Windows
+	//   5. <cliDir>/<name>                           direct go-build Unix
+	//   6. <cliDir>/<name>.exe                       direct go-build Windows
+	// The generator's --validate "build runnable binary" gate emits the
+	// binary under build/stage/bin/. The generated Makefile writes bin/.
+	// Manual fix loops often rebuild directly into cliDir.
+	stagedDir := filepath.Join(cliDir, "build", "stage", "bin")
+	makefileBinDir := filepath.Join(cliDir, "bin")
+	if candidate == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(stagedDir, candidate),
+		platform.ExecutablePathForGOOS(filepath.Join(stagedDir, candidate), goos),
+		filepath.Join(makefileBinDir, candidate),
+		platform.ExecutablePathForGOOS(filepath.Join(makefileBinDir, candidate), goos),
+		filepath.Join(cliDir, candidate),
+		platform.ExecutablePathForGOOS(filepath.Join(cliDir, candidate), goos),
+	}
 }
 
 // runFeaturesConcurrent distributes the per-feature checks across a worker

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -342,7 +342,7 @@ func liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos string) []stri
 	if candidate == "" {
 		return nil
 	}
-	return []string{
+	paths := []string{
 		filepath.Join(stagedDir, candidate),
 		platform.ExecutablePathForGOOS(filepath.Join(stagedDir, candidate), goos),
 		filepath.Join(makefileBinDir, candidate),
@@ -350,6 +350,16 @@ func liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos string) []stri
 		filepath.Join(cliDir, candidate),
 		platform.ExecutablePathForGOOS(filepath.Join(cliDir, candidate), goos),
 	}
+	deduped := paths[:0:0]
+	seen := map[string]struct{}{}
+	for _, path := range paths {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		deduped = append(deduped, path)
+	}
+	return deduped
 }
 
 // runFeaturesConcurrent distributes the per-feature checks across a worker

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -497,8 +497,12 @@ func TestLiveCheck_BinaryAutoDerivation(t *testing.T) {
 	// CLIDir basename is the last path segment. Build a stub named that way
 	// and a stub named `<name>-pp-cli`; the latter should be preferred.
 	base := filepath.Base(dir)
-	writeStubBinary(t, dir, base+"-pp-cli", `echo "matched via -pp-cli"`)
-	writeStubBinary(t, dir, base, `echo "matched via base"`)
+	preferredPath := writeStubBinary(t, dir, base+"-pp-cli", `echo "matched via -pp-cli"`)
+	fallbackPath := writeStubBinary(t, dir, base, `echo "matched via base"`)
+	oldTime := time.Now().Add(-time.Hour)
+	newTime := time.Now()
+	require.NoError(t, os.Chtimes(preferredPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(fallbackPath, newTime, newTime))
 	writeTestResearchJSON(t, dir, []NovelFeature{
 		{Name: "X", Command: "x", Example: `stub x matched`},
 	})
@@ -506,6 +510,7 @@ func TestLiveCheck_BinaryAutoDerivation(t *testing.T) {
 	require.False(t, result.Unable, "should have found a binary: %s", result.Reason)
 	require.Equal(t, 1, result.Passed)
 	require.Contains(t, result.Features[0].Example, "stub x matched")
+	require.Contains(t, result.Features[0].OutputSample, "matched via -pp-cli")
 }
 
 func TestLiveCheckBinaryCandidatesPreferBuildStageBin(t *testing.T) {
@@ -514,26 +519,116 @@ func TestLiveCheckBinaryCandidatesPreferBuildStageBin(t *testing.T) {
 	dir := filepath.Join("tmp", "sample-cli")
 	stagedUnix := filepath.Join(dir, "build", "stage", "bin", "sample-cli-pp-cli")
 	stagedWin := platform.ExecutablePathForGOOS(filepath.Join(dir, "build", "stage", "bin", "sample-cli-pp-cli"), "windows")
+	makefileUnix := filepath.Join(dir, "bin", "sample-cli-pp-cli")
+	makefileWin := platform.ExecutablePathForGOOS(filepath.Join(dir, "bin", "sample-cli-pp-cli"), "windows")
 	legacyUnix := filepath.Join(dir, "sample-cli-pp-cli")
 
 	cands := liveCheckBinaryCandidatesForGOOS(dir, "", "windows")
 	assert.Contains(t, cands, stagedUnix)
 	assert.Contains(t, cands, stagedWin)
+	assert.Contains(t, cands, makefileUnix)
+	assert.Contains(t, cands, makefileWin)
 	assert.Contains(t, cands, legacyUnix)
 
-	// Canonical staged path must come before the legacy cliDir fallback.
+	// Canonical staged path must come before the other fallback layouts.
 	stagedIdx := -1
+	makefileIdx := -1
 	legacyIdx := -1
 	for i, c := range cands {
 		if c == stagedUnix && stagedIdx == -1 {
 			stagedIdx = i
 		}
+		if c == makefileUnix && makefileIdx == -1 {
+			makefileIdx = i
+		}
 		if c == legacyUnix && legacyIdx == -1 {
 			legacyIdx = i
 		}
 	}
-	assert.True(t, stagedIdx >= 0 && legacyIdx >= 0 && stagedIdx < legacyIdx,
-		"staged build/stage/bin path must be tried before cliDir legacy path, got order %v", cands)
+	assert.True(t, stagedIdx >= 0 && makefileIdx >= 0 && legacyIdx >= 0 && stagedIdx < makefileIdx && makefileIdx < legacyIdx,
+		"staged build/stage/bin path must be tried before bin/ and cliDir fallback paths, got order %v", cands)
+}
+
+func TestLiveCheckResolveBinaryPathPicksNewestCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	makefileBinDir := filepath.Join(dir, "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+	require.NoError(t, os.MkdirAll(makefileBinDir, 0o755))
+
+	stagedPath := filepath.Join(stagedDir, "stub")
+	require.NoError(t, os.WriteFile(stagedPath, []byte("#!/bin/sh\necho staged\n"), 0o755))
+	makefilePath := filepath.Join(makefileBinDir, "stub")
+	require.NoError(t, os.WriteFile(makefilePath, []byte("#!/bin/sh\necho makefile\n"), 0o755))
+	rootPath := writeStubBinary(t, dir, "stub", `echo root`)
+
+	staleTime := time.Now().Add(-time.Hour)
+	freshTime := time.Now()
+	require.NoError(t, os.Chtimes(stagedPath, staleTime, staleTime))
+	require.NoError(t, os.Chtimes(makefilePath, staleTime, staleTime))
+	require.NoError(t, os.Chtimes(rootPath, freshTime, freshTime))
+
+	got, err := resolveBinaryPath(dir, "stub")
+	require.NoError(t, err)
+	require.Equal(t, rootPath, got)
+}
+
+func TestLiveCheck_RelativeCLIDirRunsResolvedBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	parent := t.TempDir()
+	t.Chdir(parent)
+	cliDir := "relative-cli"
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	writeStubBinary(t, cliDir, "stub", `echo '{"data":[{"id":"1"}]}'`)
+	writeTestResearchJSON(t, cliDir, []NovelFeature{
+		{Name: "List items", Command: "items list", Example: "stub items list --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: cliDir, BinaryName: "stub", Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+}
+
+func TestLiveCheckResolveBinaryPathIncludesMakefileBinOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	makefileBinDir := filepath.Join(dir, "bin")
+	require.NoError(t, os.MkdirAll(makefileBinDir, 0o755))
+
+	makefilePath := filepath.Join(makefileBinDir, "stub")
+	require.NoError(t, os.WriteFile(makefilePath, []byte("#!/bin/sh\necho makefile\n"), 0o755))
+
+	got, err := resolveBinaryPath(dir, "stub")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(makefilePath), got)
+}
+
+func TestLiveCheckResolveBinaryPathSkipsNonExecutableCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+
+	stagedPath := filepath.Join(stagedDir, "stub")
+	require.NoError(t, os.WriteFile(stagedPath, []byte("#!/bin/sh\necho staged\n"), 0o644))
+	rootPath := writeStubBinary(t, dir, "stub", `echo root`)
+
+	got, err := resolveBinaryPath(dir, "stub")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(rootPath), got)
 }
 
 func TestLiveCheckExecutableHonorsWindowsExeExtension(t *testing.T) {


### PR DESCRIPTION
## Summary

Live checks now run the freshly rebuilt printed CLI instead of silently choosing a stale binary from another build location. The resolver covers all three generated CLI binary layouts seen in fix loops: validate-stage `build/stage/bin/<cli>`, Makefile `bin/<cli>`, and direct root builds.

When the binary name is inferred, `<api>-pp-cli` remains preferred over the bare directory name. Freshness is applied within that logical binary name, and the selected path is absolutized so relative `--dir` values still execute correctly from inside the CLI directory.

Closes #1468

## Tests

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `go test ./internal/pipeline -count=1`
- `go test ./internal/pressauth -run TestCaptureTimeoutCleansTempDir -count=1`
- `GOLANGCI_LINT_CACHE=$(mktemp -d /tmp/golangci-issue1468.XXXXXX) golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
