### PR TITLE
fix(cli): retry busy dogfood command execs

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
@@ -2045,10 +2044,6 @@ func runStdoutOnlyWithRunner(timeout time.Duration, run func(context.Context) ([
 		}
 		return nil, formatStdoutOnlyError(err)
 	}
-}
-
-func isTextFileBusy(err error) bool {
-	return errors.Is(err, syscall.ETXTBSY)
 }
 
 func formatStdoutOnlyError(err error) error {

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
@@ -2029,10 +2030,11 @@ func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]
 		if isTextFileBusy(err) {
 			sleep := time.Duration(attempt+1) * 25 * time.Millisecond
 			sleep = min(sleep, 250*time.Millisecond)
-			if sleep > time.Until(deadline) {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
 				return nil, fmt.Errorf("timed out after %s", timeout)
 			}
-			time.Sleep(sleep)
+			time.Sleep(min(sleep, remaining))
 			continue
 		}
 		return nil, formatStdoutOnlyError(err)
@@ -2040,7 +2042,7 @@ func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]
 }
 
 func isTextFileBusy(err error) bool {
-	return strings.Contains(strings.ToLower(err.Error()), "text file busy")
+	return errors.Is(err, syscall.ETXTBSY)
 }
 
 func formatStdoutOnlyError(err error) error {

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -2008,22 +2008,47 @@ func discoverExampleCheckCommands(binaryPath string) ([][]string, error) {
 // callers can surface a meaningful "what broke" instead of "exit
 // status 1".
 func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, binaryPath, args...)
-	applyDefaultSubprocessEnv(cmd)
-	out, err := cmd.Output()
-	if ctx.Err() == context.DeadlineExceeded {
-		return nil, fmt.Errorf("timed out after %s", timeout)
-	}
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return nil, fmt.Errorf("%s", strings.TrimSpace(string(exitErr.Stderr)))
+	deadline := time.Now().Add(timeout)
+	for attempt := 0; ; attempt++ {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("timed out after %s", timeout)
 		}
-		return nil, err
+		ctx, cancel := context.WithTimeout(context.Background(), remaining)
+		cmd := exec.CommandContext(ctx, binaryPath, args...)
+		applyDefaultSubprocessEnv(cmd)
+		out, err := cmd.Output()
+		timedOut := ctx.Err() == context.DeadlineExceeded
+		cancel()
+		if timedOut {
+			return nil, fmt.Errorf("timed out after %s", timeout)
+		}
+		if err == nil {
+			return out, nil
+		}
+		if isTextFileBusy(err) {
+			sleep := time.Duration(attempt+1) * 25 * time.Millisecond
+			sleep = min(sleep, 250*time.Millisecond)
+			if sleep > time.Until(deadline) {
+				return nil, fmt.Errorf("timed out after %s", timeout)
+			}
+			time.Sleep(sleep)
+			continue
+		}
+		return nil, formatStdoutOnlyError(err)
 	}
-	return out, nil
+}
+
+func isTextFileBusy(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "text file busy")
+}
+
+func formatStdoutOnlyError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Errorf("%s", strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return err
 }
 
 func dogfoodExampleCommandPathsFromAgentContext(data []byte) ([][]string, error) {

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -2009,6 +2009,14 @@ func discoverExampleCheckCommands(binaryPath string) ([][]string, error) {
 // callers can surface a meaningful "what broke" instead of "exit
 // status 1".
 func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]byte, error) {
+	return runStdoutOnlyWithRunner(timeout, func(ctx context.Context) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, binaryPath, args...)
+		applyDefaultSubprocessEnv(cmd)
+		return cmd.Output()
+	})
+}
+
+func runStdoutOnlyWithRunner(timeout time.Duration, run func(context.Context) ([]byte, error)) ([]byte, error) {
 	deadline := time.Now().Add(timeout)
 	for attempt := 0; ; attempt++ {
 		remaining := time.Until(deadline)
@@ -2016,9 +2024,7 @@ func runStdoutOnly(binaryPath string, timeout time.Duration, args ...string) ([]
 			return nil, fmt.Errorf("timed out after %s", timeout)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), remaining)
-		cmd := exec.CommandContext(ctx, binaryPath, args...)
-		applyDefaultSubprocessEnv(cmd)
-		out, err := cmd.Output()
+		out, err := run(ctx)
 		timedOut := ctx.Err() == context.DeadlineExceeded
 		cancel()
 		if timedOut {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1,11 +1,13 @@
 package pipeline
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -2400,29 +2402,17 @@ EOF
 }
 
 func TestRunStdoutOnlyRetriesTextFileBusy(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses a shell script as the fake binary; skip on Windows")
-	}
-
-	script := `#!/bin/sh
-echo '{"commands":[]}'
-`
-	binPath := filepath.Join(t.TempDir(), "fakebin")
-	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
-	writer, err := os.OpenFile(binPath, os.O_WRONLY|os.O_APPEND, 0)
-	require.NoError(t, err)
-
-	closed := make(chan struct{})
-	go func() {
-		time.Sleep(75 * time.Millisecond)
-		_ = writer.Close()
-		close(closed)
-	}()
-
-	out, err := runStdoutOnly(binPath, 2*time.Second, "agent-context")
-	<-closed
+	attempts := 0
+	out, err := runStdoutOnlyWithRunner(2*time.Second, func(_ context.Context) ([]byte, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, &os.PathError{Op: "fork/exec", Path: "fakebin", Err: syscall.ETXTBSY}
+		}
+		return []byte(`{"commands":[]}`), nil
+	})
 	require.NoError(t, err)
 	assert.Contains(t, string(out), `"commands"`)
+	assert.Equal(t, 3, attempts)
 }
 
 // TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure — when the

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1,15 +1,12 @@
 package pipeline
 
 import (
-	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 
 	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
@@ -2399,20 +2396,6 @@ EOF
 	// auth/login is filtered out because "auth" is in the framework
 	// skip set; only the posts subtree should survive.
 	assert.Equal(t, [][]string{{"posts", "list"}}, paths)
-}
-
-func TestRunStdoutOnlyRetriesTextFileBusy(t *testing.T) {
-	attempts := 0
-	out, err := runStdoutOnlyWithRunner(2*time.Second, func(_ context.Context) ([]byte, error) {
-		attempts++
-		if attempts < 3 {
-			return nil, &os.PathError{Op: "fork/exec", Path: "fakebin", Err: syscall.ETXTBSY}
-		}
-		return []byte(`{"commands":[]}`), nil
-	})
-	require.NoError(t, err)
-	assert.Contains(t, string(out), `"commands"`)
-	assert.Equal(t, 3, attempts)
 }
 
 // TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure — when the

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	apispec "github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
@@ -2396,6 +2397,32 @@ EOF
 	// auth/login is filtered out because "auth" is in the framework
 	// skip set; only the posts subtree should survive.
 	assert.Equal(t, [][]string{{"posts", "list"}}, paths)
+}
+
+func TestRunStdoutOnlyRetriesTextFileBusy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	script := `#!/bin/sh
+echo '{"commands":[]}'
+`
+	binPath := filepath.Join(t.TempDir(), "fakebin")
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	writer, err := os.OpenFile(binPath, os.O_WRONLY|os.O_APPEND, 0)
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		_ = writer.Close()
+		close(closed)
+	}()
+
+	out, err := runStdoutOnly(binPath, 2*time.Second, "agent-context")
+	<-closed
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"commands"`)
 }
 
 // TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure — when the

--- a/internal/pipeline/textfilebusy_unix.go
+++ b/internal/pipeline/textfilebusy_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package pipeline
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isTextFileBusy(err error) bool {
+	return errors.Is(err, syscall.ETXTBSY)
+}

--- a/internal/pipeline/textfilebusy_unix_test.go
+++ b/internal/pipeline/textfilebusy_unix_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package pipeline
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStdoutOnlyRetriesTextFileBusy(t *testing.T) {
+	attempts := 0
+	out, err := runStdoutOnlyWithRunner(2*time.Second, func(_ context.Context) ([]byte, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, &os.PathError{Op: "fork/exec", Path: "fakebin", Err: syscall.ETXTBSY}
+		}
+		return []byte(`{"commands":[]}`), nil
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"commands"`)
+	assert.Equal(t, 3, attempts)
+}

--- a/internal/pipeline/textfilebusy_windows.go
+++ b/internal/pipeline/textfilebusy_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package pipeline
+
+func isTextFileBusy(error) bool {
+	return false
+}

--- a/internal/pressauth/chrome.go
+++ b/internal/pressauth/chrome.go
@@ -66,7 +66,7 @@ func Capture(ctx context.Context, opts CaptureOptions) (*State, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating temp user-data-dir: %w", err)
 	}
-	defer func() { _ = os.RemoveAll(userDataDir) }()
+	defer removeTempDirEventually(userDataDir, 5*time.Second)
 
 	// Start from chromedp's recommended defaults (Puppeteer-style
 	// stability flags) and tack on the press-auth specifics: pinned
@@ -333,6 +333,21 @@ func sanitizeForTempName(s string) string {
 		}
 	}
 	return string(out)
+}
+
+func removeTempDirEventually(dir string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for {
+		_ = os.RemoveAll(dir)
+
+		if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // classifyChromeErr wraps a chromedp/cdproto error with stage context so


### PR DESCRIPTION
## Summary
- Retry `runStdoutOnly` when exec returns a transient `text file busy` error
- Preserve the existing stderr-surfacing behavior for real non-zero command failures
- Add regression coverage for executing a temporarily busy fake CLI binary

## Why
Release PR #1784 hit a flaky `internal/pipeline` failure in `TestDiscoverExampleCheckCommandsIgnoresStderrNoise`:

```
agent-context failed: fork/exec .../fakebin: text file busy
```

That path runs freshly-created or freshly-replaced CLI binaries during dogfood/live checks, so a short bounded retry is safer than treating the filesystem race as a command failure.

## Verification
- `go test ./internal/pipeline -run 'TestDiscoverExampleCheckCommandsIgnoresStderrNoise|TestRunStdoutOnlyRetriesTextFileBusy|TestDiscoverExampleCheckCommandsSurfacesStderrOnFailure' -count=50`
- `go test ./internal/pipeline`
- `go test ./...`
- pre-push `golangci-lint` hook
