### PR TITLE
fix(cli): reject placeholder auth credentials

### DIFF
--- a/internal/generator/placeholder_auth_test.go
+++ b/internal/generator/placeholder_auth_test.go
@@ -1,0 +1,385 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientRejectsPlaceholderConfigTokenBeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("placeholder-auth")
+	apiSpec.Auth.Type = "bearer_token"
+	apiSpec.Auth.EnvVars = []string{"PLACEHOLDER_AUTH_TOKEN"}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"placeholder-auth-pp-cli/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestPlaceholderAccessTokenIsRejectedBeforeRequest(t *testing.T) {
+	for _, token := range []string{"<PAT>", "<your-token>", "YOUR_TOKEN_HERE"} {
+		t.Run(token, func(t *testing.T) {
+			var calls int
+			cfg := &config.Config{
+				BaseURL:     "https://api.example.invalid",
+				AccessToken: token,
+				Path:        "/tmp/placeholder-auth-config.toml",
+			}
+			c := New(cfg, time.Second, 0)
+			c.NoCache = true
+			c.HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls++
+				t.Fatal("placeholder auth should be rejected before transport")
+				return nil, nil
+			})}
+
+			_, err := c.Get("/items", nil)
+			if !errors.Is(err, ErrPlaceholderCredential) {
+				t.Fatalf("expected placeholder auth error for %q, got %v", token, err)
+			}
+			if calls != 0 {
+				t.Fatalf("transport called %d time(s), want 0", calls)
+			}
+			msg := err.Error()
+			for _, want := range []string{"placeholder credential", "PLACEHOLDER_AUTH_TOKEN", "auth set-token"} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("placeholder auth error %q missing %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestPlaceholderEnvTokenIsRejectedBeforeRequest(t *testing.T) {
+	t.Setenv("PLACEHOLDER_AUTH_TOKEN", "<PAT>")
+	var calls int
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	cfg.BaseURL = "https://api.example.invalid"
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		t.Fatal("placeholder auth should be rejected before transport")
+		return nil, nil
+	})}
+
+	_, err = c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("transport called %d time(s), want 0", calls)
+	}
+}
+
+func TestPlaceholderAccessTokenFailsBeforeCacheHit(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:     "https://api.example.invalid",
+		AccessToken: "<PAT>",
+		Path:        "/tmp/placeholder-auth-config.toml",
+	}
+	c := New(cfg, time.Second, 0)
+	c.cacheDir = t.TempDir()
+	c.writeCache("/items", nil, []byte(` + "`" + `{"cached":true}` + "`" + `))
+
+	_, err := c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error before cache hit, got %v", err)
+	}
+}
+
+func TestRealTokensReachTransport(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "saved-token",
+			cfg: &config.Config{
+				BaseURL:     "https://api.example.invalid",
+				AccessToken: "real-saved-token",
+			},
+		},
+		{
+			name: "env-token",
+			cfg: &config.Config{
+				BaseURL:              "https://api.example.invalid",
+				PlaceholderAuthToken: "real-env-token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			c := New(tt.cfg, time.Second, 0)
+			c.NoCache = true
+			c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if got := req.Header.Get("Authorization"); !strings.Contains(got, "real-") {
+					t.Fatalf("Authorization = %q, want real token", got)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(` + "`" + `{"ok":true}` + "`" + `)),
+					Request:    req,
+				}, nil
+			})}
+
+			if _, err := c.Get("/items", nil); err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if calls != 1 {
+				t.Fatalf("transport called %d time(s), want 1", calls)
+			}
+		})
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "placeholder_auth_test.go"), []byte(clientTest), 0o644))
+
+	const cliTest = `package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"placeholder-auth-pp-cli/internal/client"
+)
+
+func TestPlaceholderAuthErrorClassifiesAsExitCode4(t *testing.T) {
+	err := classifyAPIError(fmt.Errorf("%w configured in /tmp/config.toml; set a real token with: export PLACEHOLDER_AUTH_TOKEN=<your-token> or placeholder-auth-pp-cli auth set-token <token>", client.ErrPlaceholderCredential), &rootFlags{})
+	if ExitCode(err) != 4 {
+		t.Fatalf("placeholder auth error exit code = %d, want 4", ExitCode(err))
+	}
+	if !errors.Is(err, client.ErrPlaceholderCredential) {
+		t.Fatalf("classified error lost placeholder sentinel: %v", err)
+	}
+	if !strings.Contains(err.Error(), "PLACEHOLDER_AUTH_TOKEN") || !strings.Contains(err.Error(), "auth set-token") {
+		t.Fatalf("classified error lost setup guidance: %v", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "placeholder_auth_test.go"), []byte(cliTest), 0o644))
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(syncSrc), "var firstPlaceholderErr error")
+	require.Contains(t, string(syncSrc), "errors.Is(res.Err, client.ErrPlaceholderCredential)")
+	require.Contains(t, string(syncSrc), "return classifyAPIError(firstPlaceholderErr, flags)")
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "./internal/cli", "-run", "TestPlaceholder", "-count=1")
+}
+
+func TestGeneratedClientRejectsBasicAuthPlaceholdersBeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("placeholder-basic")
+	apiSpec.Auth.Type = "api_key"
+	apiSpec.Auth.Format = "Basic {username}:{password}"
+	apiSpec.Auth.EnvVarSpecs = []spec.AuthEnvVar{
+		{Name: "PLACEHOLDER_BASIC_USERNAME", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+		{Name: "PLACEHOLDER_BASIC_PASSWORD", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"placeholder-basic-pp-cli/internal/config"
+)
+
+func TestBasicAuthPlaceholderIsRejectedBeforeRequest(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:                  "https://api.example.invalid",
+		PlaceholderBasicUsername: "<PAT>",
+		PlaceholderBasicPassword: "secret",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+
+	_, err := c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error, got %v", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "placeholder_basic_test.go"), []byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestBasicAuthPlaceholder", "-count=1")
+}
+
+func TestGeneratedClientRejectsClientCredentialsPlaceholdersBeforeMint(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("placeholder-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "bearer_token",
+		Header: "Authorization",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "PLACEHOLDER_CC_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+			{Name: "PLACEHOLDER_CC_CLIENT_SECRET", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: true},
+		},
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://api.example.invalid/token",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"placeholder-cc-pp-cli/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestClientCredentialsPlaceholdersRejectedBeforeMint(t *testing.T) {
+	var calls int
+	cfg := &config.Config{
+		BaseURL:      "https://api.example.invalid",
+		ClientID:     "<PAT>",
+		ClientSecret: "secret",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		t.Fatal("placeholder client credentials should be rejected before token mint")
+		return nil, nil
+	})}
+
+	_, err := c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("transport called %d time(s), want 0", calls)
+	}
+}
+
+func TestClientCredentialsPlaceholdersRejectedBeforeCacheHit(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:      "https://api.example.invalid",
+		ClientID:     "<PAT>",
+		ClientSecret: "secret",
+	}
+	c := New(cfg, time.Second, 0)
+	c.cacheDir = t.TempDir()
+	c.writeCache("/items", nil, []byte(` + "`" + `{"cached":true}` + "`" + `))
+
+	_, err := c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error before cache hit, got %v", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "placeholder_cc_test.go"), []byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestClientCredentialsPlaceholders", "-count=1")
+}
+
+func TestGeneratedClientRejectsRefreshPlaceholdersBeforeRefresh(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("placeholder-oauth-refresh")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		AuthorizationURL: "https://api.example.invalid/auth",
+		TokenURL:         "https://api.example.invalid/token",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"placeholder-oauth-refresh-pp-cli/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestRefreshPlaceholdersRejectedBeforeRefresh(t *testing.T) {
+	var calls int
+	cfg := &config.Config{
+		BaseURL:      "https://api.example.invalid",
+		AccessToken:  "expired-real-token",
+		RefreshToken: "<PAT>",
+		TokenExpiry:  time.Now().Add(-time.Minute),
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		t.Fatal("placeholder refresh token should be rejected before token refresh")
+		return nil, nil
+	})}
+
+	_, err := c.Get("/items", nil)
+	if !errors.Is(err, ErrPlaceholderCredential) {
+		t.Fatalf("expected placeholder auth error, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("transport called %d time(s), want 0", calls)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "placeholder_refresh_test.go"), []byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestRefreshPlaceholders", "-count=1")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -42,6 +42,11 @@ import (
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+var ErrPlaceholderCredential = errors.New("auth placeholder credential")
+
+{{- end}}
+
 type Client struct {
 	BaseURL    string
 {{- if .BasePath}}
@@ -200,7 +205,11 @@ func (c *Client) authForRequest() (requestAuth, error) {
 	{{- else}}
 		value := tierValue0
 	{{- end}}
-		return requestAuth{Value: value, In: {{printf "%q" $placement}}, Name: {{printf "%q" $name}}}, nil
+		auth := requestAuth{Value: value, In: {{printf "%q" $placement}}, Name: {{printf "%q" $name}}}
+		if authHeaderLooksLikePlaceholderCredential(auth.Value) {
+			return requestAuth{}, authPlaceholderCredentialErrorWithSetup(c.Config, "export {{index $tier.Auth.EnvVars 0}}=<your-token>")
+		}
+		return auth, nil
 	{{- else}}
 		return requestAuth{In: {{printf "%q" $placement}}, Name: {{printf "%q" $name}}}, nil
 	{{- end}}
@@ -437,6 +446,9 @@ func (c *Client) Get(path string, params map[string]string) (json.RawMessage, er
 }
 
 func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(); err != nil {
+		return nil, err
+	}
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		if cached, ok := c.readCache(path, params); ok {
@@ -472,6 +484,34 @@ func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, he
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) validateCachedRequestAuth() error {
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+{{- if .HasTierRouting}}
+	authInfo, err := c.authForRequest()
+	if err != nil {
+		return err
+	}
+	if authHeaderLooksLikePlaceholderCredential(authInfo.Value) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+{{- else}}
+	if c == nil || c.Config == nil {
+		return nil
+	}
+{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+	clientID, clientSecret := resolveClientCredentials(c.Config)
+	if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+{{- end}}
+	if authHeaderLooksLikePlaceholderCredential(c.Config.AuthHeader()) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+{{- end}}
+{{- end}}
+	return nil
 }
 
 func (c *Client) ProbeGet(path string) (int, error) {
@@ -1112,6 +1152,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 		if c.Config != nil {
 {{- range .Auth.AdditionalHeaders}}
 			if v := c.Config.{{resolveEnvVarField .EnvVar.Name}}; v != "" {
+				if authHeaderLooksLikePlaceholderCredential(v) {
+					return nil, 0, authPlaceholderCredentialErrorWithSetup(c.Config, "export {{.EnvVar.Name}}=<your-token>")
+				}
 				req.Header.Set("{{.Header}}", v)
 			}
 {{- end}}
@@ -1525,6 +1568,10 @@ func (c *Client) authHeader() (string, error) {
 		if needsClientCredentialsMint(c.Config) {
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
+				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					c.ccMu.Unlock()
+					return "", authPlaceholderCredentialError(c.Config)
+				}
 				if err := c.mintClientCredentials(clientID, clientSecret); err != nil {
 					c.ccMu.Unlock()
 					return "", err
@@ -1535,13 +1582,89 @@ func (c *Client) authHeader() (string, error) {
 	}
 {{- else if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" {
+		if authHeaderLooksLikePlaceholderCredential(c.Config.AccessToken) || authHeaderLooksLikePlaceholderCredential(c.Config.RefreshToken) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientID) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientSecret) {
+			return "", authPlaceholderCredentialError(c.Config)
+		}
 		if err := c.refreshAccessToken(); err != nil {
 			return "", err
 		}
 	}
 {{- end}}
-	return c.Config.AuthHeader(), nil
+	authHeader := c.Config.AuthHeader()
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+	if authHeaderLooksLikePlaceholderCredential(authHeader) {
+		return "", authPlaceholderCredentialError(c.Config)
+	}
+{{- end}}
+	return authHeader, nil
 }
+
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+
+func authHeaderLooksLikePlaceholderCredential(header string) bool {
+	if scheme, encoded, ok := strings.Cut(strings.TrimSpace(header), " "); ok && strings.EqualFold(scheme, "Basic") {
+		encoded = strings.TrimSpace(encoded)
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err == nil && authHeaderLooksLikePlaceholderCredential(string(decoded)) {
+			return true
+		}
+	}
+	if !strings.Contains(header, "<") && !strings.Contains(header, "YOUR_TOKEN_HERE") && !strings.Contains(header, "your-token") && !strings.Contains(header, "your-key") {
+		return false
+	}
+	for _, field := range strings.Fields(header) {
+		field = strings.Trim(field, `"'`)
+		if idx := strings.LastIndex(field, "="); idx >= 0 {
+			field = field[idx+1:]
+		}
+		if idx := strings.Index(field, ":"); idx >= 0 {
+			if looksLikeCredentialPlaceholder(field[:idx]) || looksLikeCredentialPlaceholder(field[idx+1:]) {
+				return true
+			}
+		}
+		if looksLikeCredentialPlaceholder(field) {
+			return true
+		}
+	}
+	return looksLikeCredentialPlaceholder(header)
+}
+
+func looksLikeCredentialPlaceholder(value string) bool {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	switch value {
+	case "<your-token>", "<your-key>", "<paste-your-key>", "YOUR_TOKEN_HERE", "your-token-here":
+		return true
+	}
+	if len(value) < 3 || value[0] != '<' || value[len(value)-1] != '>' {
+		return false
+	}
+	for _, r := range value[1 : len(value)-1] {
+		if r != '_' && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+func authPlaceholderCredentialError(cfg *config.Config) error {
+{{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
+	return authPlaceholderCredentialErrorWithSetup(cfg, "{{.Name}}-pp-cli auth login or {{.Name}}-pp-cli auth set-token <token>")
+{{- else if eq .Auth.Type "oauth2"}}
+	return authPlaceholderCredentialErrorWithSetup(cfg, "{{.Name}}-pp-cli auth login")
+{{- else}}
+	return authPlaceholderCredentialErrorWithSetup(cfg, "{{- with .Auth.CanonicalEnvVar}}export {{.Name}}=<your-token> or {{end}}{{.Name}}-pp-cli auth set-token <token>")
+{{- end}}
+}
+
+func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) error {
+	location := "config file"
+	if cfg != nil && cfg.Path != "" {
+		location = cfg.Path
+	}
+	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
+}
+
+{{- end}}
 
 {{- if eq .Auth.EffectiveOAuth2Grant "client_credentials"}}
 

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -5,6 +5,9 @@ package cli
 
 import (
 	"encoding/json"
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+	"errors"
+{{- end}}
 	"fmt"
 	"os"
 	"regexp"
@@ -167,12 +170,24 @@ Exit codes & warnings:
 			var errCount int
 			var warnCount int
 			var successCount int
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+			var firstErr error
+			var firstPlaceholderErr error
+{{- end}}
 			for res := range results {
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
+{{- end}}
 				} else if res.Warn != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: warning: %v\n", res.Resource, res.Warn)
@@ -203,6 +218,11 @@ Exit codes & warnings:
 			}
 
 			if errCount > 0 {
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+				if firstPlaceholderErr != nil {
+					return classifyAPIError(firstPlaceholderErr, flags)
+				}
+{{- end}}
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)
 			}
 			if warnCount > 0 && successCount == 0 {
@@ -454,4 +474,3 @@ func parseSinceDuration(s string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("unknown unit %q", matches[2])
 	}
 }
-

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -33,7 +33,7 @@ import (
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
-{{- if .HasDataLayer}}
+{{- if or .HasDataLayer (and .Auth.Type (ne .Auth.Type "none"))}}
 	"{{modulePath}}/internal/client"
 {{- end}}
 	"github.com/spf13/cobra"
@@ -559,6 +559,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
+	case errors.Is(err, client.ErrPlaceholderCredential):
+		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
 		return authErr(fmt.Errorf("%w\nhint: the API rejected the request — this usually means auth is missing or invalid."+
 {{- with $canonicalEnvVar}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -8,6 +8,9 @@ package cli
 
 import (
 	"encoding/json"
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+	"errors"
+{{- end}}
 	"fmt"
 	"net/url"
 	"os"
@@ -21,7 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
-{{- if .HasTierRouting}}
+{{- if or .HasTierRouting (and .Auth.Type (ne .Auth.Type "none"))}}
 	"{{modulePath}}/internal/client"
 {{- end}}
 	"{{modulePath}}/internal/cliutil"
@@ -319,12 +322,24 @@ Resource scoping:
 			var criticalErrCount int
 			var warnCount int
 			var successCount int
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+			var firstErr error
+			var firstPlaceholderErr error
+{{- end}}
 			for res := range results {
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
+{{- end}}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -351,6 +366,14 @@ Resource scoping:
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
+{{- end}}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -393,6 +416,11 @@ Resource scoping:
 			// one-shot sync_warning with reason "exit_policy_default_changed" so
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
+{{- if and .Auth.Type (ne .Auth.Type "none")}}
+			if firstPlaceholderErr != nil {
+				return classifyAPIError(firstPlaceholderErr, flags)
+			}
+{{- end}}
 			if strict && errCount > 0 {
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -482,6 +482,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
+	case errors.Is(err, client.ErrPlaceholderCredential):
+		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
 		return authErr(fmt.Errorf("%w\nhint: the API rejected the request — this usually means auth is missing or invalid."+
 			"\n      Set your API key: export EMBEDDED_PAGED_API_KEY=<your-key>"+

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -27,6 +27,8 @@ import (
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
+var ErrPlaceholderCredential = errors.New("auth placeholder credential")
+
 type Client struct {
 	BaseURL    string
 	Config     *config.Config
@@ -109,6 +111,9 @@ func (c *Client) Get(path string, params map[string]string) (json.RawMessage, er
 }
 
 func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(); err != nil {
+		return nil, err
+	}
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		if cached, ok := c.readCache(path, params); ok {
@@ -144,6 +149,20 @@ func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, he
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) validateCachedRequestAuth() error {
+	if c == nil || c.Config == nil {
+		return nil
+	}
+	clientID, clientSecret := resolveClientCredentials(c.Config)
+	if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+	if authHeaderLooksLikePlaceholderCredential(c.Config.AuthHeader()) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+	return nil
 }
 
 func (c *Client) ProbeGet(path string) (int, error) {
@@ -582,6 +601,10 @@ func (c *Client) authHeader() (string, error) {
 		if needsClientCredentialsMint(c.Config) {
 			clientID, clientSecret := resolveClientCredentials(c.Config)
 			if clientID != "" && clientSecret != "" {
+				if authHeaderLooksLikePlaceholderCredential(clientID) || authHeaderLooksLikePlaceholderCredential(clientSecret) {
+					c.ccMu.Unlock()
+					return "", authPlaceholderCredentialError(c.Config)
+				}
 				if err := c.mintClientCredentials(clientID, clientSecret); err != nil {
 					c.ccMu.Unlock()
 					return "", err
@@ -590,7 +613,68 @@ func (c *Client) authHeader() (string, error) {
 		}
 		c.ccMu.Unlock()
 	}
-	return c.Config.AuthHeader(), nil
+	authHeader := c.Config.AuthHeader()
+	if authHeaderLooksLikePlaceholderCredential(authHeader) {
+		return "", authPlaceholderCredentialError(c.Config)
+	}
+	return authHeader, nil
+}
+
+func authHeaderLooksLikePlaceholderCredential(header string) bool {
+	if scheme, encoded, ok := strings.Cut(strings.TrimSpace(header), " "); ok && strings.EqualFold(scheme, "Basic") {
+		encoded = strings.TrimSpace(encoded)
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err == nil && authHeaderLooksLikePlaceholderCredential(string(decoded)) {
+			return true
+		}
+	}
+	if !strings.Contains(header, "<") && !strings.Contains(header, "YOUR_TOKEN_HERE") && !strings.Contains(header, "your-token") && !strings.Contains(header, "your-key") {
+		return false
+	}
+	for _, field := range strings.Fields(header) {
+		field = strings.Trim(field, `"'`)
+		if idx := strings.LastIndex(field, "="); idx >= 0 {
+			field = field[idx+1:]
+		}
+		if idx := strings.Index(field, ":"); idx >= 0 {
+			if looksLikeCredentialPlaceholder(field[:idx]) || looksLikeCredentialPlaceholder(field[idx+1:]) {
+				return true
+			}
+		}
+		if looksLikeCredentialPlaceholder(field) {
+			return true
+		}
+	}
+	return looksLikeCredentialPlaceholder(header)
+}
+
+func looksLikeCredentialPlaceholder(value string) bool {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	switch value {
+	case "<your-token>", "<your-key>", "<paste-your-key>", "YOUR_TOKEN_HERE", "your-token-here":
+		return true
+	}
+	if len(value) < 3 || value[0] != '<' || value[len(value)-1] != '>' {
+		return false
+	}
+	for _, r := range value[1 : len(value)-1] {
+		if r != '_' && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+func authPlaceholderCredentialError(cfg *config.Config) error {
+	return authPlaceholderCredentialErrorWithSetup(cfg, "printing-press-oauth2-pp-cli auth login or printing-press-oauth2-pp-cli auth set-token <token>")
+}
+
+func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) error {
+	location := "config file"
+	if cfg != nil && cfg.Path != "" {
+		location = cfg.Path
+	}
+	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
 }
 
 func needsClientCredentialsMint(cfg *config.Config) bool {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -481,6 +481,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
+	case errors.Is(err, client.ErrPlaceholderCredential):
+		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
 		return authErr(fmt.Errorf("%w\nhint: the API rejected the request — this usually means auth is missing or invalid."+
 			"\n      Set your API key: export RICH_AUTH_API_KEY=<your-key>"+

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -482,6 +482,8 @@ func classifyAPIError(err error, flags *rootFlags) error {
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified
+	case errors.Is(err, client.ErrPlaceholderCredential):
+		return authErr(err)
 	case strings.Contains(msg, "HTTP 400") && cliutil.LooksLikeAuthError(msg):
 		return authErr(fmt.Errorf("%w\nhint: the API rejected the request — this usually means auth is missing or invalid."+
 			"\n      Set your API key: export PRINTING_PRESS_GOLDEN_API_KEY=<your-key>"+

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -5,10 +5,12 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	"net/url"
 	"os"
+	"printing-press-golden-pp-cli/internal/client"
 	"printing-press-golden-pp-cli/internal/cliutil"
 	"printing-press-golden-pp-cli/internal/store"
 	"regexp"
@@ -228,12 +230,20 @@ Resource scoping:
 			var criticalErrCount int
 			var warnCount int
 			var successCount int
+			var firstErr error
+			var firstPlaceholderErr error
 			for res := range results {
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -258,6 +268,12 @@ Resource scoping:
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -299,6 +315,9 @@ Resource scoping:
 			// one-shot sync_warning with reason "exit_policy_default_changed" so
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
+			if firstPlaceholderErr != nil {
+				return classifyAPIError(firstPlaceholderErr, flags)
+			}
 			if strict && errCount > 0 {
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -26,6 +26,8 @@ import (
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
+var ErrPlaceholderCredential = errors.New("auth placeholder credential")
+
 type Client struct {
 	BaseURL    string
 	Config     *config.Config
@@ -103,6 +105,9 @@ func (c *Client) Get(path string, params map[string]string) (json.RawMessage, er
 }
 
 func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(); err != nil {
+		return nil, err
+	}
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		if cached, ok := c.readCache(path, params); ok {
@@ -138,6 +143,16 @@ func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, he
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) validateCachedRequestAuth() error {
+	if c == nil || c.Config == nil {
+		return nil
+	}
+	if authHeaderLooksLikePlaceholderCredential(c.Config.AuthHeader()) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+	return nil
 }
 
 func (c *Client) ProbeGet(path string) (int, error) {
@@ -661,7 +676,68 @@ func (c *Client) authHeader() (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-	return c.Config.AuthHeader(), nil
+	authHeader := c.Config.AuthHeader()
+	if authHeaderLooksLikePlaceholderCredential(authHeader) {
+		return "", authPlaceholderCredentialError(c.Config)
+	}
+	return authHeader, nil
+}
+
+func authHeaderLooksLikePlaceholderCredential(header string) bool {
+	if scheme, encoded, ok := strings.Cut(strings.TrimSpace(header), " "); ok && strings.EqualFold(scheme, "Basic") {
+		encoded = strings.TrimSpace(encoded)
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err == nil && authHeaderLooksLikePlaceholderCredential(string(decoded)) {
+			return true
+		}
+	}
+	if !strings.Contains(header, "<") && !strings.Contains(header, "YOUR_TOKEN_HERE") && !strings.Contains(header, "your-token") && !strings.Contains(header, "your-key") {
+		return false
+	}
+	for _, field := range strings.Fields(header) {
+		field = strings.Trim(field, `"'`)
+		if idx := strings.LastIndex(field, "="); idx >= 0 {
+			field = field[idx+1:]
+		}
+		if idx := strings.Index(field, ":"); idx >= 0 {
+			if looksLikeCredentialPlaceholder(field[:idx]) || looksLikeCredentialPlaceholder(field[idx+1:]) {
+				return true
+			}
+		}
+		if looksLikeCredentialPlaceholder(field) {
+			return true
+		}
+	}
+	return looksLikeCredentialPlaceholder(header)
+}
+
+func looksLikeCredentialPlaceholder(value string) bool {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	switch value {
+	case "<your-token>", "<your-key>", "<paste-your-key>", "YOUR_TOKEN_HERE", "your-token-here":
+		return true
+	}
+	if len(value) < 3 || value[0] != '<' || value[len(value)-1] != '>' {
+		return false
+	}
+	for _, r := range value[1 : len(value)-1] {
+		if r != '_' && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+func authPlaceholderCredentialError(cfg *config.Config) error {
+	return authPlaceholderCredentialErrorWithSetup(cfg, "export PRINTING_PRESS_GOLDEN_API_KEY=<your-token> or printing-press-golden-pp-cli auth set-token <token>")
+}
+
+func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) error {
+	location := "config file"
+	if cfg != nil && cfg.Path != "" {
+		location = cfg.Path
+	}
+	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
 }
 
 // binaryResponseEnvelope wraps a non-textual success body so it survives the

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync-walker-golden-pp-cli/internal/client"
 	"sync-walker-golden-pp-cli/internal/cliutil"
 	"sync-walker-golden-pp-cli/internal/store"
 	"sync/atomic"
@@ -228,12 +230,20 @@ Resource scoping:
 			var criticalErrCount int
 			var warnCount int
 			var successCount int
+			var firstErr error
+			var firstPlaceholderErr error
 			for res := range results {
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -258,6 +268,12 @@ Resource scoping:
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -299,6 +315,9 @@ Resource scoping:
 			// one-shot sync_warning with reason "exit_policy_default_changed" so
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
+			if firstPlaceholderErr != nil {
+				return classifyAPIError(firstPlaceholderErr, flags)
+			}
 			if strict && errCount > 0 {
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	"net/url"
@@ -226,12 +227,20 @@ Resource scoping:
 			var criticalErrCount int
 			var warnCount int
 			var successCount int
+			var firstErr error
+			var firstPlaceholderErr error
 			for res := range results {
 				if res.Err != nil {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "  %s: error: %v\n", res.Resource, res.Err)
 					}
 					errCount++
+					if firstErr == nil {
+						firstErr = res.Err
+					}
+					if firstPlaceholderErr == nil && errors.Is(res.Err, client.ErrPlaceholderCredential) {
+						firstPlaceholderErr = res.Err
+					}
 					if criticalResources[res.Resource] {
 						criticalErrCount++
 					}
@@ -273,6 +282,9 @@ Resource scoping:
 			// one-shot sync_warning with reason "exit_policy_default_changed" so
 			// CI scripts that depend on $? != 0 can discover the contract change
 			// without reading the CHANGELOG.
+			if firstPlaceholderErr != nil {
+				return classifyAPIError(firstPlaceholderErr, flags)
+			}
 			if strict && errCount > 0 {
 				return fmt.Errorf("%d resource(s) failed to sync", errCount)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -25,6 +25,8 @@ import (
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
+var ErrPlaceholderCredential = errors.New("auth placeholder credential")
+
 type Client struct {
 	BaseURL     string
 	Config      *config.Config
@@ -100,7 +102,11 @@ func (c *Client) authForRequest() (requestAuth, error) {
 			"enterprise_token":      tierValue0,
 			"TIER_ENTERPRISE_TOKEN": tierValue0,
 		})
-		return requestAuth{Value: value, In: "header", Name: "Authorization"}, nil
+		auth := requestAuth{Value: value, In: "header", Name: "Authorization"}
+		if authHeaderLooksLikePlaceholderCredential(auth.Value) {
+			return requestAuth{}, authPlaceholderCredentialErrorWithSetup(c.Config, "export TIER_ENTERPRISE_TOKEN=<your-token>")
+		}
+		return auth, nil
 	case "free":
 		return requestAuth{}, nil
 	case "paid":
@@ -109,7 +115,11 @@ func (c *Client) authForRequest() (requestAuth, error) {
 			return requestAuth{In: "query", Name: "api_key"}, nil
 		}
 		value := tierValue0
-		return requestAuth{Value: value, In: "query", Name: "api_key"}, nil
+		auth := requestAuth{Value: value, In: "query", Name: "api_key"}
+		if authHeaderLooksLikePlaceholderCredential(auth.Value) {
+			return requestAuth{}, authPlaceholderCredentialErrorWithSetup(c.Config, "export TIER_PAID_KEY=<your-token>")
+		}
+		return auth, nil
 	default:
 		value, err := c.authHeader()
 		if err != nil {
@@ -191,6 +201,9 @@ func (c *Client) Get(path string, params map[string]string) (json.RawMessage, er
 }
 
 func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(); err != nil {
+		return nil, err
+	}
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		if cached, ok := c.readCache(path, params); ok {
@@ -226,6 +239,17 @@ func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, he
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) validateCachedRequestAuth() error {
+	authInfo, err := c.authForRequest()
+	if err != nil {
+		return err
+	}
+	if authHeaderLooksLikePlaceholderCredential(authInfo.Value) {
+		return authPlaceholderCredentialError(c.Config)
+	}
+	return nil
 }
 
 func (c *Client) ProbeGet(path string) (int, error) {
@@ -669,7 +693,68 @@ func (c *Client) authHeader() (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
-	return c.Config.AuthHeader(), nil
+	authHeader := c.Config.AuthHeader()
+	if authHeaderLooksLikePlaceholderCredential(authHeader) {
+		return "", authPlaceholderCredentialError(c.Config)
+	}
+	return authHeader, nil
+}
+
+func authHeaderLooksLikePlaceholderCredential(header string) bool {
+	if scheme, encoded, ok := strings.Cut(strings.TrimSpace(header), " "); ok && strings.EqualFold(scheme, "Basic") {
+		encoded = strings.TrimSpace(encoded)
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err == nil && authHeaderLooksLikePlaceholderCredential(string(decoded)) {
+			return true
+		}
+	}
+	if !strings.Contains(header, "<") && !strings.Contains(header, "YOUR_TOKEN_HERE") && !strings.Contains(header, "your-token") && !strings.Contains(header, "your-key") {
+		return false
+	}
+	for _, field := range strings.Fields(header) {
+		field = strings.Trim(field, `"'`)
+		if idx := strings.LastIndex(field, "="); idx >= 0 {
+			field = field[idx+1:]
+		}
+		if idx := strings.Index(field, ":"); idx >= 0 {
+			if looksLikeCredentialPlaceholder(field[:idx]) || looksLikeCredentialPlaceholder(field[idx+1:]) {
+				return true
+			}
+		}
+		if looksLikeCredentialPlaceholder(field) {
+			return true
+		}
+	}
+	return looksLikeCredentialPlaceholder(header)
+}
+
+func looksLikeCredentialPlaceholder(value string) bool {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	switch value {
+	case "<your-token>", "<your-key>", "<paste-your-key>", "YOUR_TOKEN_HERE", "your-token-here":
+		return true
+	}
+	if len(value) < 3 || value[0] != '<' || value[len(value)-1] != '>' {
+		return false
+	}
+	for _, r := range value[1 : len(value)-1] {
+		if r != '_' && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+func authPlaceholderCredentialError(cfg *config.Config) error {
+	return authPlaceholderCredentialErrorWithSetup(cfg, "export TIER_GLOBAL_TOKEN=<your-token> or tier-routing-golden-pp-cli auth set-token <token>")
+}
+
+func authPlaceholderCredentialErrorWithSetup(cfg *config.Config, setup string) error {
+	location := "config file"
+	if cfg != nil && cfg.Path != "" {
+		location = cfg.Path
+	}
+	return fmt.Errorf("%w configured in %s; set a real token with: %s", ErrPlaceholderCredential, location, setup)
 }
 
 // binaryResponseEnvelope wraps a non-textual success body so it survives the


### PR DESCRIPTION
## Summary
- Reject generated auth placeholders before any HTTP transport, token mint, refresh, cache return, or sync aggregate path can hide them
- Preserve auth exit code 4 by classifying `client.ErrPlaceholderCredential` in endpoint and sync paths
- Add generated-CLI regressions for saved/env bearer tokens, real token negatives, Basic auth, OAuth client credentials, OAuth refresh tokens, cached GETs, and sync classification; update goldens

Closes #1423

## Verification
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator -run 'TestGeneratedClientRejects' -count=1`
- `go test ./internal/generator`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run --allow-parallel-runners ./...`
