### PR TITLE
fix(cli): scope framework collision renames

### DIFF
--- a/internal/generator/framework_collision_test.go
+++ b/internal/generator/framework_collision_test.go
@@ -1,0 +1,184 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateNoAuthRegistersAuthResource(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("publicauth")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"auth": {
+			Description: "Public auth endpoints",
+			Endpoints: map[string]spec.Endpoint{
+				"check_email": {Method: "GET", Path: "/api/auth/check-email", Description: "Check email"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "publicauth-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	authSrc := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newAuthCmd(flags))", "the API resource should be registered when the framework auth command is inactive")
+	assert.Contains(t, authSrc, "func newAuthCmd(flags *rootFlags) *cobra.Command")
+	assert.Contains(t, authSrc, `Use:   "auth"`)
+	assert.NotContains(t, authSrc, "set-token", "no framework auth template should overwrite the API resource parent")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestGenerateRegistersHealthResourceWhenHealthCommandInactive(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("publichealth")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"health": {
+			Description: "API health endpoint",
+			Endpoints: map[string]spec.Endpoint{
+				"get":    {Method: "GET", Path: "/health", Description: "Health"},
+				"status": {Method: "GET", Path: "/health/status", Description: "Health status"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "publichealth-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	healthSrc := readGeneratedFile(t, outputDir, "internal", "cli", "health.go")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newHealthCmd(flags))", "the API resource should be registered when the framework health command is inactive")
+	assert.NotContains(t, rootSrc, "rootCmd.AddCommand(newPublichealthHealthCmd(flags))")
+	assert.Contains(t, healthSrc, "func newHealthCmd(flags *rootFlags) *cobra.Command")
+	assert.Contains(t, healthSrc, `Use:   "health"`)
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestActiveFrameworkCobraUseNamesMatchesGeneratedRoot(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("activecmds")
+	apiSpec.BearerRefresh = spec.BearerRefreshConfig{
+		BundleURL: "https://example.com/main.js",
+		Pattern:   `accessToken:"([^"]+)"`,
+	}
+	apiSpec.Share = spec.ShareConfig{Enabled: true, SnapshotTables: []string{"items"}}
+
+	outputDir := filepath.Join(t.TempDir(), "activecmds-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{
+		Export:    true,
+		Import:    true,
+		Store:     true,
+		Search:    true,
+		Sync:      true,
+		Tail:      true,
+		Analytics: true,
+		Workflows: []string{
+			"workflows/pm_stale.go.tmpl",
+			"workflows/pm_orphans.go.tmpl",
+			"workflows/pm_load.go.tmpl",
+		},
+		Insights: []string{
+			"insights/health_score.go.tmpl",
+			"insights/similar.go.tmpl",
+		},
+	}
+	gen.AsyncJobs = map[string]AsyncJobInfo{
+		"items/list": {ResourceName: "items", EndpointName: "list"},
+	}
+	require.NoError(t, gen.Generate())
+
+	active := gen.activeFrameworkCobraUseNames()
+	delete(active, "completion")
+	delete(active, "help")
+
+	rootReserved := generatedRootReservedUseNames(t, outputDir)
+	assert.Equal(t, sortedKeys(rootReserved), sortedKeys(active),
+		"activeFrameworkCobraUseNames must stay aligned with generated root framework registrations")
+}
+
+func generatedRootReservedUseNames(t *testing.T, outputDir string) map[string]struct{} {
+	t.Helper()
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	ctorRE := regexp.MustCompile(`rootCmd\.AddCommand\(new(\w+)Cmd\(`)
+	ctors := map[string]struct{}{}
+	for _, match := range ctorRE.FindAllStringSubmatch(rootSrc, -1) {
+		ctors[match[1]] = struct{}{}
+	}
+
+	useByConstructor := map[string]string{}
+	funcRE := regexp.MustCompile(`func new(\w+)Cmd[^{]*\{[\s\S]*?Use:\s*"([^"]+)"`)
+	err := filepath.WalkDir(filepath.Join(outputDir, "internal", "cli"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, match := range funcRE.FindAllStringSubmatch(string(data), -1) {
+			useByConstructor[match[1]] = strings.Fields(match[2])[0]
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	out := map[string]struct{}{}
+	for ctor := range ctors {
+		use, ok := useByConstructor[ctor]
+		if !ok {
+			continue
+		}
+		if _, reserved := spec.ReservedCobraUseNames[use]; reserved {
+			out[use] = struct{}{}
+		}
+	}
+	return out
+}
+
+func TestGenerateRenamesHealthResourceOnlyWhenHealthCommandIsActive(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("healthapi")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"health": {
+			Description: "API health endpoint",
+			Endpoints: map[string]spec.Endpoint{
+				"get":    {Method: "GET", Path: "/health", Description: "Health"},
+				"status": {Method: "GET", Path: "/health/status", Description: "Health status"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "healthapi-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Insights: []string{"insights/health_score.go.tmpl"}}
+	require.NoError(t, gen.Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newHealthCmd(flags))", "the generated insight keeps the framework health command")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newHealthapiHealthCmd(flags))", "the API health resource is renamed only when the framework command is active")
+	assert.NotContains(t, rootSrc, "rootCmd.AddCommand(newHealthCmd(flags))\n\trootCmd.AddCommand(newHealthCmd(flags))")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}

--- a/internal/generator/framework_collision_test.go
+++ b/internal/generator/framework_collision_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,6 +180,34 @@ func TestGenerateRenamesHealthResourceOnlyWhenHealthCommandIsActive(t *testing.T
 	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newHealthCmd(flags))", "the generated insight keeps the framework health command")
 	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newHealthapiHealthCmd(flags))", "the API health resource is renamed only when the framework command is active")
 	assert.NotContains(t, rootSrc, "rootCmd.AddCommand(newHealthCmd(flags))\n\trootCmd.AddCommand(newHealthCmd(flags))")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
+func TestGenerateRenamesAuthResourceWhenTrafficAnalysisEmitsAuthCommand(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("graphqlapi")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"auth": {
+			Description: "Public auth endpoint",
+			Endpoints: map[string]spec.Endpoint{
+				"check":  {Method: "GET", Path: "/api/auth/check", Description: "Check auth"},
+				"status": {Method: "GET", Path: "/api/auth/status", Description: "Auth status"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "graphqlapi-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.TrafficAnalysis = &browsersniff.TrafficAnalysis{GenerationHints: []string{"graphql_persisted_query"}}
+	require.NoError(t, gen.Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newAuthCmd(flags))", "the traffic-analysis hint should emit the framework auth command")
+	assert.Contains(t, rootSrc, "rootCmd.AddCommand(newGraphqlapiAuthCmd(flags))", "the public auth resource should be renamed and stay registered")
+	assert.NotContains(t, rootSrc, "rootCmd.AddCommand(newAuthCmd(flags))\n\trootCmd.AddCommand(newAuthCmd(flags))")
 
 	runGoCommand(t, outputDir, "build", "./internal/cli")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1752,7 +1752,13 @@ func (g *Generator) Generate() error {
 
 func (g *Generator) renameActiveFrameworkResourceCollisions() bool {
 	active := g.activeFrameworkCobraUseNames()
-	renamed := false
+	type resourceRename struct {
+		from     string
+		to       string
+		use      string
+		resource spec.Resource
+	}
+	var renames []resourceRename
 	for name, resource := range g.Spec.Resources {
 		kebab := strings.ReplaceAll(strings.ToLower(name), "_", "-")
 		if _, ok := active[kebab]; !ok {
@@ -1761,13 +1767,19 @@ func (g *Generator) renameActiveFrameworkResourceCollisions() bool {
 		if g.Spec.ParseTimeReservedCobraUseName(kebab) {
 			continue
 		}
-		next := uniqueFrameworkResourceName(g.Spec, kebab)
-		delete(g.Spec.Resources, name)
-		g.Spec.Resources[next] = resource
-		fmt.Fprintf(os.Stderr, "warning: resource %q would shadow active framework cobra command %q; renamed to %q\n", name, kebab, next)
-		renamed = true
+		renames = append(renames, resourceRename{
+			from:     name,
+			to:       g.Spec.UniqueFrameworkCollisionResourceName(kebab),
+			use:      kebab,
+			resource: resource,
+		})
 	}
-	return renamed
+	for _, rename := range renames {
+		delete(g.Spec.Resources, rename.from)
+		g.Spec.Resources[rename.to] = rename.resource
+		fmt.Fprintf(os.Stderr, "warning: resource %q would shadow active framework cobra command %q; renamed to %q\n", rename.from, rename.use, rename.to)
+	}
+	return len(renames) > 0
 }
 
 func (g *Generator) activeFrameworkCobraUseNames() map[string]struct{} {
@@ -1836,23 +1848,6 @@ func frameworkUseNameForTemplate(tmpl string) string {
 		return ""
 	}
 	return strings.ReplaceAll(naming.Snake(ctor), "_", "-")
-}
-
-func uniqueFrameworkResourceName(s *spec.APISpec, original string) string {
-	slug := s.Name
-	if slug == "" {
-		slug = "api"
-	}
-	candidate := slug + "-" + original
-	if _, exists := s.Resources[candidate]; !exists {
-		return candidate
-	}
-	for i := 2; ; i++ {
-		next := fmt.Sprintf("%s-%d", candidate, i)
-		if _, exists := s.Resources[next]; !exists {
-			return next
-		}
-	}
 }
 
 // GenerateMCPSurface rewrites the generated MCP entrypoint, tools package,

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1447,6 +1447,9 @@ func (g *Generator) prepareOutput() error {
 		g.profile = profiler.Profile(g.Spec)
 	}
 	g.VisionSet = constrainVisionTemplates(g.Spec, g.VisionSet)
+	if g.renameActiveFrameworkResourceCollisions() {
+		g.profile = profiler.Profile(g.Spec)
+	}
 	if err := g.validateFreshnessCommandCoverage(); err != nil {
 		return err
 	}
@@ -1745,6 +1748,111 @@ func (g *Generator) Generate() error {
 		return err
 	}
 	return g.renderVisionAndRootFiles(g.PromotedCommands, g.PromotedResourceNames)
+}
+
+func (g *Generator) renameActiveFrameworkResourceCollisions() bool {
+	active := g.activeFrameworkCobraUseNames()
+	renamed := false
+	for name, resource := range g.Spec.Resources {
+		kebab := strings.ReplaceAll(strings.ToLower(name), "_", "-")
+		if _, ok := active[kebab]; !ok {
+			continue
+		}
+		if g.Spec.ParseTimeReservedCobraUseName(kebab) {
+			continue
+		}
+		next := uniqueFrameworkResourceName(g.Spec, kebab)
+		delete(g.Spec.Resources, name)
+		g.Spec.Resources[next] = resource
+		fmt.Fprintf(os.Stderr, "warning: resource %q would shadow active framework cobra command %q; renamed to %q\n", name, kebab, next)
+		renamed = true
+	}
+	return renamed
+}
+
+func (g *Generator) activeFrameworkCobraUseNames() map[string]struct{} {
+	names := map[string]struct{}{
+		"agent-context": {},
+		"completion":    {},
+		"doctor":        {},
+		"feedback":      {},
+		"help":          {},
+		"profile":       {},
+		"version":       {},
+		"which":         {},
+	}
+	if g.shouldEmitAuth() {
+		names["auth"] = struct{}{}
+	}
+	if g.Spec.BearerRefresh.Enabled() {
+		names["refresh-bearer"] = struct{}{}
+	}
+	if len(g.AsyncJobs) > 0 {
+		names["jobs"] = struct{}{}
+	}
+	if g.VisionSet.Export {
+		names["export"] = struct{}{}
+	}
+	if g.VisionSet.Import {
+		names["import"] = struct{}{}
+	}
+	if g.VisionSet.Search {
+		names["search"] = struct{}{}
+	}
+	if g.VisionSet.Sync {
+		names["sync"] = struct{}{}
+	}
+	if g.VisionSet.Tail {
+		names["tail"] = struct{}{}
+	}
+	if g.VisionSet.Analytics {
+		names["analytics"] = struct{}{}
+	}
+	if g.VisionSet.Store {
+		names["workflow"] = struct{}{}
+	}
+	if g.Spec.Share.Enabled {
+		names["share"] = struct{}{}
+	}
+	if len(g.PromotedCommands) > 0 {
+		names["api"] = struct{}{}
+	}
+	for _, tmpl := range g.VisionSet.Workflows {
+		if name := frameworkUseNameForTemplate(tmpl); name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	for _, tmpl := range g.VisionSet.Insights {
+		if name := frameworkUseNameForTemplate(tmpl); name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func frameworkUseNameForTemplate(tmpl string) string {
+	ctor := commandConstructorForTemplate(tmpl)
+	if ctor == "" {
+		return ""
+	}
+	return strings.ReplaceAll(naming.Snake(ctor), "_", "-")
+}
+
+func uniqueFrameworkResourceName(s *spec.APISpec, original string) string {
+	slug := s.Name
+	if slug == "" {
+		slug = "api"
+	}
+	candidate := slug + "-" + original
+	if _, exists := s.Resources[candidate]; !exists {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		next := fmt.Sprintf("%s-%d", candidate, i)
+		if _, exists := s.Resources[next]; !exists {
+			return next
+		}
+	}
 }
 
 // GenerateMCPSurface rewrites the generated MCP entrypoint, tools package,

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -314,7 +314,7 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	}
 
 {{- range $name, $resource := .Resources}}
-{{- if and (not (index $.PromotedResourceNames $name)) (ne $name "auth") (not (index $.VisionCmdNames $name))}}
+{{- if and (not (index $.PromotedResourceNames $name)) (not (and (eq $name "auth") $.HasAuthCommand)) (not (index $.VisionCmdNames $name))}}
 	rootCmd.AddCommand(new{{camel $name}}Cmd(flags))
 {{- end}}
 {{- end}}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2166,7 +2166,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			// sub-resource.
 			if renamed, ok := frameworkRenames[primaryName]; ok {
 				primaryName = renamed
-			} else if _, reserved := spec.ReservedCobraUseNames[primaryName]; reserved {
+			} else if out.ParseTimeReservedCobraUseName(primaryName) {
 				originalName := primaryName
 				primaryName = renameForFrameworkCollision(out, primaryName, path)
 				frameworkRenames[originalName] = primaryName

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5989,22 +5989,7 @@ func warnf(format string, args ...any) {
 // Falls back to "api" when out.Name is empty so the rename never
 // produces a leading-hyphen name like "-version".
 func renameForFrameworkCollision(out *spec.APISpec, original, path string) string {
-	slug := out.Name
-	if slug == "" {
-		slug = "api"
-	}
-	candidate := slug + "-" + original
-	if _, exists := out.Resources[candidate]; exists {
-		// Suffix-bump on self-collision. Bounded by maxResources, which
-		// the outer loop already enforces, so the loop terminates.
-		for i := 2; ; i++ {
-			next := fmt.Sprintf("%s-%d", candidate, i)
-			if _, exists := out.Resources[next]; !exists {
-				candidate = next
-				break
-			}
-		}
-	}
+	candidate := out.UniqueFrameworkCollisionResourceName(original)
 	warnf("resource %q from path %q would shadow framework cobra command %q; renamed to %q", original, path, original, candidate)
 	return candidate
 }

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -5773,6 +5773,42 @@ paths:
 	assert.NotContains(t, output, "shadow framework cobra command", "non-colliding spec must not emit a collision warning")
 }
 
+func TestParseFrameworkCollisionAllowsConditionalFrameworkNamesWhenInactive(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      responses:
+        "200":
+          description: ok
+  /api/auth/check-email:
+    get:
+      operationId: checkEmail
+      responses:
+        "200":
+          description: ok
+`)
+
+	var parsed *spec.APISpec
+	output := captureWarnings(t, func() {
+		var err error
+		parsed, err = Parse(yamlSpec)
+		require.NoError(t, err)
+	})
+
+	require.Contains(t, parsed.Resources, "health", "health is not a parser-time collision unless the generator emits the health insight command")
+	require.Contains(t, parsed.Resources, "auth", "public auth resources should keep their natural name when no framework auth command is emitted")
+	assert.NotContains(t, parsed.Resources, "testapi-health")
+	assert.NotContains(t, parsed.Resources, "testapi-auth")
+	assert.NotContains(t, output, "shadow framework cobra command")
+}
+
 // TestParseFrameworkCollisionExemptsSubresources verifies sub-resources
 // don't trigger the collision check — paths like /games/{id}/version
 // produce a `version` sub-resource under `games`, which registers as a

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1797,12 +1797,39 @@ var ReservedCobraUseNames = map[string]struct{}{
 	"workflow":       {},
 }
 
+// ParseTimeReservedCobraUseName reports whether name is known, at spec-parse
+// time, to collide with a framework cobra command that this CLI will emit.
+// Some ReservedCobraUseNames entries are capability-gated by generation
+// profiling, so parsers must not reject or rename them before the generator
+// knows the actual root command set.
+func (s *APISpec) ParseTimeReservedCobraUseName(name string) bool {
+	kebab := snakeToKebab(name)
+	if kebab == "auth" {
+		return s.emitsAuthCommand()
+	}
+	if kebab == "health" {
+		return false
+	}
+	_, reserved := ReservedCobraUseNames[kebab]
+	return reserved
+}
+
+func (s *APISpec) emitsAuthCommand() bool {
+	if s == nil {
+		return false
+	}
+	return s.Auth.Type != "none" || s.Auth.AuthorizationURL != ""
+}
+
 // validateReservedNames rejects specs whose top-level resource names would
 // collide with reserved Printing Press templates. Sub-resource names are not
 // checked because they emit under a parent prefix (`<parent>_<sub>.go`,
 // `new<Parent><Sub>Cmd`) that does not collide with single-file templates.
 func (s *APISpec) validateReservedNames() error {
 	for name := range s.Resources {
+		if name == "auth" && !s.emitsAuthCommand() {
+			continue
+		}
 		if _, reserved := ReservedCLIResourceNames[name]; reserved {
 			return fmt.Errorf("resource name %q collides with a reserved Printing Press template (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename the resource — e.g. %q",
 				name, name, snakeToPascal(name), name+"_resource")
@@ -1818,7 +1845,7 @@ func (s *APISpec) validateReservedNames() error {
 func (s *APISpec) validateFrameworkCobraCollisions() error {
 	for name := range s.Resources {
 		kebab := snakeToKebab(name)
-		if _, reserved := ReservedCobraUseNames[kebab]; reserved {
+		if s.ParseTimeReservedCobraUseName(kebab) {
 			suggestion := name + "_resource"
 			if s.Name != "" {
 				suggestion = snakeToKebab(s.Name) + "_" + name

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1814,10 +1814,34 @@ func (s *APISpec) ParseTimeReservedCobraUseName(name string) bool {
 	return reserved
 }
 
+// UniqueFrameworkCollisionResourceName returns the canonical resource rename
+// for a top-level resource that would shadow a framework cobra command.
+func (s *APISpec) UniqueFrameworkCollisionResourceName(original string) string {
+	slug := "api"
+	if s != nil && s.Name != "" {
+		slug = s.Name
+	}
+	candidate := slug + "-" + original
+	if s == nil || s.Resources == nil {
+		return candidate
+	}
+	if _, exists := s.Resources[candidate]; !exists {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		next := fmt.Sprintf("%s-%d", candidate, i)
+		if _, exists := s.Resources[next]; !exists {
+			return next
+		}
+	}
+}
+
 func (s *APISpec) emitsAuthCommand() bool {
 	if s == nil {
 		return false
 	}
+	// Traffic-analysis-only auth is not known at parse time; the generator
+	// handles that conditional collision once traffic hints are attached.
 	return s.Auth.Type != "none" || s.Auth.AuthorizationURL != ""
 }
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3327,6 +3327,25 @@ resources:
 		assert.Contains(t, err.Error(), `"auth"`)
 	})
 
+	t.Run("auth resource is allowed when no auth command is emitted", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  auth:
+    description: Public auth helpers
+    endpoints:
+      check_email:
+        method: GET
+        path: /api/auth/check-email
+        description: Check email
+`
+		_, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+	})
+
 	t.Run("non-reserved name with reserved-substring is allowed", func(t *testing.T) {
 		t.Parallel()
 		// "customer_feedback" contains "feedback" but is not itself reserved;
@@ -3452,6 +3471,25 @@ resources:
         method: GET
         path: /stores
         description: List
+`
+		_, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+	})
+
+	t.Run("health resource passes until the generator emits a health command", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  health:
+    description: API health
+    endpoints:
+      get:
+        method: GET
+        path: /health
+        description: Health
 `
 		_, err := ParseBytes([]byte(input))
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- allow parser-time `auth` and `health` resources to keep their natural names when the corresponding framework command is inactive
- register public no-auth `auth` resources instead of always skipping them from root command wiring
- rename conditional active framework collisions during generator preparation before derived generator state is built
- add parser, spec, and generator regression coverage for inactive and active conditional collisions

## Verification
- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `git diff --check`

Closes #1487