### PR TITLE
fix(cli): merge compatible auth metadata across specs

### DIFF
--- a/docs/solutions/logic-errors/multi-spec-auth-scope-union-2026-05-22.md
+++ b/docs/solutions/logic-errors/multi-spec-auth-scope-union-2026-05-22.md
@@ -1,0 +1,55 @@
+---
+title: Multi-spec auth metadata must merge only across compatible auth boundaries
+date: 2026-05-22
+category: logic-errors
+module: multi-spec OpenAPI generation
+problem_type: logic_error
+component: authentication
+symptoms:
+  - Generated combo CLIs requested only the primary spec's OAuth scopes
+  - Secondary API endpoints failed live calls with insufficient-permission responses
+root_cause: scope_issue
+resolution_type: code_fix
+severity: high
+tags: [multi-spec, oauth, auth-merge, generator]
+---
+
+# Multi-spec auth metadata must merge only across compatible auth boundaries
+
+## Problem
+Multi-spec generated CLIs used a single merged `AuthConfig`, but the merge path carried the primary spec's auth metadata instead of collecting compatible auth requirements from every input spec. OAuth-only combo CLIs could authenticate successfully and still fail secondary API calls because the consent flow never requested the secondary spec's scopes.
+
+## Symptoms
+- Generated `internal/cli/auth.go` contained only the primary spec's OAuth scopes.
+- Live calls to secondary API endpoints returned insufficient-permission errors.
+- Static checks stayed green because the generated CLI compiled and the missing scope surfaced only after a real secondary endpoint call.
+
+## What Didn't Work
+- Treating this as a printed-CLI issue would require hand-editing generated `auth.go`, but the next regeneration would drop the secondary scopes again.
+- Blindly unioning all auth metadata is unsafe. A single generated client sends `Auth.AdditionalHeaders` globally, so secondary API-key headers can leak to unrelated origins if they are promoted without an origin guard. OAuth scopes also cannot be mixed across different authorization or token URLs.
+
+## Solution
+Fix the generator-side multi-spec merge so it preserves the selected auth block but accumulates compatible auth requirements:
+
+- Union OAuth scopes only when the contributing spec has the same auth type, effective OAuth grant, authorization URL, token URL, and refresh-token mechanism.
+- Promote secondary header API keys only when they are explicit `in: header` credentials, have one canonical request credential, and share the selected auth spec's origin.
+- Keep query keys, ambiguous OR-style credential sets, and cross-origin secondary headers out of the global `Auth.AdditionalHeaders` list.
+
+The regression coverage should include both the happy path and the safety boundaries:
+
+- shared-provider OAuth specs produce an `auth.go` scope literal containing scopes from both specs
+- single-spec generation does not pick up unrelated secondary scopes
+- a later OAuth spec still becomes the merged auth source when the primary spec has no login URL
+- mismatched OAuth providers and cross-origin API-key specs do not pollute the selected auth block
+
+## Why This Works
+The generated CLI has one login flow and one global auth header path. Scope union is correct only when every contributing scope belongs to the same OAuth authority; otherwise the selected provider receives scopes it cannot grant. Additional API-key headers are also global today, so promoting them is safe only when the secondary spec shares the same origin as the selected auth source and the credential-to-header mapping is unambiguous.
+
+## Prevention
+- When broadening a multi-spec merge, audit whether the merged field is global at runtime or scoped per resource/endpoint.
+- Add negative tests for incompatible auth boundaries whenever a merge starts collecting metadata from secondary specs.
+- Prefer compatibility predicates over product-name special cases; combo CLIs should work across API families without hardcoded vendor assumptions.
+
+## Related Issues
+- GitHub issue #1526
+- `docs/solutions/design-patterns/auth-envvar-rich-model-2026-05-05.md`

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1011,7 +1011,7 @@ func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
 			In:     "header",
 			Scheme: "StandaloneKey",
 			EnvVarSpecs: []spec.AuthEnvVar{
-				{Name: "STANDALONE_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+				{Name: " STANDALONE_KEY ", Required: true, Sensitive: true},
 			},
 		},
 		Resources: map[string]spec.Resource{
@@ -1087,14 +1087,30 @@ func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
 		},
 		Types: map[string]spec.TypeDef{},
 	}
+	noFlowOAuth := &spec.APISpec{
+		Name:    "noflowoauth",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "bearer_token",
+			Header: "Authorization",
+			Scopes: []string{"read.noflow"},
+		},
+		Resources: map[string]spec.Resource{
+			"noflowoauth": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/noflowoauth"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
 
-	merged := mergeSpecs([]*spec.APISpec{primary, secondary, standaloneKey, queryKey, ambiguousKey, crossHostKey, foreignOAuth}, "combo")
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary, standaloneKey, queryKey, ambiguousKey, crossHostKey, foreignOAuth, noFlowOAuth}, "combo")
 
 	assert.Equal(t, []string{"read.primary", "read.secondary"}, merged.Auth.Scopes)
 	require.Len(t, merged.Auth.AdditionalHeaders, 3)
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Primary-Key", "PRIMARY_KEY")
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Secondary-Key", "SECONDARY_KEY")
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Standalone-Key", "STANDALONE_KEY")
+	assert.Equal(t, " STANDALONE_KEY ", standaloneKey.Auth.EnvVarSpecs[0].Name)
+	assert.Empty(t, standaloneKey.Auth.EnvVarSpecs[0].Kind)
 }
 
 func TestMergeSpecsUsesLaterOAuthAuthWhenPrimaryHasNoLogin(t *testing.T) {

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -959,6 +959,287 @@ func TestMergeSpecsPreservesPerSpecBaseURLPrefixes(t *testing.T) {
 	)
 }
 
+func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/auth",
+			TokenURL:         "https://accounts.example.com/token",
+			Scopes:           []string{"read.primary"},
+			AdditionalHeaders: []spec.AdditionalAuthHeader{
+				{Header: "X-Primary-Key", EnvVar: spec.AuthEnvVar{Name: "PRIMARY_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"primary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/primary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "secondary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/auth",
+			TokenURL:         "https://accounts.example.com/token",
+			Scopes:           []string{"read.secondary", "read.primary"},
+			AdditionalHeaders: []spec.AdditionalAuthHeader{
+				{Header: "X-Secondary-Key", EnvVar: spec.AuthEnvVar{Name: "SECONDARY_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+				{Header: "X-Primary-Key", EnvVar: spec.AuthEnvVar{Name: "PRIMARY_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"secondary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/secondary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	standaloneKey := &spec.APISpec{
+		Name:    "standalone",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "X-Standalone-Key",
+			In:     "header",
+			Scheme: "StandaloneKey",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "STANDALONE_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"standalone": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/standalone"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	queryKey := &spec.APISpec{
+		Name:    "querykey",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "api_key",
+			In:     "query",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "QUERY_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"querykey": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/querykey"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	ambiguousKey := &spec.APISpec{
+		Name:    "ambiguous",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "X-Ambiguous-Key",
+			In:     "header",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "AMBIGUOUS_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+				{Name: "AMBIGUOUS_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"ambiguous": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/ambiguous"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	crossHostKey := &spec.APISpec{
+		Name:    "crosshost",
+		Version: "0.1.0",
+		BaseURL: "https://other.example.net",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "X-Cross-Host-Key",
+			In:     "header",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "CROSS_HOST_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"crosshost": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/crosshost"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	foreignOAuth := &spec.APISpec{
+		Name:    "foreignoauth",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://login.other.example.net/auth",
+			TokenURL:         "https://login.other.example.net/token",
+			Scopes:           []string{"read.foreign"},
+		},
+		Resources: map[string]spec.Resource{
+			"foreignoauth": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/foreignoauth"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary, standaloneKey, queryKey, ambiguousKey, crossHostKey, foreignOAuth}, "combo")
+
+	assert.Equal(t, []string{"read.primary", "read.secondary"}, merged.Auth.Scopes)
+	require.Len(t, merged.Auth.AdditionalHeaders, 3)
+	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Primary-Key", "PRIMARY_KEY")
+	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Secondary-Key", "SECONDARY_KEY")
+	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Standalone-Key", "STANDALONE_KEY")
+}
+
+func TestMergeSpecsUsesLaterOAuthAuthWhenPrimaryHasNoLogin(t *testing.T) {
+	t.Parallel()
+
+	primary := &spec.APISpec{
+		Name:    "primary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"primary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/primary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	secondary := &spec.APISpec{
+		Name:    "secondary",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/auth",
+			TokenURL:         "https://accounts.example.com/token",
+			Scopes:           []string{"read.secondary"},
+		},
+		Resources: map[string]spec.Resource{
+			"secondary": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/secondary"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary}, "combo")
+
+	assert.Equal(t, "bearer_token", merged.Auth.Type)
+	assert.Equal(t, "https://accounts.example.com/auth", merged.Auth.AuthorizationURL)
+	assert.Equal(t, "https://accounts.example.com/token", merged.Auth.TokenURL)
+	assert.Equal(t, []string{"read.secondary"}, merged.Auth.Scopes)
+}
+
+func assertAdditionalAuthHeader(t *testing.T, headers []spec.AdditionalAuthHeader, wantHeader, wantEnvVar string) {
+	t.Helper()
+	for _, header := range headers {
+		if header.Header == wantHeader && header.EnvVar.Name == wantEnvVar {
+			return
+		}
+	}
+	assert.Failf(t, "missing additional auth header", "header %q with env var %q not found in %#v", wantHeader, wantEnvVar, headers)
+}
+
+func TestGenerateMultiSpecUnionsOAuthScopes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	primarySpecPath := filepath.Join(dir, "youtube.yaml")
+	analyticsSpecPath := filepath.Join(dir, "analytics.yaml")
+	outputDir := filepath.Join(dir, "youtube")
+	require.NoError(t, os.WriteFile(primarySpecPath, []byte(`openapi: 3.0.3
+info:
+  title: YouTube
+  version: 1.0.0
+servers:
+  - url: https://www.googleapis.com/youtube/v3
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/youtube: Manage YouTube account
+            https://www.googleapis.com/auth/youtube.readonly: View YouTube account
+security:
+  - OAuth2: []
+paths:
+  /channels:
+    get:
+      operationId: listChannels
+      responses:
+        "200":
+          description: OK
+`), 0o644))
+	require.NoError(t, os.WriteFile(analyticsSpecPath, []byte(`openapi: 3.0.3
+info:
+  title: YouTube Analytics
+  version: 1.0.0
+servers:
+  - url: https://youtubeanalytics.googleapis.com/v2
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/yt-analytics.readonly: View YouTube analytics reports
+security:
+  - OAuth2: []
+paths:
+  /reports:
+    get:
+      operationId: queryReports
+      responses:
+        "200":
+          description: OK
+`), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", primarySpecPath,
+		"--spec", analyticsSpecPath,
+		"--name", "youtube",
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	authFile, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	authSource := string(authFile)
+	assert.Contains(t, authSource, `"https://www.googleapis.com/auth/youtube"`)
+	assert.Contains(t, authSource, `"https://www.googleapis.com/auth/youtube.readonly"`)
+	assert.Contains(t, authSource, `"https://www.googleapis.com/auth/yt-analytics.readonly"`)
+
+	singleOutputDir := filepath.Join(dir, "youtube-single")
+	cmd = newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", primarySpecPath,
+		"--name", "youtube",
+		"--output", singleOutputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	singleAuthFile, err := os.ReadFile(filepath.Join(singleOutputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(singleAuthFile), "yt-analytics.readonly")
+}
+
 func TestGenerateMultiSpecEmitsNestedResourceBaseURLPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1151,6 +1151,31 @@ func TestMergeSpecsUsesLaterOAuthAuthWhenPrimaryHasNoLogin(t *testing.T) {
 	assert.Equal(t, []string{"read.secondary"}, merged.Auth.Scopes)
 }
 
+func TestMergeSpecsPreservesSingleSpecAuthScopeOrder(t *testing.T) {
+	t.Parallel()
+
+	single := &spec.APISpec{
+		Name:    "single",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/auth",
+			TokenURL:         "https://accounts.example.com/token",
+			Scopes:           []string{"scope.z", "scope.a"},
+		},
+		Resources: map[string]spec.Resource{
+			"single": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/single"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{single}, "single")
+
+	assert.Equal(t, []string{"scope.z", "scope.a"}, merged.Auth.Scopes)
+}
+
 func assertAdditionalAuthHeader(t *testing.T, headers []spec.AdditionalAuthHeader, wantHeader, wantEnvVar string) {
 	t.Helper()
 	for _, header := range headers {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -911,6 +911,10 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 }
 
 func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
+	if len(specs) == 1 {
+		return specs[0].Auth
+	}
+
 	auth := specs[0].Auth
 	authSpecIndex := 0
 	if auth.AuthorizationURL == "" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -844,7 +845,7 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 		Version:     specs[0].Version,
 		BaseURL:     mergedBaseURL,
 		BasePath:    specs[0].BasePath,
-		Auth:        specs[0].Auth,
+		Auth:        mergeMultiSpecAuth(specs),
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
@@ -901,16 +902,183 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 			merged.Types[key] = typeDef
 		}
 
-		if s.Auth.AuthorizationURL != "" && merged.Auth.AuthorizationURL == "" {
-			merged.Auth = s.Auth
-		}
-
 		if mcpConfigured(s.MCP) && !mcpConfigured(merged.MCP) {
 			merged.MCP = rewriteMCPIntentEndpointRefs(s.MCP, resourceRenames)
 		}
 	}
 
 	return merged
+}
+
+func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
+	auth := specs[0].Auth
+	authSpecIndex := 0
+	if auth.AuthorizationURL == "" {
+		for i, s := range specs[1:] {
+			if s.Auth.AuthorizationURL != "" {
+				auth = s.Auth
+				authSpecIndex = i + 1
+				break
+			}
+		}
+	}
+	authOrigin := baseURLOrigin(specs[authSpecIndex].BaseURL)
+
+	scopeSet := make(map[string]struct{}, len(auth.Scopes))
+	for _, scope := range auth.Scopes {
+		if scope = strings.TrimSpace(scope); scope != "" {
+			scopeSet[scope] = struct{}{}
+		}
+	}
+	headers := append([]spec.AdditionalAuthHeader(nil), auth.AdditionalHeaders...)
+	seenHeaders := make(map[string]struct{}, len(headers)+1)
+	seenEnvVars := make(map[string]struct{}, len(headers)+len(auth.EnvVarSpecs)+len(auth.EnvVars))
+	seedAuthHeaderDedupe(seenHeaders, seenEnvVars, auth)
+
+	for _, s := range specs {
+		if compatibleOAuthScopeAuth(auth, s.Auth) {
+			for _, scope := range s.Auth.Scopes {
+				if scope = strings.TrimSpace(scope); scope != "" {
+					scopeSet[scope] = struct{}{}
+				}
+			}
+		}
+		headers = appendUniqueAdditionalAuthHeaders(headers, seenHeaders, seenEnvVars, s.Auth, baseURLOrigin(s.BaseURL) == authOrigin)
+	}
+
+	auth.Scopes = sortedScopes(scopeSet)
+	auth.AdditionalHeaders = headers
+	return auth
+}
+
+func seedAuthHeaderDedupe(seenHeaders, seenEnvVars map[string]struct{}, auth spec.AuthConfig) {
+	if header := strings.TrimSpace(auth.Header); header != "" {
+		seenHeaders[header] = struct{}{}
+	}
+	for _, envVar := range auth.EnvVarSpecs {
+		if name := strings.TrimSpace(envVar.Name); name != "" {
+			seenEnvVars[name] = struct{}{}
+		}
+	}
+	for _, name := range auth.EnvVars {
+		if name = strings.TrimSpace(name); name != "" {
+			seenEnvVars[name] = struct{}{}
+		}
+	}
+	for _, header := range auth.AdditionalHeaders {
+		if name := strings.TrimSpace(header.Header); name != "" {
+			seenHeaders[name] = struct{}{}
+		}
+		if name := strings.TrimSpace(header.EnvVar.Name); name != "" {
+			seenEnvVars[name] = struct{}{}
+		}
+	}
+}
+
+func compatibleOAuthScopeAuth(base, incoming spec.AuthConfig) bool {
+	if len(incoming.Scopes) == 0 {
+		return false
+	}
+	if base.Type != incoming.Type || base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
+		return false
+	}
+	if normalizeAuthURL(base.AuthorizationURL) != normalizeAuthURL(incoming.AuthorizationURL) {
+		return false
+	}
+	if normalizeAuthURL(base.TokenURL) != normalizeAuthURL(incoming.TokenURL) {
+		return false
+	}
+	return strings.TrimSpace(base.RefreshTokenMechanism) == strings.TrimSpace(incoming.RefreshTokenMechanism)
+}
+
+func appendUniqueAdditionalAuthHeaders(headers []spec.AdditionalAuthHeader, seenHeaders, seenEnvVars map[string]struct{}, auth spec.AuthConfig, sameOrigin bool) []spec.AdditionalAuthHeader {
+	var candidates []spec.AdditionalAuthHeader
+	if sameOrigin {
+		candidates = append(candidates, auth.AdditionalHeaders...)
+		if promoted, ok := additionalHeaderFromAPIKeyAuth(auth); ok {
+			candidates = append(candidates, promoted)
+		}
+	}
+	for _, candidate := range candidates {
+		header := strings.TrimSpace(candidate.Header)
+		envVarName := strings.TrimSpace(candidate.EnvVar.Name)
+		if header == "" || envVarName == "" {
+			continue
+		}
+		if _, exists := seenHeaders[header]; exists {
+			continue
+		}
+		if _, exists := seenEnvVars[envVarName]; exists {
+			continue
+		}
+		seenHeaders[header] = struct{}{}
+		seenEnvVars[envVarName] = struct{}{}
+		headers = append(headers, candidate)
+	}
+	return headers
+}
+
+func sortedScopes(scopeSet map[string]struct{}) []string {
+	if len(scopeSet) == 0 {
+		return nil
+	}
+	scopes := make([]string, 0, len(scopeSet))
+	for scope := range scopeSet {
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	return scopes
+}
+
+func additionalHeaderFromAPIKeyAuth(auth spec.AuthConfig) (spec.AdditionalAuthHeader, bool) {
+	if auth.Type != "api_key" || strings.TrimSpace(auth.Header) == "" || !strings.EqualFold(strings.TrimSpace(auth.In), "header") {
+		return spec.AdditionalAuthHeader{}, false
+	}
+	if strings.Contains(strings.ToLower(auth.Format), "basic ") {
+		return spec.AdditionalAuthHeader{}, false
+	}
+	if auth.IsAuthEnvVarORCase() {
+		return spec.AdditionalAuthHeader{}, false
+	}
+	auth.NormalizeEnvVarSpecs("")
+	var requestCredential spec.AuthEnvVar
+	for _, envVar := range auth.EnvVarSpecs {
+		if envVar.IsRequestCredential() && strings.TrimSpace(envVar.Name) != "" {
+			if strings.TrimSpace(requestCredential.Name) != "" {
+				return spec.AdditionalAuthHeader{}, false
+			}
+			requestCredential = envVar
+		}
+	}
+	if strings.TrimSpace(requestCredential.Name) == "" {
+		return spec.AdditionalAuthHeader{}, false
+	}
+	return spec.AdditionalAuthHeader{
+		Header: strings.TrimSpace(auth.Header),
+		In:     "header",
+		Scheme: auth.Scheme,
+		EnvVar: requestCredential,
+	}, true
+}
+
+func baseURLOrigin(raw string) string {
+	host, _ := splitBaseURL(raw)
+	return host
+}
+
+func normalizeAuthURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return strings.TrimRight(raw, "/")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return parsed.String()
 }
 
 func rewriteMCPIntentEndpointRefs(mcp spec.MCPConfig, resourceRenames map[string]string) spec.MCPConfig {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -979,6 +979,9 @@ func compatibleOAuthScopeAuth(base, incoming spec.AuthConfig) bool {
 	if len(incoming.Scopes) == 0 {
 		return false
 	}
+	if strings.TrimSpace(base.AuthorizationURL) == "" {
+		return false
+	}
 	if base.Type != incoming.Type || base.EffectiveOAuth2Grant() != incoming.EffectiveOAuth2Grant() {
 		return false
 	}
@@ -1040,6 +1043,7 @@ func additionalHeaderFromAPIKeyAuth(auth spec.AuthConfig) (spec.AdditionalAuthHe
 	if auth.IsAuthEnvVarORCase() {
 		return spec.AdditionalAuthHeader{}, false
 	}
+	auth.EnvVarSpecs = append([]spec.AuthEnvVar(nil), auth.EnvVarSpecs...)
 	auth.NormalizeEnvVarSpecs("")
 	var requestCredential spec.AuthEnvVar
 	for _, envVar := range auth.EnvVarSpecs {


### PR DESCRIPTION
## Summary

Multi-spec OpenAPI generation now carries compatible auth requirements from secondary specs into the generated CLI. Combo CLIs that share one OAuth authority request the union of scopes, so secondary API commands can authorize without hand-editing generated `auth.go`.

The merge stays bounded by auth boundaries: OAuth scopes are unioned only when the provider metadata matches, and secondary header credentials are promoted only for same-origin specs with one unambiguous request credential. Cross-origin API keys, query keys, OR-style credentials, and foreign OAuth scopes stay out of the global auth config.

I also captured the root cause and guardrails in `docs/solutions/logic-errors/multi-spec-auth-scope-union-2026-05-22.md`.

Closes #1526

## Verification

- `GOCACHE=/tmp/pp-issue-1526-go-cache go test ./internal/cli`
- `GOCACHE=/tmp/pp-issue-1526-go-cache go test ./...`
- `GOCACHE=/tmp/pp-issue-1526-go-cache go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `GOCACHE=/tmp/pp-issue-1526-go-cache go fmt ./...`
- `GOCACHE=/tmp/pp-issue-1526-go-cache golangci-lint run ./...`
- `GOCACHE=/tmp/pp-issue-1526-go-cache scripts/golden.sh verify`
