### PR TITLE
test(cli): cover OpenAPI multipart command generation

### DIFF
--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -146,6 +146,8 @@ paths:
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	uploadSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
+	assert.Contains(t, uploadSrc, `return fmt.Errorf("required flag \"%s\" not set", "asset-data")`)
+	assert.Contains(t, uploadSrc, `return fmt.Errorf("required flag \"%s\" not set", "filename")`)
 	assert.Contains(t, uploadSrc, `fileFields["assetData"] = bodyAssetData`)
 	assert.Contains(t, uploadSrc, `fields["filename"] = bodyFilename`)
 	assert.Contains(t, uploadSrc, `c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)`)
@@ -156,6 +158,9 @@ paths:
 	assert.Contains(t, createSrc, `body["title"] = bodyTitle`)
 	assert.Contains(t, createSrc, `c.PostWithParams(cmd.Context(), path, params, body)`)
 	assert.NotContains(t, createSrc, `c.PostMultipartWithParams`)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
 }
 
 func TestGenerateBinaryResponseWritesRawBytes(t *testing.T) {

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,6 +87,75 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestGenerateOpenAPIMultipartRequestBodyUsesMultipartClient(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Upload API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /assets:
+    post:
+      operationId: uploadAsset
+      summary: Upload asset
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [assetData, filename]
+              properties:
+                assetData:
+                  type: string
+                  format: binary
+                  description: Asset file
+                filename:
+                  type: string
+                  description: File name
+      responses:
+        "201":
+          description: created
+  /notes:
+    post:
+      operationId: createNote
+      summary: Create note
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title:
+                  type: string
+      responses:
+        "201":
+          description: created
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	uploadSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
+	assert.Contains(t, uploadSrc, `fileFields["assetData"] = bodyAssetData`)
+	assert.Contains(t, uploadSrc, `fields["filename"] = bodyFilename`)
+	assert.Contains(t, uploadSrc, `c.PostMultipartWithParams(cmd.Context(), path, params, fields, fileFields)`)
+	assert.NotContains(t, uploadSrc, `body["assetData"] = bodyAssetData`)
+	assert.NotContains(t, uploadSrc, `body["filename"] = bodyFilename`)
+
+	createSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_notes.go")
+	assert.Contains(t, createSrc, `body["title"] = bodyTitle`)
+	assert.Contains(t, createSrc, `c.PostWithParams(cmd.Context(), path, params, body)`)
+	assert.NotContains(t, createSrc, `c.PostMultipartWithParams`)
 }
 
 func TestGenerateBinaryResponseWritesRawBytes(t *testing.T) {


### PR DESCRIPTION
## Summary

OpenAPI-derived multipart upload commands are now pinned end to end: a multipart/form-data request body with a binary part must generate CLI code that populates multipart file fields and calls `PostMultipartWithParams`, while a JSON-only POST in the same parsed spec still generates the JSON `PostWithParams` path.

This confirms the current generator route handles the Immich-style shape from #1545 and protects it from regressing back to JSON body emission.

## Tests

- `go fmt ./...`
- `go test ./internal/generator -run 'TestGenerate(OpenAPIMultipartRequestBodyUsesMultipartClient|MultipartRequestBodyUsesMultipartClient)' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1545

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
