### PR TITLE
fix(cli): distinguish verify-skill prose invocations

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -68,6 +68,8 @@ def read_utf8(path: Path) -> str:
 COMMON_FLAGS = {"help", "version"}
 
 CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
+FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+INLINE_CODE = re.compile(r"`[^`\n]*`")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
     re.DOTALL | re.MULTILINE | re.IGNORECASE,
@@ -594,12 +596,123 @@ def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# SKILL.md extraction
+# Prose source extraction
 # ---------------------------------------------------------------------------
 
 
-def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> list[tuple[list[str], list[str], list[str]]]:
-    """Return list of (cmd_path, positional_args, flags) tuples from bash blocks.
+def _cli_invocation_from_tokens(
+    tokens: list[str],
+    cli_dir: Path | None,
+) -> tuple[list[str], list[str], list[str]]:
+    if not tokens:
+        return [], [], []
+
+    cmd_path: list[str] = [tokens[0].lower()]
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("-"):
+            break
+        if (
+            t.startswith("<") or t.startswith("[")
+            or t.startswith('"') or t.startswith("'")
+            or t.startswith("$") or t.startswith("http")
+            or "/" in t or "=" in t
+            or re.match(r"^[A-Z]", t)
+            or re.match(r"^\d", t)
+        ):
+            break
+        if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
+            # Verify adding this token still maps to a valid command. If the
+            # extended path has no source match, this token is an argument.
+            if cli_dir is not None:
+                trial = cmd_path + [t]
+                files, _, _ = find_command_source(cli_dir, trial)
+                if not files:
+                    break
+            cmd_path.append(t)
+            i += 1
+            continue
+        break
+
+    positional: list[str] = []
+    flags: list[str] = []
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("--"):
+            flags.append(t)
+            # Skip value if present and not another flag
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+                i += 2
+                continue
+        elif t.startswith("-"):
+            # Short flag, skip its value heuristically
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+                i += 2
+                continue
+        else:
+            positional.append(t)
+        i += 1
+
+    return cmd_path, positional, flags
+
+
+def _extract_prose_invocations(
+    text: str,
+    cli_binary: str,
+    cli_dir: Path | None = None,
+) -> list[tuple[list[str], list[str], list[str], str]]:
+    """Return invocation-shaped plain-prose mentions of the CLI.
+
+    Plain `<cli> <word>` mentions are common narrative prose, so this only
+    treats a prose mention as command-shaped when a long flag appears after a
+    plausible command token. Markdown code spans and fenced blocks are stripped
+    first; those are handled by bash recipe and inline-reference scanners.
+    """
+    plain = INLINE_CODE.sub("", FENCED_CODE.sub("", text))
+    binary = re.escape(cli_binary)
+    mention_re = re.compile(rf"(?<![\w.-]){binary}\s+")
+    results: list[tuple[list[str], list[str], list[str], str]] = []
+
+    for raw_line in plain.splitlines():
+        if cli_binary not in raw_line or "--" not in raw_line:
+            continue
+        mentions = list(mention_re.finditer(raw_line))
+        for idx, m in enumerate(mentions):
+            end = mentions[idx + 1].start() if idx + 1 < len(mentions) else len(raw_line)
+            fragment = raw_line[m.end():end]
+            try:
+                tokens = shlex.split(fragment, posix=True)
+            except ValueError:
+                tokens = fragment.split()
+            tokens = [t.strip(".,;:)") for t in tokens if t.strip(".,;:)")]
+            if len(tokens) < 2:
+                continue
+
+            first = tokens[0].lower()
+            if not re.match(r"^[a-z][a-z0-9-]*$", first):
+                continue
+            first_files, _, _ = find_command_source(cli_dir, [first]) if cli_dir is not None else ([], None, None)
+            # Unknown first tokens are warning-worthy only for tight
+            # invocation shapes like `<cli> fake --flag`, not for narrative
+            # prose such as `<cli> wraps the API ... --flag`.
+            if not first_files and not tokens[1].startswith("-"):
+                continue
+
+            cmd_path, _positional, flags = _cli_invocation_from_tokens(tokens, cli_dir)
+            if not flags:
+                continue
+            results.append((cmd_path, [], flags, "prose invocation"))
+
+    return results
+
+
+@lru_cache(maxsize=None)
+def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> tuple[tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], str], ...]:
+    """Return cached (cmd_path, positional_args, flags, surface) tuples.
+
+    Surfaces include fenced bash recipes and plain prose that is shaped like a
+    real CLI invocation because it includes a long flag.
 
     cmd_path: leading lowercase-hyphenated tokens (up to 3)
     positional_args: non-flag tokens after cmd_path (shell-quoted strings preserved)
@@ -607,7 +720,7 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
     """
     text = read_utf8(skill)
     blocks = CODEBLOCK_BASH.findall(text)
-    results = []
+    results: list[tuple[list[str], list[str], list[str], str]] = []
     for block in blocks:
         # Merge line continuations
         merged = []
@@ -648,57 +761,22 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
                 tokens = shlex.split(after, posix=True)
             except ValueError:
                 tokens = after.split()
-            if not tokens:
-                continue
-            cmd_path: list[str] = [tokens[0].lower()]
-            i = 1
-            while i < len(tokens):
-                t = tokens[i]
-                if t.startswith("-"):
-                    break
-                if (
-                    t.startswith("<") or t.startswith("[")
-                    or t.startswith('"') or t.startswith("'")
-                    or t.startswith("$") or t.startswith("http")
-                    or "/" in t or "=" in t
-                    or re.match(r"^[A-Z]", t)
-                    or re.match(r"^\d", t)
-                ):
-                    break
-                if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
-                    # Verify adding this token still maps to a valid command.
-                    # If the extended path has no source match (e.g. the
-                    # parent command's Use documents <positional> and this
-                    # token is just the arg), treat it as positional.
-                    if cli_dir is not None:
-                        trial = cmd_path + [t]
-                        files, _, _ = find_command_source(cli_dir, trial)
-                        if not files:
-                            break
-                    cmd_path.append(t)
-                    i += 1
-                    continue
-                break
-            positional: list[str] = []
-            flags: list[str] = []
-            while i < len(tokens):
-                t = tokens[i]
-                if t.startswith("--"):
-                    flags.append(t)
-                    # Skip value if present and not another flag
-                    if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
-                        i += 2
-                        continue
-                elif t.startswith("-"):
-                    # Short flag, skip its value heuristically
-                    if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
-                        i += 2
-                        continue
-                else:
-                    positional.append(t)
-                i += 1
-            results.append((cmd_path, positional, flags))
-    return results
+            cmd_path, positional, flags = _cli_invocation_from_tokens(tokens, cli_dir)
+            if cmd_path:
+                results.append((cmd_path, positional, flags, "bash recipe"))
+    results.extend(_extract_prose_invocations(text, cli_binary, cli_dir))
+    return tuple(
+        (tuple(cmd_path), tuple(positional), tuple(flags), surface)
+        for cmd_path, positional, flags, surface in results
+    )
+
+
+def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> list[tuple[list[str], list[str], list[str]]]:
+    return [
+        (list(cmd_path), list(positional), list(flags))
+        for cmd_path, positional, flags, _surface in extract_cli_invocations(skill, cli_binary, cli_dir)
+        if _surface == "bash recipe"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -707,10 +785,9 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
 
 
 def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
-    # Scoped to recipes so flags belonging to other tools invoked from
-    # the prose (npx installers, gh, go, curl, ...) don't get reported as
-    # missing declarations on the printed CLI. extract_recipes already
-    # filters to lines starting with `cli_binary + " "`.
+    # Scoped to printed-CLI invocations so flags belonging to other tools
+    # invoked from prose (npx installers, gh, go, curl, ...) don't get
+    # reported as missing declarations on the printed CLI.
     #
     # The `seen` set is scoped per source: a flag undeclared in SKILL.md
     # is reported separately from the same flag undeclared in README.md
@@ -720,7 +797,8 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[str] = set()
-        for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 if flag in COMMON_FLAGS or flag in seen:
@@ -744,7 +822,8 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[tuple[str, str]] = set()
-        for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             path_str = " ".join(cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
@@ -900,9 +979,10 @@ def check_unknown_commands(cli_dir: Path, sources: list[Path], cli_binary: str, 
     refs: list[tuple[list[str], str]] = []
 
     for src in sources:
-        for cmd_path, _pos, _flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _pos, _flags, surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             if cmd_path:
-                refs.append((cmd_path, f"bash recipe ({src.name})"))
+                refs.append((cmd_path, f"{surface} ({src.name})"))
         if src.name == "SKILL.md":
             skill_text = read_utf8(src)
             for cmd_path in _extract_inline_commands(skill_text, cli_binary):

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -639,6 +639,9 @@ def _cli_invocation_from_tokens(
     flags: list[str] = []
     while i < len(tokens):
         t = tokens[i]
+        if t == "--":
+            i += 1
+            continue
         if t.startswith("--"):
             flags.append(t)
             # Skip value if present and not another flag
@@ -801,7 +804,7 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
             cmd_path = list(raw_cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
-                if flag in COMMON_FLAGS or flag in seen:
+                if not flag or flag in COMMON_FLAGS or flag in seen:
                     continue
                 if flag_declared_in(all_files, flag):
                     continue
@@ -828,7 +831,7 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 key = (path_str, flag)
-                if flag in COMMON_FLAGS or key in seen:
+                if not flag or flag in COMMON_FLAGS or key in seen:
                     continue
                 cmd_files, _, _ = find_command_source(cli_dir, cmd_path)
                 if cmd_files and flag_declared_in(cmd_files, flag):

--- a/internal/cli/verify_skill_unknown_command_test.go
+++ b/internal/cli/verify_skill_unknown_command_test.go
@@ -150,3 +150,157 @@ description: "fixture"
 	require.NotContains(t, string(out), "[unknown-command]",
 		"no findings expected — help/completion/version are whitelisted")
 }
+
+func TestVerifySkill_UnknownCommandIgnoresNaturalLanguageCliProse(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+fixture-pp-cli wraps the official Fixture API with typed commands for every endpoint.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	return &cobra.Command{Use: "fixture-pp-cli"}
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "unknown-command").CombinedOutput()
+	require.NoError(t, err, "natural-language prose must not be treated as a command reference: %s", string(out))
+	require.NotContains(t, string(out), "[unknown-command]")
+}
+
+func TestVerifySkill_ProseInvocationWithFlagIsChecked(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+Use fixture-pp-cli sync --base USD when you need a specific base currency.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSyncCmd())
+	return rootCmd
+}
+`,
+		"sync.go": `package cli
+import "github.com/spf13/cobra"
+func newSyncCmd() *cobra.Command {
+	return &cobra.Command{Use: "sync"}
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-commands").CombinedOutput()
+	require.Error(t, err, "prose that contains an invocation-shaped flag must still be verified")
+	require.Contains(t, string(out), "--base is not declared anywhere")
+	require.Contains(t, string(out), "SKILL.md")
+}
+
+func TestVerifySkill_ProseInvocationDoesNotAffectPositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+Use fixture-pp-cli search pizza --limit 5 when you need a filtered search.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSearchCmd())
+	return rootCmd
+}
+`,
+		"search.go": `package cli
+import "github.com/spf13/cobra"
+func newSearchCmd() *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{Use: "search <query>"}
+	cmd.Flags().IntVar(&limit, "limit", 10, "Limit")
+	return cmd
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.NoError(t, err, "plain-prose invocations must not be counted as bash recipes for positional args: %s", string(out))
+}
+
+func TestVerifySkill_ProseInvocationSplitsMultipleCliMentions(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+Use fixture-pp-cli sync --base USD or fixture-pp-cli export --format csv for local handoffs.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSyncCmd())
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd
+}
+`,
+		"sync.go": `package cli
+import "github.com/spf13/cobra"
+func newSyncCmd() *cobra.Command {
+	return &cobra.Command{Use: "sync"}
+}
+`,
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&format, "format", "", "Format")
+	return cmd
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-commands").CombinedOutput()
+	require.Error(t, err, "bad sync flag should still be reported")
+	require.Contains(t, string(out), "--base is not declared anywhere")
+	require.NotContains(t, string(out), "--format is declared elsewhere but not on sync")
+}

--- a/internal/cli/verify_skill_unknown_command_test.go
+++ b/internal/cli/verify_skill_unknown_command_test.go
@@ -218,6 +218,44 @@ func newSyncCmd() *cobra.Command {
 	require.Contains(t, string(out), "SKILL.md")
 }
 
+func TestVerifySkill_ProseInvocationFlagNameIsChecked(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+Use fixture-pp-cli sync --base USD when you need a specific base currency.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSyncCmd())
+	return rootCmd
+}
+`,
+		"sync.go": `package cli
+import "github.com/spf13/cobra"
+func newSyncCmd() *cobra.Command {
+	return &cobra.Command{Use: "sync"}
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-names").CombinedOutput()
+	require.Error(t, err, "prose invocation flags must still be checked by flag-names")
+	require.Contains(t, string(out), "--base is referenced")
+	require.Contains(t, string(out), "SKILL.md")
+}
+
 func TestVerifySkill_ProseInvocationDoesNotAffectPositionalArgs(t *testing.T) {
 	t.Parallel()
 
@@ -303,4 +341,54 @@ func newExportCmd() *cobra.Command {
 	require.Error(t, err, "bad sync flag should still be reported")
 	require.Contains(t, string(out), "--base is not declared anywhere")
 	require.NotContains(t, string(out), "--format is declared elsewhere but not on sync")
+}
+
+func TestVerifySkill_ProseInvocationIgnoresBareSeparatorBetweenMentions(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := `---
+name: pp-fixture
+description: "fixture"
+---
+
+# Fixture
+
+Use fixture-pp-cli sync --base USD -- fixture-pp-cli export --format csv for local handoffs.
+`
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSyncCmd())
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd
+}
+`,
+		"sync.go": `package cli
+import "github.com/spf13/cobra"
+func newSyncCmd() *cobra.Command {
+	var base string
+	cmd := &cobra.Command{Use: "sync"}
+	cmd.Flags().StringVar(&base, "base", "", "Base")
+	return cmd
+}
+`,
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&format, "format", "", "Format")
+	return cmd
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-names").CombinedOutput()
+	require.NoError(t, err, "bare -- separator between prose mentions must not produce an empty-flag finding: %s", string(out))
+	require.NotContains(t, string(out), "[flag-names]")
 }

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -68,6 +68,8 @@ def read_utf8(path: Path) -> str:
 COMMON_FLAGS = {"help", "version"}
 
 CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
+FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+INLINE_CODE = re.compile(r"`[^`\n]*`")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
     re.DOTALL | re.MULTILINE | re.IGNORECASE,
@@ -594,12 +596,123 @@ def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# SKILL.md extraction
+# Prose source extraction
 # ---------------------------------------------------------------------------
 
 
-def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> list[tuple[list[str], list[str], list[str]]]:
-    """Return list of (cmd_path, positional_args, flags) tuples from bash blocks.
+def _cli_invocation_from_tokens(
+    tokens: list[str],
+    cli_dir: Path | None,
+) -> tuple[list[str], list[str], list[str]]:
+    if not tokens:
+        return [], [], []
+
+    cmd_path: list[str] = [tokens[0].lower()]
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("-"):
+            break
+        if (
+            t.startswith("<") or t.startswith("[")
+            or t.startswith('"') or t.startswith("'")
+            or t.startswith("$") or t.startswith("http")
+            or "/" in t or "=" in t
+            or re.match(r"^[A-Z]", t)
+            or re.match(r"^\d", t)
+        ):
+            break
+        if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
+            # Verify adding this token still maps to a valid command. If the
+            # extended path has no source match, this token is an argument.
+            if cli_dir is not None:
+                trial = cmd_path + [t]
+                files, _, _ = find_command_source(cli_dir, trial)
+                if not files:
+                    break
+            cmd_path.append(t)
+            i += 1
+            continue
+        break
+
+    positional: list[str] = []
+    flags: list[str] = []
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("--"):
+            flags.append(t)
+            # Skip value if present and not another flag
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+                i += 2
+                continue
+        elif t.startswith("-"):
+            # Short flag, skip its value heuristically
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+                i += 2
+                continue
+        else:
+            positional.append(t)
+        i += 1
+
+    return cmd_path, positional, flags
+
+
+def _extract_prose_invocations(
+    text: str,
+    cli_binary: str,
+    cli_dir: Path | None = None,
+) -> list[tuple[list[str], list[str], list[str], str]]:
+    """Return invocation-shaped plain-prose mentions of the CLI.
+
+    Plain `<cli> <word>` mentions are common narrative prose, so this only
+    treats a prose mention as command-shaped when a long flag appears after a
+    plausible command token. Markdown code spans and fenced blocks are stripped
+    first; those are handled by bash recipe and inline-reference scanners.
+    """
+    plain = INLINE_CODE.sub("", FENCED_CODE.sub("", text))
+    binary = re.escape(cli_binary)
+    mention_re = re.compile(rf"(?<![\w.-]){binary}\s+")
+    results: list[tuple[list[str], list[str], list[str], str]] = []
+
+    for raw_line in plain.splitlines():
+        if cli_binary not in raw_line or "--" not in raw_line:
+            continue
+        mentions = list(mention_re.finditer(raw_line))
+        for idx, m in enumerate(mentions):
+            end = mentions[idx + 1].start() if idx + 1 < len(mentions) else len(raw_line)
+            fragment = raw_line[m.end():end]
+            try:
+                tokens = shlex.split(fragment, posix=True)
+            except ValueError:
+                tokens = fragment.split()
+            tokens = [t.strip(".,;:)") for t in tokens if t.strip(".,;:)")]
+            if len(tokens) < 2:
+                continue
+
+            first = tokens[0].lower()
+            if not re.match(r"^[a-z][a-z0-9-]*$", first):
+                continue
+            first_files, _, _ = find_command_source(cli_dir, [first]) if cli_dir is not None else ([], None, None)
+            # Unknown first tokens are warning-worthy only for tight
+            # invocation shapes like `<cli> fake --flag`, not for narrative
+            # prose such as `<cli> wraps the API ... --flag`.
+            if not first_files and not tokens[1].startswith("-"):
+                continue
+
+            cmd_path, _positional, flags = _cli_invocation_from_tokens(tokens, cli_dir)
+            if not flags:
+                continue
+            results.append((cmd_path, [], flags, "prose invocation"))
+
+    return results
+
+
+@lru_cache(maxsize=None)
+def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> tuple[tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], str], ...]:
+    """Return cached (cmd_path, positional_args, flags, surface) tuples.
+
+    Surfaces include fenced bash recipes and plain prose that is shaped like a
+    real CLI invocation because it includes a long flag.
 
     cmd_path: leading lowercase-hyphenated tokens (up to 3)
     positional_args: non-flag tokens after cmd_path (shell-quoted strings preserved)
@@ -607,7 +720,7 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
     """
     text = read_utf8(skill)
     blocks = CODEBLOCK_BASH.findall(text)
-    results = []
+    results: list[tuple[list[str], list[str], list[str], str]] = []
     for block in blocks:
         # Merge line continuations
         merged = []
@@ -648,57 +761,22 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
                 tokens = shlex.split(after, posix=True)
             except ValueError:
                 tokens = after.split()
-            if not tokens:
-                continue
-            cmd_path: list[str] = [tokens[0].lower()]
-            i = 1
-            while i < len(tokens):
-                t = tokens[i]
-                if t.startswith("-"):
-                    break
-                if (
-                    t.startswith("<") or t.startswith("[")
-                    or t.startswith('"') or t.startswith("'")
-                    or t.startswith("$") or t.startswith("http")
-                    or "/" in t or "=" in t
-                    or re.match(r"^[A-Z]", t)
-                    or re.match(r"^\d", t)
-                ):
-                    break
-                if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
-                    # Verify adding this token still maps to a valid command.
-                    # If the extended path has no source match (e.g. the
-                    # parent command's Use documents <positional> and this
-                    # token is just the arg), treat it as positional.
-                    if cli_dir is not None:
-                        trial = cmd_path + [t]
-                        files, _, _ = find_command_source(cli_dir, trial)
-                        if not files:
-                            break
-                    cmd_path.append(t)
-                    i += 1
-                    continue
-                break
-            positional: list[str] = []
-            flags: list[str] = []
-            while i < len(tokens):
-                t = tokens[i]
-                if t.startswith("--"):
-                    flags.append(t)
-                    # Skip value if present and not another flag
-                    if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
-                        i += 2
-                        continue
-                elif t.startswith("-"):
-                    # Short flag, skip its value heuristically
-                    if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
-                        i += 2
-                        continue
-                else:
-                    positional.append(t)
-                i += 1
-            results.append((cmd_path, positional, flags))
-    return results
+            cmd_path, positional, flags = _cli_invocation_from_tokens(tokens, cli_dir)
+            if cmd_path:
+                results.append((cmd_path, positional, flags, "bash recipe"))
+    results.extend(_extract_prose_invocations(text, cli_binary, cli_dir))
+    return tuple(
+        (tuple(cmd_path), tuple(positional), tuple(flags), surface)
+        for cmd_path, positional, flags, surface in results
+    )
+
+
+def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -> list[tuple[list[str], list[str], list[str]]]:
+    return [
+        (list(cmd_path), list(positional), list(flags))
+        for cmd_path, positional, flags, _surface in extract_cli_invocations(skill, cli_binary, cli_dir)
+        if _surface == "bash recipe"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -707,10 +785,9 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
 
 
 def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
-    # Scoped to recipes so flags belonging to other tools invoked from
-    # the prose (npx installers, gh, go, curl, ...) don't get reported as
-    # missing declarations on the printed CLI. extract_recipes already
-    # filters to lines starting with `cli_binary + " "`.
+    # Scoped to printed-CLI invocations so flags belonging to other tools
+    # invoked from prose (npx installers, gh, go, curl, ...) don't get
+    # reported as missing declarations on the printed CLI.
     #
     # The `seen` set is scoped per source: a flag undeclared in SKILL.md
     # is reported separately from the same flag undeclared in README.md
@@ -720,7 +797,8 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[str] = set()
-        for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 if flag in COMMON_FLAGS or flag in seen:
@@ -744,7 +822,8 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
     all_files = list((cli_dir / "internal/cli").glob("*.go"))
     for src in sources:
         seen: set[tuple[str, str]] = set()
-        for cmd_path, _positional, flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _positional, flags, _surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             path_str = " ".join(cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
@@ -900,9 +979,10 @@ def check_unknown_commands(cli_dir: Path, sources: list[Path], cli_binary: str, 
     refs: list[tuple[list[str], str]] = []
 
     for src in sources:
-        for cmd_path, _pos, _flags in extract_recipes(src, cli_binary, cli_dir):
+        for raw_cmd_path, _pos, _flags, surface in extract_cli_invocations(src, cli_binary, cli_dir):
+            cmd_path = list(raw_cmd_path)
             if cmd_path:
-                refs.append((cmd_path, f"bash recipe ({src.name})"))
+                refs.append((cmd_path, f"{surface} ({src.name})"))
         if src.name == "SKILL.md":
             skill_text = read_utf8(src)
             for cmd_path in _extract_inline_commands(skill_text, cli_binary):

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -639,6 +639,9 @@ def _cli_invocation_from_tokens(
     flags: list[str] = []
     while i < len(tokens):
         t = tokens[i]
+        if t == "--":
+            i += 1
+            continue
         if t.startswith("--"):
             flags.append(t)
             # Skip value if present and not another flag
@@ -801,7 +804,7 @@ def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report
             cmd_path = list(raw_cmd_path)
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
-                if flag in COMMON_FLAGS or flag in seen:
+                if not flag or flag in COMMON_FLAGS or flag in seen:
                     continue
                 if flag_declared_in(all_files, flag):
                     continue
@@ -828,7 +831,7 @@ def check_flag_commands(cli_dir: Path, sources: list[Path], cli_binary: str, rep
             for raw_flag in flags:
                 flag = raw_flag.lstrip("-")
                 key = (path_str, flag)
-                if flag in COMMON_FLAGS or key in seen:
+                if not flag or flag in COMMON_FLAGS or key in seen:
                     continue
                 cmd_files, _, _ = find_command_source(cli_dir, cmd_path)
                 if cmd_files and flag_declared_in(cmd_files, flag):


### PR DESCRIPTION
## Intent

Closes #1556.

`verify-skill` should ignore natural prose like `<cli> wraps the API...` while still catching prose that is shaped like a real CLI invocation with flags.

## Approach

The verifier now has a shared invocation extractor for fenced bash recipes and plain prose mentions that include long flags. Plain prose is stripped of markdown code spans before scanning, and multiple CLI mentions on one line are split so flags stay attributed to the right command.

Bash recipe extraction remains the only source for positional argument validation. Flag checks and unknown-command checks consume the broader invocation set.

## Scope

Primary area: verifier and scorer support code.

Why this belongs in this repo: the false positive comes from the Printing Press `verify-skill` scanner, not from a single printed CLI.

## Risk

The risk is verifier classification drift. Regression tests cover natural prose, invocation-shaped prose flags, positional-arg separation, multiple CLI mentions on one line, and script-to-bundled sync.

## Output Contract

N/A

## Verification

- `python3 -m py_compile scripts/verify-skill/verify_skill.py internal/cli/verify_skill_bundled.py`
- `go test ./internal/cli -run 'TestVerifySkill_(UnknownCommandIgnoresNaturalLanguageCliProse|ProseInvocationWithFlagIsChecked|ProseInvocationDoesNotAffectPositionalArgs|ProseInvocationSplitsMultipleCliMentions)' -count=1`
- `go test ./internal/cli -run 'TestVerifySkill_(UnknownCommandIgnoresNaturalLanguageCliProse|ProseInvocationWithFlagIsChecked|ProseInvocationDoesNotAffectPositionalArgs|ProseInvocationSplitsMultipleCliMentions|ScriptInSync)' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/cli -run TestVerifySkillScriptInSync -count=1`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
