### PR TITLE
fix(cli): use Windows executable names for MCPB companions

### DIFF
--- a/docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md
+++ b/docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md
@@ -1,0 +1,66 @@
+---
+title: "Windows MCPB companion CLIs need target executable names"
+date: 2026-05-23
+category: logic-errors
+module: internal/generator/templates/cobratree
+problem_type: logic_error
+component: tooling
+related_components:
+  - internal/cli
+  - internal/pipeline
+symptoms:
+  - "Windows MCPB-bundled cobratree shell-out tools reported companion CLI binary not found."
+  - "Generated SiblingCLIPath searched for the unsuffixed CLI name even though Windows bundle binaries use .exe."
+  - "A template-only fix could still miss the bundled sibling when bundle staging archived the companion under the raw logical name."
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - mcpb
+  - windows
+  - cobratree
+  - executable-names
+  - companion-cli
+---
+
+# Windows MCPB companion CLIs need target executable names
+
+## Problem
+
+Printed CLI MCP servers shell out to their companion CLI for cobratree-mirrored tools. On Windows MCPB installs, the companion binary must be found as a sibling executable with a `.exe` suffix, or every runtime-mirrored tool fails before it can call the CLI.
+
+## Symptoms
+
+- MCPB-bundled Windows installs failed cobratree shell-out tools with `companion CLI binary not found`.
+- The generated `internal/mcp/cobratree/cli_path.go` built the sibling candidate from the logical CLI name without the Windows suffix.
+- A partial fix in the template was insufficient unless `cli-printing-press bundle` also staged and zipped the companion CLI under the same target executable name.
+
+## What Didn't Work
+
+- Patching a generated printed CLI was not durable because `internal/mcp/cobratree/` is generator-owned and overwritten on regen.
+- Updating only `SiblingCLIPath` left a second mismatch: cross-compilation uses the exact `go build -o` path, so the bundle code also has to choose a target-GOOS output and archive name for the companion CLI.
+- Storing the companion CLI path in `manifest.json` is not the right escape hatch. MCPB v0.3 hosts reject unknown manifest keys, so the manifest stays schema-clean and the runtime keeps sibling, env-var, and PATH resolution.
+
+## Solution
+
+Keep logical binary names platform-agnostic, and resolve filesystem/archive executable names at the target boundary:
+
+- Generated `SiblingCLIPath` calls a small `cliExecutableName(runtime.GOOS)` helper so Windows searches for `<api>-pp-cli.exe`, while Linux and macOS keep `<api>-pp-cli`.
+- `cli-printing-press bundle` uses `internal/platform.ExecutablePathForGOOS` when choosing the companion CLI staging path and zip entry for the bundle target platform.
+- The bundle still passes the raw logical CLI name to `go build` as the package name, and keeps MCPB `manifest.json` free of companion-CLI metadata.
+
+## Why This Works
+
+The runtime resolver and the bundle archive now agree on the same target-specific filename. A Windows MCPB bundle contains `bin/<api>-pp-cli.exe`, and the generated MCP server looks for the same sibling before falling back to `<API>_CLI_PATH` or `PATH`.
+
+Separating logical names from executable paths also avoids leaking platform suffixes into package names, manifest identity, or generated command names.
+
+## Prevention
+
+- For Windows target builds, route filesystem executable paths through `internal/platform.ExecutablePathForGOOS` or an emitted equivalent when generated code cannot import the generator package.
+- When changing cobratree runtime resolution, check bundle staging and archive names in the same pass. The generated resolver and MCPB package layout are one contract.
+- Add tests at both layers: generated cobratree helpers should simulate Windows and non-Windows GOOS values, and bundle tests should assert the companion CLI zip entry uses the target executable name.
+
+## Related
+
+- `docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md`

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -83,8 +84,9 @@ from another build pipeline.`,
 				binaryPath = pipeline.StagedMCPBinaryPath(cliDir, manifest.Name)
 			}
 			cliName := pipeline.ReadCLIBinaryName(cliDir)
+			cliArchiveName := bundleCLIBinaryArchiveName(cliName, goos)
 			if cliBinaryPath == "" && cliName != "" {
-				cliBinaryPath = pipeline.StagedMCPBinaryPath(cliDir, cliName)
+				cliBinaryPath = bundleCLIBinaryPath(cliDir, cliName, goos)
 			}
 			if err := buildBundleBinaries(cliDir, manifest.Name, binaryPath, skipBuild, cliName, cliBinaryPath, cliSkipBuild, goos, goarch); err != nil {
 				return err
@@ -97,7 +99,7 @@ from another build pipeline.`,
 			if err := pipeline.BuildMCPBBundle(pipeline.BundleParams{
 				CLIDir:        cliDir,
 				BinaryPath:    binaryPath,
-				CLIBinaryName: cliName,
+				CLIBinaryName: cliArchiveName,
 				CLIBinaryPath: cliBinaryPath,
 				OutputPath:    output,
 			}); err != nil {
@@ -156,9 +158,10 @@ func autoBundleForHost(cliDir string, w io.Writer) {
 	}
 	binaryPath := pipeline.StagedMCPBinaryPath(cliDir, manifest.Name)
 	cliName := pipeline.ReadCLIBinaryName(cliDir)
+	cliArchiveName := bundleCLIBinaryArchiveName(cliName, runtime.GOOS)
 	cliBinaryPath := ""
 	if cliName != "" {
-		cliBinaryPath = pipeline.StagedMCPBinaryPath(cliDir, cliName)
+		cliBinaryPath = bundleCLIBinaryPath(cliDir, cliName, runtime.GOOS)
 	}
 	if err := buildBundleBinaries(cliDir, manifest.Name, binaryPath, false, cliName, cliBinaryPath, false, runtime.GOOS, runtime.GOARCH); err != nil {
 		fmt.Fprintf(w, "warning: %v\n", err)
@@ -168,7 +171,7 @@ func autoBundleForHost(cliDir string, w io.Writer) {
 	if err := pipeline.BuildMCPBBundle(pipeline.BundleParams{
 		CLIDir:        cliDir,
 		BinaryPath:    binaryPath,
-		CLIBinaryName: cliName,
+		CLIBinaryName: cliArchiveName,
 		CLIBinaryPath: cliBinaryPath,
 		OutputPath:    output,
 	}); err != nil {
@@ -201,6 +204,20 @@ func buildBundleBinaries(cliDir, mcpName, mcpPath string, skipMCP bool, cliName,
 		})
 	}
 	return g.Wait()
+}
+
+func bundleCLIBinaryPath(cliDir, cliName, goos string) string {
+	if cliName == "" {
+		return ""
+	}
+	return pipeline.StagedMCPBinaryPath(cliDir, bundleCLIBinaryArchiveName(cliName, goos))
+}
+
+func bundleCLIBinaryArchiveName(cliName, goos string) string {
+	if cliName == "" {
+		return ""
+	}
+	return platform.ExecutablePathForGOOS(cliName, goos)
 }
 
 // resolvePlatform parses an optional "<os>/<arch>" string and falls back

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -43,6 +43,24 @@ func TestResolvePlatform(t *testing.T) {
 	})
 }
 
+func TestBundleCLIBinaryTargetPathUsesWindowsExecutableSuffix(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join("tmp", "demo")
+	assert.Equal(t,
+		filepath.Join("tmp", "demo", "build", "stage", "bin", "demo-pp-cli.exe"),
+		bundleCLIBinaryPath(dir, "demo-pp-cli", "windows"),
+	)
+	assert.Equal(t,
+		filepath.Join("tmp", "demo", "build", "stage", "bin", "demo-pp-cli"),
+		bundleCLIBinaryPath(dir, "demo-pp-cli", "linux"),
+	)
+	assert.Equal(t, "demo-pp-cli.exe", bundleCLIBinaryArchiveName("demo-pp-cli", "windows"))
+	assert.Equal(t, "demo-pp-cli", bundleCLIBinaryArchiveName("demo-pp-cli", "darwin"))
+	assert.Empty(t, bundleCLIBinaryPath(dir, "", "windows"))
+	assert.Empty(t, bundleCLIBinaryArchiveName("", "windows"))
+}
+
 func TestAutoBundleForHost(t *testing.T) {
 	t.Run("no manifest is silent", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -55,7 +55,7 @@ func TestMCPRegistersCobraTreeMirror(t *testing.T) {
 
 	cobratreeCLIPath, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "cli_path.go"))
 	require.NoError(t, err)
-	assert.Contains(t, string(cobratreeCLIPath), `const cliName = "noveltest-pp-cli"`)
+	assert.Contains(t, string(cobratreeCLIPath), `cliExecutableName(runtime.GOOS)`)
 	assert.Contains(t, string(cobratreeCLIPath), `os.Getenv("NOVELTEST_CLI_PATH")`)
 
 	cobratreeShellout, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "shellout.go"))
@@ -218,6 +218,36 @@ func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 }
 `)
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "framework_depth_test.go"), []byte(testSrc.String()), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
+}
+
+func TestMCPCobraTreeSiblingCLIPathUsesWindowsExecutableSuffix(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("pathcheck")
+	outputDir := filepath.Join(t.TempDir(), "pathcheck-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	var testSrc strings.Builder
+	testSrc.WriteString(`package cobratree
+
+import "testing"
+
+func TestCLIExecutableNameUsesWindowsSuffix(t *testing.T) {
+	if got := cliExecutableName("windows"); got != "pathcheck-pp-cli.exe" {
+		t.Fatalf("cliExecutableName(windows) = %q, want pathcheck-pp-cli.exe", got)
+	}
+	if got := cliExecutableName("linux"); got != "pathcheck-pp-cli" {
+		t.Fatalf("cliExecutableName(linux) = %q, want pathcheck-pp-cli", got)
+	}
+	if got := cliExecutableName("darwin"); got != "pathcheck-pp-cli" {
+		t.Fatalf("cliExecutableName(darwin) = %q, want pathcheck-pp-cli", got)
+	}
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "cli_path_extra_test.go"), []byte(testSrc.String()), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/mcp/cobratree")
 }

--- a/internal/generator/templates/cobratree/cli_path.go.tmpl
+++ b/internal/generator/templates/cobratree/cli_path.go.tmpl
@@ -7,12 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // SiblingCLIPath resolves the companion CLI via sibling-of-executable,
 // {{envPrefix .Name}}_CLI_PATH env var, then PATH.
 func SiblingCLIPath() (string, error) {
-	const cliName = "{{.Name}}-pp-cli"
+	cliName := cliExecutableName(runtime.GOOS)
 	if exe, err := os.Executable(); err == nil {
 		candidate := filepath.Join(filepath.Dir(exe), cliName)
 		if _, err := os.Stat(candidate); err == nil {
@@ -23,4 +24,12 @@ func SiblingCLIPath() (string, error) {
 		return v, nil
 	}
 	return exec.LookPath(cliName)
+}
+
+func cliExecutableName(goos string) string {
+	name := "{{.Name}}-pp-cli"
+	if goos == "windows" {
+		return name + ".exe"
+	}
+	return name
 }

--- a/internal/pipeline/mcpb_bundle_test.go
+++ b/internal/pipeline/mcpb_bundle_test.go
@@ -51,6 +51,40 @@ func TestBuildMCPBBundle(t *testing.T) {
 		assert.Contains(t, entries, "bin/demo-pp-mcp", "bundle must place binary at server.entry_point")
 	})
 
+	t.Run("packages companion CLI binary under provided archive name", func(t *testing.T) {
+		dir := t.TempDir()
+
+		manifest := MCPBManifest{
+			ManifestVersion: MCPBManifestVersion,
+			Name:            "demo-pp-mcp",
+			Server: MCPBServer{
+				Type:       "binary",
+				EntryPoint: "bin/demo-pp-mcp",
+				MCPConfig:  MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+			},
+		}
+		mData, _ := json.Marshal(manifest)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), mData, 0o644))
+
+		mcpPath := filepath.Join(dir, "fake-mcp")
+		cliPath := filepath.Join(dir, "fake-cli.exe")
+		require.NoError(t, os.WriteFile(mcpPath, []byte("#!/bin/sh\necho mcp\n"), 0o755))
+		require.NoError(t, os.WriteFile(cliPath, []byte("cli"), 0o755))
+
+		out := filepath.Join(dir, "demo.mcpb")
+		err := BuildMCPBBundle(BundleParams{
+			CLIDir:        dir,
+			BinaryPath:    mcpPath,
+			CLIBinaryName: "demo-pp-cli.exe",
+			CLIBinaryPath: cliPath,
+			OutputPath:    out,
+		})
+		require.NoError(t, err)
+
+		entries := readZipEntries(t, out)
+		assert.Contains(t, entries, "bin/demo-pp-cli.exe")
+	})
+
 	t.Run("missing manifest skips silently", func(t *testing.T) {
 		dir := t.TempDir()
 		// No manifest.json written; bundle call should no-op.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/cli_path.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/cli_path.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 // SiblingCLIPath resolves the companion CLI via sibling-of-executable,
 // PRINTING_PRESS_GOLDEN_CLI_PATH env var, then PATH.
 func SiblingCLIPath() (string, error) {
-	const cliName = "printing-press-golden-pp-cli"
+	cliName := cliExecutableName(runtime.GOOS)
 	if exe, err := os.Executable(); err == nil {
 		candidate := filepath.Join(filepath.Dir(exe), cliName)
 		if _, err := os.Stat(candidate); err == nil {
@@ -23,4 +24,12 @@ func SiblingCLIPath() (string, error) {
 		return v, nil
 	}
 	return exec.LookPath(cliName)
+}
+
+func cliExecutableName(goos string) string {
+	name := "printing-press-golden-pp-cli"
+	if goos == "windows" {
+		return name + ".exe"
+	}
+	return name
 }


### PR DESCRIPTION
## Summary

Windows MCPB bundles can now resolve cobratree companion CLIs consistently: generated MCP servers look for `<api>-pp-cli.exe` on Windows, and `cli-printing-press bundle` stages and zips the companion CLI under that same target executable name.

This keeps MCPB `manifest.json` schema-clean while preserving the existing sibling, env-var, and PATH fallback contract for runtime-mirrored MCP tools.

Closes #1834

## Test Plan

- `go test ./internal/generator -run 'TestMCP(RegistersCobraTreeMirror|CobraTreeSiblingCLIPathUsesWindowsExecutableSuffix)'`
- `go test ./internal/cli -run TestBundleCLIBinaryTargetPathUsesWindowsExecutableSuffix`
- `go test ./internal/pipeline -run TestBuildMCPBBundle`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `python3 /Users/tmchow/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.8.4/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md`

## Compounded learnings

- Added `docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md` to capture the target executable-name rule across generated cobratree runtime resolution and MCPB bundle packaging.
