### PR TITLE
fix(cli): use FNV-1a hash for FTS rowid to avoid collisions

### DIFF
--- a/internal/generator/fts_rowid_test.go
+++ b/internal/generator/fts_rowid_test.go
@@ -1,0 +1,42 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateStoreFTSRowIDContract verifies the generated store package keeps
+// ftsRowID deterministic, non-negative, and domain-separated across the
+// scope/id boundary.
+func TestGenerateStoreFTSRowIDContract(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("fts-rowid")
+	outputDir := filepath.Join(t.TempDir(), "fts-rowid-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "store", "fts_rowid_contract_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package store
+
+import "testing"
+
+func TestFTSRowIDContract(t *testing.T) {
+	a := ftsRowID("resource", "123")
+	b := ftsRowID("resource", "123")
+	if a != b {
+		t.Fatalf("ftsRowID must be deterministic: %d != %d", a, b)
+	}
+	if a < 0 {
+		t.Fatalf("ftsRowID must be non-negative, got %d", a)
+	}
+	if ftsRowID("ab", "c") == ftsRowID("a", "bc") {
+		t.Fatalf("ftsRowID must separate scope/id boundary")
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestFTSRowIDContract", "-count=1")
+}

--- a/internal/generator/fts_rowid_test.go
+++ b/internal/generator/fts_rowid_test.go
@@ -16,7 +16,9 @@ func TestGenerateStoreFTSRowIDContract(t *testing.T) {
 
 	apiSpec := minimalSpec("fts-rowid")
 	outputDir := filepath.Join(t.TempDir(), "fts-rowid-pp-cli")
-	require.NoError(t, New(apiSpec, outputDir).Generate())
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
 
 	testPath := filepath.Join(outputDir, "internal", "store", "fts_rowid_contract_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(`package store

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -728,15 +729,11 @@ func extractObjectID(obj map[string]any) string {
 // modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
 // on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
 func ftsRowID(scope, id string) int64 {
-	var h uint64
-	for _, c := range scope {
-		h = h*31 + uint64(c)
-	}
-	h *= 31
-	for _, c := range id {
-		h = h*31 + uint64(c)
-	}
-	return int64(h & 0x7FFFFFFFFFFFFFFF) // ensure positive
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(scope))
+	_, _ = h.Write([]byte{0}) // separator so ("ab","c") != ("a","bc")
+	_, _ = h.Write([]byte(id))
+	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
 // LookupFieldValue resolves a field value from a JSON object map, trying the

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -682,15 +683,11 @@ func extractObjectID(obj map[string]any) string {
 // modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
 // on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
 func ftsRowID(scope, id string) int64 {
-	var h uint64
-	for _, c := range scope {
-		h = h*31 + uint64(c)
-	}
-	h *= 31
-	for _, c := range id {
-		h = h*31 + uint64(c)
-	}
-	return int64(h & 0x7FFFFFFFFFFFFFFF) // ensure positive
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(scope))
+	_, _ = h.Write([]byte{0}) // separator so ("ab","c") != ("a","bc")
+	_, _ = h.Write([]byte(id))
+	return int64(h.Sum64() & 0x7FFFFFFFFFFFFFFF) // ensure positive
 }
 
 // LookupFieldValue resolves a field value from a JSON object map, trying the


### PR DESCRIPTION
## Intent

Issue: Fixes #1671

The generator-emitted `ftsRowID` helper (`internal/store/store.go`) used a weak polynomial rolling hash (`h*31 + c`) to derive FTS5 rowids. Two different `(scope, id)` pairs can collide with non-negligible probability at scale; on collision, `DELETE FROM resources_fts WHERE rowid = ?` removes the *wrong* FTS entry — leaving the deleted item searchable and the new item invisible to search. (Greptile finding on printing-press-library#701.)

## Approach

Derive the rowid with `hash/fnv` FNV-1a over `scope`, a `0x00` separator (so `("ab","c")` and `("a","bc")` no longer collide), and `id`. Keep the existing `& 0x7FFFFFFFFFFFFFFF` mask to preserve the positive-int64 rowid contract.

## Scope

Primary area: generator (`internal/generator/templates/store.go.tmpl`). Machine change — `store.go` is emitted into every printed CLI with a data layer; `store.go` carries a `DO NOT EDIT` header, so the fix belongs in the template, not as a per-CLI hand edit.

## Risk

Low for newly generated CLIs (fresh stores). For an *already-populated* store that is regenerated to the new hash, FTS rows written under the old rowids become orphaned (the delete-by-old-rowid no-ops); they linger until the next full sync / store rebuild, which can surface stale FTS search hits in the interim. The main `resources` table is unaffected. This is left as a known, low-severity transition rather than bundling a `StoreSchemaVersion` bump + `resources_fts` rebuild migration into a hash fix — happy to add that as a follow-up if maintainers prefer.

## Output Contract

Generated `internal/store/store.go`: adds `hash/fnv` import and rewrites `ftsRowID`. Golden fixture `generate-sync-walker-api` (the case that snapshots `internal/store/store.go`) regenerated; diff is the import + function body only.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — pass
- `go vet ./...` — pass
- `golangci-lint run ./...` (v2.11.4) — 0 issues
- `go test -short ./...` — pass (incl. new `TestGenerateStoreFTSRowIDContract`: a generated behavioral test asserting determinism, the separator disambiguation, and non-negative output)
- `scripts/golden.sh verify` → 1 intentional case; `scripts/golden.sh update` applied; diff inspected (import + ftsRowID only)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
