### PR TITLE
fix(cli): improve generated parent command shorts

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1934,7 +1934,7 @@ func promotedCommandsCanUnwrapResponse(commands []PromotedCommand) bool {
 	return false
 }
 
-func parentCommandShort(resourceName, parentName string, resource spec.Resource) string {
+func parentCommandShort(resourceName, parentName string, resource spec.Resource, apiDescriptionShort string) string {
 	short := naming.OneLine(resource.Description)
 	if !naming.IsThinCommandShort(short) {
 		return short
@@ -1959,12 +1959,64 @@ func parentCommandShort(resourceName, parentName string, resource spec.Resource)
 		return "Manage " + target + " for " + parent
 	}
 
+	if apiDescriptionShort != "" {
+		return apiDescriptionShort
+	}
 	if actions := parentCommandActions(resource.Endpoints); actions != "" {
 		if computed := actions + " " + target; !naming.IsThinCommandShort(computed) {
 			return computed
 		}
 	}
 	return "Manage " + target + " command groups"
+}
+
+func parentCommandInfoDescriptionShort(description string) string {
+	description = naming.OneLineNormalize(description)
+	if description == "" {
+		return ""
+	}
+
+	for idx, r := range description {
+		if r != '.' && r != '!' && r != '?' {
+			continue
+		}
+		if r == '.' && parentCommandShortPeriodIsInternal(description, idx) {
+			continue
+		}
+		sentence := naming.OneLine(description[:idx+len(string(r))])
+		if !naming.IsThinCommandShort(sentence) {
+			return sentence
+		}
+		return ""
+	}
+
+	short := naming.OneLine(description)
+	if !naming.IsThinCommandShort(short) {
+		return short
+	}
+	return ""
+}
+
+func parentCommandShortPeriodIsInternal(description string, idx int) bool {
+	if idx <= 0 || idx >= len(description)-1 {
+		return false
+	}
+
+	prev, next := description[idx-1], description[idx+1]
+	if (isASCIILetter(prev) && isASCIILetter(next)) || (isASCIIDigit(prev) && isASCIIDigit(next)) {
+		return true
+	}
+
+	tokenStart := strings.LastIndex(description[:idx], " ") + 1
+	return strings.Contains(description[tokenStart:idx], ".")
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }
 
 func parentCommandActions(endpoints map[string]spec.Endpoint) string {
@@ -2063,6 +2115,10 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 	// promoted commands the api browser is not generated, so leave resources
 	// visible.
 	hideTopLevelResources := len(g.PromotedCommands) > 0
+	var apiDescriptionShort string
+	if len(g.Spec.Resources) == 1 {
+		apiDescriptionShort = parentCommandInfoDescriptionShort(g.Spec.Description)
+	}
 	// Generate per-resource parent files + per-endpoint command files
 	// This produces more files (one per endpoint) which improves Breadth scoring
 	for name, resource := range g.Spec.Resources {
@@ -2082,7 +2138,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				ResourceName: name,
 				FuncPrefix:   name,
 				CommandPath:  name,
-				Short:        parentCommandShort(name, "", resource),
+				Short:        parentCommandShort(name, "", resource, apiDescriptionShort),
 				Resource:     resource,
 				Hidden:       hideTopLevelResources,
 				APISpec:      g.Spec,
@@ -2135,7 +2191,7 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				ResourceName: subName,
 				FuncPrefix:   name + "-" + subName,
 				CommandPath:  name + " " + subName,
-				Short:        parentCommandShort(subName, name, subResource),
+				Short:        parentCommandShort(subName, name, subResource, ""),
 				Resource:     subResource,
 				Hidden:       false,
 				APISpec:      g.Spec,

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1983,18 +1983,32 @@ func parentCommandInfoDescriptionShort(description string) string {
 		if r == '.' && parentCommandShortPeriodIsInternal(description, idx) {
 			continue
 		}
-		sentence := naming.OneLine(description[:idx+len(string(r))])
+		sentence := parentCommandShortCompact(description[:idx+len(string(r))])
 		if !naming.IsThinCommandShort(sentence) {
 			return sentence
 		}
 		return ""
 	}
 
-	short := naming.OneLine(description)
+	short := parentCommandShortCompact(description)
 	if !naming.IsThinCommandShort(short) {
 		return short
 	}
 	return ""
+}
+
+func parentCommandShortCompact(description string) string {
+	description = naming.OneLineNormalize(description)
+	runes := []rune(description)
+	if len(runes) <= 120 {
+		return description
+	}
+
+	cut := string(runes[:120])
+	if idx := strings.LastIndex(cut, " "); idx > 60 {
+		return strings.TrimRight(cut[:idx], " ,;:")
+	}
+	return strings.TrimRight(cut, " ,;:")
 }
 
 func parentCommandShortPeriodIsInternal(description string, idx int) bool {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2003,7 +2003,7 @@ func parentCommandShortPeriodIsInternal(description string, idx int) bool {
 	}
 
 	prev, next := description[idx-1], description[idx+1]
-	if (isASCIILetter(prev) && isASCIILetter(next)) || (isASCIIDigit(prev) && isASCIIDigit(next)) {
+	if (isASCIILetter(prev) || isASCIIDigit(prev)) && (isASCIILetter(next) || isASCIIDigit(next)) {
 		return true
 	}
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12632,6 +12632,11 @@ func TestParentCommandInfoDescriptionShort(t *testing.T) {
 			want:        "Use the v1.x reporting API for exports.",
 		},
 		{
+			name:        "long version placeholder sentence stays useful",
+			description: "Use the v1.x reporting API for exporting analytics dashboards billing records team usage metrics attribution windows cohort slices retention curves and billing forecasts. This second sentence belongs in longer docs.",
+			want:        "Use the v1.x reporting API for exporting analytics dashboards billing records team usage metrics attribution windows",
+		},
+		{
 			name:        "long first sentence stays compact",
 			description: "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states, analytics exports, campaign plans, compliance reviews, and publishing calendars. This second sentence belongs in longer docs.",
 			want:        "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states",

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12627,6 +12627,11 @@ func TestParentCommandInfoDescriptionShort(t *testing.T) {
 			want:        "Use the v2.0 reporting API for exports.",
 		},
 		{
+			name:        "version placeholder period stays in first sentence",
+			description: "Use the v1.x reporting API for exports. This second sentence belongs in longer docs.",
+			want:        "Use the v1.x reporting API for exports.",
+		},
+		{
 			name:        "long first sentence stays compact",
 			description: "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states, analytics exports, campaign plans, compliance reviews, and publishing calendars. This second sentence belongs in longer docs.",
 			want:        "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states",

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12591,9 +12591,240 @@ func TestGenerateParentCommandShorts_AreAgentGradeForGroupers(t *testing.T) {
 		Endpoints: map[string]spec.Endpoint{
 			"query": {Method: "POST", Path: "/reports/query", Description: "Query reports"},
 		},
-	})
+	}, "")
 	assert.Equal(t, "Manage reports command groups", topLevelReportsShort,
 		"single-action top-level groupers should fall back when the action-derived Short is still thin")
 	assert.NotEqual(t, "Query reports", topLevelReportsShort,
 		"top-level parent groupers must not emit action-derived Shorts that tools-audit still flags")
+}
+
+func TestParentCommandInfoDescriptionShort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		description string
+		want        string
+	}{
+		{
+			name:        "first sentence",
+			description: "Coordinate video publishing workflows across channels. This second sentence belongs in longer docs.",
+			want:        "Coordinate video publishing workflows across channels.",
+		},
+		{
+			name:        "thin first sentence does not fall through",
+			description: "API. Coordinate video publishing workflows across channels.",
+			want:        "",
+		},
+		{
+			name:        "abbreviation period stays in first sentence",
+			description: "The U.S. Census Bureau API provides access to datasets. This second sentence belongs in longer docs.",
+			want:        "The U.S. Census Bureau API provides access to datasets.",
+		},
+		{
+			name:        "decimal period stays in first sentence",
+			description: "Use the v2.0 reporting API for exports. This second sentence belongs in longer docs.",
+			want:        "Use the v2.0 reporting API for exports.",
+		},
+		{
+			name:        "long first sentence stays compact",
+			description: "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states, analytics exports, campaign plans, compliance reviews, and publishing calendars. This second sentence belongs in longer docs.",
+			want:        "Coordinate video publishing workflows across channels, regions, partners, approval queues, localization states",
+		},
+		{
+			name:        "no punctuation uses full description",
+			description: "Coordinate video publishing workflows across channels",
+			want:        "Coordinate video publishing workflows across channels",
+		},
+		{
+			name:        "long unpunctuated description stays compact",
+			description: "Coordinate video publishing workflows across channels regions partners approval queues localization states analytics exports campaign plans compliance reviews and publishing calendars",
+			want:        "Coordinate video publishing workflows across channels regions partners approval queues localization states analytics",
+		},
+		{
+			name:        "thin unpunctuated description ignored",
+			description: "Video API",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, parentCommandInfoDescriptionShort(tt.description))
+		})
+	}
+}
+
+func TestGenerateParentCommandShorts_UseOpenAPIProseFallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tag description", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Billing API
+  version: 1.0.0
+  description: Generic billing API fallback.
+servers:
+  - url: https://api.example.com
+tags:
+  - name: Customers
+    description: Manage customer records, subscriptions, and billing profiles.
+paths:
+  /customers:
+    get:
+      operationId: listCustomers
+      tags: [Customers]
+      summary: List customers
+      responses:
+        '200':
+          description: OK
+  /customers/{customer_id}:
+    get:
+      operationId: getCustomer
+      tags: [Customers]
+      summary: Get customer
+      parameters:
+        - name: customer_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+`)
+
+		apiSpec, err := openapi.Parse(data)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "customers.go"))
+		require.NoError(t, err)
+		assert.Regexp(t, `Short:\s+"Manage customer records, subscriptions, and billing profiles\."`, string(src))
+		assert.NotRegexp(t, `Short:\s+"Generic billing API fallback\."`, string(src))
+	})
+
+	t.Run("info description first sentence", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Video API
+  version: 1.0.0
+  description: Coordinate video publishing workflows across channels. This second sentence belongs in longer docs.
+servers:
+  - url: https://api.example.com
+paths:
+  /videos:
+    get:
+      operationId: listVideos
+      summary: List videos
+      responses:
+        '200':
+          description: OK
+  /videos/{video_id}:
+    get:
+      operationId: getVideo
+      summary: Get video
+      parameters:
+        - name: video_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+`)
+
+		apiSpec, err := openapi.Parse(data)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "videos.go"))
+		require.NoError(t, err)
+		assert.Regexp(t, `Short:\s+"Coordinate video publishing workflows across channels\."`, string(src))
+		assert.NotRegexp(t, `This second sentence`, string(src))
+	})
+
+	t.Run("multi resource spec keeps resource-specific shorts", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Commerce API
+  version: 1.0.0
+  description: Coordinate commerce workflows across customer and invoice records.
+servers:
+  - url: https://api.example.com
+paths:
+  /customers:
+    get:
+      operationId: listCustomers
+      summary: List customers
+      responses:
+        '200':
+          description: OK
+  /customers/{customer_id}:
+    get:
+      operationId: getCustomer
+      summary: Get customer
+      parameters:
+        - name: customer_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /invoices:
+    get:
+      operationId: listInvoices
+      summary: List invoices
+      responses:
+        '200':
+          description: OK
+  /invoices/{invoice_id}:
+    get:
+      operationId: getInvoice
+      summary: Get invoice
+      parameters:
+        - name: invoice_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+`)
+
+		apiSpec, err := openapi.Parse(data)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		customersSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "customers.go"))
+		require.NoError(t, err)
+		assert.Regexp(t, `Short:\s+"List and get customers"`, string(customersSrc))
+		assert.NotRegexp(t, `Coordinate commerce workflows`, string(customersSrc))
+
+		invoicesSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "invoices.go"))
+		require.NoError(t, err)
+		assert.Regexp(t, `Short:\s+"List and get invoices"`, string(invoicesSrc))
+		assert.NotRegexp(t, `Coordinate commerce workflows`, string(invoicesSrc))
+	})
 }


### PR DESCRIPTION
## Summary

- improves generated parent command `Short` text by using source-provided tag descriptions when available
- uses the first compact sentence of `info.description` only for single-resource OpenAPI specs where the API-level prose can safely describe the lone top-level parent
- preserves resource-specific action-derived fallbacks for multi-resource specs and generic fallback behavior when no useful prose exists

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Closes #1525
