### PR TITLE
fix(generator): support embedded-json selector shapes

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2477,6 +2477,19 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 			_, _ = w.Write([]byte(`<html><body>
 				<script id="ARTICLE_DATA" type="application/json">{"items":[{"slug":"a"},{"slug":"b"}]}</script>
 			</body></html>`))
+		case "/jsonld":
+			// Schema.org JSON-LD is emitted by browser-sniff reachability defaults as
+			// script[type="application/ld+json"]. The generated runtime must understand
+			// that attribute-selector shape, not only tag#id.
+			_, _ = w.Write([]byte(`<html><body>
+				<script type="application/ld+json">{"@context":"https://schema.org","@type":"ItemList","itemListElement":[{"name":"Tacos"},{"name":"Burritos"}]}</script>
+			</body></html>`))
+		case "/state-view":
+			// Browser-sniff also emits script.state-view for some SSR state blobs.
+			// Keep class selector support covered by the generated runtime test.
+			_, _ = w.Write([]byte(`<html><body>
+				<script class="state-view">{"items":[{"slug":"sv-a"},{"slug":"sv-b"}]}</script>
+			</body></html>`))
 		case "/missing":
 			// No matching script tag — should produce an extractor error.
 			_, _ = w.Write([]byte(`<html><body><p>nothing here</p></body></html>`))
@@ -2542,6 +2555,40 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 					},
 				},
 			},
+			"jsonld": {
+				Description: "Browse JSON-LD records",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/jsonld",
+						Description:    "List records via schema.org JSON-LD",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: `script[type="application/ld+json"]`,
+							JSONPath:       "itemListElement",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "object"},
+					},
+				},
+			},
+			"stateview": {
+				Description: "Browse state-view records",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/state-view",
+						Description:    "List records via state-view class selector",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: "script.state-view",
+							JSONPath:       "items",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "object"},
+					},
+				},
+			},
 		},
 	}
 
@@ -2582,6 +2629,32 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 	require.Len(t, articleEnv.Results, 2)
 	assert.Equal(t, "a", articleEnv.Results[0]["slug"])
 	assert.Equal(t, "b", articleEnv.Results[1]["slug"])
+
+	// Attribute selector generated for schema.org JSON-LD pages.
+	cmd = exec.Command(binaryPath, "jsonld", "list", "--json")
+	cmd.Env = append(os.Environ(), "EMBEDDEDJSON_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var jsonldEnv struct {
+		Results []map[string]any `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &jsonldEnv), string(out))
+	require.Len(t, jsonldEnv.Results, 2)
+	assert.Equal(t, "Tacos", jsonldEnv.Results[0]["name"])
+	assert.Equal(t, "Burritos", jsonldEnv.Results[1]["name"])
+
+	// Class selector generated for state-view SSR pages.
+	cmd = exec.Command(binaryPath, "stateview", "list", "--json")
+	cmd.Env = append(os.Environ(), "EMBEDDEDJSON_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var stateViewEnv struct {
+		Results []map[string]any `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &stateViewEnv), string(out))
+	require.Len(t, stateViewEnv.Results, 2)
+	assert.Equal(t, "sv-a", stateViewEnv.Results[0]["slug"])
+	assert.Equal(t, "sv-b", stateViewEnv.Results[1]["slug"])
 
 	// Missing script tag: extractor reports an actionable error rather
 	// than silently returning empty data.

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -160,8 +160,8 @@ func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 	if selector == "" {
 		selector = "script#__NEXT_DATA__"
 	}
-	tag, idFilter := parseSimpleSelector(selector)
-	scriptText, found := findScriptByTagAndID(doc, tag, idFilter)
+	parsedSelector := parseSimpleSelector(selector)
+	scriptText, found := findScriptBySelector(doc, parsedSelector)
 	if !found {
 		return nil, fmt.Errorf("embedded-json: no element matching selector %q found in page", selector)
 	}
@@ -180,32 +180,72 @@ func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 	return json.RawMessage(out), nil
 }
 
-// parseSimpleSelector splits a "tag" or "tag#id" selector into its
-// components. Returns ("script", "__NEXT_DATA__") for the canonical
-// Next.js case; ("script", "") for a tag-only selector. Anything more
-// complex (CSS classes, attribute selectors) is out of scope for v1.
-func parseSimpleSelector(selector string) (tag, id string) {
-	if i := strings.Index(selector, "#"); i >= 0 {
-		return selector[:i], selector[i+1:]
-	}
-	return selector, ""
+type simpleHTMLSelector struct {
+	Tag          string
+	ID           string
+	Class        string
+	AttrName     string
+	AttrValue    string
+	AttrValueSet bool
 }
 
-// findScriptByTagAndID walks the parsed HTML document looking for the
-// first element whose tag matches `tag` and (when `id` is non-empty)
-// whose id attribute matches `id`. Returns the element's concatenated
-// text content. Tags are matched case-insensitively; ids are
-// case-sensitive (per HTML5 spec).
-func findScriptByTagAndID(root *xhtml.Node, tag, id string) (string, bool) {
+// parseSimpleSelector handles the small selector grammar emitted by specs and
+// browser-sniff reachability defaults for embedded JSON state blobs: "tag",
+// "tag#id", "tag.class", and `tag[attr="value"]`. It is intentionally not a
+// full CSS selector parser; unsupported shapes fall back to a tag-name match so
+// extractor errors stay actionable rather than silently broadening selection.
+func parseSimpleSelector(selector string) simpleHTMLSelector {
+	selector = strings.TrimSpace(selector)
+	parsed := simpleHTMLSelector{Tag: selector}
+	if selector == "" {
+		parsed.Tag = "script"
+		return parsed
+	}
+	if open := strings.Index(selector, "["); open >= 0 && strings.HasSuffix(selector, "]") {
+		parsed.Tag = strings.TrimSpace(selector[:open])
+		inner := strings.TrimSpace(strings.TrimSuffix(selector[open+1:], "]"))
+		if name, value, ok := strings.Cut(inner, "="); ok {
+			parsed.AttrName = strings.TrimSpace(name)
+			parsed.AttrValue = strings.Trim(strings.TrimSpace(value), `"'`)
+			parsed.AttrValueSet = true
+		} else {
+			parsed.AttrName = inner
+		}
+		return parsed
+	}
+	if i := strings.Index(selector, "#"); i >= 0 {
+		parsed.Tag = strings.TrimSpace(selector[:i])
+		parsed.ID = strings.TrimSpace(selector[i+1:])
+		return parsed
+	}
+	if i := strings.Index(selector, "."); i >= 0 {
+		parsed.Tag = strings.TrimSpace(selector[:i])
+		parsed.Class = strings.TrimSpace(selector[i+1:])
+		return parsed
+	}
+	return parsed
+}
+
+// findScriptBySelector walks the parsed HTML document looking for the first
+// element matching the limited selector grammar used by embedded-json. Returns
+// the element's concatenated text content. Tags are matched case-insensitively;
+// id, class, and attribute values are case-sensitive per HTML/CSS convention.
+func findScriptBySelector(root *xhtml.Node, selector simpleHTMLSelector) (string, bool) {
 	var found *xhtml.Node
 	walkHTML(root, func(n *xhtml.Node) {
 		if found != nil || n.Type != xhtml.ElementNode {
 			return
 		}
-		if !strings.EqualFold(n.Data, tag) {
+		if selector.Tag != "" && !strings.EqualFold(n.Data, selector.Tag) {
 			return
 		}
-		if id != "" && attrValue(n, "id") != id {
+		if selector.ID != "" && attrValue(n, "id") != selector.ID {
+			return
+		}
+		if selector.Class != "" && !hasHTMLClass(n, selector.Class) {
+			return
+		}
+		if selector.AttrName != "" && !matchesHTMLAttr(n, selector.AttrName, selector.AttrValue, selector.AttrValueSet) {
 			return
 		}
 		found = n
@@ -214,6 +254,25 @@ func findScriptByTagAndID(root *xhtml.Node, tag, id string) (string, bool) {
 		return "", false
 	}
 	return nodeText(found), true
+}
+
+func hasHTMLClass(n *xhtml.Node, class string) bool {
+	for _, token := range strings.Fields(attrValue(n, "class")) {
+		if token == class {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesHTMLAttr(n *xhtml.Node, name, value string, valueSet bool) bool {
+	for _, attr := range n.Attr {
+		if !strings.EqualFold(attr.Key, name) {
+			continue
+		}
+		return !valueSet || attr.Val == value
+	}
+	return false
 }
 
 // walkJSONDotPath descends a parsed JSON value via dot-notation


### PR DESCRIPTION
## Summary

Addresses mvanhorn/cli-printing-press#1642 by making the generated `embedded-json` extractor understand the selector shapes that browser-sniff reachability defaults already emit for SSR state blobs.

Specifically, the generated runtime now supports this limited selector grammar:

- `tag`
- `tag#id`
- `tag.class`
- `tag[attr="value"]`

This covers schema.org JSON-LD selectors such as `script[type="application/ld+json"]` and existing `script.state-view` defaults without introducing a broad CSS selector engine.

## Test-first behavior

Before the implementation change, the new JSON-LD generated-runtime case failed with:

```text
Error: embedded-json: no element matching selector "script[type=\"application/ld+json\"]" found in page
```

After the implementation change, the generated CLI extracts both:

- schema.org JSON-LD via `script[type="application/ld+json"]`
- state-view JSON via `script.state-view`

## Test plan

Ran locally:

```bash
go test ./internal/spec ./internal/browsersniff -count=1
go test ./internal/generator -run 'TestGenerateHTMLExtraction(EmbeddedJSONMode|PerModeGating)' -count=1
```

Result:

```text
ok  github.com/mvanhorn/cli-printing-press/v4/internal/spec          0.093s
ok  github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff  0.631s
ok  github.com/mvanhorn/cli-printing-press/v4/internal/generator     9.489s
```

I also ran the focused embedded-json test alone:

```text
ok  github.com/mvanhorn/cli-printing-press/v4/internal/generator  3.205s
```

Note: I attempted the full `go test ./internal/generator -count=1`, but stopped that local run after it produced no output for several minutes. No failure output was produced from that interrupted run.

## Transparency

This PR was prepared with AI assistance. I reviewed the generated changes and ran the local tests listed above.
