### PR TITLE
fix(cli): tighten scoreTypeFidelity flag-decl regex and drop MarkFlagRequired reward

### DIFF
--- a/docs/solutions/logic-errors/scoretypefidelity-flag-decl-regex-and-mark-required-2026-05-22.md
+++ b/docs/solutions/logic-errors/scoretypefidelity-flag-decl-regex-and-mark-required-2026-05-22.md
@@ -1,0 +1,67 @@
+---
+title: "scoreTypeFidelity flag-decl regex over-matches and MarkFlagRequired reward conflicts with the SKILL"
+date: 2026-05-22
+category: logic-errors
+module: internal/pipeline
+problem_type: logic_error
+component: scorer
+symptoms:
+  - "Hand-authored CLIs lose 1pt on type_fidelity because the description word-count check averages a short kebab token"
+  - "Flag names ending in non-id tokens (e.g. price-paid-cents) classify as ID flags via the 'paid' substring and fail the all-StringVar rule"
+  - "SKILL-compliant CLIs without MarkFlagRequired calls cap at 4/5 on the type_fidelity dim by design"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - internal/pipeline/scorecard.go
+tags:
+  - scorer
+  - type-fidelity
+  - regex
+  - skill-conflict
+---
+
+# scoreTypeFidelity flag-decl regex over-matches and MarkFlagRequired reward conflicts with the SKILL
+
+## Problem
+
+`scoreTypeFidelity` in `internal/pipeline/scorecard.go` had three independent defects that systematically penalised SKILL-compliant CLIs:
+
+1. The package-level `flagDeclRe` regex used `[^,]+` for the variable-pointer and untyped-arg captures. `[^,]+` matches newlines, so consecutive `cmd.Flags()....` calls bled into one another and the first call's description capture pulled in the next call's flag name.
+2. The ID-flag classifier was `strings.Contains(name, "id")` with no word boundary. Kebab-case flag names that *contained* the substring `id` inside another word (e.g. `price-paid-cents` → matched on the `id` inside `paid`) were classified as ID flags, then graded as non-`StringVar` failures.
+3. The scorer awarded `+1` when a sample of command files contained `MarkFlagRequired(...)` three or more times. The SKILL's Phase-3 build checklist explicitly forbids `MarkFlagRequired` on hand-authored novel commands because Cobra evaluates it before `RunE`, which makes the verifier's `--dry-run` probe fail with `required flag "X" not set`. A SKILL-compliant CLI cannot earn this point.
+
+## Symptoms
+
+- `printing-press scorecard` reports `type_fidelity` 1pt below the dim cap on CLIs whose flags use long, descriptive help strings — the average drops because the first flag's "description" capture is a short kebab-case token from the next line.
+- A flag named `price-paid-cents` (or any name containing `id` mid-word) classifies as a non-`StringVar` ID flag and costs the 2-point ID-fidelity sub-check.
+- SKILL-compliant CLIs that route required-flag validation through `RunE` cap at 4/5 on `type_fidelity` and have no honest path to the dim cap.
+
+## What Didn't Work
+
+- Renaming flags to dodge the `id` substring (e.g. `price-paid-cents` → `price-cents`) is a per-CLI workaround and propagates into the printed CLI's public surface for no real reason.
+- Adding `MarkFlagRequired` calls "for the point" breaks `verify --dry-run` and is forbidden by the SKILL.
+- Re-shaping flag declarations to single-line forms is a regression in readability for the same per-CLI workaround pattern.
+
+## Resolution
+
+- Tighten the regex to `[^,\n]+` in both capture segments so the match cannot span newlines.
+- Extract `isIDFlagName(name string) bool` and replace the substring check with kebab-case word boundaries: equal to `id`, prefix `id-`, suffix `-id`, or contains `-id-`.
+- Remove the `MarkFlagRequired` reward (the `requiredRe`, the `requiredCount` accumulator, and the `>=3` block). Required-flag validation belongs inside `RunE` per the SKILL.
+- Cover each fix with dedicated tests in `scorecard_tier2_test.go`: `TestIsIDFlagName` (table-driven word-boundary cases including the `price-paid-cents` regression), `TestScoreTypeFidelity_FlagDeclRegexBoundedToOneLine` (consecutive `Flags()` calls don't pollute each other's capture), and `TestScoreTypeFidelity_DoesNotRewardMarkFlagRequired` (a fixture with three `MarkFlagRequired` calls scores the same as one with none).
+
+## Why It Works
+
+The regex constraint is the smallest change that bounds each capture to a single Go statement; `[^,\n]+` is already the convention used elsewhere in the scorer for flag-call parsing. The kebab-case predicate matches the actual naming convention generated CLIs use, so it has no false positives on real flag names. Dropping the `MarkFlagRequired` reward removes the direct scorer-versus-SKILL conflict; SKILL-compliant CLIs can still reach the 5/5 cap via the ID-string check, the description-length check, and the dummy-guard-absence check.
+
+## Verification
+
+- `go test ./internal/pipeline/ -run 'TestScoreTypeFidelity|TestIsIDFlagName' -count=1` — all new tests pass.
+- `go test ./...` — full suite passes.
+- `scripts/golden.sh verify` — passes without golden diffs; no existing fixture relied on the dropped reward path.
+
+## Related Issues
+
+- Closes #1720 — `scoreTypeFidelity` regex over-matches across newlines and `id` substring false positive.
+- Closes #1559 — `scoreTypeFidelity` rewards `MarkFlagRequired` which the SKILL forbids.
+- Related to #1561 — same pattern of scorer substring greps drifting from the SKILL's sanctioned scaffolding (different dimension).

--- a/docs/solutions/logic-errors/scoretypefidelity-flag-decl-regex-and-mark-required-2026-05-22.md
+++ b/docs/solutions/logic-errors/scoretypefidelity-flag-decl-regex-and-mark-required-2026-05-22.md
@@ -35,7 +35,7 @@ tags:
 
 - `printing-press scorecard` reports `type_fidelity` 1pt below the dim cap on CLIs whose flags use long, descriptive help strings — the average drops because the first flag's "description" capture is a short kebab-case token from the next line.
 - A flag named `price-paid-cents` (or any name containing `id` mid-word) classifies as a non-`StringVar` ID flag and costs the 2-point ID-fidelity sub-check.
-- SKILL-compliant CLIs that route required-flag validation through `RunE` cap at 4/5 on `type_fidelity` and have no honest path to the dim cap.
+- SKILL-compliant CLIs that route required-flag validation through `RunE` have no honest path to the historical 5-point cap because the only +1 path the SKILL forbids was the difference.
 
 ## What Didn't Work
 
@@ -52,7 +52,7 @@ tags:
 
 ## Why It Works
 
-The regex constraint is the smallest change that bounds each capture to a single Go statement; `[^,\n]+` is already the convention used elsewhere in the scorer for flag-call parsing. The kebab-case predicate matches the actual naming convention generated CLIs use, so it has no false positives on real flag names. Dropping the `MarkFlagRequired` reward removes the direct scorer-versus-SKILL conflict; SKILL-compliant CLIs can still reach the 5/5 cap via the ID-string check, the description-length check, and the dummy-guard-absence check.
+The regex constraint is the smallest change that bounds each capture to a single Go statement; `[^,\n]+` is already the convention used elsewhere in the scorer for flag-call parsing. The kebab-case predicate matches the actual naming convention generated CLIs use, so it has no false positives on real flag names. Dropping the `MarkFlagRequired` reward removes the direct scorer-versus-SKILL conflict; the achievable maximum for `scoreTypeFidelity` is now `+2` (ID-flag check) `+1` (description-length check) `+1` (dummy-guard-absence check) `= 4`. The dim's structural allocation in the tier rollup (`tier2Max` base) still leaves a 5-slot for `type_fidelity`, so the in-function clamp now matches the achievable max (4) rather than the structural slot (5). Reconciling the tier rollup itself is a separate concern outside this fix's scope because it changes the percentage for every printed CLI and needs a coordinated golden refresh.
 
 ## Verification
 

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -74,7 +74,7 @@ type SteinerScore struct {
 	AuthProtocol          int    `json:"auth_protocol"`           // 0-10
 	DataPipelineIntegrity int    `json:"data_pipeline_integrity"` // 0-10
 	SyncCorrectness       int    `json:"sync_correctness"`        // 0-10
-	TypeFidelity          int    `json:"type_fidelity"`           // 0-5
+	TypeFidelity          int    `json:"type_fidelity"`           // 0-4 (declared cap 5; +1 MarkFlagRequired path dropped per SKILL conflict)
 	DeadCode              int    `json:"dead_code"`               // 0-5
 	LiveAPIVerification   int    `json:"live_api_verification"`   // 0-10; unscored when verify ran in mock/structural mode or was skipped
 	Total                 int    `json:"total"`                   // 0-100 (weighted: 50% infrastructure + 50% domain)
@@ -2380,8 +2380,12 @@ func scoreTypeFidelity(dir string) int {
 		score++
 	}
 
-	if score > 5 {
-		score = 5
+	// Achievable max is 4 (+2 ID-flag check, +1 description avg, +1 no dummy
+	// guards). The +1 MarkFlagRequired path was removed because the SKILL
+	// explicitly forbids it. The tier rollup still allocates 5 raw points to
+	// this dimension, so the highest a SKILL-compliant CLI can score is 4/5.
+	if score > 4 {
+		score = 4
 	}
 	return score
 }

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2334,19 +2334,21 @@ func scoreTypeFidelity(dir string) int {
 		return 0
 	}
 
-	flagDeclRe := regexp.MustCompile(`Flags\(\)\.(StringVar|IntVar|StringVarP|IntVarP)\(&[^,]+,\s*"([^"]+)"(?:,\s*[^,]+){1,2},\s*"([^"]*)"`)
-	requiredRe := regexp.MustCompile(`MarkFlagRequired\("([^"]+)"\)`)
+	// [^,\n]+ keeps each capture inside a single Flags() call. The previous
+	// [^,]+ would greedily consume across newlines into the next Flags()
+	// invocation, dragging the next flag's name into the current flag's
+	// description capture.
+	flagDeclRe := regexp.MustCompile(`Flags\(\)\.(StringVar|IntVar|StringVarP|IntVarP)\(&[^,\n]+,\s*"([^"]+)"(?:,\s*[^,\n]+){1,2},\s*"([^"]*)"`)
 
 	totalIDFlags := 0
 	stringIDFlags := 0
-	requiredCount := 0
 	descWordCount := 0
 	descCount := 0
 
 	for _, content := range cmdFiles {
 		for _, match := range flagDeclRe.FindAllStringSubmatch(content, -1) {
 			name := strings.ToLower(match[2])
-			if strings.Contains(name, "id") {
+			if isIDFlagName(name) {
 				totalIDFlags++
 				if strings.HasPrefix(match[1], "StringVar") {
 					stringIDFlags++
@@ -2355,15 +2357,14 @@ func scoreTypeFidelity(dir string) int {
 			descWordCount += len(strings.Fields(match[3]))
 			descCount++
 		}
-		requiredCount += len(requiredRe.FindAllStringSubmatch(content, -1))
 	}
 
 	if totalIDFlags == 0 || stringIDFlags == totalIDFlags {
 		score += 2
 	}
-	if requiredCount >= 3 {
-		score++
-	}
+	// MarkFlagRequired is intentionally not credited: the SKILL's verify-friendly
+	// RunE rule forbids it (Cobra evaluates it before RunE, so --dry-run probes
+	// fail with "required flag not set"). Required validation belongs inside RunE.
 	if descCount > 0 && descWordCount/descCount > 5 {
 		score++
 	}
@@ -2383,6 +2384,19 @@ func scoreTypeFidelity(dir string) int {
 		score = 5
 	}
 	return score
+}
+
+// isIDFlagName returns true when a kebab-case flag name denotes an identifier
+// (id, *-id, id-*, *-id-*). Word boundaries prevent false positives like
+// "price-paid-cents" matching on the "id" substring inside "paid".
+func isIDFlagName(name string) bool {
+	if name == "id" {
+		return true
+	}
+	if strings.HasPrefix(name, "id-") || strings.HasSuffix(name, "-id") {
+		return true
+	}
+	return strings.Contains(name, "-id-")
 }
 
 func scoreDeadCode(dir string) int {

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -522,7 +522,7 @@ func init() {
 		assert.Equal(t, 0, scoreTypeFidelity(dir))
 	})
 
-	t.Run("scores string id flags required markers and clear descriptions high", func(t *testing.T) {
+	t.Run("scores string id flags and clear descriptions high", func(t *testing.T) {
 		dir := t.TempDir()
 
 		writeScorecardFixture(t, dir, "internal/cli/messages.go", `
@@ -533,13 +533,12 @@ func init() {
 	cmd.Flags().StringVar(&flagAfterID, "after-id", "", "Snowflake ID to fetch results after the given message")
 	cmd.Flags().StringVar(&flagChannelID, "channel-id", "", "Channel ID containing the messages to fetch for sync")
 	cmd.Flags().StringVar(&flagGuildID, "guild-id", "", "Guild ID used to scope channel and message syncing")
-	_ = cmd.MarkFlagRequired("after-id")
-	_ = cmd.MarkFlagRequired("channel-id")
-	_ = cmd.MarkFlagRequired("guild-id")
 }
 `)
 
-		assert.GreaterOrEqual(t, scoreTypeFidelity(dir), 4)
+		// +2 ID flags are all StringVar, +1 descriptions average well over 5 words,
+		// +1 no dummy `var _ = strings.ReplaceAll` / `var _ = fmt.Sprintf` guards.
+		assert.Equal(t, 4, scoreTypeFidelity(dir))
 	})
 }
 
@@ -588,14 +587,13 @@ func init() {
 }
 `)
 
-	// 0 ID flags (+2) + 3 long descriptions averaging well over 5 words (+1) +
-	// no dummy guards (+1) = 4. With the old cross-line regex, the description
-	// capture for "alpha" would have been "Alpha description with at least
-	// seven words here\n\tcmd.Flags().StringVar(&flagBravo" and the words
-	// would have averaged the same — the failure mode shows up with shorter
-	// descriptions, but the rule under test here is the capture is bounded.
-	score := scoreTypeFidelity(dir)
-	assert.GreaterOrEqual(t, score, 4, "well-formed flags with long descriptions should score at least 4")
+	// With the pre-fix greedy [^,]+ regex, the description capture for "alpha"
+	// absorbed the next line's `&flagBravo` token, dragging descWordCount and
+	// descCount so the average dropped to ≤5, costing the +1 description point
+	// (score 3). The bounded [^,\n]+ regex keeps each capture inside its own
+	// statement: +2 ID-flag check (no ID flags), +1 descriptions averaging >5
+	// words, +1 no dummy guards = 4.
+	assert.Equal(t, 4, scoreTypeFidelity(dir))
 }
 
 // TestScoreTypeFidelity_DoesNotRewardMarkFlagRequired pins that

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -543,6 +543,98 @@ func init() {
 	})
 }
 
+// TestIsIDFlagName pins the kebab-case word-boundary semantics that replaced
+// the bare `strings.Contains(name, "id")` check. The old check classified
+// "price-paid-cents" as an ID flag because "paid" contains "id", which then
+// failed the "all ID flags must be StringVar" rule on IntVar money columns.
+func TestIsIDFlagName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"id", true},
+		{"user-id", true},
+		{"id-prefix", true},
+		{"parent-id-child", true},
+		{"price-paid-cents", false},
+		{"validate", false},
+		{"kid", false},
+		{"wide", false},
+		{"video", false},
+		{"identity", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isIDFlagName(tc.name))
+		})
+	}
+}
+
+// TestScoreTypeFidelity_FlagDeclRegexBoundedToOneLine pins that consecutive
+// Flags() calls capture their own description, not the next call's flag name.
+// Before the [^,\n]+ fix the greedy [^,]+ spanned newlines, so the first
+// flag's description capture pulled in the next flag's name (a short kebab
+// token) and dragged the description word-count average below the >5 threshold.
+func TestScoreTypeFidelity_FlagDeclRegexBoundedToOneLine(t *testing.T) {
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, "internal/cli/messages.go", `
+package cli
+
+func init() {
+	cmd := messagesCmd
+	cmd.Flags().StringVar(&flagAlpha, "alpha", "", "Alpha description with at least seven words here")
+	cmd.Flags().StringVar(&flagBravo, "bravo", "", "Bravo description with at least seven words here")
+	cmd.Flags().StringVar(&flagCharlie, "charlie", "", "Charlie description with at least seven words here")
+}
+`)
+
+	// 0 ID flags (+2) + 3 long descriptions averaging well over 5 words (+1) +
+	// no dummy guards (+1) = 4. With the old cross-line regex, the description
+	// capture for "alpha" would have been "Alpha description with at least
+	// seven words here\n\tcmd.Flags().StringVar(&flagBravo" and the words
+	// would have averaged the same — the failure mode shows up with shorter
+	// descriptions, but the rule under test here is the capture is bounded.
+	score := scoreTypeFidelity(dir)
+	assert.GreaterOrEqual(t, score, 4, "well-formed flags with long descriptions should score at least 4")
+}
+
+// TestScoreTypeFidelity_DoesNotRewardMarkFlagRequired pins that
+// MarkFlagRequired no longer earns a point. The SKILL's verify-friendly RunE
+// rule forbids it (Cobra evaluates it before RunE, so --dry-run probes fail).
+// Rewarding it created a direct scorer-versus-SKILL conflict — a compliant
+// agent would always lose this point.
+func TestScoreTypeFidelity_DoesNotRewardMarkFlagRequired(t *testing.T) {
+	withRequired := t.TempDir()
+	writeScorecardFixture(t, withRequired, "internal/cli/messages.go", `
+package cli
+
+func init() {
+	cmd := messagesCmd
+	cmd.Flags().StringVar(&flagAlpha, "alpha", "", "Alpha description with at least seven words here")
+	cmd.Flags().StringVar(&flagBravo, "bravo", "", "Bravo description with at least seven words here")
+	cmd.Flags().StringVar(&flagCharlie, "charlie", "", "Charlie description with at least seven words here")
+	_ = cmd.MarkFlagRequired("alpha")
+	_ = cmd.MarkFlagRequired("bravo")
+	_ = cmd.MarkFlagRequired("charlie")
+}
+`)
+
+	withoutRequired := t.TempDir()
+	writeScorecardFixture(t, withoutRequired, "internal/cli/messages.go", `
+package cli
+
+func init() {
+	cmd := messagesCmd
+	cmd.Flags().StringVar(&flagAlpha, "alpha", "", "Alpha description with at least seven words here")
+	cmd.Flags().StringVar(&flagBravo, "bravo", "", "Bravo description with at least seven words here")
+	cmd.Flags().StringVar(&flagCharlie, "charlie", "", "Charlie description with at least seven words here")
+}
+`)
+
+	assert.Equal(t, scoreTypeFidelity(withoutRequired), scoreTypeFidelity(withRequired),
+		"MarkFlagRequired must not earn a scorecard point — it is forbidden by the SKILL's verify-friendly RunE rule")
+}
+
 func TestScoreSyncCorrectness_NonSyncFilename(t *testing.T) {
 	t.Run("finds sync patterns in non-sync.go files", func(t *testing.T) {
 		dir := t.TempDir()


### PR DESCRIPTION
## Intent

`scoreTypeFidelity` in `internal/pipeline/scorecard.go` had three independent defects that systematically penalised SKILL-compliant CLIs. This PR fixes all three in one place, with dedicated regression tests for each.

Issue: Closes #1720, Closes #1559

## Approach

1. **`flagDeclRe` over-matched across newlines** (#1720 Bug A) — `[^,]+` matches newlines, so consecutive `cmd.Flags()....` calls bled into each other and the first call's description capture pulled in the next call's flag-name token. Replaced with `[^,\n]+` to bound each capture to a single Go statement.

2. **ID-flag substring false-positive** (#1720 Bug B) — `strings.Contains(name, "id")` matched any flag name containing `id` mid-word, including `price-paid-cents` (matched on the `id` inside `paid`). Extracted `isIDFlagName` with kebab-case word boundaries (equal to `id`, prefix `id-`, suffix `-id`, or contains `-id-`).

3. **MarkFlagRequired reward conflicted with the SKILL** (#1559) — the scorer awarded `+1` for sample files containing `MarkFlagRequired` 3+ times, but the SKILL's Phase-3 build checklist explicitly forbids it on hand-authored novel commands because Cobra evaluates it before `RunE`, breaking the verifier's `--dry-run` probe. Removed the reward block; required-flag validation belongs inside `RunE`.

Tests pin each fix individually so any future regression fails loudly. Solutions doc added under `docs/solutions/logic-errors/` per repo convention.

## Scope

Primary area: scorer (`internal/pipeline/scorecard.go`).

Why this belongs in this repo: the bug is in the machine's scorer, not in any one printed CLI. Every freshly generated CLI is affected.

## Risk

Low. All three fixes can only *stop* false negatives/positives — the regex tightening can't credit fewer things than before (it only stops over-matching across line boundaries), the word-boundary check is strictly more conservative on what it classifies as an ID flag, and dropping the MarkFlagRequired reward removes a path no SKILL-compliant CLI could legitimately use.

## Output Contract

`scripts/golden.sh verify` passes unchanged (20/20). No golden fixture used `MarkFlagRequired` or hit the cross-line capture failure mode, so no golden scorecard moved.

## Verification

- `go test ./internal/pipeline/ -run 'TestScoreTypeFidelity|TestIsIDFlagName' -count=1 -v` — pass.
- `go test ./...` — pass.
- `scripts/golden.sh verify` — pass (20/20).
- `go vet ./...` — pass.
- `go fmt ./...` — clean.

The reviewer agent flagged one Important issue on the first cut: a comment on the new regex test was misleading about whether the fixture was load-bearing, when it in fact pinned the fix (pre-fix code scores 3, fixed code scores 4). Verified empirically and fixed in commit `06a28d0`, along with cleaning up the pre-existing `"scores ... high"` subtest whose `MarkFlagRequired` calls became inert with the reward gone.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change