### PR TITLE
fix(cli): bump golang.org/x/net template pin past GO-2026-5026

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2140,7 +2140,7 @@ func TestGenerateHTMLExtractionEndpoint(t *testing.T) {
 	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "html_extract.go"))
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "golang.org/x/net v0.53.0")
+	assert.Contains(t, string(gomod), "golang.org/x/net v0.55.0")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	binaryPath := filepath.Join(outputDir, "webhtml-pp-cli")

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -12,7 +12,7 @@ require (
 {{- end}}
 	github.com/spf13/cobra v1.9.1
 {{- if .HasHTMLExtraction}}
-	golang.org/x/net v0.53.0
+	golang.org/x/net v0.55.0
 {{- end}}
 {{- if eq .Config.Format "toml"}}
 	github.com/pelletier/go-toml/v2 v2.2.4


### PR DESCRIPTION
## Intent

The generator's `go.mod.tmpl` pinned `golang.org/x/net v0.53.0`, which is below the **GO-2026-5026** fix line (`v0.55.0`). Every CLI emitted from `main` was shipping vulnerable code, and the post-emit `govulncheck` quality gate failed on fresh prints.

Issue: Fixes #1865

## Approach

Bump the conditional `golang.org/x/net` require in `internal/generator/templates/go.mod.tmpl` from `v0.53.0` to `v0.55.0` (the GO-2026-5026 fix line). Update the matching version assertion in `internal/generator/generator_test.go` so the existing html-extract integration test continues to verify the floor against the new pin. This is the minimum surface that clears the vuln; `x/sys` / `x/text` are only transitive in the template, so `go mod tidy` will resolve them to fixed versions during the generator's emit-then-tidy step (observed: `x/sys v0.35.0 -> v0.45.0`, `x/text v0.35.0 -> v0.37.0` ride along with the `x/net` bump).

Discovered while reprinting `factor75` from current `main` to validate the recent retro PRs (#1602, #1641, #1644, #1645). `cli-printing-press generate` succeeded; the `govulncheck` gate then failed with:

~~~
Vulnerability #1: GO-2026-5026
    Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.43.0
    Fixed in: golang.org/x/net@v0.55.0
~~~

## Scope

Primary area: generator template (`internal/generator/templates/go.mod.tmpl`).

Why this belongs in this repo: the floor lives in the template, so the fix has to land here to compound to every future printed CLI. A per-CLI bump in `~/printing-press/library/<api-slug>/go.mod` would only fix one CLI and would drift back on the next regen.

## Risk

Low. The change is a single conditional-block version string in the template (`HasHTMLExtraction == true`) plus the matching test assertion. The version is current latest stable for `x/net` (v0.55.0).

- Generator output: only affects CLIs whose spec enables HTML extraction. The require line is unchanged in shape; only the version string moves forward.
- Goldens: `scripts/golden.sh verify` is clean (22/22 PASS). None of the existing golden fixtures exercise the `HasHTMLExtraction` branch, so no golden go.mod files reference this line.
- Downstream contract: not a breaking change — bumping a transitive dep version does not rename or remove any documented surface.

## Output Contract

Only affected generated artifact is `go.mod` for printed CLIs that enable HTML extraction (`x.html` extension / `response_format: html`). For those CLIs the line `golang.org/x/net v0.53.0` becomes `golang.org/x/net v0.55.0`. No goldens needed updating because no existing fixture covers this branch (verified by `scripts/golden.sh verify`).

## Verification

- ` ` `go fmt ./...`  -- clean
- ` ` `scripts/golden.sh verify`  -- 22/22 PASS
- ` ` `go test ./...`  -- all packages pass (incl. `internal/generator` html-extract integration test that now asserts `v0.55.0`)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change