### PR TITLE
fix(cli): thread generated client context

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -52,7 +52,7 @@ func TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars(t *testing.T) {
 	require.NoError(t, err)
 	clientContent := string(clientSrc)
 	verifyIdx := strings.Index(clientContent, `cliutil.IsVerifyEnv()`)
-	mintIdx := strings.Index(clientContent, `c.mintClientCredentials(clientID, clientSecret)`)
+	mintIdx := strings.Index(clientContent, `c.mintClientCredentials(ctx, clientID, clientSecret)`)
 	require.NotEqual(t, -1, verifyIdx, "mock verification should short-circuit before token minting")
 	require.NotEqual(t, -1, mintIdx, "client_credentials mint path should still be emitted")
 	assert.Less(t, verifyIdx, mintIdx, "mock verification must not dial the real token endpoint")

--- a/internal/generator/auth_oauth_url_override_test.go
+++ b/internal/generator/auth_oauth_url_override_test.go
@@ -65,6 +65,10 @@ func TestOAuth2URLs_RuntimeOverrideEmittedForAuthCodeGrant(t *testing.T) {
 	client := string(clientSrc)
 	require.Contains(t, client, "tokenURL := c.Config.TokenURL",
 		"refreshAccessToken must read c.Config.TokenURL before falling back to spec default")
+	require.Contains(t, client, "func (c *Client) refreshAccessToken(ctx context.Context) error",
+		"refreshAccessToken must accept the caller context")
+	require.Contains(t, client, "http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))",
+		"refreshAccessToken must attach the caller context to the token request")
 }
 
 func TestOAuth2URLs_RuntimeOverrideEmittedForClientCredentialsGrant(t *testing.T) {
@@ -103,6 +107,10 @@ func TestOAuth2URLs_RuntimeOverrideEmittedForClientCredentialsGrant(t *testing.T
 	client := string(clientSrc)
 	require.Contains(t, client, "tokenURL = c.Config.TokenURL",
 		"mintClientCredentials must read c.Config.TokenURL via the c.Config != nil guard")
+	require.Contains(t, client, "func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error",
+		"mintClientCredentials must accept the caller context")
+	require.Contains(t, client, "http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))",
+		"mintClientCredentials must attach the caller context to the token request")
 
 	// Pin the auto-refresh expiry guard: without it a server returning
 	// expires_in: 0 makes every request re-trigger mintClientCredentials in

--- a/internal/generator/auth_status_test.go
+++ b/internal/generator/auth_status_test.go
@@ -29,7 +29,7 @@ func TestDoctorWithoutVerifyPathDoesNotClaimCredentialsValid(t *testing.T) {
 	// Both probe branches (VerifyPath and VerifyQuery) emit `report["credentials"] = "valid"`
 	// when the probe succeeds; anchor on the verify-path-shaped invocation so this
 	// assertion stays specific to "no REST probe ran" rather than "the literal `valid` never appears."
-	require.NotContains(t, src, `c.GetWithHeaders(verifyPath`,
+	require.NotContains(t, src, `c.GetWithHeaders(cmd.Context(), verifyPath`,
 		"without auth.verify_path, doctor must not emit a REST verification call")
 	require.NotContains(t, src, "but auth was accepted",
 		"without auth.verify_path, non-auth HTTP statuses do not prove the API accepted the credentials")

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -59,7 +59,7 @@ func TestGenerateBinaryPaginatedPromotedThreadsHeader(t *testing.T) {
 		"binary paginated promoted must declare headerOverrides")
 	assert.Contains(t, endpointSrc, `"X-Printing-Press-Binary-Response": "true",`,
 		"binary paginated promoted must include the binary sentinel")
-	assert.Contains(t, endpointSrc, `paginatedGet(c, path, map[string]string{`,
+	assert.Contains(t, endpointSrc, `paginatedGet(cmd.Context(), c, path, map[string]string{`,
 		"non-HasStore pagination must use paginatedGet")
 	assert.NotContains(t, endpointSrc, `}, nil, flagAll,`,
 		"paginated binary endpoint must pass headerOverrides, not nil")
@@ -137,6 +137,6 @@ func TestGenerateBinaryMCPToolsThreadHeaderOverrides(t *testing.T) {
 		"typed MCP tools must carry per-endpoint header overrides")
 	assert.Contains(t, mcpSrc, `headers[client.BinaryResponseHeader] = "true"`,
 		"typed MCP tools must still add the binary sentinel")
-	assert.Contains(t, mcpSrc, `data, err = c.GetWithHeaders(path, params, headers)`,
+	assert.Contains(t, mcpSrc, `data, err = c.GetWithHeaders(ctx, path, params, headers)`,
 		"typed MCP tools must dispatch through WithHeaders when headers are present")
 }

--- a/internal/generator/client_context_test.go
+++ b/internal/generator/client_context_test.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientThreadsCallContextThroughHTTPRequestsAndRetryWaits(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("client-context")
+	outputDir := filepath.Join(t.TempDir(), "client-context-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	emitted := string(src)
+
+	assert.Contains(t, emitted, `"context"`,
+		"client.go should import context for per-call cancellation")
+	assert.Contains(t, emitted, "func sleepContext(ctx context.Context, wait time.Duration) error",
+		"client.go should emit a context-aware retry sleep helper")
+
+	for _, signature := range []string{
+		"func (c *Client) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error)",
+		"func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)",
+		"func (c *Client) Post(ctx context.Context, path string, body any) (json.RawMessage, int, error)",
+		"func (c *Client) DeleteWithParams(ctx context.Context, path string, params map[string]string) (json.RawMessage, int, error)",
+		"func (c *Client) Put(ctx context.Context, path string, body any) (json.RawMessage, int, error)",
+		"func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error)",
+	} {
+		assert.Contains(t, emitted, signature)
+	}
+
+	assert.Contains(t, emitted, "func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error)")
+	assert.Contains(t, emitted, "func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error)")
+	assert.Contains(t, emitted, "func (c *Client) doInternal(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error)")
+
+	doStart := strings.Index(emitted, "func (c *Client) doInternal(")
+	require.NotEqual(t, -1, doStart, "client.go must contain Client.doInternal function")
+	doRest := emitted[doStart:]
+	nextFunc := strings.Index(doRest[1:], "\nfunc ")
+	require.NotEqual(t, -1, nextFunc, "client.go should have at least one func after doInternal")
+	doBody := doRest[:nextFunc+1]
+
+	assert.Contains(t, doBody, "http.NewRequestWithContext(ctx, method, targetURL, bodyReader)",
+		"regular client requests should use the caller's context")
+	assert.Contains(t, doBody, "if ctxErr := ctx.Err(); ctxErr != nil {\n\t\t\t\treturn nil, 0, ctxErr\n\t\t\t}",
+		"request cancellation should not burn through retry attempts")
+	assert.Contains(t, doBody, "if err := sleepContext(ctx, wait); err != nil {\n\t\t\t\treturn nil, 0, err\n\t\t\t}",
+		"retry sleeps should return promptly when the caller context is cancelled")
+	assert.NotContains(t, doBody, "http.NewRequest(method, targetURL, bodyReader)")
+	assert.NotContains(t, doBody, "time.Sleep(wait)")
+}

--- a/internal/generator/client_invalidate_cache_test.go
+++ b/internal/generator/client_invalidate_cache_test.go
@@ -63,9 +63,9 @@ func TestGenerateEmitsInvalidateCacheSymmetry(t *testing.T) {
 	// the cache-invalidation call site stays single. A future edit that
 	// inlines do()'s implementation back into do() would silently move
 	// the call out of doInternal — pin the wrapper shape here too.
-	assert.Contains(t, clientGo, "func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(method, path, params, body, headerOverrides, false)\n}",
+	assert.Contains(t, clientGo, "func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(ctx, method, path, params, body, headerOverrides, false)\n}",
 		"Client.do must be a thin wrapper delegating to doInternal(..., false)")
-	assert.Contains(t, clientGo, "func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(method, path, params, body, headerOverrides, true)\n}",
+	assert.Contains(t, clientGo, "func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(ctx, method, path, params, body, headerOverrides, true)\n}",
 		"Client.doRead must be a thin wrapper delegating to doInternal(..., true)")
 
 	// Prong 3: writeCache must still be present (asymmetry diagnostic

--- a/internal/generator/client_redirect_auth_test.go
+++ b/internal/generator/client_redirect_auth_test.go
@@ -32,8 +32,8 @@ func TestClientCheckRedirectReappliesAuth(t *testing.T) {
 			"CheckRedirect must cap depth at 10 to match Go's default policy")
 		require.Contains(t, closure, `return errors.New("stopped after 10 redirects")`,
 			"depth cap must return a plain error so Do() propagates it; ErrUseLastResponse would silently surface the 3xx body as a successful response")
-		require.Contains(t, closure, `c.authHeader()`,
-			"CheckRedirect must call c.authHeader() so nonce-bound schemes get a fresh signature")
+		require.Contains(t, closure, `c.authHeader(req.Context())`,
+			"CheckRedirect must call c.authHeader with the redirect request context so nonce-bound schemes get a fresh cancellable signature")
 		require.Contains(t, closure, `req.Header.Set("Authorization", h)`,
 			"bearer auth must re-set Authorization on redirect to refresh nonce-bound headers")
 		require.Contains(t, closure, "req.URL.Host == via[0].URL.Host",

--- a/internal/generator/client_refresh_token_gate_test.go
+++ b/internal/generator/client_refresh_token_gate_test.go
@@ -90,8 +90,8 @@ func TestRefreshAccessToken_GatedByTokenURL(t *testing.T) {
 
 			clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 
-			methodPresent := strings.Contains(clientSrc, "func (c *Client) refreshAccessToken()")
-			callPresent := strings.Contains(clientSrc, "c.refreshAccessToken()")
+			methodPresent := strings.Contains(clientSrc, "func (c *Client) refreshAccessToken(ctx context.Context)")
+			callPresent := strings.Contains(clientSrc, "c.refreshAccessToken(ctx)")
 			assert.Equal(t, tt.want, methodPresent,
 				"refreshAccessToken method definition emission must follow Auth.TokenURL non-empty")
 			assert.Equal(t, tt.want, callPresent,

--- a/internal/generator/client_verify_short_circuit_test.go
+++ b/internal/generator/client_verify_short_circuit_test.go
@@ -82,9 +82,9 @@ func TestClient_VerifyShortCircuit(t *testing.T) {
 	// do() and doRead() must both be thin wrappers around doInternal() so
 	// the gate-check site stays single. A future edit that inlines the
 	// gate into do() would split the source of truth and could drift.
-	assert.Contains(t, emitted, "func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(method, path, params, body, headerOverrides, false)\n}",
+	assert.Contains(t, emitted, "func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(ctx, method, path, params, body, headerOverrides, false)\n}",
 		"do() must be a thin wrapper passing readOnlyIntent=false to doInternal()")
-	assert.Contains(t, emitted, "func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(method, path, params, body, headerOverrides, true)\n}",
+	assert.Contains(t, emitted, "func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {\n\treturn c.doInternal(ctx, method, path, params, body, headerOverrides, true)\n}",
 		"doRead() must be a thin wrapper passing readOnlyIntent=true to doInternal()")
 
 	// Read-only POST surface (GraphQL queries, RPC reads, search-by-POST)
@@ -95,8 +95,8 @@ func TestClient_VerifyShortCircuit(t *testing.T) {
 		"client.go should expose PostQueryWithParams for read-only POST operations")
 	assert.Contains(t, emitted, "func (c *Client) PostQueryWithParamsAndHeaders(",
 		"client.go should expose PostQueryWithParamsAndHeaders for read-only POST operations")
-	assert.Contains(t, emitted, `return c.doRead("POST", path, params, body, nil)`,
+	assert.Contains(t, emitted, `return c.doRead(ctx, "POST", path, params, body, nil)`,
 		"PostQueryWithParams must delegate to doRead so the verify-mode gate is bypassed")
-	assert.Contains(t, emitted, `return c.doRead("POST", path, params, body, headers)`,
+	assert.Contains(t, emitted, `return c.doRead(ctx, "POST", path, params, body, headers)`,
 		"PostQueryWithParamsAndHeaders must delegate to doRead so the verify-mode gate is bypassed")
 }

--- a/internal/generator/config_headers_test.go
+++ b/internal/generator/config_headers_test.go
@@ -19,6 +19,7 @@ func TestGeneratedClientAppliesConfigHeadersBeforeRequestOverrides(t *testing.T)
 	const behaviorTest = `package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -56,7 +57,7 @@ func TestConfigHeadersAreAppliedBeforeRequestOverrides(t *testing.T) {
 	c := New(cfg, time.Second, 0)
 	c.NoCache = true
 
-	if _, err := c.GetWithHeaders("/items", nil, map[string]string{"x-api-version": "override-version"}); err != nil {
+	if _, err := c.GetWithHeaders(context.Background(), "/items", nil, map[string]string{"x-api-version": "override-version"}); err != nil {
 		t.Fatalf("GetWithHeaders returned error: %v", err)
 	}
 	if seen != 1 {

--- a/internal/generator/doctor_credentials_probe_test.go
+++ b/internal/generator/doctor_credentials_probe_test.go
@@ -28,7 +28,7 @@ func TestGeneratedDoctor_EmitsGraphQLProbeWhenVerifyQuerySet(t *testing.T) {
 
 	assert.Contains(t, content, `verifyBody := map[string]string{"query": "{ viewer { id } }"}`,
 		"doctor should serialize the spec-declared verify_query into the request body")
-	assert.Contains(t, content, `c.PostQueryWithParamsAndHeaders("",`,
+	assert.Contains(t, content, `c.PostQueryWithParamsAndHeaders(cmd.Context(), "",`,
 		"doctor should route the GraphQL probe through PostQueryWithParamsAndHeaders so verify-mode does not short-circuit reads")
 	assert.Contains(t, content, `Errors []json.RawMessage `+"`json:\"errors\"`",
 		"doctor should parse the response for a top-level errors array")

--- a/internal/generator/doctor_health_path_test.go
+++ b/internal/generator/doctor_health_path_test.go
@@ -281,7 +281,7 @@ func TestGeneratedDoctor_DerivesHealthCheckPathFromVerifyPath(t *testing.T) {
 
 	assert.Contains(t, content, `healthPath := "/v1/account"`,
 		"doctor should probe Auth.VerifyPath when HealthCheckPath is unset")
-	assert.NotContains(t, content, `reachBody, reachErr := c.Get("/", nil)`,
+	assert.NotContains(t, content, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`,
 		"the bare-root fallback branch should not be rendered when a derived path exists")
 }
 
@@ -397,7 +397,7 @@ func TestGeneratedDoctor_DerivesAuthVerifyPathFromMeEndpoint(t *testing.T) {
 
 	assert.Contains(t, content, `verifyPath := "/users/me"`,
 		"doctor should probe the derived me-shaped path for credential validity")
-	assert.Contains(t, content, `c.GetWithHeaders(verifyPath`,
+	assert.Contains(t, content, `c.GetWithHeaders(cmd.Context(), verifyPath`,
 		"doctor should issue the authenticated probe through the configured client")
 	assert.NotContains(t, content, `"present (not verified — set auth.verify_path in spec for an API acceptance check)"`,
 		"the no-verify-path placeholder branch must not be rendered once a path is derived")
@@ -493,7 +493,7 @@ func TestGeneratedDoctor_NoCandidateFallsBackToRoot(t *testing.T) {
 	require.NoError(t, err)
 	content := string(doctorGo)
 
-	assert.Contains(t, content, `reachBody, reachErr := c.Get("/", nil)`,
+	assert.Contains(t, content, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`,
 		"specs with no derivable probe path should keep the bare-root fallback")
 	assert.NotContains(t, content, `healthPath := "`,
 		"no healthPath variable should be declared when the spec has nothing to derive")

--- a/internal/generator/embedded_paged_test.go
+++ b/internal/generator/embedded_paged_test.go
@@ -53,7 +53,7 @@ func TestEmbeddedPagedHelperEmitted_NonPromoted(t *testing.T) {
 		"non-promoted GET should emit a fetchFull<Resource><Endpoint><Property> helper")
 	assert.Contains(t, body, "childPath := \"/playlists/{id}/tracks\"",
 		"helper should hard-code the conventional child path so callers pass only path-param values")
-	assert.Contains(t, body, "fetchEmbeddedPagedSubresource(c, childPath,",
+	assert.Contains(t, body, "fetchEmbeddedPagedSubresource(ctx, c, childPath,",
 		"per-endpoint helper should delegate to the shared runtime helper rather than open-coding the page loop")
 
 	helpersSrc, err := os.ReadFile(filepath.Join(outDir, "internal", "cli", "helpers.go"))
@@ -151,7 +151,7 @@ func TestEmbeddedPagedHelperEmitted_HasMore(t *testing.T) {
 	require.NoError(t, err)
 	body := string(getSrc)
 	assert.Contains(t, body, "func fetchFullCustomersGetSubscriptions(")
-	assert.Contains(t, body, `fetchEmbeddedPagedSubresource(c, childPath, "has_more", false, true)`,
+	assert.Contains(t, body, `fetchEmbeddedPagedSubresource(ctx, c, childPath, "has_more", false, true)`,
 		"has_more-style envelopes should delegate to the shared paginator with nextIsURL=false, nextIsBoolean=true")
 
 	runGoCommand(t, outDir, "build", "./internal/cli")

--- a/internal/generator/endpoint_is_write_test.go
+++ b/internal/generator/endpoint_is_write_test.go
@@ -273,7 +273,7 @@ func TestPromotedCommandVerbBranching(t *testing.T) {
 				Body:        []spec.Param{{Name: "queryText", Type: "string"}},
 			},
 			mustContain: []string{"c.PostWithParams("},
-			mustNotHave: []string{"c.Get(path, params)"},
+			mustNotHave: []string{"c.Get(cmd.Context(), path, params)"},
 		},
 		{
 			name:         "GET endpoint keeps c.Get / resolveRead",
@@ -300,7 +300,7 @@ func TestPromotedCommandVerbBranching(t *testing.T) {
 				Path:        "/status",
 				Description: "Probe status",
 			},
-			mustContain: []string{"c.Get(path, params)"},
+			mustContain: []string{"c.Get(cmd.Context(), path, params)"},
 			mustNotHave: []string{"c.Head(", "c.Options("},
 		},
 	}
@@ -561,7 +561,7 @@ func TestPromotedCommandPlumbsBodyFields(t *testing.T) {
 		"promoted command must build a body map from body flags")
 	require.Contains(t, src, `body["name"] = bodyName`,
 		"body map must use the spec-declared field name, not the camelCased flag var")
-	require.Contains(t, src, `c.PostWithParams(path, params, body)`,
+	require.Contains(t, src, `c.PostWithParams(cmd.Context(), path, params, body)`,
 		"promoted command must pass the body map to c.PostWithParams, not the params map")
 	require.NotContains(t, src, `c.Post(path, params)`,
 		"promoted command must NOT pass params (URL/path params) as the request body — that was the bug")

--- a/internal/generator/form_test.go
+++ b/internal/generator/form_test.go
@@ -60,8 +60,8 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
-	assert.Contains(t, clientSrc, `func (c *Client) PostForm(path string, fields url.Values) (json.RawMessage, int, error)`)
-	assert.Contains(t, clientSrc, `func (c *Client) PostFormWithHeaders(path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `func (c *Client) PostForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `func (c *Client) PostFormWithHeaders(ctx context.Context, path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error)`)
 	assert.Contains(t, clientSrc, `type formRequestBody struct {`)
 	assert.Contains(t, clientSrc, `func encodeFormBody(body formRequestBody) ([]byte, string, error)`)
 	assert.Contains(t, clientSrc, `body.Fields.Encode()`)
@@ -72,7 +72,7 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	assert.Contains(t, endpointSrc, `fields := url.Values{}`)
 	assert.Contains(t, endpointSrc, `fields.Set("grant_type", bodyGrantType)`)
 	assert.Contains(t, endpointSrc, `fields.Set("client_id", bodyClientId)`)
-	assert.Contains(t, endpointSrc, `c.PostFormWithParams(path, params, fields)`)
+	assert.Contains(t, endpointSrc, `c.PostFormWithParams(cmd.Context(), path, params, fields)`)
 	assert.NotContains(t, endpointSrc, `var stdinBody bool`)
 	assert.NotContains(t, endpointSrc, `c.Post(path, body)`)
 	// Required-flag check should fire at top-level, not inside `if !stdinBody`.
@@ -84,12 +84,12 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	venuesSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_venues.go")
 	assert.Contains(t, venuesSrc, `if !json.Valid([]byte(bodyStructData))`)
 	assert.Contains(t, venuesSrc, `fields.Set("struct_data", bodyStructData)`)
-	assert.Contains(t, venuesSrc, `c.PostFormWithParams(path, params, fields)`)
+	assert.Contains(t, venuesSrc, `c.PostFormWithParams(cmd.Context(), path, params, fields)`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	assert.Contains(t, mcpSrc, `RequestContentType: "application/x-www-form-urlencoded"`)
 	assert.Contains(t, mcpSrc, `formFields := url.Values{}`)
-	assert.Contains(t, mcpSrc, `data, _, err = c.PostFormWithParams(path, params, formFields)`)
+	assert.Contains(t, mcpSrc, `data, _, err = c.PostFormWithParams(ctx, path, params, formFields)`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3691,6 +3691,7 @@ func TestGenerateDependentSyncInjectsSubResourceParentFK(t *testing.T) {
 	inlineTest := `package cli
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -3700,7 +3701,7 @@ import (
 
 type dependentParentFKClient struct{}
 
-func (dependentParentFKClient) Get(path string, params map[string]string) (json.RawMessage, error) {
+func (dependentParentFKClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
 	return json.RawMessage(` + "`" + `[
 		{"id":"contact-injected","email":"injected@example.test"},
 		{"id":"contact-preserved","lists_id":"api-list","email":"preserved@example.test"}
@@ -3723,6 +3724,7 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 	}
 
 	res := syncDependentResource(
+		context.Background(),
 		dependentParentFKClient{},
 		db,
 		dependentResourceDef{Name: "contacts", ParentTable: "lists", ParentIDParam: "listId", PathTemplate: "/lists/{listId}/contacts"},
@@ -7027,7 +7029,7 @@ func TestGeneratedDoctor_AuthVerifyPathProbesEndpoint(t *testing.T) {
 	// not bare baseURL. The doctor uses flags.newClient() now (Surf-aware)
 	// instead of stdlib http.Client.
 	assert.Contains(t, content, `verifyPath := "/me?fields=id"`)
-	assert.Contains(t, content, `c.GetWithHeaders(verifyPath`)
+	assert.Contains(t, content, `c.GetWithHeaders(cmd.Context(), verifyPath`)
 	assert.NotContains(t, content, `&http.Client{`)
 	// When verify_path is set, HTTP 401 keeps the strict "invalid" verdict.
 	// 403 is handled separately as scope-limited; see
@@ -7049,8 +7051,8 @@ func TestGeneratedDoctor_HealthCheckPathProbesEndpoint(t *testing.T) {
 	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
 	assert.Contains(t, doctorSrc, `healthPath := "api/marketStatus"`)
 	assert.Contains(t, doctorSrc, `if !strings.HasPrefix(healthPath, "/") {`)
-	assert.Contains(t, doctorSrc, `reachBody, reachErr := c.Get(healthPath, nil)`)
-	assert.NotContains(t, doctorSrc, `reachBody, reachErr := c.Get("/", nil)`)
+	assert.Contains(t, doctorSrc, `reachBody, reachErr := c.Get(cmd.Context(), healthPath, nil)`)
+	assert.NotContains(t, doctorSrc, `reachBody, reachErr := c.Get(cmd.Context(), "/", nil)`)
 }
 
 func TestGeneratedDoctor_InterstitialMarkersAreTitleAnchored(t *testing.T) {
@@ -7146,7 +7148,7 @@ func TestGeneratedDoctor_NoVerifyPathReportsCredentialsPresent(t *testing.T) {
 	// now suggests a read command (resolved at doctor-time from the cobra
 	// tree) instead of pointing the user at a spec field they don't own.
 	assert.NotContains(t, content, `verifyPath := "/"`)
-	assert.NotContains(t, content, `c.GetWithHeaders(verifyPath`)
+	assert.NotContains(t, content, `c.GetWithHeaders(cmd.Context(), verifyPath`)
 	assert.NotContains(t, content, `&http.Client{`)
 	assert.Contains(t, content, `"present, not verified. Run `)
 	assert.NotContains(t, content, `set auth.verify_path in spec`,
@@ -9966,7 +9968,7 @@ func TestGenerateGraphQLEndpointPathRendersTemplatedURL(t *testing.T) {
 		"graphql.go must render GraphQLEndpointPath into a const")
 	assert.NotContains(t, graphqlGo, `c.Post("/graphql"`,
 		"graphql.go must not retain the hardcoded /graphql path after PR-1")
-	assert.Contains(t, graphqlGo, "c.Post(graphqlEndpointPath",
+	assert.Contains(t, graphqlGo, "c.Post(ctx, graphqlEndpointPath",
 		"Query/Mutate must post against the rendered constant, not a literal")
 
 	// The config struct must carry the templated BaseURL through unchanged so
@@ -11169,8 +11171,8 @@ func TestGenerateWaitForJobBypassesResponseCache(t *testing.T) {
 
 	assert.Contains(t, jobsBody, "c.GetNoCache(path, nil)",
 		"WaitForJob must poll with GetNoCache to avoid locking on the cached initial response")
-	assert.NotContains(t, jobsBody, "c.Get(path, nil)",
-		"WaitForJob must not call c.Get(path, nil); cached non-terminal status would lock the poll")
+	assert.NotContains(t, jobsBody, "c.Get(ctx, path, nil)",
+		"WaitForJob must not call c.Get(ctx, path, nil); cached non-terminal status would lock the poll")
 }
 
 // TestGenerateMCPHandlerPreservesQueryPositionals proves the makeAPIHandler
@@ -11355,11 +11357,11 @@ func TestMCPHandlerPassesBodyArgsMap(t *testing.T) {
 		"MCP handler must not pre-marshal bodyArgs: client.do() json.Marshals what it receives, "+
 			"so a []byte arrives base64-encoded on the wire and strict APIs reject the payload")
 
-	assert.Contains(t, mcpSource, "c.PostWithParams(path, params, bodyArgs)",
+	assert.Contains(t, mcpSource, "c.PostWithParams(ctx, path, params, bodyArgs)",
 		"POST branch must forward bodyArgs directly to the client")
-	assert.Contains(t, mcpSource, "c.PutWithParams(path, params, bodyArgs)",
+	assert.Contains(t, mcpSource, "c.PutWithParams(ctx, path, params, bodyArgs)",
 		"PUT branch must forward bodyArgs directly to the client")
-	assert.Contains(t, mcpSource, "c.PatchWithParams(path, params, bodyArgs)",
+	assert.Contains(t, mcpSource, "c.PatchWithParams(ctx, path, params, bodyArgs)",
 		"PATCH branch must forward bodyArgs directly to the client")
 }
 
@@ -11418,11 +11420,11 @@ func TestMCPCodeOrchPassesParamsMap(t *testing.T) {
 		"code-orch handler must not pre-marshal params: client.do() json.Marshals what it receives, "+
 			"so a []byte arrives base64-encoded on the wire and strict APIs reject the payload")
 
-	assert.Contains(t, mcpSource, "c.Post(path, params)",
+	assert.Contains(t, mcpSource, "c.Post(ctx, path, params)",
 		"POST branch must forward params directly to the client")
-	assert.Contains(t, mcpSource, "c.Put(path, params)",
+	assert.Contains(t, mcpSource, "c.Put(ctx, path, params)",
 		"PUT branch must forward params directly to the client")
-	assert.Contains(t, mcpSource, "c.Patch(path, params)",
+	assert.Contains(t, mcpSource, "c.Patch(ctx, path, params)",
 		"PATCH branch must forward params directly to the client")
 }
 

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -57,7 +57,7 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
-	assert.Contains(t, clientSrc, `func (c *Client) PostMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error)`)
 	assert.Contains(t, clientSrc, `writer.CreateFormFile(fieldName, filepath.Base(filePath))`)
 	assert.Contains(t, clientSrc, `req.Header.Set("Content-Type", contentType)`)
 
@@ -67,14 +67,14 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	assert.Contains(t, endpointSrc, `fileFields["assetData"] = bodyAssetData`)
 	assert.Contains(t, endpointSrc, `fields["filename"] = bodyFilename`)
 	assert.Contains(t, endpointSrc, `fields["metadata"] = bodyMetadata`)
-	assert.Contains(t, endpointSrc, `c.PostMultipartWithParams(path, params, fields, fileFields)`)
+	assert.Contains(t, endpointSrc, `c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)`)
 	assert.NotContains(t, endpointSrc, `"stdin"`)
 
 	promotedSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_avatars.go")
 	assert.Contains(t, promotedSrc, `return fmt.Errorf("required flag \"%s\" not set", "image")`)
 	assert.Contains(t, promotedSrc, `fileFields["image"] = bodyImage`)
 	assert.Contains(t, promotedSrc, `fields["label"] = bodyLabel`)
-	assert.Contains(t, promotedSrc, `c.PostMultipartWithParams(path, params, fields, fileFields)`)
+	assert.Contains(t, promotedSrc, `c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)`)
 	assert.NotContains(t, promotedSrc, `"stdin"`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
@@ -82,7 +82,7 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	assert.Contains(t, mcpSrc, `Format: "binary"`)
 	assert.Contains(t, mcpSrc, `RequestContentType: "multipart/form-data"`)
 	assert.Contains(t, mcpSrc, `multipartFileFields[binding.WireName] = fmt.Sprintf("%v", v)`)
-	assert.Contains(t, mcpSrc, `data, _, err = c.PostMultipartWithParams(path, params, multipartFields, multipartFileFields)`)
+	assert.Contains(t, mcpSrc, `data, _, err = c.PostMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/mutating_query_params_test.go
+++ b/internal/generator/mutating_query_params_test.go
@@ -39,16 +39,16 @@ func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
-	assert.Contains(t, clientSrc, `func (c *Client) PostWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `func (c *Client) PostWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error)`)
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_text-to-speech.go")
 	assert.Contains(t, endpointSrc, `params := map[string]string{}`)
 	assert.Contains(t, endpointSrc, `params["output_format"] = fmt.Sprintf("%v", flagOutputFormat)`)
-	assert.Contains(t, endpointSrc, `c.PostWithParamsAndHeaders(path, params, body, headerOverrides)`)
+	assert.Contains(t, endpointSrc, `c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	assert.Contains(t, mcpSrc, `PublicName: "output_format", WireName: "output_format", Location: "query"`)
-	assert.Contains(t, mcpSrc, `data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)`)
+	assert.Contains(t, mcpSrc, `data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)`)
 	assert.Contains(t, mcpSrc, `"content_encoding": "base64"`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -82,6 +82,7 @@ func TestPaginatedGetHandlesNumericCursorAndMissingAllSignal(t *testing.T) {
 	behaviorTest := `package cli
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -94,7 +95,8 @@ type paginatedTestClient struct {
 	params    []map[string]string
 }
 
-func (c *paginatedTestClient) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+func (c *paginatedTestClient) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	_ = ctx
 	copied := map[string]string{}
 	for k, v := range params {
 		copied[k] = v
@@ -135,7 +137,7 @@ func TestPaginatedGetAcceptsNumericNextCursor(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
 		json.RawMessage(` + "`" + `{"items":[{"id":"two"}],"meta":{}}` + "`" + `),
 	}}
-	data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -158,7 +160,7 @@ func TestPaginatedGetStopsAtNumericZeroNextCursor(t *testing.T) {
 	client := &paginatedTestClient{responses: []json.RawMessage{
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":0}}` + "`" + `),
 	}}
-	data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
+	data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "meta.nextPage", "")
 	if err != nil {
 		t.Fatalf("paginatedGet returned error: %v", err)
 	}
@@ -179,7 +181,7 @@ func TestPaginatedGetWarnsForSinglePageNumericNextCursor(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"nextPage":2}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		_, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "meta.nextPage", "")
+		_, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, false, "page", "meta.nextPage", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -194,7 +196,7 @@ func TestPaginatedGetWarnsWhenAllHasNoAdvanceSignal(t *testing.T) {
 		json.RawMessage(` + "`" + `[{"id":"one"}]` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -219,7 +221,7 @@ func TestPaginatedGetWarnsWhenHasMoreCannotAdvance(t *testing.T) {
 		json.RawMessage(` + "`" + `{"items":[{"id":"one"}],"meta":{"has_more":true}}` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "meta.has_more")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "", "meta.has_more")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}

--- a/internal/generator/placeholder_auth_test.go
+++ b/internal/generator/placeholder_auth_test.go
@@ -23,6 +23,7 @@ func TestGeneratedClientRejectsPlaceholderConfigTokenBeforeRequest(t *testing.T)
 	const clientTest = `package client
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -56,7 +57,7 @@ func TestPlaceholderAccessTokenIsRejectedBeforeRequest(t *testing.T) {
 				return nil, nil
 			})}
 
-			_, err := c.Get("/items", nil)
+			_, err := c.Get(context.Background(), "/items", nil)
 			if !errors.Is(err, ErrPlaceholderCredential) {
 				t.Fatalf("expected placeholder auth error for %q, got %v", token, err)
 			}
@@ -89,7 +90,7 @@ func TestPlaceholderEnvTokenIsRejectedBeforeRequest(t *testing.T) {
 		return nil, nil
 	})}
 
-	_, err = c.Get("/items", nil)
+	_, err = c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error, got %v", err)
 	}
@@ -108,7 +109,7 @@ func TestPlaceholderAccessTokenFailsBeforeCacheHit(t *testing.T) {
 	c.cacheDir = t.TempDir()
 	c.writeCache("/items", nil, []byte(` + "`" + `{"cached":true}` + "`" + `))
 
-	_, err := c.Get("/items", nil)
+	_, err := c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error before cache hit, got %v", err)
 	}
@@ -152,7 +153,7 @@ func TestRealTokensReachTransport(t *testing.T) {
 				}, nil
 			})}
 
-			if _, err := c.Get("/items", nil); err != nil {
+			if _, err := c.Get(context.Background(), "/items", nil); err != nil {
 				t.Fatalf("Get() error = %v", err)
 			}
 			if calls != 1 {
@@ -216,6 +217,7 @@ func TestGeneratedClientRejectsBasicAuthPlaceholdersBeforeRequest(t *testing.T) 
 	const clientTest = `package client
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -232,7 +234,7 @@ func TestBasicAuthPlaceholderIsRejectedBeforeRequest(t *testing.T) {
 	c := New(cfg, time.Second, 0)
 	c.NoCache = true
 
-	_, err := c.Get("/items", nil)
+	_, err := c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error, got %v", err)
 	}
@@ -264,6 +266,7 @@ func TestGeneratedClientRejectsClientCredentialsPlaceholdersBeforeMint(t *testin
 	const clientTest = `package client
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -293,7 +296,7 @@ func TestClientCredentialsPlaceholdersRejectedBeforeMint(t *testing.T) {
 		return nil, nil
 	})}
 
-	_, err := c.Get("/items", nil)
+	_, err := c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error, got %v", err)
 	}
@@ -312,7 +315,7 @@ func TestClientCredentialsPlaceholdersRejectedBeforeCacheHit(t *testing.T) {
 	c.cacheDir = t.TempDir()
 	c.writeCache("/items", nil, []byte(` + "`" + `{"cached":true}` + "`" + `))
 
-	_, err := c.Get("/items", nil)
+	_, err := c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error before cache hit, got %v", err)
 	}
@@ -340,6 +343,7 @@ func TestGeneratedClientRejectsRefreshPlaceholdersBeforeRefresh(t *testing.T) {
 	const clientTest = `package client
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -370,7 +374,7 @@ func TestRefreshPlaceholdersRejectedBeforeRefresh(t *testing.T) {
 		return nil, nil
 	})}
 
-	_, err := c.Get("/items", nil)
+	_, err := c.Get(context.Background(), "/items", nil)
 	if !errors.Is(err, ErrPlaceholderCredential) {
 		t.Fatalf("expected placeholder auth error, got %v", err)
 	}

--- a/internal/generator/promoted_poststore_test.go
+++ b/internal/generator/promoted_poststore_test.go
@@ -51,7 +51,7 @@ func TestPromotedHasStorePostRoutesThroughVerbBranch(t *testing.T) {
 
 	assert.NotContains(t, got, "resolveRead(",
 		"HasStore + POST must NOT route through resolveRead (GET-only internally)")
-	assert.Contains(t, got, "c.PostWithParams(path, params, body)",
+	assert.Contains(t, got, "c.PostWithParams(cmd.Context(), path, params, body)",
 		"HasStore + POST must route through the verb branch with a built body")
 	assert.Contains(t, got, `attachFreshness(DataProvenance{Source: "live"}, flags)`,
 		"non-GET HasStore commands must synthesize a live-call prov so the downstream HasStore block compiles")
@@ -89,7 +89,7 @@ func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
 
 	assert.Contains(t, got, "resolveRead(",
 		"HasStore + GET must keep routing through resolveRead (the cached fast-path)")
-	assert.NotContains(t, got, "c.Get(path, params)",
+	assert.NotContains(t, got, "c.Get(cmd.Context(), path, params)",
 		"HasStore + GET must not also emit a direct c.Get call (would mean both branches fired)")
 }
 
@@ -97,7 +97,7 @@ func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
 // other tests don't reach. The provenance synthesis lives in a single
 // post-chain block, so a regression that drops it from one verb shape
 // drops it from all of them — but DELETE has its own pre-existing
-// `data, _, err := c.DeleteWithParams(path, params)` call site, so an explicit assertion
+// `data, _, err := c.DeleteWithParams(cmd.Context(), path, params)` call site, so an explicit assertion
 // guards against template refactors that re-introduce the dup.
 func TestPromotedHasStoreDeleteSynthesizesProv(t *testing.T) {
 	t.Parallel()
@@ -128,7 +128,7 @@ func TestPromotedHasStoreDeleteSynthesizesProv(t *testing.T) {
 
 	assert.NotContains(t, got, "resolveRead(",
 		"HasStore + DELETE must NOT route through resolveRead")
-	assert.Contains(t, got, "c.DeleteWithParams(path, params)",
+	assert.Contains(t, got, "c.DeleteWithParams(cmd.Context(), path, params)",
 		"HasStore + DELETE must route through c.DeleteWithParams")
 	assert.Contains(t, got, `attachFreshness(DataProvenance{Source: "live"}, flags)`,
 		"HasStore + DELETE must synthesize a live-call prov for the downstream provenance block")

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -16,7 +16,7 @@ import (
 {{- if or $hasCookieBrowserAuth $hasQueryRefresh}}
 	"bytes"
 {{- end}}
-{{- if $hasAuth0SPA}}
+{{- if or $hasAuth0SPA .Auth.RequiresBrowserSession}}
 	"context"
 {{- end}}
 {{- if .Auth.RequiresBrowserSession}}
@@ -305,7 +305,7 @@ profile by name when the installed backend supports it.`,
 			}
 {{- if .Auth.RequiresBrowserSession}}
 			fmt.Fprintf(w, "Validating browser session...")
-			if err := validateAndWriteBrowserSessionProof(cfg, flags); err != nil {
+			if err := validateAndWriteBrowserSessionProof(cmd.Context(), cfg, flags); err != nil {
 				_ = cfg.ClearTokens()
 				_ = clearBrowserSessionProof(cfg)
 				fmt.Fprintf(w, " %s\n", red("failed"))
@@ -354,7 +354,7 @@ profile by name when the installed backend supports it.`,
 			}
 {{- if .Auth.RequiresBrowserSession}}
 			fmt.Fprintf(w, "Validating browser session...")
-			if err := validateAndWriteBrowserSessionProof(cfg, flags); err != nil {
+			if err := validateAndWriteBrowserSessionProof(cmd.Context(), cfg, flags); err != nil {
 				_ = cfg.ClearTokens()
 				_ = clearBrowserSessionProof(cfg)
 				fmt.Fprintf(w, " %s\n", red("failed"))
@@ -630,7 +630,7 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			fmt.Fprintf(w, "Validating browser session...")
-			if err := validateAndWriteBrowserSessionProofWithRetry(cfg, flags, waitTimeout); err != nil {
+			if err := validateAndWriteBrowserSessionProofWithRetry(cmd.Context(), cfg, flags, waitTimeout); err != nil {
 				fmt.Fprintf(w, " %s\n", red("failed"))
 				return authErr(fmt.Errorf("browser session validation failed: %w", err))
 			}
@@ -1785,7 +1785,7 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 	return true, fmt.Sprintf("%s %s verified at %s", proof.ValidationMethod, proof.ValidationPath, proof.VerifiedAt)
 }
 
-func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) error {
+func validateAndWriteBrowserSessionProof(ctx context.Context, cfg *config.Config, flags *rootFlags) error {
 	validationPath := strings.TrimSpace("{{.Auth.BrowserSessionValidationPath}}")
 	if validationPath == "" {
 		return fmt.Errorf("no browser-session validation endpoint configured in this CLI")
@@ -1805,7 +1805,7 @@ func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) e
 
 	c := client.New(cfg, flags.timeout, flags.rateLimit)
 	c.NoCache = true
-	status, err := c.ProbeGet(validationPath)
+	status, err := c.ProbeGet(ctx, validationPath)
 	if err != nil {
 		return err
 	}
@@ -1832,11 +1832,11 @@ func validateAndWriteBrowserSessionProof(cfg *config.Config, flags *rootFlags) e
 	return writeBrowserSessionProof(cfg, data)
 }
 
-func validateAndWriteBrowserSessionProofWithRetry(cfg *config.Config, flags *rootFlags, timeout time.Duration) error {
+func validateAndWriteBrowserSessionProofWithRetry(ctx context.Context, cfg *config.Config, flags *rootFlags, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for {
-		if err := validateAndWriteBrowserSessionProof(cfg, flags); err != nil {
+		if err := validateAndWriteBrowserSessionProof(ctx, cfg, flags); err != nil {
 			lastErr = err
 		} else {
 			return nil
@@ -1844,7 +1844,13 @@ func validateAndWriteBrowserSessionProofWithRetry(cfg *config.Config, flags *roo
 		if time.Now().After(deadline) {
 			return lastErr
 		}
-		time.Sleep(time.Second)
+		timer := time.NewTimer(time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
 	}
 }
 

--- a/internal/generator/templates/auto_refresh.go.tmpl
+++ b/internal/generator/templates/auto_refresh.go.tmpl
@@ -215,7 +215,7 @@ func runAutoRefresh(ctx context.Context, flags *rootFlags, db *store.Store, reso
 			return ctx.Err()
 		default:
 		}
-		result := syncResource({{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, "", false, 1{{if not (isGraphQL .APISpec)}}, true{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil{{end}})
+		result := syncResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, "", false, 1{{if not (isGraphQL .APISpec)}}, true{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil{{end}})
 		if result.Err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", resource, result.Err))
 		}

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -289,7 +289,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 
 			for _, resource := range resources {
-				res := syncResource({{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil{{end}})
+				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil{{end}})
 				if res.Err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
 					continue

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -5,6 +5,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 {{- if .UsesHTTP2DisabledTransport}}
 	"crypto/tls"
 {{- end}}
@@ -175,7 +176,7 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
-func (c *Client) authForRequest() (requestAuth, error) {
+func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 	switch c.requestTier {
 {{- range $tierName, $tier := .TierRouting.Tiers}}
 	case {{printf "%q" $tierName}}:
@@ -216,7 +217,7 @@ func (c *Client) authForRequest() (requestAuth, error) {
 	{{- end}}
 {{- end}}
 	default:
-		value, err := c.authHeader()
+		value, err := c.authHeader(ctx)
 		if err != nil {
 			return requestAuth{}, err
 		}
@@ -412,7 +413,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// receive the auth credential, even though we are inside
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
-			if h, err := c.authHeader(); err == nil && h != "" {
+			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{.Auth.TokenParamName}}", h)
 			}
 		}
@@ -426,7 +427,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// receive the auth credential, even though we are inside
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
-			if h, err := c.authHeader(); err == nil && h != "" {
+			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
 			}
 		}
@@ -441,12 +442,12 @@ func (c *Client) RateLimit() float64 {
 	return c.limiter.Rate()
 }
 
-func (c *Client) Get(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeaders(path, params, nil)
+func (c *Client) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, path, params, nil)
 }
 
-func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	if err := c.validateCachedRequestAuth(); err != nil {
+func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
 	// Check cache for GET requests
@@ -455,7 +456,7 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 			return cached, nil
 		}
 	}
-	result, _, err := c.do("GET", path, params, nil, headers)
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
@@ -471,25 +472,25 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 // (e.g. a follow-up `... get <id>` after WaitForJob returns) see the
 // terminal value, not the stale non-terminal snapshot left behind by the
 // first poll.
-func (c *Client) GetNoCache(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeadersNoCache(path, params, nil)
+func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
 // GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
 // still writes the fresh response on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
-func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	result, _, err := c.do("GET", path, params, nil, headers)
+func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
 	return result, err
 }
 
-func (c *Client) validateCachedRequestAuth() error {
+func (c *Client) validateCachedRequestAuth(ctx context.Context) error {
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 {{- if .HasTierRouting}}
-	authInfo, err := c.authForRequest()
+	authInfo, err := c.authForRequest(ctx)
 	if err != nil {
 		return err
 	}
@@ -514,8 +515,8 @@ func (c *Client) validateCachedRequestAuth() error {
 	return nil
 }
 
-func (c *Client) ProbeGet(path string) (int, error) {
-	_, status, err := c.do("GET", path, nil, nil, nil)
+func (c *Client) ProbeGet(ctx context.Context, path string) (int, error) {
+	_, status, err := c.do(ctx, "GET", path, nil, nil, nil)
 	return status, err
 }
 
@@ -594,20 +595,20 @@ func (c *Client) invalidateCache() {
 	_ = os.RemoveAll(c.cacheDir)
 }
 
-func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, nil)
+func (c *Client) Post(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, nil)
 }
 
-func (c *Client) PostWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, nil)
+func (c *Client) PostWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, nil)
 }
 
-func (c *Client) PostWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, headers)
+func (c *Client) PostWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, headers)
 }
 
-func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, headers)
+func (c *Client) PostWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, headers)
 }
 
 // PostQueryWithParams is a POST that does not mutate remote state — used
@@ -615,171 +616,171 @@ func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string,
 // queries, JSON-RPC reads, POST-based search endpoints). The verify-mode
 // short-circuit does not fire for these calls; the request reaches the
 // real transport even under PRINTING_PRESS_VERIFY=1 without LIVE_HTTP=1.
-func (c *Client) PostQueryWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, nil)
+func (c *Client) PostQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, nil)
 }
 
 // PostQueryWithParamsAndHeaders is the headers-aware counterpart to
 // PostQueryWithParams. See PostQueryWithParams for the verify-mode rationale.
-func (c *Client) PostQueryWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, headers)
+func (c *Client) PostQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, headers)
 }
 
 {{- if .HasMultipartRequest }}
-func (c *Client) PostMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PostMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PostMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PostMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PostMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) PostMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PostMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 {{ end }}
 {{- if .HasFormRequest }}
-func (c *Client) PostForm(path string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, formRequestBody{Fields: fields}, nil)
+func (c *Client) PostForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PostFormWithParams(path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, formRequestBody{Fields: fields}, nil)
+func (c *Client) PostFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PostFormWithHeaders(path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, formRequestBody{Fields: fields}, headers)
+func (c *Client) PostFormWithHeaders(ctx context.Context, path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, formRequestBody{Fields: fields}, headers)
 }
 
-func (c *Client) PostFormWithParamsAndHeaders(path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, formRequestBody{Fields: fields}, headers)
+func (c *Client) PostFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, formRequestBody{Fields: fields}, headers)
 }
 
 {{ end }}
 
-func (c *Client) Delete(path string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, nil)
+func (c *Client) Delete(ctx context.Context, path string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, nil)
 }
 
-func (c *Client) DeleteWithParams(path string, params map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, nil)
+func (c *Client) DeleteWithParams(ctx context.Context, path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, nil)
 }
 
-func (c *Client) DeleteWithHeaders(path string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, headers)
+func (c *Client) DeleteWithHeaders(ctx context.Context, path string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, headers)
 }
 
-func (c *Client) DeleteWithParamsAndHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, headers)
+func (c *Client) DeleteWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, headers)
 }
 
-func (c *Client) Put(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, nil)
+func (c *Client) Put(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, nil)
 }
 
-func (c *Client) PutWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, nil)
+func (c *Client) PutWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, nil)
 }
 
-func (c *Client) PutWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, headers)
+func (c *Client) PutWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, headers)
 }
 
-func (c *Client) PutWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, headers)
+func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
 {{- if .HasMultipartRequest }}
-func (c *Client) PutMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PutMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PutMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PutMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PutMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PutMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) PutMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PutMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 {{ end }}
 {{- if .HasFormRequest }}
-func (c *Client) PutForm(path string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, formRequestBody{Fields: fields}, nil)
+func (c *Client) PutForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PutFormWithParams(path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, formRequestBody{Fields: fields}, nil)
+func (c *Client) PutFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PutFormWithHeaders(path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, formRequestBody{Fields: fields}, headers)
+func (c *Client) PutFormWithHeaders(ctx context.Context, path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, formRequestBody{Fields: fields}, headers)
 }
 
-func (c *Client) PutFormWithParamsAndHeaders(path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, formRequestBody{Fields: fields}, headers)
+func (c *Client) PutFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, formRequestBody{Fields: fields}, headers)
 }
 
 {{ end }}
 
-func (c *Client) Patch(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, nil)
+func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
 
-func (c *Client) PatchWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, nil)
+func (c *Client) PatchWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, nil)
 }
 
-func (c *Client) PatchWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, headers)
+func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, headers)
 }
 
-func (c *Client) PatchWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, headers)
+func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, headers)
 }
 
 {{- if .HasMultipartRequest }}
-func (c *Client) PatchMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PatchMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PatchMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PatchMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PatchMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PatchMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) PatchMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PatchMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 {{ end }}
 {{- if .HasFormRequest }}
-func (c *Client) PatchForm(path string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, formRequestBody{Fields: fields}, nil)
+func (c *Client) PatchForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PatchFormWithParams(path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, formRequestBody{Fields: fields}, nil)
+func (c *Client) PatchFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, formRequestBody{Fields: fields}, nil)
 }
 
-func (c *Client) PatchFormWithHeaders(path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, formRequestBody{Fields: fields}, headers)
+func (c *Client) PatchFormWithHeaders(ctx context.Context, path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, formRequestBody{Fields: fields}, headers)
 }
 
-func (c *Client) PatchFormWithParamsAndHeaders(path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, formRequestBody{Fields: fields}, headers)
+func (c *Client) PatchFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, formRequestBody{Fields: fields}, headers)
 }
 
 {{ end }}
@@ -872,10 +873,21 @@ func verifyShortCircuitEnvelope(method, path string) json.RawMessage {
 	return json.RawMessage(body)
 }
 
+func sleepContext(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // do executes an HTTP request. headerOverrides, when non-nil, override global
 // RequiredHeaders for this specific request (used for per-endpoint API versioning).
-func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, false)
+func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, false)
 }
 
 // doRead is do() minus the verify-mode mutating-verb gate. Used by the
@@ -884,15 +896,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 // The wire verb is still POST/PUT/PATCH so the server sees a real request,
 // but the verify-mode short-circuit does not fire because the operation
 // does not mutate remote state.
-func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, true)
+func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, true)
 }
 
 // doInternal is the shared implementation behind do() and doRead(). The
 // readOnlyIntent flag is set by doRead() callers (read-only POST/PUT/PATCH
 // operations like GraphQL queries) to skip the mutating-verb verify-mode
 // gate. Plain do() callers leave it false and get the usual short-circuit.
-func (c *Client) doInternal(method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
+func (c *Client) doInternal(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
 	// Verify-mode transport-layer gate. When the verifier (or any consumer
 	// that sets PRINTING_PRESS_VERIFY=1) drives a mutating verb without
 	// the LIVE_HTTP=1 opt-in, return a synthetic envelope without dialing,
@@ -1018,10 +1030,10 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 	// requires a network refresh will be re-fetched on the live request path,
 	// not during dry-run.
 {{- if .HasTierRouting}}
-	authInfo, err := c.authForRequest()
+	authInfo, err := c.authForRequest(ctx)
 	authHeader := authInfo.Value
 {{- else}}
-	authHeader, err := c.authHeader()
+	authHeader, err := c.authHeader(ctx)
 {{- end}}
 	if err != nil {
 		return nil, 0, err
@@ -1085,7 +1097,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			return nil, 0, fmt.Errorf("marshaling proxy envelope: %w", err)
 		}
 
-		req, err := http.NewRequest("POST", targetURL, strings.NewReader(string(envelopeBytes)))
+		req, err := http.NewRequestWithContext(ctx, "POST", targetURL, strings.NewReader(string(envelopeBytes)))
 		if err != nil {
 			return nil, 0, fmt.Errorf("creating request: %w", err)
 		}
@@ -1096,7 +1108,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			bodyReader = strings.NewReader(string(bodyBytes))
 		}
 
-		req, err := http.NewRequest(method, targetURL, bodyReader)
+		req, err := http.NewRequestWithContext(ctx, method, targetURL, bodyReader)
 		if err != nil {
 			return nil, 0, fmt.Errorf("creating request: %w", err)
 		}
@@ -1214,6 +1226,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
 			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
 			continue
 		}
@@ -1260,7 +1275,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			c.limiter.OnRateLimit()
 			wait := cliutil.RetryAfter(resp)
 			fmt.Fprintf(os.Stderr, "rate limited, waiting %s (attempt %d/%d, rate adjusted to %.1f req/s)\n", wait, attempt+1, maxRetries, c.limiter.Rate())
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -1284,7 +1301,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 		if resp.StatusCode >= 500 && attempt < maxRetries {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -1301,7 +1320,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 // call — the caller is responsible for passing cached auth material only.
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, authHeader string) (json.RawMessage, int, error) {
 {{- if .HasTierRouting}}
-	authInfo, _ := c.authForRequest()
+	authInfo, _ := c.authForRequest(context.Background())
 	authInfo.Value = authHeader
 {{- end}}
 {{- if eq .ClientPattern "proxy-envelope"}}
@@ -1549,7 +1568,7 @@ func (c *Client) ConfiguredTimeout() time.Duration {
 	return 30 * time.Second
 }
 
-func (c *Client) authHeader() (string, error) {
+func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
@@ -1572,7 +1591,7 @@ func (c *Client) authHeader() (string, error) {
 					c.ccMu.Unlock()
 					return "", authPlaceholderCredentialError(c.Config)
 				}
-				if err := c.mintClientCredentials(clientID, clientSecret); err != nil {
+				if err := c.mintClientCredentials(ctx, clientID, clientSecret); err != nil {
 					c.ccMu.Unlock()
 					return "", err
 				}
@@ -1585,7 +1604,7 @@ func (c *Client) authHeader() (string, error) {
 		if authHeaderLooksLikePlaceholderCredential(c.Config.AccessToken) || authHeaderLooksLikePlaceholderCredential(c.Config.RefreshToken) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientID) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientSecret) {
 			return "", authPlaceholderCredentialError(c.Config)
 		}
-		if err := c.refreshAccessToken(); err != nil {
+		if err := c.refreshAccessToken(ctx); err != nil {
 			return "", err
 		}
 	}
@@ -1697,7 +1716,7 @@ func resolveClientCredentials(cfg *config.Config) (string, string) {
 	return id, secret
 }
 
-func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
+func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error {
 	tokenURL := ""
 {{- if .Auth.TokenURL}}
 	if c.Config != nil {
@@ -1715,7 +1734,7 @@ func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
 	}
-	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("building token request: %w", err)
 	}
@@ -1756,7 +1775,7 @@ func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
 
 {{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 
-func (c *Client) refreshAccessToken() error {
+func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.Config == nil {
 		return nil
 	}
@@ -1778,7 +1797,12 @@ func (c *Client) refreshAccessToken() error {
 		params.Set("client_secret", c.Config.ClientSecret)
 	}
 
-	resp, err := c.HTTPClient.PostForm(tokenURL, params)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return fmt.Errorf("building refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("refreshing access token: %w", err)
 	}

--- a/internal/generator/templates/client_verify_short_circuit_test.go.tmpl
+++ b/internal/generator/templates/client_verify_short_circuit_test.go.tmpl
@@ -5,6 +5,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -64,7 +65,7 @@ func TestClient_VerifyShortCircuit_MutatingVerbs(t *testing.T) {
 			t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "")
 			c, rec := newClientWithRecorder(t)
 
-			body, status, err := c.do(verb, "/test", nil, nil, nil)
+			body, status, err := c.do(context.Background(), verb, "/test", nil, nil, nil)
 			if err != nil {
 				t.Fatalf("do(%s) returned error: %v", verb, err)
 			}
@@ -105,7 +106,7 @@ func TestClient_VerifyShortCircuit_LiveHTTPOptIn(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "1")
 	c, rec := newClientWithRecorder(t)
 
-	_, _, _ = c.do("DELETE", "/test", nil, nil, nil)
+	_, _, _ = c.do(context.Background(), "DELETE", "/test", nil, nil, nil)
 
 	if rec.calls < 1 {
 		t.Fatalf("LIVE_HTTP=1 should opt back in to real dial; recorder saw %d calls", rec.calls)
@@ -120,7 +121,7 @@ func TestClient_VerifyShortCircuit_NoEnv(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "")
 	c, rec := newClientWithRecorder(t)
 
-	_, _, _ = c.do("DELETE", "/test", nil, nil, nil)
+	_, _, _ = c.do(context.Background(), "DELETE", "/test", nil, nil, nil)
 
 	if rec.calls < 1 {
 		t.Fatalf("no verify env should dial normally; recorder saw %d calls", rec.calls)
@@ -137,7 +138,7 @@ func TestClient_VerifyShortCircuit_GETControl(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "")
 	c, rec := newClientWithRecorder(t)
 
-	_, _, _ = c.do("GET", "/test", nil, nil, nil)
+	_, _, _ = c.do(context.Background(), "GET", "/test", nil, nil, nil)
 
 	if rec.calls < 1 {
 		t.Fatalf("GET must never short-circuit; recorder saw %d calls", rec.calls)
@@ -158,7 +159,7 @@ func TestClient_VerifyShortCircuit_ReadOnlyPOST(t *testing.T) {
 			t.Setenv("PRINTING_PRESS_VERIFY_LIVE_HTTP", "")
 			c, rec := newClientWithRecorder(t)
 
-			_, _, _ = c.doRead(verb, "/test", nil, nil, nil)
+			_, _, _ = c.doRead(context.Background(), verb, "/test", nil, nil, nil)
 
 			if rec.calls < 1 {
 				t.Fatalf("doRead(%s) must dial through; recorder saw %d calls", verb, rec.calls)

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -7,7 +7,7 @@
 package cli
 
 import (
-{{- if .IsAsync}}
+{{- if or .IsAsync .Endpoint.EmbeddedPagedSubresources}}
 	"context"
 {{- end}}
 	"encoding/json"
@@ -181,18 +181,18 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			var data json.RawMessage
 			if flagAll && !flags.dryRun {
 				var items []json.RawMessage
-				items, err = c.PaginatedQuery(client.{{pascal .ResourceName}}ListQuery, variables, "{{graphqlQueryField .Endpoint.ResponsePath}}", flagFirst)
+				items, err = c.PaginatedQuery(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables, "{{graphqlQueryField .Endpoint.ResponsePath}}", flagFirst)
 				if err == nil {
 					data, err = json.Marshal(items)
 				}
 			} else {
-				data, err = c.Query(client.{{pascal .ResourceName}}ListQuery, variables)
+				data, err = c.Query(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables)
 				if err == nil && !flags.dryRun {
 					data, err = extractGraphQLConnection(data, "{{graphqlQueryField .Endpoint.ResponsePath}}")
 				}
 			}
 {{- else}}
-			data, err := c.Query(client.{{pascal .ResourceName}}ListQuery, variables)
+			data, err := c.Query(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables)
 			if err == nil && !flags.dryRun {
 				data, err = extractGraphQLConnection(data, "{{graphqlQueryField .Endpoint.ResponsePath}}")
 			}
@@ -201,7 +201,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 {{- end}}
 {{- else if and $isGraphQLEndpoint (eq .EndpointName "get")}}
-			data, err := c.Query(client.{{pascal .ResourceName}}GetQuery, map[string]any{
+			data, err := c.Query(cmd.Context(), client.{{pascal .ResourceName}}GetQuery, map[string]any{
 				"id": args[0],
 			})
 			if err == nil && !flags.dryRun {
@@ -223,7 +223,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- else}}
-			data, err := paginatedGet(c, path, map[string]string{
+			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -250,9 +250,9 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{if .Endpoint.Pagination}}true{{else}}false{{end}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}})
 {{- else}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, err := c.GetWithHeaders(path, params, headerOverrides)
+			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
-			data, err := c.Get(path, params)
+			data, err := c.Get(cmd.Context(), path, params)
 {{- end}}
 {{- end}}
 {{- end}}
@@ -273,17 +273,17 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PostMultipartWithParamsAndHeaders(path, params, fields, fileFields, headerOverrides)
+			data, statusCode, err := c.PostMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PostMultipartWithParams(path, params, fields, fileFields)
+			data, statusCode, err := c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PostFormWithParamsAndHeaders(path, params, fields, headerOverrides)
+			data, statusCode, err := c.PostFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PostFormWithParams(path, params, fields)
+			data, statusCode, err := c.PostFormWithParams(cmd.Context(), path, params, fields)
 {{- end}}
 {{- else}}
 			var body map[string]any
@@ -302,15 +302,15 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{bodyMapForEndpoint .Endpoint "\t\t\t\t"}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 {{- if .IsReadOnly}}
-			data, statusCode, err := c.PostQueryWithParamsAndHeaders(path, params, body, headerOverrides)
+			data, statusCode, err := c.PostQueryWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PostWithParamsAndHeaders(path, params, body, headerOverrides)
+			data, statusCode, err := c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- end}}
 {{- else}}
 {{- if .IsReadOnly}}
-			data, statusCode, err := c.PostQueryWithParams(path, params, body)
+			data, statusCode, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 {{- else}}
-			data, statusCode, err := c.PostWithParams(path, params, body)
+			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 {{- end}}
 {{- end}}
 {{- end}}
@@ -327,9 +327,9 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 {{- end}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.DeleteWithParamsAndHeaders(path, params, headerOverrides)
+			data, statusCode, err := c.DeleteWithParamsAndHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.DeleteWithParams(path, params)
+			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)
 {{- end}}
 {{- else if eq .Endpoint.Method "PUT"}}
 			params := map[string]string{}
@@ -348,17 +348,17 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PutMultipartWithParamsAndHeaders(path, params, fields, fileFields, headerOverrides)
+			data, statusCode, err := c.PutMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PutMultipartWithParams(path, params, fields, fileFields)
+			data, statusCode, err := c.PutMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PutFormWithParamsAndHeaders(path, params, fields, headerOverrides)
+			data, statusCode, err := c.PutFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PutFormWithParams(path, params, fields)
+			data, statusCode, err := c.PutFormWithParams(cmd.Context(), path, params, fields)
 {{- end}}
 {{- else}}
 			var body map[string]any
@@ -376,9 +376,9 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 				body = map[string]any{}
 {{bodyMapForEndpoint .Endpoint "\t\t\t\t"}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PutWithParamsAndHeaders(path, params, body, headerOverrides)
+			data, statusCode, err := c.PutWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PutWithParams(path, params, body)
+			data, statusCode, err := c.PutWithParams(cmd.Context(), path, params, body)
 {{- end}}
 {{- end}}
 {{- else if eq .Endpoint.Method "PATCH"}}
@@ -398,17 +398,17 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PatchMultipartWithParamsAndHeaders(path, params, fields, fileFields, headerOverrides)
+			data, statusCode, err := c.PatchMultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PatchMultipartWithParams(path, params, fields, fileFields)
+			data, statusCode, err := c.PatchMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PatchFormWithParamsAndHeaders(path, params, fields, headerOverrides)
+			data, statusCode, err := c.PatchFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PatchFormWithParams(path, params, fields)
+			data, statusCode, err := c.PatchFormWithParams(cmd.Context(), path, params, fields)
 {{- end}}
 {{- else}}
 			var body map[string]any
@@ -426,9 +426,9 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 				body = map[string]any{}
 {{bodyMapForEndpoint .Endpoint "\t\t\t\t"}}			}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, statusCode, err := c.PatchWithParamsAndHeaders(path, params, body, headerOverrides)
+			data, statusCode, err := c.PatchWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
 {{- else}}
-			data, statusCode, err := c.PatchWithParams(path, params, body)
+			data, statusCode, err := c.PatchWithParams(cmd.Context(), path, params, body)
 {{- end}}
 {{- end}}
 {{- end}}
@@ -756,14 +756,14 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 // companion calls the dedicated child endpoint and paginates until
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
-func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "{{.ChildPath}}"
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
 }
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -10,6 +10,9 @@
 package cli
 
 import (
+{{- if .Endpoint.EmbeddedPagedSubresources}}
+	"context"
+{{- end}}
 	"encoding/json"
 	"fmt"
 {{- if and (or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")) $isForm}}
@@ -155,7 +158,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
 {{- else}}
-			data, err := paginatedGet(c, path, map[string]string{
+			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
@@ -182,15 +185,15 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{if .Endpoint.Pagination}}true{{else}}false{{end}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}})
 {{- else if eq $method "GET"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, err := c.GetWithHeaders(path, params, headerOverrides)
+			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
-			data, err := c.Get(path, params)
+			data, err := c.Get(cmd.Context(), path, params)
 {{- end}}
 {{- else if eq (upper .Endpoint.Method) "DELETE"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, _, err := c.DeleteWithParamsAndHeaders(path, params, headerOverrides)
+			data, _, err := c.DeleteWithParamsAndHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
-			data, _, err := c.DeleteWithParams(path, params)
+			data, _, err := c.DeleteWithParams(cmd.Context(), path, params)
 {{- end}}
 {{- else if or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")}}
 {{- if $isMultipart}}
@@ -198,17 +201,17 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			fileFields := map[string]string{}
 {{multipartBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, _, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParamsAndHeaders(path, params, fields, fileFields, headerOverrides)
+			data, _, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParamsAndHeaders(cmd.Context(), path, params, fields, fileFields, headerOverrides)
 {{- else}}
-			data, _, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParams(path, params, fields, fileFields)
+			data, _, err := c.{{pascal (lower .Endpoint.Method)}}MultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 {{- end}}
 {{- else if $isForm}}
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, _, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParamsAndHeaders(path, params, fields, headerOverrides)
+			data, _, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
 {{- else}}
-			data, _, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParams(path, params, fields)
+			data, _, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParams(cmd.Context(), path, params, fields)
 {{- end}}
 {{- else}}
 			// HasStore + non-GET falls through to a live API call here
@@ -216,8 +219,8 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// body-aware cached read helper is filed as #425 for when a
 			// second store-backed POST-search consumer ships.
 			body := map[string]any{}
-{{bodyMapForEndpoint .Endpoint "\t\t\t"}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(path, params, body, headerOverrides)
-{{else}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}WithParams(path, params, body)
+{{bodyMapForEndpoint .Endpoint "\t\t\t"}}{{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}WithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)
+{{else}}			data, _, err := c.{{pascal (lower .Endpoint.Method)}}WithParams(cmd.Context(), path, params, body)
 {{end}}
 {{- end}}
 {{- else}}
@@ -225,9 +228,9 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			// stays compileable. Spec authors who genuinely need these verbs
 			// should add a typed client method and a dedicated template branch.
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
-			data, err := c.GetWithHeaders(path, params, headerOverrides)
+			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)
 {{- else}}
-			data, err := c.Get(path, params)
+			data, err := c.Get(cmd.Context(), path, params)
 {{- end}}
 {{- end}}
 {{- if and .HasStore (ne (upper .Endpoint.Method) "GET")}}
@@ -381,14 +384,14 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 // companion calls the dedicated child endpoint and paginates until
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
-func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "{{.ChildPath}}"
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
 }
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -100,14 +100,14 @@ func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resour
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := c.GetWithHeaders(path, params, headers)
+		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := c.GetWithHeaders(path, params, headers)
+		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
@@ -136,14 +136,14 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 		return data, attachFreshness(prov, flags), err
 
 	case "live":
-		data, err := paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
-		data, err := paginatedGet(c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
+		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, nextCursorPath, hasMoreField)
 		if err == nil {
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -445,9 +445,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					if !strings.HasPrefix(healthPath, "/") {
 						healthPath = "/" + healthPath
 					}
-					reachBody, reachErr := c.Get(healthPath, nil)
+					reachBody, reachErr := c.Get(cmd.Context(), healthPath, nil)
 {{- else}}
-					reachBody, reachErr := c.Get("/", nil)
+					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
 {{- end}}
 					var reachAPIErr *client.APIError
 					switch {
@@ -531,7 +531,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						if !strings.HasPrefix(verifyPath, "/") {
 							verifyPath = "/" + verifyPath
 						}
-						_, authErr := c.GetWithHeaders(verifyPath, authParams, authHeaders)
+						_, authErr := c.GetWithHeaders(cmd.Context(), verifyPath, authParams, authHeaders)
 						var authAPIErr *client.APIError
 						switch {
 						case authErr == nil:
@@ -557,7 +557,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						// probe under PRINTING_PRESS_VERIFY=1.
 						authHeaders["Content-Type"] = "application/json"
 						verifyBody := map[string]string{"query": {{printf "%q" .Auth.VerifyQuery}}}
-						respBody, _, gqlErr := c.PostQueryWithParamsAndHeaders("", authParams, verifyBody, authHeaders)
+						respBody, _, gqlErr := c.PostQueryWithParamsAndHeaders(cmd.Context(), "", authParams, verifyBody, authHeaders)
 						var gqlAPIErr *client.APIError
 						switch {
 						case gqlErr == nil:

--- a/internal/generator/templates/export.go.tmpl
+++ b/internal/generator/templates/export.go.tmpl
@@ -78,7 +78,7 @@ large datasets as it has no memory pressure.`,
 				defer writer.Flush()
 			}
 
-			data, err := c.Get(path, nil)
+			data, err := c.Get(cmd.Context(), path, nil)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/internal/generator/templates/graphql_client.go.tmpl
+++ b/internal/generator/templates/graphql_client.go.tmpl
@@ -4,9 +4,7 @@
 package client
 
 import (
-{{- if .HasCostThrottling}}
 	"context"
-{{- end}}
 	"encoding/json"
 	"fmt"
 {{- if .HasCostThrottling}}
@@ -164,12 +162,12 @@ func (c *Client) awaitBudget(ctx context.Context, cost float64) error {
 
 // Query executes a GraphQL query via POST against graphqlEndpointPath and
 // returns the raw data payload.
-func (c *Client) Query(query string, variables map[string]any) (json.RawMessage, error) {
+func (c *Client) Query(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
 {{- if .HasCostThrottling}}
-	return c.queryWithThrottle(context.Background(), query, variables)
+	return c.queryWithThrottle(ctx, query, variables)
 {{- else}}
 	req := GraphQLRequest{Query: query, Variables: variables}
-	raw, _, err := c.Post(graphqlEndpointPath, req)
+	raw, _, err := c.Post(ctx, graphqlEndpointPath, req)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +214,7 @@ func (c *Client) queryWithThrottle(ctx context.Context, query string, variables 
 		if err := c.awaitBudget(ctx, defaultThrottleQueryCost); err != nil {
 			return nil, err
 		}
-		raw, _, err := c.Post(graphqlEndpointPath, req)
+		raw, _, err := c.Post(ctx, graphqlEndpointPath, req)
 		if err != nil {
 			return nil, err
 		}
@@ -272,14 +270,14 @@ func (c *Client) queryWithThrottle(ctx context.Context, query string, variables 
 // Mutate executes a GraphQL mutation via POST against graphqlEndpointPath and
 // returns the raw data payload. Identical transport to Query; separate method
 // for clarity.
-func (c *Client) Mutate(query string, variables map[string]any) (json.RawMessage, error) {
-	return c.Query(query, variables)
+func (c *Client) Mutate(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	return c.Query(ctx, query, variables)
 }
 
 // PaginatedQuery fetches all pages of a Connection field using first/after pagination.
 // fieldPath is the top-level field name in the response (e.g., "issues").
 // Returns all collected nodes across all pages.
-func (c *Client) PaginatedQuery(query string, variables map[string]any, fieldPath string, pageSize int) ([]json.RawMessage, error) {
+func (c *Client) PaginatedQuery(ctx context.Context, query string, variables map[string]any, fieldPath string, pageSize int) ([]json.RawMessage, error) {
 	if variables == nil {
 		variables = map[string]any{}
 	}
@@ -291,7 +289,7 @@ func (c *Client) PaginatedQuery(query string, variables map[string]any, fieldPat
 	var all []json.RawMessage
 	hasNext := true
 	for hasNext {
-		data, err := c.Query(query, variables)
+		data, err := c.Query(ctx, query, variables)
 		if err != nil {
 			return all, err
 		}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	"errors"
@@ -148,7 +149,7 @@ Exit codes & warnings:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full, maxPages)
+						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages)
 						results <- res
 					}
 				}()
@@ -264,7 +265,7 @@ func graphqlSyncDefs() map[string]graphqlSyncDef {
 }
 
 // syncResource handles the full paginated sync of a single resource via GraphQL.
-func syncResource(c *client.Client, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
+func syncResource(ctx context.Context, c *client.Client, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -303,7 +304,7 @@ func syncResource(c *client.Client, db *store.Store, resource, sinceTS string, f
 			variables["after"] = cursor
 		}
 
-		data, err := c.Query(def.Query, variables)
+		data, err := c.Query(ctx, def.Query, variables)
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -8,6 +8,7 @@ import (
 {{- if .HasDataLayer}}
 	"bytes"
 {{- end}}
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -729,8 +730,8 @@ func replacePathParam(path, name, value string) string {
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
 // endpoint has no per-endpoint header overrides.
-func paginatedGet(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func paginatedGet(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
@@ -745,7 +746,7 @@ func paginatedGet(c interface {
 	}
 
 	if !fetchAll {
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -764,7 +765,7 @@ func paginatedGet(c interface {
 			fmt.Fprintf(os.Stderr, `{"event":"page_fetch","page":%d}`+"\n", page)
 		}
 
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -959,8 +960,8 @@ const embeddedPagedSubresourcePageCap = 500
 // Envelope lookups are case-insensitive: API authors sometimes
 // describe envelopes in one casing in the schema and serve another on
 // the wire (`NextPageToken` vs `nextPageToken`).
-func fetchEmbeddedPagedSubresource(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, childPath, nextField string, nextIsURL, nextIsBoolean bool) ([]json.RawMessage, error) {
 	all := make([]json.RawMessage, 0)
 	nextURL := ""
@@ -969,7 +970,7 @@ func fetchEmbeddedPagedSubresource(c interface {
 		if nextURL != "" {
 			target = relativizeNextURL(nextURL)
 		}
-		data, err := c.GetWithHeaders(target, nil, nil)
+		data, err := c.GetWithHeaders(ctx, target, nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: %w", childPath, page+1, err)
 		}

--- a/internal/generator/templates/import.go.tmpl
+++ b/internal/generator/templates/import.go.tmpl
@@ -74,7 +74,7 @@ but do not stop the import.`,
 					continue
 				}
 
-				_, _, err := c.Post(path, body)
+				_, _, err := c.Post(cmd.Context(), path, body)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					failed++

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -259,33 +259,33 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	switch ep.Method {
 	case "GET":
 		if len(hdrs) > 0 {
-			data, err = c.GetWithHeaders(path, query, hdrs)
+			data, err = c.GetWithHeaders(ctx, path, query, hdrs)
 		} else {
-			data, err = c.Get(path, query)
+			data, err = c.Get(ctx, path, query)
 		}
 	case "DELETE":
 		if len(hdrs) > 0 {
-			data, _, err = c.DeleteWithParamsAndHeaders(path, query, hdrs)
+			data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, query, hdrs)
 		} else {
-			data, _, err = c.DeleteWithParams(path, query)
+			data, _, err = c.DeleteWithParams(ctx, path, query)
 		}
 	case "POST":
 		if len(hdrs) > 0 {
-			data, _, err = c.PostWithHeaders(path, params, hdrs)
+			data, _, err = c.PostWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Post(path, params)
+			data, _, err = c.Post(ctx, path, params)
 		}
 	case "PUT":
 		if len(hdrs) > 0 {
-			data, _, err = c.PutWithHeaders(path, params, hdrs)
+			data, _, err = c.PutWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Put(path, params)
+			data, _, err = c.Put(ctx, path, params)
 		}
 	case "PATCH":
 		if len(hdrs) > 0 {
-			data, _, err = c.PatchWithHeaders(path, params, hdrs)
+			data, _, err = c.PatchWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Patch(path, params)
+			data, _, err = c.Patch(ctx, path, params)
 		}
 	default:
 		return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -61,7 +61,7 @@ func handle{{pascal .Name}}(ctx context.Context, req mcplib.CallToolRequest) (*m
 			params[{{printf "%q" $paramName}}] = v
 		}
 {{- end}}
-		resp, err := callIntentEndpoint(c, {{printf "%q" $step.Endpoint}}, params)
+		resp, err := callIntentEndpoint(ctx, c, {{printf "%q" $step.Endpoint}}, params)
 		if err != nil {
 			return mcplib.NewToolResultError(fmt.Sprintf("step %d ({{$step.Endpoint}}) failed: %v", {{add $i 1}}, err)), nil
 		}
@@ -132,7 +132,7 @@ func resolveIntentBinding(scope map[string]any, expr string) (any, bool) {
 // client. It uses the generator-emitted endpoint registry below to look up
 // the HTTP method, path template, and positional-param set so the intent
 // handler can stay generic across endpoints.
-func callIntentEndpoint(c *client.Client, ref string, params map[string]any) (any, error) {
+func callIntentEndpoint(ctx context.Context, c *client.Client, ref string, params map[string]any) (any, error) {
 	ep, ok := intentEndpoints[ref]
 	if !ok {
 		return nil, fmt.Errorf("unknown endpoint %q", ref)
@@ -160,9 +160,9 @@ func callIntentEndpoint(c *client.Client, ref string, params map[string]any) (an
 	// code built `query` but never passed it.
 	switch ep.method {
 	case "GET":
-		data, err = c.Get(path, query)
+		data, err = c.Get(ctx, path, query)
 	case "DELETE":
-		data, _, err = c.DeleteWithParams(path, query)
+		data, _, err = c.DeleteWithParams(ctx, path, query)
 	default:
 		body, mErr := json.Marshal(params)
 		if mErr != nil {
@@ -170,11 +170,11 @@ func callIntentEndpoint(c *client.Client, ref string, params map[string]any) (an
 		}
 		switch ep.method {
 		case "POST":
-			data, _, err = c.Post(path, body)
+			data, _, err = c.Post(ctx, path, body)
 		case "PUT":
-			data, _, err = c.Put(path, body)
+			data, _, err = c.Put(ctx, path, body)
 		case "PATCH":
-			data, _, err = c.Patch(path, body)
+			data, _, err = c.Patch(ctx, path, body)
 		default:
 			return nil, fmt.Errorf("unsupported method %q", ep.method)
 		}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -345,124 +345,124 @@ func makeAPIHandler(method, pathTemplate string, binaryResponse bool, headerOver
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 {{- if $hasMultipartRequest}}
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PostMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PostMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PostMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PostMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 {{- end}}
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
-					data, _, err = c.PostFormWithParamsAndHeaders(path, params, formFields, headers)
+					data, _, err = c.PostFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
 					break
 				}
-				data, _, err = c.PostFormWithParams(path, params, formFields)
+				data, _, err = c.PostFormWithParams(ctx, path, params, formFields)
 				break
 			}
 {{- end}}
 {{- if $hasBodyJSONFallback}}
 			if len(bodyJSONOverride) > 0 {
 				if len(headers) > 0 {
-					data, _, err = c.PostWithParamsAndHeaders(path, params, bodyJSONOverride, headers)
+					data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
 					break
 				}
-				data, _, err = c.PostWithParams(path, params, bodyJSONOverride)
+				data, _, err = c.PostWithParams(ctx, path, params, bodyJSONOverride)
 				break
 			}
 {{- end}}
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 {{- if $hasMultipartRequest}}
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PutMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PutMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PutMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PutMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 {{- end}}
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
-					data, _, err = c.PutFormWithParamsAndHeaders(path, params, formFields, headers)
+					data, _, err = c.PutFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
 					break
 				}
-				data, _, err = c.PutFormWithParams(path, params, formFields)
+				data, _, err = c.PutFormWithParams(ctx, path, params, formFields)
 				break
 			}
 {{- end}}
 {{- if $hasBodyJSONFallback}}
 			if len(bodyJSONOverride) > 0 {
 				if len(headers) > 0 {
-					data, _, err = c.PutWithParamsAndHeaders(path, params, bodyJSONOverride, headers)
+					data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
 					break
 				}
-				data, _, err = c.PutWithParams(path, params, bodyJSONOverride)
+				data, _, err = c.PutWithParams(ctx, path, params, bodyJSONOverride)
 				break
 			}
 {{- end}}
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 {{- if $hasMultipartRequest}}
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PatchMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PatchMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PatchMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PatchMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 {{- end}}
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
-					data, _, err = c.PatchFormWithParamsAndHeaders(path, params, formFields, headers)
+					data, _, err = c.PatchFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
 					break
 				}
-				data, _, err = c.PatchFormWithParams(path, params, formFields)
+				data, _, err = c.PatchFormWithParams(ctx, path, params, formFields)
 				break
 			}
 {{- end}}
 {{- if $hasBodyJSONFallback}}
 			if len(bodyJSONOverride) > 0 {
 				if len(headers) > 0 {
-					data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyJSONOverride, headers)
+					data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyJSONOverride, headers)
 					break
 				}
-				data, _, err = c.PatchWithParams(path, params, bodyJSONOverride)
+				data, _, err = c.PatchWithParams(ctx, path, params, bodyJSONOverride)
 				break
 			}
 {{- end}}
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -122,14 +122,14 @@ In local mode: searches locally synced data only.`,
 					return err
 				}
 {{- if eq .SearchEndpointMethod "POST"}}
-				data, _, getErr := c.Post("{{.SearchEndpointPath}}", map[string]any{
+				data, _, getErr := c.Post(cmd.Context(), "{{.SearchEndpointPath}}", map[string]any{
 					"{{.SearchQueryParam}}": query,
 {{- range .SearchBodyFields}}
 					"{{.Name}}": {{goLiteral .Default}},
 {{- end}}
 				})
 {{- else}}
-				data, getErr := c.Get("{{.SearchEndpointPath}}", map[string]string{
+				data, getErr := c.Get(cmd.Context(), "{{.SearchEndpointPath}}", map[string]string{
 					"{{.SearchQueryParam}}": query,
 				})
 {{- end}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -10,6 +10,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	"errors"
@@ -302,7 +303,7 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource({{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, sinceTS, full, maxPages, effectiveLatestOnly{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams)
+						res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, sinceTS, full, maxPages, effectiveLatestOnly{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams)
 						results <- res
 					}
 				}()
@@ -362,7 +363,7 @@ Resource scoping:
 
 {{- if .DependentSyncResources}}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams)
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -476,10 +477,10 @@ Resource scoping:
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
 // channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
 // keep both call sites in sync if this signature changes.
-func syncResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 {{- if $hasPostSync}}
-	PostWithParams(string, map[string]string, any) (json.RawMessage, int, error)
+	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 {{- end}}
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) syncResult {
@@ -624,9 +625,9 @@ func syncResource(c interface {
 		userParams.applyTo(resource, params, false)
 
 {{ if $hasPostSync -}}
-		data, err := syncFetch(c, resource, path, params)
+		data, err := syncFetch(ctx, c, resource, path, params)
 {{ else -}}
-		data, err := c.Get(path, params)
+		data, err := c.Get(ctx, path, params)
 {{ end -}}
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
@@ -874,15 +875,15 @@ func resourceSupportsPagination(resource string) bool {
 
 {{- if $hasPostSync}}
 
-func syncFetch(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
-	PostWithParams(string, map[string]string, any) (json.RawMessage, int, error)
+func syncFetch(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
+	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 }, resource string, path string, params map[string]string) (json.RawMessage, error) {
 	if syncResourceMethod(resource) != "POST" {
-		return c.Get(path, params)
+		return c.Get(ctx, path, params)
 	}
 	queryParams, body := splitSyncPostParams(resource, params)
-	data, _, err := c.PostWithParams(path, queryParams, body)
+	data, _, err := c.PostWithParams(ctx, path, queryParams, body)
 	return data, err
 }
 
@@ -1506,10 +1507,10 @@ func dependentResourceDefs() []dependentResourceDef {
 // syncDependentResources iterates parent tables and syncs child resources per parent ID.
 // parentFilter mirrors the user's --resources flag (empty = sync everything). A dependent
 // runs when its parent table or its own name appears in the filter.
-func syncDependentResources(c {{if .HasTierRouting}}*client.Client{{else}}interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResources(ctx context.Context, c {{if .HasTierRouting}}*client.Client{{else}}interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 {{- if $hasPostSync}}
-	PostWithParams(string, map[string]string, any) (json.RawMessage, int, error)
+	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 {{- end}}
 	RateLimit() float64
 }{{end}}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) []syncResult {
@@ -1522,17 +1523,17 @@ func syncDependentResources(c {{if .HasTierRouting}}*client.Client{{else}}interf
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource({{if .HasTierRouting}}syncClientForResource(c, dep.Name){{else}}c{{end}}, db, dep, sinceTS, full, maxPages, latestOnly{{if .Pagination.DateRangeParam}}, dates{{end}}, userParams)
+		res := syncDependentResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, dep.Name){{else}}c{{end}}, db, dep, sinceTS, full, maxPages, latestOnly{{if .Pagination.DateRangeParam}}, dates{{end}}, userParams)
 		results = append(results, res)
 	}
 	return results
 }
 
 // syncDependentResource syncs a single child resource by iterating all parent IDs.
-func syncDependentResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 {{- if $hasPostSync}}
-	PostWithParams(string, map[string]string, any) (json.RawMessage, int, error)
+	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 {{- end}}
 	RateLimit() float64
 }, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) syncResult {
@@ -1631,9 +1632,9 @@ func syncDependentResource(c interface {
 			userParams.applyTo(dep.Name, params, true)
 
 {{ if $hasPostSync -}}
-			data, err := syncFetch(c, dep.Name, path, params)
+			data, err := syncFetch(ctx, c, dep.Name, path, params)
 {{ else -}}
-			data, err := c.Get(path, params)
+			data, err := c.Get(ctx, path, params)
 {{ end -}}
 			if err != nil {
 				// Non-fatal per parent: log and continue to next parent.

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -74,7 +75,7 @@ native streaming instead of polling.`,
 			fmt.Fprintf(os.Stderr, "Tailing %s every %s (Ctrl+C to stop)\n", resource, interval)
 
 			// Initial fetch
-			if err := fetchAndEmit(c, path, enc); err != nil {
+			if err := fetchAndEmit(cmd.Context(), c, path, enc); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: initial fetch failed: %v\n", err)
 			}
 
@@ -84,7 +85,7 @@ native streaming instead of polling.`,
 					fmt.Fprintln(os.Stderr, "\nShutting down gracefully...")
 					return nil
 				case <-ticker.C:
-					if err := fetchAndEmit(c, path, enc); err != nil {
+					if err := fetchAndEmit(cmd.Context(), c, path, enc); err != nil {
 						fmt.Fprintf(os.Stderr, "warning: poll failed: %v\n", err)
 					}
 				}
@@ -110,8 +111,10 @@ func tailKnownResources() []string {
 	}
 }
 
-func fetchAndEmit(c interface{ Get(string, map[string]string) (json.RawMessage, error) }, path string, enc *json.Encoder) error {
-	data, err := c.Get(path, nil)
+func fetchAndEmit(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
+}, path string, enc *json.Encoder) error {
+	data, err := c.Get(ctx, path, nil)
 	if err != nil {
 		return err
 	}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -89,12 +90,12 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 // companion calls the dedicated child endpoint and paginates until
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
-func fetchFullCustomersGetSubscriptions(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchFullCustomersGetSubscriptions(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/customers/{id}/subscriptions"
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(c, childPath, "has_more", false, true)
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "has_more", false, true)
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"embedded-paged-pp-cli/internal/client"
 	"embedded-paged-pp-cli/internal/cliutil"
 	"encoding/json"
@@ -531,8 +532,8 @@ func replacePathParam(path, name, value string) string {
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
 // endpoint has no per-endpoint header overrides.
-func paginatedGet(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func paginatedGet(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
@@ -547,7 +548,7 @@ func paginatedGet(c interface {
 	}
 
 	if !fetchAll {
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -566,7 +567,7 @@ func paginatedGet(c interface {
 			fmt.Fprintf(os.Stderr, `{"event":"page_fetch","page":%d}`+"\n", page)
 		}
 
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -759,8 +760,8 @@ const embeddedPagedSubresourcePageCap = 500
 // Envelope lookups are case-insensitive: API authors sometimes
 // describe envelopes in one casing in the schema and serve another on
 // the wire (`NextPageToken` vs `nextPageToken`).
-func fetchEmbeddedPagedSubresource(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, childPath, nextField string, nextIsURL, nextIsBoolean bool) ([]json.RawMessage, error) {
 	all := make([]json.RawMessage, 0)
 	nextURL := ""
@@ -769,7 +770,7 @@ func fetchEmbeddedPagedSubresource(c interface {
 		if nextURL != "" {
 			target = relativizeNextURL(nextURL)
 		}
-		data, err := c.GetWithHeaders(target, nil, nil)
+		data, err := c.GetWithHeaders(ctx, target, nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: %w", childPath, page+1, err)
 		}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -89,12 +90,12 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 // companion calls the dedicated child endpoint and paginates until
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
-func fetchFullPagesGetChildren(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchFullPagesGetChildren(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/pages/{id}/children"
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(c, childPath, "next_cursor", false, false)
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "next_cursor", false, false)
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -89,12 +90,12 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 // companion calls the dedicated child endpoint and paginates until
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
-func fetchFullPlaylistsGetTracks(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func fetchFullPlaylistsGetTracks(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/playlists/{id}/tracks"
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(c, childPath, "next", true, false)
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "next", true, false)
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -92,7 +93,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// receive the auth credential, even though we are inside
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
-			if h, err := c.authHeader(); err == nil && h != "" {
+			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("Authorization", h)
 			}
 		}
@@ -106,12 +107,12 @@ func (c *Client) RateLimit() float64 {
 	return c.limiter.Rate()
 }
 
-func (c *Client) Get(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeaders(path, params, nil)
+func (c *Client) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, path, params, nil)
 }
 
-func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	if err := c.validateCachedRequestAuth(); err != nil {
+func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
 	// Check cache for GET requests
@@ -120,7 +121,7 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 			return cached, nil
 		}
 	}
-	result, _, err := c.do("GET", path, params, nil, headers)
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
@@ -136,22 +137,22 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 // (e.g. a follow-up `... get <id>` after WaitForJob returns) see the
 // terminal value, not the stale non-terminal snapshot left behind by the
 // first poll.
-func (c *Client) GetNoCache(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeadersNoCache(path, params, nil)
+func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
 // GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
 // still writes the fresh response on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
-func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	result, _, err := c.do("GET", path, params, nil, headers)
+func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
 	return result, err
 }
 
-func (c *Client) validateCachedRequestAuth() error {
+func (c *Client) validateCachedRequestAuth(ctx context.Context) error {
 	if c == nil || c.Config == nil {
 		return nil
 	}
@@ -165,8 +166,8 @@ func (c *Client) validateCachedRequestAuth() error {
 	return nil
 }
 
-func (c *Client) ProbeGet(path string) (int, error) {
-	_, status, err := c.do("GET", path, nil, nil, nil)
+func (c *Client) ProbeGet(ctx context.Context, path string) (int, error) {
+	_, status, err := c.do(ctx, "GET", path, nil, nil, nil)
 	return status, err
 }
 
@@ -224,20 +225,20 @@ func (c *Client) invalidateCache() {
 	_ = os.RemoveAll(c.cacheDir)
 }
 
-func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, nil)
+func (c *Client) Post(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, nil)
 }
 
-func (c *Client) PostWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, nil)
+func (c *Client) PostWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, nil)
 }
 
-func (c *Client) PostWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, headers)
+func (c *Client) PostWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, headers)
 }
 
-func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, headers)
+func (c *Client) PostWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, headers)
 }
 
 // PostQueryWithParams is a POST that does not mutate remote state — used
@@ -245,62 +246,62 @@ func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string,
 // queries, JSON-RPC reads, POST-based search endpoints). The verify-mode
 // short-circuit does not fire for these calls; the request reaches the
 // real transport even under PRINTING_PRESS_VERIFY=1 without LIVE_HTTP=1.
-func (c *Client) PostQueryWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, nil)
+func (c *Client) PostQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, nil)
 }
 
 // PostQueryWithParamsAndHeaders is the headers-aware counterpart to
 // PostQueryWithParams. See PostQueryWithParams for the verify-mode rationale.
-func (c *Client) PostQueryWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, headers)
+func (c *Client) PostQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, headers)
 }
 
-func (c *Client) Delete(path string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, nil)
+func (c *Client) Delete(ctx context.Context, path string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, nil)
 }
 
-func (c *Client) DeleteWithParams(path string, params map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, nil)
+func (c *Client) DeleteWithParams(ctx context.Context, path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, nil)
 }
 
-func (c *Client) DeleteWithHeaders(path string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, headers)
+func (c *Client) DeleteWithHeaders(ctx context.Context, path string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, headers)
 }
 
-func (c *Client) DeleteWithParamsAndHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, headers)
+func (c *Client) DeleteWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, headers)
 }
 
-func (c *Client) Put(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, nil)
+func (c *Client) Put(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, nil)
 }
 
-func (c *Client) PutWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, nil)
+func (c *Client) PutWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, nil)
 }
 
-func (c *Client) PutWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, headers)
+func (c *Client) PutWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, headers)
 }
 
-func (c *Client) PutWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, headers)
+func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
-func (c *Client) Patch(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, nil)
+func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
 
-func (c *Client) PatchWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, nil)
+func (c *Client) PatchWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, nil)
 }
 
-func (c *Client) PatchWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, headers)
+func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, headers)
 }
 
-func (c *Client) PatchWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, headers)
+func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.
@@ -335,10 +336,21 @@ func verifyShortCircuitEnvelope(method, path string) json.RawMessage {
 	return json.RawMessage(body)
 }
 
+func sleepContext(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // do executes an HTTP request. headerOverrides, when non-nil, override global
 // RequiredHeaders for this specific request (used for per-endpoint API versioning).
-func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, false)
+func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, false)
 }
 
 // doRead is do() minus the verify-mode mutating-verb gate. Used by the
@@ -347,15 +359,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 // The wire verb is still POST/PUT/PATCH so the server sees a real request,
 // but the verify-mode short-circuit does not fire because the operation
 // does not mutate remote state.
-func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, true)
+func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, true)
 }
 
 // doInternal is the shared implementation behind do() and doRead(). The
 // readOnlyIntent flag is set by doRead() callers (read-only POST/PUT/PATCH
 // operations like GraphQL queries) to skip the mutating-verb verify-mode
 // gate. Plain do() callers leave it false and get the usual short-circuit.
-func (c *Client) doInternal(method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
+func (c *Client) doInternal(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
 	// Verify-mode transport-layer gate. When the verifier (or any consumer
 	// that sets PRINTING_PRESS_VERIFY=1) drives a mutating verb without
 	// the LIVE_HTTP=1 opt-in, return a synthetic envelope without dialing,
@@ -390,7 +402,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 	// exactly what would be sent. Uses only cached credentials; a token that
 	// requires a network refresh will be re-fetched on the live request path,
 	// not during dry-run.
-	authHeader, err := c.authHeader()
+	authHeader, err := c.authHeader(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -411,7 +423,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			bodyReader = strings.NewReader(string(bodyBytes))
 		}
 
-		req, err := http.NewRequest(method, targetURL, bodyReader)
+		req, err := http.NewRequestWithContext(ctx, method, targetURL, bodyReader)
 		if err != nil {
 			return nil, 0, fmt.Errorf("creating request: %w", err)
 		}
@@ -469,6 +481,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
 			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
 			continue
 		}
@@ -515,7 +530,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			c.limiter.OnRateLimit()
 			wait := cliutil.RetryAfter(resp)
 			fmt.Fprintf(os.Stderr, "rate limited, waiting %s (attempt %d/%d, rate adjusted to %.1f req/s)\n", wait, attempt+1, maxRetries, c.limiter.Rate())
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -524,7 +541,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 		if resp.StatusCode >= 500 && attempt < maxRetries {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -583,7 +602,7 @@ func (c *Client) ConfiguredTimeout() time.Duration {
 	return 30 * time.Second
 }
 
-func (c *Client) authHeader() (string, error) {
+func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}
@@ -605,7 +624,7 @@ func (c *Client) authHeader() (string, error) {
 					c.ccMu.Unlock()
 					return "", authPlaceholderCredentialError(c.Config)
 				}
-				if err := c.mintClientCredentials(clientID, clientSecret); err != nil {
+				if err := c.mintClientCredentials(ctx, clientID, clientSecret); err != nil {
 					c.ccMu.Unlock()
 					return "", err
 				}
@@ -702,7 +721,7 @@ func resolveClientCredentials(cfg *config.Config) (string, string) {
 	return id, secret
 }
 
-func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
+func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error {
 	tokenURL := ""
 	if c.Config != nil {
 		tokenURL = c.Config.TokenURL
@@ -718,7 +737,7 @@ func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
 	}
-	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("building token request: %w", err)
 	}
@@ -756,7 +775,7 @@ func (c *Client) mintClientCredentials(clientID, clientSecret string) error {
 	return nil
 }
 
-func (c *Client) refreshAccessToken() error {
+func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.Config == nil {
 		return nil
 	}
@@ -778,7 +797,12 @@ func (c *Client) refreshAccessToken() error {
 		params.Set("client_secret", c.Config.ClientSecret)
 	}
 
-	resp, err := c.HTTPClient.PostForm(tokenURL, params)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return fmt.Errorf("building refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("refreshing access token: %w", err)
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -271,7 +271,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get("/", nil)
+					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -524,8 +525,8 @@ func newTabWriter(w io.Writer) *tabwriter.Writer {
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
 // endpoint has no per-endpoint header overrides.
-func paginatedGet(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func paginatedGet(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
@@ -540,7 +541,7 @@ func paginatedGet(c interface {
 	}
 
 	if !fetchAll {
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +560,7 @@ func paginatedGet(c interface {
 			fmt.Fprintf(os.Stderr, `{"event":"page_fetch","page":%d}`+"\n", page)
 		}
 
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -145,34 +145,34 @@ func makeAPIHandler(method, pathTemplate string, binaryResponse bool, headerOver
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -219,7 +219,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get("/", nil)
+					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -531,8 +532,8 @@ func replacePathParam(path, name, value string) string {
 // argument carries per-endpoint required headers (e.g. cal-api-version) that
 // must be sent on every page request, including the first; pass nil when the
 // endpoint has no per-endpoint header overrides.
-func paginatedGet(c interface {
-	GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+func paginatedGet(ctx context.Context, c interface {
+	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, path string, params map[string]string, headers map[string]string, fetchAll bool, cursorParam, nextCursorPath, hasMoreField string) (json.RawMessage, error) {
 	// Cursor params are exempt from the "0"/"false" strip: offset-paginated
 	// APIs send offset=0 on the first page.
@@ -547,7 +548,7 @@ func paginatedGet(c interface {
 	}
 
 	if !fetchAll {
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -566,7 +567,7 @@ func paginatedGet(c interface {
 			fmt.Fprintf(os.Stderr, `{"event":"page_fetch","page":%d}`+"\n", page)
 		}
 
-		data, err := c.GetWithHeaders(path, clean, headers)
+		data, err := c.GetWithHeaders(ctx, path, clean, headers)
 		if err != nil {
 			return nil, err
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/import.go
@@ -74,7 +74,7 @@ but do not stop the import.`,
 					continue
 				}
 
-				_, _, err := c.Post(path, body)
+				_, _, err := c.Post(cmd.Context(), path, body)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "warning: failed to import record: %v\n", err)
 					failed++

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -46,7 +46,7 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 				fileFields["file"] = bodyFile
 			}
 
-			data, statusCode, err := c.PutMultipartWithParams(path, params, fields, fileFields)
+			data, statusCode, err := c.PutMultipartWithParams(cmd.Context(), path, params, fields, fileFields)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -62,7 +62,7 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 					body["visibility"] = bodyVisibility
 				}
 			}
-			data, statusCode, err := c.PostWithParams(path, params, body)
+			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -69,7 +69,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 					body["title"] = bodyTitle
 				}
 			}
-			data, statusCode, err := c.PatchWithParams(path, params, body)
+			data, statusCode, err := c.PatchWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -207,7 +208,7 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
+						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
 						results <- res
 					}
 				}()
@@ -261,7 +262,7 @@ Resource scoping:
 				}
 			}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams)
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -364,8 +365,8 @@ Resource scoping:
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
 // channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
 // keep both call sites in sync if this signature changes.
-func syncResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -480,7 +481,7 @@ func syncResource(c interface {
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
 
-		data, err := c.Get(path, params)
+		data, err := c.Get(ctx, path, params)
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
@@ -1134,8 +1135,8 @@ func dependentResourceDefs() []dependentResourceDef {
 // syncDependentResources iterates parent tables and syncs child resources per parent ID.
 // parentFilter mirrors the user's --resources flag (empty = sync everything). A dependent
 // runs when its parent table or its own name appears in the filter.
-func syncDependentResources(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResources(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string, userParams *syncUserParams) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
@@ -1147,15 +1148,15 @@ func syncDependentResources(c interface {
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource(c, db, dep, sinceTS, full, maxPages, latestOnly, userParams)
+		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, userParams)
 		results = append(results, res)
 	}
 	return results
 }
 
 // syncDependentResource syncs a single child resource by iterating all parent IDs.
-func syncDependentResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -1239,7 +1240,7 @@ func syncDependentResource(c interface {
 			// segment); --global-param and --resource-param still apply.
 			userParams.applyTo(dep.Name, params, true)
 
-			data, err := c.Get(path, params)
+			data, err := c.Get(ctx, path, params)
 			if err != nil {
 				// Non-fatal per parent: log and continue to next parent.
 				// Track access-denial separately so an all-denied dependent

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -86,7 +87,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// receive the auth credential, even though we are inside
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
-			if h, err := c.authHeader(); err == nil && h != "" {
+			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("X-API-Key", h)
 			}
 		}
@@ -100,12 +101,12 @@ func (c *Client) RateLimit() float64 {
 	return c.limiter.Rate()
 }
 
-func (c *Client) Get(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeaders(path, params, nil)
+func (c *Client) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, path, params, nil)
 }
 
-func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	if err := c.validateCachedRequestAuth(); err != nil {
+func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
 	// Check cache for GET requests
@@ -114,7 +115,7 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 			return cached, nil
 		}
 	}
-	result, _, err := c.do("GET", path, params, nil, headers)
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
@@ -130,22 +131,22 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 // (e.g. a follow-up `... get <id>` after WaitForJob returns) see the
 // terminal value, not the stale non-terminal snapshot left behind by the
 // first poll.
-func (c *Client) GetNoCache(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeadersNoCache(path, params, nil)
+func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
 // GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
 // still writes the fresh response on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
-func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	result, _, err := c.do("GET", path, params, nil, headers)
+func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
 	return result, err
 }
 
-func (c *Client) validateCachedRequestAuth() error {
+func (c *Client) validateCachedRequestAuth(ctx context.Context) error {
 	if c == nil || c.Config == nil {
 		return nil
 	}
@@ -155,8 +156,8 @@ func (c *Client) validateCachedRequestAuth() error {
 	return nil
 }
 
-func (c *Client) ProbeGet(path string) (int, error) {
-	_, status, err := c.do("GET", path, nil, nil, nil)
+func (c *Client) ProbeGet(ctx context.Context, path string) (int, error) {
+	_, status, err := c.do(ctx, "GET", path, nil, nil, nil)
 	return status, err
 }
 
@@ -214,20 +215,20 @@ func (c *Client) invalidateCache() {
 	_ = os.RemoveAll(c.cacheDir)
 }
 
-func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, nil)
+func (c *Client) Post(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, nil)
 }
 
-func (c *Client) PostWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, nil)
+func (c *Client) PostWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, nil)
 }
 
-func (c *Client) PostWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, headers)
+func (c *Client) PostWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, headers)
 }
 
-func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, headers)
+func (c *Client) PostWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, headers)
 }
 
 // PostQueryWithParams is a POST that does not mutate remote state — used
@@ -235,107 +236,107 @@ func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string,
 // queries, JSON-RPC reads, POST-based search endpoints). The verify-mode
 // short-circuit does not fire for these calls; the request reaches the
 // real transport even under PRINTING_PRESS_VERIFY=1 without LIVE_HTTP=1.
-func (c *Client) PostQueryWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, nil)
+func (c *Client) PostQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, nil)
 }
 
 // PostQueryWithParamsAndHeaders is the headers-aware counterpart to
 // PostQueryWithParams. See PostQueryWithParams for the verify-mode rationale.
-func (c *Client) PostQueryWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, headers)
+func (c *Client) PostQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, headers)
 }
-func (c *Client) PostMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
-}
-
-func (c *Client) PostMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PostMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PostMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PostMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PostMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PostMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) Delete(path string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, nil)
+func (c *Client) PostMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) DeleteWithParams(path string, params map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, nil)
+func (c *Client) Delete(ctx context.Context, path string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, nil)
 }
 
-func (c *Client) DeleteWithHeaders(path string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, headers)
+func (c *Client) DeleteWithParams(ctx context.Context, path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, nil)
 }
 
-func (c *Client) DeleteWithParamsAndHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, headers)
+func (c *Client) DeleteWithHeaders(ctx context.Context, path string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, headers)
 }
 
-func (c *Client) Put(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, nil)
+func (c *Client) DeleteWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, headers)
 }
 
-func (c *Client) PutWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, nil)
+func (c *Client) Put(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, nil)
 }
 
-func (c *Client) PutWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, headers)
+func (c *Client) PutWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, nil)
 }
 
-func (c *Client) PutWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, headers)
-}
-func (c *Client) PutMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PutWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, headers)
 }
 
-func (c *Client) PutMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, headers)
+}
+func (c *Client) PutMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PutMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PutMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PutMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PutMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) Patch(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, nil)
+func (c *Client) PutMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
-func (c *Client) PatchWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, nil)
+func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
 
-func (c *Client) PatchWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, headers)
+func (c *Client) PatchWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, nil)
 }
 
-func (c *Client) PatchWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, headers)
-}
-func (c *Client) PatchMultipart(path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, headers)
 }
 
-func (c *Client) PatchMultipartWithParams(path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
+func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, headers)
+}
+func (c *Client) PatchMultipart(ctx context.Context, path string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PatchMultipartWithHeaders(path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PatchMultipartWithParams(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, nil)
 }
 
-func (c *Client) PatchMultipartWithParamsAndHeaders(path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+func (c *Client) PatchMultipartWithHeaders(ctx context.Context, path string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
+}
+
+func (c *Client) PatchMultipartWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields map[string]string, fileFields map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, multipartRequestBody{Fields: fields, FileFields: fileFields}, headers)
 }
 
 type multipartRequestBody struct {
@@ -412,10 +413,21 @@ func verifyShortCircuitEnvelope(method, path string) json.RawMessage {
 	return json.RawMessage(body)
 }
 
+func sleepContext(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // do executes an HTTP request. headerOverrides, when non-nil, override global
 // RequiredHeaders for this specific request (used for per-endpoint API versioning).
-func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, false)
+func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, false)
 }
 
 // doRead is do() minus the verify-mode mutating-verb gate. Used by the
@@ -424,15 +436,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 // The wire verb is still POST/PUT/PATCH so the server sees a real request,
 // but the verify-mode short-circuit does not fire because the operation
 // does not mutate remote state.
-func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, true)
+func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, true)
 }
 
 // doInternal is the shared implementation behind do() and doRead(). The
 // readOnlyIntent flag is set by doRead() callers (read-only POST/PUT/PATCH
 // operations like GraphQL queries) to skip the mutating-verb verify-mode
 // gate. Plain do() callers leave it false and get the usual short-circuit.
-func (c *Client) doInternal(method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
+func (c *Client) doInternal(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
 	// Verify-mode transport-layer gate. When the verifier (or any consumer
 	// that sets PRINTING_PRESS_VERIFY=1) drives a mutating verb without
 	// the LIVE_HTTP=1 opt-in, return a synthetic envelope without dialing,
@@ -478,7 +490,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 	// exactly what would be sent. Uses only cached credentials; a token that
 	// requires a network refresh will be re-fetched on the live request path,
 	// not during dry-run.
-	authHeader, err := c.authHeader()
+	authHeader, err := c.authHeader(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -499,7 +511,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			bodyReader = strings.NewReader(string(bodyBytes))
 		}
 
-		req, err := http.NewRequest(method, targetURL, bodyReader)
+		req, err := http.NewRequestWithContext(ctx, method, targetURL, bodyReader)
 		if err != nil {
 			return nil, 0, fmt.Errorf("creating request: %w", err)
 		}
@@ -558,6 +570,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
 			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
 			continue
 		}
@@ -604,7 +619,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			c.limiter.OnRateLimit()
 			wait := cliutil.RetryAfter(resp)
 			fmt.Fprintf(os.Stderr, "rate limited, waiting %s (attempt %d/%d, rate adjusted to %.1f req/s)\n", wait, attempt+1, maxRetries, c.limiter.Rate())
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -613,7 +630,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 		if resp.StatusCode >= 500 && attempt < maxRetries {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -672,7 +691,7 @@ func (c *Client) ConfiguredTimeout() time.Duration {
 	return 30 * time.Second
 }
 
-func (c *Client) authHeader() (string, error) {
+func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -283,58 +283,58 @@ func makeAPIHandler(method, pathTemplate string, binaryResponse bool, headerOver
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PostMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PostMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PostMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PostMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PutMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PutMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PutMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PutMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 			if multipart {
 				if len(headers) > 0 {
-					data, _, err = c.PatchMultipartWithParamsAndHeaders(path, params, multipartFields, multipartFileFields, headers)
+					data, _, err = c.PatchMultipartWithParamsAndHeaders(ctx, path, params, multipartFields, multipartFileFields, headers)
 					break
 				}
-				data, _, err = c.PatchMultipartWithParams(path, params, multipartFields, multipartFileFields)
+				data, _, err = c.PatchMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)
 				break
 			}
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_get.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_get.go
@@ -49,7 +49,7 @@ func newThingsGetCmd(flags *rootFlags) *cobra.Command {
 			} else {
 				body = map[string]any{}
 			}
-			data, statusCode, err := c.PostQueryWithParams(path, params, body)
+			data, statusCode, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -45,7 +45,7 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 			} else {
 				body = map[string]any{}
 			}
-			data, statusCode, err := c.PostQueryWithParams(path, params, body)
+			data, statusCode, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -223,33 +223,33 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	switch ep.Method {
 	case "GET":
 		if len(hdrs) > 0 {
-			data, err = c.GetWithHeaders(path, query, hdrs)
+			data, err = c.GetWithHeaders(ctx, path, query, hdrs)
 		} else {
-			data, err = c.Get(path, query)
+			data, err = c.Get(ctx, path, query)
 		}
 	case "DELETE":
 		if len(hdrs) > 0 {
-			data, _, err = c.DeleteWithParamsAndHeaders(path, query, hdrs)
+			data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, query, hdrs)
 		} else {
-			data, _, err = c.DeleteWithParams(path, query)
+			data, _, err = c.DeleteWithParams(ctx, path, query)
 		}
 	case "POST":
 		if len(hdrs) > 0 {
-			data, _, err = c.PostWithHeaders(path, params, hdrs)
+			data, _, err = c.PostWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Post(path, params)
+			data, _, err = c.Post(ctx, path, params)
 		}
 	case "PUT":
 		if len(hdrs) > 0 {
-			data, _, err = c.PutWithHeaders(path, params, hdrs)
+			data, _, err = c.PutWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Put(path, params)
+			data, _, err = c.Put(ctx, path, params)
 		}
 	case "PATCH":
 		if len(hdrs) > 0 {
-			data, _, err = c.PatchWithHeaders(path, params, hdrs)
+			data, _, err = c.PatchWithHeaders(ctx, path, params, hdrs)
 		} else {
-			data, _, err = c.Patch(path, params)
+			data, _, err = c.Patch(ctx, path, params)
 		}
 	default:
 		return mcplib.NewToolResultError(fmt.Sprintf("unsupported method %q", ep.Method)), nil

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -139,34 +139,34 @@ func makeAPIHandler(method, pathTemplate string, binaryResponse bool, headerOver
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -51,7 +51,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 					body["store_code"] = bodyStoreCode
 				}
 			}
-			data, statusCode, err := c.PostWithParams(path, params, body)
+			data, statusCode, err := c.PostWithParams(cmd.Context(), path, params, body)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -40,7 +40,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			if flagC != "" {
 				params["c"] = fmt.Sprintf("%v", flagC)
 			}
-			data, err := c.Get(path, params)
+			data, err := c.Get(cmd.Context(), path, params)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -144,34 +144,34 @@ func makeAPIHandler(method, pathTemplate string, binaryResponse bool, headerOver
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -207,7 +208,7 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
+						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
 						results <- res
 					}
 				}()
@@ -261,7 +262,7 @@ Resource scoping:
 				}
 			}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams)
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -364,8 +365,8 @@ Resource scoping:
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
 // channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
 // keep both call sites in sync if this signature changes.
-func syncResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -480,7 +481,7 @@ func syncResource(c interface {
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
 
-		data, err := c.Get(path, params)
+		data, err := c.Get(ctx, path, params)
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
@@ -1120,8 +1121,8 @@ func dependentResourceDefs() []dependentResourceDef {
 // syncDependentResources iterates parent tables and syncs child resources per parent ID.
 // parentFilter mirrors the user's --resources flag (empty = sync everything). A dependent
 // runs when its parent table or its own name appears in the filter.
-func syncDependentResources(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResources(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string, userParams *syncUserParams) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
@@ -1133,15 +1134,15 @@ func syncDependentResources(c interface {
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource(c, db, dep, sinceTS, full, maxPages, latestOnly, userParams)
+		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, userParams)
 		results = append(results, res)
 	}
 	return results
 }
 
 // syncDependentResource syncs a single child resource by iterating all parent IDs.
-func syncDependentResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncDependentResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -1225,7 +1226,7 @@ func syncDependentResource(c interface {
 			// segment); --global-param and --resource-param still apply.
 			userParams.applyTo(dep.Name, params, true)
 
-			data, err := c.Get(path, params)
+			data, err := c.Get(ctx, path, params)
 			if err != nil {
 				// Non-fatal per parent: log and continue to next parent.
 				// Track access-denial separately so an all-denied dependent

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -241,7 +241,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["api"] = fmt.Sprintf("client init error: %s", clientErr)
 				} else {
 					// Step 1: Basic reachability via the configured transport.
-					reachBody, reachErr := c.Get("/", nil)
+					reachBody, reachErr := c.Get(cmd.Context(), "/", nil)
 					var reachAPIErr *client.APIError
 					switch {
 					case reachErr == nil:

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -204,7 +205,7 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(syncClientForResource(c, resource), db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
+						res := syncResource(cmd.Context(), syncClientForResource(c, resource), db, resource, sinceTS, full, maxPages, effectiveLatestOnly, userParams)
 						results <- res
 					}
 				}()
@@ -331,8 +332,8 @@ Resource scoping:
 // It resumes from the last cursor unless sinceTS or full mode overrides it.
 // channel_workflow.go.tmpl mirrors the trailing dates arg conditional;
 // keep both call sites in sync if this signature changes.
-func syncResource(c interface {
-	Get(string, map[string]string) (json.RawMessage, error)
+func syncResource(ctx context.Context, c interface {
+	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -447,7 +448,7 @@ func syncResource(c interface {
 		// endpoint whose OpenAPI spec marks the filter optional).
 		userParams.applyTo(resource, params, false)
 
-		data, err := c.Get(path, params)
+		data, err := c.Get(ctx, path, params)
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -89,7 +90,7 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
-func (c *Client) authForRequest() (requestAuth, error) {
+func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 	switch c.requestTier {
 	case "enterprise":
 		tierValue0 := os.Getenv("TIER_ENTERPRISE_TOKEN")
@@ -121,7 +122,7 @@ func (c *Client) authForRequest() (requestAuth, error) {
 		}
 		return auth, nil
 	default:
-		value, err := c.authHeader()
+		value, err := c.authHeader(ctx)
 		if err != nil {
 			return requestAuth{}, err
 		}
@@ -196,12 +197,12 @@ func (c *Client) RateLimit() float64 {
 	return c.limiter.Rate()
 }
 
-func (c *Client) Get(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeaders(path, params, nil)
+func (c *Client) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, path, params, nil)
 }
 
-func (c *Client) GetWithHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	if err := c.validateCachedRequestAuth(); err != nil {
+func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
 	// Check cache for GET requests
@@ -210,7 +211,7 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 			return cached, nil
 		}
 	}
-	result, _, err := c.do("GET", path, params, nil, headers)
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
@@ -226,23 +227,23 @@ func (c *Client) GetWithHeaders(path string, params map[string]string, headers m
 // (e.g. a follow-up `... get <id>` after WaitForJob returns) see the
 // terminal value, not the stale non-terminal snapshot left behind by the
 // first poll.
-func (c *Client) GetNoCache(path string, params map[string]string) (json.RawMessage, error) {
-	return c.GetWithHeadersNoCache(path, params, nil)
+func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
 // GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
 // still writes the fresh response on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
-func (c *Client) GetWithHeadersNoCache(path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
-	result, _, err := c.do("GET", path, params, nil, headers)
+func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
 		c.writeCache(path, params, result)
 	}
 	return result, err
 }
 
-func (c *Client) validateCachedRequestAuth() error {
-	authInfo, err := c.authForRequest()
+func (c *Client) validateCachedRequestAuth(ctx context.Context) error {
+	authInfo, err := c.authForRequest(ctx)
 	if err != nil {
 		return err
 	}
@@ -252,8 +253,8 @@ func (c *Client) validateCachedRequestAuth() error {
 	return nil
 }
 
-func (c *Client) ProbeGet(path string) (int, error) {
-	_, status, err := c.do("GET", path, nil, nil, nil)
+func (c *Client) ProbeGet(ctx context.Context, path string) (int, error) {
+	_, status, err := c.do(ctx, "GET", path, nil, nil, nil)
 	return status, err
 }
 
@@ -312,20 +313,20 @@ func (c *Client) invalidateCache() {
 	_ = os.RemoveAll(c.cacheDir)
 }
 
-func (c *Client) Post(path string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, nil)
+func (c *Client) Post(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, nil)
 }
 
-func (c *Client) PostWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, nil)
+func (c *Client) PostWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, nil)
 }
 
-func (c *Client) PostWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, nil, body, headers)
+func (c *Client) PostWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, nil, body, headers)
 }
 
-func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("POST", path, params, body, headers)
+func (c *Client) PostWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "POST", path, params, body, headers)
 }
 
 // PostQueryWithParams is a POST that does not mutate remote state — used
@@ -333,62 +334,62 @@ func (c *Client) PostWithParamsAndHeaders(path string, params map[string]string,
 // queries, JSON-RPC reads, POST-based search endpoints). The verify-mode
 // short-circuit does not fire for these calls; the request reaches the
 // real transport even under PRINTING_PRESS_VERIFY=1 without LIVE_HTTP=1.
-func (c *Client) PostQueryWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, nil)
+func (c *Client) PostQueryWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, nil)
 }
 
 // PostQueryWithParamsAndHeaders is the headers-aware counterpart to
 // PostQueryWithParams. See PostQueryWithParams for the verify-mode rationale.
-func (c *Client) PostQueryWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.doRead("POST", path, params, body, headers)
+func (c *Client) PostQueryWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, body, headers)
 }
 
-func (c *Client) Delete(path string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, nil)
+func (c *Client) Delete(ctx context.Context, path string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, nil)
 }
 
-func (c *Client) DeleteWithParams(path string, params map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, nil)
+func (c *Client) DeleteWithParams(ctx context.Context, path string, params map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, nil)
 }
 
-func (c *Client) DeleteWithHeaders(path string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, nil, nil, headers)
+func (c *Client) DeleteWithHeaders(ctx context.Context, path string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, nil, nil, headers)
 }
 
-func (c *Client) DeleteWithParamsAndHeaders(path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("DELETE", path, params, nil, headers)
+func (c *Client) DeleteWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "DELETE", path, params, nil, headers)
 }
 
-func (c *Client) Put(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, nil)
+func (c *Client) Put(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, nil)
 }
 
-func (c *Client) PutWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, nil)
+func (c *Client) PutWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, nil)
 }
 
-func (c *Client) PutWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, nil, body, headers)
+func (c *Client) PutWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, nil, body, headers)
 }
 
-func (c *Client) PutWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PUT", path, params, body, headers)
+func (c *Client) PutWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PUT", path, params, body, headers)
 }
 
-func (c *Client) Patch(path string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, nil)
+func (c *Client) Patch(ctx context.Context, path string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, nil)
 }
 
-func (c *Client) PatchWithParams(path string, params map[string]string, body any) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, nil)
+func (c *Client) PatchWithParams(ctx context.Context, path string, params map[string]string, body any) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, nil)
 }
 
-func (c *Client) PatchWithHeaders(path string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, nil, body, headers)
+func (c *Client) PatchWithHeaders(ctx context.Context, path string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, nil, body, headers)
 }
 
-func (c *Client) PatchWithParamsAndHeaders(path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
-	return c.do("PATCH", path, params, body, headers)
+func (c *Client) PatchWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, body any, headers map[string]string) (json.RawMessage, int, error) {
+	return c.do(ctx, "PATCH", path, params, body, headers)
 }
 
 // isMutatingVerb reports whether the HTTP method writes server state.
@@ -423,10 +424,21 @@ func verifyShortCircuitEnvelope(method, path string) json.RawMessage {
 	return json.RawMessage(body)
 }
 
+func sleepContext(ctx context.Context, wait time.Duration) error {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // do executes an HTTP request. headerOverrides, when non-nil, override global
 // RequiredHeaders for this specific request (used for per-endpoint API versioning).
-func (c *Client) do(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, false)
+func (c *Client) do(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, false)
 }
 
 // doRead is do() minus the verify-mode mutating-verb gate. Used by the
@@ -435,15 +447,15 @@ func (c *Client) do(method, path string, params map[string]string, body any, hea
 // The wire verb is still POST/PUT/PATCH so the server sees a real request,
 // but the verify-mode short-circuit does not fire because the operation
 // does not mutate remote state.
-func (c *Client) doRead(method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
-	return c.doInternal(method, path, params, body, headerOverrides, true)
+func (c *Client) doRead(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string) (json.RawMessage, int, error) {
+	return c.doInternal(ctx, method, path, params, body, headerOverrides, true)
 }
 
 // doInternal is the shared implementation behind do() and doRead(). The
 // readOnlyIntent flag is set by doRead() callers (read-only POST/PUT/PATCH
 // operations like GraphQL queries) to skip the mutating-verb verify-mode
 // gate. Plain do() callers leave it false and get the usual short-circuit.
-func (c *Client) doInternal(method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
+func (c *Client) doInternal(ctx context.Context, method, path string, params map[string]string, body any, headerOverrides map[string]string, readOnlyIntent bool) (json.RawMessage, int, error) {
 	// Verify-mode transport-layer gate. When the verifier (or any consumer
 	// that sets PRINTING_PRESS_VERIFY=1) drives a mutating verb without
 	// the LIVE_HTTP=1 opt-in, return a synthetic envelope without dialing,
@@ -479,7 +491,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 	// exactly what would be sent. Uses only cached credentials; a token that
 	// requires a network refresh will be re-fetched on the live request path,
 	// not during dry-run.
-	authInfo, err := c.authForRequest()
+	authInfo, err := c.authForRequest(ctx)
 	authHeader := authInfo.Value
 	if err != nil {
 		return nil, 0, err
@@ -501,7 +513,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			bodyReader = strings.NewReader(string(bodyBytes))
 		}
 
-		req, err := http.NewRequest(method, targetURL, bodyReader)
+		req, err := http.NewRequestWithContext(ctx, method, targetURL, bodyReader)
 		if err != nil {
 			return nil, 0, fmt.Errorf("creating request: %w", err)
 		}
@@ -565,6 +577,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 
 		resp, err := c.HTTPClient.Do(req)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, 0, ctxErr
+			}
 			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
 			continue
 		}
@@ -611,7 +626,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 			c.limiter.OnRateLimit()
 			wait := cliutil.RetryAfter(resp)
 			fmt.Fprintf(os.Stderr, "rate limited, waiting %s (attempt %d/%d, rate adjusted to %.1f req/s)\n", wait, attempt+1, maxRetries, c.limiter.Rate())
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -620,7 +637,9 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 		if resp.StatusCode >= 500 && attempt < maxRetries {
 			wait := time.Duration(math.Pow(2, float64(attempt))) * time.Second
 			fmt.Fprintf(os.Stderr, "server error %d, retrying in %s (attempt %d/%d)\n", resp.StatusCode, wait, attempt+1, maxRetries)
-			time.Sleep(wait)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, 0, err
+			}
 			lastErr = apiErr
 			continue
 		}
@@ -636,7 +655,7 @@ func (c *Client) doInternal(method, path string, params map[string]string, body 
 // using the auth material already resolved in `do()`. Never triggers a network
 // call — the caller is responsible for passing cached auth material only.
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, authHeader string) (json.RawMessage, int, error) {
-	authInfo, _ := c.authForRequest()
+	authInfo, _ := c.authForRequest(context.Background())
 	authInfo.Value = authHeader
 	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
 	queryPrinted := false
@@ -689,7 +708,7 @@ func (c *Client) ConfiguredTimeout() time.Duration {
 	return 30 * time.Second
 }
 
-func (c *Client) authHeader() (string, error) {
+func (c *Client) authHeader(ctx context.Context) (string, error) {
 	if c.Config == nil {
 		return "", nil
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -164,34 +164,34 @@ func makeAPIHandler(method, pathTemplate, tier string, binaryResponse bool, head
 		switch method {
 		case "GET":
 			if len(headers) > 0 {
-				data, err = c.GetWithHeaders(path, params, headers)
+				data, err = c.GetWithHeaders(ctx, path, params, headers)
 				break
 			}
-			data, err = c.Get(path, params)
+			data, err = c.Get(ctx, path, params)
 		case "POST":
 			if len(headers) > 0 {
-				data, _, err = c.PostWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PostWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PostWithParams(path, params, bodyArgs)
+			data, _, err = c.PostWithParams(ctx, path, params, bodyArgs)
 		case "PUT":
 			if len(headers) > 0 {
-				data, _, err = c.PutWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PutWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PutWithParams(path, params, bodyArgs)
+			data, _, err = c.PutWithParams(ctx, path, params, bodyArgs)
 		case "PATCH":
 			if len(headers) > 0 {
-				data, _, err = c.PatchWithParamsAndHeaders(path, params, bodyArgs, headers)
+				data, _, err = c.PatchWithParamsAndHeaders(ctx, path, params, bodyArgs, headers)
 				break
 			}
-			data, _, err = c.PatchWithParams(path, params, bodyArgs)
+			data, _, err = c.PatchWithParams(ctx, path, params, bodyArgs)
 		case "DELETE":
 			if len(headers) > 0 {
-				data, _, err = c.DeleteWithParamsAndHeaders(path, params, headers)
+				data, _, err = c.DeleteWithParamsAndHeaders(ctx, path, params, headers)
 				break
 			}
-			data, _, err = c.DeleteWithParams(path, params)
+			data, _, err = c.DeleteWithParams(ctx, path, params)
 		default:
 			return mcplib.NewToolResultError("unsupported method: " + method), nil
 		}


### PR DESCRIPTION
## Intent

Closes #1475.

Generated CLIs now preserve command and MCP cancellation through the generated HTTP client instead of dropping the caller context before request construction or retry backoff.

## Approach

The generated client API now accepts `context.Context` on read, write, form, multipart, GraphQL, and probe helpers, then builds outbound requests with `http.NewRequestWithContext`. Retry waits for 429 and 5xx responses use a context-aware sleep helper, and canceled request contexts return immediately instead of burning through retry attempts.

All generated CLI, MCP, sync, doctor, auth-browser validation, embedded pagination, and GraphQL call sites now pass the active command or tool context. The updated golden fixtures pin the generated output contract across representative CLI shapes.

## Scope

Primary area: generated client and generated call-site templates.

Why this belongs in this repo: this is a Printing Press generator bug. Fixing a printed CLI directly would leave every future generated CLI with the same context-cancellation gap.

## Risk

This changes generated client method signatures, so the main risk is a missed generated call site. The generator suite, full repo tests, lint, and golden verification all passed after updating the template and fixture contract.

## Output Contract

Generated client methods now take `context.Context` as their first argument. Generated CLI commands pass `cmd.Context()`, MCP handlers pass their tool `ctx`, sync helpers thread their existing context, and generated HTTP requests are constructed with `http.NewRequestWithContext`.

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run TestClientThreadsCallContextThroughHTTPRequestsAndRetryWaits`
- `go test -v ./internal/generator`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
