### PR TITLE
fix(cli): flatten nested allOf body schemas

### DIFF
--- a/internal/generator/json_string_validation_test.go
+++ b/internal/generator/json_string_validation_test.go
@@ -180,6 +180,52 @@ func TestJSONStringBodyParamEmitsLocalValidation(t *testing.T) {
 	require.NotContains(t, code, `body["metadata"] = parsedMetadata`)
 }
 
+func TestHTMLStringBodyParamDoesNotEmitJSONValidation(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("html-body-param")
+	apiSpec.Resources["tasks"] = spec.Resource{
+		Description: "Tasks",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/tasks",
+				Description: "List tasks",
+			},
+			"update": {
+				Method:      "PATCH",
+				Path:        "/tasks/{task_gid}",
+				Description: "Update task",
+				Params: []spec.Param{
+					{Name: "task_gid", Type: "string", Positional: true, PathParam: true, Required: true},
+				},
+				Body: []spec.Param{
+					{
+						Name:        "data",
+						Type:        "object",
+						Description: "Request payload",
+						Fields: []spec.Param{
+							{Name: "html_text", Type: "string", Description: "HTML formatted text for a comment."},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "html-body-param-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "tasks_update.go"))
+	require.NoError(t, err)
+	code := string(src)
+
+	require.Contains(t, code, `cmd.Flags().StringVar(&bodyDataHtmlText, "data-html-text"`)
+	require.Contains(t, code, `nestedData["html_text"] = bodyDataHtmlText`)
+	require.NotContains(t, code, `parsedDataHtmlText`)
+	require.NotContains(t, code, `parsing --data-html-text JSON`)
+}
+
 func TestJSONStringParamDoesNotSuggestUnrelatedEnum(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -3229,45 +3228,71 @@ func bodyParamSchema(schema *openapi3.Schema) *openapi3.Schema {
 	if schema == nil || len(schema.AllOf) == 0 {
 		return schema
 	}
-	if schema.Type != nil || len(schema.Properties) > 0 || schema.Items != nil {
+
+	if scalar, hasObject := firstAllOfNonObjectSchema(schema, map[*openapi3.Schema]struct{}{}); scalar != nil && !hasObject {
+		return scalar
+	}
+
+	properties := map[string]*openapi3.SchemaRef{}
+	required := map[string]struct{}{}
+	if collectAllOfProperties(&openapi3.SchemaRef{Value: schema}, properties, required, map[*openapi3.Schema]struct{}{}) || len(properties) == 0 {
 		return schema
 	}
 
-	var mergedObject *openapi3.Schema
-	required := map[string]struct{}{}
+	merged := &openapi3.Schema{
+		Type:        &openapi3.Types{openapi3.TypeObject},
+		Properties:  properties,
+		Description: schema.Description,
+		Default:     schema.Default,
+	}
+	for name := range required {
+		merged.Required = append(merged.Required, name)
+	}
+	sort.Strings(merged.Required)
+	return merged
+}
+
+func firstAllOfNonObjectSchema(schema *openapi3.Schema, visited map[*openapi3.Schema]struct{}) (*openapi3.Schema, bool) {
+	if schema == nil {
+		return nil, false
+	}
+	if _, ok := visited[schema]; ok {
+		return nil, false
+	}
+	visited[schema] = struct{}{}
+	defer delete(visited, schema)
+
+	hasObject := hasDirectObjectShape(schema)
+	var firstScalar *openapi3.Schema
 	for _, candidate := range schema.AllOf {
 		value := schemaRefValue(candidate)
 		if value == nil {
 			continue
 		}
-		if isObjectSchema(value) {
-			if mergedObject == nil {
-				mergedObject = &openapi3.Schema{
-					Type:       &openapi3.Types{openapi3.TypeObject},
-					Properties: map[string]*openapi3.SchemaRef{},
-				}
-			}
-			if mergedObject.Description == "" {
-				mergedObject.Description = value.Description
-			}
-			maps.Copy(mergedObject.Properties, value.Properties)
-			for _, name := range value.Required {
-				required[name] = struct{}{}
-			}
-			continue
+		if hasDirectObjectShape(value) {
+			hasObject = true
+		} else if firstScalar == nil && (value.Items != nil || (value.Type != nil && !value.Type.Includes(openapi3.TypeObject))) {
+			firstScalar = value
 		}
-		if mergedObject == nil && (value.Type != nil || value.Items != nil) {
-			return value
+		nestedScalar, nestedHasObject := firstAllOfNonObjectSchema(value, visited)
+		if firstScalar == nil && nestedScalar != nil {
+			firstScalar = nestedScalar
+		}
+		if nestedHasObject {
+			hasObject = true
 		}
 	}
-	if mergedObject != nil {
-		for name := range required {
-			mergedObject.Required = append(mergedObject.Required, name)
-		}
-		sort.Strings(mergedObject.Required)
-		return mergedObject
+	return firstScalar, hasObject
+}
+
+func hasDirectObjectShape(schema *openapi3.Schema) bool {
+	if schema == nil {
+		return false
 	}
-	return schema
+	if schema.Type != nil && schema.Type.Includes(openapi3.TypeObject) {
+		return true
+	}
+	return len(schema.Properties) > 0
 }
 
 func mapBodyFields(schema *openapi3.Schema) []spec.Param {
@@ -3343,6 +3368,11 @@ func collectAllOfProperties(
 		return true
 	}
 
+	for _, sub := range schema.AllOf {
+		if collectAllOfProperties(sub, properties, required, visited) {
+			return true
+		}
+	}
 	for _, field := range schema.Required {
 		required[field] = struct{}{}
 	}
@@ -3351,11 +3381,6 @@ func collectAllOfProperties(
 			continue
 		}
 		properties[naming.ASCIIFold(name)] = prop
-	}
-	for _, sub := range schema.AllOf {
-		if collectAllOfProperties(sub, properties, required, visited) {
-			return true
-		}
 	}
 
 	return false

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -612,6 +613,18 @@ paths:
                   allOf:
                     - $ref: "#/components/schemas/PaymentPurpose"
                     - $ref: "#/components/schemas/PurposeMetadata"
+                details:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Specific detail name.
+                  allOf:
+                    - $ref: "#/components/schemas/BaseDetails"
+                mixed:
+                  allOf:
+                    - $ref: "#/components/schemas/PurposeMetadata"
+                    - $ref: "#/components/schemas/StringEnumWrapper"
       responses:
         "200":
           description: ok
@@ -642,6 +655,18 @@ components:
       properties:
         memo:
           type: string
+    BaseDetails:
+      type: object
+      properties:
+        inherited:
+          type: string
+        name:
+          type: string
+          description: Base detail name.
+    StringEnumWrapper:
+      allOf:
+        - type: string
+          enum: [simple, complex]
 `))
 	require.NoError(t, err)
 
@@ -662,6 +687,156 @@ components:
 		{Name: "memo", Type: "string", Required: true, Description: "Memo"},
 		{Name: "simple", Type: "string", Description: "Simple"},
 	}, byName["purpose"].Fields)
+	assert.Equal(t, []spec.Param{
+		{Name: "inherited", Type: "string", Description: "Inherited"},
+		{Name: "name", Type: "string", Description: "Specific detail name."},
+	}, byName["details"].Fields)
+	assert.Equal(t, "object", byName["mixed"].Type)
+	assert.Equal(t, []spec.Param{
+		{Name: "memo", Type: "string", Required: true, Description: "Memo"},
+	}, byName["mixed"].Fields)
+}
+
+const dataEnvelopeAllOfTaskSpec = `
+openapi: 3.0.3
+info:
+  title: Task API
+  version: 1.0.0
+servers:
+  - url: https://api.example.test
+paths:
+  /tasks/{task_gid}:
+    patch:
+      operationId: updateTask
+      parameters:
+        - name: task_gid
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "#/components/schemas/TaskUpdateRequest"
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    TaskBase:
+      type: object
+      required: [name]
+      properties:
+        completed:
+          type: boolean
+          description: Whether the task is complete.
+        due_on:
+          type: string
+          format: date
+          description: Date the task is due.
+        html_notes:
+          type: string
+          description: HTML formatted text for the task notes.
+        name:
+          type: string
+          description: Name of the task.
+        notes:
+          type: string
+          description: Plain text task notes.
+    TaskRequestBase:
+      allOf:
+        - $ref: "#/components/schemas/TaskBase"
+        - type: object
+          properties:
+            assignee:
+              type: string
+              description: GID of the assignee.
+    TaskUpdateRequest:
+      allOf:
+        - $ref: "#/components/schemas/TaskRequestBase"
+        - type: object
+          properties:
+            custom_type:
+              type: string
+              description: GID of a task custom type.
+`
+
+func TestParseMapsDataEnvelopeAllOfRequestBodyFields(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(dataEnvelopeAllOfTaskSpec))
+	require.NoError(t, err)
+
+	endpoint := findParsedEndpointByPath(t, parsed, "PATCH", "/tasks/{task_gid}")
+	require.Len(t, endpoint.Body, 1)
+	data := endpoint.Body[0]
+	require.Equal(t, "data", data.Name)
+	require.Equal(t, "object", data.Type)
+
+	fields := map[string]spec.Param{}
+	for _, field := range data.Fields {
+		fields[field.Name] = field
+	}
+	for _, want := range []string{"assignee", "completed", "custom_type", "due_on", "html_notes", "name", "notes"} {
+		assert.Contains(t, fields, want)
+	}
+	assert.True(t, fields["name"].Required)
+	assert.Equal(t, "bool", fields["completed"].Type)
+	assert.Equal(t, "date", fields["due_on"].Format)
+	assert.Equal(t, "string", fields["html_notes"].Type)
+	assert.Equal(t, "HTML formatted text for the task notes.", fields["html_notes"].Description)
+}
+
+func TestGenerateDataEnvelopeAllOfBodyFlags(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("OpenAPI generated CLI compile coverage runs in the generated-test CI lane")
+	}
+
+	parsed, err := Parse([]byte(dataEnvelopeAllOfTaskSpec))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+	gen := generator.New(parsed, outputDir)
+	gen.VisionSet = generator.VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	binaryPath := filepath.Join(outputDir, naming.CLI(parsed.Name))
+	runGo(t, outputDir, "mod", "tidy")
+	runGo(t, outputDir, "build", "-o", binaryPath, "./cmd/"+naming.CLI(parsed.Name))
+
+	helpOut, err := exec.Command(binaryPath, "tasks", "update-task", "--help").CombinedOutput()
+	require.NoError(t, err, string(helpOut))
+	help := string(helpOut)
+	for _, want := range []string{
+		"--data-name",
+		"--data-notes",
+		"--data-html-notes",
+		"--data-assignee",
+		"--data-completed",
+		"--data-due-on",
+		"--data-custom-type",
+	} {
+		assert.Contains(t, help, want)
+	}
+	assert.NotContains(t, help, "--data-data-")
+
+	cmd := exec.Command(binaryPath, "tasks", "update-task", "123", "--data-html-notes", "<body>foo</body>", "--dry-run")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	bodyJSON := extractDryRunBody(t, string(out))
+	var body struct {
+		Data struct {
+			HTMLNotes string `json:"html_notes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(bodyJSON), &body))
+	assert.Equal(t, "<body>foo</body>", body.Data.HTMLNotes)
 }
 
 func TestParseRecursiveRequestBodyFieldsStopsAtCycle(t *testing.T) {
@@ -1697,6 +1872,19 @@ func runGo(t *testing.T, dir string, args ...string) {
 	cmd.Env = os.Environ()
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
+}
+
+func extractDryRunBody(t *testing.T, output string) string {
+	t.Helper()
+
+	const bodyMarker = "  Body:\n"
+	start := strings.Index(output, bodyMarker)
+	require.NotEqual(t, -1, start, output)
+	start += len(bodyMarker)
+
+	end := strings.Index(output[start:], "\n\n(dry run")
+	require.NotEqual(t, -1, end, output)
+	return output[start : start+end]
 }
 
 func TestSanitizeResourceName(t *testing.T) {


### PR DESCRIPTION
## Intent

Closes #1427.

Nested OpenAPI `allOf` schemas inside request-body envelope fields were not fully surfaced as generated `--data-*` flags, so APIs with `{data: ...}` request shapes could lose inherited body fields. HTML rich-text string fields also need to stay plain strings instead of being treated as JSON payload hints.

## Approach

This reuses the existing recursive `allOf` property collector for body field schemas, while preserving the scalar/array fallback path for non-object `allOf` wrappers. The tests cover the parsed body fields, generated CLI help flags, and dry-run serialization for an HTML string body value.

## Verification

- `go fmt ./...`
- `go test ./internal/openapi -run 'Test(ParseMapsDataEnvelopeAllOfRequestBodyFields|GenerateDataEnvelopeAllOfBodyFlags)' -count=1`
- `go test ./internal/generator -run 'TestHTMLStringBodyParamDoesNotEmitJSONValidation|TestJSONStringParamRejectsInvalidValueBeforeClient' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `git diff --check`
