### PR TITLE
fix(cli): inject field selectors during sync

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8783,6 +8783,97 @@ func TestGeneratedSyncGatesSinceParamPerResource(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGeneratedSyncInjectsFieldSelectorDefaults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "fieldsync",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"FIELDSYNC_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/fieldsync-pp-cli/config.toml",
+		},
+		Types: map[string]spec.TypeDef{
+			"Task": {Fields: []spec.TypeField{
+				{Name: "gid", Type: "string"},
+				{Name: "completed", Type: "bool"},
+				{Name: "assignee", Type: "object"},
+				{Name: "custom_fields", Type: "array"},
+			}},
+		},
+		Resources: map[string]spec.Resource{
+			"tasks": {
+				Description: "Tasks",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/tasks",
+						Description: "List tasks",
+						Response:    spec.ResponseDef{Type: "array", Item: "Task"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						Params: []spec.Param{{
+							Name:                 "opt_fields",
+							Type:                 "string",
+							Purpose:              spec.ParamPurposeFieldSelector,
+							FieldSelectorDefault: "gid,completed,assignee.gid,custom_fields.gid",
+						}},
+					},
+				},
+			},
+			"users": {
+				Description: "Users",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/users",
+						Description: "List users",
+						Response:    spec.ResponseDef{Type: "array"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+
+	assert.Contains(t, syncContent, "func syncResourceFieldSelector(resource string) (string, string)",
+		"sync.go must emit per-resource field-selector defaults")
+
+	fieldSelectorStart := strings.Index(syncContent, "func syncResourceFieldSelector(resource string) (string, string)")
+	require.NotEqual(t, -1, fieldSelectorStart, "sync.go must emit syncResourceFieldSelector")
+	fieldSelectorBody := syncContent[fieldSelectorStart:]
+	if nextFunc := strings.Index(fieldSelectorBody[1:], "\nfunc "); nextFunc != -1 {
+		fieldSelectorBody = fieldSelectorBody[:nextFunc+1]
+	}
+
+	assert.Contains(t, fieldSelectorBody, `case "tasks":`,
+		"tasks must appear in the field-selector switch")
+	assert.Contains(t, fieldSelectorBody, `return "opt_fields", "gid,completed,assignee.gid,custom_fields.gid"`,
+		"tasks must map to the spec-declared field selector and generated default")
+	assert.NotContains(t, fieldSelectorBody, `case "users":`,
+		"resources without a field selector must not inject an opt_fields-like query param")
+
+	defaultIdx := strings.Index(syncContent, "fieldSelectorKey, fieldSelectorValue := syncResourceFieldSelector(resource)")
+	applyIdx := strings.Index(syncContent, "userParams.applyTo(resource, params, false)")
+	require.NotEqual(t, -1, defaultIdx, "syncResource must apply field-selector defaults")
+	require.NotEqual(t, -1, applyIdx, "syncResource must still apply user params")
+	assert.Less(t, defaultIdx, applyIdx,
+		"user-supplied --param/--resource-param must override field-selector defaults")
+}
+
 func TestGeneratedSyncGatesPaginationParamsPerResource(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3,6 +3,9 @@
 {{- $hasPostSync := false -}}
 {{- range .SyncableResources}}{{if eq .Method "POST"}}{{- $hasPostSync = true -}}{{end}}{{end -}}
 {{- range .DependentSyncResources}}{{if eq .Method "POST"}}{{- $hasPostSync = true -}}{{end}}{{end }}
+{{- $hasFieldSelector := false -}}
+{{- range .SyncableResources}}{{if and .FieldSelector.Name .FieldSelector.Default}}{{- $hasFieldSelector = true -}}{{end}}{{end -}}
+{{- range .DependentSyncResources}}{{if and .FieldSelector.Name .FieldSelector.Default}}{{- $hasFieldSelector = true -}}{{end}}{{end }}
 
 package cli
 
@@ -541,6 +544,9 @@ func syncResource(c interface {
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
+{{- if $hasFieldSelector}}
+	fieldSelectorKey, fieldSelectorValue := syncResourceFieldSelector(resource)
+{{- end}}
 
 	var progressCount int64
 	pagesFetched := 0
@@ -576,6 +582,11 @@ func syncResource(c interface {
 		// Set date range filter (pass-through to API)
 		if dates != "" {
 			params[determineDateRangeParam()] = dates
+		}
+{{- end}}
+{{- if $hasFieldSelector}}
+		if fieldSelectorKey != "" && fieldSelectorValue != "" {
+			params[fieldSelectorKey] = fieldSelectorValue
 		}
 {{- end}}
 
@@ -987,6 +998,26 @@ func syncResourceSinceParam(resource string) string {
 	}
 	return ""
 }
+{{- if $hasFieldSelector}}
+
+func syncResourceFieldSelector(resource string) (string, string) {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if and .FieldSelector.Name .FieldSelector.Default}}
+	case "{{.Name}}":
+		return {{printf "%q" .FieldSelector.Name}}, {{printf "%q" .FieldSelector.Default}}
+{{- end}}
+{{- end}}
+{{- range .DependentSyncResources}}
+{{- if and .FieldSelector.Name .FieldSelector.Default}}
+	case "{{.Name}}":
+		return {{printf "%q" .FieldSelector.Name}}, {{printf "%q" .FieldSelector.Default}}
+{{- end}}
+{{- end}}
+	}
+	return "", ""
+}
+{{- end}}
 {{- if .Pagination.DateRangeParam}}
 
 // determineDateRangeParam returns the query parameter name for date-range sync filtering.
@@ -1520,6 +1551,9 @@ func syncDependentResource(c interface {
 		}
 		depSinceTS = ""
 	}
+{{- if $hasFieldSelector}}
+	fieldSelectorKey, fieldSelectorValue := syncResourceFieldSelector(dep.Name)
+{{- end}}
 	// Per-resource extract-failure tracking for the F4b symptom probe and
 	// per-item primary_key_unresolved warning. See syncResource for the
 	// concurrency rationale (one goroutine per resource → no race).
@@ -1553,6 +1587,11 @@ func syncDependentResource(c interface {
 {{- if .Pagination.DateRangeParam}}
 			if dates != "" {
 				params[determineDateRangeParam()] = dates
+			}
+{{- end}}
+{{- if $hasFieldSelector}}
+			if fieldSelectorKey != "" && fieldSelectorValue != "" {
+				params[fieldSelectorKey] = fieldSelectorValue
 			}
 {{- end}}
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2255,6 +2255,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			// same endpointName ("list") don't collide on a shared
 			// "ListItem" Types entry.
 			endpoint.Response, endpoint.ResponsePath = mapResponse(op, targetResourceName+"_"+endpointName, out)
+			populateFieldSelectorDefaults(&endpoint, op)
 			if strings.ToUpper(method) == "GET" {
 				endpoint.Pagination = detectPagination(endpoint.Params, op)
 				// Only single-resource fetches (GET /resource/{id}) can carry
@@ -2975,6 +2976,9 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 			Enum:        schemaEnum(schema),
 			Format:      schemaFormat(schema),
 		}
+		if parameter.In == openapi3.ParameterInQuery && isFieldSelectorParameter(paramName, description) {
+			param.Purpose = spec.ParamPurposeFieldSelector
+		}
 		if schema != nil && schema.Default != nil {
 			param.Default = schema.Default
 		}
@@ -2990,6 +2994,161 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 	reclassifyPathParamModifiers(params)
 
 	return params
+}
+
+func isFieldSelectorParameter(name, description string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	switch normalized {
+	case "opt_fields", "fields", "expand", "include", "select":
+		return true
+	}
+	description = strings.ToLower(description)
+	return (strings.Contains(description, "field") && strings.Contains(description, "return")) ||
+		(strings.Contains(description, "field") && strings.Contains(description, "include")) ||
+		(strings.Contains(description, "expand") && strings.Contains(description, "response"))
+}
+
+func populateFieldSelectorDefaults(endpoint *spec.Endpoint, op *openapi3.Operation) {
+	if endpoint == nil {
+		return
+	}
+	for i := range endpoint.Params {
+		if endpoint.Params[i].Purpose == spec.ParamPurposeFieldSelector {
+			endpoint.Params[i].FieldSelectorDefault = fieldSelectorDefaultFromOperation(op, endpoint.Params[i].Name)
+		}
+	}
+}
+
+func fieldSelectorDefaultFromOperation(op *openapi3.Operation, paramName string) string {
+	if op == nil || op.Responses == nil {
+		return ""
+	}
+	success := selectSuccessResponse(op.Responses)
+	if success == nil || success.Value == nil {
+		return ""
+	}
+	schemaRef := selectResponseSchema(success.Value)
+	if schemaRef == nil || schemaRef.Value == nil {
+		return ""
+	}
+	itemSchema := unwrapItemSchema(schemaRef.Value)
+	var fields []string
+	switch strings.ToLower(strings.TrimSpace(paramName)) {
+	case "expand", "include":
+		fields = fieldSelectorRelationshipFields(itemSchema)
+	default:
+		fields = fieldSelectorFields(itemSchema)
+	}
+	return strings.Join(fields, ",")
+}
+
+func fieldSelectorFields(schema *openapi3.Schema) []string {
+	if schema == nil {
+		return nil
+	}
+	properties := map[string]*openapi3.SchemaRef{}
+	collectFieldSelectorProperties(schema, properties, map[*openapi3.Schema]struct{}{})
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fields := make([]string, 0, len(names))
+	for _, key := range []string{"gid", "id", "sid", "uid", "uuid", "guid"} {
+		propSchema := schemaRefValue(properties[key])
+		if isScalarSchema(propSchema) {
+			fields = append(fields, key)
+		}
+	}
+	for _, name := range names {
+		if isIdentifierFieldName(name) {
+			continue
+		}
+		propSchema := schemaRefValue(properties[name])
+		if isScalarSchema(propSchema) {
+			fields = append(fields, name)
+			continue
+		}
+		if nestedID := nestedObjectIDField(propSchema); nestedID != "" {
+			fields = append(fields, name+"."+nestedID)
+		}
+	}
+	return fields
+}
+
+func fieldSelectorRelationshipFields(schema *openapi3.Schema) []string {
+	if schema == nil {
+		return nil
+	}
+	properties := map[string]*openapi3.SchemaRef{}
+	collectFieldSelectorProperties(schema, properties, map[*openapi3.Schema]struct{}{})
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fields := make([]string, 0, len(names))
+	for _, name := range names {
+		propSchema := schemaRefValue(properties[name])
+		if isObjectSchema(propSchema) || isObjectArraySchema(propSchema) {
+			fields = append(fields, name)
+		}
+	}
+	return fields
+}
+
+func isObjectArraySchema(schema *openapi3.Schema) bool {
+	return isArraySchema(schema) && schema.Items != nil && isObjectSchema(schemaRefValue(schema.Items))
+}
+
+func isIdentifierFieldName(name string) bool {
+	switch name {
+	case "gid", "id", "sid", "uid", "uuid", "guid":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectFieldSelectorProperties(schema *openapi3.Schema, properties map[string]*openapi3.SchemaRef, visited map[*openapi3.Schema]struct{}) {
+	if schema == nil {
+		return
+	}
+	if _, ok := visited[schema]; ok {
+		return
+	}
+	visited[schema] = struct{}{}
+	for name, prop := range schema.Properties {
+		if strings.HasPrefix(name, "_") || prop == nil {
+			continue
+		}
+		properties[name] = prop
+	}
+	for _, sub := range schema.AllOf {
+		collectFieldSelectorProperties(schemaRefValue(sub), properties, visited)
+	}
+}
+
+func nestedObjectIDField(schema *openapi3.Schema) string {
+	if schema == nil {
+		return ""
+	}
+	if isArraySchema(schema) && schema.Items != nil {
+		schema = schemaRefValue(schema.Items)
+	}
+	if !isObjectSchema(schema) {
+		return ""
+	}
+	properties := map[string]*openapi3.SchemaRef{}
+	collectFieldSelectorProperties(schema, properties, map[*openapi3.Schema]struct{}{})
+	for _, key := range []string{"gid", "id", "sid", "uid", "uuid", "guid"} {
+		if prop := schemaRefValue(properties[key]); isScalarSchema(prop) {
+			return key
+		}
+	}
+	return ""
 }
 
 // reclassifyPathParamModifiers converts path params that are modifiers (pagination,

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -51,6 +51,106 @@ func TestParsePetstore(t *testing.T) {
 	assert.Contains(t, parsed.Types, "Pet")
 }
 
+func TestParseMarksFieldSelectorParamsWithSyncDefault(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Field Selector API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /tasks:
+    get:
+      operationId: listTasks
+      parameters:
+        - name: opt_fields
+          in: query
+          description: Fields to return in the response.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        gid:
+                          type: string
+                        completed:
+                          type: boolean
+                        assignee:
+                          type: object
+                          properties:
+                            gid:
+                              type: string
+                            name:
+                              type: string
+                        custom_fields:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              gid:
+                                type: string
+                              display_value:
+                                type: string
+`))
+	require.NoError(t, err)
+
+	tasks := parsed.Resources["tasks"].Endpoints["list"]
+	require.Len(t, tasks.Params, 1)
+	assert.Equal(t, spec.ParamPurposeFieldSelector, tasks.Params[0].Purpose)
+	assert.Equal(t, "gid,assignee.gid,completed,custom_fields.gid", tasks.Params[0].FieldSelectorDefault)
+}
+
+func TestMapParametersOnlyMarksQueryFieldSelectors(t *testing.T) {
+	t.Parallel()
+
+	pathItem := &openapi3.PathItem{}
+	op := &openapi3.Operation{
+		Parameters: openapi3.Parameters{
+			{
+				Value: &openapi3.Parameter{
+					Name:        "fields",
+					In:          openapi3.ParameterInPath,
+					Description: "Fields to return in the response.",
+					Required:    true,
+					Schema:      openapi3.NewStringSchema().NewRef(),
+				},
+			},
+			{
+				Value: &openapi3.Parameter{
+					Name:        "opt_fields",
+					In:          openapi3.ParameterInQuery,
+					Description: "Fields to return in the response.",
+					Schema:      openapi3.NewStringSchema().NewRef(),
+				},
+			},
+		},
+	}
+
+	params := mapParameters(pathItem, op)
+	require.Len(t, params, 2)
+
+	byName := make(map[string]spec.Param, len(params))
+	for _, param := range params {
+		byName[param.Name] = param
+	}
+
+	assert.Empty(t, byName["fields"].Purpose, "path params must not become sync query field selectors")
+	assert.Equal(t, spec.ParamPurposeFieldSelector, byName["opt_fields"].Purpose)
+}
+
 func readAICLargeSpec(tb testing.TB) []byte {
 	tb.Helper()
 	data, err := os.ReadFile(filepath.Join("..", "..", "testdata", "openapi", "artic-openapi.json"))

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -66,6 +66,13 @@ type SyncBodyField struct {
 	HasDefault bool
 }
 
+// FieldSelector describes a query param that asks sparse-response APIs to
+// include a richer set of response fields during sync.
+type FieldSelector struct {
+	Name    string
+	Default string
+}
+
 // DiscriminatorMapping routes one discriminator value to the concrete resource
 // whose typed table should receive the item.
 type DiscriminatorMapping struct {
@@ -116,6 +123,8 @@ type SyncableResource struct {
 	// RPC-style list calls.
 	BodyFields []SyncBodyField
 
+	FieldSelector FieldSelector
+
 	// Discriminator routes heterogeneous response items to concrete typed
 	// resources before storage. Empty when the endpoint returns a homogeneous
 	// resource.
@@ -158,6 +167,8 @@ type DependentResource struct {
 
 	// BodyFields mirrors SyncableResource.BodyFields for child sync paths.
 	BodyFields []SyncBodyField
+
+	FieldSelector FieldSelector
 
 	// Discriminator routes heterogeneous dependent-resource response items to
 	// concrete typed resources before storage.
@@ -1120,6 +1131,7 @@ func detectDependentResources(parameterized map[string]parameterizedEntry, synca
 			SinceParam:         entry.meta.SinceParam,
 			SupportsPagination: entry.meta.SupportsPagination,
 			BodyFields:         entry.meta.BodyFields,
+			FieldSelector:      entry.meta.FieldSelector,
 			Discriminator:      entry.meta.Discriminator,
 		})
 	}
@@ -1228,6 +1240,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				SinceParam:         meta.SinceParam,
 				SupportsPagination: meta.SupportsPagination,
 				BodyFields:         meta.BodyFields,
+				FieldSelector:      meta.FieldSelector,
 				Discriminator:      meta.Discriminator,
 				KeyField:           keyField,
 			})
@@ -1310,6 +1323,7 @@ type syncableMeta struct {
 	SinceParam         string
 	SupportsPagination bool
 	BodyFields         []SyncBodyField
+	FieldSelector      FieldSelector
 	Discriminator      DiscriminatorDispatch
 }
 
@@ -1341,6 +1355,7 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		SinceParam:         detectEndpointSinceParam(e.Params),
 		SupportsPagination: endpointSupportsPagination(e),
 		BodyFields:         syncBodyFieldsFromEndpoint(e),
+		FieldSelector:      detectEndpointFieldSelector(e),
 		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
 	}
 }
@@ -1384,6 +1399,21 @@ func detectEndpointSinceParam(params []spec.Param) string {
 		}
 	}
 	return ""
+}
+
+func detectEndpointFieldSelector(endpoint spec.Endpoint) FieldSelector {
+	for _, param := range endpoint.Params {
+		if param.Purpose != spec.ParamPurposeFieldSelector || strings.TrimSpace(param.FieldSelectorDefault) == "" {
+			continue
+		}
+		// Sync applies one field-selector param per endpoint; the spec order
+		// chooses which one wins when an API exposes several.
+		return FieldSelector{
+			Name:    param.WireName(),
+			Default: strings.TrimSpace(param.FieldSelectorDefault),
+		}
+	}
+	return FieldSelector{}
 }
 
 func endpointSupportsPagination(endpoint spec.Endpoint) bool {
@@ -1601,6 +1631,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			SinceParam:         meta.SinceParam,
 			SupportsPagination: meta.SupportsPagination,
 			BodyFields:         meta.BodyFields,
+			FieldSelector:      meta.FieldSelector,
 			Discriminator:      meta.Discriminator,
 		}
 	}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1485,6 +1485,60 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 	assert.Empty(t, byName["users"].SinceParam, "endpoints without a since-like param yield empty SinceParam — the sync template treats this as 'do not send'")
 }
 
+func TestProfileSyncableResourceFieldSelectorPropagation(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "selectors",
+		Types: map[string]spec.TypeDef{
+			"Task": {Fields: []spec.TypeField{
+				{Name: "gid", Type: "string"},
+				{Name: "completed", Type: "bool"},
+				{Name: "assignee", Type: "object"},
+				{Name: "custom_fields", Type: "array"},
+			}},
+		},
+		Resources: map[string]spec.Resource{
+			"tasks": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/tasks",
+						Response: spec.ResponseDef{Type: "array", Item: "Task"},
+						Params: []spec.Param{{
+							Name:                 "opt_fields",
+							Type:                 "string",
+							Purpose:              spec.ParamPurposeFieldSelector,
+							FieldSelectorDefault: "gid,completed,assignee.gid,custom_fields.gid",
+						}},
+					},
+				},
+			},
+			"users": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/users",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := make(map[string]SyncableResource, len(profile.SyncableResources))
+	for _, r := range profile.SyncableResources {
+		byName[r.Name] = r
+	}
+
+	require.Contains(t, byName, "tasks")
+	assert.Equal(t, "opt_fields", byName["tasks"].FieldSelector.Name)
+	assert.Equal(t, "gid,completed,assignee.gid,custom_fields.gid", byName["tasks"].FieldSelector.Default)
+
+	require.Contains(t, byName, "users")
+	assert.Empty(t, byName["users"].FieldSelector.Name)
+	assert.Empty(t, byName["users"].FieldSelector.Default)
+}
+
 // TestProfileDependentResourceSinceParamPropagation mirrors
 // TestProfileSyncableResourceSinceParamPropagation for parameterized child
 // paths so dependent-resource sync gets the same per-endpoint gating as flat

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -49,6 +49,10 @@ const (
 )
 
 const (
+	ParamPurposeFieldSelector = "field_selector"
+)
+
+const (
 	TierAuthTypeNone        = "none"
 	TierAuthTypeAPIKey      = "api_key"
 	TierAuthTypeBearerToken = "bearer_token"
@@ -1498,6 +1502,12 @@ type Param struct {
 	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
 	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
 	Format      string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
+	Purpose     string   `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	// FieldSelectorDefault is a sync-time default for field-selector params
+	// such as opt_fields, fields, expand, include, or select. It stays separate
+	// from Default so generated endpoint commands do not silently change their
+	// own flag defaults when sync needs richer stored rows.
+	FieldSelectorDefault string `yaml:"field_selector_default,omitempty" json:"field_selector_default,omitempty"`
 	// IdentName, when set, overrides Name for Go identifier and CLI flag
 	// derivation (camel/flagName). Name remains the wire-side parameter name
 	// used in URLs, JSON keys, and path substitution. Populated by the


### PR DESCRIPTION
## Summary
- Classifies OpenAPI query field-selector params and derives sync defaults from response schemas.
- Carries selector defaults through the profiler into generated sync code, applying them before user params so overrides still win.
- Adds parser, profiler, and generator coverage for field-selector sync behavior.

Closes #1421

## Tests
- go fmt ./...
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- go test ./...
- scripts/golden.sh verify
- golangci-lint run ./...
