### PR TITLE
fix(cli): preserve generated catalog display names

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -2605,6 +2605,43 @@ func TestRunGenerateProjectUsesCatalogDescription(t *testing.T) {
 	assert.False(t, strings.HasSuffix(got.CatalogDescription, "..."))
 }
 
+func TestRunGenerateProjectReturnsResearchNarrativeCatalogMetadata(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	researchData, err := json.Marshal(&pipeline.ResearchResult{
+		APIName: "alaska-airlines",
+		Narrative: &pipeline.ReadmeNarrative{
+			DisplayName: "Alaska Airlines",
+			Headline:    "Search Alaska Airlines flights and check Atmos Rewards balance from the terminal, with offline-cached airports and agent-native JSON output.",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), researchData, 0o644))
+	apiSpec := &spec.APISpec{
+		Name:        "alaska-airlines",
+		Description: "Weak source-spec fallback copy.",
+		Version:     "1.0",
+		BaseURL:     "https://api.example.com",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "alaska-airlines")
+
+	got, err := runGenerateProject(apiSpec, outputDir, generateProjectOptions{researchDir: researchDir})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alaska Airlines", got.DisplayName)
+	assert.Equal(t, "Search Alaska Airlines flights and check Atmos Rewards balance from the terminal, with offline-cached airports and agent-native JSON output.", got.CatalogDescription)
+}
+
 func TestEnrichSpecFromCatalogReplacesTitleDerivedDisplayName(t *testing.T) {
 	apiSpec := &spec.APISpec{
 		Name:                        "trigger-dev",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -205,6 +205,7 @@ func newGenerateCmd() *cobra.Command {
 					DocsURL:       docsURL,
 					OutputDir:     absOut,
 					Description:   generateResult.CatalogDescription,
+					DisplayName:   generateResult.DisplayName,
 					Owner:         parsed.Owner,
 					Printer:       parsed.Printer,
 					PrinterName:   parsed.PrinterName,
@@ -415,6 +416,7 @@ func newGenerateCmd() *cobra.Command {
 				SpecURL:       specURL,
 				OutputDir:     absOut,
 				Description:   generateResult.CatalogDescription,
+				DisplayName:   generateResult.DisplayName,
 				Owner:         apiSpec.Owner,
 				Printer:       apiSpec.Printer,
 				PrinterName:   apiSpec.PrinterName,
@@ -516,6 +518,7 @@ type generateProjectOptions struct {
 type generateProjectResult struct {
 	NovelFeatures      []pipeline.NovelFeatureManifest
 	CatalogDescription string
+	DisplayName        string
 	Polished           bool
 }
 
@@ -570,6 +573,7 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	return generateProjectResult{
 		NovelFeatures:      novelFeatures,
 		CatalogDescription: gen.CatalogDescription(),
+		DisplayName:        gen.CatalogDisplayName(),
 		Polished:           runGeneratePolishPass(opts.polish, apiSpec.Name, absOut),
 	}, nil
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -873,6 +873,20 @@ func (g *Generator) CatalogDescription() string {
 	return fmt.Sprintf("Printing Press CLI for %s.", g.proseName())
 }
 
+// CatalogDisplayName returns the best generated brand name for durable catalog
+// metadata.
+func (g *Generator) CatalogDisplayName() string {
+	if g.Narrative != nil {
+		if displayName := strings.TrimSpace(g.Narrative.DisplayName); displayName != "" {
+			return displayName
+		}
+	}
+	if g.Spec != nil {
+		return strings.TrimSpace(g.Spec.EffectiveDisplayName())
+	}
+	return ""
+}
+
 func (g *Generator) skillDescription() string {
 	switch {
 	case g.Narrative != nil && strings.TrimSpace(g.Narrative.Headline) != "":

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -591,6 +591,7 @@ type GenerateManifestParams struct {
 	DocsURL       string   // --docs URL, if used
 	OutputDir     string
 	Description   string                 // best generated user-facing catalog description
+	DisplayName   string                 // best generated user-facing catalog display name
 	Owner         string                 // resolved owner attribution (manifest preserve > copyright parse > git config)
 	Printer       string                 // resolved printer @handle (manifest preserve > git config github.user > empty)
 	PrinterName   string                 // resolved printer display name (manifest preserve > git config user.name > empty)
@@ -729,6 +730,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		if entry.DisplayName != "" {
 			m.DisplayName = entry.DisplayName
 		}
+	}
+	if displayName := strings.TrimSpace(p.DisplayName); displayName != "" {
+		m.DisplayName = displayName
 	}
 	// Fall back to spec.Category for synthetic CLIs that aren't in the
 	// embedded catalog. Without this, manifest.Category stays empty even

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -731,9 +731,6 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 			m.DisplayName = entry.DisplayName
 		}
 	}
-	if displayName := strings.TrimSpace(p.DisplayName); displayName != "" {
-		m.DisplayName = displayName
-	}
 	// Fall back to spec.Category for synthetic CLIs that aren't in the
 	// embedded catalog. Without this, manifest.Category stays empty even
 	// when the spec sets `category: travel`, and verify-skill's canonical-
@@ -754,6 +751,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	// Populate MCP metadata from the parsed spec.
 	if p.Spec != nil {
 		populateMCPMetadata(&m, p.Spec)
+	}
+	if displayName := strings.TrimSpace(p.DisplayName); displayName != "" {
+		m.DisplayName = displayName
 	}
 	if description := strings.TrimSpace(p.Description); description != "" {
 		m.Description = description

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1771,6 +1771,26 @@ func TestWriteManifestForGenerateUsesExplicitCatalogDescription(t *testing.T) {
 	assert.False(t, strings.HasSuffix(got.Description, "..."))
 }
 
+func TestWriteManifestForGenerateUsesExplicitCatalogDisplayName(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:     "alaska-airlines",
+		OutputDir:   dir,
+		DisplayName: "Alaska Airlines",
+		Spec: &spec.APISpec{
+			Name:                        "alaska-airlines",
+			DisplayName:                 "Alaska Airlines API",
+			DisplayNameDerivedFromTitle: true,
+			Auth:                        spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "Alaska Airlines", got.DisplayName)
+}
+
 func TestWriteManifestForGeneratePreservesExistingDurableDescription(t *testing.T) {
 	dir := t.TempDir()
 	existing := "Curated CLI description that should survive force regeneration."

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -636,6 +636,25 @@ func TestWriteManifestForGenerateKeepsCatalogDisplayNameOverTitleFallback(t *tes
 	assert.Equal(t, "Product Hunt", got.DisplayName)
 }
 
+func TestWriteManifestForGenerateKeepsGeneratedDisplayNameOverExplicitSpecName(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:     "synthetic-display-name",
+		OutputDir:   dir,
+		DisplayName: "Research Narrative Name",
+		Spec: &spec.APISpec{
+			Name:        "synthetic-display-name",
+			DisplayName: "Explicit Spec Name",
+			Auth:        spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "Research Narrative Name", got.DisplayName)
+}
+
 func TestWriteManifestForGenerateMatchesCatalogBySpecURLWhenSlugDiffers(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- carry generated catalog display names from README/research narrative into `.printing-press.json`
- keep the existing catalog description path and add Alaska-style regression coverage

## Tests
- `PATH="/opt/homebrew/bin:$PATH" go test ./...`
- `PATH="/opt/homebrew/bin:$PATH" scripts/golden.sh verify`

Fixes #1854