### PR TITLE
fix(cli): sync-param-drop gate detects named-map call argument

### DIFF
--- a/internal/pipeline/sync_param_drop.go
+++ b/internal/pipeline/sync_param_drop.go
@@ -219,7 +219,23 @@ func walkSyncParamDropCalls(fset *token.FileSet, file *ast.File, fileName string
 		}
 	}
 
-	ast.Inspect(file, func(n ast.Node) bool {
+	// Walk function declarations explicitly (rather than ast.Inspect over
+	// the whole file) so each recognized client call has its enclosing
+	// function in hand. callPassedKeys uses the function context to
+	// resolve a named-map arg back to its declaration + subsequent
+	// `m["k"] = v` assignments — the standard Go pattern for conditional
+	// query params, which a literal-only walker would silently skip.
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		walkFuncForSyncParamDropCalls(fset, fn, fileName, captured, suppressionLines, result)
+	}
+}
+
+func walkFuncForSyncParamDropCalls(fset *token.FileSet, fn *ast.FuncDecl, fileName string, captured capturedKeysIndex, suppressionLines map[int]bool, result *SyncParamDropResult) {
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -239,7 +255,7 @@ func walkSyncParamDropCalls(fset *token.FileSet, file *ast.File, fileName string
 		if path == "" {
 			return true
 		}
-		passedKeys := callPassedKeys(call.Args[1:])
+		passedKeys := callPassedKeys(call.Args[1:], fn, call.Pos())
 		// Bodies / params that don't parse into a key set produce no
 		// signal — silently skip rather than guessing.
 		if passedKeys == nil {
@@ -339,25 +355,43 @@ func receiverLooksLikeHTTPClient(expr ast.Expr) bool {
 }
 
 // callPassedKeys extracts the param-or-body key set from the remaining
-// arguments of a recognized client call. Two shapes are supported:
+// arguments of a recognized client call. Three shapes are supported:
 //
 //   - A composite literal map[string]<T>{ "a": ..., "b": ... } — common
 //     for query params and form/JSON bodies built inline.
 //   - A struct literal whose field names form the key set —
 //     `MenuParams{Week: ..., Country: ...}` — common for typed param
 //     containers.
+//   - A named local variable that holds a map built up with an initial
+//     literal and subsequent `m["k"] = v` assignments — the standard Go
+//     pattern for conditional query params. The walker follows the
+//     ident back to its declaration in the same function scope and
+//     unions the initial keys with every string-keyed assignment that
+//     precedes the call site. Keys added inside `if`/`else`/`switch`
+//     branches count as present (loud-when-uncertain beats mute):
+//     false-positive risk on a never-taken branch is far smaller than
+//     the false-negative this resolution exists to close.
 //
 // nil return means "no recognizable key set" and the call is not
 // counted toward Checked. An empty (but non-nil) slice means "explicit
 // zero-key call" which is still counted: the capture for the same path
 // may hold keys, in which case all of them are reported as dropped.
-func callPassedKeys(args []ast.Expr) []string {
+//
+// Out of scope (would need broader analysis): for-range population, map
+// passed through helper functions, or alias chains (`m2 := m1`). Those
+// remain silent skips, captured as known limitations.
+func callPassedKeys(args []ast.Expr, fn *ast.FuncDecl, callPos token.Pos) []string {
 	if len(args) == 0 {
 		return []string{}
 	}
 	for _, arg := range args {
 		if keys, ok := extractCompositeLiteralKeys(arg); ok {
 			return keys
+		}
+		if ident, ok := arg.(*ast.Ident); ok && fn != nil {
+			if keys, ok := resolveNamedMapKeys(fn, ident.Name, callPos); ok {
+				return keys
+			}
 		}
 	}
 	// No composite literal we can read; if the only remaining arg is a
@@ -366,6 +400,113 @@ func callPassedKeys(args []ast.Expr) []string {
 		return []string{}
 	}
 	return nil
+}
+
+// resolveNamedMapKeys follows a named-map identifier back to its
+// declaration in the same function and collects the full key set:
+// initial composite literal + every `name["k"] = v` assignment that
+// precedes callPos in source order. Returns (keys, false) when the
+// ident has no recognizable declaration (e.g. it's a parameter, a
+// closure capture, or a non-map type) — caller treats false as "skip,"
+// matching the legacy behavior for unrecognized shapes.
+func resolveNamedMapKeys(fn *ast.FuncDecl, name string, callPos token.Pos) ([]string, bool) {
+	if fn.Body == nil {
+		return nil, false
+	}
+	var (
+		found    bool
+		keys     []string
+		seen     = make(map[string]struct{})
+		declSeen bool
+	)
+	addKey := func(k string) {
+		if _, ok := seen[k]; ok {
+			return
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if n == nil || n.Pos() >= callPos {
+			// Stop at the call site: later assignments don't reflect
+			// what the call actually passes.
+			return false
+		}
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			// `name := map[string]X{...}` or `name = map[string]X{...}`
+			// — initial value or full-replacement assignment.
+			for i, lhs := range s.Lhs {
+				lhsIdent, ok := lhs.(*ast.Ident)
+				if !ok || lhsIdent.Name != name {
+					continue
+				}
+				if i >= len(s.Rhs) {
+					continue
+				}
+				rhs := s.Rhs[i]
+				if litKeys, ok := extractCompositeLiteralKeys(rhs); ok {
+					found = true
+					declSeen = true
+					for _, k := range litKeys {
+						addKey(k)
+					}
+				}
+			}
+			// `name["k"] = v` — index assignment adding a key.
+			if len(s.Lhs) == 1 && len(s.Rhs) == 1 {
+				if idx, ok := s.Lhs[0].(*ast.IndexExpr); ok {
+					if xIdent, ok := idx.X.(*ast.Ident); ok && xIdent.Name == name {
+						if keyLit, ok := idx.Index.(*ast.BasicLit); ok && keyLit.Kind == token.STRING {
+							if k, ok := syncParamStringLiteral(keyLit); ok {
+								found = true
+								addKey(k)
+							}
+						}
+					}
+				}
+			}
+		case *ast.GenDecl:
+			// `var name = map[string]X{...}` or `var name map[string]X`.
+			if s.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range s.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, n := range vs.Names {
+					if n.Name != name || i >= len(vs.Values) {
+						continue
+					}
+					if litKeys, ok := extractCompositeLiteralKeys(vs.Values[i]); ok {
+						found = true
+						declSeen = true
+						for _, k := range litKeys {
+							addKey(k)
+						}
+					}
+				}
+			}
+		}
+		return true
+	})
+	if !found {
+		return nil, false
+	}
+	// If we only saw index assignments without ever seeing a declaration
+	// or full-replacement literal in this function, the ident likely
+	// refers to a map declared in an outer scope (a parameter, a struct
+	// field, a closure capture). The keys we collected are real but the
+	// initial-state of the map is unknown — skip to avoid a confidently
+	// wrong key set. The declaration-present case is the named-map
+	// pattern this resolver was written for.
+	if !declSeen {
+		return nil, false
+	}
+	sort.Strings(keys)
+	return keys, true
 }
 
 func extractCompositeLiteralKeys(expr ast.Expr) ([]string, bool) {

--- a/internal/pipeline/sync_param_drop.go
+++ b/internal/pipeline/sync_param_drop.go
@@ -219,23 +219,67 @@ func walkSyncParamDropCalls(fset *token.FileSet, file *ast.File, fileName string
 		}
 	}
 
-	// Walk function declarations explicitly (rather than ast.Inspect over
-	// the whole file) so each recognized client call has its enclosing
-	// function in hand. callPassedKeys uses the function context to
-	// resolve a named-map arg back to its declaration + subsequent
-	// `m["k"] = v` assignments — the standard Go pattern for conditional
-	// query params, which a literal-only walker would silently skip.
+	// Walk function bodies explicitly (rather than ast.Inspect over the
+	// whole file) so each recognized client call has its enclosing
+	// function-or-closure body in hand. walkBlockForSyncParamDropCalls
+	// uses that body as the scope when resolving a named-map arg back to
+	// its declaration + subsequent `m["k"] = v` assignments — the
+	// standard Go pattern for conditional query params, which a
+	// literal-only walker would silently skip.
+	//
+	// Two top-level shapes carry function bodies: ordinary `*ast.FuncDecl`
+	// entries and `var name = func(...) {...}` package-level value specs
+	// (a `*ast.GenDecl` holding `*ast.FuncLit` initializers). Both are
+	// real sync entry points in printed CLIs; ast.Inspect would have
+	// found their calls under the old implementation but the explicit
+	// decl walk drops the GenDecl path unless we handle it here.
 	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Body == nil {
+				continue
+			}
+			walkBlockForSyncParamDropCalls(fset, d.Body, fileName, captured, suppressionLines, result)
+		case *ast.GenDecl:
+			if d.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range d.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, v := range vs.Values {
+					if fl, ok := v.(*ast.FuncLit); ok && fl.Body != nil {
+						walkBlockForSyncParamDropCalls(fset, fl.Body, fileName, captured, suppressionLines, result)
+					}
+				}
+			}
 		}
-		walkFuncForSyncParamDropCalls(fset, fn, fileName, captured, suppressionLines, result)
 	}
 }
 
-func walkFuncForSyncParamDropCalls(fset *token.FileSet, fn *ast.FuncDecl, fileName string, captured capturedKeysIndex, suppressionLines map[int]bool, result *SyncParamDropResult) {
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
+// walkBlockForSyncParamDropCalls walks a single function/closure body
+// looking for recognized client calls. The `body` parameter is the
+// scope used for named-map resolution: when the walker encounters a
+// nested `*ast.FuncLit`, it recurses with the FuncLit's own Body so
+// calls inside the closure resolve their named-map args against the
+// closure's scope, not the outer function's. Without this, an inner
+// `params := map[string]string{...}` that shadows an outer same-named
+// map would have its key set silently unioned with the outer map's,
+// hiding real drops inside the closure.
+func walkBlockForSyncParamDropCalls(fset *token.FileSet, body *ast.BlockStmt, fileName string, captured capturedKeysIndex, suppressionLines map[int]bool, result *SyncParamDropResult) {
+	if body == nil {
+		return
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		if fl, ok := n.(*ast.FuncLit); ok {
+			// Recurse into the nested closure with its own body as the
+			// scope, then stop ast.Inspect from descending into it
+			// under the outer body's scope.
+			walkBlockForSyncParamDropCalls(fset, fl.Body, fileName, captured, suppressionLines, result)
+			return false
+		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -255,7 +299,7 @@ func walkFuncForSyncParamDropCalls(fset *token.FileSet, fn *ast.FuncDecl, fileNa
 		if path == "" {
 			return true
 		}
-		passedKeys := callPassedKeys(call.Args[1:], fn, call.Pos())
+		passedKeys := callPassedKeys(call.Args[1:], body, call.Pos())
 		// Bodies / params that don't parse into a key set produce no
 		// signal — silently skip rather than guessing.
 		if passedKeys == nil {
@@ -380,7 +424,7 @@ func receiverLooksLikeHTTPClient(expr ast.Expr) bool {
 // Out of scope (would need broader analysis): for-range population, map
 // passed through helper functions, or alias chains (`m2 := m1`). Those
 // remain silent skips, captured as known limitations.
-func callPassedKeys(args []ast.Expr, fn *ast.FuncDecl, callPos token.Pos) []string {
+func callPassedKeys(args []ast.Expr, scope *ast.BlockStmt, callPos token.Pos) []string {
 	if len(args) == 0 {
 		return []string{}
 	}
@@ -388,8 +432,8 @@ func callPassedKeys(args []ast.Expr, fn *ast.FuncDecl, callPos token.Pos) []stri
 		if keys, ok := extractCompositeLiteralKeys(arg); ok {
 			return keys
 		}
-		if ident, ok := arg.(*ast.Ident); ok && fn != nil {
-			if keys, ok := resolveNamedMapKeys(fn, ident.Name, callPos); ok {
+		if ident, ok := arg.(*ast.Ident); ok && scope != nil {
+			if keys, ok := resolveNamedMapKeys(scope, ident.Name, callPos); ok {
 				return keys
 			}
 		}
@@ -403,14 +447,21 @@ func callPassedKeys(args []ast.Expr, fn *ast.FuncDecl, callPos token.Pos) []stri
 }
 
 // resolveNamedMapKeys follows a named-map identifier back to its
-// declaration in the same function and collects the full key set:
-// initial composite literal + every `name["k"] = v` assignment that
-// precedes callPos in source order. Returns (keys, false) when the
-// ident has no recognizable declaration (e.g. it's a parameter, a
-// closure capture, or a non-map type) — caller treats false as "skip,"
-// matching the legacy behavior for unrecognized shapes.
-func resolveNamedMapKeys(fn *ast.FuncDecl, name string, callPos token.Pos) ([]string, bool) {
-	if fn.Body == nil {
+// declaration in the same scope (function body or closure body) and
+// collects the full key set: initial composite literal + every
+// `name["k"] = v` assignment that precedes callPos in source order.
+// Returns (keys, false) when the ident has no recognizable declaration
+// (e.g. it's a parameter, a closure capture, or a non-map type) —
+// caller treats false as "skip," matching the legacy behavior for
+// unrecognized shapes.
+//
+// Nested `*ast.FuncLit` bodies are NOT descended into: a same-named
+// map inside an inner closure is a separate binding, and unioning its
+// keys with the outer map would hide real drops inside the closure.
+// Each closure is walked independently with its own body as the scope
+// by walkBlockForSyncParamDropCalls.
+func resolveNamedMapKeys(scope *ast.BlockStmt, name string, callPos token.Pos) ([]string, bool) {
+	if scope == nil {
 		return nil, false
 	}
 	var (
@@ -426,10 +477,16 @@ func resolveNamedMapKeys(fn *ast.FuncDecl, name string, callPos token.Pos) ([]st
 		seen[k] = struct{}{}
 		keys = append(keys, k)
 	}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
+	ast.Inspect(scope, func(n ast.Node) bool {
 		if n == nil || n.Pos() >= callPos {
 			// Stop at the call site: later assignments don't reflect
 			// what the call actually passes.
+			return false
+		}
+		// Do not descend into nested function literals — they introduce
+		// a new scope, and any same-named map inside is a separate
+		// binding from the one we're resolving.
+		if _, ok := n.(*ast.FuncLit); ok {
 			return false
 		}
 		switch s := n.(type) {

--- a/internal/pipeline/sync_param_drop_test.go
+++ b/internal/pipeline/sync_param_drop_test.go
@@ -707,6 +707,101 @@ func sync(client *Client, menuParams map[string]string) error {
 	}
 }
 
+// Regression: a package-level `var syncFn = func(...) {...}` holding a
+// function literal is still walked. Under an earlier refactor of
+// walkSyncParamDropCalls that iterated `file.Decls` and filtered for
+// *ast.FuncDecl only, this shape regressed from checked to silently
+// unchecked. The walker must also descend into *ast.GenDecl /
+// *ast.ValueSpec values that are *ast.FuncLit.
+func TestCheckSyncParamDrop_PackageLevelFuncLit_DropsFlagged(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+var syncFn = func(client *Client) error {
+	menuParams := map[string]string{
+		"a": "1",
+		"b": "2",
+	}
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture("GET", "/menu", "a", "b", "c", "d"))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings: want 1, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+	f := got.Findings[0]
+	wantDropped := []string{"c", "d"}
+	if strings.Join(f.DroppedKeys, ",") != strings.Join(wantDropped, ",") {
+		t.Errorf("DroppedKeys: want %v, got %v", wantDropped, f.DroppedKeys)
+	}
+}
+
+// Regression: a nested closure that re-declares a same-named map must
+// be resolved against its own scope, not the outer function's. The
+// outer `params` holds one key; the inner closure's `params` holds
+// three. The inner call passes the inner map, so the gate must read
+// 3 passed keys (not 4 from a union with the outer map) and flag the
+// captured-only key as dropped. Without scope-isolation in
+// resolveNamedMapKeys, the outer "a" would silently union into the
+// inner key set and hide drops inside the closure.
+func TestCheckSyncParamDrop_NestedClosure_SameNamedMap_NotUnioned(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func runSync(client *Client) error {
+	params := map[string]string{"a": "1"}
+	_ = params
+	inner := func() error {
+		params := map[string]string{
+			"a": "1",
+			"b": "2",
+			"c": "3",
+		}
+		return client.Get("/menu", params)
+	}
+	return inner()
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture("GET", "/menu", "a", "b", "c", "d"))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings: want 1, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+	f := got.Findings[0]
+	wantPassed := map[string]bool{"a": true, "b": true, "c": true}
+	if len(f.PassedKeys) != len(wantPassed) {
+		t.Fatalf("PassedKeys count: want %d, got %d (%v)", len(wantPassed), len(f.PassedKeys), f.PassedKeys)
+	}
+	for _, k := range f.PassedKeys {
+		if !wantPassed[k] {
+			t.Errorf("unexpected passed key %q (closure scope leaked into outer)", k)
+		}
+	}
+	wantDropped := []string{"d"}
+	if strings.Join(f.DroppedKeys, ",") != strings.Join(wantDropped, ",") {
+		t.Errorf("DroppedKeys: want %v, got %v", wantDropped, f.DroppedKeys)
+	}
+}
+
 func TestCanonicalSyncPath(t *testing.T) {
 	cases := map[string]string{
 		"/menu":                        "/menu",

--- a/internal/pipeline/sync_param_drop_test.go
+++ b/internal/pipeline/sync_param_drop_test.go
@@ -481,6 +481,232 @@ func TestNormalizeParamKey(t *testing.T) {
 	}
 }
 
+// Named-map AC1: ident arg whose declaration is a single composite
+// literal in the same function — walker must follow the ident back to
+// the declaration and read the literal keys. Drops two of four captured
+// keys; gate flags them.
+func TestCheckSyncParamDrop_NamedMap_LiteralOnly_DropsFlagged(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func sync(client *Client) error {
+	menuParams := map[string]string{
+		"a": "1",
+		"b": "2",
+	}
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture("GET", "/menu", "a", "b", "c", "d"))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings: want 1, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+	f := got.Findings[0]
+	wantDropped := []string{"c", "d"}
+	if strings.Join(f.DroppedKeys, ",") != strings.Join(wantDropped, ",") {
+		t.Errorf("DroppedKeys: want %v, got %v", wantDropped, f.DroppedKeys)
+	}
+}
+
+// Named-map AC2: ident arg whose declaration mixes an initial literal
+// with subsequent `m["k"] = v` assignments. The full union of keys must
+// be visible to the gate. Drops one captured key vs the union.
+func TestCheckSyncParamDrop_NamedMap_LiteralPlusAssignments_DropsFlagged(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func sync(client *Client, sub string, sku string) error {
+	menuParams := map[string]string{
+		"week":   "w1",
+		"locale": "en",
+	}
+	menuParams["subscription"] = sub
+	menuParams["product-sku"] = sku
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture(
+		"GET", "/menu",
+		"week", "locale", "subscription", "product-sku", "servings",
+	))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings: want 1, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+	f := got.Findings[0]
+	wantDropped := []string{"servings"}
+	if strings.Join(f.DroppedKeys, ",") != strings.Join(wantDropped, ",") {
+		t.Errorf("DroppedKeys: want %v, got %v", wantDropped, f.DroppedKeys)
+	}
+}
+
+// Named-map AC3: keys added inside `if` branches must count as present
+// (loud-when-uncertain beats mute). A capture-key set wider than the
+// union of all branches still produces a drop finding.
+func TestCheckSyncParamDrop_NamedMap_ConditionalBranchesCountAsPresent(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func sync(client *Client, subID int, sku string, meals int) error {
+	menuParams := map[string]string{
+		"week":    "w1",
+		"country": "us",
+		"locale":  "en",
+	}
+	if subID != 0 {
+		menuParams["subscription"] = "s"
+	}
+	if sku != "" {
+		menuParams["product-sku"] = sku
+	}
+	if meals > 0 {
+		menuParams["servings"] = "x"
+	} else {
+		menuParams["delivery-option"] = "y"
+	}
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture(
+		"GET", "/menu",
+		"week", "country", "locale", "subscription", "product-sku",
+		"servings", "delivery-option", "postcode", "preference",
+	))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 1 {
+		t.Fatalf("Findings: want 1, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+	f := got.Findings[0]
+	wantDropped := map[string]bool{"postcode": true, "preference": true}
+	if len(f.DroppedKeys) != len(wantDropped) {
+		t.Fatalf("DroppedKeys count: want %d, got %d (%v)", len(wantDropped), len(f.DroppedKeys), f.DroppedKeys)
+	}
+	for _, k := range f.DroppedKeys {
+		if !wantDropped[k] {
+			t.Errorf("unexpected dropped key %q", k)
+		}
+	}
+	// Sanity: keys added inside branches MUST appear in the resolved
+	// passed-key set, not just the initial literal three.
+	wantPassed := map[string]bool{
+		"week": true, "country": true, "locale": true,
+		"subscription": true, "product-sku": true,
+		"servings": true, "delivery-option": true,
+	}
+	if len(f.PassedKeys) != len(wantPassed) {
+		t.Fatalf("PassedKeys count: want %d, got %d (%v)", len(wantPassed), len(f.PassedKeys), f.PassedKeys)
+	}
+	for _, k := range f.PassedKeys {
+		if !wantPassed[k] {
+			t.Errorf("unexpected passed key %q", k)
+		}
+	}
+}
+
+// Named-map AC4: full coverage — every captured key is reachable across
+// the union of the literal + all branches. Gate MUST NOT fire.
+func TestCheckSyncParamDrop_NamedMap_AllCapturedKeysPresent_NotFlagged(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func sync(client *Client) error {
+	menuParams := map[string]string{
+		"week":         "w1",
+		"country":      "us",
+		"locale":       "en",
+		"subscription": "s",
+		"product-sku":  "sku",
+	}
+	menuParams["servings"] = "4"
+	menuParams["delivery-option"] = "weekly"
+	if true {
+		menuParams["postcode"] = "00000"
+		menuParams["preference"] = "veg"
+	}
+	menuParams["customerPlanId"] = "p1"
+	menuParams["include-future-feedback"] = "true"
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture(
+		"GET", "/menu",
+		"week", "country", "locale", "subscription", "product-sku",
+		"servings", "delivery-option", "postcode", "preference",
+		"customerPlanId", "include-future-feedback",
+	))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Findings) != 0 {
+		t.Fatalf("Findings: want 0, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+}
+
+// Regression: index assignments to a name that has no declaration in
+// the same function (e.g. a parameter or an outer-scope map) must not
+// produce a confidently wrong key set. The resolver returns no signal
+// and the call is silently skipped — matching the legacy "unrecognized"
+// behavior for shapes we can't reason about.
+func TestCheckSyncParamDrop_NamedMap_NoLocalDeclaration_NotFlagged(t *testing.T) {
+	src := `package syncer
+
+type Client struct{}
+
+func (c *Client) Get(path string, params map[string]string) error { return nil }
+
+func sync(client *Client, menuParams map[string]string) error {
+	menuParams["week"] = "w1"
+	return client.Get("/menu", menuParams)
+}
+`
+	cliDir, analysisPath := seedSyncParamDropFixture(t, src, makeCapture("GET", "/menu", "week", "country", "locale"))
+	got := CheckSyncParamDrop(cliDir, analysisPath)
+	if got.Skipped {
+		t.Fatalf("Skipped: want false, got true")
+	}
+	if got.Checked != 0 {
+		t.Fatalf("Checked: want 0, got %d", got.Checked)
+	}
+	if len(got.Findings) != 0 {
+		t.Fatalf("Findings: want 0, got %d (%+v)", len(got.Findings), got.Findings)
+	}
+}
+
 func TestCanonicalSyncPath(t *testing.T) {
 	cases := map[string]string{
 		"/menu":                        "/menu",


### PR DESCRIPTION
## Intent

The `sync-param-drop` gate from PR #1644 was written to catch the exact Factor75 retro scenario (F1 in `docs/retros/2026-05-17-factor75-retro.md` lines 12-32): a hand-authored syncer calls a personalization-aware endpoint with fewer keys than the browser-sniff capture observed, the gateway returns a generic template payload, and the local store quietly stores the wrong data. Running the gate against Factor75's actual syncer today produces `Checked: 0, findings: 0` — the gate is mute on the very pattern it was designed for.

The walker only read keys when the param arg was an inline `*ast.CompositeLit`. Factor75's syncer (and every CLI using the standard Go idiom for conditional query params) names a local map, conditionally indexes into it, then passes the ident — `client.Get("/gw/my-deliveries/menu", menuParams)`. The walker returned nil, skipped the call, and never incremented `Checked`.

Issue: Fixes #1871

## Approach

Two-part change inside `internal/pipeline/sync_param_drop.go`:

1. Iterate `*ast.FuncDecl` first instead of `ast.Inspect` over the whole file. Each recognized client call now has its enclosing function in hand.
2. `callPassedKeys` accepts the enclosing function + call position. When the arg is an `*ast.Ident`, it walks the function body up to (but not including) the call site, unions:
   - the initial composite literal from `:=` or `var ... = map{...}` declaration / full-replacement assignment,
   - every `name["k"] = v` assignment with a string-literal key,

   and returns the deduped key set. Keys added inside `if`/`else`/`switch` branches count as present — false-positive risk on a never-taken branch is strictly smaller than the false-negative "we didn't check at all" the gate was producing before; loud-when-uncertain beats mute.

Idents whose name has no declaration in the same function (parameters, outer-scope maps, struct fields, closure captures) deliberately produce no signal: the resolver returns `(nil, false)` and the call is silently skipped, matching the legacy behavior for shapes we can't reason about. This avoids confidently-wrong keys when we don't actually know the map's initial state.

### What's intentionally out of scope

The named-map-with-conditional-adds pattern is what Factor75 uses and what the retro motivated. The following resolution paths are real gaps but require broader analysis and are left as separate follow-ups:

- `for k, v := range otherMap { m[k] = v }` (value-flow analysis)
- Helper functions that populate the map (`populateMenuParams(menuParams)`)
- Alias chains (`m2 := m1; client.Get(path, m2)`)

I'm filing each of those as its own follow-up issue.

### Verified end-to-end against Factor75

Built the binary against this branch and ran against the published Factor75 CLI's actual syncer plus a synthetic 11-key capture (the manuscripted `traffic-analysis.json` has `request_shape.fields: []` for the menu endpoint, separate capture-quality issue — not in scope here):

```
sync-param-drop: 2 call(s) checked, 1 finding(s), 0 suppressed
- internal/syncer/syncer.go:130: GET /gw/my-deliveries/menu — dropped params: customerPlanId, include-future-feedback, postcode, preference
```

The four dropped params are exactly what the retro's hand-fix had not yet added. Before this PR: `Checked: 0`.

## Scope

Primary area: `internal/pipeline/sync_param_drop.go` (the AST walker for the gate) + `internal/pipeline/sync_param_drop_test.go` (new positive/negative cases for the named-map pattern).

Why this belongs in this repo: the gate runs against every sniffed-BFF CLI's hand-authored syncer at retro/scorecard time. The bug compounded across every CLI whose syncer used the standard Go pattern for conditional params — the most common shape. Same machine vs printed-CLI calculus as PR #1644 itself: this fix lives in the machine.

## Risk

- The fix can change `Checked` and (potentially) `Findings` for any printed CLI whose syncer uses the named-map pattern with a `traffic-analysis.json` whose `request_shape.fields` is populated. That's the intended outcome — the gate firing on previously-silent cases is the point. If a CLI now surfaces drops it didn't before, the two valid fix paths (add the params, or annotate `// pp:sync-params-intentional-subset reason=...`) are unchanged from PR #1644.
- `scripts/golden.sh verify` — 22/22 pass. The existing `sync-param-drop-help` golden is untouched (no `--help` surface change). The fix does not change any generator-emitted files; only the gate's own analysis output.
- `golangci-lint run ./...` — clean.
- `go test ./...` — green.

## Output Contract

No changes to CLI flags, JSON shape, or template output. The gate's `Checked` counter and `Findings` list reflect the corrected analysis for affected printed CLIs; that's the only observable behavior delta.

## Verification

- `go build ./...` — passes.
- `go test ./...` — all packages green.
- `go test ./internal/pipeline/ -run TestCheckSyncParamDrop -v` — 18/18 pass, including the four new named-map cases:
  - `TestCheckSyncParamDrop_NamedMap_LiteralOnly_DropsFlagged`
  - `TestCheckSyncParamDrop_NamedMap_LiteralPlusAssignments_DropsFlagged`
  - `TestCheckSyncParamDrop_NamedMap_ConditionalBranchesCountAsPresent`
  - `TestCheckSyncParamDrop_NamedMap_AllCapturedKeysPresent_NotFlagged`
  - and the no-local-declaration regression: `TestCheckSyncParamDrop_NamedMap_NoLocalDeclaration_NotFlagged`
- `golangci-lint run ./...` — 0 issues.
- `scripts/golden.sh verify` — 22/22 pass.
- Manual end-to-end against the published Factor75 syncer + synthetic 11-key capture — gate now produces the expected dropped-params finding (see "Verified end-to-end against Factor75" above).

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission