### PR TITLE
fix(cli): exclude hidden MCP endpoint mirrors from description gates

### DIFF
--- a/docs/solutions/logic-errors/hidden-endpoint-mirrors-scorecard-denominator.md
+++ b/docs/solutions/logic-errors/hidden-endpoint-mirrors-scorecard-denominator.md
@@ -1,0 +1,86 @@
+---
+title: "Hidden endpoint mirrors must not score as visible MCP tools"
+date: "2026-05-22"
+category: logic-errors
+module: internal/pipeline
+problem_type: logic_error
+component: tooling
+severity: medium
+symptoms:
+  - "tools-audit emitted thin-mcp-description findings for endpoint mirrors hidden behind code orchestration"
+  - "MCPDescriptionQuality counted hidden endpoint catalog records in its denominator"
+  - "Polish could not legitimately resolve prose-poor endpoint findings because those endpoints were not registered as individual MCP tools"
+root_cause: logic_error
+resolution_type: code_fix
+tags:
+  - mcp
+  - scorecard
+  - tools-audit
+  - tools-manifest
+  - code-orchestration
+---
+
+# Hidden endpoint mirrors must not score as visible MCP tools
+
+## Problem
+
+`tools-manifest.json` serves two related but different consumers. In endpoint-mirror mode, its `tools` records describe agent-visible typed MCP tools. In code-orchestration mode, those same endpoint records are used as the search/execute catalog behind the thin `<api>_search` and `<api>_execute` surface.
+
+The scorer and `tools-audit` treated every manifest tool as agent-visible. For prose-poor large specs, that made `thin-mcp-description` and `MCPDescriptionQuality` block shipping on endpoint records agents never see as standalone tools.
+
+## Symptoms
+
+- Code-orchestration CLIs could produce hundreds or thousands of pending `thin-mcp-description` findings for hidden endpoint catalog entries.
+- `MCPDescriptionQuality` could score the hidden endpoint catalog as 0/10 even though the visible MCP surface was the generated search/execute pair plus framework and novel tools.
+- Polish had no legitimate path to `ship` because fabricating endpoint descriptions is forbidden and accepting bulk thin-description findings leaves the scorecard unchanged.
+
+## What Didn't Work
+
+- Treating `tools-manifest.json` as only a visible-tool manifest ignored its catalog role in code-orchestration mode.
+- Returning full credit for hidden endpoint records would also be wrong. Hidden endpoint records should be removed from the `MCPDescriptionQuality` denominator, not counted as richly described visible tools.
+- Fixing only `tools-audit` would leave the scorecard gate stale. Both surfaces read the same manifest and must share the same visibility policy.
+
+## Solution
+
+Persist the MCP endpoint visibility fields needed by manifest consumers:
+
+```go
+type ManifestMCP struct {
+    EndpointTools string `json:"endpoint_tools,omitempty"`
+    Orchestration string `json:"orchestration,omitempty"`
+}
+```
+
+Keep the visibility rule canonical on `spec.MCPConfig`:
+
+```go
+func (m MCPConfig) EndpointMirrorsVisible() bool {
+    if m.IsCodeOrchestration() {
+        return false
+    }
+    return m.EndpointTools != "hidden"
+}
+```
+
+Then have manifest consumers branch on that rule:
+
+- `tools-audit` skips manifest endpoint-description findings when endpoint mirrors are hidden.
+- `MCPDescriptionQuality` returns unscored for hidden endpoint mirrors, so the scorecard denominator excludes records that are not agent-visible tools.
+- Visible endpoint-mirror manifests still get `thin-mcp-description` findings and score penalties.
+
+## Why This Works
+
+The scoring unit is the agent-visible tool, not every endpoint catalog record. Code orchestration still needs endpoint metadata so `<api>_execute` can reach the whole API surface, but those records are not registered as one tool per endpoint.
+
+Separating endpoint visibility from manifest presence keeps both truths intact: the catalog remains available for code orchestration, and the ship gates only judge descriptions agents can actually select as tools.
+
+## Prevention
+
+- When a verifier reads `tools-manifest.json`, first decide whether it is evaluating visible tools or endpoint catalog metadata.
+- Optional scorecard dimensions should return unscored when their denominator has no applicable visible surface.
+- Regression tests should pair a positive hidden-surface case with a negative visible-surface case so future changes do not silently disable endpoint-mirror quality gates.
+
+## Related
+
+- `docs/solutions/best-practices/steinberger-scorecard-scoring-architecture-2026-03-27.md`
+- `docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md`

--- a/internal/cli/tools_audit.go
+++ b/internal/cli/tools_audit.go
@@ -252,6 +252,9 @@ func auditMCPManifest(m *pipeline.ToolsManifest) []ToolsAuditFinding {
 	if m == nil {
 		return nil
 	}
+	if !m.EndpointMirrorsVisible() {
+		return nil
+	}
 	var findings []ToolsAuditFinding
 	for _, t := range m.Tools {
 		if t.Name == "" {

--- a/internal/cli/tools_audit_test.go
+++ b/internal/cli/tools_audit_test.go
@@ -32,6 +32,42 @@ func TestRequiresPreDecisionFields(t *testing.T) {
 	}
 }
 
+func TestAuditMCPManifestSkipsHiddenEndpointMirrors(t *testing.T) {
+	manifest := &pipeline.ToolsManifest{
+		MCP: &pipeline.ManifestMCP{
+			EndpointTools: "hidden",
+			Orchestration: "code",
+		},
+		Tools: []pipeline.ManifestTool{
+			{Name: "demo_get", Description: "Get"},
+			{Name: "demo_create", Description: "Create"},
+		},
+	}
+
+	if got := auditMCPManifest(manifest); len(got) != 0 {
+		t.Fatalf("got %d findings for hidden endpoint mirrors, want 0: %#v", len(got), got)
+	}
+}
+
+func TestAuditMCPManifestStillFlagsVisibleEndpointMirrors(t *testing.T) {
+	manifest := &pipeline.ToolsManifest{
+		MCP: &pipeline.ManifestMCP{
+			EndpointTools: "visible",
+		},
+		Tools: []pipeline.ManifestTool{
+			{Name: "demo_get", Description: "Get"},
+		},
+	}
+
+	got := auditMCPManifest(manifest)
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1: %#v", len(got), got)
+	}
+	if got[0].Kind != kindThinMCPDesc {
+		t.Fatalf("kind = %q, want %q", got[0].Kind, kindThinMCPDesc)
+	}
+}
+
 func TestMissingPreDecisionFields(t *testing.T) {
 	full := ToolsAuditFinding{
 		SpecSourceMaterial: "summary + 3 params",

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -751,6 +751,9 @@ func ScoreMCPDescriptionQualityForManifest(m *ToolsManifest) (score int, scored 
 	if m == nil || len(m.Tools) == 0 {
 		return 0, false
 	}
+	if !m.EndpointMirrorsVisible() {
+		return 0, false
+	}
 	thin := 0
 	for _, t := range m.Tools {
 		if IsThinMCPDescription(t.Description) {

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -88,6 +88,18 @@ func TestScoreMCPDescriptionQuality(t *testing.T) {
 		}
 		return dir
 	}
+	mkManifest := func(t *testing.T, manifest ToolsManifest) string {
+		t.Helper()
+		dir := t.TempDir()
+		data, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "tools-manifest.json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
 
 	t.Run("missing manifest is unscored", func(t *testing.T) {
 		dir := t.TempDir()
@@ -132,6 +144,39 @@ func TestScoreMCPDescriptionQuality(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("hidden endpoint mirrors are not counted", func(t *testing.T) {
+		dir := mkManifest(t, ToolsManifest{
+			MCP: &ManifestMCP{
+				EndpointTools: "hidden",
+				Orchestration: "code",
+			},
+			Tools: []ManifestTool{
+				{Name: "demo_get", Description: "Get"},
+				{Name: "demo_create", Description: "Create"},
+			},
+		})
+		score, scored := scoreMCPDescriptionQuality(dir)
+		if scored {
+			t.Errorf("score=%d scored=%v, want unscored", score, scored)
+		}
+	})
+
+	t.Run("visible endpoint mirrors are still counted", func(t *testing.T) {
+		dir := mkManifest(t, ToolsManifest{
+			MCP: &ManifestMCP{
+				EndpointTools: "visible",
+			},
+			Tools: []ManifestTool{
+				{Name: "demo_get", Description: "Get"},
+				{Name: "demo_create", Description: "Create"},
+			},
+		})
+		score, scored := scoreMCPDescriptionQuality(dir)
+		if !scored || score != 0 {
+			t.Errorf("score=%d scored=%v, want 0/true", score, scored)
+		}
+	})
 }
 
 func appendN(prefix []string, val string, n int) []string {
@@ -873,6 +918,24 @@ func runLinks() string {
 		assert.ElementsMatch(t, []string{"mcp_description_quality", "mcp_token_efficiency", "mcp_remote_transport", "mcp_tool_design", "mcp_surface_strategy", "cache_freshness", "path_validity", "auth_protocol", "live_api_verification"}, sc.UnscoredDimensions)
 		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
 		assert.NotContains(t, sc.GapReport, "auth_protocol scored 0/10 - needs improvement")
+	})
+
+	t.Run("hidden endpoint mirrors omit mcp description quality from scoring", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, ToolsManifestFilename, `{
+  "mcp": {
+    "endpoint_tools": "hidden",
+    "orchestration": "code"
+  },
+  "tools": [
+    {"name": "demo_get", "description": "Get"},
+    {"name": "demo_create", "description": "Create"}
+  ]
+}`)
+
+		sc, err := RunScorecard(dir, t.TempDir(), "", nil)
+		assert.NoError(t, err)
+		assert.Contains(t, sc.UnscoredDimensions, DimMCPDescriptionQuality)
 	})
 
 	t.Run("missing security schemes renormalizes tier2 instead of treating auth as zero", func(t *testing.T) {

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -30,10 +30,32 @@ type ToolsManifest struct {
 	Description     string           `json:"description"`
 	MCPReady        string           `json:"mcp_ready"`
 	HTTPTransport   string           `json:"http_transport,omitempty"`
+	MCP             *ManifestMCP     `json:"mcp,omitempty"`
 	Auth            ManifestAuth     `json:"auth"`
 	TierRouting     *ManifestTiers   `json:"tier_routing,omitempty"`
 	RequiredHeaders []ManifestHeader `json:"required_headers"`
 	Tools           []ManifestTool   `json:"tools"`
+}
+
+// ManifestMCP persists the endpoint visibility fields needed by manifest
+// consumers without coupling tools-manifest.json to the full spec MCP shape.
+type ManifestMCP struct {
+	EndpointTools string `json:"endpoint_tools,omitempty"`
+	Orchestration string `json:"orchestration,omitempty"`
+}
+
+// EndpointMirrorsVisible reports whether Tools entries are registered as
+// per-endpoint MCP tools. Hidden endpoint mirrors remain in the manifest as
+// endpoint metadata for code-orchestration search/execute, but agents do not
+// see them as individual tools.
+func (m *ToolsManifest) EndpointMirrorsVisible() bool {
+	if m == nil || m.MCP == nil {
+		return true
+	}
+	return spec.MCPConfig{
+		EndpointTools: m.MCP.EndpointTools,
+		Orchestration: m.MCP.Orchestration,
+	}.EndpointMirrorsVisible()
 }
 
 // ManifestAuth captures the auth configuration needed to make authenticated
@@ -174,6 +196,12 @@ func WriteToolsManifestWithDescription(dir string, parsed *spec.APISpec, manifes
 		Auth:            manifestAuth(parsed.Auth),
 		RequiredHeaders: make([]ManifestHeader, 0, len(parsed.RequiredHeaders)),
 		Tools:           make([]ManifestTool, 0),
+	}
+	if parsed.MCP.EndpointTools != "" || parsed.MCP.Orchestration != "" {
+		manifest.MCP = &ManifestMCP{
+			EndpointTools: parsed.MCP.EndpointTools,
+			Orchestration: parsed.MCP.Orchestration,
+		}
 	}
 	if description := strings.TrimSpace(manifestDescription); description != "" {
 		manifest.Description = description

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -983,6 +983,34 @@ func TestWriteToolsManifest_MCPDescriptionAnnotations(t *testing.T) {
 	}
 }
 
+func TestWriteToolsManifest_MCPSurfaceMetadata(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "surface-api",
+		BaseURL: "https://api.example.com",
+		MCP: spec.MCPConfig{
+			EndpointTools: "hidden",
+			Orchestration: "code",
+		},
+		Resources: map[string]spec.Resource{
+			"Items": {
+				Endpoints: map[string]spec.Endpoint{
+					"Get": {Method: "GET", Path: "/items/{id}", Description: "Get"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got.MCP)
+	assert.Equal(t, "hidden", got.MCP.EndpointTools)
+	assert.Equal(t, "code", got.MCP.Orchestration)
+	assert.False(t, got.EndpointMirrorsVisible())
+}
+
 func TestWriteToolsManifest_EmptyParamType(t *testing.T) {
 	dir := t.TempDir()
 	parsed := &spec.APISpec{

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3095,6 +3095,16 @@ func (m MCPConfig) IsCodeOrchestration() bool {
 	return m.Orchestration == "code"
 }
 
+// EndpointMirrorsVisible reports whether per-endpoint MCP tools are registered
+// directly. Code orchestration always suppresses endpoint mirrors because
+// <api>_search + <api>_execute cover the endpoint catalog.
+func (m MCPConfig) EndpointMirrorsVisible() bool {
+	if m.IsCodeOrchestration() {
+		return false
+	}
+	return m.EndpointTools != "hidden"
+}
+
 // EffectiveMCPTransports returns the transport list the generated MCP binary
 // should compile support for, taking endpoint count into account. When the
 // spec leaves mcp.transport unset and the typed-endpoint surface is at or

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -2676,6 +2676,10 @@ func TestMCPOrchestrationValidation(t *testing.T) {
 	assert.Equal(t, 100, MCPConfig{OrchestrationThreshold: 100}.EffectiveOrchestrationThreshold())
 	assert.True(t, MCPConfig{Orchestration: "code"}.IsCodeOrchestration())
 	assert.False(t, MCPConfig{Orchestration: "intent"}.IsCodeOrchestration())
+	assert.True(t, MCPConfig{}.EndpointMirrorsVisible())
+	assert.True(t, MCPConfig{EndpointTools: "visible"}.EndpointMirrorsVisible())
+	assert.False(t, MCPConfig{EndpointTools: "hidden"}.EndpointMirrorsVisible())
+	assert.False(t, MCPConfig{EndpointTools: "visible", Orchestration: "code"}.EndpointMirrorsVisible())
 }
 
 func TestMCPConfigAcceptsValidShapes(t *testing.T) {


### PR DESCRIPTION
## Summary

Code-orchestration CLIs no longer get stuck on impossible MCP-description gates for hidden endpoint mirrors. `tools-audit` now skips endpoint catalog records that are not registered as per-endpoint MCP tools, and `MCPDescriptionQuality` removes those records from its denominator instead of treating them as visible tools.

The manifest now carries the MCP endpoint visibility fields needed by downstream diagnostics, while the visibility rule remains canonical on `spec.MCPConfig`. Visible endpoint-mirror CLIs still receive thin-description findings and score penalties.

## Tests

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## Compounded learnings

- Added `docs/solutions/logic-errors/hidden-endpoint-mirrors-scorecard-denominator.md` documenting the distinction between endpoint catalog records and agent-visible MCP tools.

Closes #1543
