### PR TITLE
fix(cli): set generation category for non-catalog runs

### DIFF
--- a/docs/solutions/logic-errors/non-catalog-category-must-enter-generate-before-emission-2026-05-22.md
+++ b/docs/solutions/logic-errors/non-catalog-category-must-enter-generate-before-emission-2026-05-22.md
@@ -1,0 +1,51 @@
+---
+title: Non-catalog category must enter generate before emission
+date: 2026-05-22
+category: logic-errors
+module: cli-printing-press generate and printing-press skill
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Non-catalog CLIs could publish with a manifest category added after generation
+  - Generated SKILL install sections could drift from manifest-derived canonical expectations
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+tags: [category, manifest, skill, generator, publish]
+---
+
+# Non-catalog category must enter generate before emission
+
+## Problem
+Non-catalog runs learn the API domain during research, but that category must reach generation before the generator writes the manifest, README, and SKILL install section. Adding a category later to satisfy publish can make those emitted surfaces disagree and trigger canonical-section failures.
+
+## Symptoms
+- Browser-sniffed, HAR, docs-derived, or hand-authored internal-spec CLIs can produce `.printing-press.json` without `category`.
+- A post-generation manifest edit can satisfy publish but leave `SKILL.md` with the category-agnostic install fallback.
+- `verify-skill canonical-sections` then compares the category-aware manifest expectation to the category-agnostic generated SKILL section and fails.
+
+## What Didn't Work
+- Treating this only as a skill prose issue missed docs-only generation. Direct `generate --docs` builds an `APISpec` in memory, so there may be no editable spec artifact where an agent can insert `category:` before emission.
+- Letting a user-provided category override catalog metadata recreated the same drift in the opposite direction: generated surfaces could use the flag value while manifest writing still preferred the embedded catalog category.
+
+## Solution
+Make category a generation-time input and keep catalog metadata authoritative:
+
+- Add `generate --category <catalog-category>` for non-catalog runs that do not already have `category:` authored into an editable spec.
+- Validate the flag against the public catalog category enum at the CLI boundary.
+- Apply the category before templates, tools manifests, and `.printing-press.json` generation read the spec.
+- Keep embedded catalog categories authoritative by letting catalog enrichment overwrite any supplied category when a catalog entry matches.
+- Update the Printing Press skill's Phase 2 command blocks so non-catalog examples carry `--category <catalog-category>`, while catalog-config runs omit it.
+
+## Why This Works
+The generated manifest, README, and SKILL are all downstream of the same `APISpec`. Supplying category before `runGenerateProject` means every emitted surface sees one value. Catalog enrichment stays the highest-precedence source for catalog entries, so a non-catalog convenience flag cannot split generated install prose from manifest-derived verification expectations.
+
+## Prevention
+- When a value affects generated files and publish metadata, route it into the generator before emission rather than patching one artifact afterward.
+- Regression tests should cover both sides of precedence: non-catalog generation accepts a category input, and catalog enrichment still wins over a conflicting supplied value.
+- Skill command blocks need the same contract as prose. If the prose says a workflow value is required, the runnable examples should show the flag or explain when to omit it.
+
+## Related Issues
+- GitHub issue #1712
+- `docs/solutions/conventions/manifest-wins-over-re-derivation-for-identity-fields-in-regen-paths-2026-05-12.md`
+- `docs/solutions/best-practices/cross-repo-coordination-with-printing-press-library-2026-05-06.md`

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -2510,6 +2510,8 @@ func TestEnrichSpecFromCatalogMatchesSpecURLWhenSlugDiffers(t *testing.T) {
 }
 
 func TestEnrichSpecFromCatalogCategoryWinsOverFlagValue(t *testing.T) {
+	t.Parallel()
+
 	apiSpec := &spec.APISpec{
 		Name:     "asana",
 		Category: "developer-tools",

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -2044,6 +2044,29 @@ func TestNormalizeHTTPTransportAllowsBrowserChromeH3(t *testing.T) {
 	require.ErrorContains(t, err, "--transport must be one of")
 }
 
+func TestApplyGenerateSpecFlagsSetsPublicCategory(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{Name: "docs-api"}
+
+	require.NoError(t, applyGenerateSpecFlags(apiSpec, "", "docs", "travel", "", "", ""))
+
+	assert.Equal(t, "docs", apiSpec.SpecSource)
+	assert.Equal(t, "travel", apiSpec.Category)
+}
+
+func TestApplyGenerateSpecFlagsRejectsUnknownCategory(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{Name: "docs-api"}
+
+	err := applyGenerateSpecFlags(apiSpec, "", "docs", "banana", "", "", "")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--category must be one of:")
+	assert.Empty(t, apiSpec.Category)
+}
+
 // TestApplyHTTPTransportDefaultPreservesH2ForProtectionPath pins the
 // protection-driven branch (Cloudflare/DataDome/html_scrape/browser
 // hints without a reachability mode). Pre-fix the template's else
@@ -2484,6 +2507,17 @@ func TestEnrichSpecFromCatalogMatchesSpecURLWhenSlugDiffers(t *testing.T) {
 	assert.False(t, apiSpec.DisplayNameDerivedFromTitle)
 	assert.Equal(t, "cloud", apiSpec.Category)
 	assert.Equal(t, "https://cloud.google.com/run/docs/reference/rest", apiSpec.WebsiteURL)
+}
+
+func TestEnrichSpecFromCatalogCategoryWinsOverFlagValue(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Name:     "asana",
+		Category: "developer-tools",
+	}
+
+	enrichSpecFromCatalog(apiSpec)
+
+	assert.Equal(t, "project-management", apiSpec.Category)
 }
 
 func TestRunGenerateProjectUsesCatalogDescription(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -112,6 +112,7 @@ func newGenerateCmd() *cobra.Command {
 	var asJSON bool
 	var dryRun bool
 	var specSource string
+	var category string
 	var clientPattern string
 	var httpTransport string
 	var researchDir string
@@ -174,7 +175,7 @@ func newGenerateCmd() *cobra.Command {
 				if err != nil {
 					return &ExitError{Code: ExitSpecError, Err: fmt.Errorf("parsing generated spec: %w", err)}
 				}
-				if err := applyGenerateSpecFlags(parsed, specSource, "docs", clientPattern, httpTransport, owner); err != nil {
+				if err := applyGenerateSpecFlags(parsed, specSource, "docs", category, clientPattern, httpTransport, owner); err != nil {
 					return err
 				}
 
@@ -350,7 +351,7 @@ func newGenerateCmd() *cobra.Command {
 				apiSpec = mergeSpecs(specs, cliName)
 			}
 
-			if err := applyGenerateSpecFlags(apiSpec, specSource, "", clientPattern, httpTransport, owner); err != nil {
+			if err := applyGenerateSpecFlags(apiSpec, specSource, "", category, clientPattern, httpTransport, owner); err != nil {
 				return err
 			}
 
@@ -458,6 +459,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Parse spec and show what would be generated without writing files (remote specs are still fetched)")
 	cmd.Flags().StringVar(&specSource, "spec-source", "", "Spec provenance: official, community, sniffed/browser-sniffed, docs (affects generated client defaults like rate limiting)")
+	cmd.Flags().StringVar(&category, "category", "", "Public-library category for non-catalog generation")
 	cmd.Flags().StringVar(&clientPattern, "client-pattern", "", "HTTP client pattern: rest (default), proxy-envelope (wraps requests in POST envelope)")
 	cmd.Flags().StringVar(&httpTransport, "transport", "", "HTTP transport: standard, browser-http, browser-chrome, or browser-chrome-h3 (defaults based on spec provenance and reachability)")
 	cmd.Flags().StringVar(&researchDir, "research-dir", "", "Pipeline directory containing research.json and discovery/ for README source credits")
@@ -566,7 +568,7 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	}, nil
 }
 
-func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource, clientPattern, httpTransport, owner string) error {
+func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource, category, clientPattern, httpTransport, owner string) error {
 	if specSource != "" {
 		normalized, err := normalizeSpecSource(specSource)
 		if err != nil {
@@ -575,6 +577,15 @@ func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource
 		apiSpec.SpecSource = normalized
 	} else if defaultSpecSource != "" {
 		apiSpec.SpecSource = defaultSpecSource
+	}
+	if category != "" {
+		if !catalog.IsPublicCategory(category) {
+			return &ExitError{
+				Code: ExitInputError,
+				Err:  fmt.Errorf("--category must be one of: %s", strings.Join(catalog.PublicCategories(), ", ")),
+			}
+		}
+		apiSpec.Category = category
 	}
 	if clientPattern != "" {
 		normalized, err := normalizeClientPattern(clientPattern)
@@ -1987,7 +1998,7 @@ func enrichSpecFromCatalogEntry(apiSpec *spec.APISpec, entry *catalog.Entry) {
 		apiSpec.BaseURL = strings.TrimRight(entry.BaseURL, "/")
 		apiSpec.BaseURLIsPlaceholder = false
 	}
-	if entry.Category != "" && apiSpec.Category == "" {
+	if entry.Category != "" {
 		apiSpec.Category = entry.Category
 	}
 	if entry.Owner != "" && apiSpec.Owner == "" {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -129,6 +129,21 @@ func TestPrintingPressSkillUsesRunstateForBuilds(t *testing.T) {
 	assert.Contains(t, skill, `$PRESS_LIBRARY/<api>`)
 }
 
+func TestPrintingPressSkillSetsNonCatalogCategoryBeforeGenerate(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	block := substringBetween(t, skill, "### Pre-Generation Category Enrichment", "### Pre-Generation Auth Enrichment")
+	generateBlocks := substringBetween(t, skill, "OpenAPI / internal YAML:", "GraphQL-only APIs:")
+
+	assert.Contains(t, block, "non-catalog CLI")
+	assert.Contains(t, block, "set the spec's top-level `category` before")
+	assert.Contains(t, block, "`docs/CATALOG.md`")
+	assert.Contains(t, block, "before the final `generate` invocation")
+	assert.Contains(t, block, "`--category <catalog-category>`")
+	assert.Contains(t, block, "Catalog-mode runs skip this step")
+	assert.Contains(t, block, "verify-skill canonical-sections")
+	assert.GreaterOrEqual(t, strings.Count(generateBlocks, "--category <catalog-category>"), 7)
+}
+
 func TestPrintingPressSkillExamplesUseCurrentCLINaming(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1755,6 +1755,34 @@ Proceed silently to Phase 2.
 
 ## Phase 2: Generate
 
+### Pre-Generation Category Enrichment
+
+Before generating a non-catalog CLI, set the spec's top-level `category` before
+running `generate`. The category must come from the Phase 1 research brief's
+domain judgment, mapped to the public catalog enum documented in
+`docs/CATALOG.md`.
+
+Non-catalog means the run is based on browser-sniffed traffic, HAR capture,
+docs-derived specs, or a hand-authored internal spec rather than
+`cli-printing-press generate <name>` using a built-in catalog entry. For
+internal YAML specs, add:
+
+```yaml
+category: <catalog-category>
+```
+
+If the source is an OpenAPI file and the workflow has an editable overlay or
+derived internal spec, carry the same top-level category into that generated
+spec artifact before the final `generate` invocation. If there is no editable
+spec artifact, such as direct `--docs` generation, pass
+`--category <catalog-category>` on the final `generate` invocation. Do not add
+the category after generation just to satisfy publish; the generated manifest,
+README, and SKILL install section must all come from the same category-aware
+spec, or `verify-skill canonical-sections` can drift.
+
+Catalog-mode runs skip this step: keep the built-in catalog entry's category
+unchanged, even if Phase 1 research would classify the API differently.
+
 ### Pre-Generation Auth Enrichment
 
 Before generating, check whether the resolved spec has auth. This matters most for
@@ -2225,6 +2253,10 @@ cli-printing-press lock acquire --cli <api>-pp-cli --scope "$PRESS_SCOPE"
 
 If acquire fails (another session holds a fresh lock), present the lock status to the user and let them decide: wait, use a different CLI name, force-reclaim, or pick a different API.
 
+The `--category <catalog-category>` flag shown below is for non-catalog runs
+whose category was not already authored into an editable spec. Omit it for
+catalog-config runs; the built-in catalog category is authoritative there.
+
 OpenAPI / internal YAML:
 
 ```bash
@@ -2232,6 +2264,7 @@ cli-printing-press generate \
   --spec <spec-path-or-url> \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --force --lenient --validate
 ```
 
@@ -2244,6 +2277,7 @@ cli-printing-press generate \
   --name <api> \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --spec-source browser-sniffed \
   --traffic-analysis "$DISCOVERY_DIR/traffic-analysis.json" \
   --force --lenient --validate
@@ -2258,6 +2292,7 @@ cli-printing-press generate \
   --spec "$RESEARCH_DIR/<api>-browser-sniff-spec.yaml" \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --spec-source browser-sniffed \
   --traffic-analysis "$DISCOVERY_DIR/traffic-analysis.json" \
   --force --lenient --validate
@@ -2274,6 +2309,7 @@ cli-printing-press generate \
   --name <api> \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --force --lenient --validate
 ```
 
@@ -2284,6 +2320,7 @@ cli-printing-press generate \
   --spec "$RESEARCH_DIR/<api>-crowd-spec.yaml" \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --force --lenient --validate
 ```
 
@@ -2297,6 +2334,7 @@ cli-printing-press generate \
   --name <api> \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --traffic-analysis "$DISCOVERY_DIR/traffic-analysis.json" \
   --force --lenient --validate
 ```
@@ -2309,6 +2347,7 @@ cli-printing-press generate \
   --name <api> \
   --output "$CLI_WORK_DIR" \
   --research-dir "$API_RUN_DIR" \
+  --category <catalog-category> \
   --force --validate
 ```
 


### PR DESCRIPTION
## Summary

Non-catalog generation can now carry the researched public-library category into generation itself, so manifest, README, and SKILL install metadata are emitted from one category-aware source instead of being patched during publish.

This adds a validated `generate --category` input for non-catalog runs, keeps embedded catalog categories authoritative when a catalog entry matches, and updates the Printing Press skill command blocks so docs, sniffed, HAR, and hand-authored spec flows have an actionable category path before emission.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## Compounded learnings

- File: `docs/solutions/logic-errors/non-catalog-category-must-enter-generate-before-emission-2026-05-22.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with manifest identity precedence docs; new doc captures category-specific generation-time propagation
- Instruction-file edit: none needed
- Refresh recommendation: none

Closes #1712
