### PR TITLE
fix(cli): derive multispec resource names from titles

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1625,6 +1625,46 @@ func TestMergeSpecsRewritesMCPIntentRefsForRenamedResources(t *testing.T) {
 	assert.Equal(t, "contacts.list", merged.MCP.Intents[0].Steps[0].Endpoint)
 }
 
+func TestMergeSpecsRequiresEachSpecToContributeToSharedPrefix(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "contacts",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"crm": {
+				Description: spec.DefaultResourceDescription("crm"),
+				Endpoints: map[string]spec.Endpoint{
+					"list":   {Method: "GET", Path: "/api/v1/crm/v3/objects/contacts"},
+					"get":    {Method: "GET", Path: "/api/v1/crm/v3/objects/contacts/{id}"},
+					"search": {Method: "GET", Path: "/api/v1/crm/v3/objects/contacts/search"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "empty",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"crm": {
+				Description: "Custom empty resource",
+				Endpoints:   map[string]spec.Endpoint{},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "crm")
+
+	assert.Contains(t, merged.Resources, "crm")
+	assert.Contains(t, merged.Resources, "empty-crm")
+	assert.NotContains(t, merged.Resources, "empty")
+	assert.Equal(t, "Custom empty resource", merged.Resources["empty-crm"].Description)
+}
+
 // TestMergeSpecsFirstDeclaringMCPWins verifies that when more than one input
 // spec declares x-mcp, the first declaring spec wins, mirroring the existing
 // first-wins precedence used for Auth.AuthorizationURL.

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1102,6 +1102,88 @@ resources:
 	assert.Contains(t, parsed.Resources, "pages", "second-input resource present in merged archive")
 }
 
+func TestGenerateMultiSpecSharedObjectPrefixUsesSpecNamesAsResourceRoots(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	contactsSpecPath := filepath.Join(dir, "contacts.yaml")
+	companiesSpecPath := filepath.Join(dir, "companies.yaml")
+	outputDir := filepath.Join(dir, "crm")
+	require.NoError(t, os.WriteFile(contactsSpecPath, []byte(`openapi: 3.0.3
+info:
+  title: Contacts
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /api/v1/crm/v3/objects/contacts:
+    get:
+      operationId: listContacts
+      responses:
+        "200":
+          description: OK
+  /api/v1/crm/v3/objects/contacts/{contactId}:
+    get:
+      operationId: getContact
+      parameters:
+        - name: contactId
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+`), 0o644))
+	require.NoError(t, os.WriteFile(companiesSpecPath, []byte(`openapi: 3.0.3
+info:
+  title: Companies
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /api/v1/crm/v3/objects/companies:
+    get:
+      operationId: listCompanies
+      responses:
+        "200":
+          description: OK
+  /api/v1/crm/v3/objects/companies/{companyId}:
+    get:
+      operationId: getCompany
+      parameters:
+        - name: companyId
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+`), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", contactsSpecPath,
+		"--spec", companiesSpecPath,
+		"--name", "crm",
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	archived, err := os.ReadFile(filepath.Join(outputDir, "spec.json"))
+	require.NoError(t, err)
+	parsed, err := spec.ParseBytes(archived)
+	require.NoError(t, err)
+
+	assert.Contains(t, parsed.Resources, "contacts")
+	assert.Contains(t, parsed.Resources, "companies")
+	assert.Equal(t, "Manage contacts", parsed.Resources["contacts"].Description)
+	assert.Equal(t, "Manage companies", parsed.Resources["companies"].Description)
+	assert.NotContains(t, parsed.Resources, "crm")
+	assert.NotContains(t, parsed.Resources, "companies-crm")
+}
+
 // TestArchiveSpecBytesBranches covers each branch of archiveSpecBytes
 // directly, including the json-input single-spec arm that the integration
 // tests above don't exercise (their fixtures are YAML).
@@ -1492,6 +1574,55 @@ func TestMergeSpecsCarriesMCPFullFieldsFromDeclaringSpec(t *testing.T) {
 	assert.Equal(t, ":7777", merged.MCP.Addr)
 	assert.Len(t, merged.MCP.Intents, 1)
 	assert.Equal(t, "search_things", merged.MCP.Intents[0].Name)
+}
+
+func TestMergeSpecsRewritesMCPIntentRefsForRenamedResources(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "contacts",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"crm": {
+				Description: spec.DefaultResourceDescription("crm"),
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/api/v1/crm/v3/objects/contacts"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+		MCP: spec.MCPConfig{
+			Intents: []spec.Intent{
+				{
+					Name: "list_contacts",
+					Steps: []spec.IntentStep{
+						{Endpoint: "crm.list"},
+					},
+				},
+			},
+		},
+	}
+	specB := &spec.APISpec{
+		Name:    "companies",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"crm": {
+				Description: spec.DefaultResourceDescription("crm"),
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/api/v1/crm/v3/objects/companies"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "crm")
+
+	require.Len(t, merged.MCP.Intents, 1)
+	require.Len(t, merged.MCP.Intents[0].Steps, 1)
+	assert.Equal(t, "contacts.list", merged.MCP.Intents[0].Steps[0].Endpoint)
 }
 
 // TestMergeSpecsFirstDeclaringMCPWins verifies that when more than one input

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -950,7 +950,7 @@ func rewriteDefaultResourceDescription(resource spec.Resource, oldName, newName 
 	if oldName == newName {
 		return resource
 	}
-	if resource.Description == spec.DefaultResourceDescription(oldName) {
+	if resource.DescriptionDerived {
 		resource.Description = spec.DefaultResourceDescription(newName)
 	}
 	return resource
@@ -961,15 +961,18 @@ func sharedMultiSpecEndpointPathPrefix(specs []*spec.APISpec) []string {
 		return nil
 	}
 	var prefix []string
-	pathCount := 0
 	for _, s := range specs {
+		specPathCount := 0
 		var stopped bool
-		prefix, stopped = foldSharedEndpointPathPrefix(prefix, s.Resources, &pathCount)
+		prefix, stopped = foldSharedEndpointPathPrefix(prefix, s.Resources, &specPathCount)
 		if stopped {
 			return nil
 		}
+		if specPathCount == 0 {
+			return nil
+		}
 	}
-	if pathCount < len(specs) || len(prefix) < 2 {
+	if len(prefix) < 2 {
 		return nil
 	}
 	return prefix
@@ -1005,7 +1008,7 @@ func foldSharedEndpointPathPrefix(prefix []string, resources map[string]spec.Res
 				continue
 			}
 			(*pathCount)++
-			if *pathCount == 1 {
+			if prefix == nil {
 				prefix = segments
 				continue
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -825,6 +825,7 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 	}
 
 	mergedBaseURL, perSpecPathPrefix := planMultiSpecBaseURL(specs)
+	sharedPathPrefix := sharedMultiSpecEndpointPathPrefix(specs)
 
 	merged := &spec.APISpec{
 		Name:        name,
@@ -859,6 +860,7 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 		}
 
 		prefix := perSpecPathPrefix[i]
+		resourceRenames := map[string]string{}
 		for resourceName, resource := range s.Resources {
 			if prefix != "" {
 				// Same-host/different-path specs are normalized by folding each
@@ -869,9 +871,13 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 			} else {
 				resource = resourceWithMergedSpecBaseURL(resource, s.BaseURL, merged.BaseURL)
 			}
-			key := resourceName
+			key := multiSpecResourceName(s, resourceName, sharedPathPrefix)
 			if _, exists := merged.Resources[key]; exists {
 				key = s.Name + "-" + resourceName
+			}
+			resource = rewriteDefaultResourceDescription(resource, resourceName, key)
+			if key != resourceName {
+				resourceRenames[resourceName] = key
 			}
 			merged.Resources[key] = resource
 		}
@@ -889,11 +895,163 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 		}
 
 		if mcpConfigured(s.MCP) && !mcpConfigured(merged.MCP) {
-			merged.MCP = s.MCP
+			merged.MCP = rewriteMCPIntentEndpointRefs(s.MCP, resourceRenames)
 		}
 	}
 
 	return merged
+}
+
+func rewriteMCPIntentEndpointRefs(mcp spec.MCPConfig, resourceRenames map[string]string) spec.MCPConfig {
+	if len(resourceRenames) == 0 || len(mcp.Intents) == 0 {
+		return mcp
+	}
+	mcp.Intents = append([]spec.Intent(nil), mcp.Intents...)
+	for intentIndex := range mcp.Intents {
+		intent := mcp.Intents[intentIndex]
+		if len(intent.Steps) == 0 {
+			continue
+		}
+		intent.Steps = append([]spec.IntentStep(nil), intent.Steps...)
+		for stepIndex := range intent.Steps {
+			intent.Steps[stepIndex].Endpoint = rewriteEndpointResourceRef(intent.Steps[stepIndex].Endpoint, resourceRenames)
+		}
+		mcp.Intents[intentIndex] = intent
+	}
+	return mcp
+}
+
+func rewriteEndpointResourceRef(ref string, resourceRenames map[string]string) string {
+	resourceName, rest, ok := strings.Cut(ref, ".")
+	if !ok {
+		return ref
+	}
+	if renamed, ok := resourceRenames[resourceName]; ok {
+		return renamed + "." + rest
+	}
+	return ref
+}
+
+func multiSpecResourceName(s *spec.APISpec, resourceName string, sharedPathPrefix []string) string {
+	if s == nil || len(s.Resources) != 1 || len(sharedPathPrefix) < 2 {
+		return resourceName
+	}
+	specName := strings.TrimSpace(s.Name)
+	if specName == "" || specName == resourceName {
+		return resourceName
+	}
+	if !sharedPrefixContainsResourceName(sharedPathPrefix, resourceName) {
+		return resourceName
+	}
+	return specName
+}
+
+func rewriteDefaultResourceDescription(resource spec.Resource, oldName, newName string) spec.Resource {
+	if oldName == newName {
+		return resource
+	}
+	if resource.Description == spec.DefaultResourceDescription(oldName) {
+		resource.Description = spec.DefaultResourceDescription(newName)
+	}
+	return resource
+}
+
+func sharedMultiSpecEndpointPathPrefix(specs []*spec.APISpec) []string {
+	if !allSpecsHaveSingleResource(specs) {
+		return nil
+	}
+	var prefix []string
+	pathCount := 0
+	for _, s := range specs {
+		var stopped bool
+		prefix, stopped = foldSharedEndpointPathPrefix(prefix, s.Resources, &pathCount)
+		if stopped {
+			return nil
+		}
+	}
+	if pathCount < len(specs) || len(prefix) < 2 {
+		return nil
+	}
+	return prefix
+}
+
+func sharedPrefixContainsResourceName(prefix []string, resourceName string) bool {
+	resourceName = normalizePathResourceSegment(resourceName)
+	for _, segment := range prefix {
+		if normalizePathResourceSegment(segment) == resourceName {
+			return true
+		}
+	}
+	return false
+}
+
+func allSpecsHaveSingleResource(specs []*spec.APISpec) bool {
+	if len(specs) < 2 {
+		return false
+	}
+	for _, s := range specs {
+		if s == nil || len(s.Resources) != 1 {
+			return false
+		}
+	}
+	return true
+}
+
+func foldSharedEndpointPathPrefix(prefix []string, resources map[string]spec.Resource, pathCount *int) ([]string, bool) {
+	for _, resource := range resources {
+		for _, endpoint := range resource.Endpoints {
+			segments := splitEndpointPath(endpoint.Path)
+			if len(segments) == 0 {
+				continue
+			}
+			(*pathCount)++
+			if *pathCount == 1 {
+				prefix = segments
+				continue
+			}
+			prefix = commonEndpointPathPrefix(prefix, segments)
+			if len(prefix) < 2 {
+				return nil, true
+			}
+		}
+		if len(resource.SubResources) > 0 {
+			var stopped bool
+			prefix, stopped = foldSharedEndpointPathPrefix(prefix, resource.SubResources, pathCount)
+			if stopped {
+				return nil, true
+			}
+		}
+	}
+	return prefix, false
+}
+
+func splitEndpointPath(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	rawSegments := strings.Split(path, "/")
+	segments := make([]string, 0, len(rawSegments))
+	for _, segment := range rawSegments {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return segments
+}
+
+func commonEndpointPathPrefix(a, b []string) []string {
+	limit := min(len(a), len(b))
+	for i := range limit {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:limit]
+}
+
+func normalizePathResourceSegment(value string) string {
+	return strings.ReplaceAll(strings.Trim(strings.ToLower(value), "/"), "_", "-")
 }
 
 func resourceWithMergedSpecBaseURL(resource spec.Resource, sourceBaseURL, mergedBaseURL string) spec.Resource {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2318,11 +2318,13 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 				sub := resource.SubResources[subName]
 				if sub.Description == "" {
 					sub.Description = humanizeResourceName(subName)
+					sub.DescriptionDerived = true
 				}
 				resource.SubResources[subName] = sub
 			}
 			if resource.Description == "" {
 				resource.Description = humanizeResourceName(primaryName)
+				resource.DescriptionDerived = true
 			}
 			out.Resources[primaryName] = resource
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5957,12 +5957,7 @@ func humanizeEndpointName(name string) string {
 }
 
 func humanizeResourceName(name string) string {
-	words := strings.Split(strings.ReplaceAll(name, "_", "-"), "-")
-	if len(words) == 0 {
-		return ""
-	}
-	sentence := "Manage " + strings.Join(words, " ")
-	return sentence
+	return spec.DefaultResourceDescription(name)
 }
 
 func humanizeConcatenated(s string) string {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1273,9 +1273,10 @@ func (m MCPConfig) HasTransport(t string) bool {
 }
 
 type Resource struct {
-	Description string   `yaml:"description" json:"description"`
-	Path        string   `yaml:"path,omitempty" json:"path,omitempty"`             // base path for operations shorthand (e.g., /api/items)
-	Operations  []string `yaml:"operations,omitempty" json:"operations,omitempty"` // shorthand: list, get, create, update, delete, search
+	Description        string   `yaml:"description" json:"description"`
+	DescriptionDerived bool     `yaml:"-" json:"-"`
+	Path               string   `yaml:"path,omitempty" json:"path,omitempty"`             // base path for operations shorthand (e.g., /api/items)
+	Operations         []string `yaml:"operations,omitempty" json:"operations,omitempty"` // shorthand: list, get, create, update, delete, search
 	// BaseURL overrides the spec-level BaseURL for this resource's
 	// endpoints. Fixed at generation time. Incompatible with the
 	// proxy-envelope client pattern, which POSTs every request to a

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1286,6 +1286,12 @@ type Resource struct {
 	SubResources map[string]Resource `yaml:"sub_resources,omitempty" json:"sub_resources,omitempty"`
 }
 
+// DefaultResourceDescription returns the parser fallback description for a
+// resource that has no source-provided prose.
+func DefaultResourceDescription(name string) string {
+	return "Manage " + strings.ReplaceAll(strings.ReplaceAll(name, "_", "-"), "-", " ")
+}
+
 // HasResourceBaseURLOverride reports whether any resource or endpoint declares
 // a BaseURL override. Used by the client template to gate the absolute-URL
 // detection branch — specs that don't opt in regenerate byte-identically.


### PR DESCRIPTION
## Summary

Multi-spec OpenAPI generates can now keep object modules like contacts and companies as independent top-level resources even when every input spec lives under the same routed path prefix. That prevents false collision names such as `crm` and `companies-crm`, and keeps copied MCP intent endpoint refs aligned when a merge-time resource rename happens.

The resource description fallback is shared through `spec.DefaultResourceDescription`, so parser defaults and merge-time rewrites stay in sync.

## Testing

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1503
