### PR TITLE
fix(cli): respect cobratree framework command depth

### DIFF
--- a/docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md
+++ b/docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md
@@ -1,0 +1,72 @@
+---
+title: "Cobratree framework command skips are depth-sensitive"
+date: "2026-05-22"
+category: logic-errors
+module: internal/generator/templates/cobratree
+problem_type: logic_error
+component: tooling
+severity: medium
+symptoms:
+  - "Nested domain commands named search, sql, doctor, or another framework command were absent from MCP tools/list"
+  - "The runtime walker treated framework command names as globally reserved instead of top-level-only"
+  - "Downstream scorer and audit code could drift when they mirrored the old leaf-name-only skip rule"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - mcp
+  - cobratree
+  - framework-commands
+  - scorecard
+  - tools-audit
+---
+
+# Cobratree framework command skips are depth-sensitive
+
+## Problem
+
+The cobratree runtime walker used the leaf command name to classify framework commands. That was correct for top-level commands such as `search` and `sql`, where typed MCP tools or non-agent-friendly framework behavior already cover the surface. It was wrong for nested domain commands such as `items search`: those commands are user-facing domain actions and should be mirrored as shell-out MCP tools.
+
+The same assumption had also leaked into dependent verifiers. The MCP token estimator counted framework names as globally skipped, and tools-audit suppressed framework-named commands instead of suppressing only true framework command files.
+
+## Symptoms
+
+- A printed CLI could expose `<cli> items search` to humans while MCP `tools/list` omitted `items_search`.
+- Static MCP token estimates undercounted nested framework-name tools.
+- `tools-audit` missed thin descriptions or missing `mcp:read-only` annotations on nested domain commands named `search` or `sql`.
+
+## What Didn't Work
+
+- Keeping `frameworkCommands` as a flat name set without depth semantics made the comment contract lie. The list was documented as top-level framework commands, but the code applied it to every command with the same leaf name.
+- Updating only the runtime walker was incomplete. The scorer and audit code mirror cobratree behavior because they cannot import generated printed-CLI code, so they need the same depth rule and tests.
+- Dedupe by constructor function name in the estimator stopped matching runtime behavior once tool names became path-aware. Reusing the same `newSearchCmd` constructor under two parents should count two tools, not one.
+
+## Solution
+
+Make the framework skip top-level-only everywhere that models the cobratree surface:
+
+- `internal/generator/templates/cobratree/classify.go.tmpl` classifies a framework name as `commandFramework` only when the command's immediate parent is the root command.
+- `internal/pipeline/mcp_size.go` carries command path depth while walking the generated Cobra constructor graph, uses path-aware tool names, and dedupes by command path instead of constructor function.
+- `internal/cli/tools_audit.go` suppresses findings for true top-level framework command files while auditing nested domain commands named `search`, `sql`, or other framework leaves.
+- The generated golden `classify.go` is refreshed so the emitted printed-CLI contract matches the template.
+
+## Why This Works
+
+Cobra depth is the contract boundary. Top-level framework commands are generator-owned affordances with typed MCP equivalents or human-only behavior. Nested commands are domain commands, even when their leaf name happens to collide with a framework word.
+
+Keeping scorer and audit code aligned with that same boundary prevents two classes of silent drift:
+
+- False negatives, where generated CLIs expose new MCP tools but verifiers still assume they are skipped.
+- False accounting, where static estimates dedupe a shared constructor even though the runtime tool names differ by path.
+
+## Prevention
+
+- When changing cobratree classification, update every mirror in the same change: runtime template, generated golden, MCP token estimator, and tools-audit.
+- Regression tests should cover both positive and negative depth cases: top-level `search` remains skipped, nested `items search` is mirrored, and reused nested constructors under different parents produce distinct tool names.
+- For verifiers that cannot import generated code, model the same semantic inputs the runtime uses. In this case that means command depth and full command path, not only the `Use` leaf.
+
+## Related
+
+- `docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md`
+- `docs/solutions/logic-errors/mcp-template-literal-type-match-missed-openapi-shapes-2026-05-14.md`
+- `docs/solutions/security-issues/mcp-sql-search-readonly-bypass-2026-05-08.md`
+- `docs/solutions/logic-errors/ship-plan-agent-readiness-gate-2026-05-18.md`

--- a/internal/cli/tools_audit.go
+++ b/internal/cli/tools_audit.go
@@ -48,11 +48,11 @@ const (
 // same predicate as the audit.
 
 // FrameworkCommands mirrors cobratree/classify.go.tmpl. The runtime
-// walker skips these names entirely — they're never registered as MCP
-// tools — so audit findings on their Cobra Short are noise. Exported
-// so the spec drift test in internal/spec can assert the cobra-Use
-// reserved set is a strict superset (anything cobratree skips at MCP
-// time would shadow at cobra time too).
+// walker skips these names only for top-level framework commands, so
+// audit findings on those Cobra Shorts are noise. Exported so the spec
+// drift test in internal/spec can assert the cobra-Use reserved set is
+// a strict superset (anything cobratree skips at MCP time would shadow
+// at cobra time too).
 var FrameworkCommands = map[string]bool{
 	"about":         true,
 	"agent-context": true,
@@ -167,10 +167,7 @@ type ToolsAuditFinding struct {
 }
 
 // readShapedNames is the heuristic for "this command name suggests a
-// read operation." We exclude verbs already in cobratree's
-// FrameworkCommands skip set (search, sql, doctor, version) — the
-// runtime walker doesn't register those as MCP tools, so a missing
-// read-only annotation is meaningless noise for them.
+// read operation."
 //
 // tail/since/report/lint were added after dub's polish-Pass-2 surfaced
 // them as commands the heuristic missed. They're consistently read-
@@ -180,7 +177,7 @@ type ToolsAuditFinding struct {
 // and writes in others; let Pass 2 catch them per CLI.
 var readShapedNames = map[string]struct{}{
 	"list": {}, "get": {}, "show": {}, "view": {},
-	"find": {}, "describe": {}, "context": {}, "stats": {},
+	"find": {}, "search": {}, "sql": {}, "describe": {}, "context": {}, "stats": {},
 	"trending": {}, "trust": {}, "health": {}, "stale": {}, "orphans": {},
 	"reconcile": {}, "analytics": {}, "tail": {}, "since": {},
 	"report": {}, "lint": {},
@@ -383,15 +380,17 @@ func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFind
 	//   - pp:endpoint commands (registered as typed tools with
 	//     spec-derived descriptions; the manifest audit covers those)
 	//   - parent groupers (no Run/RunE means not actionable)
-	//   - framework commands (auth, doctor, version, etc.) — including
-	//     their entire subtree. Generated CLIs put children (e.g.
-	//     `auth status`, `profile list`) in the same file as the parent,
-	//     so the file basename's leading token tells us the subtree
-	//     even when the child's own Use field doesn't match a framework
-	//     name.
+	//   - top-level framework command files (auth, doctor, version,
+	//     etc.) — including their true framework subtree. Generated CLIs
+	//     put children (e.g. `auth status`, `profile list`) in the same
+	//     file as the parent, so the file basename's leading token tells
+	//     us the subtree even when the child's own Use field doesn't
+	//     match a framework name. A nested domain command named `search`
+	//     in a non-framework file still becomes a shell-out MCP tool and
+	//     must be audited.
 	// For all of these, the Cobra Short isn't the MCP tool description
 	// the agent will see, so flagging it would be noise.
-	isShellOut := !f.hasEndpoint && f.hasRunE && !FrameworkCommands[name] && !inFrameworkSubtree(file)
+	isShellOut := !f.hasEndpoint && f.hasRunE && !inFrameworkSubtree(file)
 
 	var out []ToolsAuditFinding
 	if isShellOut {
@@ -426,7 +425,7 @@ func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFind
 // both the parent and its subtree without needing to track AddCommand
 // edges across files.
 func inFrameworkSubtree(file string) bool {
-	base := strings.TrimSuffix(file, ".go")
+	base := strings.TrimSuffix(filepath.Base(file), ".go")
 	if i := strings.IndexByte(base, '_'); i > 0 {
 		base = base[:i]
 	}

--- a/internal/cli/tools_audit_test.go
+++ b/internal/cli/tools_audit_test.go
@@ -543,6 +543,40 @@ func TestAuditCommandFieldsThinShortStillFlagsShellOutCommands(t *testing.T) {
 	}
 }
 
+func TestAuditCommandFieldsFrameworkNamesOnlySkippedInFrameworkSubtrees(t *testing.T) {
+	t.Run("nested framework-named domain command is audited", func(t *testing.T) {
+		findings := auditCommandFields("items.go", 1, commandFields{
+			use:     "search",
+			short:   "Find",
+			hasRunE: true,
+		})
+
+		var gotThin, gotMissingReadOnly bool
+		for _, f := range findings {
+			switch f.Kind {
+			case kindThinShort:
+				gotThin = true
+			case kindMissingReadOnly:
+				gotMissingReadOnly = true
+			}
+		}
+		if !gotThin || !gotMissingReadOnly {
+			t.Fatalf("nested search findings = %+v, want thin-short and missing-read-only", findings)
+		}
+	})
+
+	t.Run("top-level framework file is skipped", func(t *testing.T) {
+		findings := auditCommandFields("search.go", 1, commandFields{
+			use:     "search",
+			short:   "Find",
+			hasRunE: true,
+		})
+		if len(findings) != 0 {
+			t.Fatalf("top-level framework search findings = %+v, want none", findings)
+		}
+	})
+}
+
 // TestInspectAnnotationsExplicitReadOnlyFalse pins the AST-level
 // helper: any value for `mcp:read-only` — including "false" — sets
 // hasExplicitReadOnly. The old behavior treated "false" as absent.

--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -143,3 +143,81 @@ func TestToolNameForPathCases(t *testing.T) {
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
 }
+
+func TestMCPFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("depthcheck")
+	outputDir := filepath.Join(t.TempDir(), "depthcheck-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	var testSrc strings.Builder
+	testSrc.WriteString(`package cobratree
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
+	for name := range frameworkCommands {
+		root := &cobra.Command{Use: "depthcheck-pp-cli"}
+		top := &cobra.Command{
+			Use: name,
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		}
+		parent := &cobra.Command{Use: "items"}
+		nested := &cobra.Command{
+			Use: name,
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		}
+		parent.AddCommand(nested)
+		root.AddCommand(top, parent)
+
+		if got := classify(top); got != commandFramework {
+			t.Fatalf("top-level %s classify() = %v, want commandFramework", name, got)
+		}
+		if got := classify(nested); got != commandNovel {
+			t.Fatalf("nested items %s classify() = %v, want commandNovel", name, got)
+		}
+	}
+
+	root := &cobra.Command{Use: "depthcheck-pp-cli"}
+	topSearch := &cobra.Command{
+		Use: "search",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	items := &cobra.Command{Use: "items"}
+	itemSearch := &cobra.Command{
+		Use: "search",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	items.AddCommand(itemSearch)
+	root.AddCommand(topSearch, items)
+
+	if got := classify(topSearch); got != commandFramework {
+		t.Fatalf("top-level search classify() = %v, want commandFramework", got)
+	}
+	if got := classify(itemSearch); got != commandNovel {
+		t.Fatalf("nested items search classify() = %v, want commandNovel", got)
+	}
+	var mirrored []string
+	walk(root, nil, func(cmd *cobra.Command, path []string) {
+		if classify(cmd) == commandNovel && cmd.Runnable() {
+			mirrored = append(mirrored, toolNameForPath(path))
+		}
+	})
+	if got := toolNameForPath([]string{"items", "search"}); got != "items_search" {
+		t.Fatalf("nested search tool name = %q, want items_search", got)
+	}
+	if len(mirrored) != 1 || mirrored[0] != "items_search" {
+		t.Fatalf("mirrored tools = %v, want only items_search", mirrored)
+	}
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "framework_depth_test.go"), []byte(testSrc.String()), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
+}

--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -77,10 +77,18 @@ func classify(cmd *cobra.Command) commandKind {
 	if endpointID(cmd) != "" {
 		return commandEndpoint
 	}
-	if frameworkCommands[cmd.Name()] {
+	if isTopLevelFrameworkCommand(cmd) {
 		return commandFramework
 	}
 	return commandNovel
+}
+
+func isTopLevelFrameworkCommand(cmd *cobra.Command) bool {
+	if cmd == nil || !frameworkCommands[cmd.Name()] {
+		return false
+	}
+	parent := cmd.Parent()
+	return parent != nil && parent.Parent() == nil
 }
 
 func endpointID(cmd *cobra.Command) string {

--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -301,36 +301,40 @@ func sourceCommandRecord(commands map[string]*cobraSourceCommand, name string) *
 
 func reachableCobratreeRuntimeTools(commands map[string]*cobraSourceCommand) []MCPToolSize {
 	var tools []MCPToolSize
-	visited := map[string]bool{}
-	var walk func(string)
-	walk = func(fnName string) {
+	visitedPaths := map[string]bool{}
+	var walk func(string, []string)
+	walk = func(fnName string, path []string) {
 		rec := commands[fnName]
 		if rec == nil {
 			return
 		}
 		for _, childName := range rec.children {
-			if visited[childName] {
-				continue
-			}
-			visited[childName] = true
 			child := commands[childName]
 			if child == nil || !child.hasLiteral {
 				continue
 			}
-			kind := cobratreeCommandKind(child.literal)
+			name := mcpCobraUseName(child.literal.use)
+			depth := len(path) + 1
+			kind := cobratreeCommandKind(child.literal, depth)
 			if kind == mcpCobraHidden || kind == mcpCobraFramework {
 				continue
 			}
+			childPath := append(append([]string{}, path...), name)
+			visitKey := strings.Join(childPath, "\x00")
+			if visitedPaths[visitKey] {
+				continue
+			}
+			visitedPaths[visitKey] = true
 			if kind == mcpCobraNovel && child.literal.runnable {
-				if tool, ok := estimateCobratreeCommandTool(child.literal); ok {
+				if tool, ok := estimateCobratreeCommandTool(child.literal, childPath); ok {
 					tools = append(tools, tool)
 				}
 			}
-			walk(childName)
+			walk(childName, childPath)
 		}
 	}
-	walk("RootCmd")
-	walk("newRootCmd")
+	walk("RootCmd", nil)
+	walk("newRootCmd", nil)
 	return tools
 }
 
@@ -380,15 +384,18 @@ func parseCobraCommandLiteral(lit *ast.CompositeLit) cobraCommandLiteral {
 	return cmd
 }
 
-func estimateCobratreeCommandTool(cmd cobraCommandLiteral) (MCPToolSize, bool) {
+func estimateCobratreeCommandTool(cmd cobraCommandLiteral, path []string) (MCPToolSize, bool) {
 	name := mcpCobraUseName(cmd.use)
 	if name == "" || cmd.hidden || !cmd.runnable {
 		return MCPToolSize{}, false
 	}
-	if cobratreeCommandKind(cmd) != mcpCobraNovel {
+	if len(path) == 0 {
+		path = []string{name}
+	}
+	if cobratreeCommandKind(cmd, len(path)) != mcpCobraNovel {
 		return MCPToolSize{}, false
 	}
-	toolName := naming.SnakeIdentifier(name)
+	toolName := naming.SnakeIdentifier(strings.Join(path, "_"))
 	if toolName == "" {
 		return MCPToolSize{}, false
 	}
@@ -407,7 +414,7 @@ func estimateCobratreeCommandTool(cmd cobraCommandLiteral) (MCPToolSize, bool) {
 	}, true
 }
 
-func cobratreeCommandKind(cmd cobraCommandLiteral) mcpCobraCommandKind {
+func cobratreeCommandKind(cmd cobraCommandLiteral, depth int) mcpCobraCommandKind {
 	name := mcpCobraUseName(cmd.use)
 	if name == "" || cmd.hidden || annotationIsTrueValue(cmd.annotations["mcp:hidden"]) {
 		return mcpCobraHidden
@@ -415,7 +422,7 @@ func cobratreeCommandKind(cmd cobraCommandLiteral) mcpCobraCommandKind {
 	if strings.TrimSpace(cmd.annotations["pp:endpoint"]) != "" {
 		return mcpCobraEndpoint
 	}
-	if cobratreeFrameworkCommands[name] {
+	if depth == 1 && cobratreeFrameworkCommands[name] {
 		return mcpCobraFramework
 	}
 	return mcpCobraNovel

--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -302,13 +303,16 @@ func sourceCommandRecord(commands map[string]*cobraSourceCommand, name string) *
 func reachableCobratreeRuntimeTools(commands map[string]*cobraSourceCommand) []MCPToolSize {
 	var tools []MCPToolSize
 	visitedPaths := map[string]bool{}
-	var walk func(string, []string)
-	walk = func(fnName string, path []string) {
+	var walk func(string, []string, map[string]bool)
+	walk = func(fnName string, path []string, ancestors map[string]bool) {
 		rec := commands[fnName]
 		if rec == nil {
 			return
 		}
 		for _, childName := range rec.children {
+			if ancestors[childName] {
+				continue
+			}
 			child := commands[childName]
 			if child == nil || !child.hasLiteral {
 				continue
@@ -330,12 +334,20 @@ func reachableCobratreeRuntimeTools(commands map[string]*cobraSourceCommand) []M
 					tools = append(tools, tool)
 				}
 			}
-			walk(childName, childPath)
+			childAncestors := cloneStringBoolMap(ancestors)
+			childAncestors[childName] = true
+			walk(childName, childPath, childAncestors)
 		}
 	}
-	walk("RootCmd", nil)
-	walk("newRootCmd", nil)
+	walk("RootCmd", nil, map[string]bool{"RootCmd": true})
+	walk("newRootCmd", nil, map[string]bool{"newRootCmd": true})
 	return tools
+}
+
+func cloneStringBoolMap(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 func isAddCommandCall(call *ast.CallExpr) bool {

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -273,6 +273,37 @@ func newSearchCmd() *cobra.Command {
 	assert.Contains(t, names, "cobratree:beta_search")
 }
 
+func TestEstimateMCPTokens_BoundsCyclicConstructorGraphs(t *testing.T) {
+	dir := writeMCPTools(t, `
+	cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)
+`)
+	writeMCPCLISource(t, dir, "root.go", `package cli
+
+import "github.com/spf13/cobra"
+
+func RootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "demo-pp-cli"}
+	rootCmd.AddCommand(newAlphaCmd())
+	return rootCmd
+}
+
+func newAlphaCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "alpha"}
+	cmd.AddCommand(newBetaCmd())
+	return cmd
+}
+
+func newBetaCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "beta"}
+	cmd.AddCommand(newAlphaCmd())
+	return cmd
+}
+`)
+
+	est := estimateMCPTokens(dir)
+	require.Equal(t, 0, est.ToolCount)
+}
+
 func TestScoreMCPTokenEfficiency_FullMarksForLeanSurface(t *testing.T) {
 	dir := writeMCPTools(t, `
 	s.AddTool(mcplib.NewTool("get", mcplib.WithDescription("get item")), nil)

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -148,6 +148,7 @@ func RootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{Use: "demo-pp-cli"}
 	rootCmd.AddCommand(newDigestCmd())
 	rootCmd.AddCommand(newTrendsCmd())
+	rootCmd.AddCommand(newItemsCmd())
 	rootCmd.AddCommand(newEndpointCmd())
 	rootCmd.AddCommand(newAuthCmd())
 	rootCmd.AddCommand(newHiddenCmd())
@@ -167,6 +168,23 @@ func newTrendsCmd() *cobra.Command {
 		Use:   "trends",
 		Long:  "Compare trending entities across synced data and explain what changed.",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+
+func newItemsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "items",
+		Short: "Work with items.",
+	}
+	cmd.AddCommand(newItemsSearchCmd())
+	return cmd
+}
+
+func newItemsSearchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "search",
+		Short: "Search within items.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
 	}
 }
 
@@ -198,7 +216,7 @@ func newHiddenCmd() *cobra.Command {
 `)
 
 	est := estimateMCPTokens(dir)
-	require.Equal(t, 3, est.ToolCount, "typed tool plus two cobratree runtime tools should all count")
+	require.Equal(t, 4, est.ToolCount, "typed tool plus top-level and nested cobratree runtime tools should all count")
 	names := make([]string, 0, len(est.PerTool))
 	for _, tool := range est.PerTool {
 		names = append(names, tool.Name)
@@ -206,6 +224,53 @@ func newHiddenCmd() *cobra.Command {
 	assert.Contains(t, names, "typed_get")
 	assert.Contains(t, names, "cobratree:digest")
 	assert.Contains(t, names, "cobratree:trends")
+	assert.Contains(t, names, "cobratree:items_search")
+	assert.NotContains(t, names, "cobratree:auth")
+}
+
+func TestEstimateMCPTokens_CountsSharedConstructorsAtDistinctPaths(t *testing.T) {
+	dir := writeMCPTools(t, `
+	cobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)
+`)
+	writeMCPCLISource(t, dir, "root.go", `package cli
+
+import "github.com/spf13/cobra"
+
+func RootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "demo-pp-cli"}
+	rootCmd.AddCommand(newAlphaCmd(), newBetaCmd())
+	return rootCmd
+}
+
+func newAlphaCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "alpha"}
+	cmd.AddCommand(newSearchCmd())
+	return cmd
+}
+
+func newBetaCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "beta"}
+	cmd.AddCommand(newSearchCmd())
+	return cmd
+}
+
+func newSearchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "search",
+		Short: "Search within the parent resource.",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+`)
+
+	est := estimateMCPTokens(dir)
+	require.Equal(t, 2, est.ToolCount)
+	names := make([]string, 0, len(est.PerTool))
+	for _, tool := range est.PerTool {
+		names = append(names, tool.Name)
+	}
+	assert.Contains(t, names, "cobratree:alpha_search")
+	assert.Contains(t, names, "cobratree:beta_search")
 }
 
 func TestScoreMCPTokenEfficiency_FullMarksForLeanSurface(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -77,10 +77,18 @@ func classify(cmd *cobra.Command) commandKind {
 	if endpointID(cmd) != "" {
 		return commandEndpoint
 	}
-	if frameworkCommands[cmd.Name()] {
+	if isTopLevelFrameworkCommand(cmd) {
 		return commandFramework
 	}
 	return commandNovel
+}
+
+func isTopLevelFrameworkCommand(cmd *cobra.Command) bool {
+	if cmd == nil || !frameworkCommands[cmd.Name()] {
+		return false
+	}
+	parent := cmd.Parent()
+	return parent != nil && parent.Parent() == nil
 }
 
 func endpointID(cmd *cobra.Command) string {


### PR DESCRIPTION
## Summary

Nested domain commands whose leaf name collides with a Printing Press framework command now stay visible to agents. A command like `<cli> items search` is mirrored as the `items_search` MCP shell-out tool, while the true top-level `search`, `sql`, `auth`, `doctor`, and other framework commands remain skipped.

The runtime walker, static MCP token estimator, and tools-audit now share the same depth-sensitive model. The estimator also counts reused command constructors by command path, so `alpha search` and `beta search` are accounted for as distinct runtime tools.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- Headless code review and simplify pass

## Compounded learnings

- Added `docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md` to capture the verifier-parity lesson for future cobratree MCP surface changes.

Closes #1516

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
