### PR TITLE
fix(cli): preserve typed api error exit codes

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5785,23 +5785,34 @@ func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
 
 func TestClassifyAPIErrorPreservesTypedCLIError(t *testing.T) {
 	cases := []struct {
-		name  string
-		err   error
-		flags *rootFlags
+		name     string
+		err      error
+		flags    *rootFlags
+		wantCode int
 	}{
-		{"semantic envelope error", usageErr(errors.New("semantic API envelope rejected input")), &rootFlags{}},
-		{"HTTP-like message with idempotent flags", usageErr(errors.New("HTTP 409: conflict")), &rootFlags{idempotent: true, asJSON: true}},
+		{"semantic envelope error", usageErr(errors.New("semantic API envelope rejected input")), &rootFlags{}, 2},
+		{"HTTP-like usage error with idempotent flags", usageErr(errors.New("HTTP 409: conflict")), &rootFlags{idempotent: true, asJSON: true}, 2},
+		{"HTTP-like auth error", authErr(errors.New("HTTP 401: unauthorized")), &rootFlags{}, 4},
+		{"HTTP-like api error with idempotent flags", apiErr(errors.New("HTTP 409: conflict")), &rootFlags{idempotent: true, asJSON: true}, 5},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			classified := classifyAPIError(tc.err, tc.flags)
+			stdout, stderr, classified := captureStdoutStderr(t, func() error {
+				return classifyAPIError(tc.err, tc.flags)
+			})
 
 			if classified != tc.err {
 				t.Fatalf("classifyAPIError should preserve typed cliError unchanged, got %#v", classified)
 			}
-			if got := ExitCode(classified); got != 2 {
-				t.Fatalf("ExitCode(classifyAPIError(usageErr(...))) = %d, want 2", got)
+			if got := ExitCode(classified); got != tc.wantCode {
+				t.Fatalf("ExitCode(classifyAPIError(%T)) = %d, want %d", tc.err, got, tc.wantCode)
+			}
+			if stdout != "" {
+				t.Fatalf("typed cliError pass-through should not write stdout, got %q", stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("typed cliError pass-through should not write stderr, got %q", stderr)
 			}
 		})
 	}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5783,6 +5783,30 @@ func TestClassifyAPIError409RequiresIdempotent(t *testing.T) {
 	requireNoopJSON(t, stdout, "already_exists")
 }
 
+func TestClassifyAPIErrorPreservesTypedCLIError(t *testing.T) {
+	cases := []struct {
+		name  string
+		err   error
+		flags *rootFlags
+	}{
+		{"semantic envelope error", usageErr(errors.New("semantic API envelope rejected input")), &rootFlags{}},
+		{"HTTP-like message with idempotent flags", usageErr(errors.New("HTTP 409: conflict")), &rootFlags{idempotent: true, asJSON: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			classified := classifyAPIError(tc.err, tc.flags)
+
+			if classified != tc.err {
+				t.Fatalf("classifyAPIError should preserve typed cliError unchanged, got %#v", classified)
+			}
+			if got := ExitCode(classified); got != 2 {
+				t.Fatalf("ExitCode(classifyAPIError(usageErr(...))) = %d, want 2", got)
+			}
+		})
+	}
+}
+
 func TestClassifyDeleteError404RequiresIgnoreMissing(t *testing.T) {
 	err := classifyDeleteError(errors.New("HTTP 404: not found"), &rootFlags{})
 	if err == nil {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -550,6 +550,11 @@ func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
 
 // classifyAPIError maps API errors to structured exit codes with actionable hints.
 func classifyAPIError(err error, flags *rootFlags) error {
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -474,6 +474,11 @@ func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
 
 // classifyAPIError maps API errors to structured exit codes with actionable hints.
 func classifyAPIError(err error, flags *rootFlags) error {
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -473,6 +473,11 @@ func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
 
 // classifyAPIError maps API errors to structured exit codes with actionable hints.
 func classifyAPIError(err error, flags *rootFlags) error {
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -474,6 +474,11 @@ func writeAPIErrorEnvelope(flags *rootFlags, err error, code int) {
 
 // classifyAPIError maps API errors to structured exit codes with actionable hints.
 func classifyAPIError(err error, flags *rootFlags) error {
+	var typed *cliError
+	if errors.As(err, &typed) {
+		return err
+	}
+
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):


### PR DESCRIPTION
## Summary

Generated CLIs now preserve caller-authored typed exit codes when `classifyAPIError` is used as the final error classifier. A custom envelope classifier can return `usageErr`, `authErr`, or another `cliError`, and that code will survive instead of being overwritten by the generic API exit code.

The regression coverage exercises both a semantic envelope error and an HTTP-looking typed error with idempotent JSON flags, so future changes must keep the typed-error pass-through ahead of the HTTP string matching. Golden fixtures are updated for the generated helper shape.

## Review Notes

The pre-PR review surfaced a broader MCP command-mirror parity gap: runtime shellout tools do not expose numeric subprocess exit codes in their MCP error result. That predates this helper fix and is accepted for later rather than expanding this issue beyond `classifyAPIError` preserving typed CLI errors.

## Testing

- `go test ./internal/generator -run TestGeneratedHelpers_IdempotentNoopsRequireOptIn -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...` (0 issues; emitted a stale-cache warning for a deleted sibling issue worktree)
- `scripts/golden.sh verify`

Closes #1549
