### PR TITLE
fix(cli): select OpenAPI auth by operation usage

### DIFF
--- a/docs/solutions/logic-errors/openapi-security-scheme-usage-counts.md
+++ b/docs/solutions/logic-errors/openapi-security-scheme-usage-counts.md
@@ -1,0 +1,60 @@
+---
+title: "OpenAPI security scheme selection by operation usage"
+date: 2026-05-22
+category: logic-errors
+module: internal/openapi
+problem_type: logic_error
+component: authentication
+symptoms:
+  - "Multi-scheme OpenAPI specs could pick a narrow security scheme as primary even when most operations used a different scheme"
+  - "Generated config and manifest auth_env_vars could point at a one-off endpoint credential instead of the API-wide credential"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - testing_framework
+tags:
+  - openapi-parser
+  - auth-selection
+  - security-schemes
+  - operation-security
+---
+
+# OpenAPI security scheme selection by operation usage
+
+## Problem
+
+OpenAPI specs can declare several `components.securitySchemes`, but not every scheme represents the API-wide credential. If the parser picks by declaration order or type priority alone, a scheme used by one operation can become the generated CLI's primary auth.
+
+## Symptoms
+
+- A Pinterest-like spec declared both OAuth2 and a narrow bearer token, but the narrow bearer scheme won primary selection.
+- Generated `Auth.EnvVars` and downstream manifests followed the wrong selected scheme.
+- Manual generated-CLI patches could fix `config.go`, but manifest metadata stayed wrong because the parser remained the source of truth.
+
+## What Didn't Work
+
+- **Components-only ranking.** `components.securitySchemes` describes available schemes, not which one the operation surface primarily uses.
+- **Type priority alone.** Keeping bearer above OAuth2 is still useful for equal alternatives, but it should not let a one-off bearer endpoint outrank a broadly referenced OAuth2 scheme.
+- **Filtering only by root security.** Operation-level `security` overrides root security, so candidate selection must consider effective operation security rather than root declarations alone.
+
+## Solution
+
+Count effective security requirements across operations before applying the existing scheme type priority. For each operation, use operation-level `security` when present, otherwise inherit root `security`. Count each scheme at most once per operation, then select the highest reference count; equal counts keep the existing `schemePriorityScore` tie-break.
+
+`AuthPreference` remains an explicit override: it resolves directly against `components.securitySchemes` before usage-based filtering.
+
+## Why This Works
+
+The selected auth scheme now reflects what the generated CLI will use for the broad operation surface, while retaining established behavior for equal alternatives, single-scheme specs, no-operation fallback cases, and explicit caller preferences.
+
+## Prevention
+
+- Add parser fixtures where a high-priority scheme is used narrowly and a lower-priority scheme is used broadly.
+- Cover root-inherited operations mixed with operation-level overrides, since both feed the same effective security histogram.
+- Keep `AuthPreference` tests independent from the default selector so explicit catalog or caller overrides cannot be broken by ranking changes.
+
+## Related Issues
+
+- [Issue #1532](https://github.com/mvanhorn/cli-printing-press/issues/1532)
+- [Inline Authorization params: conservative bearer inference](inline-authorization-param-bearer-inference-2026-05-05.md)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1985,8 +1985,6 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 		return "", nil
 	}
 
-	usageCounts := securitySchemeOperationUsageCounts(doc)
-
 	if pref := strings.TrimSpace(authPreference); pref != "" {
 		for _, name := range allSecuritySchemeNames(doc) {
 			if !strings.EqualFold(name, pref) {
@@ -1999,6 +1997,7 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 		}
 	}
 
+	usageCounts := securitySchemeOperationUsageCounts(doc)
 	candidates := candidateSecuritySchemeNames(doc, usageCounts)
 
 	bestScore := math.MaxInt
@@ -2498,26 +2497,22 @@ func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op 
 //   - The operation has security: [{}] (empty object = anonymous alternative)
 //   - The operation inherits global security and the global security is empty
 func operationAllowsAnonymous(op *openapi3.Operation, doc *openapi3.T) bool {
-	requirements := effectiveSecurityRequirements(op, doc)
 	if op != nil && op.Security != nil {
-		// Per-operation security declared
-		if len(requirements) == 0 {
-			return true // security: []
-		}
-		for _, req := range requirements {
-			if len(req) == 0 {
-				return true // security: [{}]
-			}
-		}
-		return false
+		return securityRequirementsAllowAnonymous(*op.Security)
 	}
-	// op.Security is nil — inherits global security
-	if doc != nil && doc.Security != nil && len(requirements) == 0 {
-		return true // global security: []
+	if doc != nil && doc.Security != nil {
+		return securityRequirementsAllowAnonymous(doc.Security)
+	}
+	return false
+}
+
+func securityRequirementsAllowAnonymous(requirements openapi3.SecurityRequirements) bool {
+	if len(requirements) == 0 {
+		return true
 	}
 	for _, req := range requirements {
 		if len(req) == 0 {
-			return true // global security: [{}]
+			return true
 		}
 	}
 	return false

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1985,10 +1985,10 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 		return "", nil
 	}
 
-	candidates := candidateSecuritySchemeNames(doc)
+	usageCounts := securitySchemeOperationUsageCounts(doc)
 
 	if pref := strings.TrimSpace(authPreference); pref != "" {
-		for _, name := range candidates {
+		for _, name := range allSecuritySchemeNames(doc) {
 			if !strings.EqualFold(name, pref) {
 				continue
 			}
@@ -1999,7 +1999,10 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 		}
 	}
 
+	candidates := candidateSecuritySchemeNames(doc, usageCounts)
+
 	bestScore := math.MaxInt
+	bestUsageCount := 0
 	var bestName string
 	var bestScheme *openapi3.SecurityScheme
 
@@ -2008,8 +2011,10 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 		if scheme == nil {
 			continue
 		}
+		usageCount := usageCounts[name]
 		score := schemePriorityScore(scheme)
-		if score < bestScore {
+		if usageCount > bestUsageCount || (usageCount == bestUsageCount && score < bestScore) {
+			bestUsageCount = usageCount
 			bestScore = score
 			bestName = name
 			bestScheme = scheme
@@ -2019,13 +2024,23 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 	return bestName, bestScheme
 }
 
-// Root security is authoritative when present: a components-only scheme
-// (e.g. an OAuth2 marketplace flow the API doesn't actually accept at the
-// document default) must not outrank an apiKey the spec explicitly named.
-// The empty-names guard handles `security: []` and `security: [{}]`
-// no-auth declarations, where falling back to components recovers the
-// previous behavior for inferred-auth specs.
-func candidateSecuritySchemeNames(doc *openapi3.T) []string {
+// Effective operation security is authoritative when present: a
+// components-only scheme (e.g. an OAuth2 marketplace flow the API doesn't
+// actually accept) must not outrank a scheme used by the operation surface.
+// The root-security fallback covers specs without paths or security-bearing
+// operations. The empty-names guard handles `security: []` and `security: [{}]`
+// no-auth declarations, where falling back to components recovers the previous
+// behavior for inferred-auth specs.
+func candidateSecuritySchemeNames(doc *openapi3.T, usageCounts map[string]int) []string {
+	if len(usageCounts) > 0 {
+		names := make([]string, 0, len(usageCounts))
+		for name := range usageCounts {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return names
+	}
+
 	seen := map[string]struct{}{}
 	var names []string
 
@@ -2049,12 +2064,59 @@ func candidateSecuritySchemeNames(doc *openapi3.T) []string {
 		}
 	}
 
-	all := make([]string, 0, len(doc.Components.SecuritySchemes))
-	for name := range doc.Components.SecuritySchemes {
-		all = append(all, name)
+	return allSecuritySchemeNames(doc)
+}
+
+func allSecuritySchemeNames(doc *openapi3.T) []string {
+	if doc == nil || doc.Components == nil {
+		return nil
 	}
-	sort.Strings(all)
-	return all
+	names := make([]string, 0, len(doc.Components.SecuritySchemes))
+	for name := range doc.Components.SecuritySchemes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func securitySchemeOperationUsageCounts(doc *openapi3.T) map[string]int {
+	counts := map[string]int{}
+	if doc == nil || doc.Paths == nil {
+		return counts
+	}
+
+	for _, pathItem := range doc.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			if op == nil {
+				continue
+			}
+			requirements := effectiveSecurityRequirements(op, doc)
+			counted := map[string]struct{}{}
+			for _, requirement := range requirements {
+				for name := range requirement {
+					if _, ok := counted[name]; ok {
+						continue
+					}
+					counted[name] = struct{}{}
+					counts[name]++
+				}
+			}
+		}
+	}
+	return counts
+}
+
+func effectiveSecurityRequirements(op *openapi3.Operation, doc *openapi3.T) openapi3.SecurityRequirements {
+	if op != nil && op.Security != nil {
+		return *op.Security
+	}
+	if doc == nil {
+		return nil
+	}
+	return doc.Security
 }
 
 // Ordering rationale: Bearer is the simplest for CLI use; OAuth2 flows rank
@@ -2436,12 +2498,13 @@ func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op 
 //   - The operation has security: [{}] (empty object = anonymous alternative)
 //   - The operation inherits global security and the global security is empty
 func operationAllowsAnonymous(op *openapi3.Operation, doc *openapi3.T) bool {
-	if op.Security != nil {
+	requirements := effectiveSecurityRequirements(op, doc)
+	if op != nil && op.Security != nil {
 		// Per-operation security declared
-		if len(*op.Security) == 0 {
+		if len(requirements) == 0 {
 			return true // security: []
 		}
-		for _, req := range *op.Security {
+		for _, req := range requirements {
 			if len(req) == 0 {
 				return true // security: [{}]
 			}
@@ -2449,10 +2512,10 @@ func operationAllowsAnonymous(op *openapi3.Operation, doc *openapi3.T) bool {
 		return false
 	}
 	// op.Security is nil — inherits global security
-	if doc.Security != nil && len(doc.Security) == 0 {
+	if doc != nil && doc.Security != nil && len(requirements) == 0 {
 		return true // global security: []
 	}
-	for _, req := range doc.Security {
+	for _, req := range requirements {
 		if len(req) == 0 {
 			return true // global security: [{}]
 		}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -1455,6 +1455,48 @@ paths:
 	assert.Equal(t, "bearer_token", parsed.Auth.Type)
 }
 
+func TestParseAuthPreferenceCanSelectUnusedComponentsScheme(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: Preference Override
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read: read access
+paths:
+  /v1/items:
+    get:
+      operationId: list items
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := ParseWithOptions(specBytes, ParseOptions{AuthPreference: "OAuth2"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "OAuth2", parsed.Auth.Scheme, "explicit auth preference must override usage-based filtering")
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, []string{"PREFERENCE_OVERRIDE_OAUTH2"}, parsed.Auth.EnvVars)
+	assert.Equal(t, "https://auth.example.com/authorize", parsed.Auth.AuthorizationURL)
+	assert.Equal(t, "https://auth.example.com/token", parsed.Auth.TokenURL)
+}
+
 func TestParseBearerPreservedOverOAuth2AuthCode(t *testing.T) {
 	t.Parallel()
 
@@ -1504,6 +1546,145 @@ paths:
 	assert.Equal(t, "bearer_token", preferred.Auth.Type)
 	assert.Equal(t, "https://auth.example.com/authorize", preferred.Auth.AuthorizationURL)
 	assert.Equal(t, "https://auth.example.com/token", preferred.Auth.TokenURL)
+}
+
+func TestParseSecuritySchemeReferenceCountBeatsTypePriority(t *testing.T) {
+	t.Parallel()
+
+	var paths strings.Builder
+	for i := range 10 {
+		fmt.Fprintf(&paths, `  /v1/oauth-items/%d:
+    get:
+      operationId: list oauth items %d
+      security:
+        - OAuth2: [read]
+      responses: {"200": {description: ok}}
+`, i, i)
+	}
+	paths.WriteString(`  /v1/events:
+    post:
+      operationId: create event
+      security:
+        - ConversionToken: []
+      responses: {"200": {description: ok}}
+`)
+
+	specBytes := fmt.Appendf(nil, `openapi: "3.0.3"
+info:
+  title: Pinterest-like
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ConversionToken:
+      type: http
+      scheme: bearer
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read: read access
+paths:
+%s`, paths.String())
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "OAuth2", parsed.Auth.Scheme, "scheme used by most operations must become the primary auth scheme")
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, []string{"PINTEREST_LIKE_OAUTH2"}, parsed.Auth.EnvVars)
+	assert.Equal(t, "https://auth.example.com/authorize", parsed.Auth.AuthorizationURL)
+	assert.Equal(t, "https://auth.example.com/token", parsed.Auth.TokenURL)
+}
+
+func TestParseOperationSecurityOverridesRootSecurityCandidates(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: Override Root
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read: read access
+paths:
+  /v1/overridden:
+    get:
+      operationId: list overridden
+      security:
+        - OAuth2: [read]
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "OAuth2", parsed.Auth.Scheme, "operation-level security overrides root security and must stay selectable")
+	assert.Equal(t, []string{"OVERRIDE_ROOT_OAUTH2"}, parsed.Auth.EnvVars)
+}
+
+func TestParseInheritedRootSecurityContributesToReferenceCount(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: Root Majority
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    BearerEventToken:
+      type: http
+      scheme: bearer
+paths:
+  /v1/root-a:
+    get:
+      operationId: list root a
+      responses: {"200": {description: ok}}
+  /v1/root-b:
+    get:
+      operationId: list root b
+      responses: {"200": {description: ok}}
+  /v1/events:
+    post:
+      operationId: create event
+      security:
+        - BearerEventToken: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ApiKeyAuth", parsed.Auth.Scheme, "root security inherited by most operations must count toward primary auth selection")
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, []string{"ROOT_MAJORITY_API_KEY"}, parsed.Auth.EnvVars)
 }
 
 func TestBearerSchemeNameCanSpecializeEnvVar(t *testing.T) {


### PR DESCRIPTION
## Summary

OpenAPI auth selection now follows the operation surface instead of letting a narrowly used scheme win solely by type priority. A Pinterest-like spec where OAuth2 protects most operations and a separate bearer token protects one endpoint now generates primary auth from the broadly used OAuth2 scheme, while equal-usage alternatives keep the existing bearer-first tie-break and explicit `AuthPreference` overrides still win.

The parser counts effective per-operation security requirements, including root-security inheritance and operation-level overrides, before falling back to the previous candidate and type-priority behavior. This keeps generated config and manifest auth metadata aligned with the same selected primary scheme.

## Compounded learnings

- Documented the durable rule in `docs/solutions/logic-errors/openapi-security-scheme-usage-counts.md`.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `ruby -rdate -ryaml -e ... docs/solutions/logic-errors/openapi-security-scheme-usage-counts.md`

Closes #1532
