### PR TITLE
fix(cli): credit cookie auth in scorecard

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1790,7 +1790,7 @@ func evaluateAuthProtocol(dir string, spec *openAPISpecInfo) dimensionScore {
 			score += 4 // env var support present
 		}
 		// AuthProtocol pattern: standard/custom header auth in generated client.
-		if strings.Contains(clientContent, "Authorization") || strings.Contains(clientContent, "X-Api-Key") || strings.Contains(clientContent, "X-Auth-Token") || strings.Contains(clientContent, "X-Access-Token") {
+		if inferredAuthHeaderAssignmentPresent(clientContent) {
 			score += 3 // client sends auth header (standard or custom)
 		}
 		// Query-param auth (e.g., TMDb ?api_key=, Google Maps ?key=):
@@ -1959,6 +1959,8 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 
 	if strings.EqualFold(scheme.Type, "apikey") && scheme.In == "header" && strings.TrimSpace(scheme.HeaderName) != "" {
 		headerName = scheme.HeaderName
+	} else if strings.EqualFold(scheme.Type, "apikey") && scheme.In == "cookie" {
+		headerName = "Cookie"
 	}
 
 	switch {
@@ -1987,7 +1989,7 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 		// For apiKey schemes, the header value format varies (Bearer, Bot, custom).
 		// Credit authHeaderMatched if the client sets the correct header name,
 		// since that proves the auth plumbing is wired correctly regardless of format.
-		if scheme.In == "header" && headerName != "" {
+		if (scheme.In == "header" || scheme.In == "cookie") && headerName != "" {
 			if headerAssignmentPresent(clientContent, headerName) {
 				authHeaderMatched = true
 			}
@@ -2167,6 +2169,15 @@ func headerAssignmentPresent(clientContent, headerName string) bool {
 	headerName = strings.ToLower(headerName)
 	return strings.Contains(clientContent, `header.set("`+headerName+`"`) ||
 		strings.Contains(clientContent, `header.add("`+headerName+`"`)
+}
+
+func inferredAuthHeaderAssignmentPresent(clientContent string) bool {
+	for _, headerName := range []string{"Authorization", "X-Api-Key", "X-Auth-Token", "X-Access-Token", "Cookie"} {
+		if headerAssignmentPresent(clientContent, headerName) {
+			return true
+		}
+	}
+	return false
 }
 
 var (

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1951,6 +1951,37 @@ func (c *Client) do() {
 			"inferred auth should score > 0")
 	})
 
+	t.Run("inferred cookie header auth is scored", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/config/config.go", `package config
+// Auth inferred from API description — verify the env var below is correct
+func Load() {
+	if v := os.Getenv("EXAMPLE_COOKIE"); v != "" {
+		cfg.Cookie = v
+	}
+}
+`)
+		writeScorecardFixture(t, dir, "internal/client/client.go", `package client
+func (c *Client) do() {
+	req.Header.Set("Cookie", authHeader)
+}
+`)
+
+		specPath := filepath.Join(dir, "spec.json")
+		writeScorecardFixture(t, dir, "spec.json", `{
+  "paths": { "/users": { "get": { "responses": { "200": { "description": "ok" } } } } },
+  "components": { "securitySchemes": {} }
+}`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
+		assert.NoError(t, err)
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol",
+			"inferred cookie auth with Cookie header should be scored")
+		assert.GreaterOrEqual(t, sc.Steinberger.AuthProtocol, 8)
+	})
+
 	t.Run("query-param auth without inferred marker stays unscored", func(t *testing.T) {
 		dir := t.TempDir()
 
@@ -2013,6 +2044,67 @@ func (c *Client) do() {
 			"inferred auth with custom header should be scored")
 		assert.Greater(t, sc.Steinberger.AuthProtocol, 0)
 	})
+}
+
+func TestEvaluateAuthProtocol_InternalCookieAuth(t *testing.T) {
+	t.Run("scores generated Cookie header for internal YAML cookie auth", func(t *testing.T) {
+		sc := scoreInternalCookieAuthProtocol(t, `package client
+func (c *Client) do() {
+	req.Header.Set("Cookie", authHeader)
+}
+`)
+
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.GreaterOrEqual(t, sc.Steinberger.AuthProtocol, 8)
+	})
+
+	t.Run("does not score Cookie mentions without header assignment", func(t *testing.T) {
+		sc := scoreInternalCookieAuthProtocol(t, `package client
+func (c *Client) do() {
+	_ = "Cookie"
+	// Cookie appears in documentation, not in an outgoing request.
+}
+`)
+
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.Less(t, sc.Steinberger.AuthProtocol, 8)
+	})
+}
+
+func scoreInternalCookieAuthProtocol(t *testing.T, clientContent string) *Scorecard {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, "internal/config/config.go", `package config
+func Load() {
+	if v := os.Getenv("EXAMPLE_COOKIE"); v != "" {
+		cfg.Cookie = v
+	}
+}
+`)
+	writeScorecardFixture(t, dir, "internal/client/client.go", clientContent)
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeScorecardFixture(t, dir, "spec.yaml", `name: example
+display_name: Example
+description: Cookie auth scorecard fixture
+base_url: https://api.example.com
+auth:
+  type: cookie
+  header: Cookie
+  env_vars:
+    - EXAMPLE_COOKIE
+resources:
+  users:
+    description: Users
+    endpoints:
+      list:
+        method: GET
+        path: /users
+`)
+
+	sc, err := RunScorecard(dir, t.TempDir(), specPath, nil)
+	assert.NoError(t, err)
+	return sc
 }
 
 func TestScoreAuthScheme_APIKeyHeaderUsesCaseInsensitiveHeaderAndGenericAPIKeyEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

Cookie-auth scorecards now recognize generated `Cookie` header emission instead of flooring `auth_protocol` at env-only credit. The scorer handles both internal YAML `auth.type: cookie` specs and inferred-auth fallback paths, while requiring an actual `Header.Set/Add("Cookie", ...)` assignment so comment or string mentions do not earn credit.

Closes #1515

## Output Contract

`auth_protocol` can now score cookie-auth CLIs at the same level as other correctly wired credential headers when the generated client sends the `Cookie` header.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/pipeline -run 'TestEvaluateAuthProtocol_(InferredAuth|InternalCookieAuth)'`
- `go test ./internal/pipeline -run 'TestEvaluateAuthProtocol|TestScoreAuthScheme_APIKeyHeaderUsesCaseInsensitiveHeaderAndGenericAPIKeyEnv'`
- `go test ./internal/pipeline`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
