### PR TITLE
fix(cli): accept root mcp in OpenAPI parser

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -209,6 +209,10 @@ Rules:
   (including `transport: [stdio]`) bypasses the default and is honored as-is.
 - May be declared at the OpenAPI root or under `info`. Root takes precedence
   when both are present.
+- For backwards compatibility, root-level `mcp:` is also accepted when
+  canonical `x-mcp` is absent. The parser emits a warning asking authors to
+  rename it to `x-mcp`. `x-mcp` and `mcp` are never merged; any canonical
+  `x-mcp` declaration, including under `info`, wins as a complete config.
 - Shape mirrors the internal YAML `mcp:` block field-for-field: `transport`,
   `addr`, `intents`, `endpoint_tools`, `orchestration`,
   `orchestration_threshold`.

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -44,6 +44,7 @@ const (
 	extensionTierRouting           = "x-tier-routing"
 	extensionTier                  = "x-tier"
 	extensionMCP                   = "x-mcp"
+	extensionLegacyMCP             = "mcp"
 	extensionSyncWalker            = "x-pp-sync-walker"
 	extensionAPIName               = "x-api-name"
 	extensionDisplayName           = "x-display-name"
@@ -422,7 +423,7 @@ func parseWithLocation(data []byte, lenient bool, location *url.URL, authPrefere
 		return nil, err
 	}
 
-	mcpConfig, err := parseTypedExtension[spec.MCPConfig](doc, extensionMCP)
+	mcpConfig, err := parseMCPExtension(doc)
 	if err != nil {
 		return nil, err
 	}
@@ -536,6 +537,27 @@ func parseTypedExtension[T any](doc *openapi3.T, key string) (T, error) {
 	if !ok {
 		return zero, nil
 	}
+	return parseTypedExtensionRaw[T](key, raw)
+}
+
+func parseMCPExtension(doc *openapi3.T) (spec.MCPConfig, error) {
+	if raw, ok := lookupOpenAPIExtension(doc, extensionMCP); ok {
+		return parseTypedExtensionRaw[spec.MCPConfig](extensionMCP, raw)
+	}
+	var zero spec.MCPConfig
+	if doc == nil || doc.Extensions == nil {
+		return zero, nil
+	}
+	raw, ok := doc.Extensions[extensionLegacyMCP]
+	if !ok {
+		return zero, nil
+	}
+	warnf("accepted root-level 'mcp:' for backwards compatibility; rename to 'x-mcp:' per OpenAPI extension convention")
+	return parseTypedExtensionRaw[spec.MCPConfig](extensionLegacyMCP, raw)
+}
+
+func parseTypedExtensionRaw[T any](key string, raw any) (T, error) {
+	var zero T
 	data, err := json.Marshal(raw)
 	if err != nil {
 		return zero, fmt.Errorf("marshaling %s: %w", key, err)

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -6092,6 +6092,116 @@ paths:
 	assert.Equal(t, "hidden", parsed.MCP.EndpointTools)
 }
 
+func TestParseMCPFallbackFromRootWarns(t *testing.T) {
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Legacy MCP API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+mcp:
+  transport: [stdio, http]
+  orchestration: code
+  endpoint_tools: hidden
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: ok
+`)
+
+	var parsed *spec.APISpec
+	var err error
+	warnings := captureWarnings(t, func() {
+		parsed, err = Parse(data)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.MCP.HasTransport("http"), "expected http transport from root mcp fallback")
+	assert.True(t, parsed.MCP.HasTransport("stdio"), "expected stdio transport from root mcp fallback")
+	assert.True(t, parsed.MCP.IsCodeOrchestration(), "expected code orchestration from root mcp fallback")
+	assert.Equal(t, "hidden", parsed.MCP.EndpointTools)
+	assert.Contains(t, warnings, "accepted root-level 'mcp:' for backwards compatibility")
+	assert.Contains(t, warnings, "rename to 'x-mcp:' per OpenAPI extension convention")
+}
+
+func TestParseMCPExtensionBeatsRootMCPFallback(t *testing.T) {
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Canonical MCP API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+mcp:
+  transport: [stdio]
+  orchestration: code
+  endpoint_tools: hidden
+x-mcp:
+  transport: [http]
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: ok
+`)
+
+	var parsed *spec.APISpec
+	var err error
+	warnings := captureWarnings(t, func() {
+		parsed, err = Parse(data)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.MCP.HasTransport("http"), "canonical x-mcp must take precedence")
+	assert.False(t, parsed.MCP.HasTransport("stdio"), "root mcp fallback must not merge into canonical x-mcp")
+	assert.False(t, parsed.MCP.IsCodeOrchestration(), "root mcp fields must not fill missing x-mcp fields")
+	assert.Empty(t, parsed.MCP.EndpointTools, "root mcp fields must not fill missing x-mcp fields")
+	assert.NotContains(t, warnings, "accepted root-level 'mcp:'", "canonical x-mcp should not emit fallback warning")
+}
+
+func TestParseMCPInfoExtensionBeatsRootMCPFallback(t *testing.T) {
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Info MCP API
+  version: 1.0.0
+  x-mcp:
+    transport: [http]
+servers:
+  - url: https://api.example.com
+mcp:
+  transport: [stdio]
+  orchestration: code
+  endpoint_tools: hidden
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: ok
+`)
+
+	var parsed *spec.APISpec
+	var err error
+	warnings := captureWarnings(t, func() {
+		parsed, err = Parse(data)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.MCP.HasTransport("http"), "info.x-mcp must take precedence over root mcp fallback")
+	assert.False(t, parsed.MCP.HasTransport("stdio"), "root mcp fallback must not merge into info.x-mcp")
+	assert.False(t, parsed.MCP.IsCodeOrchestration(), "root mcp fields must not fill missing info.x-mcp fields")
+	assert.Empty(t, parsed.MCP.EndpointTools, "root mcp fields must not fill missing info.x-mcp fields")
+	assert.NotContains(t, warnings, "accepted root-level 'mcp:'", "info.x-mcp should not emit fallback warning")
+}
+
 func TestParseMCPExtensionFromInfo(t *testing.T) {
 	t.Parallel()
 	data := []byte(`


### PR DESCRIPTION
## Summary

- Accept root-level `mcp:` in OpenAPI specs as a backwards-compatible fallback when canonical `x-mcp` is absent.
- Preserve canonical `x-mcp` precedence, including `info.x-mcp`, without merging fields from legacy `mcp:`.
- Document the fallback and add parser coverage for warning, precedence, and no-merge behavior.

Closes #1110

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/openapi -run 'TestParse(MCPExtension|MCPFallback)' -count=1`
- `go test ./internal/spec -run MCP -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
