### PR TITLE
fix(cli): redact PII audit ledger cli dir

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -832,7 +832,7 @@ func runPIIAudit(dir string, persist bool) (PIIAuditResult, error) {
 	if persist {
 		ledger := &PIILedger{
 			Timestamp: time.Now().UTC(),
-			CLIDir:    dir,
+			CLIDir:    RedactCLIDirRoot(dir),
 			Findings:  findings,
 		}
 		if previous != nil {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -608,6 +608,22 @@ func TestReadWritePIILedger_RoundTrip(t *testing.T) {
 	assert.Len(t, got.Findings, 1)
 }
 
+func TestRunPIIAudit_RedactsCLIDirInLedger(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "captured.json"), `{"email":"leak@example.com"}`)
+
+	_, err := RunPIIAudit(dir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, PIILedgerFilename))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), dir)
+
+	got := ReadPIILedger(dir)
+	require.NotNil(t, got)
+	assert.Equal(t, filepath.Join(CLIDirPlaceholder, filepath.Base(dir)), got.CLIDir)
+}
+
 func TestReadPIILedger_CorruptDeletesFile(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, PIILedgerFilename), []byte("not json"), 0644))


### PR DESCRIPTION
## Intent

Issue: Fixes #1840

The PII audit ledger was writing the absolute printed-CLI directory into `.printing-press-pii-polish.json`, even though the sibling tools-audit ledger already redacts the same value to `<cli-dir>/<api-slug>`. Since the ledger can travel with publish artifacts and public-library PRs, it should not expose the operator's local workspace path.

## Approach

Use the existing `artifacts.RedactCLIDirRoot` helper when `RunPIIAudit` constructs the persisted PII ledger. This keeps the in-memory scan target unchanged, while ensuring the serialized `cli_dir` follows the same placeholder convention as tools-audit.

Added a regression test that runs the PII audit against a temp CLI directory, reads the written ledger, and verifies the absolute temp path is absent while the decoded ledger contains `<cli-dir>/<basename>`.

## Scope

Primary area: CLI audit artifacts

Why this belongs in this repo: `.printing-press-pii-polish.json` is emitted by the Printing Press PII audit machinery and affects every printed CLI audit/publish workflow, not one generated CLI.

## Risk

Low. This changes only the persisted ledger metadata field; scan input, finding identities, reconciliation, completion gates, and caller behavior remain unchanged. Consumers that need the display slug still get it via the placeholder path basename, matching the existing tools-audit behavior.

## Output Contract

This intentionally changes the PII-polish JSON artifact contract for `cli_dir` from an absolute local path to `<cli-dir>/<slug>`. Existing golden fixtures do not cover this ledger, so I added a focused regression test instead and still ran the golden verifier because the change touches a pipeline artifact surface.

## Verification

- `go test ./internal/artifacts -run TestRunPIIAudit_RedactsCLIDirInLedger -count=1 -v`
- `go test ./internal/artifacts ./internal/pipeline ./internal/cli`
- `go test ./...`
- `scripts/golden.sh verify`
- `git diff --check`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: AI or automation was used, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
