### PR TITLE
fix(cli): add OAuth scope coverage dogfood check

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -180,6 +180,26 @@ func printDogfoodReport(report *pipeline.DogfoodReport) {
 	}
 	fmt.Println()
 
+	scopeStatus := "SKIP"
+	if !report.OAuthScopeCoverage.Skipped {
+		scopeStatus = "PASS"
+		if len(report.OAuthScopeCoverage.Violations) > 0 {
+			scopeStatus = "FAIL"
+		}
+	}
+	fmt.Printf("OAuth Scope Cover: %d/%d endpoints covered (%s)\n", report.OAuthScopeCoverage.Covered, report.OAuthScopeCoverage.Checked, scopeStatus)
+	if report.OAuthScopeCoverage.Detail != "" {
+		fmt.Printf("  Detail: %s\n", report.OAuthScopeCoverage.Detail)
+	}
+	for _, violation := range report.OAuthScopeCoverage.Violations {
+		op := violation.OperationID
+		if op == "" {
+			op = "unknown"
+		}
+		fmt.Printf("  - %s (op-id %s) %s, none in auth.go\n", violation.Endpoint, op, describeOAuthScopeRequirement(violation))
+	}
+	fmt.Println()
+
 	flagsStatus := "PASS"
 	if report.DeadFlags.Dead >= 3 {
 		flagsStatus = "FAIL"
@@ -276,6 +296,33 @@ func printDogfoodReport(report *pipeline.DogfoodReport) {
 	fmt.Printf("Verdict: %s\n", report.Verdict)
 	for _, issue := range report.Issues {
 		fmt.Printf("  - %s\n", issue)
+	}
+}
+
+func describeOAuthScopeRequirement(violation pipeline.OAuthScopeCoverageViolation) string {
+	alternatives := violation.RequiredScopeAlternatives
+	if len(alternatives) == 0 && len(violation.RequiredScopes) > 0 {
+		alternatives = [][]string{violation.RequiredScopes}
+	}
+
+	switch len(alternatives) {
+	case 0:
+		return "requires OAuth scopes"
+	case 1:
+		if len(alternatives[0]) == 1 {
+			return "requires " + alternatives[0][0]
+		}
+		return "requires all of " + strings.Join(alternatives[0], ", ")
+	default:
+		options := make([]string, 0, len(alternatives))
+		for _, alternative := range alternatives {
+			if len(alternative) == 1 {
+				options = append(options, alternative[0])
+			} else {
+				options = append(options, "all of "+strings.Join(alternative, ", "))
+			}
+		}
+		return "requires one of " + strings.Join(options, "; ")
 	}
 }
 

--- a/internal/cli/dogfood_test.go
+++ b/internal/cli/dogfood_test.go
@@ -56,6 +56,31 @@ func TestPrintDogfoodReportRendersEmptyMatrixAsNA(t *testing.T) {
 	assert.NotContains(t, out, "Path Validity:     0/0 valid (FAIL)")
 }
 
+func TestPrintDogfoodReportDescribesOAuthScopeAlternatives(t *testing.T) {
+	report := &pipeline.DogfoodReport{
+		Dir:      t.TempDir(),
+		SpecPath: "youtube.yaml",
+		OAuthScopeCoverage: pipeline.OAuthScopeCoverageResult{
+			Checked: 1,
+			Violations: []pipeline.OAuthScopeCoverageViolation{
+				{
+					Endpoint:                  "GET /analytics",
+					OperationID:               "listAnalytics",
+					RequiredScopes:            []string{"youtube", "yt-analytics.readonly"},
+					RequiredScopeAlternatives: [][]string{{"youtube", "yt-analytics.readonly"}},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printDogfoodReport(report)
+	})
+
+	assert.Contains(t, out, "GET /analytics (op-id listAnalytics) requires all of youtube, yt-analytics.readonly, none in auth.go")
+	assert.NotContains(t, out, "requires one of youtube, yt-analytics.readonly")
+}
+
 func TestDogfoodHelpIncludesLiveFlags(t *testing.T) {
 	cmd := newDogfoodCmd()
 	cmd.SetArgs([]string{"--help"})

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +43,7 @@ type DogfoodReport struct {
 	PathCheck              PathCheckResult              `json:"path_check"`
 	AuthCheck              AuthCheckResult              `json:"auth_check"`
 	BrowserSessionCheck    BrowserSessionCheckResult    `json:"browser_session_check"`
+	OAuthScopeCoverage     OAuthScopeCoverageResult     `json:"oauth_scope_coverage_check"`
 	DeadFlags              DeadCodeResult               `json:"dead_flags"`
 	DeadFuncs              DeadCodeResult               `json:"dead_functions"`
 	PipelineCheck          PipelineResult               `json:"pipeline_check"`
@@ -117,6 +122,21 @@ type AuthCheckResult struct {
 	Detail       string `json:"detail"`
 }
 
+type OAuthScopeCoverageResult struct {
+	Checked    int                           `json:"checked"`
+	Covered    int                           `json:"covered"`
+	Violations []OAuthScopeCoverageViolation `json:"violations,omitempty"`
+	Skipped    bool                          `json:"skipped,omitempty"`
+	Detail     string                        `json:"detail,omitempty"`
+}
+
+type OAuthScopeCoverageViolation struct {
+	Endpoint                  string     `json:"endpoint"`
+	OperationID               string     `json:"operation_id,omitempty"`
+	RequiredScopes            []string   `json:"required_scopes"`
+	RequiredScopeAlternatives [][]string `json:"required_scope_alternatives,omitempty"`
+}
+
 type BrowserSessionCheckResult struct {
 	Required              bool   `json:"required"`
 	HasAuthLoginChrome    bool   `json:"has_auth_login_chrome,omitempty"`
@@ -190,10 +210,11 @@ type WorkflowCompleteResult struct {
 }
 
 type openAPISpec struct {
-	Paths         []string
-	Auth          apispec.AuthConfig
-	Kind          string // see apispec.KindREST / apispec.KindSynthetic
-	HTTPTransport string
+	Paths                  []string
+	Auth                   apispec.AuthConfig
+	Kind                   string // see apispec.KindREST / apispec.KindSynthetic
+	HTTPTransport          string
+	OAuthScopeRequirements []oauthScopeRequirement
 	// ParamDefaults maps a positional placeholder name (lowercase) to its
 	// spec-declared default value, when one is set. Verify mock-mode uses
 	// this as the first step in its lookup chain so spec authors can name
@@ -276,6 +297,7 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 		}
 		report.AuthCheck = checkAuth(dir, spec.Auth)
 		report.BrowserSessionCheck = checkBrowserSessionAuth(dir, spec.Auth)
+		report.OAuthScopeCoverage = checkOAuthScopeCoverage(dir, spec.OAuthScopeRequirements)
 	} else {
 		report.AuthCheck = AuthCheckResult{
 			Match:  true,
@@ -284,6 +306,10 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 		report.BrowserSessionCheck = BrowserSessionCheckResult{
 			Pass:   true,
 			Detail: "spec not provided; browser-session auth check skipped",
+		}
+		report.OAuthScopeCoverage = OAuthScopeCoverageResult{
+			Skipped: true,
+			Detail:  "spec not provided; OAuth scope coverage check skipped",
 		}
 	}
 
@@ -904,22 +930,28 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 		return internalSpecToDogfoodSpec(internal), nil
 	}
 
+	summary, summaryErr := loadOpenAPISpecData(data, specPath)
 	parsed, parseErr := openapiparser.ParseWithPathLenient(data, specPath)
 	if parseErr == nil {
+		var scopeRequirements []oauthScopeRequirement
+		if summary != nil {
+			scopeRequirements = summary.OAuthScopeRequirements
+		}
 		return &openAPISpec{
-			Paths: collectDogfoodSpecPaths(parsed.Resources),
-			Auth:  parsed.Auth,
+			Paths:                  collectDogfoodSpecPaths(parsed.Resources),
+			Auth:                   parsed.Auth,
+			OAuthScopeRequirements: scopeRequirements,
 		}, nil
 	}
 
-	summary, err := loadOpenAPISpec(specPath)
-	if err != nil {
+	if summaryErr != nil {
 		return nil, parseErr
 	}
 
 	return &openAPISpec{
-		Paths: summary.Paths,
-		Auth:  deriveDogfoodAuth(summary),
+		Paths:                  summary.Paths,
+		Auth:                   deriveDogfoodAuth(summary),
+		OAuthScopeRequirements: summary.OAuthScopeRequirements,
 	}, nil
 }
 
@@ -1134,6 +1166,190 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 		result.Detail = fmt.Sprintf(`spec expects %q but generated client uses %q`, strings.TrimSpace(expectedPrefix), strings.TrimSpace(result.GeneratedFmt))
 	}
 	return result
+}
+
+func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement) OAuthScopeCoverageResult {
+	if len(requirements) == 0 {
+		return OAuthScopeCoverageResult{
+			Skipped: true,
+			Detail:  "no OAuth-scoped endpoints in spec",
+		}
+	}
+
+	generatedScopes := generatedOAuthScopes(dir)
+	generated := make(map[string]bool, len(generatedScopes))
+	for _, scope := range generatedScopes {
+		generated[scope] = true
+	}
+
+	result := OAuthScopeCoverageResult{Checked: len(requirements)}
+	for _, requirement := range requirements {
+		if oauthScopeRequirementCovered(requirement, generated) {
+			result.Covered++
+			continue
+		}
+		result.Violations = append(result.Violations, OAuthScopeCoverageViolation{
+			Endpoint:                  requirement.Endpoint,
+			OperationID:               requirement.OperationID,
+			RequiredScopes:            oauthScopeRequirementScopes(requirement),
+			RequiredScopeAlternatives: oauthScopeRequirementAlternatives(requirement),
+		})
+	}
+
+	if len(result.Violations) == 0 {
+		result.Detail = "all OAuth-scoped endpoints covered by generated auth scopes"
+	} else if len(generatedScopes) == 0 {
+		result.Detail = "generated auth.go declares no OAuth scopes"
+	} else {
+		result.Detail = fmt.Sprintf("%d OAuth-scoped endpoint(s) lack a generated auth scope", len(result.Violations))
+	}
+	return result
+}
+
+func oauthScopeRequirementCovered(requirement oauthScopeRequirement, generated map[string]bool) bool {
+	for _, alternative := range requirement.Alternatives {
+		covered := len(alternative.Scopes) > 0
+		for _, scope := range alternative.Scopes {
+			if !generated[scope] {
+				covered = false
+				break
+			}
+		}
+		if covered {
+			return true
+		}
+	}
+	return false
+}
+
+func oauthScopeRequirementScopes(requirement oauthScopeRequirement) []string {
+	var scopes []string
+	for _, alternative := range requirement.Alternatives {
+		scopes = append(scopes, alternative.Scopes...)
+	}
+	return uniqueSorted(scopes)
+}
+
+func oauthScopeRequirementAlternatives(requirement oauthScopeRequirement) [][]string {
+	alternatives := make([][]string, 0, len(requirement.Alternatives))
+	for _, alternative := range requirement.Alternatives {
+		scopes := uniqueSorted(alternative.Scopes)
+		if len(scopes) > 0 {
+			alternatives = append(alternatives, scopes)
+		}
+	}
+	return alternatives
+}
+
+func generatedOAuthScopes(dir string) []string {
+	file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(dir, "internal", "cli", "auth.go"), nil, 0)
+	if err != nil {
+		return nil
+	}
+
+	scopeVars := scopeJoinVars(file)
+	var scopes []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			name, ok := dogfoodIdentName(lhs)
+			if !ok || !scopeVars[name] || i >= len(assign.Rhs) {
+				continue
+			}
+			switch expr := assign.Rhs[i].(type) {
+			case *ast.CompositeLit:
+				scopes = append(scopes, stringCompositeValues(expr)...)
+			case *ast.CallExpr:
+				scopes = append(scopes, appendedStringValues(expr, scopeVars)...)
+			}
+		}
+		return true
+	})
+	return uniqueSorted(scopes)
+}
+
+func scopeJoinVars(file *ast.File) map[string]bool {
+	vars := map[string]bool{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 || dogfoodSelectorName(call.Fun) != "Set" || dogfoodStringLiteral(call.Args[0]) != "scope" {
+			return true
+		}
+		join, ok := call.Args[1].(*ast.CallExpr)
+		if !ok || dogfoodSelectorName(join.Fun) != "Join" || len(join.Args) == 0 {
+			return true
+		}
+		name, ok := dogfoodIdentName(join.Args[0])
+		if ok {
+			vars[name] = true
+		}
+		return true
+	})
+	return vars
+}
+
+func appendedStringValues(call *ast.CallExpr, scopeVars map[string]bool) []string {
+	if name := dogfoodCallName(call.Fun); name != "append" || len(call.Args) < 2 {
+		return nil
+	}
+	name, ok := dogfoodIdentName(call.Args[0])
+	if !ok || !scopeVars[name] {
+		return nil
+	}
+	return stringExprValues(call.Args[1:]...)
+}
+
+func stringCompositeValues(lit *ast.CompositeLit) []string {
+	return stringExprValues(lit.Elts...)
+}
+
+func stringExprValues(exprs ...ast.Expr) []string {
+	var values []string
+	for _, expr := range exprs {
+		if value := strings.TrimSpace(dogfoodStringLiteral(expr)); value != "" {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func dogfoodSelectorName(expr ast.Expr) string {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	return selector.Sel.Name
+}
+
+func dogfoodCallName(expr ast.Expr) string {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
+}
+
+func dogfoodIdentName(expr ast.Expr) (string, bool) {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return ident.Name, true
+}
+
+func dogfoodStringLiteral(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
 }
 
 type authPrefixCandidate struct {
@@ -1784,6 +2000,9 @@ var dogfoodVerdictRules = []dogfoodVerdictRule{
 	{"FAIL", func(r *DogfoodReport, hasSpec bool) bool {
 		return hasSpec && r.BrowserSessionCheck.Required && !r.BrowserSessionCheck.Pass
 	}},
+	{"FAIL", func(r *DogfoodReport, hasSpec bool) bool {
+		return hasSpec && len(r.OAuthScopeCoverage.Violations) > 0
+	}},
 	{"FAIL", func(r *DogfoodReport, _ bool) bool { return r.DeadFlags.Dead >= 3 }},
 	{"FAIL", func(r *DogfoodReport, _ bool) bool {
 		return r.ExampleCheck.Tested > 0 && (r.ExampleCheck.WithExamples*100/r.ExampleCheck.Tested) < 50
@@ -1841,6 +2060,9 @@ func collectDogfoodIssues(report *DogfoodReport, hasSpec bool) []string {
 	}
 	if hasSpec && report.BrowserSessionCheck.Required && !report.BrowserSessionCheck.Pass {
 		issues = append(issues, "browser-session auth proof wiring incomplete: "+report.BrowserSessionCheck.Detail)
+	}
+	if hasSpec && len(report.OAuthScopeCoverage.Violations) > 0 {
+		issues = append(issues, fmt.Sprintf("OAuth scope coverage missing for %d endpoint(s)", len(report.OAuthScopeCoverage.Violations)))
 	}
 	if report.DeadFlags.Dead >= 3 {
 		issues = append(issues, fmt.Sprintf("%d dead flags found", report.DeadFlags.Dead))

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -197,6 +197,415 @@ security:
 	assert.True(t, report.AuthCheck.Match)
 }
 
+func TestRunDogfoodOAuthScopeCoveragePassesCoveredEndpoint(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube"}
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /videos:
+    get:
+      operationId: listVideos
+      security:
+        - OAuth2: [youtube]
+      responses:
+        "200":
+          description: ok
+  /analytics:
+    get:
+      operationId: listAnalytics
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            youtube: YouTube read access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Covered)
+	assert.Empty(t, report.OAuthScopeCoverage.Violations)
+}
+
+func TestRunDogfoodOAuthScopeCoverageFailsUncoveredEndpoint(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube"}
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /videos:
+    get:
+      operationId: listVideos
+      responses:
+        "200":
+          description: ok
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [yt-analytics.readonly]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            youtube: YouTube read access
+            yt-analytics.readonly: Analytics read access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
+	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
+	assert.Equal(t, "GET /analytics", report.OAuthScopeCoverage.Violations[0].Endpoint)
+	assert.Equal(t, "listAnalytics", report.OAuthScopeCoverage.Violations[0].OperationID)
+	assert.Equal(t, []string{"yt-analytics.readonly"}, report.OAuthScopeCoverage.Violations[0].RequiredScopes)
+	assert.Contains(t, report.Issues, "OAuth scope coverage missing for 1 endpoint(s)")
+}
+
+func TestRunDogfoodOAuthScopeCoverageRequiresAllScopesInAlternative(t *testing.T) {
+	specYAML := `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [youtube, yt-analytics.readonly]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            youtube: YouTube read access
+            yt-analytics.readonly: Analytics read access
+`
+
+	t.Run("partial coverage fails", func(t *testing.T) {
+		dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube"}
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, specYAML)
+
+		report, err := RunDogfood(dir, specPath)
+		require.NoError(t, err)
+
+		assert.Equal(t, "FAIL", report.Verdict)
+		assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+		assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
+		require.Len(t, report.OAuthScopeCoverage.Violations, 1)
+		assert.Equal(t, []string{"youtube", "yt-analytics.readonly"}, report.OAuthScopeCoverage.Violations[0].RequiredScopes)
+		assert.Equal(t, [][]string{{"youtube", "yt-analytics.readonly"}}, report.OAuthScopeCoverage.Violations[0].RequiredScopeAlternatives)
+	})
+
+	t.Run("full coverage passes", func(t *testing.T) {
+		dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube", "yt-analytics.readonly"}
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, specYAML)
+
+		report, err := RunDogfood(dir, specPath)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+		assert.Equal(t, 1, report.OAuthScopeCoverage.Covered)
+		assert.Empty(t, report.OAuthScopeCoverage.Violations)
+	})
+}
+
+func TestRunDogfoodOAuthScopeCoverageReadsAppendedGeneratedScope(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube"}
+	scopes = append(scopes, "offline")
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /refresh:
+    get:
+      operationId: refreshAccess
+      security:
+        - OAuth2: [offline]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            youtube: YouTube read access
+            offline: Refresh access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Covered)
+	assert.Empty(t, report.OAuthScopeCoverage.Violations)
+}
+
+func TestRunDogfoodOAuthScopeCoverageIgnoresUnjoinedScopesVariable(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func helper() {
+	scopes := []string{"yt-analytics.readonly"}
+	_ = scopes
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [yt-analytics.readonly]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            yt-analytics.readonly: Analytics read access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
+	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
+	assert.Equal(t, "generated auth.go declares no OAuth scopes", report.OAuthScopeCoverage.Detail)
+}
+
+func TestRunDogfoodOAuthScopeCoverageSurvivesUndefinedNonOAuthScheme(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {
+	scopes := []string{"youtube"}
+	params.Set("scope", strings.Join(scopes, " "))
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [yt-analytics.readonly]
+          MissingAPIKey: []
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            youtube: YouTube read access
+            yt-analytics.readonly: Analytics read access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
+	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
+	assert.Equal(t, "GET /analytics", report.OAuthScopeCoverage.Violations[0].Endpoint)
+	assert.Equal(t, []string{"yt-analytics.readonly"}, report.OAuthScopeCoverage.Violations[0].RequiredScopes)
+}
+
+func TestLoadOpenAPISpecCollectsRootOAuthScopeRequirements(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: Root Scoped API
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            items.read: Read items
+security:
+  - OAuth2: [items.read]
+`)
+
+	info, err := loadOpenAPISpec(specPath)
+	require.NoError(t, err)
+	require.Len(t, info.OAuthScopeRequirements, 1)
+	assert.Equal(t, "GET /items", info.OAuthScopeRequirements[0].Endpoint)
+	assert.Equal(t, "listItems", info.OAuthScopeRequirements[0].OperationID)
+	assert.Equal(t, []string{"items.read"}, info.OAuthScopeRequirements[0].Alternatives[0].Scopes)
+}
+
+func TestLoadOpenAPISpecCombinesOAuthSchemesWithinRequirement(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: Combined Scoped API
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      security:
+        - OAuthA: [a.read]
+          OAuthB: [b.read]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuthA:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth-a
+          tokenUrl: https://example.com/token-a
+          scopes:
+            a.read: Read A
+    OAuthB:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth-b
+          tokenUrl: https://example.com/token-b
+          scopes:
+            b.read: Read B
+`)
+
+	info, err := loadOpenAPISpec(specPath)
+	require.NoError(t, err)
+	require.Len(t, info.OAuthScopeRequirements, 1)
+	require.Len(t, info.OAuthScopeRequirements[0].Alternatives, 1)
+	assert.Equal(t, []string{"a.read", "b.read"}, info.OAuthScopeRequirements[0].Alternatives[0].Scopes)
+}
+
+func writeOAuthScopeCoverageFixture(t *testing.T, authGo, specYAML string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "store"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "root.go"), `package cli
+type rootFlags struct{}
+func initFlags(flags *rootFlags) { _ = flags }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "videos_get.go"), `package cli
+func videosGet() {
+	path := "/videos"
+}
+func analyticsGet() {
+	path := "/analytics"
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "auth.go"), authGo)
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader(token string) string {
+	return "Bearer " + token
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "store", "store.go"), "package store\n")
+
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeTestFile(t, specPath, specYAML)
+	return dir, specPath
+}
+
 func TestCountDomainTables(t *testing.T) {
 	storeSource := `
 CREATE TABLE IF NOT EXISTS users (

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1568,11 +1568,22 @@ type securityRequirementSet struct {
 	AllowsAnonymous bool
 }
 
+type oauthScopeRequirement struct {
+	Endpoint     string                  `json:"endpoint"`
+	OperationID  string                  `json:"operation_id,omitempty"`
+	Alternatives []oauthScopeAlternative `json:"alternatives"`
+}
+
+type oauthScopeAlternative struct {
+	Scopes []string `json:"scopes"`
+}
+
 type openAPISpecInfo struct {
-	Paths                []string
-	SecuritySchemes      map[string]openAPISecurityScheme
-	SecurityRequirements []securityRequirementSet
-	Kind                 string // see apispec.KindREST / apispec.KindSynthetic
+	Paths                  []string
+	SecuritySchemes        map[string]openAPISecurityScheme
+	SecurityRequirements   []securityRequirementSet
+	OAuthScopeRequirements []oauthScopeRequirement
+	Kind                   string // see apispec.KindREST / apispec.KindSynthetic
 }
 
 func (s *openAPISpecInfo) IsSynthetic() bool {
@@ -1588,7 +1599,10 @@ func loadOpenAPISpec(specPath string) (*openAPISpecInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading spec: %w", err)
 	}
+	return loadOpenAPISpecData(data, specPath)
+}
 
+func loadOpenAPISpecData(data []byte, specPath string) (*openAPISpecInfo, error) {
 	// Detect internal YAML spec format and convert to openAPISpecInfo.
 	if isInternalYAMLSpec(data) {
 		internal, err := apispec.ParseBytes(data)
@@ -1681,17 +1695,30 @@ func loadOpenAPISpec(specPath string) (*openAPISpecInfo, error) {
 	}
 
 	rootSecurity, rootHasSecurity := parseSecurityRequirementSet(raw["security"])
+	rootOAuthScopes, rootHasOAuthScopes := parseOAuthScopeAlternatives(raw["security"], info.SecuritySchemes)
 	foundOperation := false
 	if paths, ok := raw["paths"].(map[string]any); ok {
-		for _, pathValue := range paths {
+		pathNames := make([]string, 0, len(paths))
+		for path := range paths {
+			pathNames = append(pathNames, path)
+		}
+		slices.Sort(pathNames)
+		for _, path := range pathNames {
+			pathValue := paths[path]
 			pathItem, ok := pathValue.(map[string]any)
 			if !ok {
 				continue
 			}
-			for method, operationValue := range pathItem {
+			methods := make([]string, 0, len(pathItem))
+			for method := range pathItem {
 				if !isHTTPMethod(method) {
 					continue
 				}
+				methods = append(methods, method)
+			}
+			slices.Sort(methods)
+			for _, method := range methods {
+				operationValue := pathItem[method]
 				foundOperation = true
 				operation, ok := operationValue.(map[string]any)
 				if !ok {
@@ -1699,10 +1726,24 @@ func loadOpenAPISpec(specPath string) (*openAPISpecInfo, error) {
 				}
 				if requirementSet, ok := parseSecurityRequirementSet(operation["security"]); ok {
 					info.SecurityRequirements = append(info.SecurityRequirements, requirementSet)
+					if alternatives, ok := parseOAuthScopeAlternatives(operation["security"], info.SecuritySchemes); ok && len(alternatives) > 0 {
+						info.OAuthScopeRequirements = append(info.OAuthScopeRequirements, oauthScopeRequirement{
+							Endpoint:     strings.ToUpper(method) + " " + path,
+							OperationID:  operationIDFromRaw(operation),
+							Alternatives: alternatives,
+						})
+					}
 					continue
 				}
 				if rootHasSecurity {
 					info.SecurityRequirements = append(info.SecurityRequirements, rootSecurity)
+				}
+				if rootHasOAuthScopes && len(rootOAuthScopes) > 0 {
+					info.OAuthScopeRequirements = append(info.OAuthScopeRequirements, oauthScopeRequirement{
+						Endpoint:     strings.ToUpper(method) + " " + path,
+						OperationID:  operationIDFromRaw(operation),
+						Alternatives: rootOAuthScopes,
+					})
 				}
 			}
 		}
@@ -1715,13 +1756,23 @@ func loadOpenAPISpec(specPath string) (*openAPISpecInfo, error) {
 		for _, alternative := range requirementSet.Alternatives {
 			for _, name := range alternative {
 				if _, ok := info.SecuritySchemes[name]; !ok {
-					return nil, fmt.Errorf("spec references undefined security scheme %q", name)
+					return info, fmt.Errorf("spec references undefined security scheme %q", name)
 				}
 			}
 		}
 	}
 
 	return info, nil
+}
+
+func operationIDFromRaw(operation map[string]any) string {
+	if operation == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(asString(operation["operationId"])); id != "" {
+		return id
+	}
+	return ""
 }
 
 type dimensionScore struct {
@@ -1892,6 +1943,61 @@ func parseSecurityRequirementSet(value any) (securityRequirementSet, bool) {
 	}
 
 	return set, true
+}
+
+func parseOAuthScopeAlternatives(value any, schemes map[string]openAPISecurityScheme) ([]oauthScopeAlternative, bool) {
+	requirements, ok := value.([]any)
+	if !ok {
+		return nil, false
+	}
+
+	var alternatives []oauthScopeAlternative
+	seen := map[string]struct{}{}
+	for _, requirement := range requirements {
+		names, ok := requirement.(map[string]any)
+		if !ok {
+			continue
+		}
+		var scopes []string
+		for name, scopeValue := range names {
+			scheme, ok := schemes[name]
+			if !ok || !isOAuthSecurityScheme(scheme) {
+				continue
+			}
+			scopes = append(scopes, parseOAuthScopeList(scopeValue)...)
+		}
+		scopes = uniqueSorted(scopes)
+		if len(scopes) == 0 {
+			continue
+		}
+		key := strings.Join(scopes, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		alternatives = append(alternatives, oauthScopeAlternative{Scopes: scopes})
+	}
+	return alternatives, true
+}
+
+func parseOAuthScopeList(value any) []string {
+	rawScopes, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	var scopes []string
+	for _, rawScope := range rawScopes {
+		scope := strings.TrimSpace(asString(rawScope))
+		if scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	slices.Sort(scopes)
+	return slices.Compact(scopes)
+}
+
+func isOAuthSecurityScheme(scheme openAPISecurityScheme) bool {
+	return scheme.Type == "oauth2" || scheme.Type == "openidconnect"
 }
 
 func referencedSecuritySchemes(requirementSets []securityRequirementSet) map[string]bool {

--- a/testdata/golden/expected/dogfood-verdict-matrix/fail-path-auth-dead.json
+++ b/testdata/golden/expected/dogfood-verdict-matrix/fail-path-auth-dead.json
@@ -49,6 +49,12 @@
     "planned": 0,
     "skipped": true
   },
+  "oauth_scope_coverage_check": {
+    "checked": 0,
+    "covered": 0,
+    "detail": "no OAuth-scoped endpoints in spec",
+    "skipped": true
+  },
   "path_check": {
     "invalid": [
       "/wrong"

--- a/testdata/golden/expected/dogfood-verdict-matrix/pass.json
+++ b/testdata/golden/expected/dogfood-verdict-matrix/pass.json
@@ -39,6 +39,12 @@
     "planned": 0,
     "skipped": true
   },
+  "oauth_scope_coverage_check": {
+    "checked": 0,
+    "covered": 0,
+    "detail": "spec not provided; OAuth scope coverage check skipped",
+    "skipped": true
+  },
   "path_check": {
     "tested": 0,
     "valid": 0,

--- a/testdata/golden/expected/dogfood-verdict-matrix/warn-priority.json
+++ b/testdata/golden/expected/dogfood-verdict-matrix/warn-priority.json
@@ -46,6 +46,12 @@
     "planned": 0,
     "skipped": true
   },
+  "oauth_scope_coverage_check": {
+    "checked": 0,
+    "covered": 0,
+    "detail": "spec not provided; OAuth scope coverage check skipped",
+    "skipped": true
+  },
   "path_check": {
     "tested": 0,
     "valid": 0,

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -42,6 +42,12 @@
     "planned": 0,
     "skipped": true
   },
+  "oauth_scope_coverage_check": {
+    "checked": 0,
+    "covered": 0,
+    "detail": "no OAuth-scoped endpoints in spec",
+    "skipped": true
+  },
   "path_check": {
     "tested": 0,
     "valid": 0,


### PR DESCRIPTION
## Summary
- add dogfood OAuth scope coverage reporting and fail verdicts when generated auth scopes miss scoped OpenAPI endpoints
- collect operation and root OAuth scope requirements from OpenAPI security metadata, including multi-scope and multi-scheme requirements
- add regressions for covered, uncovered, multi-scope, appended generated scopes, and root-level scope requirements

## Tests
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- go test ./...
- go vet ./...
- golangci-lint run ./...
- scripts/golden.sh verify

Closes #1527
