### PR TITLE
fix(cli): format CSV float64 cells without scientific notation

### DIFF
--- a/internal/generator/print_csv_float_test.go
+++ b/internal/generator/print_csv_float_test.go
@@ -1,0 +1,50 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintCSVFloat64AvoidsScientificNotation(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("csv-float")
+	outputDir := filepath.Join(t.TempDir(), "csv-float-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "print_csv_float_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPrintCSVFloat64AvoidsScientificNotation(t *testing.T) {
+	payload, err := json.Marshal([]map[string]any{{"population": 3483757.0}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := printCSV(&out, payload); err != nil {
+		t.Fatalf("printCSV() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "3483757") {
+		t.Fatalf("expected decimal float rendering, got %s", got)
+	}
+	if strings.Contains(got, "e+") || strings.Contains(got, "E+") {
+		t.Fatalf("expected no scientific notation, got %s", got)
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintCSVFloat64AvoidsScientificNotation", "-count=1")
+}

--- a/internal/generator/print_csv_float_test.go
+++ b/internal/generator/print_csv_float_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestPrintCSVFloat64AvoidsScientificNotation(t *testing.T) {
-	payload, err := json.Marshal([]map[string]any{{"population": 3483757.0}})
+	// Large value (>= 1e6) previously rendered as 3.483757e+06; small value
+	// (< 1e-4) previously rendered as 1e-05. Cover both exponent signs.
+	payload, err := json.Marshal([]map[string]any{{"population": 3483757.0, "ratio": 0.00001}})
 	if err != nil {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
@@ -38,10 +40,14 @@ func TestPrintCSVFloat64AvoidsScientificNotation(t *testing.T) {
 
 	got := out.String()
 	if !strings.Contains(got, "3483757") {
-		t.Fatalf("expected decimal float rendering, got %s", got)
+		t.Fatalf("expected decimal float rendering of large value, got %s", got)
 	}
-	if strings.Contains(got, "e+") || strings.Contains(got, "E+") {
-		t.Fatalf("expected no scientific notation, got %s", got)
+	if !strings.Contains(got, "0.00001") {
+		t.Fatalf("expected fixed-notation rendering of small value, got %s", got)
+	}
+	if strings.Contains(got, "e+") || strings.Contains(got, "E+") ||
+		strings.Contains(got, "e-") || strings.Contains(got, "E-") {
+		t.Fatalf("expected no scientific notation (neither exponent sign), got %s", got)
 	}
 }
 `), 0o644))

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -24,6 +24,7 @@ import (
 	"regexp"
 {{- end}}
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 {{- if .HasDataLayer}}
@@ -1457,7 +1458,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 			if v == nil {
 				vals = append(vals, "")
 			} else {
-				s := fmt.Sprintf("%v", v)
+				var s string
+				if f, ok := v.(float64); ok {
+					s = strconv.FormatFloat(f, 'f', -1, 64)
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
 				if strings.ContainsAny(s, ",\"\n") {
 					s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 				}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -1226,7 +1227,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 			if v == nil {
 				vals = append(vals, "")
 			} else {
-				s := fmt.Sprintf("%v", v)
+				var s string
+				if f, ok := v.(float64); ok {
+					s = strconv.FormatFloat(f, 'f', -1, 64)
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
 				if strings.ContainsAny(s, ",\"\n") {
 					s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 				}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -18,6 +18,7 @@ import (
 	"printing-press-rich-pp-cli/internal/cliutil"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -1117,7 +1118,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 			if v == nil {
 				vals = append(vals, "")
 			} else {
-				s := fmt.Sprintf("%v", v)
+				var s string
+				if f, ok := v.(float64); ok {
+					s = strconv.FormatFloat(f, 'f', -1, 64)
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
 				if strings.ContainsAny(s, ",\"\n") {
 					s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 				}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -19,6 +19,7 @@ import (
 	"printing-press-golden-pp-cli/internal/cliutil"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -1124,7 +1125,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 			if v == nil {
 				vals = append(vals, "")
 			} else {
-				s := fmt.Sprintf("%v", v)
+				var s string
+				if f, ok := v.(float64); ok {
+					s = strconv.FormatFloat(f, 'f', -1, 64)
+				} else {
+					s = fmt.Sprintf("%v", v)
+				}
 				if strings.ContainsAny(s, ",\"\n") {
 					s = `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 				}


### PR DESCRIPTION
## Intent

Issue: Fixes #1724

The generated `printCSV` helper renders large numbers in scientific notation (`3.483757e+06` instead of `3483757`), silently corrupting CSV output for the exact use case CSV exists for — piping numeric data into R/Excel. JSON output is unaffected; only CSV is wrong.

## Approach

`printCSV` formatted every cell with `fmt.Sprintf("%v", v)`. `json.Unmarshal` decodes JSON numbers into `float64`, and `%v` prints any `float64` >= 1e6 (or < 1e-4) in scientific notation. The fix formats `float64` cells with `strconv.FormatFloat(f, 'f', -1, 64)` (shortest exact decimal — whole numbers become integer strings, decimals stay fixed) and keeps `%v` for all other types. CSV-escaping behavior is unchanged.

## Scope

Primary area: generator (`internal/generator/templates/helpers.go.tmpl`).

Why this belongs in this repo: this is a machine change. `printCSV` is template-emitted into every printed CLI, so the fix corrects all current and future CLIs that emit CSV with numeric fields (statistics, payments/commerce amounts, analytics metrics) rather than patching one printed CLI.

## Risk

Low. The change only affects `float64` cells; bools, strings, and ints fall through to the unchanged `%v` path. `strconv` is added to the unconditional import block and `printCSV` is always emitted, so there is no unused-import risk. Non-finite floats (`NaN`/`Inf`) render textually as before.

## Output Contract

Generated `helpers.go` changes: adds the `strconv` import and the `float64` formatting branch in `printCSV`. Golden fixtures regenerated for the three cases that snapshot `internal/cli/helpers.go` (`generate-golden-api`, `generate-golden-api-rich-auth`, `generate-embedded-paged-api`); the only diff is the import line and the float branch.

## Verification

Run from the change:
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — pass
- `go vet ./...` — pass
- `golangci-lint run ./...` (v2.11.4) — 0 issues
- `go test -short ./...` — pass (incl. new `TestPrintCSVFloat64AvoidsScientificNotation`, a behavioral test that generates a CLI and asserts `printCSV` renders `3483757`, not `e+`)
- `scripts/golden.sh verify` — failed on 3 expected cases (intentional); `scripts/golden.sh update` applied; diff inspected (import + float branch only)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
