### PR TITLE
fix(cli): preflight framework narrative flags

### DIFF
--- a/internal/cli/validate_narrative.go
+++ b/internal/cli/validate_narrative.go
@@ -16,11 +16,12 @@ import (
 
 func newValidateNarrativeCmd() *cobra.Command {
 	var (
-		researchPath string
-		binaryPath   string
-		strict       bool
-		fullExamples bool
-		asJSON       bool
+		researchPath  string
+		binaryPath    string
+		strict        bool
+		fullExamples  bool
+		frameworkOnly bool
+		asJSON        bool
 	)
 
 	cmd := &cobra.Command{
@@ -32,6 +33,9 @@ func newValidateNarrativeCmd() *cobra.Command {
 in research.json and runs '<binary> <words> --help' to confirm each command
 path exists. With --full-examples, also runs each complete example under
 PRINTING_PRESS_VERIFY=1, appending --dry-run when the command advertises it.
+With --framework-only, checks stable generated framework-command flags directly
+from research.json and does not require --binary; use this before rendering
+README/SKILL examples from newly authored narrative.
 
 Without this check, broken commands ship to the README's Quick Start and
 the SKILL's recipes; users hit "unknown command" on copy-paste.`,
@@ -53,12 +57,16 @@ the SKILL's recipes; users hit "unknown command" on copy-paste.`,
   # JSON output for downstream tooling
   cli-printing-press validate-narrative --json \
     --research $API_RUN_DIR/research.json \
-    --binary $CLI_WORK_DIR/myapi-pp-cli`,
+    --binary $CLI_WORK_DIR/myapi-pp-cli
+
+  # Pre-render framework command check (no generated binary required)
+  cli-printing-press validate-narrative --strict --framework-only \
+    --research $API_RUN_DIR/research.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if researchPath == "" {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--research is required")}
 			}
-			if binaryPath == "" {
+			if binaryPath == "" && !frameworkOnly {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--binary is required")}
 			}
 
@@ -68,7 +76,8 @@ the SKILL's recipes; users hit "unknown command" on copy-paste.`,
 			defer cancel()
 
 			report, err := narrativecheck.ValidateWithOptions(ctx, researchPath, binaryPath, narrativecheck.Options{
-				FullExamples: fullExamples,
+				FullExamples:  fullExamples,
+				FrameworkOnly: frameworkOnly,
 			})
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
@@ -101,9 +110,10 @@ the SKILL's recipes; users hit "unknown command" on copy-paste.`,
 		},
 	}
 	cmd.Flags().StringVar(&researchPath, "research", "", "Path to research.json (required)")
-	cmd.Flags().StringVar(&binaryPath, "binary", "", "Path to the built CLI binary to walk (required)")
+	cmd.Flags().StringVar(&binaryPath, "binary", "", "Path to the built CLI binary to walk (required unless --framework-only is set)")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero on any missing command or empty narrative (default: warn-only)")
 	cmd.Flags().BoolVar(&fullExamples, "full-examples", false, "Also run full narrative examples safely with PRINTING_PRESS_VERIFY=1 and --dry-run where supported")
+	cmd.Flags().BoolVar(&frameworkOnly, "framework-only", false, "Only validate stable framework-command flag vocabulary from research.json; does not require --binary")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit machine-readable JSON instead of the human report")
 	return cmd
 }
@@ -125,6 +135,10 @@ func printHumanReport(w io.Writer, report *narrativecheck.Report) {
 		}
 	}
 	if !report.HasFailures() && !report.ResearchEmpty {
+		if report.FrameworkOnly {
+			fmt.Fprintf(w, "OK: %d framework-command narrative examples passed static checks\n", report.Walked)
+			return
+		}
 		if report.FullExamples {
 			fmt.Fprintf(w, "OK: %d narrative commands resolved and full examples passed\n", report.Walked)
 			return

--- a/internal/cli/validate_narrative.go
+++ b/internal/cli/validate_narrative.go
@@ -136,6 +136,10 @@ func printHumanReport(w io.Writer, report *narrativecheck.Report) {
 	}
 	if !report.HasFailures() && !report.ResearchEmpty {
 		if report.FrameworkOnly {
+			if report.Walked == 0 {
+				fmt.Fprintln(w, "N/A: no framework-command narrative examples found; static framework check skipped")
+				return
+			}
 			fmt.Fprintf(w, "OK: %d framework-command narrative examples passed static checks\n", report.Walked)
 			return
 		}

--- a/internal/cli/validate_narrative_test.go
+++ b/internal/cli/validate_narrative_test.go
@@ -90,3 +90,51 @@ func TestValidateNarrativeCmd_MissingResearchIsNotApplicable(t *testing.T) {
 		t.Fatalf("stderr = %q, want N/A skip message", got)
 	}
 }
+
+func TestValidateNarrativeCmd_FrameworkOnlyDoesNotRequireBinary(t *testing.T) {
+	t.Parallel()
+
+	research := filepath.Join(t.TempDir(), "research.json")
+	if err := os.WriteFile(research, []byte(`{"narrative":{"quickstart":[{"command":"demo-pp-cli sync --resources users --since 7d"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newValidateNarrativeCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetArgs([]string{"--strict", "--framework-only", "--research", research})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --framework-only without --binary to pass documented flags, got %v", err)
+	}
+	if got := stdout.String() + stderr.String(); !strings.Contains(got, "framework-command narrative examples passed static checks") {
+		t.Fatalf("output = %q, want framework-only OK output", got)
+	}
+}
+
+func TestValidateNarrativeCmd_FrameworkOnlyFailsInventedFlags(t *testing.T) {
+	t.Parallel()
+
+	research := filepath.Join(t.TempDir(), "research.json")
+	if err := os.WriteFile(research, []byte(`{"narrative":{"quickstart":[{"command":"demo-pp-cli sync --entities users"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newValidateNarrativeCmd()
+	cmd.SetArgs([]string{"--strict", "--framework-only", "--research", research})
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected --framework-only --strict to fail on invented framework flags")
+	}
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != ExitInputError {
+		t.Errorf("Code = %d, want ExitInputError (%d)", exitErr.Code, ExitInputError)
+	}
+}

--- a/internal/cli/validate_narrative_test.go
+++ b/internal/cli/validate_narrative_test.go
@@ -138,3 +138,25 @@ func TestValidateNarrativeCmd_FrameworkOnlyFailsInventedFlags(t *testing.T) {
 		t.Errorf("Code = %d, want ExitInputError (%d)", exitErr.Code, ExitInputError)
 	}
 }
+
+func TestValidateNarrativeCmd_FrameworkOnlyReportsNoFrameworkCommands(t *testing.T) {
+	t.Parallel()
+
+	research := filepath.Join(t.TempDir(), "research.json")
+	if err := os.WriteFile(research, []byte(`{"narrative":{"quickstart":[{"command":"demo-pp-cli customers list --limit 5"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newValidateNarrativeCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetArgs([]string{"--strict", "--framework-only", "--research", research})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected endpoint-only narrative to skip framework-only validation, got %v", err)
+	}
+	if got := stdout.String() + stderr.String(); !strings.Contains(got, "no framework-command narrative examples found") {
+		t.Fatalf("output = %q, want no-framework-command skip output", got)
+	}
+}

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
@@ -75,6 +76,7 @@ type Report struct {
 	Unsupported   int      `json:"unsupported,omitempty"`
 	Results       []Result `json:"results"`
 	FullExamples  bool     `json:"full_examples,omitempty"`
+	FrameworkOnly bool     `json:"framework_only,omitempty"`
 	// ResearchEmpty is true when neither narrative.quickstart nor
 	// narrative.recipes contained any entries. The LLM may have
 	// omitted both sections by mistake; the caller's --strict flag
@@ -92,6 +94,10 @@ type Options struct {
 	// Cobra path. The example is run with PRINTING_PRESS_VERIFY=1 and
 	// --dry-run appended when the command advertises --dry-run.
 	FullExamples bool
+	// FrameworkOnly validates only stable framework-command vocabulary
+	// without requiring a generated CLI binary. It is intended for the
+	// pre-render research.json gate, before README/SKILL examples exist.
+	FrameworkOnly bool
 }
 
 // Validate parses researchPath, walks every narrative.quickstart and
@@ -108,6 +114,9 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 	commands, err := loadCommands(researchPath)
 	if err != nil {
 		return nil, err
+	}
+	if opts.FrameworkOnly {
+		return validateFrameworkOnly(commands), nil
 	}
 	var templateVarAssignments []string
 	if opts.FullExamples {
@@ -136,6 +145,29 @@ func ValidateWithOptions(ctx context.Context, researchPath, binaryPath string, o
 		report.Results = append(report.Results, r)
 	}
 	return report, nil
+}
+
+func validateFrameworkOnly(commands []sectionCommand) *Report {
+	report := &Report{
+		Results:       []Result{},
+		ResearchEmpty: len(commands) == 0,
+		FrameworkOnly: true,
+	}
+	for _, sc := range commands {
+		results := classifyFrameworkCommand(sc.Section, sc.Command)
+		for _, r := range results {
+			switch r.Status {
+			case StatusOK:
+				report.Walked++
+			case StatusEmptyWords:
+				report.Empty++
+			case StatusExampleFailed:
+				report.ExampleFailed++
+			}
+			report.Results = append(report.Results, r)
+		}
+	}
+	return report
 }
 
 // HasFailures reports whether the run found any missing or empty-words
@@ -254,6 +286,233 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 		last = sub
 	}
 	return finish(last)
+}
+
+var (
+	sinceDurationPattern = regexp.MustCompile(`^\d+[dhwm]$`)
+	globalFrameworkFlags = map[string]frameworkFlagSpec{
+		"agent":                 {Name: "agent"},
+		"allow-partial-failure": {Name: "allow-partial-failure"},
+		"compact":               {Name: "compact"},
+		"config":                {Name: "config", RequiresValue: true},
+		"csv":                   {Name: "csv"},
+		"data-source":           {Name: "data-source", RequiresValue: true},
+		"deliver":               {Name: "deliver", RequiresValue: true},
+		"dry-run":               {Name: "dry-run"},
+		"human-friendly":        {Name: "human-friendly"},
+		"idempotent":            {Name: "idempotent"},
+		"ignore-missing":        {Name: "ignore-missing"},
+		"json":                  {Name: "json"},
+		"no-cache":              {Name: "no-cache"},
+		"no-color":              {Name: "no-color"},
+		"no-input":              {Name: "no-input"},
+		"plain":                 {Name: "plain"},
+		"profile":               {Name: "profile", RequiresValue: true},
+		"quiet":                 {Name: "quiet"},
+		"rate-limit":            {Name: "rate-limit", RequiresValue: true},
+		"select":                {Name: "select", RequiresValue: true},
+		"throttle-mode":         {Name: "throttle-mode", RequiresValue: true},
+		"timeout":               {Name: "timeout", RequiresValue: true},
+		"yes":                   {Name: "yes"},
+	}
+	frameworkCommandSpecs = map[string]frameworkCommandSpec{
+		"sync": {
+			Flags: []frameworkFlagSpec{
+				{Name: "resources", Example: "--resources <csv>", RequiresValue: true},
+				{Name: "since", Example: "--since <duration>", RequiresValue: true, Validate: validateSinceDuration},
+				{Name: "full", Example: "--full"},
+				{Name: "latest-only", Example: "--latest-only"},
+				{Name: "max-pages", Example: "--max-pages <int>", RequiresValue: true},
+				{Name: "param", Example: "--param key=value", RequiresValue: true},
+				{Name: "resource-param", Example: "--resource-param resource:key=value", RequiresValue: true},
+				{Name: "global-param", Example: "--global-param key=value", RequiresValue: true},
+				{Name: "db", Example: "--db <path>", RequiresValue: true},
+				{Name: "concurrency", Example: "--concurrency <int>", RequiresValue: true},
+				{Name: "strict", Example: "--strict"},
+				{Name: "path-context", Example: "--path-context key=value", RequiresValue: true},
+				{Name: "dates", Example: "--dates <range>", RequiresValue: true},
+			},
+		},
+		"search": {
+			Flags: []frameworkFlagSpec{
+				{Name: "type", Example: "--type <single resource>", RequiresValue: true},
+				{Name: "limit", Example: "--limit <int>", RequiresValue: true},
+				{Name: "db", Example: "--db <path>", RequiresValue: true},
+			},
+		},
+		"analytics": {
+			Flags: []frameworkFlagSpec{
+				{Name: "type", Example: "--type <resource>", RequiresValue: true},
+				{Name: "group-by", Example: "--group-by <field>", RequiresValue: true},
+				{Name: "limit", Example: "--limit <int>", RequiresValue: true},
+				{Name: "db", Example: "--db <path>", RequiresValue: true},
+			},
+		},
+		"tail": {
+			Flags: []frameworkFlagSpec{
+				{Name: "resource", Example: "--resource <resource>", RequiresValue: true},
+				{Name: "interval", Example: "--interval <duration>", RequiresValue: true},
+				{Name: "since", Example: "--since <timestamp>", RequiresValue: true},
+				{Name: "follow", Example: "--follow"},
+			},
+		},
+		"doctor": {
+			Flags: []frameworkFlagSpec{
+				{Name: "fail-on", Example: "--fail-on <level>", RequiresValue: true},
+				{Name: "refresh-bearer", Example: "--refresh-bearer"},
+				{Name: "bearer-bundle-url", Example: "--bearer-bundle-url <url>", RequiresValue: true},
+				{Name: "bearer-pattern", Example: "--bearer-pattern <regexp>", RequiresValue: true},
+			},
+		},
+	}
+)
+
+type frameworkCommandSpec struct {
+	Flags []frameworkFlagSpec
+}
+
+type frameworkFlagSpec struct {
+	Name          string
+	Example       string
+	RequiresValue bool
+	Validate      func(string) error
+}
+
+func classifyFrameworkCommand(section Section, command string) []Result {
+	segments, err := splitShellChain(command)
+	if err != nil {
+		return []Result{{
+			Section: section,
+			Command: command,
+			Status:  StatusExampleFailed,
+			Error:   err.Error(),
+		}}
+	}
+
+	var out []Result
+	for _, seg := range segments {
+		if seg.AfterPipe {
+			continue
+		}
+		cleaned, _ := stripRedirects(seg.Text)
+		tokens, err := shellargs.Split(cleaned)
+		if err != nil {
+			out = append(out, Result{
+				Section: section,
+				Command: command,
+				Status:  StatusExampleFailed,
+				Error:   err.Error(),
+			})
+			continue
+		}
+		if len(tokens) <= 1 {
+			continue
+		}
+		args := tokens[1:]
+		commandIndex, commandName, ok := findFrameworkCommand(args)
+		if !ok {
+			continue
+		}
+		spec := frameworkCommandSpecs[commandName]
+		r := Result{
+			Section: section,
+			Command: command,
+			Words:   commandName,
+			Status:  StatusOK,
+		}
+		if err := validateFrameworkFlags(commandName, args[commandIndex+1:], spec); err != nil {
+			r.Status = StatusExampleFailed
+			r.Error = err.Error()
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func findFrameworkCommand(args []string) (int, string, bool) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if _, ok := frameworkCommandSpecs[arg]; ok {
+			return i, arg, true
+		}
+		if !strings.HasPrefix(arg, "--") || arg == "--" {
+			return 0, "", false
+		}
+		name, _, hasInlineValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		flag, ok := globalFrameworkFlags[name]
+		if !ok {
+			continue
+		}
+		if flag.RequiresValue && !hasInlineValue {
+			i++
+		}
+	}
+	return 0, "", false
+}
+
+func validateFrameworkFlags(commandName string, args []string, spec frameworkCommandSpec) error {
+	for i := range args {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") || arg == "--" {
+			continue
+		}
+		name, value, hasInlineValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		if name == "" {
+			continue
+		}
+		flag, ok := spec.flag(name)
+		if !ok {
+			flag, ok = globalFrameworkFlags[name]
+		}
+		if !ok {
+			return fmt.Errorf("framework command %q does not emit --%s; use documented flags such as %s", commandName, name, frameworkFlagSummary(spec))
+		}
+		if flag.RequiresValue || flag.Validate != nil {
+			if !hasInlineValue {
+				if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+					return fmt.Errorf("framework command %q requires --%s to have a value", commandName, name)
+				}
+				value = args[i+1]
+			}
+			if flag.Validate != nil {
+				if err := flag.Validate(value); err != nil {
+					return fmt.Errorf("framework command %q has invalid --%s: %w", commandName, name, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s frameworkCommandSpec) flag(name string) (frameworkFlagSpec, bool) {
+	for _, flag := range s.Flags {
+		if flag.Name == name {
+			return flag, true
+		}
+	}
+	return frameworkFlagSpec{}, false
+}
+
+func validateSinceDuration(value string) error {
+	if sinceDurationPattern.MatchString(strings.TrimSpace(value)) {
+		return nil
+	}
+	return fmt.Errorf("use a relative duration like 7d, 24h, 1w, or 30m, got %q", value)
+}
+
+func frameworkFlagSummary(spec frameworkCommandSpec) string {
+	if len(spec.Flags) == 0 {
+		return "the command's generated help"
+	}
+	parts := make([]string, 0, len(spec.Flags))
+	for _, flag := range spec.Flags {
+		if flag.Example != "" {
+			parts = append(parts, flag.Example)
+		} else {
+			parts = append(parts, "--"+flag.Name)
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 func classifySegment(ctx context.Context, binaryPath string, section Section, command string, opts Options, templateVarAssignments []string) Result {

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -409,7 +409,7 @@ func classifyFrameworkCommand(section Section, command string) []Result {
 			continue
 		}
 		args := tokens[1:]
-		commandIndex, commandName, ok := findFrameworkCommand(args)
+		commandIndex, commandName, preCommandErr, ok := findFrameworkCommand(args)
 		if !ok {
 			continue
 		}
@@ -420,7 +420,10 @@ func classifyFrameworkCommand(section Section, command string) []Result {
 			Words:   commandName,
 			Status:  StatusOK,
 		}
-		if err := validateFrameworkFlags(commandName, args[commandIndex+1:], spec); err != nil {
+		if preCommandErr != nil {
+			r.Status = StatusExampleFailed
+			r.Error = preCommandErr.Error()
+		} else if err := validateFrameworkFlags(commandName, args[commandIndex+1:], spec); err != nil {
 			r.Status = StatusExampleFailed
 			r.Error = err.Error()
 		}
@@ -429,29 +432,36 @@ func classifyFrameworkCommand(section Section, command string) []Result {
 	return out
 }
 
-func findFrameworkCommand(args []string) (int, string, bool) {
+func findFrameworkCommand(args []string) (int, string, error, bool) {
+	var unknownPreCommandFlag string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if _, ok := frameworkCommandSpecs[arg]; ok {
-			return i, arg, true
+			if unknownPreCommandFlag != "" {
+				return i, arg, fmt.Errorf("framework command %q does not emit --%s before the command; use documented global flags before the command or documented %s flags after it", arg, unknownPreCommandFlag, arg), true
+			}
+			return i, arg, nil, true
 		}
 		if !strings.HasPrefix(arg, "--") || arg == "--" {
-			return 0, "", false
+			return 0, "", nil, false
 		}
 		name, _, hasInlineValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
 		flag, ok := globalFrameworkFlags[name]
 		if !ok {
+			if unknownPreCommandFlag == "" {
+				unknownPreCommandFlag = name
+			}
 			continue
 		}
 		if flag.RequiresValue && !hasInlineValue {
 			i++
 		}
 	}
-	return 0, "", false
+	return 0, "", nil, false
 }
 
 func validateFrameworkFlags(commandName string, args []string, spec frameworkCommandSpec) error {
-	for i := range args {
+	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if !strings.HasPrefix(arg, "--") || arg == "--" {
 			continue
@@ -469,10 +479,11 @@ func validateFrameworkFlags(commandName string, args []string, spec frameworkCom
 		}
 		if flag.RequiresValue || flag.Validate != nil {
 			if !hasInlineValue {
-				if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				if i+1 >= len(args) {
 					return fmt.Errorf("framework command %q requires --%s to have a value", commandName, name)
 				}
 				value = args[i+1]
+				i++
 			}
 			if flag.Validate != nil {
 				if err := flag.Validate(value); err != nil {

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -217,6 +217,98 @@ func TestValidateWithOptions_FullExamplesCatchesInvalidFlag(t *testing.T) {
 	}
 }
 
+func TestValidateWithOptions_FrameworkOnlyCatchesInventedFrameworkFlags(t *testing.T) {
+	t.Parallel()
+
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stripe-pp-cli sync --since 2026-01-01 --resources customers,charges"},
+			{"command":"stripe-pp-cli sync --since 7d --entities customers,charges"},
+			{"command":"stripe-pp-cli --json sync --since 7d --entities customers,charges"},
+			{"command":"stripe-pp-cli search \"acme.co\" --entities customers,invoices --json"},
+			{"command":"stripe-pp-cli customers list --entities ignored-for-endpoint-command"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, "", Options{FrameworkOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Walked != 0 {
+		t.Errorf("Walked = %d, want 0", report.Walked)
+	}
+	if report.ExampleFailed != 4 {
+		t.Fatalf("ExampleFailed = %d, want 4; results=%+v", report.ExampleFailed, report.Results)
+	}
+	if !report.HasFailures() {
+		t.Fatal("HasFailures should be true for invented framework flags")
+	}
+	gotErrors := []string{report.Results[0].Error, report.Results[1].Error, report.Results[2].Error, report.Results[3].Error}
+	if !strings.Contains(gotErrors[0], "--since") {
+		t.Errorf("first error should catch absolute --since duration, got %q", gotErrors[0])
+	}
+	if !strings.Contains(gotErrors[1], "--entities") {
+		t.Errorf("second error should catch invented sync --entities flag, got %q", gotErrors[1])
+	}
+	if !strings.Contains(gotErrors[2], "--entities") {
+		t.Errorf("third error should catch invented sync --entities after a global flag, got %q", gotErrors[2])
+	}
+	if !strings.Contains(gotErrors[3], "--entities") {
+		t.Errorf("fourth error should catch invented search --entities flag, got %q", gotErrors[3])
+	}
+}
+
+func TestValidateWithOptions_FrameworkOnlyCatchesMissingFlagValues(t *testing.T) {
+	t.Parallel()
+
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stripe-pp-cli sync --resources"},
+			{"command":"stripe-pp-cli search \"acme.co\" --type"},
+			{"command":"stripe-pp-cli search \"acme.co\" --select"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, "", Options{FrameworkOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.ExampleFailed != 3 {
+		t.Fatalf("ExampleFailed = %d, want 3; results=%+v", report.ExampleFailed, report.Results)
+	}
+	for _, result := range report.Results {
+		if !strings.Contains(result.Error, "requires --") || !strings.Contains(result.Error, "to have a value") {
+			t.Errorf("Error %q should report a missing flag value", result.Error)
+		}
+	}
+}
+
+func TestValidateWithOptions_FrameworkOnlyAcceptsDocumentedFrameworkFlags(t *testing.T) {
+	t.Parallel()
+
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stripe-pp-cli --json sync --since 7d --resources customers,charges"},
+			{"command":"stripe-pp-cli sync --since 7d --resources customers,charges --max-pages 1 --json"},
+			{"command":"stripe-pp-cli search \"acme.co\" --type customers --limit 10 --json"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, "", Options{FrameworkOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.HasFailures() {
+		t.Fatalf("documented framework flags should pass, got %+v", report.Results)
+	}
+	if report.Walked != 3 {
+		t.Errorf("Walked = %d, want 3", report.Walked)
+	}
+}
+
 func TestValidateWithOptions_FullExamplesSeedsTemplateVarEnv(t *testing.T) {
 	unsetEnv(t, "SHOPIFY_SHOP")
 	unsetEnv(t, "SHOPIFY_API_VERSION")

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -225,6 +225,7 @@ func TestValidateWithOptions_FrameworkOnlyCatchesInventedFrameworkFlags(t *testi
 			{"command":"stripe-pp-cli sync --since 2026-01-01 --resources customers,charges"},
 			{"command":"stripe-pp-cli sync --since 7d --entities customers,charges"},
 			{"command":"stripe-pp-cli --json sync --since 7d --entities customers,charges"},
+			{"command":"stripe-pp-cli --entities sync --since 7d --resources customers,charges"},
 			{"command":"stripe-pp-cli search \"acme.co\" --entities customers,invoices --json"},
 			{"command":"stripe-pp-cli customers list --entities ignored-for-endpoint-command"}
 		]
@@ -238,13 +239,13 @@ func TestValidateWithOptions_FrameworkOnlyCatchesInventedFrameworkFlags(t *testi
 	if report.Walked != 0 {
 		t.Errorf("Walked = %d, want 0", report.Walked)
 	}
-	if report.ExampleFailed != 4 {
-		t.Fatalf("ExampleFailed = %d, want 4; results=%+v", report.ExampleFailed, report.Results)
+	if report.ExampleFailed != 5 {
+		t.Fatalf("ExampleFailed = %d, want 5; results=%+v", report.ExampleFailed, report.Results)
 	}
 	if !report.HasFailures() {
 		t.Fatal("HasFailures should be true for invented framework flags")
 	}
-	gotErrors := []string{report.Results[0].Error, report.Results[1].Error, report.Results[2].Error, report.Results[3].Error}
+	gotErrors := []string{report.Results[0].Error, report.Results[1].Error, report.Results[2].Error, report.Results[3].Error, report.Results[4].Error}
 	if !strings.Contains(gotErrors[0], "--since") {
 		t.Errorf("first error should catch absolute --since duration, got %q", gotErrors[0])
 	}
@@ -255,7 +256,10 @@ func TestValidateWithOptions_FrameworkOnlyCatchesInventedFrameworkFlags(t *testi
 		t.Errorf("third error should catch invented sync --entities after a global flag, got %q", gotErrors[2])
 	}
 	if !strings.Contains(gotErrors[3], "--entities") {
-		t.Errorf("fourth error should catch invented search --entities flag, got %q", gotErrors[3])
+		t.Errorf("fourth error should catch invented --entities before a framework command, got %q", gotErrors[3])
+	}
+	if !strings.Contains(gotErrors[4], "--entities") {
+		t.Errorf("fifth error should catch invented search --entities flag, got %q", gotErrors[4])
 	}
 }
 
@@ -292,7 +296,8 @@ func TestValidateWithOptions_FrameworkOnlyAcceptsDocumentedFrameworkFlags(t *tes
 		"quickstart":[
 			{"command":"stripe-pp-cli --json sync --since 7d --resources customers,charges"},
 			{"command":"stripe-pp-cli sync --since 7d --resources customers,charges --max-pages 1 --json"},
-			{"command":"stripe-pp-cli search \"acme.co\" --type customers --limit 10 --json"}
+			{"command":"stripe-pp-cli search \"acme.co\" --type customers --limit 10 --json"},
+			{"command":"stripe-pp-cli search \"acme.co\" --type \"--temporary-resource\" --json"}
 		]
 	}}`)
 
@@ -304,8 +309,8 @@ func TestValidateWithOptions_FrameworkOnlyAcceptsDocumentedFrameworkFlags(t *tes
 	if report.HasFailures() {
 		t.Fatalf("documented framework flags should pass, got %+v", report.Results)
 	}
-	if report.Walked != 3 {
-		t.Errorf("Walked = %d, want 3", report.Walked)
+	if report.Walked != 4 {
+		t.Errorf("Walked = %d, want 4", report.Walked)
 	}
 }
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1591,6 +1591,25 @@ For each tool, fill in what you know from the research. Stars and command_count 
 10. All `narrative` fields are optional. Omit fields you can't populate honestly rather than emit filler. The generator falls back to generic content gracefully.
 11. **Avoid hardcoded counts in narrative copy when the count tracks a runtime list.** A number embedded in `headline` or `value_prop` ("across N trusted sources", "from N retailers", "queries N vendors") propagates into root.go's Short/Long, the README, the SKILL, the MCP tools description, and `which.go` — every output surface that reads the narrative. When the underlying registry grows or shrinks, the count goes stale across all of those surfaces simultaneously, and a single-line edit to add a source requires hunting down ~10 hardcoded copies. Prefer plural-without-count phrasing ("across the major sources", "from a curated set of retailers") or describe the breadth qualitatively ("dozens of vendors") rather than committing to a specific integer. If a count is load-bearing for the value prop, keep the brief's narrative count-free and have the printed-CLI's README/SKILL author write the count once into a single hand-edited paragraph after generation — accepting that it will need a manual update whenever the registry changes.
 
+**Pre-render framework-command check.** Before running `generate --research-dir`,
+validate the framework command examples already present in `research.json`.
+This catches stable template vocabulary mistakes while the fix is still a
+single-file `research.json` edit, before README.md, SKILL.md, `.printing-press.json`,
+root help, and other generated surfaces consume the bad narrative.
+
+```bash
+cli-printing-press validate-narrative --strict --framework-only \
+  --research "$API_RUN_DIR/research.json"
+```
+
+If this reports `sync --entities`, `search --entities`, `search --types`, an
+absolute date for `sync --since`, or another framework-command flag mismatch,
+fix `research.json` now and rerun this check before generation. This is a
+cheap floor, not a replacement for Phase 4 shipcheck: after the CLI exists,
+`shipcheck` still runs `validate-narrative --strict --full-examples` against
+the built binary to catch API-specific command paths, generated endpoint flags,
+and runtime dry-run failures.
+
 Also write discovery pages if browser-sniff was used. The generator reads these from `$API_RUN_DIR/discovery/browser-sniff-report.md` (which the browser-sniff gate already writes there). No additional action needed for discovery pages -- they are already in the right location.
 
 ### Priority inversion check (combo CLIs only)

--- a/skills/printing-press/references/novel-features-subagent.md
+++ b/skills/printing-press/references/novel-features-subagent.md
@@ -180,6 +180,23 @@ Apply the rubric's kill/keep checks (LLM dependency, external service, auth
 gap, scope creep, verifiability, reimplementation) inline. Reframe or cut
 obvious failures NOW so they don't waste Pass 3 attention.
 
+## Framework command flags
+
+The generated framework commands have stable flag vocabularies. Use these
+verbatim in `narrative.quickstart`, `narrative.recipes`, and any example that
+calls a framework command:
+
+- `sync`: `--resources <csv>`, `--since <duration like 7d/24h/1w/30m>`, `--full`, `--latest-only`, `--max-pages <int>`, `--param key=value`, `--resource-param resource:key=value`, `--global-param key=value`, `--db <path>`
+- `search`: `--type <single resource>`, `--limit <int>`, `--db <path>`
+- `analytics`: `--type <single resource>`, `--group-by <field>`, `--limit <int>`, `--db <path>`
+- `tail`: `--resource <single resource>`, `--interval <duration>`, `--since <timestamp>`, `--follow`
+- global output flags on any command: `--json`, `--agent`, `--select <fields>`, `--compact`, `--quiet`, `--plain`, `--csv`
+
+Do not invent plausible variants such as `--entities`, `--types`, `--query`, or
+absolute dates for `sync --since`. If you need multiple resources, use
+`sync --resources customers,charges`. If you need search scoped to one resource,
+use `search "term" --type customers`. Do not use `search --entities`.
+
 ## Pass 3: Adversarial cut pass
 
 This is the pass that exists because brainstorms without it produce flabby


### PR DESCRIPTION
## Summary
- Add `validate-narrative --framework-only` to statically check stable framework-command examples directly from `research.json` before a generated binary exists.
- Teach the Printing Press skill and novel-features subagent to run/use the pre-render guard before README, SKILL, manifest, and help surfaces consume narrative examples.
- Add regression coverage for invented `--entities`, absolute `sync --since` values, pre-command global flags, and missing values for value-taking framework/global flags.

## Tests
- `go test ./internal/narrativecheck ./internal/cli -run 'TestValidateNarrative|TestValidateWithOptions_FrameworkOnly'`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`
- Bad Stripe-shaped `research.json` repro fails under `validate-narrative --strict --framework-only` with `sync --since` and `search --entities` errors.

Closes #1483
