### PR TITLE
docs(cli): require upstream breadcrumbs for temporary CLI patches

### DIFF
--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -53,10 +53,28 @@ Minimum shape:
       "summary": "What changed (one sentence).",
       "reason": "Why this customization was needed (one or two sentences).",
       "files": ["internal/cli/foo.go"],
-      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix."
     }
   ]
+}
+```
+
+Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
+
+```json
+{
+  "id": "temporary-bridge",
+  "summary": "What changed (one sentence).",
+  "reason": "Why this customization was needed (one or two sentences).",
+  "files": ["internal/cli/foo.go"],
+  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
+      "reason": "Why the local patch is temporary or API-specific"
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
 }
 ```
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -177,6 +177,25 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	require.NotEqual(t, -1, copyIntoLibrary)
 }
 
+func TestAmendSkillRequiresUpstreamBreadcrumbsForTemporaryPatches(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md"))
+
+	assert.Contains(t, skill, `"deferred_to_upstream": [`)
+	assert.Contains(t, skill, `"upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"`)
+	assert.Contains(t, skill, "Do not leave a machine-level or API-publication dependency only in the PR body")
+}
+
+func TestGeneratedAgentsTemplateDocumentsUpstreamPatchHandoff(t *testing.T) {
+	template := readContractFile(t, filepath.Join("..", "generator", "templates", "agents.md.tmpl"))
+	minimumShape := substringBetween(t, template, "Minimum shape:", "Use `deferred_to_upstream`")
+
+	assert.Contains(t, template, `"deferred_to_upstream": [`)
+	assert.Contains(t, template, `"upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"`)
+	assert.Contains(t, template, "Use `deferred_to_upstream` when a local patch is a temporary bridge")
+	assert.NotContains(t, minimumShape, "deferred_to_upstream")
+	assert.NotContains(t, minimumShape, "upstream_issue")
+}
+
 func TestPolishSkillHardGatesPublishValidate(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
 
@@ -271,6 +290,19 @@ func extractContractBlock(t *testing.T, content string) string {
 
 	endIdx := strings.Index(content[startIdx:], end)
 	require.NotEqual(t, -1, endIdx, "missing contract end marker")
+
+	return content[startIdx : startIdx+endIdx]
+}
+
+func substringBetween(t *testing.T, content, start, end string) string {
+	t.Helper()
+
+	startIdx := strings.Index(content, start)
+	require.NotEqual(t, -1, startIdx, "missing start marker %q", start)
+	startIdx += len(start)
+
+	endIdx := strings.Index(content[startIdx:], end)
+	require.NotEqual(t, -1, endIdx, "missing end marker %q", end)
 
 	return content[startIdx : startIdx+endIdx]
 }

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -519,13 +519,29 @@ For each finding in dependency order:
    }
    ```
 
+   For a temporary patch with a future supersession path, include the upstream handoff fields in that same patch entry:
+
+   ```json
+   {
+     "deferred_to_upstream": [
+       {
+         "feature": "Generator or upstream API capability this printed-CLI patch should eventually supersede",
+         "reason": "Why the local patch is intentionally temporary or API-specific."
+       }
+     ],
+     "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+   }
+   ```
+
    Both halves of the contract — `// PATCH(...)` source comments AND `.printing-press-patches.json` entries — are MANDATORY. The library's `verify-library-conventions` workflow rejects PRs where one is present without the other. See `~/printing-press-library/AGENTS.md` "How to record a hand-edit" for the authoritative spec.
+
+   Use `deferred_to_upstream` only when the patch intentionally leaves a future supersession path: a public API endpoint is missing today, the command relies on an unofficial host or alternate auth source, a live response shape drifted from generator assumptions, or the fix would become unnecessary once the Printing Press learns the pattern. In those cases, search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one before the library PR, then set `upstream_issue` to that URL. Do not leave a machine-level or API-publication dependency only in the PR body.
 
 4. **Machine-vs-printed-CLI judgment** (per AGENTS.md): when a finding's fix would generalize to every printed CLI (e.g. "the generator should emit `--type sent` for any threads list command"), surface as a borderline case:
 
    > "Finding F5 (`--type sent` missing) looks like a machine-level fix — the generator template `internal/generator/templates/threads.go.tmpl` should emit it for every CLI with this endpoint shape, not just `<slug>-pp-cli`. Defer to a `/printing-press-retro` follow-up, or proceed CLI-specific?"
 
-   When deferred, drop into the deferred-list with classification `machine-level`. When kept, add a comment in the patch noting the generalize-eventually intent.
+   When deferred, drop into the deferred-list with classification `machine-level`. When kept because the printed CLI needs a narrow fix now, and the patch still carries a future supersession path, create or reuse the upstream Printing Press issue before opening the library PR, add the issue URL to `.printing-press-patches.json`, and add a `deferred_to_upstream` item naming the machine-level or upstream-API condition that should supersede the local patch.
 
 ### Step 4 — Validate
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -53,10 +53,28 @@ Minimum shape:
       "summary": "What changed (one sentence).",
       "reason": "Why this customization was needed (one or two sentences).",
       "files": ["internal/cli/foo.go"],
-      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix."
     }
   ]
+}
+```
+
+Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
+
+```json
+{
+  "id": "temporary-bridge",
+  "summary": "What changed (one sentence).",
+  "reason": "Why this customization was needed (one or two sentences).",
+  "files": ["internal/cli/foo.go"],
+  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
+      "reason": "Why the local patch is temporary or API-specific"
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
 }
 ```
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -53,10 +53,28 @@ Minimum shape:
       "summary": "What changed (one sentence).",
       "reason": "Why this customization was needed (one or two sentences).",
       "files": ["internal/cli/foo.go"],
-      "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-      "upstream_issue": "Optional: https://github.com/mvanhorn/cli-printing-press/issues/<n>"
+      "validated_outcome": "Optional: non-obvious test result that confirms the fix."
     }
   ]
+}
+```
+
+Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
+
+```json
+{
+  "id": "temporary-bridge",
+  "summary": "What changed (one sentence).",
+  "reason": "Why this customization was needed (one or two sentences).",
+  "files": ["internal/cli/foo.go"],
+  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
+  "deferred_to_upstream": [
+    {
+      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
+      "reason": "Why the local patch is temporary or API-specific"
+    }
+  ],
+  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
 }
 ```
 


### PR DESCRIPTION
## Summary
- document when printed-CLI patch manifests should carry `deferred_to_upstream` and `upstream_issue` breadcrumbs
- keep the baseline patch-manifest shape minimal while adding conditional temporary-bridge guidance to generated AGENTS files
- add contract coverage and refresh affected golden AGENTS fixtures

## Verification
- `GOCACHE="$PWD/.gotmp/gocache" go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `GOCACHE="$PWD/.gotmp/gocache" go test ./...`
- `golangci-lint run ./...`
- `GOCACHE="$PWD/.gotmp/gocache-golden" scripts/golden.sh verify`
- `./cli-printing-press verify-internal-skill --dir skills/printing-press-amend --json`
- `git diff --check`

Closes #1528