### PR TITLE
fix(generator): support JSON-LD script selectors

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2569,6 +2569,22 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 					},
 				},
 			},
+			"badattr": {
+				Description: "Reject unsupported attribute selectors",
+				Endpoints: map[string]spec.Endpoint{
+					"show": {
+						Method:         "GET",
+						Path:           "/jsonld",
+						Description:    "Read structured data with an invalid selector",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: "script[async]",
+						},
+						Response: spec.ResponseDef{Type: "object"},
+					},
+				},
+			},
 			"missing": {
 				Description: "Missing script tag",
 				Endpoints: map[string]spec.Endpoint{
@@ -2650,6 +2666,15 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &stateViewEnv), string(out))
 	require.Len(t, stateViewEnv.Results, 1)
 	assert.Equal(t, "state-a", stateViewEnv.Results[0]["slug"])
+
+	// Unsupported attribute-existence selectors should fail explicitly instead
+	// of silently degrading to a broad tag-only match.
+	cmd = exec.Command(binaryPath, "badattr", "show", "--json")
+	cmd.Env = append(os.Environ(), "EMBEDDEDJSON_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.Error(t, err, string(out))
+	assert.Contains(t, string(out), "embedded-json: invalid selector")
+	assert.Contains(t, string(out), `tag[attr="value"]`)
 
 	// Missing script tag: extractor reports an actionable error rather
 	// than silently returning empty data.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2477,6 +2477,17 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 			_, _ = w.Write([]byte(`<html><body>
 				<script id="ARTICLE_DATA" type="application/json">{"items":[{"slug":"a"},{"slug":"b"}]}</script>
 			</body></html>`))
+		case "/jsonld":
+			// JSON-LD structured data uses an attribute selector emitted by
+			// browser sniffing for schema.org SSR pages.
+			_, _ = w.Write([]byte(`<html><body>
+				<script type="application/ld+json">{"@type":"Restaurant","name":"El Farolito","servesCuisine":["Tacos","Mexicana"]}</script>
+			</body></html>`))
+		case "/state-view":
+			// Some SSR pages expose state in a classed script tag.
+			_, _ = w.Write([]byte(`<html><body>
+				<script class="state-view" type="application/json">{"items":[{"slug":"state-a"}]}</script>
+			</body></html>`))
 		case "/missing":
 			// No matching script tag — should produce an extractor error.
 			_, _ = w.Write([]byte(`<html><body><p>nothing here</p></body></html>`))
@@ -2521,6 +2532,38 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 						HTMLExtract: &spec.HTMLExtract{
 							Mode:           spec.HTMLExtractModeEmbeddedJSON,
 							ScriptSelector: "script#ARTICLE_DATA",
+						},
+						Response: spec.ResponseDef{Type: "object"},
+					},
+				},
+			},
+			"jsonld": {
+				Description: "Read schema.org JSON-LD",
+				Endpoints: map[string]spec.Endpoint{
+					"show": {
+						Method:         "GET",
+						Path:           "/jsonld",
+						Description:    "Read structured data",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: `script[type="application/ld+json"]`,
+						},
+						Response: spec.ResponseDef{Type: "object"},
+					},
+				},
+			},
+			"stateview": {
+				Description: "Read classed state view JSON",
+				Endpoints: map[string]spec.Endpoint{
+					"show": {
+						Method:         "GET",
+						Path:           "/state-view",
+						Description:    "Read state view data",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract: &spec.HTMLExtract{
+							Mode:           spec.HTMLExtractModeEmbeddedJSON,
+							ScriptSelector: "script.state-view",
 						},
 						Response: spec.ResponseDef{Type: "object"},
 					},
@@ -2582,6 +2625,31 @@ func TestGenerateHTMLExtractionEmbeddedJSONMode(t *testing.T) {
 	require.Len(t, articleEnv.Results, 2)
 	assert.Equal(t, "a", articleEnv.Results[0]["slug"])
 	assert.Equal(t, "b", articleEnv.Results[1]["slug"])
+
+	// Attribute selector: returns schema.org JSON-LD blocks such as restaurants,
+	// products, and recipes.
+	cmd = exec.Command(binaryPath, "jsonld", "show", "--json")
+	cmd.Env = append(os.Environ(), "EMBEDDEDJSON_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var jsonLDEnv struct {
+		Results map[string]any `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &jsonLDEnv), string(out))
+	assert.Equal(t, "Restaurant", jsonLDEnv.Results["@type"])
+	assert.Equal(t, "El Farolito", jsonLDEnv.Results["name"])
+
+	// Class selector: returns state blobs emitted as classed script tags.
+	cmd = exec.Command(binaryPath, "stateview", "show", "--json")
+	cmd.Env = append(os.Environ(), "EMBEDDEDJSON_BASE_URL="+server.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	var stateViewEnv struct {
+		Results []map[string]any `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(out, &stateViewEnv), string(out))
+	require.Len(t, stateViewEnv.Results, 1)
+	assert.Equal(t, "state-a", stateViewEnv.Results[0]["slug"])
 
 	// Missing script tag: extractor reports an actionable error rather
 	// than silently returning empty data.

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -160,7 +160,10 @@ func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 	if selector == "" {
 		selector = "script#__NEXT_DATA__"
 	}
-	parsedSelector := parseSimpleSelector(selector)
+	parsedSelector, err := parseSimpleSelector(selector)
+	if err != nil {
+		return nil, fmt.Errorf("embedded-json: invalid selector %q: %w", selector, err)
+	}
 	scriptText, found := findScriptBySelector(doc, parsedSelector)
 	if !found {
 		return nil, fmt.Errorf("embedded-json: no element matching selector %q found in page", selector)
@@ -193,7 +196,7 @@ type simpleSelector struct {
 // "tag[attr=\"value\"]". This intentionally avoids a full CSS selector
 // engine while covering selectors emitted by browser sniffing for common SSR
 // state and JSON-LD script tags.
-func parseSimpleSelector(selector string) simpleSelector {
+func parseSimpleSelector(selector string) (simpleSelector, error) {
 	selector = strings.TrimSpace(selector)
 	out := simpleSelector{tag: selector}
 	if i := strings.Index(selector, "["); i >= 0 && strings.HasSuffix(selector, "]") {
@@ -202,20 +205,25 @@ func parseSimpleSelector(selector string) simpleSelector {
 		if eq := strings.Index(expr, "="); eq >= 0 {
 			out.attrName = strings.TrimSpace(expr[:eq])
 			out.attrValue = strings.Trim(strings.TrimSpace(expr[eq+1:]), `"'`)
+			if out.attrName == "" {
+				return simpleSelector{}, fmt.Errorf("attribute selector is missing an attribute name")
+			}
+		} else {
+			return simpleSelector{}, fmt.Errorf("attribute selector %q must use tag[attr=\"value\"]", selector)
 		}
-		return out
+		return out, nil
 	}
 	if i := strings.Index(selector, "#"); i >= 0 {
 		out.tag = selector[:i]
 		out.id = selector[i+1:]
-		return out
+		return out, nil
 	}
 	if i := strings.Index(selector, "."); i >= 0 {
 		out.tag = selector[:i]
 		out.className = selector[i+1:]
-		return out
+		return out, nil
 	}
-	return out
+	return out, nil
 }
 
 // findScriptBySelector walks the parsed HTML document looking for the first

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -27,7 +27,7 @@ type htmlExtractionOptions struct {
 	ContentType    string
 	LinkPrefixes   []string
 	Limit          int
-	ScriptSelector string // for mode: embedded-json — selector "tag" or "tag#id"
+	ScriptSelector string // for mode: embedded-json — selector "tag", "tag#id", "tag.class", or "tag[attr=\"value\"]"
 	JSONPath       string // for mode: embedded-json — dot-notation walk
 }
 
@@ -160,8 +160,8 @@ func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 	if selector == "" {
 		selector = "script#__NEXT_DATA__"
 	}
-	tag, idFilter := parseSimpleSelector(selector)
-	scriptText, found := findScriptByTagAndID(doc, tag, idFilter)
+	parsedSelector := parseSimpleSelector(selector)
+	scriptText, found := findScriptBySelector(doc, parsedSelector)
 	if !found {
 		return nil, fmt.Errorf("embedded-json: no element matching selector %q found in page", selector)
 	}
@@ -180,32 +180,63 @@ func extractEmbeddedJSON(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 	return json.RawMessage(out), nil
 }
 
-// parseSimpleSelector splits a "tag" or "tag#id" selector into its
-// components. Returns ("script", "__NEXT_DATA__") for the canonical
-// Next.js case; ("script", "") for a tag-only selector. Anything more
-// complex (CSS classes, attribute selectors) is out of scope for v1.
-func parseSimpleSelector(selector string) (tag, id string) {
-	if i := strings.Index(selector, "#"); i >= 0 {
-		return selector[:i], selector[i+1:]
-	}
-	return selector, ""
+type simpleSelector struct {
+	tag       string
+	id        string
+	className string
+	attrName  string
+	attrValue string
 }
 
-// findScriptByTagAndID walks the parsed HTML document looking for the
-// first element whose tag matches `tag` and (when `id` is non-empty)
-// whose id attribute matches `id`. Returns the element's concatenated
-// text content. Tags are matched case-insensitively; ids are
-// case-sensitive (per HTML5 spec).
-func findScriptByTagAndID(root *xhtml.Node, tag, id string) (string, bool) {
+// parseSimpleSelector parses the limited selector grammar used by generated
+// embedded-json extraction: "tag", "tag#id", "tag.class", or
+// "tag[attr=\"value\"]". This intentionally avoids a full CSS selector
+// engine while covering selectors emitted by browser sniffing for common SSR
+// state and JSON-LD script tags.
+func parseSimpleSelector(selector string) simpleSelector {
+	selector = strings.TrimSpace(selector)
+	out := simpleSelector{tag: selector}
+	if i := strings.Index(selector, "["); i >= 0 && strings.HasSuffix(selector, "]") {
+		out.tag = selector[:i]
+		expr := strings.TrimSuffix(selector[i+1:], "]")
+		if eq := strings.Index(expr, "="); eq >= 0 {
+			out.attrName = strings.TrimSpace(expr[:eq])
+			out.attrValue = strings.Trim(strings.TrimSpace(expr[eq+1:]), `"'`)
+		}
+		return out
+	}
+	if i := strings.Index(selector, "#"); i >= 0 {
+		out.tag = selector[:i]
+		out.id = selector[i+1:]
+		return out
+	}
+	if i := strings.Index(selector, "."); i >= 0 {
+		out.tag = selector[:i]
+		out.className = selector[i+1:]
+		return out
+	}
+	return out
+}
+
+// findScriptBySelector walks the parsed HTML document looking for the first
+// element matching the limited selector grammar. Tags are matched
+// case-insensitively; ids/classes/attribute values are case-sensitive.
+func findScriptBySelector(root *xhtml.Node, selector simpleSelector) (string, bool) {
 	var found *xhtml.Node
 	walkHTML(root, func(n *xhtml.Node) {
 		if found != nil || n.Type != xhtml.ElementNode {
 			return
 		}
-		if !strings.EqualFold(n.Data, tag) {
+		if selector.tag != "" && !strings.EqualFold(n.Data, selector.tag) {
 			return
 		}
-		if id != "" && attrValue(n, "id") != id {
+		if selector.id != "" && attrValue(n, "id") != selector.id {
+			return
+		}
+		if selector.className != "" && !hasHTMLClass(n, selector.className) {
+			return
+		}
+		if selector.attrName != "" && attrValue(n, selector.attrName) != selector.attrValue {
 			return
 		}
 		found = n
@@ -214,6 +245,15 @@ func findScriptByTagAndID(root *xhtml.Node, tag, id string) (string, bool) {
 		return "", false
 	}
 	return nodeText(found), true
+}
+
+func hasHTMLClass(n *xhtml.Node, className string) bool {
+	for _, part := range strings.Fields(attrValue(n, "class")) {
+		if part == className {
+			return true
+		}
+	}
+	return false
 }
 
 // walkJSONDotPath descends a parsed JSON value via dot-notation


### PR DESCRIPTION
## Summary

This updates the generated `embedded-json` HTML extractor to support the limited selector shapes that browser sniffing can already emit for SSR state blobs:

- `tag`
- `tag#id`
- `tag.class`
- `tag[attr="value"]`

That covers schema.org JSON-LD blocks such as `script[type="application/ld+json"]` without pulling in a full CSS selector engine or changing the existing `__NEXT_DATA__` path.

Fixes #1642.

## Root cause

`internal/browsersniff` can promote HTML extraction to `embedded-json` and emit selectors like:

- `script[type="application/ld+json"]`
- `script.state-view`

But the generated runtime helper in `internal/generator/templates/html_extract.go.tmpl` only parsed `tag` and `tag#id`. As a result, generated CLIs could be configured with the right selector and still fail at runtime with `no element matching selector ... found in page`.

## What changed

- Replaced the old tag/id-only selector parser with a tiny selector struct for the supported grammar.
- Added matching for class selectors via `class` token membership.
- Added matching for exact quoted attribute selectors, enough for JSON-LD script tags.
- Expanded the existing embedded-json generator test with:
  - a JSON-LD `script[type="application/ld+json"]` fixture
  - a `script.state-view` fixture

## Test plan

Local commands run:

```bash
go test ./internal/generator -run TestGenerateHTMLExtractionEmbeddedJSONMode -count=1
go test ./internal/spec ./internal/browsersniff ./internal/generator -count=1
scripts/golden.sh verify
```

Results:

- targeted embedded-json test: passed
- spec/browsersniff/generator packages: passed
- golden verify: passed, 22 cases

## Transparency

This PR was prepared with AI assistance. I reviewed the generated diff locally and validated it with the commands above before opening the PR.
