### PR TITLE
fix(cli): honor HTML extraction in sync

### DIFF
--- a/docs/solutions/logic-errors/html-response-format-sync-extraction.md
+++ b/docs/solutions/logic-errors/html-response-format-sync-extraction.md
@@ -1,0 +1,98 @@
+---
+title: HTML response-format transforms must run before sync item extraction
+date: 2026-05-22
+category: docs/solutions/logic-errors
+module: cli-printing-press
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Generated HTML extraction corrupted non-UTF-8 pages such as ISO-8859-1.
+  - Cached HTML responses lost header-only charset hints.
+  - Generated sync commands stored raw HTML as one row for html_extract resources.
+  - Dependent sync resources missed the same HTML extraction path before page item extraction.
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: medium
+tags: [html-extraction, sync, generator, charset, response-format]
+---
+
+# HTML response-format transforms must run before sync item extraction
+
+## Problem
+
+Generated CLIs mishandled endpoints marked with `response_format: html` or `html_extract`. Direct HTML extraction converted raw bytes to a string before parsing, while sync paths skipped HTML extraction entirely before attempting JSON-style item extraction.
+
+## Symptoms
+
+- Pages served with a non-UTF-8 charset, such as ISO-8859-1, produced corrupted extracted text.
+- HTML-backed sync resources stored one raw HTML document row instead of extracted link or page objects.
+- Dependent sync resources had the same missing transform path as flat sync resources.
+- A dependent sync HTML extraction failure could abort later parents if handled as a whole-resource error.
+
+## What Didn't Work
+
+- Parsing with `xhtml.Parse(strings.NewReader(string(raw)))` assumed the response bytes were already valid UTF-8.
+- Preserving only the response body in the HTTP response cache meant cache hits could not replay the `Content-Type` charset hint.
+- Calling `extractPageItems` directly on HTML responses treated the original document as the item payload instead of first normalizing it through the endpoint's `html_extract` contract.
+- Fixing only direct endpoint commands was insufficient because generated sync and dependent sync use separate templates.
+
+## Solution
+
+Decode HTML response bytes with the charset-aware reader before parsing, passing through the response `Content-Type` so header-only charset declarations are honored:
+
+```go
+reader, err := charset.NewReader(bytes.NewReader(raw), contentType)
+if err != nil {
+	reader = bytes.NewReader(raw)
+}
+return xhtml.Parse(reader)
+```
+
+Persist the response `Content-Type` beside cached response bodies for generated clients that have HTML extraction, and restore it into `LastContentType()` on cache hits.
+
+Propagate the chosen list endpoint's HTML response contract through profiling:
+
+```go
+UsesHTMLResponse bool
+HTMLExtract      *spec.HTMLExtract
+```
+
+Then have generated sync apply the response transform before page item extraction:
+
+```go
+if opts, ok := syncHTMLExtractionOptions(resource, "", c.RequestBaseURL(), c.LastContentType(), path, params); ok {
+	data, err = extractHTMLResponse(data, opts)
+}
+items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+```
+
+Apply the same flow to dependent sync resources, using parent-qualified option keys such as `channels.messages` so a flat resource and a dependent resource with the same name cannot collide. Emit `RequestBaseURL` and `LastContentType` only for generated clients that need HTML extraction, so non-HTML generated clients do not gain unrelated surface area.
+
+In dependent sync, treat HTML extraction errors like fetch errors: report the failing parent and break out of that parent's page loop, but continue with later parents.
+
+## Why This Works
+
+`charset.NewReader` lets the HTML parser consume response bytes using the page's declared or detected charset instead of forcing an early UTF-8 conversion.
+
+The cache metadata sidecar preserves the same charset input on cache hits that live responses had, which keeps repeated syncs from decoding cached HTML differently.
+
+Running HTML extraction before `extractPageItems` restores the intended pipeline:
+
+```text
+HTTP response bytes -> extracted HTML data -> page item extraction -> store rows
+```
+
+Carrying `UsesHTMLResponse` and `HTMLExtract` through the profiler keeps the template decision resource-specific and avoids hardcoding behavior for one API.
+
+## Prevention
+
+- Cover response-format transforms with generated runtime tests, not only parser or template assertions.
+- When changing response transforms, verify direct commands, flat sync, and dependent sync paths.
+- Include non-UTF-8 HTML fixtures, including header-only charset cases, so byte-to-string conversions fail visibly.
+- Re-run header-only charset fixtures from the generated response cache, not only from a live test server.
+- For dependent sync transforms, include one failing parent followed by one successful parent so early-return regressions are visible.
+- For generated sync behavior, assert stored row shape rather than command success alone.
+
+## Related Issues
+
+- mvanhorn/cli-printing-press#1499

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/japanese"
 )
 
 func TestGenerateProjectsCompile(t *testing.T) {
@@ -1970,6 +1971,9 @@ func TestGenerateCookieHTMLDefaultsBrowserChromeTransport(t *testing.T) {
 }
 
 func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
+	shiftJISHTML, err := japanese.ShiftJIS.NewEncoder().String(`<html><body><a href="/products/tokyo">東京</a></body></html>`)
+	require.NoError(t, err)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		switch r.URL.Path {
@@ -1980,6 +1984,12 @@ func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
 			// data-src (Pinterest/NYT Cooking pattern). firstImageSrc must
 			// prefer data-src over src.
 			_, _ = w.Write([]byte(`<html><head><title>Makers</title></head><body><a href="/@alice"><img src="data:image/gif;base64,placeholder" data-src="/img/alice-real.jpg" alt="Alice">Alice</a><a href="/@bob"><img srcset="/img/bob-1x.jpg 1x, /img/bob-2x.jpg 2x" alt="Bob">Bob</a></body></html>`))
+		case "/latin1":
+			w.Header().Set("Content-Type", "text/html; charset=ISO-8859-1")
+			_, _ = w.Write([]byte("<html><body><a href=\"/products/cafe\">Caf\xe9</a></body></html>"))
+		case "/shift-jis":
+			w.Header().Set("Content-Type", "text/html; charset=Shift_JIS")
+			_, _ = w.Write([]byte(shiftJISHTML))
 		default:
 			// Anchor 1 wraps its image in <noscript> (Dotdash/Meredith pattern).
 			// nodeTextSuppressing must skip the noscript subtree so "<img src=...>"
@@ -2054,6 +2064,40 @@ func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
 						HTMLExtract: &spec.HTMLExtract{
 							Mode:         spec.HTMLExtractModeLinks,
 							LinkPrefixes: []string{"/@"},
+							Limit:        10,
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+					},
+				},
+			},
+			"latin": {
+				Description: "Browse Latin-1 pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/latin1",
+						Description:    "Fetch Latin-1 links",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:         spec.HTMLExtractModeLinks,
+							LinkPrefixes: []string{"/products"},
+							Limit:        10,
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+					},
+				},
+			},
+			"shiftjis": {
+				Description: "Browse Shift-JIS pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/shift-jis",
+						Description:    "Fetch Shift-JIS links",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:         spec.HTMLExtractModeLinks,
+							LinkPrefixes: []string{"/products"},
 							Limit:        10,
 						},
 						Response: spec.ResponseDef{Type: "array", Item: "html_link"},
@@ -2143,6 +2187,248 @@ func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
 	assert.Equal(t, server.URL+"/@bob", envelope.Results[1]["url"])
 	assert.Contains(t, envelope.Results[1]["image"], "bob-1x.jpg",
 		"first srcset URL should be selected when src is absent; got %v", envelope.Results[1]["image"])
+
+	cmd = exec.Command(binaryPath, "latin", "list", "--json")
+	cmd.Env = append(os.Environ(), "WEBHTML_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, json.Unmarshal(out, &envelope), string(out))
+	require.Len(t, envelope.Results, 1)
+	assert.Equal(t, "Caf\u00e9", envelope.Results[0]["name"])
+
+	shiftJISEnv := append(os.Environ(), "WEBHTML_BASE_URL="+server.URL, "HOME="+t.TempDir())
+	cmd = exec.Command(binaryPath, "shiftjis", "list", "--json")
+	cmd.Env = shiftJISEnv
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, json.Unmarshal(out, &envelope), string(out))
+	require.Len(t, envelope.Results, 1)
+	assert.Equal(t, "東京", envelope.Results[0]["name"])
+
+	server.Close()
+	cmd = exec.Command(binaryPath, "shiftjis", "list", "--json")
+	cmd.Env = shiftJISEnv
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, json.Unmarshal(out, &envelope), string(out))
+	require.Len(t, envelope.Results, 1)
+	assert.Equal(t, "東京", envelope.Results[0]["name"], "cached HTML responses must preserve the HTTP charset hint")
+}
+
+func TestGeneratedSyncHonorsHTMLExtraction(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "htmlsync",
+		Version: "0.1.0",
+		BaseURL: "https://example.test",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/htmlsync-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"pages": {
+				Description: "HTML pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/pages",
+						Description:    "List pages from HTML",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:         spec.HTMLExtractModeLinks,
+							LinkPrefixes: []string{"/pages"},
+							Limit:        10,
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "html_link"},
+					},
+				},
+			},
+			"json_pages": {
+				Description: "JSON pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/json-pages",
+						Description: "List pages from JSON",
+						Response:    spec.ResponseDef{Type: "array", Item: "object"},
+					},
+				},
+			},
+			"channels": {
+				Description: "Channel records",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/channels",
+						Description: "List channels",
+						Response:    spec.ResponseDef{Type: "array", Item: "object"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+			"messages": {
+				Description: "HTML messages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/channels/{channelId}/messages",
+						Description:    "List messages from HTML",
+						ResponseFormat: spec.ResponseFormatHTML,
+						Params:         []spec.Param{{Name: "channelId", Type: "string", Required: true, PathParam: true}},
+						Pagination:     &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: "script#MESSAGES_DATA",
+							JSONPath:       "items",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "object"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, "syncHTMLExtractionOptions",
+		"sync.go must route HTML sync responses through extractHTMLResponse before extractPageItems")
+	assert.Contains(t, syncSrc, `case "pages":`,
+		"HTML extraction options must be emitted for the HTML sync resource")
+	assert.Contains(t, syncSrc, `case "channels.messages":`,
+		"dependent HTML extraction options must be keyed by parent and child resource")
+	assert.NotContains(t, syncSrc, `case "json_pages":`,
+		"JSON sync resources must not get HTML extraction options")
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type htmlSyncClient struct{}
+
+func (htmlSyncClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(` + "`" + `<html><body><a href="/pages/alpha">Alpha</a><a href="/pages/beta">Beta</a><a href="/other">Other</a></body></html>` + "`" + `), nil
+}
+
+func (htmlSyncClient) RequestBaseURL() string {
+	return "https://example.test"
+}
+
+func (htmlSyncClient) LastContentType() string {
+	return "text/html; charset=utf-8"
+}
+
+func (htmlSyncClient) RateLimit() float64 {
+	return 0
+}
+
+type dependentHTMLSyncClient struct{}
+
+func (dependentHTMLSyncClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	if strings.Contains(path, "/bad/messages") {
+		return json.RawMessage(` + "`" + `<html><body>missing embedded JSON</body></html>` + "`" + `), nil
+	}
+	return json.RawMessage(` + "`" + `<html><body><script id="MESSAGES_DATA" type="application/json">{"items":[{"id":"msg-good","text":"ok"}]}</script></body></html>` + "`" + `), nil
+}
+
+func (dependentHTMLSyncClient) RequestBaseURL() string {
+	return "https://example.test"
+}
+
+func (dependentHTMLSyncClient) LastContentType() string {
+	return "text/html; charset=utf-8"
+}
+
+func (dependentHTMLSyncClient) RateLimit() float64 {
+	return 0
+}
+
+func TestSyncResourceExtractsHTMLLinks(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	res := syncResource(context.Background(), htmlSyncClient{}, db, "pages", "", false, 1, false, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if res.Count != 2 {
+		t.Fatalf("synced count = %d, want 2", res.Count)
+	}
+
+	rows, err := db.List("pages", 10)
+	if err != nil {
+		t.Fatalf("list pages: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("stored rows = %d, want 2", len(rows))
+	}
+	body := string(rows[0]) + "\n" + string(rows[1])
+	if !strings.Contains(body, "\"slug\":\"alpha\"") || !strings.Contains(body, "\"slug\":\"beta\"") {
+		t.Fatalf("stored rows did not include extracted HTML links: %s", body)
+	}
+}
+
+func TestSyncDependentResourceContinuesAfterHTMLExtractionError(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("channels", "bad", []byte(` + "`" + `{"id":"bad"}` + "`" + `)); err != nil {
+		t.Fatalf("insert bad parent: %v", err)
+	}
+	if err := db.Upsert("channels", "good", []byte(` + "`" + `{"id":"good"}` + "`" + `)); err != nil {
+		t.Fatalf("insert good parent: %v", err)
+	}
+
+	res := syncDependentResource(
+		context.Background(),
+		dependentHTMLSyncClient{},
+		db,
+		dependentResourceDef{Name: "messages", ParentTable: "channels", ParentIDParam: "channelId", PathTemplate: "/channels/{channelId}/messages"},
+		"", false, 1, false, nil,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("synced count = %d, want 1", res.Count)
+	}
+
+	rows, err := db.List("messages", 10)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("stored rows = %d, want 1", len(rows))
+	}
+	body := string(rows[0])
+	if !strings.Contains(body, "\"id\":\"msg-good\"") || !strings.Contains(body, "\"channels_id\":\"good\"") {
+		t.Fatalf("stored rows did not include the successful parent message with its parent FK: %s", body)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_html_extract_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestSync(ResourceExtractsHTMLLinks|DependentResourceContinuesAfterHTMLExtractionError)", "./internal/cli")
 }
 
 // TestGenerateHTMLExtractionEmbeddedJSONMode exercises the embedded-json mode

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -61,6 +61,9 @@ type Client struct {
 	NoCache    bool
 	cacheDir   string
 	limiter    *cliutil.AdaptiveLimiter
+{{- if .HasHTMLExtraction}}
+	lastContentType string
+{{- end}}
 {{- if .HasTierRouting}}
 	requestTier string
 	limiters    map[string]*cliutil.AdaptiveLimiter
@@ -176,6 +179,23 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
+{{- if .HasHTMLExtraction}}
+
+// RequestBaseURL returns the base URL used by the current request tier.
+func (c *Client) RequestBaseURL() string {
+	return c.baseURLForRequest()
+}
+
+// LastContentType returns the last response Content-Type observed by this client.
+func (c *Client) LastContentType() string {
+	if c == nil {
+		return ""
+	}
+	return c.lastContentType
+}
+
+{{- end}}
+
 func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 	switch c.requestTier {
 {{- range $tierName, $tier := .TierRouting.Tiers}}
@@ -233,6 +253,23 @@ func applyTierAuthFormat(format string, replacements map[string]string) string {
 		return ""
 	}
 	return format
+}
+
+{{- end}}
+
+{{- if and (not .HasTierRouting) .HasHTMLExtraction}}
+
+// RequestBaseURL returns the base URL used for requests.
+func (c *Client) RequestBaseURL() string {
+	return c.BaseURL{{if .BasePath}} + c.BasePath{{end}}
+}
+
+// LastContentType returns the last response Content-Type observed by this client.
+func (c *Client) LastContentType() string {
+	if c == nil {
+		return ""
+	}
+	return c.lastContentType
 }
 
 {{- end}}
@@ -452,13 +489,20 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	}
 	// Check cache for GET requests
 	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
+{{- if .HasHTMLExtraction}}
+		if cached, contentType, ok := c.readCache(path, params); ok {
+			c.lastContentType = contentType
+			return cached, nil
+		}
+{{- else}}
 		if cached, ok := c.readCache(path, params); ok {
 			return cached, nil
 		}
+	{{- end}}
 	}
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
-		c.writeCache(path, params, result)
+		c.writeCache(path, params, result{{if .HasHTMLExtraction}}, c.lastContentType{{end}})
 	}
 	return result, err
 }
@@ -482,7 +526,7 @@ func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]
 func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
 	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
-		c.writeCache(path, params, result)
+		c.writeCache(path, params, result{{if .HasHTMLExtraction}}, c.lastContentType{{end}})
 	}
 	return result, err
 }
@@ -566,24 +610,64 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	return hex.EncodeToString(h[:8])
 }
 
-func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {
+func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, {{if .HasHTMLExtraction}}string, {{end}}bool) {
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > 5*time.Minute {
-		return nil, false
+		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
 	}
 	data, err := os.ReadFile(cacheFile)
 	if err != nil {
-		return nil, false
+		return nil, {{if .HasHTMLExtraction}}"", {{end}}false
 	}
+{{- if .HasHTMLExtraction}}
+	contentType := c.readCacheContentType(cacheFile)
+	return json.RawMessage(data), contentType, true
+{{- else}}
 	return json.RawMessage(data), true
+{{- end}}
 }
 
-func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
+func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage{{if .HasHTMLExtraction}}, contentType string{{end}}) {
 	os.MkdirAll(c.cacheDir, 0o755)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
 	os.WriteFile(cacheFile, []byte(data), 0o644)
+{{- if .HasHTMLExtraction}}
+	c.writeCacheContentType(cacheFile, contentType)
+{{- end}}
 }
+
+{{- if .HasHTMLExtraction}}
+
+type cacheMetadata struct {
+	ContentType string `json:"content_type,omitempty"`
+}
+
+func (c *Client) readCacheContentType(cacheFile string) string {
+	data, err := os.ReadFile(cacheFile + ".meta.json")
+	if err != nil {
+		return ""
+	}
+	var meta cacheMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return ""
+	}
+	return meta.ContentType
+}
+
+func (c *Client) writeCacheContentType(cacheFile, contentType string) {
+	if contentType == "" {
+		_ = os.Remove(cacheFile + ".meta.json")
+		return
+	}
+	data, err := json.Marshal(cacheMetadata{ContentType: contentType})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(cacheFile+".meta.json", data, 0o644)
+}
+
+{{- end}}
 
 // invalidateCache wholesale-removes the cache directory so the next read
 // after a mutation cannot return a stale snapshot. Selective per-resource
@@ -1241,6 +1325,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		// Success
 		if resp.StatusCode < 400 {
+{{- if .HasHTMLExtraction}}
+			c.lastContentType = resp.Header.Get("Content-Type")
+{{- end}}
 			c.limiter.OnSuccess()
 			if method != http.MethodGet && !c.DryRun {
 				c.invalidateCache()

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -265,6 +265,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				data, err = extractHTMLResponse(data, htmlExtractionOptions{
 					Mode: "{{with .Endpoint.HTMLExtract}}{{.EffectiveMode}}{{else}}page{{end}}",
 					BaseURL: htmlExtractionRequestURL(c.BaseURL, path, htmlRequestParams),
+					ContentType: c.LastContentType(),
 					LinkPrefixes: []string{
 {{- with .Endpoint.HTMLExtract}}
 {{- range .LinkPrefixes}}

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 {{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
@@ -16,12 +17,14 @@ import (
 {{- end }}
 	"strings"
 
+	"golang.org/x/net/html/charset"
 	xhtml "golang.org/x/net/html"
 )
 
 type htmlExtractionOptions struct {
 	Mode           string
 	BaseURL        string
+	ContentType    string
 	LinkPrefixes   []string
 	Limit          int
 	ScriptSelector string // for mode: embedded-json — selector "tag" or "tag#id"
@@ -89,7 +92,7 @@ func extractHTMLResponse(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 // Both require parsing the HTML and walking the DOM; the only difference
 // is what they return at the end.
 func extractHTMLPageOrLinks(raw []byte, opts htmlExtractionOptions) (json.RawMessage, error) {
-	doc, err := xhtml.Parse(strings.NewReader(string(raw)))
+	doc, err := parseHTMLDocument(raw, opts.ContentType)
 	if err != nil {
 		return nil, fmt.Errorf("parsing HTML response: %w", err)
 	}
@@ -149,7 +152,7 @@ func extractHTMLPageOrLinks(raw []byte, opts htmlExtractionOptions) (json.RawMes
 // Nuxt, and other SSR-React frameworks that embed serialized page state
 // in a known script tag.
 func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessage, error) {
-	doc, err := xhtml.Parse(strings.NewReader(string(raw)))
+	doc, err := parseHTMLDocument(raw, opts.ContentType)
 	if err != nil {
 		return nil, fmt.Errorf("parsing HTML for embedded-json: %w", err)
 	}
@@ -321,6 +324,17 @@ func normalizeHTMLURL(raw string, base string) string {
 }
 
 {{- end }}
+
+func parseHTMLDocument(raw []byte, contentType string) (*xhtml.Node, error) {
+	if strings.TrimSpace(contentType) == "" {
+		contentType = "text/html"
+	}
+	reader, err := charset.NewReader(bytes.NewReader(raw), contentType)
+	if err != nil {
+		reader = bytes.NewReader(raw)
+	}
+	return xhtml.Parse(reader)
+}
 
 func htmlExtractionRequestURL(base string, path string, params map[string]string) string {
 	baseURL, err := url.Parse(base)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -6,6 +6,9 @@
 {{- $hasFieldSelector := false -}}
 {{- range .SyncableResources}}{{if and .FieldSelector.Name .FieldSelector.Default}}{{- $hasFieldSelector = true -}}{{end}}{{end -}}
 {{- range .DependentSyncResources}}{{if and .FieldSelector.Name .FieldSelector.Default}}{{- $hasFieldSelector = true -}}{{end}}{{end }}
+{{- $hasHTMLSync := false -}}
+{{- range .SyncableResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end -}}
+{{- range .DependentSyncResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end }}
 
 package cli
 
@@ -482,6 +485,10 @@ func syncResource(ctx context.Context, c interface {
 {{- if $hasPostSync}}
 	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 {{- end}}
+{{- if $hasHTMLSync}}
+	RequestBaseURL() string
+	LastContentType() string
+{{- end}}
 	RateLimit() float64
 }, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) syncResult {
 	started := time.Now()
@@ -656,6 +663,18 @@ func syncResource(ctx context.Context, c interface {
 			return syncResult{Resource: resource, Count: 0, Duration: time.Since(started)}
 		}
 
+{{ if $hasHTMLSync}}
+		if opts, ok := syncHTMLExtractionOptions(resource, "", c.RequestBaseURL(), c.LastContentType(), path, params); ok {
+			data, err = extractHTMLResponse(data, opts)
+			if err != nil {
+				if !humanFriendly {
+					fmt.Fprintln(os.Stdout, syncErrorJSON(resource, "", err))
+				}
+				return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("extracting HTML for %s: %w", resource, err), Duration: time.Since(started)}
+			}
+		}
+
+{{ end}}
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
 		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
@@ -1456,6 +1475,61 @@ func syncResourcePath(resource string) (string, error) {
 	return "", fmt.Errorf("unknown sync resource %q", resource)
 }
 
+{{- if $hasHTMLSync}}
+
+func syncHTMLExtractionOptions(resource string, parentResource string, baseURL string, contentType string, path string, params map[string]string) (htmlExtractionOptions, bool) {
+	key := resource
+	if parentResource != "" {
+		key = parentResource + "." + resource
+	}
+	switch key {
+{{- range .SyncableResources}}
+{{- if .UsesHTMLResponse}}
+	case "{{.Name}}":
+		return htmlExtractionOptions{
+			Mode: "{{with .HTMLExtract}}{{.EffectiveMode}}{{else}}page{{end}}",
+			BaseURL: htmlExtractionRequestURL(baseURL, path, params),
+			ContentType: contentType,
+			LinkPrefixes: []string{
+{{- with .HTMLExtract}}
+{{- range .LinkPrefixes}}
+				{{printf "%q" .}},
+{{- end}}
+{{- end}}
+			},
+			Limit: {{with .HTMLExtract}}{{.Limit}}{{else}}0{{end}},
+			ScriptSelector: {{with .HTMLExtract}}{{printf "%q" .EffectiveScriptSelector}}{{else}}""{{end}},
+			JSONPath: {{with .HTMLExtract}}{{printf "%q" .JSONPath}}{{else}}""{{end}},
+		}, true
+{{- end}}
+{{- end}}
+{{- range .DependentSyncResources}}
+{{- if .UsesHTMLResponse}}
+	case "{{.ParentResource}}.{{.Name}}":
+		return htmlExtractionOptions{
+			Mode: "{{with .HTMLExtract}}{{.EffectiveMode}}{{else}}page{{end}}",
+			BaseURL: htmlExtractionRequestURL(baseURL, path, params),
+			ContentType: contentType,
+			LinkPrefixes: []string{
+{{- with .HTMLExtract}}
+{{- range .LinkPrefixes}}
+				{{printf "%q" .}},
+{{- end}}
+{{- end}}
+			},
+			Limit: {{with .HTMLExtract}}{{.Limit}}{{else}}0{{end}},
+			ScriptSelector: {{with .HTMLExtract}}{{printf "%q" .EffectiveScriptSelector}}{{else}}""{{end}},
+			JSONPath: {{with .HTMLExtract}}{{printf "%q" .JSONPath}}{{else}}""{{end}},
+		}, true
+{{- end}}
+{{- end}}
+	default:
+		return htmlExtractionOptions{}, false
+	}
+}
+
+{{- end}}
+
 {{- if .HasTierRouting}}
 
 var syncResourceTiers = map[string]string{
@@ -1512,6 +1586,10 @@ func syncDependentResources(ctx context.Context, c {{if .HasTierRouting}}*client
 {{- if $hasPostSync}}
 	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
 {{- end}}
+{{- if $hasHTMLSync}}
+	RequestBaseURL() string
+	LastContentType() string
+{{- end}}
 	RateLimit() float64
 }{{end}}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
@@ -1534,6 +1612,10 @@ func syncDependentResource(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 {{- if $hasPostSync}}
 	PostWithParams(context.Context, string, map[string]string, any) (json.RawMessage, int, error)
+{{- end}}
+{{- if $hasHTMLSync}}
+	RequestBaseURL() string
+	LastContentType() string
 {{- end}}
 	RateLimit() float64
 }, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams) syncResult {
@@ -1662,6 +1744,20 @@ func syncDependentResource(ctx context.Context, c interface {
 				break
 			}
 
+{{ if $hasHTMLSync}}
+			if opts, ok := syncHTMLExtractionOptions(dep.Name, dep.ParentTable, c.RequestBaseURL(), c.LastContentType(), path, params); ok {
+				data, err = extractHTMLResponse(data, opts)
+				if err != nil {
+					if humanFriendly {
+						fmt.Fprintf(os.Stderr, "\n  %s: HTML extraction error for parent %s: %v\n", dep.Name, parentID, err)
+					} else {
+						fmt.Fprintln(os.Stdout, syncErrorJSON(dep.Name, parentID, err))
+					}
+					break
+				}
+			}
+
+{{ end}}
 			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
 
 			// Page-int paginator fallback: mirrors syncResource so dependent

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -118,6 +118,12 @@ type SyncableResource struct {
 	// endpoints.
 	SupportsPagination bool
 
+	// UsesHTMLResponse and HTMLExtract mirror the chosen list endpoint's
+	// response_format/html_extract contract so sync can normalize HTML into
+	// JSON before passing the body into the JSON page extractor.
+	UsesHTMLResponse bool
+	HTMLExtract      *spec.HTMLExtract
+
 	// BodyFields names request-body fields on POST list endpoints. Sync uses
 	// this to send pagination and user-supplied params in the body for
 	// RPC-style list calls.
@@ -164,6 +170,11 @@ type DependentResource struct {
 	// paths so dependent syncs skip synthetic limit/offset params on endpoints
 	// that do not declare page-size pagination.
 	SupportsPagination bool
+
+	// UsesHTMLResponse and HTMLExtract mirror SyncableResource for child sync
+	// paths.
+	UsesHTMLResponse bool
+	HTMLExtract      *spec.HTMLExtract
 
 	// BodyFields mirrors SyncableResource.BodyFields for child sync paths.
 	BodyFields []SyncBodyField
@@ -1130,6 +1141,8 @@ func detectDependentResources(parameterized map[string]parameterizedEntry, synca
 			Critical:           entry.meta.Critical,
 			SinceParam:         entry.meta.SinceParam,
 			SupportsPagination: entry.meta.SupportsPagination,
+			UsesHTMLResponse:   entry.meta.UsesHTMLResponse,
+			HTMLExtract:        entry.meta.HTMLExtract,
 			BodyFields:         entry.meta.BodyFields,
 			FieldSelector:      entry.meta.FieldSelector,
 			Discriminator:      entry.meta.Discriminator,
@@ -1239,6 +1252,8 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				Critical:           meta.Critical,
 				SinceParam:         meta.SinceParam,
 				SupportsPagination: meta.SupportsPagination,
+				UsesHTMLResponse:   meta.UsesHTMLResponse,
+				HTMLExtract:        meta.HTMLExtract,
 				BodyFields:         meta.BodyFields,
 				FieldSelector:      meta.FieldSelector,
 				Discriminator:      meta.Discriminator,
@@ -1322,6 +1337,8 @@ type syncableMeta struct {
 	Critical           bool
 	SinceParam         string
 	SupportsPagination bool
+	UsesHTMLResponse   bool
+	HTMLExtract        *spec.HTMLExtract
 	BodyFields         []SyncBodyField
 	FieldSelector      FieldSelector
 	Discriminator      DiscriminatorDispatch
@@ -1354,6 +1371,8 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		Critical:           e.Critical,
 		SinceParam:         detectEndpointSinceParam(e.Params),
 		SupportsPagination: endpointSupportsPagination(e),
+		UsesHTMLResponse:   e.UsesHTMLResponse(),
+		HTMLExtract:        e.HTMLExtract,
 		BodyFields:         syncBodyFieldsFromEndpoint(e),
 		FieldSelector:      detectEndpointFieldSelector(e),
 		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
@@ -1630,6 +1649,8 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			Critical:           meta.Critical,
 			SinceParam:         meta.SinceParam,
 			SupportsPagination: meta.SupportsPagination,
+			UsesHTMLResponse:   meta.UsesHTMLResponse,
+			HTMLExtract:        meta.HTMLExtract,
 			BodyFields:         meta.BodyFields,
 			FieldSelector:      meta.FieldSelector,
 			Discriminator:      meta.Discriminator,


### PR DESCRIPTION
## Summary

Generated sync now honors `response_format: html` by applying HTML extraction before item extraction for both flat and dependent sync resources. HTML parsing now decodes response bytes with the page charset first, so non-UTF-8 pages such as ISO-8859-1 keep their extracted text intact.

Closes #1499.

## Scope

Primary area: generator templates and profiler metadata.

Why this belongs in this repo: this fixes future generated CLIs at the Printing Press layer instead of patching one printed CLI.

## Output Contract

Generated CLIs with HTML extraction can now emit `RequestBaseURL`, `syncHTMLExtractionOptions`, and sync-time `extractHTMLResponse` calls. JSON-only generated clients remain unchanged, which is covered by golden verification.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator -run 'TestGenerateHTMLExtractionEndpoint|TestGeneratedSyncHonorsHTMLExtraction' -count=1`
- `go test ./internal/generator ./internal/profiler`
- `scripts/golden.sh verify`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`
- `ruby -e 'require "yaml"; require "date"; ...' docs/solutions/logic-errors/html-response-format-sync-extraction.md`

The compound frontmatter helper referenced by the skill is not present in this repo, so the solution note frontmatter was validated with Ruby YAML parsing instead.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
