### PR TITLE
fix(cli): stub missing local schema refs in lenient mode

### DIFF
--- a/docs/solutions/logic-errors/lenient-openapi-missing-local-schema-refs.md
+++ b/docs/solutions/logic-errors/lenient-openapi-missing-local-schema-refs.md
@@ -1,0 +1,80 @@
+---
+title: "Lenient OpenAPI parsing must stub missing local schema refs visibly"
+date: 2026-05-22
+category: logic-errors
+module: internal/openapi
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "generate --lenient still exits when a converted OpenAPI spec references a missing local schema"
+  - "agents patch generated specs by hand before every regen to replace dangling refs with permissive objects"
+  - "existing lenient cleanup can strip a broken path instead of preserving the endpoint with degraded schema fidelity"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - openapi-parser
+  - lenient-mode
+  - schema-refs
+  - generated-cli
+---
+
+# Lenient OpenAPI parsing must stub missing local schema refs visibly
+
+## Problem
+
+Converted OpenAPI specs can contain local `$ref` values pointing at `#/components/schemas/<Name>` entries the converter failed to emit. Before this fix, `generate --lenient` still aborted on those dangling local schema refs, even though the operator had explicitly chosen tolerant parsing.
+
+## Symptoms
+
+- `generate --lenient` logs a cleanup attempt, then exits with `map key "<Name>" not found`.
+- A manual pre-generation patcher that injects `{type: object, additionalProperties: true}` for each missing schema lets the same spec generate successfully.
+- The older lenient cleanup path removes references or entire paths, which can turn a recoverable missing schema into lost endpoint coverage.
+
+## What Didn't Work
+
+- Treating the issue as a printed-CLI patch would only help one generated CLI. The next regeneration from the same upstream spec would fail again.
+- Letting the old lenient cleanup remove paths preserves parser success in some cases, but it silently drops endpoint surface area.
+- Stubbing every `$ref`-looking string in the raw document is too broad. Example payloads and vendor extensions can legitimately contain literal `$ref` data that is not an OpenAPI Reference Object.
+
+## Solution
+
+Handle exact missing local schema refs before the OpenAPI loader runs in lenient mode:
+
+```go
+schemas[name] = map[string]any{
+    "type":                 "object",
+    "description":          fmt.Sprintf("Stub for missing local schema ref %s.", name),
+    "additionalProperties": true,
+}
+warnf("stubbing missing local schema ref %q as permissive object", name)
+```
+
+The recovery is deliberately narrow:
+
+- Only exact `#/components/schemas/<Name>` refs are stubbable.
+- Nested pointers like `#/components/schemas/<Name>/properties/id` stay strict because a top-level object stub does not satisfy the full pointer path.
+- Example/default payloads and extension values are skipped so literal `$ref` strings do not create fake missing schemas.
+- `--strict-refs` keeps lenient cleanup available while failing on missing local schema refs.
+
+The same parser option is wired through both `generate` and `public-param-audit`, so command surfaces that expose `--lenient` have a matching strict-ref opt-out.
+
+## Why This Works
+
+The permissive object stub preserves endpoint coverage while making the degradation visible through warnings. It avoids inventing typed fields from request parameters or examples, so downstream generated types degrade to an object-shaped placeholder instead of a plausible but false schema.
+
+Failing early for `--lenient --strict-refs` prevents the older cleanup loop from deleting only the broken path and reporting success when another healthy path remains. That keeps the strict-ref contract about missing local schema refs precise without changing unrelated lenient cleanup behavior.
+
+## Prevention
+
+- Add parser-level coverage for both the tolerant path and the strict opt-out.
+- Add command-level coverage when a parser option is surfaced as a CLI flag.
+- Include adversarial fixtures for literal `$ref` strings in example/default data and for nested local schema pointers.
+- Update the Printing Press skill whenever a machine behavior changes what agents should assume during generation.
+
+## Related Issues
+
+- Issue #1534
+- `docs/solutions/logic-errors/openapi-parser-missing-x-mcp-extension-support-2026-05-08.md`
+- `docs/solutions/conventions/soft-validation-in-reusable-library-packages-2026-05-06.md`
+- `docs/solutions/logic-errors/store-columns-sourced-from-request-params-instead-of-response-2026-05-08.md`

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/catalogmeta"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,59 @@ func TestGenerateCmdHelpDescribesForceAsGeneratedOverwrite(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, out.String(), "Recreate the base output directory while preserving hand-edits to generated files via AST-based merge")
+	assert.Contains(t, out.String(), "--strict-refs")
+}
+
+func TestGenerateCmdLenientMissingLocalSchemaRefs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "missing-ref.yaml")
+	outputDir := filepath.Join(dir, "missing-ref")
+	require.NoError(t, os.WriteFile(specPath, []byte(`
+openapi: 3.0.3
+info:
+  title: Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  widget:
+                    $ref: "#/components/schemas/MissingWidget"
+components:
+  schemas:
+    Present:
+      type: object
+      properties:
+        id:
+          type: string
+`), 0o644))
+
+	runGenerate := func(args ...string) error {
+		cmd := newGenerateCmd()
+		baseArgs := []string{
+			"--spec", specPath,
+			"--output", outputDir,
+			"--dry-run",
+		}
+		cmd.SetArgs(append(baseArgs, args...))
+		return cmd.Execute()
+	}
+
+	require.Error(t, runGenerate())
+	require.NoError(t, runGenerate("--lenient"))
+	require.Error(t, runGenerate("--lenient", "--strict-refs"))
 }
 
 // TestGenerateCmdForcePreservesIssue907HandEdits exercises the canonical
@@ -2445,12 +2499,12 @@ paths:
 	pref := openAPIAuthPreferenceForGenerate("", "", []string{jira.SpecURL}, "")
 	require.Equal(t, "basicAuth", pref)
 
-	parsed, err := parseOpenAPISpec(filepath.Join(t.TempDir(), "spec.yaml"), specBytes, false, pref)
+	parsed, err := parseOpenAPISpec(filepath.Join(t.TempDir(), "spec.yaml"), specBytes, openapi.ParseOptions{AuthPreference: pref})
 	require.NoError(t, err)
 	assert.Equal(t, "basicAuth", parsed.Auth.Scheme)
 	assert.Equal(t, "api_key", parsed.Auth.Type)
 
-	defaultParsed, err := parseOpenAPISpec(filepath.Join(t.TempDir(), "spec2.yaml"), specBytes, false, "")
+	defaultParsed, err := parseOpenAPISpec(filepath.Join(t.TempDir(), "spec2.yaml"), specBytes, openapi.ParseOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "OAuth2", defaultParsed.Auth.Scheme, "without catalog-driven preference, OAuth2 wins")
 }

--- a/internal/cli/public_param_audit.go
+++ b/internal/cli/public_param_audit.go
@@ -17,6 +17,7 @@ func newPublicParamAuditCmd() *cobra.Command {
 	var specFiles []string
 	var cliName string
 	var lenient bool
+	var strictRefs bool
 	var ledgerPath string
 	var asJSON bool
 	var strict bool
@@ -36,7 +37,10 @@ a real flag_name in the spec or an evidence-backed skip decision in the ledger.`
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--spec is required")}
 			}
 
-			apiSpec, err := parsePublicParamAuditSpec(specFiles, cliName, lenient)
+			apiSpec, err := parsePublicParamAuditSpec(specFiles, cliName, openapi.ParseOptions{
+				Lenient:    lenient,
+				StrictRefs: strictRefs,
+			})
 			if err != nil {
 				return err
 			}
@@ -77,13 +81,14 @@ a real flag_name in the spec or an evidence-backed skip decision in the ledger.`
 	cmd.Flags().StringSliceVar(&specFiles, "spec", nil, "Path or URL to API spec (can be repeated)")
 	cmd.Flags().StringVar(&cliName, "name", "", "CLI name (required when using multiple specs)")
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
+	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs")
 	cmd.Flags().StringVar(&ledgerPath, "ledger", "", "Path to an agent-edited public parameter audit ledger")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON instead of a human-readable summary")
 	cmd.Flags().BoolVar(&strict, "strict", false, "fail when unresolved findings remain")
 	return cmd
 }
 
-func parsePublicParamAuditSpec(specFiles []string, cliName string, lenient bool) (*spec.APISpec, error) {
+func parsePublicParamAuditSpec(specFiles []string, cliName string, opts openapi.ParseOptions) (*spec.APISpec, error) {
 	var specs []*spec.APISpec
 	for _, specFile := range specFiles {
 		data, err := readSpec(specFile, false, true)
@@ -93,7 +98,7 @@ func parsePublicParamAuditSpec(specFiles []string, cliName string, lenient bool)
 
 		var apiSpec *spec.APISpec
 		if openapi.IsOpenAPI(data) {
-			apiSpec, err = parseOpenAPISpec(specFile, data, lenient, "")
+			apiSpec, err = parseOpenAPISpec(specFile, data, opts)
 		} else if graphql.IsGraphQLSDL(data) {
 			apiSpec, err = graphql.ParseSDLBytes(specFile, data)
 		} else {

--- a/internal/cli/public_param_audit.go
+++ b/internal/cli/public_param_audit.go
@@ -81,7 +81,7 @@ a real flag_name in the spec or an evidence-backed skip decision in the ledger.`
 	cmd.Flags().StringSliceVar(&specFiles, "spec", nil, "Path or URL to API spec (can be repeated)")
 	cmd.Flags().StringVar(&cliName, "name", "", "CLI name (required when using multiple specs)")
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
-	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs")
+	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs (only meaningful with --lenient)")
 	cmd.Flags().StringVar(&ledgerPath, "ledger", "", "Path to an agent-edited public parameter audit ledger")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON instead of a human-readable summary")
 	cmd.Flags().BoolVar(&strict, "strict", false, "fail when unresolved findings remain")

--- a/internal/cli/public_param_audit_test.go
+++ b/internal/cli/public_param_audit_test.go
@@ -158,6 +158,47 @@ types:
 	require.NoError(t, cmd.Execute())
 }
 
+func TestPublicParamAuditStrictRefsDisablesLenientLocalSchemaStubs(t *testing.T) {
+	specPath := writePublicParamAuditSpec(t, `
+openapi: 3.0.3
+info:
+  title: Public Param Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /stores:
+    get:
+      operationId: findStores
+      parameters:
+        - name: s
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MissingStore"
+components:
+  schemas: {}
+`)
+
+	cmd := newPublicParamAuditCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--spec", specPath, "--lenient"})
+	require.NoError(t, cmd.Execute())
+
+	cmd = newPublicParamAuditCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--spec", specPath, "--lenient", "--strict-refs"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing local schema refs: MissingStore")
+}
+
 func writePublicParamAuditSpec(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "spec.yaml")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -107,6 +107,7 @@ func newGenerateCmd() *cobra.Command {
 	var refresh bool
 	var force bool
 	var lenient bool
+	var strictRefs bool
 	var docsURL string
 	var polish bool
 	var asJSON bool
@@ -310,7 +311,11 @@ func newGenerateCmd() *cobra.Command {
 
 				var apiSpec *spec.APISpec
 				if openapi.IsOpenAPI(data) {
-					apiSpec, err = parseOpenAPISpec(specFile, data, lenient, openAPIParseAuthPref)
+					apiSpec, err = parseOpenAPISpec(specFile, data, openapi.ParseOptions{
+						Lenient:        lenient,
+						StrictRefs:     strictRefs,
+						AuthPreference: openAPIParseAuthPref,
+					})
 				} else if graphql.IsGraphQLSDL(data) {
 					apiSpec, err = graphql.ParseSDLBytes(specFile, data)
 				} else {
@@ -454,6 +459,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh cached remote spec before generating")
 	cmd.Flags().BoolVar(&force, "force", false, "Recreate the base output directory while preserving hand-edits to generated files via AST-based merge")
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
+	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs")
 	cmd.Flags().StringVar(&docsURL, "docs", "", "API documentation URL to generate spec from")
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
@@ -783,8 +789,7 @@ func readSpec(specFile string, refresh bool, skipCache bool) ([]byte, error) {
 	return data, nil
 }
 
-func parseOpenAPISpec(specFile string, data []byte, lenient bool, authPreference string) (*spec.APISpec, error) {
-	opts := openapi.ParseOptions{Lenient: lenient, AuthPreference: authPreference}
+func parseOpenAPISpec(specFile string, data []byte, opts openapi.ParseOptions) (*spec.APISpec, error) {
 	if !openapi.IsRemoteSpecSource(specFile) {
 		opts.Path = specFile
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -459,7 +459,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh cached remote spec before generating")
 	cmd.Flags().BoolVar(&force, "force", false, "Recreate the base output directory while preserving hand-edits to generated files via AST-based merge")
 	cmd.Flags().BoolVar(&lenient, "lenient", false, "Skip validation errors from broken $refs in OpenAPI specs")
-	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs")
+	cmd.Flags().BoolVar(&strictRefs, "strict-refs", false, "Disable lenient stubbing for missing local schema refs (only meaningful with --lenient)")
 	cmd.Flags().StringVar(&docsURL, "docs", "", "API documentation URL to generate spec from")
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -173,6 +173,131 @@ func stripBrokenRefs(data []byte, errMsg string) []byte {
 	return data
 }
 
+func stubMissingLocalSchemaRefs(data []byte) ([]byte, int, error) {
+	root, _, schemas, names, err := findMissingLocalSchemaRefs(data)
+	if err != nil {
+		return data, 0, err
+	}
+	if len(names) == 0 {
+		return data, 0, nil
+	}
+
+	for _, name := range names {
+		if _, exists := schemas[name]; exists {
+			continue
+		}
+		schemas[name] = map[string]any{
+			"type":                 "object",
+			"description":          fmt.Sprintf("Stub for missing local schema ref %s.", name),
+			"additionalProperties": true,
+		}
+		warnf("stubbing missing local schema ref %q as permissive object", name)
+	}
+
+	stubbed, err := json.Marshal(root)
+	if err != nil {
+		return data, 0, err
+	}
+	return stubbed, len(names), nil
+}
+
+func findMissingLocalSchemaRefs(data []byte) (map[string]any, map[string]any, map[string]any, []string, error) {
+	if !bytes.Contains(data, []byte(localSchemaRefPrefix)) {
+		return nil, nil, nil, nil, nil
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	components := objectValue(root["components"])
+	schemas := objectValue(components["schemas"])
+	missing := make(map[string]struct{})
+	collectMissingLocalSchemaRefs(root, "", schemas, missing)
+	if len(missing) == 0 {
+		return root, components, schemas, nil, nil
+	}
+
+	if components == nil {
+		components = make(map[string]any)
+		root["components"] = components
+	}
+	if schemas == nil {
+		schemas = make(map[string]any)
+		components["schemas"] = schemas
+	}
+
+	names := make([]string, 0, len(missing))
+	for name := range missing {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return root, components, schemas, names, nil
+}
+
+func collectMissingLocalSchemaRefs(v any, parentKey string, schemas map[string]any, missing map[string]struct{}) {
+	if isArbitrarySpecDataKey(parentKey) || strings.HasPrefix(parentKey, "x-") {
+		return
+	}
+	switch typed := v.(type) {
+	case map[string]any:
+		if rawRef, ok := typed["$ref"].(string); ok {
+			if name, ok := localSchemaRefName(rawRef); ok {
+				if _, exists := schemas[name]; !exists {
+					missing[name] = struct{}{}
+				}
+			}
+		}
+		for key, child := range typed {
+			collectMissingLocalSchemaRefs(child, key, schemas, missing)
+		}
+	case []any:
+		for _, child := range typed {
+			collectMissingLocalSchemaRefs(child, parentKey, schemas, missing)
+		}
+	}
+}
+
+func isArbitrarySpecDataKey(key string) bool {
+	switch key {
+	case "example", "examples", "default":
+		return true
+	default:
+		return false
+	}
+}
+
+func localSchemaRefName(ref string) (string, bool) {
+	if !strings.HasPrefix(ref, localSchemaRefPrefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(ref, localSchemaRefPrefix)
+	if rest == "" {
+		return "", false
+	}
+	name, suffix, hasSuffix := strings.Cut(rest, "/")
+	if name == "" {
+		return "", false
+	}
+	if hasSuffix && suffix != "" {
+		return "", false
+	}
+	if unescaped, err := url.PathUnescape(name); err == nil {
+		name = unescaped
+	}
+	name = strings.NewReplacer("~1", "/", "~0", "~").Replace(name)
+	return name, true
+}
+
+const localSchemaRefPrefix = "#/components/schemas/"
+
+func objectValue(v any) map[string]any {
+	obj, _ := v.(map[string]any)
+	return obj
+}
+
 // Parse parses an OpenAPI spec strictly. Use ParseLenient for specs with broken $refs.
 func Parse(data []byte) (*spec.APISpec, error) {
 	return ParseWithOptions(data, ParseOptions{})
@@ -220,6 +345,9 @@ type ParseOptions struct {
 	Path string
 	// Lenient skips validation errors from broken $refs.
 	Lenient bool
+	// Set when callers need other lenient cleanup while preserving missing-ref
+	// failures.
+	StrictRefs bool
 	// AuthPreference names a security scheme from components.securitySchemes
 	// that should win over the parser's default selection priority. Used when
 	// a spec exposes multiple valid schemes (e.g. OAuth2 + basic) and the
@@ -233,13 +361,13 @@ type ParseOptions struct {
 // path/lenient settings.
 func ParseWithOptions(data []byte, opts ParseOptions) (*spec.APISpec, error) {
 	if opts.Path == "" {
-		return parseWithLocation(data, opts.Lenient, nil, opts.AuthPreference)
+		return parseWithLocation(data, opts.Lenient, opts.StrictRefs, nil, opts.AuthPreference)
 	}
 	location, err := fileLocation(opts.Path)
 	if err != nil {
 		return nil, err
 	}
-	return parseWithLocation(data, opts.Lenient, location, opts.AuthPreference)
+	return parseWithLocation(data, opts.Lenient, opts.StrictRefs, location, opts.AuthPreference)
 }
 
 func parseFileWithOptions(path string, opts ParseOptions) (*spec.APISpec, error) {
@@ -251,11 +379,21 @@ func parseFileWithOptions(path string, opts ParseOptions) (*spec.APISpec, error)
 	return ParseWithOptions(data, opts)
 }
 
-func parseWithLocation(data []byte, lenient bool, location *url.URL, authPreference string) (*spec.APISpec, error) {
+func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url.URL, authPreference string) (*spec.APISpec, error) {
 	var metadata specDataMetadata
 	if normalized, meta, err := normalizeSpecDataWithMetadata(data); err == nil {
 		data = normalized
 		metadata = meta
+	}
+	if lenient && !strictRefs {
+		if stubbed, count, err := stubMissingLocalSchemaRefs(data); err == nil && count > 0 {
+			data = stubbed
+		}
+	}
+	if lenient && strictRefs {
+		if _, _, _, missing, err := findMissingLocalSchemaRefs(data); err == nil && len(missing) > 0 {
+			return nil, fmt.Errorf("missing local schema refs: %s", strings.Join(missing, ", "))
+		}
 	}
 	doc, err := loadOpenAPIDoc(data, lenient, location)
 	if err != nil {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -52,6 +52,265 @@ func TestParsePetstore(t *testing.T) {
 	assert.Contains(t, parsed.Types, "Pet")
 }
 
+func TestParseLenientStubsMissingLocalSchemaRefs(t *testing.T) {
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  widget:
+                    $ref: "#/components/schemas/MissingWidget"
+components:
+  schemas:
+    Present:
+      type: object
+      properties:
+        id:
+          type: string
+`)
+
+	var parsed *spec.APISpec
+	var err error
+	warnings := captureWarnings(t, func() {
+		parsed, err = ParseLenient(specBytes)
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	normalized, normalizeErr := normalizeSpecData(specBytes)
+	require.NoError(t, normalizeErr)
+	stubbed, count, stubErr := stubMissingLocalSchemaRefs(normalized)
+	require.NoError(t, stubErr)
+	require.Equal(t, 1, count)
+	var root map[string]any
+	require.NoError(t, json.Unmarshal(stubbed, &root))
+	schema := root["components"].(map[string]any)["schemas"].(map[string]any)["MissingWidget"].(map[string]any)
+	assert.Equal(t, "object", schema["type"])
+	assert.Equal(t, true, schema["additionalProperties"])
+	assert.Contains(t, parsed.Types, "MissingWidget")
+	assert.Contains(t, warnings, `warning: stubbing missing local schema ref "MissingWidget"`)
+}
+
+func TestParseMissingLocalSchemaRefsStayStrictByDefault(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MissingWidget"
+components:
+  schemas: {}
+`)
+
+	_, err := Parse(specBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `map key "MissingWidget" not found`)
+}
+
+func TestParseStrictRefsDisablesLenientLocalSchemaStubs(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MissingWidget"
+components:
+  schemas: {}
+`)
+
+	_, err := ParseWithOptions(specBytes, ParseOptions{Lenient: true, StrictRefs: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing local schema refs: MissingWidget")
+}
+
+func TestParseStrictRefsFailsBeforeLenientPathStripping(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /broken:
+    get:
+      operationId: getBroken
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MissingWidget"
+  /healthy:
+    get:
+      operationId: getHealthy
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+components:
+  schemas: {}
+`)
+
+	_, err := ParseWithOptions(specBytes, ParseOptions{Lenient: true, StrictRefs: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing local schema refs: MissingWidget")
+}
+
+func TestParseLenientIgnoresRefStringsInsideExampleData(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Example Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+              example:
+                widget:
+                  $ref: "#/components/schemas/MissingWidget"
+components:
+  schemas: {}
+`)
+
+	parsed, err := ParseLenient(specBytes)
+	require.NoError(t, err)
+	assert.NotContains(t, parsed.Types, "MissingWidget")
+}
+
+func TestParseLenientDoesNotStubNestedLocalSchemaPointers(t *testing.T) {
+	t.Parallel()
+
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Nested Missing Ref API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MissingWidget/properties/id"
+components:
+  schemas: {}
+`)
+
+	_, err := ParseLenient(specBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `map key "MissingWidget" not found`)
+}
+
+func TestParseLenientCleanSpecDoesNotWarnAboutSchemaStubs(t *testing.T) {
+	specBytes := []byte(`
+openapi: 3.0.3
+info:
+  title: Clean API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Widget"
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+`)
+
+	var err error
+	warnings := captureWarnings(t, func() {
+		_, err = ParseLenient(specBytes)
+	})
+
+	require.NoError(t, err)
+	assert.NotContains(t, warnings, "stubbing missing local schema ref")
+}
+
 func TestParseMarksFieldSelectorParamsWithSyncDefault(t *testing.T) {
 	t.Parallel()
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2265,6 +2265,11 @@ The `--category <catalog-category>` flag shown below is for non-catalog runs
 whose category was not already authored into an editable spec. Omit it for
 catalog-config runs; the built-in catalog category is authoritative there.
 
+`--lenient` stubs missing local `#/components/schemas/<Name>` refs as
+permissive object schemas with warnings so converted OpenAPI specs can still
+generate. Add `--strict-refs` only when a run must fail instead of accepting
+those local schema stubs; it does not change the rest of lenient cleanup.
+
 OpenAPI / internal YAML:
 
 ```bash


### PR DESCRIPTION
## Summary

`generate --lenient` can now recover converted OpenAPI specs that reference missing local schemas by injecting visible permissive object stubs instead of aborting or dropping endpoint paths. Operators who need the old fail-fast behavior for missing local schema refs can pass `--strict-refs`; the same opt-out is available on `public-param-audit`.

This keeps the recovery narrow: only exact `#/components/schemas/<Name>` refs are stubbed, literal `$ref` values inside examples/defaults are ignored, and nested schema pointers remain strict rather than receiving fake partial structures.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`

## Compounded learnings

- Added `docs/solutions/logic-errors/lenient-openapi-missing-local-schema-refs.md` to capture the narrow recovery pattern and adversarial parser cases.

Closes #1534
