### PR TITLE
fix(cli): support GeoJSON FeatureCollection in sync extraction

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3186,6 +3186,10 @@ func TestSyncExtractPaginationNestedCursor(t *testing.T) {
 		"paginationWrapperKeys must include response_metadata (Slack's envelope)")
 	assert.Contains(t, src, `"pagination"`,
 		"paginationWrapperKeys must include pagination (MongoDB Atlas-style)")
+	assert.Contains(t, src, `"features"`,
+		"pageItemKeys must include features (GeoJSON support)")
+	assert.Contains(t, src, `"Features"`,
+		"pageItemKeys must include Features (PascalCase GeoJSON support)")
 
 	// Tier 2: behavioral test, written into the generated tree as a
 	// same-package _test.go so it can call the unexported helper.
@@ -3195,6 +3199,43 @@ import (
 	"encoding/json"
 	"testing"
 )
+
+func TestExtractPageItemsGeoJSON(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"type": "FeatureCollection",
+		"bbox": [-180, -90, 180, 90],
+		"features": [{"id":"1"},{"id":"2"}]
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("GeoJSON: want 2 items, got %d", len(items))
+	}
+}
+
+func TestExtractPageItemsGeoJSONPascal(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"Type": "FeatureCollection",
+		"Bbox": [-180, -90, 180, 90],
+		"Features": [{"Id":"1"},{"Id":"2"}]
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("GeoJSON Pascal: want 2 items, got %d", len(items))
+	}
+}
+
+func TestExtractPageItemsNonArrayFeaturesFallback(t *testing.T) {
+	// features: true should fall through to ambiguity scan or return nil.
+	// In this case, there are NO arrays, so it returns nil.
+	body := []byte(` + "`" + `{
+		"features": true,
+		"other": "val"
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 0 {
+		t.Fatalf("Non-array features: want 0 items, got %d", len(items))
+	}
+}
 
 func TestExtractPageItemsSlackEnvelope(t *testing.T) {
 	body := []byte(` + "`" + `{

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3237,6 +3237,25 @@ func TestExtractPageItemsNonArrayFeaturesFallback(t *testing.T) {
 	}
 }
 
+func TestExtractPageItemsFeaturesPrecedenceConflict(t *testing.T) {
+	// Greptile feedback: when "features" is a valid array of non-objects
+	// (e.g. strings) but another array (e.g. "markets") exists, the fast-path
+	// for "features" will fail unmarshal (into []RawMessage) if the items
+	// are not objects, and fall through to the ambiguity scan.
+	//
+	// However, if "features" IS an array of objects but they aren't the
+	// resources we want, the fast-path WILL match. This test confirms
+	// the behavior for non-object arrays.
+	body := []byte(` + "`" + `{
+		"markets": [{"id":"m1"}],
+		"features": ["dark_mode", "beta"]
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 1 {
+		t.Fatalf("Features conflict: want 1 item (from markets), got %d. Result should fall through 'features' because strings are not RawMessage objects.", len(items))
+	}
+}
+
 func TestExtractPageItemsSlackEnvelope(t *testing.T) {
 	body := []byte(` + "`" + `{
 		"ok": true,

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1096,6 +1096,14 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			if err := json.Unmarshal(raw, &items); err == nil && len(items) > 0 {
+				// Verify items are objects. If the first item is not an object
+				// (e.g. a string flag), skip this key and fall through.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 				return items, nextCursor, hasMore
 			}
@@ -1111,6 +1119,12 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for key, raw := range envelope {
 		var candidate []json.RawMessage
 		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) > 0 {
+			// Verify items are objects. If the first item is not an object,
+			// this isn't a resource collection; skip it.
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(candidate[0], &obj); err != nil {
+				continue
+			}
 			arrayKey = key
 			arrayItems = candidate
 			arrayCount++
@@ -1164,6 +1178,15 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 		if raw, ok := envelope[key]; ok {
 			var items []json.RawMessage
 			if err := json.Unmarshal(raw, &items); err == nil && !isJSONNull(raw) {
+				// If the array is empty, we still consider it a match for the
+				// key-based strategy. If it's NOT empty, we verify it's an
+				// array of objects to stay consistent with extractPageItems.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				return len(items) == 0
 			}
 		}
@@ -1172,8 +1195,17 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 	arrayCount := 0
 	for _, raw := range envelope {
 		var candidate []json.RawMessage
-		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) == 0 && !isJSONNull(raw) {
-			arrayCount++
+		if err := json.Unmarshal(raw, &candidate); err == nil && !isJSONNull(raw) {
+			// Skip candidate arrays that contain primitives (not objects).
+			if len(candidate) > 0 {
+				var obj map[string]json.RawMessage
+				if err := json.Unmarshal(candidate[0], &obj); err != nil {
+					continue
+				}
+			}
+			if len(candidate) == 0 {
+				arrayCount++
+			}
 		}
 	}
 	return arrayCount == 1

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1927,8 +1927,8 @@ var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", 
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
 // single-array sibling miscount silently truncates sync.
 var pageItemKeys = []string{
-	"data", "results", "items", "records", "nodes", "entries",
-	"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	"data", "results", "items", "records", "nodes", "entries", "features",
+	"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1434,8 +1434,8 @@ var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", 
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
 // single-array sibling miscount silently truncates sync.
 var pageItemKeys = []string{
-	"data", "results", "items", "records", "nodes", "entries",
-	"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	"data", "results", "items", "records", "nodes", "entries", "features",
+	"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -758,6 +758,14 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			if err := json.Unmarshal(raw, &items); err == nil && len(items) > 0 {
+				// Verify items are objects. If the first item is not an object
+				// (e.g. a string flag), skip this key and fall through.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 				return items, nextCursor, hasMore
 			}
@@ -773,6 +781,12 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for key, raw := range envelope {
 		var candidate []json.RawMessage
 		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) > 0 {
+			// Verify items are objects. If the first item is not an object,
+			// this isn't a resource collection; skip it.
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(candidate[0], &obj); err != nil {
+				continue
+			}
 			arrayKey = key
 			arrayItems = candidate
 			arrayCount++
@@ -826,6 +840,15 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 		if raw, ok := envelope[key]; ok {
 			var items []json.RawMessage
 			if err := json.Unmarshal(raw, &items); err == nil && !isJSONNull(raw) {
+				// If the array is empty, we still consider it a match for the
+				// key-based strategy. If it's NOT empty, we verify it's an
+				// array of objects to stay consistent with extractPageItems.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				return len(items) == 0
 			}
 		}
@@ -834,8 +857,17 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 	arrayCount := 0
 	for _, raw := range envelope {
 		var candidate []json.RawMessage
-		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) == 0 && !isJSONNull(raw) {
-			arrayCount++
+		if err := json.Unmarshal(raw, &candidate); err == nil && !isJSONNull(raw) {
+			// Skip candidate arrays that contain primitives (not objects).
+			if len(candidate) > 0 {
+				var obj map[string]json.RawMessage
+				if err := json.Unmarshal(candidate[0], &obj); err != nil {
+					continue
+				}
+			}
+			if len(candidate) == 0 {
+				arrayCount++
+			}
 		}
 	}
 	return arrayCount == 1

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -754,6 +754,14 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			if err := json.Unmarshal(raw, &items); err == nil && len(items) > 0 {
+				// Verify items are objects. If the first item is not an object
+				// (e.g. a string flag), skip this key and fall through.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 				return items, nextCursor, hasMore
 			}
@@ -769,6 +777,12 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for key, raw := range envelope {
 		var candidate []json.RawMessage
 		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) > 0 {
+			// Verify items are objects. If the first item is not an object,
+			// this isn't a resource collection; skip it.
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(candidate[0], &obj); err != nil {
+				continue
+			}
 			arrayKey = key
 			arrayItems = candidate
 			arrayCount++
@@ -822,6 +836,15 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 		if raw, ok := envelope[key]; ok {
 			var items []json.RawMessage
 			if err := json.Unmarshal(raw, &items); err == nil && !isJSONNull(raw) {
+				// If the array is empty, we still consider it a match for the
+				// key-based strategy. If it's NOT empty, we verify it's an
+				// array of objects to stay consistent with extractPageItems.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				return len(items) == 0
 			}
 		}
@@ -830,8 +853,17 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 	arrayCount := 0
 	for _, raw := range envelope {
 		var candidate []json.RawMessage
-		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) == 0 && !isJSONNull(raw) {
-			arrayCount++
+		if err := json.Unmarshal(raw, &candidate); err == nil && !isJSONNull(raw) {
+			// Skip candidate arrays that contain primitives (not objects).
+			if len(candidate) > 0 {
+				var obj map[string]json.RawMessage
+				if err := json.Unmarshal(candidate[0], &obj); err != nil {
+					continue
+				}
+			}
+			if len(candidate) == 0 {
+				arrayCount++
+			}
 		}
 	}
 	return arrayCount == 1

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1419,8 +1419,8 @@ var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", 
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
 // single-array sibling miscount silently truncates sync.
 var pageItemKeys = []string{
-	"data", "results", "items", "records", "nodes", "entries",
-	"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	"data", "results", "items", "records", "nodes", "entries", "features",
+	"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1097,8 +1097,8 @@ var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", 
 // {"Items": [...]} envelopes fall through to the ambiguity scan and a
 // single-array sibling miscount silently truncates sync.
 var pageItemKeys = []string{
-	"data", "results", "items", "records", "nodes", "entries",
-	"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	"data", "results", "items", "records", "nodes", "entries", "features",
+	"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 }
 
 // criticalResources is the template-time projection of per-resource Critical

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -723,6 +723,14 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for _, key := range pageItemKeys {
 		if raw, ok := envelope[key]; ok {
 			if err := json.Unmarshal(raw, &items); err == nil && len(items) > 0 {
+				// Verify items are objects. If the first item is not an object
+				// (e.g. a string flag), skip this key and fall through.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 				return items, nextCursor, hasMore
 			}
@@ -738,6 +746,12 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	for key, raw := range envelope {
 		var candidate []json.RawMessage
 		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) > 0 {
+			// Verify items are objects. If the first item is not an object,
+			// this isn't a resource collection; skip it.
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(candidate[0], &obj); err != nil {
+				continue
+			}
 			arrayKey = key
 			arrayItems = candidate
 			arrayCount++
@@ -791,6 +805,15 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 		if raw, ok := envelope[key]; ok {
 			var items []json.RawMessage
 			if err := json.Unmarshal(raw, &items); err == nil && !isJSONNull(raw) {
+				// If the array is empty, we still consider it a match for the
+				// key-based strategy. If it's NOT empty, we verify it's an
+				// array of objects to stay consistent with extractPageItems.
+				if len(items) > 0 {
+					var obj map[string]json.RawMessage
+					if err := json.Unmarshal(items[0], &obj); err != nil {
+						continue
+					}
+				}
 				return len(items) == 0
 			}
 		}
@@ -799,8 +822,17 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 	arrayCount := 0
 	for _, raw := range envelope {
 		var candidate []json.RawMessage
-		if err := json.Unmarshal(raw, &candidate); err == nil && len(candidate) == 0 && !isJSONNull(raw) {
-			arrayCount++
+		if err := json.Unmarshal(raw, &candidate); err == nil && !isJSONNull(raw) {
+			// Skip candidate arrays that contain primitives (not objects).
+			if len(candidate) > 0 {
+				var obj map[string]json.RawMessage
+				if err := json.Unmarshal(candidate[0], &obj); err != nil {
+					continue
+				}
+			}
+			if len(candidate) == 0 {
+				arrayCount++
+			}
 		}
 	}
 	return arrayCount == 1


### PR DESCRIPTION
<!--
2 Maintainer-owned PRs may use a shorter body. Community PRs must keep these sections.
3 Write for reviewers: explain why this change is right, not every line that changed.
4 -->

## Intent

This PR adds support for GeoJSON `FeatureCollection` responses in the sync extraction logic. Previously, GeoJSON APIs (like USGS Earthquakes or NOAA Weather) would often be stored as a single JSON blob instead of individual feature rows because the extraction logic didn't recognize the `"features"` key and was confused by sibling arrays like `"bbox"`.

Issue: #1658 

Fixes:  #1658 

## Approach

I added `"features"` and `"Features"` to the `pageItemKeys` priority list in the sync template. This allows the extractor's "fast path" to find the correct items array even when the response contains other top-level arrays (like GeoJSON's standard `bbox`), which previously caused the "ambiguity scan" fallback to fail.

## Scope

Primary area: `internal/generator/templates/sync.go.tmpl`

Why this belongs in this repo: This is a systemic fix for the sync template (the "machine"). Every printed CLI targeting a GeoJSON-conformant API was silently hitting this extraction failure, resulting in unsearchable single-row resource tables.

## Risk

N/A

## Output Contract

This change modifies `internal/generator/templates/sync.go.tmpl`, which affects the generated `internal/cli/sync.go` file in every printed CLI. The `pageItemKeys` list in the generated code now includes `"features"` and `"Features"`.

## Verification

The following commands were run to verify the fix and ensure no regressions:

1. **Unit Tests**: `go test -v ./internal/generator -run TestSync`
   - Verified that the new Tier 1 emission canaries pass.
   - Verified that the new Tier 2 behavioral tests (`TestExtractPageItemsGeoJSON`, `TestExtractPageItemsGeoJSONPascal`, and `TestExtractPageItemsNonArrayFeaturesFallback`) pass.
2. **Golden Tests**: `bash scripts/golden.sh verify`
   - Confirmed that the intentional drift in 3 generated `sync.go` fixtures is stable and matches the expected template change.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change