### PR TITLE
docs(cli): update generated install package name

### DIFF
--- a/cmd/printing-press/main.go
+++ b/cmd/printing-press/main.go
@@ -20,7 +20,7 @@ Generator install:
   go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
 
 Catalog installer:
-  npx -y @mvanhorn/printing-press %s
+  npx -y @mvanhorn/printing-press-library %s
 `, command, command)
 		os.Exit(cli.ExitInputError)
 	}

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -280,7 +280,7 @@ func Execute() error {
 
 // TestVerifySkill_IgnoresExternalToolFlags is the regression guard for
 // the trigger-dev / linear SKILL.md slip: the install instructions contain
-// `npx -y @mvanhorn/printing-press install <api> --cli-only`. --cli-only
+// `npx -y @mvanhorn/printing-press-library install <api> --cli-only`. --cli-only
 // belongs to the outer Printing Press installer, not to <api>-pp-cli, so
 // it must not be reported as an undeclared flag-names finding. Before the
 // scoping fix, flag-names regex-scanned the whole SKILL.md and fired on
@@ -296,7 +296,7 @@ func TestVerifySkill_IgnoresExternalToolFlags(t *testing.T) {
 	// SKILL.md uses --cli-only on an npx invocation (not on fixture-pp-cli)
 	// and uses only declared flags on its own binary's recipes.
 	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n## Prerequisites\n\n" +
-		"```bash\nnpx -y @mvanhorn/printing-press install fixture --cli-only\n```\n\n" +
+		"```bash\nnpx -y @mvanhorn/printing-press-library install fixture --cli-only\n```\n\n" +
 		"## Usage\n\n```bash\nfixture-pp-cli search --limit 5\n```\n"
 	writeVerifySkillFixture(t, dir, map[string]string{
 		"search.go": `package cli

--- a/internal/generator/agents_test.go
+++ b/internal/generator/agents_test.go
@@ -33,7 +33,7 @@ func TestGeneratedAgentsGuideRendersPortableAgentContract(t *testing.T) {
 	assert.Contains(t, content, "SKILL.md")
 
 	assert.NotContains(t, content, "## Command Reference")
-	assert.NotContains(t, content, "npx -y @mvanhorn/printing-press install")
+	assert.NotContains(t, content, "npx -y @mvanhorn/printing-press-library install")
 	assert.NotContains(t, content, "export ")
 	assert.NotContains(t, content, "<cli>")
 	assert.NotContains(t, content, "Claude Code")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2836,7 +2836,7 @@ func TestGenerateWithOwnerField(t *testing.T) {
 	assert.Contains(t, string(mainGo), "testowner")
 	readme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(readme), "npx -y @mvanhorn/printing-press install owned")
+	assert.Contains(t, string(readme), "npx -y @mvanhorn/printing-press-library install owned")
 	assert.NotContains(t, string(readme), "library/other/owned")
 }
 

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -29,7 +29,7 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 	"\n" +
 	"1. Install via the Printing Press installer:\n" +
 	"   ```bash\n" +
-	"   npx -y @mvanhorn/printing-press install %[1]s --cli-only\n" +
+	"   npx -y @mvanhorn/printing-press-library install %[1]s --cli-only\n" +
 	"   ```\n" +
 	"2. Verify: `%[1]s-pp-cli --version`\n" +
 	"3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.\n" +

--- a/internal/generator/install_section_test.go
+++ b/internal/generator/install_section_test.go
@@ -81,7 +81,7 @@ func TestCategorylessInstallSectionsAvoidOtherLibraryPath(t *testing.T) {
 			content := string(rendered)
 			require.NotContains(t, content, "library/other/gohighlevel",
 				"category-less generation must not bake in a publish-time placeholder category")
-			require.Contains(t, content, "npx -y @mvanhorn/printing-press install gohighlevel",
+			require.Contains(t, content, "npx -y @mvanhorn/printing-press-library install gohighlevel",
 				"category-less generation should keep the category-agnostic installer path")
 		})
 	}

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -679,7 +679,7 @@ func TestSkillFrontmatterMetadataOmitsUnknownCategoryInstall(t *testing.T) {
 
 	assert.NotContains(t, content, "library/other/uncategorized",
 		"empty Category should not bake a placeholder category into install metadata")
-	assert.Contains(t, content, "npx -y @mvanhorn/printing-press install uncategorized --cli-only",
+	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install uncategorized --cli-only",
 		"empty Category should keep the category-agnostic installer path")
 }
 

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -25,26 +25,26 @@ Printed by [@{{.Printer}}](https://github.com/{{.Printer}}){{if .PrinterName}} (
 The recommended path installs both the `{{.Name}}-pp-cli` binary and the `pp-{{.Name}}` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install {{.Name}}
+npx -y @mvanhorn/printing-press-library install {{.Name}}
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install {{.Name}} --cli-only
+npx -y @mvanhorn/printing-press-library install {{.Name}} --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install {{.Name}} --skill-only
+npx -y @mvanhorn/printing-press-library install {{.Name}} --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install {{.Name}} --agent claude-code
-npx -y @mvanhorn/printing-press install {{.Name}} --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install {{.Name}} --agent claude-code
+npx -y @mvanhorn/printing-press-library install {{.Name}} --agent claude-code --agent codex
 ```
 {{ if .Category}}
 ### Without Node (Go fallback)

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -26,7 +26,7 @@ This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is in
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install {{.Name}} --cli-only
+   npx -y @mvanhorn/printing-press-library install {{.Name}} --cli-only
    ```
 2. Verify: `{{.Name}}-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -9,26 +9,26 @@ Printed by [@printing-press-golden](https://github.com/printing-press-golden) (p
 The recommended path installs both the `printing-press-rich-pp-cli` binary and the `pp-printing-press-rich` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-rich
+npx -y @mvanhorn/printing-press-library install printing-press-rich
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-rich --cli-only
+npx -y @mvanhorn/printing-press-library install printing-press-rich --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-rich --skill-only
+npx -y @mvanhorn/printing-press-library install printing-press-rich --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-rich --agent claude-code
-npx -y @mvanhorn/printing-press install printing-press-rich --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install printing-press-rich --agent claude-code
+npx -y @mvanhorn/printing-press-library install printing-press-rich --agent claude-code --agent codex
 ```
 
 ### Without Node

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `printing-press-rich-pp-cli` binary. **You must verify the
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install printing-press-rich --cli-only
+   npx -y @mvanhorn/printing-press-library install printing-press-rich --cli-only
    ```
 2. Verify: `printing-press-rich-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -9,26 +9,26 @@ Printed by [@printing-press-golden](https://github.com/printing-press-golden) (p
 The recommended path installs both the `printing-press-golden-pp-cli` binary and the `pp-printing-press-golden` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-golden
+npx -y @mvanhorn/printing-press-library install printing-press-golden
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-golden --cli-only
+npx -y @mvanhorn/printing-press-library install printing-press-golden --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-golden --skill-only
+npx -y @mvanhorn/printing-press-library install printing-press-golden --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install printing-press-golden --agent claude-code
-npx -y @mvanhorn/printing-press install printing-press-golden --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install printing-press-golden --agent claude-code
+npx -y @mvanhorn/printing-press-library install printing-press-golden --agent claude-code --agent codex
 ```
 
 ### Without Node

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `printing-press-golden-pp-cli` binary. **You must verify t
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install printing-press-golden --cli-only
+   npx -y @mvanhorn/printing-press-library install printing-press-golden --cli-only
    ```
 2. Verify: `printing-press-golden-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -9,26 +9,26 @@ Printed by [@printing-press-golden](https://github.com/printing-press-golden) (p
 The recommended path installs both the `public-param-golden-pp-cli` binary and the `pp-public-param-golden` agent skill (Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and other agents supported by the upstream [`skills`](https://github.com/vercel-labs/skills) CLI) in one shot:
 
 ```bash
-npx -y @mvanhorn/printing-press install public-param-golden
+npx -y @mvanhorn/printing-press-library install public-param-golden
 ```
 
 For CLI only (no skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install public-param-golden --cli-only
+npx -y @mvanhorn/printing-press-library install public-param-golden --cli-only
 ```
 
 For skill only — installs the skill into the same agents as the default command above, but skips the CLI binary (use this to update or reinstall just the skill):
 
 ```bash
-npx -y @mvanhorn/printing-press install public-param-golden --skill-only
+npx -y @mvanhorn/printing-press-library install public-param-golden --skill-only
 ```
 
 To constrain the skill install to one or more specific agents (repeatable — agent names match the [`skills`](https://github.com/vercel-labs/skills) CLI):
 
 ```bash
-npx -y @mvanhorn/printing-press install public-param-golden --agent claude-code
-npx -y @mvanhorn/printing-press install public-param-golden --agent claude-code --agent codex
+npx -y @mvanhorn/printing-press-library install public-param-golden --agent claude-code
+npx -y @mvanhorn/printing-press-library install public-param-golden --agent claude-code --agent codex
 ```
 
 ### Without Node

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `public-param-golden-pp-cli` binary. **You must verify the
 
 1. Install via the Printing Press installer:
    ```bash
-   npx -y @mvanhorn/printing-press install public-param-golden --cli-only
+   npx -y @mvanhorn/printing-press-library install public-param-golden --cli-only
    ```
 2. Verify: `public-param-golden-pp-cli --version`
 3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.


### PR DESCRIPTION
## Summary
- update generated per-CLI README install examples to use `@mvanhorn/printing-press-library`
- update generated SKILL prerequisite install snippets and canonical install-section tests
- update golden fixtures and the legacy `printing-press` shim hint to point at the renamed catalog installer

## Follow-up
- Published-library sweep tracking: https://github.com/mvanhorn/printing-press-library/issues/760

## Verification
- `go test ./internal/generator ./internal/cli`
- `scripts/golden.sh verify`
- `go test ./...`