### PR TITLE
fix(cli): use narrative commands for generated examples

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/format"
+	"maps"
 	"net/url"
 	"os"
 	"path"
@@ -22,6 +23,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/mcpdesc"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -267,9 +269,10 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return false
 		},
-		"exampleLine":        g.exampleLine,
-		"commandExampleArgs": commandExampleArgs,
-		"currentYear":        func() string { return strconv.Itoa(time.Now().Year()) },
+		"exampleLine":         g.exampleLine,
+		"promotedExampleLine": g.promotedExampleLine,
+		"commandExampleArgs":  commandExampleArgs,
+		"currentYear":         func() string { return strconv.Itoa(time.Now().Year()) },
 		"modulePath": func() string {
 			if g.ModulePath != "" {
 				return g.ModulePath
@@ -4771,13 +4774,222 @@ func exampleValue(p spec.Param) string {
 }
 
 func (g *Generator) exampleLine(commandPath, endpointName string, endpoint spec.Endpoint) string {
+	commandParts := append(strings.Fields(commandPath), toKebab(endpointName))
+	if line, ok := g.narrativeExampleLine(commandParts, endpoint); ok {
+		return line
+	}
+	if endpoint.Alias != "" {
+		aliasParts := append(strings.Fields(commandPath), endpoint.Alias)
+		if line, ok := g.narrativeExampleLine(aliasParts, endpoint); ok {
+			return line
+		}
+	}
+
 	var parts []string
 	parts = append(parts, naming.CLI(g.Spec.Name))
-	parts = append(parts, strings.Fields(commandPath)...)
-	parts = append(parts, toKebab(endpointName))
+	parts = append(parts, commandParts...)
 	parts = append(parts, commandExampleArgParts(endpoint)...)
 
 	return "  " + strings.Join(parts, " ")
+}
+
+func (g *Generator) promotedExampleLine(promotedName string, endpoint spec.Endpoint) string {
+	if line, ok := g.narrativeExampleLine([]string{promotedName}, endpoint); ok {
+		return line
+	}
+
+	parts := []string{naming.CLI(g.Spec.Name), promotedName}
+	parts = append(parts, commandExampleArgParts(endpoint)...)
+	return "  " + strings.Join(parts, " ")
+}
+
+func (g *Generator) narrativeExampleLine(commandParts []string, endpoint spec.Endpoint) (string, bool) {
+	if g == nil || g.Narrative == nil {
+		return "", false
+	}
+
+	for _, command := range g.narrativeExampleCommands() {
+		segments, err := shellargs.SplitChain(command)
+		if err != nil {
+			continue
+		}
+		for _, segment := range segments {
+			if segment.AfterPipe {
+				continue
+			}
+			if narrativeCommandMatches(g.Spec.Name, segment.Text, commandParts, endpoint) {
+				return "  " + strings.TrimSpace(segment.Text), true
+			}
+		}
+	}
+	return "", false
+}
+
+func (g *Generator) narrativeExampleCommands() []string {
+	if g == nil || g.Narrative == nil {
+		return nil
+	}
+
+	var commands []string
+	for _, step := range g.Narrative.QuickStart {
+		if command := strings.TrimSpace(step.Command); command != "" {
+			commands = append(commands, command)
+		}
+	}
+	for _, recipe := range g.Narrative.Recipes {
+		if command := strings.TrimSpace(recipe.Command); command != "" {
+			commands = append(commands, command)
+		}
+	}
+	return commands
+}
+
+func narrativeCommandMatches(apiName, command string, commandParts []string, endpoint spec.Endpoint) bool {
+	tokens, err := shellargs.Split(command)
+	if err != nil || len(tokens) < 1+len(commandParts) {
+		return false
+	}
+	if tokens[0] != naming.CLI(apiName) {
+		return false
+	}
+	args := tokens[1:]
+	commandIndex, ok := narrativeCommandStart(args)
+	if !ok || len(args[commandIndex:]) < len(commandParts) {
+		return false
+	}
+	for i, part := range commandParts {
+		if args[commandIndex+i] != part {
+			return false
+		}
+	}
+	return narrativeTailMatches(args[commandIndex+len(commandParts):], endpoint)
+}
+
+func narrativeTailMatches(args []string, endpoint spec.Endpoint) bool {
+	flags := narrativeEndpointFlags()
+	for _, p := range endpoint.Params {
+		if p.Positional {
+			continue
+		}
+		flags[publicFlagName(p)] = !isBoolParam(p)
+	}
+	for _, p := range endpoint.Body {
+		flags[publicFlagName(p)] = !isBoolParam(p)
+	}
+
+	positionals := 0
+	expectedPositionals := endpointPositionalCount(endpoint)
+	for i := 0; i < len(args); {
+		if strings.HasPrefix(args[i], "--") {
+			next, ok := skipNarrativeFlag(args, i, flags)
+			if !ok {
+				return false
+			}
+			i = next
+			continue
+		}
+		if positionals >= expectedPositionals {
+			return false
+		}
+		positionals++
+		i++
+	}
+	return positionals == expectedPositionals
+}
+
+func endpointPositionalCount(endpoint spec.Endpoint) int {
+	count := 0
+	for _, p := range endpoint.Params {
+		if p.Positional {
+			count++
+		}
+	}
+	return count
+}
+
+func narrativeEndpointFlags() map[string]bool {
+	flags := maps.Clone(narrativeGlobalFlags)
+	flags["all"] = false
+	flags["body-json"] = true
+	flags["stdin"] = false
+	flags["wait"] = false
+	flags["wait-interval"] = true
+	flags["wait-timeout"] = true
+	return flags
+}
+
+func skipNarrativeFlag(args []string, index int, flags map[string]bool) (int, bool) {
+	arg := args[index]
+	if arg == "--" {
+		return 0, false
+	}
+	name, _, hasInlineValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+	requiresValue, ok := flags[name]
+	if !ok {
+		return 0, false
+	}
+	next := index + 1
+	if requiresValue && !hasInlineValue {
+		if next >= len(args) {
+			return 0, false
+		}
+		next++
+	}
+	return next, true
+}
+
+func isBoolParam(p spec.Param) bool {
+	switch p.Type {
+	case "boolean", "bool":
+		return true
+	default:
+		return false
+	}
+}
+
+func narrativeCommandStart(args []string) (int, bool) {
+	for i := 0; i < len(args); {
+		arg := args[i]
+		if arg == "--" {
+			return 0, false
+		}
+		if !strings.HasPrefix(arg, "--") {
+			return i, true
+		}
+		next, ok := skipNarrativeFlag(args, i, narrativeGlobalFlags)
+		if !ok {
+			return 0, false
+		}
+		i = next
+	}
+	return 0, false
+}
+
+var narrativeGlobalFlags = map[string]bool{
+	"agent":                 false,
+	"allow-partial-failure": false,
+	"compact":               false,
+	"config":                true,
+	"csv":                   false,
+	"data-source":           true,
+	"deliver":               true,
+	"dry-run":               false,
+	"human-friendly":        false,
+	"idempotent":            false,
+	"ignore-missing":        false,
+	"json":                  false,
+	"max-age":               true,
+	"no-cache":              false,
+	"no-color":              false,
+	"no-input":              false,
+	"plain":                 false,
+	"profile":               true,
+	"quiet":                 false,
+	"rate-limit":            true,
+	"select":                true,
+	"throttle-mode":         true,
+	"timeout":               true,
+	"yes":                   false,
 }
 
 func flagName(name string) string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6657,6 +6657,419 @@ func TestExampleLineUsesRenderedCommandAndFlagNames(t *testing.T) {
 	assert.NotContains(t, got, "--idempotencyKey")
 }
 
+func TestGeneratedCommandExamplePrefersNarrativeQuickStart(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-examples")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Params: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/users/{id}",
+				Description: "Get a user",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-examples-pp-cli users list --pcgs-no 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "users_list.go")
+	assert.Contains(t, source, `"  narrative-examples-pp-cli users list --pcgs-no 7356"`)
+	assert.NotContains(t, source, "--pcgs-no example-value")
+}
+
+func TestGeneratedCommandExampleFallsBackWhenNarrativeDoesNotMatchCommand(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-fallback")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Params: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/users/{id}",
+				Description: "Get a user",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-fallback-pp-cli projects list --project-id p_12345"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "users_list.go")
+	assert.Contains(t, source, `narrative-fallback-pp-cli users list --pcgs-no example-value`)
+	assert.NotContains(t, source, "p_12345")
+}
+
+func TestGeneratedCommandExampleUsesNarrativeRecipeWhenQuickStartDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-recipes")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Params: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/users/{id}",
+				Description: "Get a user",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-recipes-pp-cli projects list --project-id p_12345"},
+		},
+		Recipes: []Recipe{
+			{Title: "List users", Command: "narrative-recipes-pp-cli users list --pcgs-no 1106065"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "users_list.go")
+	assert.Contains(t, source, `"  narrative-recipes-pp-cli users list --pcgs-no 1106065"`)
+	assert.NotContains(t, source, "--pcgs-no example-value")
+}
+
+func TestGeneratedPromotedCommandExamplePrefersNarrativeQuickStart(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-promoted")
+	apiSpec.Resources["lookup"] = spec.Resource{
+		Description: "Lookup",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/lookup",
+				Description: "Lookup an item",
+				Body: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-promoted-pp-cli lookup --pcgs-no 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_lookup.go")
+	assert.Contains(t, source, `"  narrative-promoted-pp-cli lookup --pcgs-no 7356"`)
+	assert.NotContains(t, source, "--pcgs-no example-value")
+}
+
+func TestGeneratedCommandExampleEscapesQuotedNarrativeArgs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-quotes")
+	apiSpec.Resources["search"] = spec.Resource{
+		Description: "Search",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/search",
+				Description: "Search items",
+				Params: []spec.Param{
+					{Name: "query", Type: "string", Required: true, Description: "Search query"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/search/{id}",
+				Description: "Get a search result",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: `narrative-quotes-pp-cli search list --query "peace dollar"`},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "search_list.go")
+	assert.Contains(t, source, `"  narrative-quotes-pp-cli search list --query \"peace dollar\""`)
+	assert.NotContains(t, source, "--query example-value")
+}
+
+func TestGeneratedCommandExampleMatchesNarrativeWithLeadingGlobalFlag(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-global-flag")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Params: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/users/{id}",
+				Description: "Get a user",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-global-flag-pp-cli --json users list --pcgs-no 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "users_list.go")
+	assert.Contains(t, source, `"  narrative-global-flag-pp-cli --json users list --pcgs-no 7356"`)
+	assert.NotContains(t, source, "--pcgs-no example-value")
+}
+
+func TestGeneratedCommandExampleMatchesNarrativeAlias(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-alias")
+	apiSpec.Resources["accounts"] = spec.Resource{
+		Description: "Accounts",
+		Endpoints: map[string]spec.Endpoint{
+			"get-account": {
+				Method:      "GET",
+				Path:        "/accounts/{accountId}",
+				Description: "Get account",
+				Alias:       "get",
+				Params:      []spec.Param{{Name: "accountId", Type: "string", Required: true, Positional: true}},
+			},
+			"list": {
+				Method:      "GET",
+				Path:        "/accounts",
+				Description: "List accounts",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-alias-pp-cli accounts get acct_123"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "accounts_get-account.go")
+	assert.Contains(t, source, `"  narrative-alias-pp-cli accounts get acct_123"`)
+	assert.NotContains(t, source, "550e8400-e29b-41d4-a716-446655440000")
+}
+
+func TestGeneratedCommandExampleMatchesLocalFlagBeforePositional(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-local-flag")
+	apiSpec.Resources["customers"] = spec.Resource{
+		Description: "Customers",
+		Endpoints: map[string]spec.Endpoint{
+			"get": {
+				Method:      "GET",
+				Path:        "/customers/{id}",
+				Description: "Get customer",
+				Params: []spec.Param{
+					{Name: "id", Type: "string", Required: true, Positional: true},
+					{Name: "expand", Type: "string", Description: "Expansion"},
+				},
+			},
+			"list": {
+				Method:      "GET",
+				Path:        "/customers",
+				Description: "List customers",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-local-flag-pp-cli customers get --expand subscriptions cus_123"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "customers_get.go")
+	assert.Contains(t, source, `"  narrative-local-flag-pp-cli customers get --expand subscriptions cus_123"`)
+	assert.NotContains(t, source, "550e8400-e29b-41d4-a716-446655440000")
+}
+
+func TestGeneratedCommandExampleUsesMatchedNarrativeChainSegment(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-chain")
+	apiSpec.Resources["users"] = spec.Resource{
+		Description: "Users",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {
+				Method:      "GET",
+				Path:        "/users",
+				Description: "List users",
+				Params: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/users/{id}",
+				Description: "Get a user",
+				Params:      []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-chain-pp-cli users list --pcgs-no 7356 && narrative-chain-pp-cli users get 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "users_list.go")
+	assert.Contains(t, source, `"  narrative-chain-pp-cli users list --pcgs-no 7356"`)
+	assert.NotContains(t, source, "&& narrative-chain-pp-cli users get")
+	assert.NotContains(t, source, "--pcgs-no example-value")
+}
+
+func TestGeneratedPromotedCommandExampleRejectsNarrativeChildCommand(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-promoted-child")
+	apiSpec.Resources["account"] = spec.Resource{
+		Description: "Account",
+		Endpoints: map[string]spec.Endpoint{
+			"get": {
+				Method:      "GET",
+				Path:        "/account/{accountId}",
+				Description: "Get account",
+				Params:      []spec.Param{{Name: "accountId", Type: "string", Required: true, Positional: true}},
+			},
+		},
+		SubResources: map[string]spec.Resource{
+			"cards": {
+				Description: "Cards",
+				Endpoints: map[string]spec.Endpoint{
+					"get-account": {
+						Method:      "GET",
+						Path:        "/account/{accountId}/cards",
+						Description: "Get cards",
+						Params:      []spec.Param{{Name: "accountId", Type: "string", Required: true, Positional: true}},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-promoted-child-pp-cli account cards get-account 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_account.go")
+	assert.Contains(t, source, `"  narrative-promoted-child-pp-cli account 550e8400-e29b-41d4-a716-446655440000"`)
+	assert.NotContains(t, source, "account cards get-account")
+}
+
+func TestGeneratedPromotedCommandExampleRejectsUnpromotedNarrativePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("narrative-unpromoted-path")
+	apiSpec.Resources["lookup"] = spec.Resource{
+		Description: "Lookup",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/lookup",
+				Description: "Lookup an item",
+				Body: []spec.Param{
+					{Name: "pcgs_no", FlagName: "pcgs-no", Type: "string", Required: true, Description: "PCGS number"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		QuickStart: []QuickStartStep{
+			{Command: "narrative-unpromoted-path-pp-cli lookup create --pcgs-no 7356"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_lookup.go")
+	assert.Contains(t, source, `"  narrative-unpromoted-path-pp-cli lookup --pcgs-no example-value"`)
+	assert.NotContains(t, source, `"  narrative-unpromoted-path-pp-cli lookup create --pcgs-no 7356"`)
+}
+
 func TestDetectAgentMoneyWorkflowFromGenericMoneyMovementShape(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -56,7 +56,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 		Aliases: []string{"{{.Endpoint.Alias}}"},
 {{- end}}
 		Short: "{{oneline .Endpoint.Description}}",
-		Example: "{{exampleLine .CommandPath .EndpointName .Endpoint}}",
+		Example: {{printf "%q" (exampleLine .CommandPath .EndpointName .Endpoint)}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if positionalArgs .Endpoint}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -42,7 +42,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Use:   "{{.PromotedName}}{{positionalArgs .Endpoint}}",
 		Short: "{{oneline .Endpoint.Description}}",
 		Long:  "Shortcut for '{{.ResourceName}} {{.EndpointName}}'. {{oneline .Endpoint.Description}}",
-		Example: "  {{modulePath}} {{.PromotedName}}{{with commandExampleArgs .Endpoint}} {{.}}{{end}}",
+		Example: {{printf "%q" (promotedExampleLine .PromotedName .Endpoint)}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- range .Endpoint.Params}}

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -722,17 +722,7 @@ func extractSubcommandWords(command string) []string {
 	return words
 }
 
-// chainSegment is one runnable (or pipe-skipped) piece of a recipe command.
-type chainSegment struct {
-	// Text is the segment as it appeared in the source, with surrounding
-	// whitespace trimmed. Pipe and redirect tokens are NOT stripped here —
-	// stripRedirects handles that downstream.
-	Text string
-	// AfterPipe is true when this segment sat to the right of a top-level
-	// `|` operator. The validator skips these segments because their input
-	// would normally arrive over a shell pipe.
-	AfterPipe bool
-}
+type chainSegment = shellargs.ChainSegment
 
 // splitShellChain walks command and returns the segments separated by
 // top-level `&&`, `||`, `;`, or `|` operators. Quoted text is preserved.
@@ -742,77 +732,7 @@ type chainSegment struct {
 // Backslash-escapes and quoted-string handling mirror shellargs.Split
 // so the segments are safe to feed back into shellargs.Split.
 func splitShellChain(command string) ([]chainSegment, error) {
-	var (
-		segments  []chainSegment
-		quote     rune
-		escaped   bool
-		afterPipe bool
-		start     int
-	)
-	flush := func(end int) {
-		if seg := strings.TrimSpace(command[start:end]); seg != "" {
-			segments = append(segments, chainSegment{Text: seg, AfterPipe: afterPipe})
-		}
-	}
-	for i := 0; i < len(command); i++ {
-		c := command[i]
-		if escaped {
-			escaped = false
-			continue
-		}
-		if quote == '\'' {
-			if c == '\'' {
-				quote = 0
-			}
-			continue
-		}
-		if quote == '"' {
-			switch c {
-			case '\\':
-				escaped = true
-			case '"':
-				quote = 0
-			}
-			continue
-		}
-		switch c {
-		case '\\':
-			escaped = true
-		case '\'', '"':
-			quote = rune(c)
-		case '&':
-			if i+1 < len(command) && command[i+1] == '&' {
-				flush(i)
-				i++
-				start = i + 1
-				// && resets the pipeline; segments after && start fresh.
-				afterPipe = false
-			}
-		case '|':
-			if i+1 < len(command) && command[i+1] == '|' {
-				flush(i)
-				i++
-				start = i + 1
-				// || resets the pipeline too.
-				afterPipe = false
-				continue
-			}
-			// Bare `|` ends the current runnable segment and marks every
-			// subsequent segment in this && / || / ; group as pipe-skipped.
-			flush(i)
-			start = i + 1
-			afterPipe = true
-		case ';':
-			flush(i)
-			start = i + 1
-			afterPipe = false
-		}
-	}
-	if quote != 0 {
-		return nil, fmt.Errorf("unclosed %s quote in %q", quoteName(quote), command)
-	}
-	flush(len(command))
-	return segments, nil
+	return shellargs.SplitChain(command)
 }
 
 // stripRedirects removes top-level shell redirects (`<file`, `>file`, `>>file`)
@@ -941,13 +861,6 @@ func stripRedirects(segment string) (string, []string) {
 		}
 	}
 	return strings.TrimSpace(cleaned.String()), redirects
-}
-
-func quoteName(r rune) string {
-	if r == '\'' {
-		return "single"
-	}
-	return "double"
 }
 
 // isIdentifierToken reports whether s contains only ASCII alphanumerics,

--- a/internal/shellargs/shellargs.go
+++ b/internal/shellargs/shellargs.go
@@ -109,6 +109,89 @@ func joinLineContinuations(s string) string {
 	return s
 }
 
+// ChainSegment is one runnable or pipe-skipped piece of a shell-style command.
+type ChainSegment struct {
+	// Text is the segment as it appeared in the source, with surrounding
+	// whitespace trimmed.
+	Text string
+	// AfterPipe is true when this segment sat to the right of a top-level
+	// pipe operator. Callers that execute commands should usually skip these
+	// because their input would normally arrive over a shell pipe.
+	AfterPipe bool
+}
+
+// SplitChain returns segments separated by top-level &&, ||, ;, or | operators.
+// Quoted text is preserved. Segments after a top-level | carry AfterPipe=true.
+func SplitChain(command string) ([]ChainSegment, error) {
+	var (
+		segments  []ChainSegment
+		quote     rune
+		escaped   bool
+		afterPipe bool
+		start     int
+	)
+	flush := func(end int) {
+		if seg := strings.TrimSpace(command[start:end]); seg != "" {
+			segments = append(segments, ChainSegment{Text: seg, AfterPipe: afterPipe})
+		}
+	}
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if quote == '\'' {
+			if c == '\'' {
+				quote = 0
+			}
+			continue
+		}
+		if quote == '"' {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\\':
+			escaped = true
+		case '\'', '"':
+			quote = rune(c)
+		case '&':
+			if i+1 < len(command) && command[i+1] == '&' {
+				flush(i)
+				i++
+				start = i + 1
+				afterPipe = false
+			}
+		case '|':
+			if i+1 < len(command) && command[i+1] == '|' {
+				flush(i)
+				i++
+				start = i + 1
+				afterPipe = false
+				continue
+			}
+			flush(i)
+			start = i + 1
+			afterPipe = true
+		case ';':
+			flush(i)
+			start = i + 1
+			afterPipe = false
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unclosed %s quote in %q", quoteName(quote), command)
+	}
+	flush(len(command))
+	return segments, nil
+}
+
 // ArgsAfterBinary returns every token after the leading binary name.
 func ArgsAfterBinary(example string) ([]string, error) {
 	tokens, err := Split(example)

--- a/internal/shellargs/shellargs_test.go
+++ b/internal/shellargs/shellargs_test.go
@@ -85,6 +85,42 @@ func TestSplitUnclosedQuote(t *testing.T) {
 	}
 }
 
+func TestSplitChain(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    []ChainSegment
+		wantErr string
+	}{
+		{"plain command", "stub widgets list", []ChainSegment{{Text: "stub widgets list"}}, ""},
+		{"and-chain", "stub sync && stub list --within 60d", []ChainSegment{{Text: "stub sync"}, {Text: "stub list --within 60d"}}, ""},
+		{"semicolon-chain", "stub sync ; stub list", []ChainSegment{{Text: "stub sync"}, {Text: "stub list"}}, ""},
+		{"or-chain", "stub sync || stub list", []ChainSegment{{Text: "stub sync"}, {Text: "stub list"}}, ""},
+		{"top-level pipe splits", "stub list | grep foo", []ChainSegment{{Text: "stub list"}, {Text: "grep foo", AfterPipe: true}}, ""},
+		{"and after pipe resets pipeline", "stub list | jq && stub show 42", []ChainSegment{{Text: "stub list"}, {Text: "jq", AfterPipe: true}, {Text: "stub show 42"}}, ""},
+		{"operators inside quotes", `stub run --msg "a && b | c"`, []ChainSegment{{Text: `stub run --msg "a && b | c"`}}, ""},
+		{"empty trailing segment dropped", "stub sync &&", []ChainSegment{{Text: "stub sync"}}, ""},
+		{"unclosed quote", `stub run "oops`, nil, "unclosed double quote"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SplitChain(tc.in)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("SplitChain(%q) error = %v, want substring %q", tc.in, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SplitChain(%q): %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("SplitChain(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestArgsAfterBinary(t *testing.T) {
 	got, err := ArgsAfterBinary(`cli goat "chicken tikka masala"`)
 	if err != nil {


### PR DESCRIPTION
## Intent

Issue: Closes #1550

Generated Cobra `Example:` fields should prefer a matching narrative quickstart or recipe command, so live dogfood happy-path checks exercise realistic values instead of synthetic fallbacks like `example-value`.

## Approach

The generator now matches endpoint and promoted-command examples against narrative commands before falling back to synthetic arguments. Matching reuses shared shell command splitting, handles aliases, leading global flags, local flags around positionals, quoted arguments, and chained commands while rejecting child/unpromoted command paths that only partially match.

## Scope

Primary area: generator templates and narrative command parsing.

Why this belongs in this repo: this changes the Printing Press generator behavior for future printed CLIs, not a one-off printed CLI.

## Risk

This changes generated Cobra `Example:` strings when a narrative command exactly matches the generated command. Non-matching commands keep the previous synthetic fallback; promoted commands reject child or unpromoted paths to avoid misleading examples.

## Output Contract

Generated command templates can now emit narrative-derived `Example:` strings. Existing goldens are unchanged because their fixtures do not provide matching narrative examples for these commands.

## Verification

- `go test ./internal/generator -run 'TestGenerated(Command|PromotedCommand)Example'`\n- `go test ./internal/shellargs ./internal/narrativecheck`\n- `go fmt ./...`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n- `go test ./...`\n- `scripts/golden.sh verify`\n- `golangci-lint run ./...`\n\n## AI / Automation Disclosure\n\n- [ ] No AI or automation was used\n- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission\n- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission\n- [ ] Fully automated: generated and submitted without human review for this specific change\n