### PR TITLE
fix(cli): preserve all-apiKey composed auth headers

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -417,6 +417,11 @@ Rules:
 - Empty and non-string list items are ignored.
 - When at least one non-empty item is present, the list replaces the parser's
   generated env var names.
+- On apiKey/header schemes that appear beside the selected auth scheme in the
+  same AND security requirement, the first non-empty item supplies the
+  generated per-call env var for that sibling header. Use `x-auth-vars` for
+  richer metadata or when more than one credential variable belongs to the
+  same scheme.
 
 Catalog-driven equivalent: when a catalog entry declares `auth_env_vars`, the
 generator layers the canonical names on top of the parser-derived default at

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -242,6 +242,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"authCommandShort":       authCommandShort,
 		"authHarvestedEnvHint":   authHarvestedEnvHint,
 		"basicAuthEnvVars":       basicAuthEnvVars,
+		"authAgentEnvVars":       authAgentEnvVars,
 		"hasAuthEnvVarKind":      hasAuthEnvVarKind,
 		"isRequestAuthEnvVar":    isRequestAuthEnvVar,
 		"effectiveTier":          effectiveTier,
@@ -1026,6 +1027,40 @@ func basicAuthEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
 		return envVars
 	}
 	return envVars[:2]
+}
+
+func authAgentEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
+	var envVars []spec.AuthEnvVar
+	seen := map[string]struct{}{}
+	add := func(envVar spec.AuthEnvVar) {
+		if strings.TrimSpace(envVar.Name) == "" || envVar.Kind == spec.AuthEnvVarKindHarvested {
+			return
+		}
+		if _, ok := seen[envVar.Name]; ok {
+			return
+		}
+		seen[envVar.Name] = struct{}{}
+		envVars = append(envVars, envVar)
+	}
+
+	if len(auth.EnvVarSpecs) > 0 {
+		for _, envVar := range auth.EnvVarSpecs {
+			add(envVar)
+		}
+	} else {
+		for _, name := range auth.EnvVars {
+			add(spec.AuthEnvVar{
+				Name:      name,
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+			})
+		}
+	}
+	for _, header := range auth.AdditionalHeaders {
+		add(header.EnvVar)
+	}
+	return envVars
 }
 
 func hasAuthEnvVarKind(envVarSpecs []spec.AuthEnvVar, kind string) bool {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1054,6 +1054,8 @@ func TestGenerateComposedApiKeyPlusBearerEmitsAdditionalHeader(t *testing.T) {
 		"doctor must check the sibling apiKey env var")
 	assert.Contains(t, doctorSrc, `configuredValue = cfg.StAppKey`,
 		"doctor must accept sibling apiKey credentials from config files")
+	assert.Contains(t, doctorSrc, `} else if authConfigured {`,
+		"doctor must apply the config fallback consistently for sibling apiKey credentials")
 	assert.Contains(t, doctorSrc, `OK %d/%d available", len(authEnvSet), 3`,
 		"doctor must include sibling apiKey credentials in the env-var count")
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1046,6 +1046,28 @@ func TestGenerateComposedApiKeyPlusBearerEmitsAdditionalHeader(t *testing.T) {
 	clientSrc := string(clientBytes)
 	assert.Contains(t, clientSrc, `req.Header.Set("ST-App-Key", v)`,
 		"client must set ST-App-Key on every outbound request when configured")
+
+	doctorBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctorSrc := string(doctorBytes)
+	assert.Contains(t, doctorSrc, `recordAdditionalAuthEnv("ST_APP_KEY", configuredValue)`,
+		"doctor must check the sibling apiKey env var")
+	assert.Contains(t, doctorSrc, `configuredValue = cfg.StAppKey`,
+		"doctor must accept sibling apiKey credentials from config files")
+	assert.Contains(t, doctorSrc, `OK %d/%d available", len(authEnvSet), 3`,
+		"doctor must include sibling apiKey credentials in the env-var count")
+
+	agentContextBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "agent_context.go"))
+	require.NoError(t, err)
+	agentContextSrc := string(agentContextBytes)
+	assert.Contains(t, agentContextSrc, `"ST_APP_KEY"`,
+		"agent-context must expose sibling apiKey credentials to agents")
+
+	mcpBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	mcpSrc := string(mcpBytes)
+	assert.Contains(t, mcpSrc, `"ST_APP_KEY"`,
+		"MCP context must expose sibling apiKey credentials to agents")
 }
 
 // OAuth2 client_credentials specs without a sibling apiKey scheme must not

--- a/internal/generator/templates/agent_context.go.tmpl
+++ b/internal/generator/templates/agent_context.go.tmpl
@@ -103,10 +103,9 @@ reading source. Schema is versioned via schema_version.`,
 }
 
 func buildAgentContext(rootCmd *cobra.Command) agentContext {
+{{- $authEnvVars := authAgentEnvVars .Auth}}
 	envVars := []agentContextAuthEnvVar{
-{{- if .Auth.EnvVarSpecs}}
-{{- range .Auth.EnvVarSpecs}}
-{{- if ne .Kind "harvested"}}
+{{- range $authEnvVars}}
 		{
 			Name:      {{printf "%q" .Name}},
 			Kind:      {{printf "%q" .Kind}},
@@ -118,17 +117,6 @@ func buildAgentContext(rootCmd *cobra.Command) agentContext {
 			Description: {{printf "%q" .Description}},
 {{- end}}
 		},
-{{- end}}
-{{- end}}
-{{- else}}
-{{- range .Auth.EnvVars}}
-		{
-			Name:      {{printf "%q" .}},
-			Kind:      "per_call",
-			Required:  true,
-			Sensitive: true,
-		},
-{{- end}}
 {{- end}}
 	}
 	authMode := {{printf "%q" .Auth.Type}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -28,7 +28,7 @@ import (
 {{- if .BearerRefresh.Enabled}}
 	"net/http"
 {{- end}}
-{{- if or .Auth.EnvVarSpecs .Auth.EnvVars .HasStore .Auth.RequiresBrowserSession .HasTierRouting}}
+{{- if or .Auth.EnvVarSpecs .Auth.EnvVars .Auth.AdditionalHeaders .HasStore .Auth.RequiresBrowserSession .HasTierRouting}}
 	"os"
 {{- end}}
 {{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
@@ -297,19 +297,30 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 {{- end}}
-{{- if not (or .Auth.EnvVarSpecs .Auth.EnvVars)}}
+{{- if not (or .Auth.EnvVarSpecs .Auth.EnvVars .Auth.AdditionalHeaders)}}
 			_ = authConfigured
 {{- end}}
 {{- end}}
 
 			// Check auth environment variables
-{{- if .Auth.EnvVarSpecs}}
+{{- if or .Auth.EnvVarSpecs .Auth.AdditionalHeaders}}
 			authEnvSet := []string{}
 			authEnvRequiredMissing := []string{}
 			authEnvInfo := []string{}
 			authEnvOptionalNames := []string{}
 			// Validation rejects multi-OR-group specs upstream, so the single optional-satisfied state is sufficient at runtime.
 			authEnvOptionalSatisfied := false
+{{- if .Auth.AdditionalHeaders}}
+			recordAdditionalAuthEnv := func(name, configuredValue string) {
+				if os.Getenv(name) != "" {
+					authEnvSet = append(authEnvSet, name)
+				} else if configuredValue != "" {
+					authEnvSet = append(authEnvSet, name)
+				} else {
+					authEnvRequiredMissing = append(authEnvRequiredMissing, name)
+				}
+			}
+{{- end}}
 {{- if hasAuthEnvVarKind .Auth.EnvVarSpecs "harvested"}}
 			authHeader := ""
 			if cfg != nil {
@@ -357,6 +368,15 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			}
 {{- end}}
 {{- end}}
+{{- range .Auth.AdditionalHeaders}}
+			{
+				configuredValue := ""
+				if cfg != nil {
+					configuredValue = cfg.{{resolveEnvVarField .EnvVar.Name}}
+				}
+				recordAdditionalAuthEnv("{{.EnvVar.Name}}", configuredValue)
+			}
+{{- end}}
 			switch {
 			case len(authEnvRequiredMissing) > 0:
 				report["env_vars"] = "ERROR missing required: " + strings.Join(authEnvRequiredMissing, ", ")
@@ -367,7 +387,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			case len(authEnvInfo) > 0:
 				report["env_vars"] = "INFO " + strings.Join(authEnvInfo, "; ")
 			default:
-				report["env_vars"] = fmt.Sprintf("OK %d/%d available", len(authEnvSet), {{len .Auth.EnvVarSpecs}})
+				report["env_vars"] = fmt.Sprintf("OK %d/%d available", len(authEnvSet), {{add (len .Auth.EnvVarSpecs) (len .Auth.AdditionalHeaders)}})
 			}
 {{- else if .Auth.EnvVars}}
 			authEnvChecked := 0

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -316,6 +316,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					authEnvSet = append(authEnvSet, name)
 				} else if configuredValue != "" {
 					authEnvSet = append(authEnvSet, name)
+				} else if authConfigured {
+					authSource, _ := report["auth_source"].(string)
+					if authSource == "" {
+						authSource = "config"
+					}
+					authEnvInfo = append(authEnvInfo, "credentials available from "+authSource)
 				} else {
 					authEnvRequiredMissing = append(authEnvRequiredMissing, name)
 				}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -731,6 +731,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 {{- end}}
 
 func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+{{- $authEnvVars := authAgentEnvVars .Auth}}
 	ctx := map[string]any{
 		"api":         {{printf "%q" .DomainContext.APIName}},
 		"description": {{printf "%q" .DomainContext.Description}},
@@ -741,10 +742,9 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 		"auth": map[string]any{
 			"type": {{printf "%q" .Auth.Type}},
-{{- if .Auth.EnvVarSpecs}}
+{{- if $authEnvVars}}
 			"env_vars": []map[string]any{
-{{- range .Auth.EnvVarSpecs}}
-{{- if ne .Kind "harvested"}}
+{{- range $authEnvVars}}
 				{
 					"name": {{printf "%q" .Name}},
 					"kind": {{printf "%q" .Kind}},
@@ -756,13 +756,6 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 					"description": {{printf "%q" .Description}},
 {{- end}}
 				},
-{{- end}}
-{{- end}}
-			},
-{{- else if .Auth.EnvVars}}
-			"env_vars": []map[string]any{
-{{- range .Auth.EnvVars}}
-				{"name": {{printf "%q" .}}, "kind": "per_call", "required": true, "sensitive": true},
 {{- end}}
 			},
 {{- end}}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -784,36 +784,20 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 	envPrefix := naming.EnvPrefix(name)
 	switch auth.Type {
 	case "api_key":
-		if authFormatIsBasic(auth.Format) {
-			auth.EnvVars = []string{envPrefix + "_USERNAME", envPrefix + "_PASSWORD"}
-		} else {
-			// Use scheme name for more specific env var (e.g. BotToken -> DISCORD_BOT_TOKEN)
-			schemeEnvSuffix := toSnakeCase(schemeName)
-			if schemeEnvSuffix != "" && !isGenericAPIKeySchemeSuffix(schemeEnvSuffix) {
-				auth.EnvVars = []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
-			} else {
-				auth.EnvVars = []string{envPrefix + "_API_KEY"}
-			}
-		}
+		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix)
 	case "bearer_token":
-		schemeEnvSuffix := toSnakeCase(schemeName)
-		switch schemeEnvSuffix {
-		case "", "bearer", "bearer_token", "token":
-			auth.EnvVars = []string{envPrefix + "_TOKEN"}
-		default:
-			auth.EnvVars = []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
-		}
+		auth.EnvVars = defaultAuthEnvVars(auth.Type, auth.Format, schemeName, envPrefix)
 	}
 	applyAuthOverrideExtensions(&auth, scheme.Extensions)
 	applyAuthEnvVarDefaults(&auth, envPrefix)
 	applyAuthVarsRichOverride(&auth, scheme.Extensions, fmt.Sprintf("components.securitySchemes.%s.%s", schemeName, extensionAuthVars))
 	applyAuthCompanionFromInfo(&auth, doc)
-	auth.AdditionalHeaders = collectAdditionalAuthHeaders(doc, schemeName)
+	auth.AdditionalHeaders = collectAdditionalAuthHeaders(doc, schemeName, envPrefix)
 	return auth
 }
 
 // collectAdditionalAuthHeaders scans AND-group siblings of the winning
-// security scheme for x-auth-vars per_call entries. Composed auth shapes
+// security scheme for per-call credential entries. Composed auth shapes
 // (apiKey + OAuth bearer, Stripe-Signature + bearer, ST-App-Key + bearer)
 // declare the apiKey scheme in the same security requirement object as the
 // bearer; selectSecurityScheme picks the bearer half, and without this sweep
@@ -827,33 +811,39 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 // header on every Bearer-authenticated request. Only schemes co-located with
 // the winner in a requirement object are promoted.
 //
-// Only apiKey-typed siblings with `in: header` and an `x-auth-vars` per_call
-// declaration are considered. When doc.Security is empty (no root-level AND
-// grouping declared), no siblings are promoted: without an explicit
-// requirement object the AND/OR relationship is ambiguous and conservative
-// behavior is to emit nothing.
-func collectAdditionalAuthHeaders(doc *openapi3.T, winner string) []spec.AdditionalAuthHeader {
+// Only apiKey-typed siblings with `in: header` are considered. Rich
+// x-auth-vars per_call declarations win; legacy x-auth-env-vars supplies the
+// same credential name for specs that do not use the rich shape. For all-apiKey
+// AND groups, missing extension metadata falls back to a deterministic
+// scheme-derived env var so every required header reaches generated config and
+// client code.
+func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []spec.AdditionalAuthHeader {
 	if doc == nil || doc.Components == nil || len(doc.Components.SecuritySchemes) <= 1 {
 		return nil
 	}
-	if winner == "" || len(doc.Security) == 0 {
+	requirements := additionalHeaderSecurityRequirements(doc)
+	if winner == "" || len(requirements) == 0 {
 		return nil
 	}
 
 	siblingSet := map[string]struct{}{}
+	fallbackEligible := map[string]bool{}
 	var siblings []string
-	for _, req := range doc.Security {
+	for _, req := range requirements {
 		if _, ok := req[winner]; !ok {
 			continue
 		}
+		allHeaderAPIKeys := requirementAllHeaderAPIKeys(doc, req)
 		for name := range req {
 			if name == winner {
 				continue
 			}
 			if _, dup := siblingSet[name]; dup {
+				fallbackEligible[name] = fallbackEligible[name] || allHeaderAPIKeys
 				continue
 			}
 			siblingSet[name] = struct{}{}
+			fallbackEligible[name] = allHeaderAPIKeys
 			siblings = append(siblings, name)
 		}
 	}
@@ -877,14 +867,7 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner string) []spec.Additio
 		if !strings.EqualFold(strings.TrimSpace(scheme.In), "header") {
 			continue
 		}
-		raw, ok := scheme.Extensions[extensionAuthVars]
-		if !ok || raw == nil {
-			continue
-		}
-		envVars, err := authVarsExtension(raw)
-		if err != nil || len(envVars) == 0 {
-			continue
-		}
+		envVars := additionalHeaderEnvVars(scheme, name, envPrefix, fallbackEligible[name])
 		for _, ev := range envVars {
 			if ev.EffectiveKind() != spec.AuthEnvVarKindPerCall {
 				continue
@@ -901,6 +884,131 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner string) []spec.Additio
 		}
 	}
 	return headers
+}
+
+func additionalHeaderSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirements {
+	if doc == nil {
+		return nil
+	}
+	var requirements openapi3.SecurityRequirements
+	visitedOperation := false
+	if doc.Paths == nil {
+		if len(doc.Security) > 0 {
+			requirements = append(requirements, doc.Security...)
+		}
+		return requirements
+	}
+	for _, pathKey := range doc.Paths.InMatchingOrder() {
+		pathItem := doc.Paths.Value(pathKey)
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			if op == nil {
+				continue
+			}
+			visitedOperation = true
+			requirements = append(requirements, effectiveSecurityRequirements(op, doc)...)
+		}
+	}
+	if visitedOperation {
+		return requirements
+	}
+	if len(doc.Security) > 0 {
+		requirements = append(requirements, doc.Security...)
+	}
+	return requirements
+}
+
+func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, envPrefix string, allowFallback bool) []spec.AuthEnvVar {
+	if scheme == nil {
+		return nil
+	}
+	if raw, ok := scheme.Extensions[extensionAuthVars]; ok && raw != nil {
+		envVars, err := authVarsExtension(raw)
+		if err == nil && len(envVars) > 0 {
+			return envVars
+		}
+	}
+	if envVars := stringListExtension(scheme.Extensions, extensionAuthEnvVars); len(envVars) > 0 {
+		if len(envVars) > 1 {
+			warnf("components.securitySchemes.%s.%s declares multiple names for one sibling header; using %s", schemeName, extensionAuthEnvVars, envVars[0])
+		}
+		name := strings.TrimSpace(envVars[0])
+		if name == "" {
+			return nil
+		}
+		return []spec.AuthEnvVar{{
+			Name:      name,
+			Kind:      spec.AuthEnvVarKindPerCall,
+			Required:  true,
+			Sensitive: true,
+			Inferred:  true,
+		}}
+	}
+	if !allowFallback {
+		return nil
+	}
+	name := derivedAdditionalHeaderEnvVar(schemeName, envPrefix)
+	if name == "" {
+		return nil
+	}
+	return []spec.AuthEnvVar{{
+		Name:      name,
+		Kind:      spec.AuthEnvVarKindPerCall,
+		Required:  true,
+		Sensitive: true,
+		Inferred:  true,
+	}}
+}
+
+func derivedAdditionalHeaderEnvVar(schemeName, envPrefix string) string {
+	envVars := defaultAuthEnvVars("api_key", "", schemeName, envPrefix)
+	if len(envVars) == 0 {
+		return ""
+	}
+	return envVars[0]
+}
+
+func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string {
+	switch authType {
+	case "api_key":
+		if authFormatIsBasic(format) {
+			return []string{envPrefix + "_USERNAME", envPrefix + "_PASSWORD"}
+		}
+		// Use scheme name for more specific env var (e.g. BotToken -> DISCORD_BOT_TOKEN).
+		schemeEnvSuffix := toSnakeCase(schemeName)
+		if schemeEnvSuffix != "" && !isGenericAPIKeySchemeSuffix(schemeEnvSuffix) {
+			return []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
+		}
+		return []string{envPrefix + "_API_KEY"}
+	case "bearer_token":
+		schemeEnvSuffix := toSnakeCase(schemeName)
+		switch schemeEnvSuffix {
+		case "", "bearer", "bearer_token", "token":
+			return []string{envPrefix + "_TOKEN"}
+		default:
+			return []string{envPrefix + "_" + strings.ToUpper(schemeEnvSuffix)}
+		}
+	default:
+		return nil
+	}
+}
+
+func requirementAllHeaderAPIKeys(doc *openapi3.T, req openapi3.SecurityRequirement) bool {
+	if doc == nil || doc.Components == nil || len(req) == 0 {
+		return false
+	}
+	for name := range req {
+		scheme := securitySchemeValue(doc.Components.SecuritySchemes[name])
+		if scheme == nil {
+			return false
+		}
+		if !strings.EqualFold(scheme.Type, "apiKey") || !strings.EqualFold(strings.TrimSpace(scheme.In), "header") {
+			return false
+		}
+	}
+	return true
 }
 
 func isGenericAPIKeySchemeSuffix(suffix string) bool {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -825,6 +825,10 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []s
 	if winner == "" || len(requirements) == 0 {
 		return nil
 	}
+	requirements = additionalHeaderRequirementsForWinner(requirements, winner)
+	if len(requirements) == 0 || !additionalHeaderRequirementsShareSiblings(requirements, winner) {
+		return nil
+	}
 
 	siblingSet := map[string]struct{}{}
 	fallbackEligible := map[string]bool{}
@@ -891,11 +895,10 @@ func additionalHeaderSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequ
 		return nil
 	}
 	var requirements openapi3.SecurityRequirements
+	seen := map[string]struct{}{}
 	visitedOperation := false
 	if doc.Paths == nil {
-		if len(doc.Security) > 0 {
-			requirements = append(requirements, doc.Security...)
-		}
+		appendUniqueSecurityRequirements(&requirements, seen, doc.Security)
 		return requirements
 	}
 	for _, pathKey := range doc.Paths.InMatchingOrder() {
@@ -908,16 +911,77 @@ func additionalHeaderSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequ
 				continue
 			}
 			visitedOperation = true
-			requirements = append(requirements, effectiveSecurityRequirements(op, doc)...)
+			appendUniqueSecurityRequirements(&requirements, seen, effectiveSecurityRequirements(op, doc))
 		}
 	}
 	if visitedOperation {
 		return requirements
 	}
-	if len(doc.Security) > 0 {
-		requirements = append(requirements, doc.Security...)
-	}
+	appendUniqueSecurityRequirements(&requirements, seen, doc.Security)
 	return requirements
+}
+
+func appendUniqueSecurityRequirements(requirements *openapi3.SecurityRequirements, seen map[string]struct{}, candidates openapi3.SecurityRequirements) {
+	for _, req := range candidates {
+		key := securityRequirementKey(req)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		*requirements = append(*requirements, req)
+	}
+}
+
+func securityRequirementKey(req openapi3.SecurityRequirement) string {
+	names := make([]string, 0, len(req))
+	for name := range req {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		scopes := slices.Clone(req[name])
+		sort.Strings(scopes)
+		parts = append(parts, name+":"+strings.Join(scopes, ","))
+	}
+	return strings.Join(parts, "|")
+}
+
+func additionalHeaderRequirementsForWinner(requirements openapi3.SecurityRequirements, winner string) openapi3.SecurityRequirements {
+	matching := make(openapi3.SecurityRequirements, 0, len(requirements))
+	for _, req := range requirements {
+		if _, ok := req[winner]; ok {
+			matching = append(matching, req)
+		}
+	}
+	return matching
+}
+
+func additionalHeaderRequirementsShareSiblings(requirements openapi3.SecurityRequirements, winner string) bool {
+	var signature string
+	for i, req := range requirements {
+		current := additionalHeaderSiblingSignature(req, winner)
+		if i == 0 {
+			signature = current
+			continue
+		}
+		if current != signature {
+			return false
+		}
+	}
+	return true
+}
+
+func additionalHeaderSiblingSignature(req openapi3.SecurityRequirement, winner string) string {
+	siblings := make([]string, 0, len(req))
+	for name := range req {
+		if name != winner {
+			siblings = append(siblings, name)
+		}
+	}
+	sort.Strings(siblings)
+	return strings.Join(siblings, "|")
 }
 
 func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, envPrefix string, allowFallback bool) []spec.AuthEnvVar {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -4183,6 +4183,61 @@ paths:
 	assert.Empty(t, parsed.Auth.AdditionalHeaders)
 }
 
+func TestOperationLevelHeterogeneousSiblingApiKeysAreSkipped(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: heterogeneous-operation-siblings
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiIntegrationCode:
+      type: apiKey
+      in: header
+      name: ApiIntegrationCode
+      x-auth-env-vars:
+        - EXAMPLE_INTEGRATION_CODE
+    Secret:
+      type: apiKey
+      in: header
+      name: Secret
+      x-auth-env-vars:
+        - EXAMPLE_SECRET
+    UserName:
+      type: apiKey
+      in: header
+      name: UserName
+      x-auth-env-vars:
+        - EXAMPLE_USERNAME
+paths:
+  /tickets:
+    get:
+      security:
+        - ApiIntegrationCode: []
+          Secret: []
+      responses:
+        "200":
+          description: OK
+  /companies:
+    get:
+      security:
+        - ApiIntegrationCode: []
+          UserName: []
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ApiIntegrationCode", parsed.Auth.Scheme)
+	assert.Empty(t, parsed.Auth.AdditionalHeaders,
+		"operation-specific sibling sets cannot be represented as global additional headers")
+}
+
 func TestOpenAPIAuthClassifiesCookieAndOAuth2ClientCredentialsEnvVars(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/swagger2_test.go
+++ b/internal/openapi/swagger2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -235,4 +236,171 @@ func TestParseSwagger2HostBasePathDefaultsToHTTPS(t *testing.T) {
 	assert.Equal(t, "https://api.setlist.fm/rest", parsed.BaseURL)
 	assert.Contains(t, parsed.Resources, "host-demo-search")
 	assert.NotContains(t, parsed.Resources, "1_0")
+}
+
+func TestParseSwagger2AllAPIKeyHeaderRequirementCollectsSiblingCredentials(t *testing.T) {
+	t.Parallel()
+
+	swagger2 := []byte(`{
+  "swagger": "2.0",
+  "info": {"title": "Autotask Shape", "version": "1.0.0"},
+  "host": "api.example.com",
+  "basePath": "/v1",
+  "schemes": ["https"],
+  "securityDefinitions": {
+    "UserName": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "UserName",
+      "x-auth-env-vars": ["AUTOTASK_USERNAME"]
+    },
+    "Secret": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Secret",
+      "x-auth-env-vars": ["AUTOTASK_SECRET"]
+    },
+    "ApiIntegrationCode": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "ApiIntegrationCode",
+      "x-auth-env-vars": ["AUTOTASK_INTEGRATION_CODE"]
+    }
+  },
+  "security": [
+    {
+      "UserName": [],
+      "Secret": [],
+      "ApiIntegrationCode": []
+    }
+  ],
+  "paths": {
+    "/tickets": {
+      "get": {
+        "operationId": "listTickets",
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  }
+}`)
+
+	parsed, err := Parse(swagger2)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.NotEqual(t, "none", parsed.Auth.Type)
+	assert.Equal(t, []string{"AUTOTASK_INTEGRATION_CODE"}, parsed.Auth.EnvVars)
+	assert.Equal(t, []spec.AuthEnvVar{{
+		Name:      "AUTOTASK_INTEGRATION_CODE",
+		Kind:      spec.AuthEnvVarKindPerCall,
+		Required:  true,
+		Sensitive: true,
+		Inferred:  true,
+	}}, parsed.Auth.EnvVarSpecs)
+	require.Len(t, parsed.Auth.AdditionalHeaders, 2)
+	assert.ElementsMatch(t, []spec.AdditionalAuthHeader{
+		{
+			Header: "Secret",
+			In:     "header",
+			Scheme: "Secret",
+			EnvVar: spec.AuthEnvVar{
+				Name:      "AUTOTASK_SECRET",
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+				Inferred:  true,
+			},
+		},
+		{
+			Header: "UserName",
+			In:     "header",
+			Scheme: "UserName",
+			EnvVar: spec.AuthEnvVar{
+				Name:      "AUTOTASK_USERNAME",
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+				Inferred:  true,
+			},
+		},
+	}, parsed.Auth.AdditionalHeaders)
+}
+
+func TestParseSwagger2OperationAllAPIKeyHeaderRequirementCollectsSiblingCredentials(t *testing.T) {
+	t.Parallel()
+
+	swagger2 := []byte(`{
+  "swagger": "2.0",
+  "info": {"title": "Autotask Shape", "version": "1.0.0"},
+  "host": "api.example.com",
+  "basePath": "/v1",
+  "schemes": ["https"],
+  "securityDefinitions": {
+    "UserName": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "UserName",
+      "x-auth-env-vars": ["AUTOTASK_USERNAME"]
+    },
+    "Secret": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Secret"
+    },
+    "ApiIntegrationCode": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "ApiIntegrationCode",
+      "x-auth-env-vars": ["AUTOTASK_INTEGRATION_CODE"]
+    }
+  },
+  "paths": {
+    "/tickets": {
+      "get": {
+        "operationId": "listTickets",
+        "security": [
+          {
+            "UserName": [],
+            "Secret": [],
+            "ApiIntegrationCode": []
+          }
+        ],
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  }
+}`)
+
+	parsed, err := Parse(swagger2)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, []string{"AUTOTASK_INTEGRATION_CODE"}, parsed.Auth.EnvVars)
+	require.Len(t, parsed.Auth.AdditionalHeaders, 2)
+	assert.ElementsMatch(t, []spec.AdditionalAuthHeader{
+		{
+			Header: "Secret",
+			In:     "header",
+			Scheme: "Secret",
+			EnvVar: spec.AuthEnvVar{
+				Name:      "AUTOTASK_SHAPE_SECRET",
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+				Inferred:  true,
+			},
+		},
+		{
+			Header: "UserName",
+			In:     "header",
+			Scheme: "UserName",
+			EnvVar: spec.AuthEnvVar{
+				Name:      "AUTOTASK_USERNAME",
+				Kind:      spec.AuthEnvVarKindPerCall,
+				Required:  true,
+				Sensitive: true,
+				Inferred:  true,
+			},
+		},
+	}, parsed.Auth.AdditionalHeaders)
 }

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2225,12 +2225,20 @@ func composedHeaderCompanionSuffix(scheme openAPISecurityScheme) bool {
 }
 
 func isComposedHeaderAlternative(schemes map[string]openAPISecurityScheme, alternative []string) bool {
+	apiKeyHeaderCount := 0
 	counts := make(map[string]int)
 	for _, key := range alternative {
-		prefix := composedHeaderPrefix(schemes[key])
+		scheme := schemes[key]
+		if isAPIKeyHeaderScheme(scheme) {
+			apiKeyHeaderCount++
+		}
+		prefix := composedHeaderPrefix(scheme)
 		if prefix != "" {
 			counts[prefix]++
 		}
+	}
+	if apiKeyHeaderCount > 1 {
+		return true
 	}
 	for _, count := range counts {
 		if count > 1 {

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1318,6 +1318,125 @@ func signKalshiRequest(req *http.Request, key string, signature string) {
 		assert.Less(t, sc.Steinberger.AuthProtocol, 5)
 	})
 
+	t.Run("all apiKey header auth scores every required header", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/client/client.go", `
+package client
+
+import "net/http"
+
+func setAutotaskAuth(req *http.Request, userName string, secret string, integrationCode string) {
+	req.Header.Set("UserName", userName)
+	req.Header.Set("Secret", secret)
+	req.Header.Set("ApiIntegrationCode", integrationCode)
+}
+`)
+
+		specPath := filepath.Join(dir, "spec-autotask-composed.json")
+		writeScorecardFixture(t, dir, "spec-autotask-composed.json", `{
+  "security": [
+    {
+      "UserName": [],
+      "Secret": [],
+      "ApiIntegrationCode": []
+    }
+  ],
+  "paths": {
+    "/tickets": {
+      "get": {
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "UserName": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "UserName"
+      },
+      "Secret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Secret"
+      },
+      "ApiIntegrationCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "ApiIntegrationCode"
+      }
+    }
+  }
+}`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
+		assert.NoError(t, err)
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.Equal(t, 10, sc.Steinberger.AuthProtocol)
+	})
+
+	t.Run("all apiKey header auth penalizes missing required header", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/client/client.go", `
+package client
+
+import "net/http"
+
+func setAutotaskAuth(req *http.Request, userName string, integrationCode string) {
+	req.Header.Set("UserName", userName)
+	req.Header.Set("ApiIntegrationCode", integrationCode)
+}
+`)
+
+		specPath := filepath.Join(dir, "spec-autotask-composed-missing.json")
+		writeScorecardFixture(t, dir, "spec-autotask-composed-missing.json", `{
+  "security": [
+    {
+      "UserName": [],
+      "Secret": [],
+      "ApiIntegrationCode": []
+    }
+  ],
+  "paths": {
+    "/tickets": {
+      "get": {
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "UserName": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "UserName"
+      },
+      "Secret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Secret"
+      },
+      "ApiIntegrationCode": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "ApiIntegrationCode"
+      }
+    }
+  }
+}`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
+		assert.NoError(t, err)
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.Less(t, sc.Steinberger.AuthProtocol, 5)
+	})
+
 	t.Run("same-prefix standalone header scheme is not pulled into composed auth", func(t *testing.T) {
 		dir := t.TempDir()
 		writeScorecardFixture(t, dir, "internal/client/client.go", `


### PR DESCRIPTION
## Summary
- Treat all-header apiKey AND requirements as composed credential sets, including operation-level security requirements.
- Wire sibling composed-auth credentials through config/client/doctor plus agent-context and MCP context surfaces.
- Update auth scoring and docs so all required apiKey headers are verified and documented.

## Verification
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- go test ./...
- golangci-lint run ./...
- scripts/golden.sh verify
- git diff --check

Closes #1538
