### PR TITLE
fix(cli): hold rate-limiter lock through lastRequest reservation

### DIFF
--- a/internal/generator/ratelimit_toctou_test.go
+++ b/internal/generator/ratelimit_toctou_test.go
@@ -1,0 +1,48 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdaptiveLimiterWait_ReservesUnderSingleLock validates the generated
+// cliutil AdaptiveLimiter implementation reserves request slots while holding
+// one contiguous lock span in Wait().
+func TestAdaptiveLimiterWait_ReservesUnderSingleLock(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("ratelimit-toctou")
+	outputDir := filepath.Join(t.TempDir(), "ratelimit-toctou-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	srcBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cliutil", "ratelimit.go"))
+	require.NoError(t, err)
+	src := string(srcBytes)
+
+	require.Contains(t, src, "l.lastRequest = time.Now().Add(sleep)",
+		"Wait must reserve the next slot under lock")
+
+	waitStart := strings.Index(src, "func (l *AdaptiveLimiter) Wait() {")
+	require.NotEqual(t, -1, waitStart, "Wait function must be emitted")
+	onSuccessStart := strings.Index(src[waitStart:], "func (l *AdaptiveLimiter) OnSuccess()")
+	require.NotEqual(t, -1, onSuccessStart, "OnSuccess marker must be emitted after Wait")
+	waitBody := src[waitStart : waitStart+onSuccessStart]
+
+	require.Equal(t, 1, strings.Count(waitBody, "l.mu.Lock()"),
+		"Wait should lock once and keep the lock across read+reservation")
+	require.Equal(t, 1, strings.Count(waitBody, "l.mu.Unlock()"),
+		"Wait should unlock once after reserving lastRequest")
+
+	writeIdx := strings.Index(waitBody, "l.lastRequest = time.Now().Add(sleep)")
+	lockIdx := strings.Index(waitBody, "l.mu.Lock()")
+	unlockIdx := strings.Index(waitBody, "l.mu.Unlock()")
+	require.NotEqual(t, -1, writeIdx, "reservation write must exist in Wait")
+	require.NotEqual(t, -1, lockIdx, "lock call must exist in Wait")
+	require.NotEqual(t, -1, unlockIdx, "unlock call must exist in Wait")
+	require.Less(t, lockIdx, writeIdx, "Wait must hold lock before reservation write")
+	require.Less(t, writeIdx, unlockIdx, "Wait must not unlock before reservation write")
+}

--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -47,13 +47,15 @@ func (l *AdaptiveLimiter) Wait() {
 	l.mu.Lock()
 	delay := time.Duration(float64(time.Second) / l.rate)
 	elapsed := time.Since(l.lastRequest)
-	l.mu.Unlock()
+	var sleep time.Duration
 	if elapsed < delay {
-		time.Sleep(delay - elapsed)
+		sleep = delay - elapsed
 	}
-	l.mu.Lock()
-	l.lastRequest = time.Now()
+	l.lastRequest = time.Now().Add(sleep)
 	l.mu.Unlock()
+	if sleep > 0 {
+		time.Sleep(sleep)
+	}
 }
 
 func (l *AdaptiveLimiter) OnSuccess() {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -47,13 +47,15 @@ func (l *AdaptiveLimiter) Wait() {
 	l.mu.Lock()
 	delay := time.Duration(float64(time.Second) / l.rate)
 	elapsed := time.Since(l.lastRequest)
-	l.mu.Unlock()
+	var sleep time.Duration
 	if elapsed < delay {
-		time.Sleep(delay - elapsed)
+		sleep = delay - elapsed
 	}
-	l.mu.Lock()
-	l.lastRequest = time.Now()
+	l.lastRequest = time.Now().Add(sleep)
 	l.mu.Unlock()
+	if sleep > 0 {
+		time.Sleep(sleep)
+	}
 }
 
 func (l *AdaptiveLimiter) OnSuccess() {


### PR DESCRIPTION
## Intent

Issue: Fixes #1669

`AdaptiveLimiter.Wait()` (generator-emitted into `internal/cliutil/ratelimit.go`) had a TOCTOU race: it released the mutex between reading `l.lastRequest` and writing it back, so concurrent `sync` goroutines could grab the same slot and fire simultaneously, bypassing the rate cap.

## Approach

Hold the lock across the read and the `lastRequest` *reservation*: compute the needed sleep under the lock, set `l.lastRequest = time.Now().Add(sleep)` (reserving the next slot), unlock, then sleep. Each subsequent caller sees the already-reserved future timestamp and reserves after it, so callers serialize. `time.Sleep` runs outside the lock, so the lock is never held while sleeping.

## Scope

Primary area: generator (`internal/generator/templates/cliutil_ratelimit.go.tmpl`). Machine change — `cliutil/ratelimit.go` is emitted into every printed CLI, so this corrects rate-cap behavior for all current/future CLIs.

## Risk

Low. Pure concurrency correctness change; single-threaded behavior is unchanged (a lone caller still waits `delay - elapsed`). No API/flag/schema change.

## Output Contract

Generated `internal/cliutil/ratelimit.go` changes the `Wait()` body. Golden fixture `generate-golden-api` (the one case that snapshots `cliutil/ratelimit.go`) regenerated; diff is the `Wait()` body only.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — pass
- `go vet ./...` — pass
- `golangci-lint run ./...` (v2.11.4) — 0 issues
- `go test -short ./...` — pass (incl. new `TestAdaptiveLimiterWait_ReservesUnderSingleLock`, asserting a single lock span and write-before-unlock ordering in the emitted source)
- `scripts/golden.sh verify` → 1 intentional case; `scripts/golden.sh update` applied; diff inspected (Wait body only)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
