### PR TITLE
fix(cli): score reachable scorer surfaces

### DIFF
--- a/docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md
+++ b/docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md
@@ -1,0 +1,62 @@
+---
+title: "Scorecard scorers must follow reachable command surfaces"
+date: 2026-05-21
+category: logic-errors
+module: internal/pipeline
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Non-REST CLIs score too low when real client, error, output, or sync logic lives in sibling internal packages"
+  - "Dead generic REST scaffolding can look like the only scored surface"
+  - "Re-adding dead scaffold would improve scores without improving the printed CLI"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - scorecard
+  - scorer
+  - non-rest
+  - reachability
+  - dead-code
+  - json-rpc
+---
+
+# Scorecard scorers must follow reachable command surfaces
+
+## Problem
+
+Several scorecard dimensions assumed generated REST scaffolding was the canonical implementation surface. For JSON-RPC or other non-REST CLIs, the real command behavior can live in a sibling package such as `internal/<api>/`, while the generic `internal/client` scaffold is absent or intentionally removed.
+
+## Symptoms
+
+- Error handling, output modes, and sync correctness were under-scored even when a registered command delegated to richer sibling-package code.
+- Renamed sync command files, such as `sync_<api>.go`, missed sync credit when the runtime Cobra mirror made them reachable.
+- Nested Cobra subcommands were invisible when only the parent command's first `Use:` literal was scanned.
+- Broad scans risked rewarding unregistered command files or dead files inside imported sibling packages.
+
+## What Didn't Work
+
+Reading fixed filenames such as `internal/cli/helpers.go`, `internal/client/client.go`, or `internal/cli/sync.go` worked for standard REST prints but contradicted the sanctioned non-REST path. Broadening to all CLI files was also insufficient: it could follow imports from orphan command files and count scoring strings from unreachable sibling-package files.
+
+## Solution
+
+Build scorer evidence from the registered command surface:
+
+- Seed CLI reachability from `root.go`, framework helper files, and constructors reachable through Cobra `AddCommand` calls.
+- Follow child command constructors so subcommands split across files remain visible.
+- Follow internal package imports from reachable files, but include only sibling-package files that define called symbols plus same-package callees.
+- Reuse the local-data signal used by the reimplementation check, including raw `database/sql` access paired with `sql.Open` or `sql.OpenDB`.
+- Run sync correctness and pagination AST checks against the same reachable files used by output and error scoring.
+
+## Why This Works
+
+The scorer now evaluates behavior a user or agent can actually reach. It gives non-REST CLIs credit for their real implementation while preserving the anti-gaming boundary: orphan commands, dead generic scaffolds, and unused sibling-package files do not inflate scores.
+
+## Prevention
+
+When adding scorecard heuristics, prefer registered-command reachability over hardcoded filenames. If a dimension needs paired signals, keep those pairs within the same source unit unless cross-file matching is deliberately justified. Add both positive reachable-package tests and negative dead-code tests so future broadening does not reintroduce scorer inflation.
+
+## Related
+
+- `docs/solutions/logic-errors/scorecard-accuracy-broadened-pattern-matching-2026-03-27.md`
+- `docs/solutions/best-practices/steinberger-scorecard-scoring-architecture-2026-03-27.md`

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -138,9 +138,10 @@ func scoreScorecardDimensions(sc *Scorecard, outputDir, specPath string, verifyR
 }
 
 func scoreInfrastructureDimensions(sc *Scorecard, outputDir string) {
-	sc.Steinberger.OutputModes = scoreOutputModes(outputDir)
+	reachableInternalContent := scorecardReachableInternalContents(outputDir)
+	sc.Steinberger.OutputModes = scoreOutputModesWithSurface(outputDir, reachableInternalContent)
 	sc.Steinberger.Auth = scoreAuth(outputDir)
-	sc.Steinberger.ErrorHandling = scoreErrorHandling(outputDir)
+	sc.Steinberger.ErrorHandling = scoreErrorHandlingFromSurface(reachableInternalContent)
 	sc.Steinberger.TerminalUX = scoreTerminalUX(outputDir)
 	sc.Steinberger.README = scoreREADME(outputDir)
 	sc.Steinberger.Doctor = scoreDoctor(outputDir)
@@ -285,8 +286,11 @@ func (sc *Scorecard) IsDimensionUnscored(name string) bool {
 }
 
 func scoreOutputModes(dir string) int {
+	return scoreOutputModesWithSurface(dir, scorecardReachableInternalContents(dir))
+}
+
+func scoreOutputModesWithSurface(dir string, surfaceContent []string) int {
 	rootContent := readFileContent(filepath.Join(dir, "internal", "cli", "root.go"))
-	helpersContent := readFileContent(filepath.Join(dir, "internal", "cli", "helpers.go"))
 	score := 0
 	// Presence tier (max 5)
 	if strings.Contains(rootContent, `"json"`) {
@@ -305,15 +309,15 @@ func scoreOutputModes(dir string) int {
 		score += 1
 	}
 	// Quality tier: field-aware select (real JSON parsing, not string ops)
-	if strings.Contains(helpersContent, "filterFields") && strings.Contains(helpersContent, "json.Unmarshal") {
+	if containsAllInAny(surfaceContent, "filterFields", "json.Unmarshal") {
 		score += 2
 	}
 	// Quality tier: pagination progress events
-	if strings.Contains(helpersContent, "page_fetch") || strings.Contains(helpersContent, "ndjson") || hasPageProgressStructure(filepath.Join(dir, "internal", "cli")) {
+	if containsAnyInAny(surfaceContent, "page_fetch", "ndjson") || hasPageProgressStructure(filepath.Join(dir, "internal", "cli")) {
 		score += 1
 	}
 	// Quality tier: tabwriter for aligned output
-	if strings.Contains(helpersContent, "tabwriter") {
+	if containsAnyInAny(surfaceContent, "tabwriter") {
 		score += 2
 	}
 	if score > 10 {
@@ -384,34 +388,36 @@ func scoreAuth(dir string) int {
 }
 
 func scoreErrorHandling(dir string) int {
-	helpersContent := readFileContent(filepath.Join(dir, "internal", "cli", "helpers.go"))
-	clientContent := readFileContent(filepath.Join(dir, "internal", "client", "client.go"))
+	return scoreErrorHandlingFromSurface(scorecardReachableInternalContents(dir))
+}
+
+func scoreErrorHandlingFromSurface(surfaceContent []string) int {
 	score := 0
 	// Presence: error hints
-	if strings.Contains(helpersContent, "hint:") || strings.Contains(helpersContent, "Hint:") {
+	if containsAnyInAny(surfaceContent, "hint:", "Hint:") {
 		score += 1
 	}
 	// Presence: at least 3 distinct exit codes
-	exitCount := strings.Count(helpersContent, "code:")
+	exitCount := countAcross(surfaceContent, "code:")
 	if exitCount >= 3 {
 		score += 2
 	} else if exitCount >= 1 {
 		score += 1
 	}
 	// Quality: rate limit handling (429 + retry)
-	if strings.Contains(clientContent, "429") && (strings.Contains(clientContent, "Retry-After") || strings.Contains(clientContent, "backoff") || strings.Contains(clientContent, "retry")) {
+	if containsAllInAny(surfaceContent, "429", "Retry-After") || containsAllInAny(surfaceContent, "429", "backoff") || containsAllInAny(surfaceContent, "429", "retry") {
 		score += 2
 	}
 	// Quality: idempotency (409 = already exists = success)
-	if strings.Contains(helpersContent, "409") && strings.Contains(helpersContent, "already exists") {
+	if containsAllInAny(surfaceContent, "409", "already exists") {
 		score += 2
 	}
 	// Quality: 404 with specific exit code
-	if strings.Contains(helpersContent, "404") {
+	if containsAnyInAny(surfaceContent, "404") {
 		score += 1
 	}
 	// Excellence: actionable suggestions in errors (not just codes)
-	if (strings.Contains(helpersContent, "Run") || strings.Contains(helpersContent, "try")) && strings.Contains(helpersContent, "doctor") {
+	if containsAllInAny(surfaceContent, "Run", "doctor") || containsAllInAny(surfaceContent, "try", "doctor") {
 		score += 2
 	}
 	if score > 10 {
@@ -429,7 +435,7 @@ func scoreTerminalUX(dir string) int {
 		score += 1
 	}
 	// Presence: TTY detection
-	if strings.Contains(helpersContent, "isatty") {
+	if strings.Contains(helpersContent, "isatty") || strings.Contains(helpersContent, "IsTerminal") || strings.Contains(helpersContent, "x/term") {
 		score += 1
 	}
 	// Presence: no-color flag
@@ -669,7 +675,7 @@ func scoreMCPQuality(dir string) int {
 		highlevelCount++
 	}
 	if (strings.Contains(mcpContent, `"sync"`) && strings.Contains(mcpContent, "handleSync")) ||
-		(hasRuntimeMirror && fileExists(filepath.Join(dir, "internal", "cli", "sync.go"))) {
+		(hasRuntimeMirror && hasRegisteredCommandFileWithPrefix(filepath.Join(dir, "internal", "cli"), "sync")) {
 		highlevelCount++
 	}
 	if highlevelCount >= 2 {
@@ -1063,7 +1069,7 @@ func scoreVision(dir string) int {
 	if fileExists(filepath.Join(cliDir, "search.go")) {
 		tier1 += 1.0
 	}
-	if fileExists(filepath.Join(cliDir, "sync.go")) {
+	if hasRegisteredCommandFileWithPrefix(cliDir, "sync") {
 		tier1 += 0.5
 	}
 	if fileExists(filepath.Join(cliDir, "tail.go")) {
@@ -1207,39 +1213,63 @@ func registeredCommandFiles(cliDir string) map[string]bool {
 	scanContent := funcDeclRe.ReplaceAllString(rootContent, "")
 
 	ctorRe := regexp.MustCompile(`\bnew([A-Z][A-Za-z0-9_]*)Cmd\s*\(`)
-	matches := ctorRe.FindAllStringSubmatch(scanContent, -1)
-	if len(matches) == 0 {
+	rootMatches := ctorRe.FindAllStringSubmatch(scanContent, -1)
+	if len(rootMatches) == 0 {
 		return map[string]bool{}
 	}
-	ctors := make(map[string]bool, len(matches))
-	for _, m := range matches {
-		ctors["new"+m[1]+"Cmd"] = true
+	reachableCtors := make(map[string]bool, len(rootMatches))
+	for _, m := range rootMatches {
+		reachableCtors["new"+m[1]+"Cmd"] = true
 	}
 
-	// Walk cli/*.go and map each file to the constructor it defines. Use a
-	// regexp for the declaration site to avoid depending on go/parser for one
-	// lookup (keeps the scorer dependency-free, which matters because it runs
-	// against third-party generated trees).
+	// Walk cli/*.go and map each file to the reachable constructor it defines.
+	// Re-scan newly reachable command files for child AddCommand calls so
+	// subcommands defined outside root.go still count as user-reachable.
 	defRe := regexp.MustCompile(`^func\s+(new[A-Z][A-Za-z0-9_]*Cmd)\s*\(`)
 	entries, err := os.ReadDir(cliDir)
 	if err != nil {
 		return map[string]bool{}
 	}
-	result := make(map[string]bool)
+	fileContent := map[string]string{}
+	fileDefs := map[string][]string{}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
 			continue
 		}
 		content := readFileContent(filepath.Join(cliDir, e.Name()))
+		fileContent[e.Name()] = content
 		for line := range strings.SplitSeq(content, "\n") {
 			sm := defRe.FindStringSubmatch(line)
-			if sm == nil {
+			if sm != nil {
+				fileDefs[e.Name()] = append(fileDefs[e.Name()], sm[1])
+			}
+		}
+	}
+
+	result := make(map[string]bool)
+	for {
+		changed := false
+		for name, defs := range fileDefs {
+			reachable := false
+			for _, def := range defs {
+				if reachableCtors[def] {
+					reachable = true
+					break
+				}
+			}
+			if !reachable || result[name] {
 				continue
 			}
-			if ctors[sm[1]] {
-				result[e.Name()] = true
-				break
+
+			result[name] = true
+			changed = true
+			callScanContent := funcDeclRe.ReplaceAllString(fileContent[name], "")
+			for _, m := range ctorRe.FindAllStringSubmatch(callScanContent, -1) {
+				reachableCtors["new"+m[1]+"Cmd"] = true
 			}
+		}
+		if !changed {
+			break
 		}
 	}
 	return result
@@ -1302,8 +1332,8 @@ func scoreWorkflows(dir string) int {
 
 		content := readFileContent(filepath.Join(cliDir, e.Name()))
 
-		// A command that uses the store is a workflow command (it uses the data layer)
-		if strings.Contains(content, "/store") || strings.Contains(content, "store.Open") || strings.Contains(content, "store.New") {
+		// A command that uses the local data layer is a workflow command.
+		if hasStoreSignal(content) {
 			compoundCommands++
 			continue
 		}
@@ -1387,14 +1417,21 @@ func scoreInsight(dir string) int {
 
 		// Signal 2: file declares a Cobra Use: matching an agent-declared novel feature.
 		if len(novelLeaves) > 0 {
-			if m := cobraUseLeafRe.FindStringSubmatch(content); m != nil && novelLeaves[strings.ToLower(m[1])] {
+			matchedNovelLeaf := false
+			for _, m := range cobraUseLeafRe.FindAllStringSubmatch(content, -1) {
+				if novelLeaves[strings.ToLower(m[1])] {
+					matchedNovelLeaf = true
+					break
+				}
+			}
+			if matchedNovelLeaf {
 				found++
 				continue
 			}
 		}
 
 		// Signal 3: store + SQL aggregation
-		usesStore := strings.Contains(content, "/store") || strings.Contains(content, "store.Open") || strings.Contains(content, "store.New")
+		usesStore := hasStoreSignal(content)
 		rateRe := regexp.MustCompile(`\brate\b|\bRate\b`)
 		hasSQLAgg := strings.Contains(content, "COUNT(") || strings.Contains(content, "SUM(") ||
 			strings.Contains(content, "GROUP BY") || strings.Contains(content, "AVG(") ||
@@ -2229,8 +2266,8 @@ func scoreDataPipelineIntegrity(dir string) int {
 }
 
 func scoreSyncCorrectness(dir string) int {
-	cliDir := filepath.Join(dir, "internal", "cli")
-	content := readAllGoFiles(cliDir)
+	reachableFiles := scorecardReachableInternalFiles(dir)
+	content := readFilesContent(reachableFiles)
 	if content == "" {
 		return 0
 	}
@@ -2245,7 +2282,7 @@ func scoreSyncCorrectness(dir string) int {
 	if strings.Contains(content, "SaveSyncState") {
 		score++
 	}
-	if hasSyncPaginationStructure(cliDir) {
+	if hasSyncPaginationStructureInFiles(reachableFiles) {
 		score += 2
 	}
 	// URL path parameters only count when other sync signals are present,
@@ -2516,16 +2553,13 @@ func uniqueMatches(re *regexp.Regexp, content string) []string {
 
 // readAllGoFiles concatenates the content of all .go files in dir.
 func readAllGoFiles(dir string) string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return ""
-	}
+	return readFilesContent(listGoFiles(dir))
+}
+
+func readFilesContent(paths []string) string {
 	var b strings.Builder
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
-			continue
-		}
-		b.WriteString(readFileContent(filepath.Join(dir, entry.Name())))
+	for _, path := range paths {
+		b.WriteString(readFileContent(path))
 		b.WriteByte('\n')
 	}
 	return b.String()

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -32,6 +32,8 @@ var infraAllFiles = map[string]bool{
 	"tail.go": true, "analytics.go": true,
 }
 
+var actionableDoctorSuggestionRE = regexp.MustCompile(`(?i)\b(run|try)\b.{0,80}\bdoctor\b`)
+
 // Scorecard holds the auto-scored evaluation of a generated CLI against the Steinberger bar.
 type Scorecard struct {
 	APIName            string       `json:"api_name"`
@@ -138,11 +140,12 @@ func scoreScorecardDimensions(sc *Scorecard, outputDir, specPath string, verifyR
 }
 
 func scoreInfrastructureDimensions(sc *Scorecard, outputDir string) {
-	reachableInternalContent := scorecardReachableInternalContents(outputDir)
-	sc.Steinberger.OutputModes = scoreOutputModesWithSurface(outputDir, reachableInternalContent)
+	reachableInternalFiles := scorecardReachableInternalFiles(outputDir)
+	reachableInternalContent := scorecardContentsFromFiles(reachableInternalFiles)
+	sc.Steinberger.OutputModes = scoreOutputModesWithSurface(outputDir, reachableInternalContent, reachableInternalFiles)
 	sc.Steinberger.Auth = scoreAuth(outputDir)
 	sc.Steinberger.ErrorHandling = scoreErrorHandlingFromSurface(reachableInternalContent)
-	sc.Steinberger.TerminalUX = scoreTerminalUX(outputDir)
+	sc.Steinberger.TerminalUX = scoreTerminalUXWithSurface(outputDir, reachableInternalContent)
 	sc.Steinberger.README = scoreREADME(outputDir)
 	sc.Steinberger.Doctor = scoreDoctor(outputDir)
 	sc.Steinberger.AgentNative = scoreAgentNative(outputDir)
@@ -286,10 +289,11 @@ func (sc *Scorecard) IsDimensionUnscored(name string) bool {
 }
 
 func scoreOutputModes(dir string) int {
-	return scoreOutputModesWithSurface(dir, scorecardReachableInternalContents(dir))
+	reachableFiles := scorecardReachableInternalFiles(dir)
+	return scoreOutputModesWithSurface(dir, scorecardContentsFromFiles(reachableFiles), reachableFiles)
 }
 
-func scoreOutputModesWithSurface(dir string, surfaceContent []string) int {
+func scoreOutputModesWithSurface(dir string, surfaceContent []string, surfaceFiles []string) int {
 	rootContent := readFileContent(filepath.Join(dir, "internal", "cli", "root.go"))
 	score := 0
 	// Presence tier (max 5)
@@ -313,7 +317,7 @@ func scoreOutputModesWithSurface(dir string, surfaceContent []string) int {
 		score += 2
 	}
 	// Quality tier: pagination progress events
-	if containsAnyInAny(surfaceContent, "page_fetch", "ndjson") || hasPageProgressStructure(filepath.Join(dir, "internal", "cli")) {
+	if containsAnyInAny(surfaceContent, "page_fetch", "ndjson") || hasPageProgressStructureInFiles(surfaceFiles) {
 		score += 1
 	}
 	// Quality tier: tabwriter for aligned output
@@ -417,7 +421,7 @@ func scoreErrorHandlingFromSurface(surfaceContent []string) int {
 		score += 1
 	}
 	// Excellence: actionable suggestions in errors (not just codes)
-	if containsAllInAny(surfaceContent, "Run", "doctor") || containsAllInAny(surfaceContent, "try", "doctor") {
+	if containsActionableDoctorSuggestion(surfaceContent) {
 		score += 2
 	}
 	if score > 10 {
@@ -426,16 +430,23 @@ func scoreErrorHandlingFromSurface(surfaceContent []string) int {
 	return score
 }
 
+func containsActionableDoctorSuggestion(surfaceContent []string) bool {
+	return slices.ContainsFunc(surfaceContent, actionableDoctorSuggestionRE.MatchString)
+}
+
 func scoreTerminalUX(dir string) int {
-	helpersContent := readFileContent(filepath.Join(dir, "internal", "cli", "helpers.go"))
+	return scoreTerminalUXWithSurface(dir, scorecardReachableInternalContents(dir))
+}
+
+func scoreTerminalUXWithSurface(dir string, surfaceContent []string) int {
 	rootContent := readFileContent(filepath.Join(dir, "internal", "cli", "root.go"))
 	score := 0
 	// Presence: NO_COLOR support
-	if strings.Contains(helpersContent, "NO_COLOR") {
+	if containsAnyInAny(surfaceContent, "NO_COLOR") {
 		score += 1
 	}
 	// Presence: TTY detection
-	if strings.Contains(helpersContent, "isatty") || strings.Contains(helpersContent, "IsTerminal") || strings.Contains(helpersContent, "x/term") {
+	if containsAnyInAny(surfaceContent, "isatty", "IsTerminal", "x/term") {
 		score += 1
 	}
 	// Presence: no-color flag
@@ -443,7 +454,7 @@ func scoreTerminalUX(dir string) int {
 		score += 1
 	}
 	// Quality: tabwriter for aligned columns
-	if strings.Contains(helpersContent, "tabwriter") {
+	if containsAnyInAny(surfaceContent, "tabwriter") {
 		score += 2
 	}
 	// Quality: help text descriptions are meaningful (not just verb names)

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -104,8 +104,482 @@ func newSearchQueryCmd(flags any) *cobra.Command { return &cobra.Command{} }`)
 	}
 }
 
+func TestScoreErrorHandling_UsesReachableSiblingClientPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newExecuteCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error {
+		return odoo.Execute()
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "errors.go"), `package odoo
+func Execute() error { return nil }
+const help = "Hint: Run doctor"
+const typed = "code: auth\ncode: not_found\ncode: rate_limited\n404\n409 already exists\n429 Retry-After retry"
+`)
+
+	if score := scoreErrorHandling(dir); score != 10 {
+		t.Fatalf("expected reachable sibling package to provide full error score, got %d", score)
+	}
+}
+
+func TestScoreErrorHandling_IgnoresUnreachableDeadClientPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newExecuteCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import "github.com/spf13/cobra"
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+const dead = "Hint: Run doctor\ncode: auth\ncode: not_found\ncode: rate_limited\n404\n409 already exists\n429 Retry-After retry"
+`)
+
+	if score := scoreErrorHandling(dir); score != 0 {
+		t.Fatalf("expected unreachable dead client package to score 0, got %d", score)
+	}
+}
+
+func TestScoreErrorHandling_DoesNotPairSignalsAcrossReachableFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newExecuteCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/limits"
+	"example.com/nonrest/internal/retry"
+)
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error {
+		limits.Mark()
+		retry.Mark()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "limits", "limits.go"), `package limits
+func Mark() string { return "429" }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "retry", "retry.go"), `package retry
+func Mark() string { return "Retry-After" }
+`)
+
+	if score := scoreErrorHandling(dir); score != 0 {
+		t.Fatalf("expected split rate-limit signals not to score, got %d", score)
+	}
+}
+
+func TestScoreErrorHandling_IgnoresOrphanCLIImportedSiblingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newLiveCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "live.go"), `package cli
+import "github.com/spf13/cobra"
+func newLiveCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "live", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+}`)
+	writeFile(t, filepath.Join(cliDir, "dead.go"), `package cli
+import "example.com/nonrest/internal/odoo"
+func newDeadCmd(flags any) { _ = odoo.Execute }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "errors.go"), `package odoo
+func Execute() error { return nil }
+const help = "Hint: Run doctor"
+const typed = "code: auth\ncode: not_found\ncode: rate_limited\n404\n409 already exists\n429 Retry-After retry"
+`)
+
+	if score := scoreErrorHandling(dir); score != 0 {
+		t.Fatalf("expected orphan command import not to inflate error score, got %d", score)
+	}
+}
+
+func TestScoreErrorHandling_IgnoresDeadFileInImportedSiblingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newExecuteCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error {
+		return odoo.Execute()
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "execute.go"), `package odoo
+func Execute() error { return nil }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "dead_errors.go"), `package odoo
+const dead = "Hint: Run doctor\ncode: auth\ncode: not_found\ncode: rate_limited\n404\n409 already exists\n429 Retry-After retry"
+`)
+
+	if score := scoreErrorHandling(dir); score != 0 {
+		t.Fatalf("expected dead sibling package file not to inflate error score, got %d", score)
+	}
+}
+
+func TestScoreOutputModes_UsesReachableSiblingFormattingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	_ = "json"
+	_ = "plain"
+	_ = "select"
+	_ = "csv"
+	_ = "quiet"
+	rootCmd.AddCommand(newFormatCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "format.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newFormatCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "format", RunE: func(cmd *cobra.Command, args []string) error {
+		return odoo.Render()
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "format.go"), `package odoo
+import (
+	"encoding/json"
+	"text/tabwriter"
+)
+func Render() error {
+	_ = tabwriter.NewWriter(nil, 0, 0, 0, ' ', 0)
+	var v any
+	_ = json.Unmarshal(nil, &v)
+	return nil
+}
+func filterFields(v any) any { return v }
+`)
+
+	if score := scoreOutputModes(dir); score != 9 {
+		t.Fatalf("expected reachable sibling formatting package to score 9, got %d", score)
+	}
+}
+
+func TestScoreTerminalUX_RecognizesXTermTTYDetection(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func init() { _ = "no-color" }
+`)
+	writeFile(t, filepath.Join(cliDir, "helpers.go"), `package cli
+import "golang.org/x/term"
+func isTerminal(fd int) bool { return term.IsTerminal(fd) }
+const noColor = "NO_COLOR"
+`)
+
+	if score := scoreTerminalUX(dir); score != 3 {
+		t.Fatalf("expected NO_COLOR, no-color flag, and x/term TTY detection to score 3, got %d", score)
+	}
+}
+
+func TestScoreVision_RecognizesRenamedRegisteredSyncCommand(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "store"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newSyncCmd(nil), newSearchCmd(nil), newExportCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "sync_bluray.go"), `package cli
+func newSyncCmd(flags any) {}
+`)
+	writeFile(t, filepath.Join(cliDir, "search.go"), `package cli
+func newSearchCmd(flags any) {}
+`)
+	writeFile(t, filepath.Join(cliDir, "export.go"), `package cli
+func newExportCmd(flags any) {}
+`)
+	writeFile(t, filepath.Join(dir, "internal", "store", "store.go"), `package store
+`)
+
+	if score := scoreVision(dir); score != 4 {
+		t.Fatalf("expected renamed registered sync command to contribute to vision score, got %d", score)
+	}
+}
+
+func TestScoreMCPQuality_RecognizesRenamedRegisteredSyncCommand(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newSyncCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "sync_bluray.go"), `package cli
+func newSyncCmd(flags any) {}
+`)
+	writeFile(t, filepath.Join(dir, "internal", "mcp", "tools.go"), `package mcp
+func RegisterTools() {
+	_ = "context"
+	handleContext()
+	_ = "sql"
+	handleSQL()
+	cobratree.RegisterAll(nil)
+}
+func handleContext() {}
+func handleSQL() {}
+`)
+
+	if score := scoreMCPQuality(dir); score != 7 {
+		t.Fatalf("expected runtime mirror plus renamed sync command to score high-level sync credit, got %d", score)
+	}
+}
+
+func TestScoreWorkflows_RecognizesRawSQLiteDataLayer(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newCatalogCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "catalog.go"), `package cli
+import "database/sql"
+func newCatalogCmd(flags any) {}
+func open() (*sql.DB, error) { return sql.Open("sqlite", "catalog.db") }
+`)
+
+	if score := scoreWorkflows(dir); score != 2 {
+		t.Fatalf("expected raw SQLite-backed command to count as workflow, got %d", score)
+	}
+}
+
+func TestScoreInsight_UsesEveryCobraUseLiteralAndRawSQLiteDataLayer(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, CLIManifestFilename), `{"novel_features":[{"name":"Check watchlist","command":"watch check","description":"Check watchlist drift"}]}`)
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newWatchCmd(nil), newCatalogCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "watch.go"), `package cli
+import "github.com/spf13/cobra"
+func newWatchCmd(flags any) *cobra.Command {
+	cmd := &cobra.Command{Use: "watch"}
+	cmd.AddCommand(&cobra.Command{Use: "check"})
+	return cmd
+}
+`)
+	writeFile(t, filepath.Join(cliDir, "catalog.go"), `package cli
+import "database/sql"
+func newCatalogCmd(flags any) {}
+func open() (*sql.DB, error) { return sql.Open("sqlite", "catalog.db") }
+const q = "SELECT COUNT(*) FROM discs GROUP BY format"
+`)
+
+	if score := scoreInsight(dir); score != 4 {
+		t.Fatalf("expected nested Cobra Use and raw SQLite aggregation to count as two insights, got %d", score)
+	}
+}
+
+func TestScoreInsight_FollowsRegisteredChildCommandFiles(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, CLIManifestFilename), `{"novel_features":[{"name":"Check watchlist","command":"watch check","description":"Check watchlist drift"}]}`)
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newWatchCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "watch.go"), `package cli
+import "github.com/spf13/cobra"
+func newWatchCmd(flags any) *cobra.Command {
+	cmd := &cobra.Command{Use: "watch"}
+	cmd.AddCommand(newCheckCmd(nil))
+	return cmd
+}
+`)
+	writeFile(t, filepath.Join(cliDir, "check.go"), `package cli
+import (
+	"database/sql"
+	"github.com/spf13/cobra"
+)
+func newCheckCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "check"}
+}
+func open() (*sql.DB, error) { return sql.Open("sqlite", "catalog.db") }
+const q = "SELECT COUNT(*) FROM discs GROUP BY format"
+`)
+
+	if score := scoreInsight(dir); score != 2 {
+		t.Fatalf("expected registered child command file to count as insight, got %d", score)
+	}
+}
+
+func TestScoreSyncCorrectness_UsesReachableSiblingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newSyncCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "sync.go"), `package cli
+import "example.com/nonrest/internal/odoo"
+func newSyncCmd(flags any) { _ = odoo.Sync }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "sync.go"), `package odoo
+var defaultSyncResources = []string{"records"}
+func GetSyncState() string { return "" }
+func SaveSyncState(s string) {}
+func Sync() {
+	cursor := "/{record_id}"
+	for {
+		Query(cursor)
+		SaveSyncState(cursor)
+		break
+	}
+}
+func Query(cursor string) {}
+`)
+
+	if score := scoreSyncCorrectness(dir); score != 10 {
+		t.Fatalf("expected reachable sibling sync implementation to score 10, got %d", score)
+	}
+}
+
+func TestScoreSyncCorrectness_IgnoresOrphanCLIImportedSiblingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newLiveCmd(nil)) }
+`)
+	writeFile(t, filepath.Join(cliDir, "live.go"), `package cli
+func newLiveCmd(flags any) {}
+`)
+	writeFile(t, filepath.Join(cliDir, "dead_sync.go"), `package cli
+import "example.com/nonrest/internal/odoo"
+func newDeadSyncCmd(flags any) { _ = odoo.Sync }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "sync.go"), `package odoo
+var defaultSyncResources = []string{"records"}
+func GetSyncState() string { return "" }
+func SaveSyncState(s string) {}
+func Sync() {
+	cursor := "/{record_id}"
+	for {
+		Query(cursor)
+		SaveSyncState(cursor)
+		break
+	}
+}
+func Query(cursor string) {}
+`)
+
+	if score := scoreSyncCorrectness(dir); score != 0 {
+		t.Fatalf("expected orphan sync command import not to inflate score, got %d", score)
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -140,6 +140,42 @@ const typed = "code: auth\ncode: not_found\ncode: rate_limited\n404\n409 already
 	}
 }
 
+func TestScoreErrorHandling_UsesDeclaredPackageNameForDefaultImportAlias(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newExecuteCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/jsonrpc_client"
+)
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error {
+		return client.Execute()
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "jsonrpc_client", "errors.go"), `package client
+func Execute() error { return nil }
+const help = "Hint: Run doctor"
+const typed = "code: auth\ncode: not_found\ncode: rate_limited\n404\n409 already exists\n429 Retry-After retry"
+`)
+
+	if score := scoreErrorHandling(dir); score != 10 {
+		t.Fatalf("expected declared package name alias to reach sibling package, got %d", score)
+	}
+}
+
 func TestScoreErrorHandling_IgnoresUnreachableDeadClientPackage(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
@@ -206,6 +242,31 @@ func Mark() string { return "Retry-After" }
 
 	if score := scoreErrorHandling(dir); score != 0 {
 		t.Fatalf("expected split rate-limit signals not to score, got %d", score)
+	}
+}
+
+func TestScoreErrorHandling_DoesNotTreatDoctorCommandAsActionableHint(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newDoctorCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "doctor.go"), `package cli
+import "github.com/spf13/cobra"
+func newDoctorCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "doctor", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+}`)
+
+	if score := scoreErrorHandling(dir); score != 0 {
+		t.Fatalf("expected doctor command registration not to score as an actionable hint, got %d", score)
 	}
 }
 
@@ -330,6 +391,169 @@ func filterFields(v any) any { return v }
 	}
 }
 
+func TestScoreOutputModes_MergesSymbolsFromMultipleImporters(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	_ = "json"
+	_ = "plain"
+	_ = "select"
+	_ = "csv"
+	_ = "quiet"
+	rootCmd.AddCommand(newExecuteCmd(nil), newFormatCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "execute.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newExecuteCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "execute", RunE: func(cmd *cobra.Command, args []string) error {
+		odoo.Execute()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(cliDir, "format.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newFormatCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "format", RunE: func(cmd *cobra.Command, args []string) error {
+		odoo.Render()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "execute.go"), `package odoo
+func Execute() {}
+`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "render.go"), `package odoo
+import "text/tabwriter"
+func Render() {
+	_ = tabwriter.NewWriter(nil, 0, 0, 0, ' ', 0)
+}
+`)
+
+	if score := scoreOutputModes(dir); score != 7 {
+		t.Fatalf("expected symbols from both odoo importers to contribute to output score, got %d", score)
+	}
+}
+
+func TestScoreOutputModes_ReprocessesPackageWhenLaterSymbolsArrive(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	_ = "json"
+	_ = "plain"
+	_ = "select"
+	_ = "csv"
+	_ = "quiet"
+	rootCmd.AddCommand(newBFirstCmd(nil), newZLaterCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "b_first.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/bpkg"
+)
+func newBFirstCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "b", RunE: func(cmd *cobra.Command, args []string) error {
+		bpkg.List()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(cliDir, "z_later.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/apkg"
+)
+func newZLaterCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "z", RunE: func(cmd *cobra.Command, args []string) error {
+		apkg.Start()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "apkg", "start.go"), `package apkg
+import "example.com/nonrest/internal/bpkg"
+func Start() { bpkg.Render() }
+`)
+	writeFile(t, filepath.Join(dir, "internal", "bpkg", "list.go"), `package bpkg
+func List() {}
+`)
+	writeFile(t, filepath.Join(dir, "internal", "bpkg", "render.go"), `package bpkg
+import "text/tabwriter"
+func Render() {
+	_ = tabwriter.NewWriter(nil, 0, 0, 0, ' ', 0)
+}
+`)
+
+	if score := scoreOutputModes(dir); score != 7 {
+		t.Fatalf("expected later bpkg.Render symbol to reprocess package and score tabwriter, got %d", score)
+	}
+}
+
+func TestScoreOutputModes_UsesReachableSiblingPageProgressStructure(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	_ = "json"
+	_ = "plain"
+	_ = "select"
+	_ = "csv"
+	_ = "quiet"
+	rootCmd.AddCommand(newProgressCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "progress.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/odoo"
+)
+func newProgressCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "progress", RunE: func(cmd *cobra.Command, args []string) error {
+		odoo.Render()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "odoo", "render.go"), `package odoo
+import "fmt"
+func Render() {
+	for page := 1; page < 2; page++ {
+		fmt.Printf("page %d", page)
+	}
+}
+`)
+
+	if score := scoreOutputModes(dir); score != 6 {
+		t.Fatalf("expected reachable sibling page-progress loop to contribute to output score, got %d", score)
+	}
+}
+
 func TestScoreTerminalUX_RecognizesXTermTTYDetection(t *testing.T) {
 	dir := t.TempDir()
 	cliDir := filepath.Join(dir, "internal", "cli")
@@ -348,6 +572,49 @@ const noColor = "NO_COLOR"
 
 	if score := scoreTerminalUX(dir); score != 3 {
 		t.Fatalf("expected NO_COLOR, no-color flag, and x/term TTY detection to score 3, got %d", score)
+	}
+}
+
+func TestScoreTerminalUX_UsesReachableSiblingFormattingPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/nonrest\n\ngo 1.24\n")
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "x"}
+	_ = "no-color"
+	rootCmd.AddCommand(newFormatCmd(nil))
+	return rootCmd
+}`)
+	writeFile(t, filepath.Join(cliDir, "format.go"), `package cli
+import (
+	"github.com/spf13/cobra"
+	"example.com/nonrest/internal/formatting"
+)
+func newFormatCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "format", RunE: func(cmd *cobra.Command, args []string) error {
+		formatting.Render()
+		return nil
+	}}
+}`)
+	writeFile(t, filepath.Join(dir, "internal", "formatting", "format.go"), `package formatting
+import (
+	"text/tabwriter"
+	"golang.org/x/term"
+)
+func Render() {
+	_ = tabwriter.NewWriter(nil, 0, 0, 0, ' ', 0)
+	_ = term.IsTerminal(1)
+}
+`)
+
+	if score := scoreTerminalUX(dir); score != 4 {
+		t.Fatalf("expected reachable sibling TTY and tabwriter signals to score 4, got %d", score)
 	}
 }
 

--- a/internal/pipeline/scorecard_structural.go
+++ b/internal/pipeline/scorecard_structural.go
@@ -18,19 +18,6 @@ type scorecardReachablePackage struct {
 	symbols map[string]bool
 }
 
-func cliGoASTFiles(dir string) []*ast.File {
-	files := listGoFiles(dir)
-	parsed := make([]*ast.File, 0, len(files))
-	for _, path := range files {
-		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-		if err != nil {
-			continue
-		}
-		parsed = append(parsed, file)
-	}
-	return parsed
-}
-
 func hasSyncPaginationStructureInFiles(paths []string) bool {
 	for _, file := range goASTFiles(paths) {
 		var found bool
@@ -99,8 +86,8 @@ func loopLooksLikePaginatedFetch(body *ast.BlockStmt) bool {
 	return hasFetchCall && hasCursorSignal && (hasStateSave || hasExit)
 }
 
-func hasPageProgressStructure(cliDir string) bool {
-	for _, file := range cliGoASTFiles(cliDir) {
+func hasPageProgressStructureInFiles(paths []string) bool {
+	for _, file := range goASTFiles(paths) {
 		var found bool
 		ast.Inspect(file, func(n ast.Node) bool {
 			if found {
@@ -121,7 +108,10 @@ func hasPageProgressStructure(cliDir string) bool {
 }
 
 func scorecardReachableInternalContents(dir string) []string {
-	files := scorecardReachableInternalFiles(dir)
+	return scorecardContentsFromFiles(scorecardReachableInternalFiles(dir))
+}
+
+func scorecardContentsFromFiles(files []string) []string {
 	contents := make([]string, 0, len(files))
 	for _, path := range files {
 		contents = append(contents, readFileContent(path))
@@ -131,36 +121,61 @@ func scorecardReachableInternalContents(dir string) []string {
 
 func scorecardReachableInternalFiles(dir string) []string {
 	var filePaths []string
-	visited := map[string]bool{}
-	queued := map[string]bool{}
+	includedFiles := map[string]bool{}
+	inQueue := map[string]bool{}
+	pendingSymbols := map[string]map[string]bool{}
 	cliDir := filepath.Join(dir, "internal", "cli")
 	queue := []scorecardReachablePackage{{dir: cliDir}}
-	queued[cliDir] = true
+	inQueue[cliDir] = true
 	modulePath := readModulePath(dir)
 
 	for len(queue) > 0 {
 		current := queue[0]
 		queue = queue[1:]
 		pkgDir := current.dir
-		if visited[pkgDir] {
-			continue
-		}
-		visited[pkgDir] = true
+		inQueue[pkgDir] = false
 
-		files := scorecardPackageSeedFiles(dir, pkgDir, current.symbols)
+		files := scorecardPackageSeedFiles(dir, pkgDir, pendingSymbols[pkgDir])
+		depsByDir := map[string]map[string]bool{}
 		for _, path := range files {
-			filePaths = append(filePaths, path)
+			if !includedFiles[path] {
+				includedFiles[path] = true
+				filePaths = append(filePaths, path)
+			}
 
 			for _, dep := range internalImportDeps(dir, modulePath, path) {
-				if !visited[dep.dir] && !queued[dep.dir] {
-					queued[dep.dir] = true
-					queue = append(queue, dep)
-				}
+				mergeSymbols(depsByDir, dep.dir, dep.symbols)
+			}
+		}
+
+		depDirs := make([]string, 0, len(depsByDir))
+		for depDir := range depsByDir {
+			depDirs = append(depDirs, depDir)
+		}
+		slices.Sort(depDirs)
+		for _, depDir := range depDirs {
+			if mergeSymbols(pendingSymbols, depDir, depsByDir[depDir]) && !inQueue[depDir] {
+				inQueue[depDir] = true
+				queue = append(queue, scorecardReachablePackage{dir: depDir})
 			}
 		}
 	}
 
 	return filePaths
+}
+
+func mergeSymbols(target map[string]map[string]bool, dir string, symbols map[string]bool) bool {
+	if target[dir] == nil {
+		target[dir] = map[string]bool{}
+	}
+	changed := false
+	for symbol := range symbols {
+		if !target[dir][symbol] {
+			target[dir][symbol] = true
+			changed = true
+		}
+	}
+	return changed
 }
 
 func scorecardPackageSeedFiles(rootDir, pkgDir string, symbols map[string]bool) []string {
@@ -194,6 +209,15 @@ func scorecardFilesForSymbols(files []string, symbols map[string]bool) []string 
 		wanted[symbol] = true
 	}
 
+	parsedFiles := map[string]*ast.File{}
+	fset := token.NewFileSet()
+	for _, path := range files {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err == nil {
+			parsedFiles[path] = file
+		}
+	}
+
 	included := map[string]bool{}
 	var selected []string
 	for {
@@ -202,8 +226,8 @@ func scorecardFilesForSymbols(files []string, symbols map[string]bool) []string 
 			if included[path] {
 				continue
 			}
-			file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-			if err != nil || !fileDefinesAny(file, wanted) {
+			file := parsedFiles[path]
+			if file == nil || !fileDefinesAny(file, wanted) {
 				continue
 			}
 			included[path] = true
@@ -323,14 +347,15 @@ func internalImportDeps(rootDir, modulePath, goFile string) []scorecardReachable
 		if internalPath == "" {
 			continue
 		}
-		alias := filepath.Base(filepath.FromSlash(internalPath))
+		dir := filepath.Join(rootDir, "internal", filepath.FromSlash(internalPath))
+		alias := defaultImportAlias(dir, internalPath)
 		if spec.Name != nil {
 			alias = spec.Name.Name
 		}
 		if alias == "_" || alias == "." {
 			continue
 		}
-		aliases[alias] = filepath.Join(rootDir, "internal", filepath.FromSlash(internalPath))
+		aliases[alias] = dir
 	}
 	if len(aliases) == 0 {
 		return nil
@@ -362,6 +387,16 @@ func internalImportDeps(rootDir, modulePath, goFile string) []scorecardReachable
 		deps = append(deps, scorecardReachablePackage{dir: dir, symbols: symbols})
 	}
 	return deps
+}
+
+func defaultImportAlias(pkgDir, internalPath string) string {
+	for _, path := range listGoFiles(pkgDir) {
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.PackageClauseOnly)
+		if err == nil && file.Name != nil {
+			return file.Name.Name
+		}
+	}
+	return filepath.Base(filepath.FromSlash(internalPath))
 }
 
 func internalImportPath(modulePath, importPath string) string {

--- a/internal/pipeline/scorecard_structural.go
+++ b/internal/pipeline/scorecard_structural.go
@@ -4,11 +4,19 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
 )
+
+const internalImportDelimiter = "/internal/"
+
+type scorecardReachablePackage struct {
+	dir     string
+	symbols map[string]bool
+}
 
 func cliGoASTFiles(dir string) []*ast.File {
 	files := listGoFiles(dir)
@@ -23,8 +31,8 @@ func cliGoASTFiles(dir string) []*ast.File {
 	return parsed
 }
 
-func hasSyncPaginationStructure(cliDir string) bool {
-	for _, file := range cliGoASTFiles(cliDir) {
+func hasSyncPaginationStructureInFiles(paths []string) bool {
+	for _, file := range goASTFiles(paths) {
 		var found bool
 		ast.Inspect(file, func(n ast.Node) bool {
 			if found {
@@ -42,6 +50,18 @@ func hasSyncPaginationStructure(cliDir string) bool {
 		}
 	}
 	return false
+}
+
+func goASTFiles(paths []string) []*ast.File {
+	parsed := make([]*ast.File, 0, len(paths))
+	for _, path := range paths {
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			continue
+		}
+		parsed = append(parsed, file)
+	}
+	return parsed
 }
 
 func loopLooksLikePaginatedFetch(body *ast.BlockStmt) bool {
@@ -94,6 +114,285 @@ func hasPageProgressStructure(cliDir string) bool {
 			return !found
 		})
 		if found {
+			return true
+		}
+	}
+	return false
+}
+
+func scorecardReachableInternalContents(dir string) []string {
+	files := scorecardReachableInternalFiles(dir)
+	contents := make([]string, 0, len(files))
+	for _, path := range files {
+		contents = append(contents, readFileContent(path))
+	}
+	return contents
+}
+
+func scorecardReachableInternalFiles(dir string) []string {
+	var filePaths []string
+	visited := map[string]bool{}
+	queued := map[string]bool{}
+	cliDir := filepath.Join(dir, "internal", "cli")
+	queue := []scorecardReachablePackage{{dir: cliDir}}
+	queued[cliDir] = true
+	modulePath := readModulePath(dir)
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		pkgDir := current.dir
+		if visited[pkgDir] {
+			continue
+		}
+		visited[pkgDir] = true
+
+		files := scorecardPackageSeedFiles(dir, pkgDir, current.symbols)
+		for _, path := range files {
+			filePaths = append(filePaths, path)
+
+			for _, dep := range internalImportDeps(dir, modulePath, path) {
+				if !visited[dep.dir] && !queued[dep.dir] {
+					queued[dep.dir] = true
+					queue = append(queue, dep)
+				}
+			}
+		}
+	}
+
+	return filePaths
+}
+
+func scorecardPackageSeedFiles(rootDir, pkgDir string, symbols map[string]bool) []string {
+	files := listGoFiles(pkgDir)
+	if pkgDir != filepath.Join(rootDir, "internal", "cli") {
+		return scorecardFilesForSymbols(files, symbols)
+	}
+
+	registeredFiles := registeredCommandFiles(pkgDir)
+	if len(registeredFiles) == 0 {
+		return files
+	}
+
+	filtered := make([]string, 0, len(files))
+	for _, path := range files {
+		name := filepath.Base(path)
+		if infraCoreFiles[name] || registeredFiles[name] {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered
+}
+
+func scorecardFilesForSymbols(files []string, symbols map[string]bool) []string {
+	if len(symbols) == 0 {
+		return files
+	}
+
+	wanted := map[string]bool{}
+	for symbol := range symbols {
+		wanted[symbol] = true
+	}
+
+	included := map[string]bool{}
+	var selected []string
+	for {
+		changed := false
+		for _, path := range files {
+			if included[path] {
+				continue
+			}
+			file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+			if err != nil || !fileDefinesAny(file, wanted) {
+				continue
+			}
+			included[path] = true
+			selected = append(selected, path)
+			changed = true
+			for symbol := range samePackageCallNames(file) {
+				wanted[symbol] = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return selected
+}
+
+func fileDefinesAny(file *ast.File, symbols map[string]bool) bool {
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if symbols[d.Name.Name] {
+				return true
+			}
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					if symbols[s.Name.Name] {
+						return true
+					}
+				case *ast.ValueSpec:
+					for _, name := range s.Names {
+						if symbols[name.Name] {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func samePackageCallNames(file *ast.File) map[string]bool {
+	calls := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			calls[ident.Name] = true
+		}
+		return true
+	})
+	return calls
+}
+
+func containsAnyInAny(contents []string, needles ...string) bool {
+	for _, content := range contents {
+		for _, needle := range needles {
+			if strings.Contains(content, needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsAllInAny(contents []string, needles ...string) bool {
+	for _, content := range contents {
+		if slices.ContainsFunc(needles, func(needle string) bool {
+			return !strings.Contains(content, needle)
+		}) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func countAcross(contents []string, needle string) int {
+	total := 0
+	for _, content := range contents {
+		total += strings.Count(content, needle)
+	}
+	return total
+}
+
+func readModulePath(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if modulePath, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(modulePath)
+		}
+	}
+	return ""
+}
+
+func internalImportDeps(rootDir, modulePath, goFile string) []scorecardReachablePackage {
+	parsed, err := parser.ParseFile(token.NewFileSet(), goFile, nil, 0)
+	if err != nil {
+		return nil
+	}
+
+	aliases := map[string]string{}
+	for _, spec := range parsed.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		internalPath := internalImportPath(modulePath, importPath)
+		if internalPath == "" {
+			continue
+		}
+		alias := filepath.Base(filepath.FromSlash(internalPath))
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		if alias == "_" || alias == "." {
+			continue
+		}
+		aliases[alias] = filepath.Join(rootDir, "internal", filepath.FromSlash(internalPath))
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+
+	symbolsByDir := map[string]map[string]bool{}
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		selector, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		dir := aliases[ident.Name]
+		if dir == "" {
+			return true
+		}
+		if symbolsByDir[dir] == nil {
+			symbolsByDir[dir] = map[string]bool{}
+		}
+		symbolsByDir[dir][selector.Sel.Name] = true
+		return true
+	})
+
+	deps := make([]scorecardReachablePackage, 0, len(symbolsByDir))
+	for dir, symbols := range symbolsByDir {
+		deps = append(deps, scorecardReachablePackage{dir: dir, symbols: symbols})
+	}
+	return deps
+}
+
+func internalImportPath(modulePath, importPath string) string {
+	if modulePath != "" {
+		prefix := modulePath + internalImportDelimiter
+		if internalPath, ok := strings.CutPrefix(importPath, prefix); ok {
+			return internalPath
+		}
+		return ""
+	}
+	if _, internalPath, ok := strings.Cut(importPath, internalImportDelimiter); ok {
+		return internalPath
+	}
+	return ""
+}
+
+func hasRegisteredCommandFileWithPrefix(cliDir, prefix string) bool {
+	registeredFiles := registeredCommandFiles(cliDir)
+	entries, err := os.ReadDir(cliDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if len(registeredFiles) > 0 && !registeredFiles[name] {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(name), prefix) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the scorecard path that under-scored non-REST printed CLIs by scoring the command-reachable implementation surface instead of fixed REST scaffold filenames.

This enables JSON-RPC and other sibling-package CLIs to earn credit for their real error handling, output formatting, sync correctness, renamed sync command files, nested Cobra subcommands, and raw SQLite-backed local-data commands without rewarding dead scaffold or orphan command code.

## What changed

- Build scorer evidence from registered Cobra command files plus reachable internal package symbols.
- Extend sync correctness and pagination checks to the same reachable surface.
- Recognize renamed registered `sync*` files for vision and MCP runtime-mirror sync credit.
- Use all Cobra `Use:` literals and recursive command registration for nested novel-feature commands.
- Reuse the existing local-data signal so raw `database/sql` access counts where the framework store wrapper is not used.
- Add regression coverage for reachable sibling packages, orphan CLI files, dead sibling package files, renamed sync files, nested subcommands, and split scoring signals.
- Document the scorer reachability pattern in `docs/solutions/`.

## Verification

- `go test ./internal/pipeline -run 'TestScore(ErrorHandling|OutputModes|TerminalUX|Vision|MCPQuality|Workflows|Insight|SyncCorrectness)'`
- `go test ./internal/pipeline`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `git diff --check`

`golangci-lint run ./...` was attempted repeatedly, but local runs and the pre-push hook were blocked by concurrent `golangci-lint` processes on the shared machine. CI should still run the lint gate.

Closes #1457
