### PR TITLE
fix(cli): mask credentials in generated URL output

### DIFF
--- a/internal/generator/client_url_redaction_test.go
+++ b/internal/generator/client_url_redaction_test.go
@@ -78,6 +78,19 @@ func newRedactionClient(secret string) *Client {
 	return c
 }
 
+func TestCredentialMaskingHandlesPrefixOverlaps(t *testing.T) {
+	const short = "a2d16a0d"
+	const long = short + "/8e81+e7fb9e6437ac=="
+	c := newRedactionClient(long)
+
+	got := c.maskCredentialText("raw="+long+"&escaped="+url.QueryEscape(long)+"&short="+short, short)
+
+	assertCredentialMasked(t, "prefix-overlap text", got, long, "****ac==", "****6a0d")
+	if strings.Contains(got, "/8e81") || strings.Contains(got, "%2F8e81") {
+		t.Fatalf("prefix-overlap text leaked long credential suffix: %s", got)
+	}
+}
+
 func forbiddenTransport() http.RoundTripper {
 	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/internal/generator/client_url_redaction_test.go
+++ b/internal/generator/client_url_redaction_test.go
@@ -1,0 +1,238 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientMasksCredentialValuesInDisplayedURLs(t *testing.T) {
+	apiSpec := minimalSpec("url-redaction")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		In:      "query",
+		Header:  "api_key",
+		EnvVars: []string{"URL_REDACTION_API_KEY"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"url-redaction-pp-cli/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = original
+	}()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stderr pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr pipe: %v", err)
+	}
+	return string(out)
+}
+
+func newRedactionClient(secret string) *Client {
+	cfg := &config.Config{
+		BaseURL:       "https://api.example.invalid",
+		AuthHeaderVal: secret,
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	return c
+}
+
+func forbiddenTransport() http.RoundTripper {
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("forbidden")),
+			Request:    req,
+		}, nil
+	})
+}
+
+func forbiddenTransportWithBody(body string) http.RoundTripper {
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+}
+
+func assertCredentialMasked(t *testing.T, label, text, secret string, wantParts ...string) {
+	t.Helper()
+	if strings.Contains(text, secret) {
+		t.Fatalf("%s leaked credential %q: %s", label, secret, text)
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(text, part) {
+			t.Fatalf("%s did not contain masked fragment %q: %s", label, part, text)
+		}
+	}
+}
+
+func TestDryRunMasksCredentialEmbeddedInURLPath(t *testing.T) {
+	const secret = "a2d16a0d/8e81+e7fb9e6437ac=="
+	c := newRedactionClient(secret)
+	c.DryRun = true
+
+	stderr := captureStderr(t, func() {
+		params := map[string]string{"echo": secret}
+		if _, err := c.Get(context.Background(), "/v6/"+url.PathEscape(secret)+"/codes", params); err != nil {
+			t.Fatalf("Get() dry-run error = %v", err)
+		}
+	})
+
+	assertCredentialMasked(t, "dry-run stderr", stderr, secret, "/v6/****ac==/codes", "echo=****ac==", "api_key=****ac==")
+}
+
+func TestAPIErrorMasksCredentialEmbeddedInURLPath(t *testing.T) {
+	const secret = "a2d16a0d/8e81+e7fb9e6437ac=="
+	c := newRedactionClient(secret)
+	c.HTTPClient = &http.Client{Transport: forbiddenTransportWithBody("forbidden for token " + secret)}
+
+	_, err := c.Get(context.Background(), "/v6/"+url.PathEscape(secret)+"/codes", nil)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	assertCredentialMasked(t, "APIError", err.Error(), secret, "/v6/****ac==/codes", "forbidden for token ****ac==")
+}
+
+func TestTransportErrorMasksCredentialInWrappedURLError(t *testing.T) {
+	const secret = "a2d16a0d/8e81+e7fb9e6437ac=="
+	c := newRedactionClient(secret)
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, &url.Error{Op: "Get", URL: req.URL.String(), Err: errors.New("dial tcp: lookup api.example.invalid: no such host")}
+	})}
+
+	_, err := c.Get(context.Background(), "/v6/"+url.PathEscape(secret)+"/pair/USD/EUR", nil)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	assertCredentialMasked(t, "transport error", err.Error(), secret, "/v6/****ac==/pair/USD/EUR", "api_key=****ac==")
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		t.Fatalf("transport error exposed unredacted URL error through unwrap chain: %v", urlErr)
+	}
+}
+
+func TestHeaderAuthDoesNotChangeUnrelatedAPIErrorText(t *testing.T) {
+	const secret = "header-only-token"
+	c := newRedactionClient(secret)
+	c.HTTPClient = &http.Client{Transport: forbiddenTransport()}
+
+	_, err := c.Get(context.Background(), "/items", nil)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if got, want := err.Error(), "GET /items returned HTTP 403: forbidden"; got != want {
+		t.Fatalf("APIError = %q, want %q", got, want)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "url_redaction_test.go"), []byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "Test.*Credential|TestHeaderAuth", "-count=1")
+}
+
+func TestGeneratedClientLeavesHeaderAuthDisplayUnchanged(t *testing.T) {
+	apiSpec := minimalSpec("header-redaction")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		In:      "header",
+		Header:  "X-Api-Key",
+		EnvVars: []string{"HEADER_REDACTION_API_KEY"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const clientTest = `package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"header-redaction-pp-cli/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestHeaderAuthDoesNotChangeUnrelatedAPIErrorText(t *testing.T) {
+	cfg := &config.Config{
+		BaseURL:       "https://api.example.invalid",
+		AuthHeaderVal: "header-only-token",
+	}
+	c := New(cfg, time.Second, 0)
+	c.NoCache = true
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("forbidden")),
+			Request:    req,
+		}, nil
+	})}
+
+	_, err := c.Get(context.Background(), "/items", nil)
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if got, want := err.Error(), "GET /items returned HTTP 403: forbidden"; got != want {
+		t.Fatalf("APIError = %q, want %q", got, want)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "header_redaction_test.go"), []byte(clientTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestHeaderAuth", "-count=1")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2097,23 +2097,34 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	if text == "" {
 		return text
 	}
-	masked := text
+	type credentialMask struct {
+		needle      string
+		replacement string
+	}
+	var masks []credentialMask
 	seen := map[string]struct{}{}
 	addValue := func(value string) {
 		value = strings.TrimSpace(value)
 		if value == "" {
 			return
 		}
-		if _, ok := seen[value]; ok {
-			return
+		replacement := maskToken(value)
+		addMask := func(needle string) {
+			if needle == "" {
+				return
+			}
+			if _, ok := seen[needle]; ok {
+				return
+			}
+			seen[needle] = struct{}{}
+			masks = append(masks, credentialMask{needle: needle, replacement: replacement})
 		}
-		seen[value] = struct{}{}
-		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		addMask(value)
 		if escaped := url.QueryEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 		if escaped := url.PathEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 	}
 	addCredential := func(value string) {
@@ -2126,32 +2137,38 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	for _, value := range extraCredentials {
 		addCredential(value)
 	}
-	if c == nil || c.Config == nil {
-		return masked
-	}
-	addCredential(c.Config.AuthHeaderVal)
-	addCredential(c.Config.AuthHeader())
+	if c != nil && c.Config != nil {
+		addCredential(c.Config.AuthHeaderVal)
+		addCredential(c.Config.AuthHeader())
 {{- if .HasAuthCommand}}
-	addCredential(c.Config.AccessToken)
-	addCredential(c.Config.RefreshToken)
-	addCredential(c.Config.ClientSecret)
+		addCredential(c.Config.AccessToken)
+		addCredential(c.Config.RefreshToken)
+		addCredential(c.Config.ClientSecret)
 {{- end}}
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 {{- if .Sensitive}}
-	addCredential(c.Config.{{resolveEnvVarField .Name}})
+		addCredential(c.Config.{{resolveEnvVarField .Name}})
 {{- end}}
 {{- end}}
 {{- else if .Auth.EnvVars}}
 {{- range .Auth.EnvVars}}
-	addCredential(c.Config.{{resolveEnvVarField .}})
+		addCredential(c.Config.{{resolveEnvVarField .}})
 {{- end}}
 {{- end}}
 {{- range .Auth.AdditionalHeaders}}
 {{- if .EnvVar.Sensitive}}
-	addCredential(c.Config.{{resolveEnvVarField .EnvVar.Name}})
+		addCredential(c.Config.{{resolveEnvVarField .EnvVar.Name}})
 {{- end}}
 {{- end}}
+	}
+	sort.SliceStable(masks, func(i, j int) bool {
+		return len(masks[i].needle) > len(masks[j].needle)
+	})
+	masked := text
+	for _, mask := range masks {
+		masked = strings.ReplaceAll(masked, mask.needle, mask.replacement)
+	}
 	return masked
 }
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -21,9 +21,7 @@ import (
 	"mime/multipart"
 {{- end}}
 	"net/http"
-{{- if or (and .HasAuthCommand .Auth.TokenURL) .HasFormRequest}}
 	"net/url"
-{{- end}}
 	"os"
 	"path/filepath"
 	"sort"
@@ -1329,7 +1327,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, 0, ctxErr
 			}
-			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
+			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
 			continue
 		}
 
@@ -1368,9 +1366,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		apiErr := &APIError{
 			Method:     method,
-			Path:       path,
+			Path:       c.displayURL(path, authHeader),
 			StatusCode: resp.StatusCode,
-			Body:       truncateBody(respBody),
+			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}
 
 		// Rate limited - adjust adaptive limiter and retry
@@ -1431,16 +1429,16 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 	envelope := proxyEnvelope{
 		Service: serviceForPath(path),
 		Method:  method,
-		Path:    cliutil.BuildPath(path, params),
+		Path:    c.displayURL(cliutil.BuildPath(path, params), authHeader),
 	}
 	if body != nil {
 		envelope.Body = json.RawMessage(body)
 	}
-	fmt.Fprintf(os.Stderr, "POST %s\n", targetURL)
+	fmt.Fprintf(os.Stderr, "POST %s\n", c.displayURL(targetURL, authHeader))
 	envelopeJSON, _ := json.MarshalIndent(envelope, "  ", "  ")
 	fmt.Fprintf(os.Stderr, "  Envelope:\n  %s\n", string(envelopeJSON))
 {{- else}}
-	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
+	fmt.Fprintf(os.Stderr, "%s %s\n", method, c.displayURL(targetURL, authHeader))
 	queryPrinted := false
 	if params != nil {
 		keys := make([]string, 0, len(params))
@@ -1455,7 +1453,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 			if queryPrinted {
 				sep = "&"
 			}
-			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, params[k])
+			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, c.maskCredentialText(params[k], authHeader))
 			queryPrinted = true
 		}
 	}
@@ -2069,6 +2067,92 @@ func maskToken(token string) string {
 		return "****"
 	}
 	return "****" + token[len(token)-4:]
+}
+
+type maskedError struct {
+	msg string
+}
+
+func (e maskedError) Error() string {
+	return e.msg
+}
+
+func (c *Client) displayURL(rawURL string, extraCredentials ...string) string {
+	return c.maskCredentialText(rawURL, extraCredentials...)
+}
+
+func (c *Client) maskError(err error, extraCredentials ...string) error {
+	if err == nil {
+		return nil
+	}
+	raw := err.Error()
+	msg := c.maskCredentialText(raw, extraCredentials...)
+	if msg == raw {
+		return err
+	}
+	return maskedError{msg: msg}
+}
+
+func (c *Client) maskCredentialText(text string, extraCredentials ...string) string {
+	if text == "" {
+		return text
+	}
+	masked := text
+	seen := map[string]struct{}{}
+	addValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		if escaped := url.QueryEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+		if escaped := url.PathEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+	}
+	addCredential := func(value string) {
+		value = strings.TrimSpace(value)
+		addValue(value)
+		if _, token, ok := strings.Cut(value, " "); ok {
+			addValue(token)
+		}
+	}
+	for _, value := range extraCredentials {
+		addCredential(value)
+	}
+	if c == nil || c.Config == nil {
+		return masked
+	}
+	addCredential(c.Config.AuthHeaderVal)
+	addCredential(c.Config.AuthHeader())
+{{- if .HasAuthCommand}}
+	addCredential(c.Config.AccessToken)
+	addCredential(c.Config.RefreshToken)
+	addCredential(c.Config.ClientSecret)
+{{- end}}
+{{- if .Auth.EnvVarSpecs}}
+{{- range .Auth.EnvVarSpecs}}
+{{- if .Sensitive}}
+	addCredential(c.Config.{{resolveEnvVarField .Name}})
+{{- end}}
+{{- end}}
+{{- else if .Auth.EnvVars}}
+{{- range .Auth.EnvVars}}
+	addCredential(c.Config.{{resolveEnvVarField .}})
+{{- end}}
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if .EnvVar.Sensitive}}
+	addCredential(c.Config.{{resolveEnvVarField .EnvVar.Name}})
+{{- end}}
+{{- end}}
+	return masked
 }
 
 func truncateBody(b []byte) string {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -979,23 +979,34 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	if text == "" {
 		return text
 	}
-	masked := text
+	type credentialMask struct {
+		needle      string
+		replacement string
+	}
+	var masks []credentialMask
 	seen := map[string]struct{}{}
 	addValue := func(value string) {
 		value = strings.TrimSpace(value)
 		if value == "" {
 			return
 		}
-		if _, ok := seen[value]; ok {
-			return
+		replacement := maskToken(value)
+		addMask := func(needle string) {
+			if needle == "" {
+				return
+			}
+			if _, ok := seen[needle]; ok {
+				return
+			}
+			seen[needle] = struct{}{}
+			masks = append(masks, credentialMask{needle: needle, replacement: replacement})
 		}
-		seen[value] = struct{}{}
-		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		addMask(value)
 		if escaped := url.QueryEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 		if escaped := url.PathEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 	}
 	addCredential := func(value string) {
@@ -1008,15 +1019,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	for _, value := range extraCredentials {
 		addCredential(value)
 	}
-	if c == nil || c.Config == nil {
-		return masked
+	if c != nil && c.Config != nil {
+		addCredential(c.Config.AuthHeaderVal)
+		addCredential(c.Config.AuthHeader())
+		addCredential(c.Config.AccessToken)
+		addCredential(c.Config.RefreshToken)
+		addCredential(c.Config.ClientSecret)
+		addCredential(c.Config.PrintingPressOauth2ClientSecret)
 	}
-	addCredential(c.Config.AuthHeaderVal)
-	addCredential(c.Config.AuthHeader())
-	addCredential(c.Config.AccessToken)
-	addCredential(c.Config.RefreshToken)
-	addCredential(c.Config.ClientSecret)
-	addCredential(c.Config.PrintingPressOauth2ClientSecret)
+	sort.SliceStable(masks, func(i, j int) bool {
+		return len(masks[i].needle) > len(masks[j].needle)
+	})
+	masked := text
+	for _, mask := range masks {
+		masked = strings.ReplaceAll(masked, mask.needle, mask.replacement)
+	}
 	return masked
 }
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -500,7 +500,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, 0, ctxErr
 			}
-			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
+			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
 			continue
 		}
 
@@ -536,9 +536,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		apiErr := &APIError{
 			Method:     method,
-			Path:       path,
+			Path:       c.displayURL(path, authHeader),
 			StatusCode: resp.StatusCode,
-			Body:       truncateBody(respBody),
+			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}
 
 		// Rate limited - adjust adaptive limiter and retry
@@ -575,7 +575,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 // using the auth material already resolved in `do()`. Never triggers a network
 // call — the caller is responsible for passing cached auth material only.
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, authHeader string) (json.RawMessage, int, error) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
+	fmt.Fprintf(os.Stderr, "%s %s\n", method, c.displayURL(targetURL, authHeader))
 	queryPrinted := false
 	if params != nil {
 		keys := make([]string, 0, len(params))
@@ -590,7 +590,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 			if queryPrinted {
 				sep = "&"
 			}
-			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, params[k])
+			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, c.maskCredentialText(params[k], authHeader))
 			queryPrinted = true
 		}
 	}
@@ -949,6 +949,75 @@ func maskToken(token string) string {
 		return "****"
 	}
 	return "****" + token[len(token)-4:]
+}
+
+type maskedError struct {
+	msg string
+}
+
+func (e maskedError) Error() string {
+	return e.msg
+}
+
+func (c *Client) displayURL(rawURL string, extraCredentials ...string) string {
+	return c.maskCredentialText(rawURL, extraCredentials...)
+}
+
+func (c *Client) maskError(err error, extraCredentials ...string) error {
+	if err == nil {
+		return nil
+	}
+	raw := err.Error()
+	msg := c.maskCredentialText(raw, extraCredentials...)
+	if msg == raw {
+		return err
+	}
+	return maskedError{msg: msg}
+}
+
+func (c *Client) maskCredentialText(text string, extraCredentials ...string) string {
+	if text == "" {
+		return text
+	}
+	masked := text
+	seen := map[string]struct{}{}
+	addValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		if escaped := url.QueryEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+		if escaped := url.PathEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+	}
+	addCredential := func(value string) {
+		value = strings.TrimSpace(value)
+		addValue(value)
+		if _, token, ok := strings.Cut(value, " "); ok {
+			addValue(token)
+		}
+	}
+	for _, value := range extraCredentials {
+		addCredential(value)
+	}
+	if c == nil || c.Config == nil {
+		return masked
+	}
+	addCredential(c.Config.AuthHeaderVal)
+	addCredential(c.Config.AuthHeader())
+	addCredential(c.Config.AccessToken)
+	addCredential(c.Config.RefreshToken)
+	addCredential(c.Config.ClientSecret)
+	addCredential(c.Config.PrintingPressOauth2ClientSecret)
+	return masked
 }
 
 func truncateBody(b []byte) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -897,23 +897,34 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	if text == "" {
 		return text
 	}
-	masked := text
+	type credentialMask struct {
+		needle      string
+		replacement string
+	}
+	var masks []credentialMask
 	seen := map[string]struct{}{}
 	addValue := func(value string) {
 		value = strings.TrimSpace(value)
 		if value == "" {
 			return
 		}
-		if _, ok := seen[value]; ok {
-			return
+		replacement := maskToken(value)
+		addMask := func(needle string) {
+			if needle == "" {
+				return
+			}
+			if _, ok := seen[needle]; ok {
+				return
+			}
+			seen[needle] = struct{}{}
+			masks = append(masks, credentialMask{needle: needle, replacement: replacement})
 		}
-		seen[value] = struct{}{}
-		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		addMask(value)
 		if escaped := url.QueryEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 		if escaped := url.PathEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 	}
 	addCredential := func(value string) {
@@ -926,15 +937,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	for _, value := range extraCredentials {
 		addCredential(value)
 	}
-	if c == nil || c.Config == nil {
-		return masked
+	if c != nil && c.Config != nil {
+		addCredential(c.Config.AuthHeaderVal)
+		addCredential(c.Config.AuthHeader())
+		addCredential(c.Config.AccessToken)
+		addCredential(c.Config.RefreshToken)
+		addCredential(c.Config.ClientSecret)
+		addCredential(c.Config.PrintingPressGoldenApiKey)
 	}
-	addCredential(c.Config.AuthHeaderVal)
-	addCredential(c.Config.AuthHeader())
-	addCredential(c.Config.AccessToken)
-	addCredential(c.Config.RefreshToken)
-	addCredential(c.Config.ClientSecret)
-	addCredential(c.Config.PrintingPressGoldenApiKey)
+	sort.SliceStable(masks, func(i, j int) bool {
+		return len(masks[i].needle) > len(masks[j].needle)
+	})
+	masked := text
+	for _, mask := range masks {
+		masked = strings.ReplaceAll(masked, mask.needle, mask.replacement)
+	}
 	return masked
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"printing-press-golden-pp-cli/internal/cliutil"
@@ -589,7 +590,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, 0, ctxErr
 			}
-			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
+			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
 			continue
 		}
 
@@ -625,9 +626,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		apiErr := &APIError{
 			Method:     method,
-			Path:       path,
+			Path:       c.displayURL(path, authHeader),
 			StatusCode: resp.StatusCode,
-			Body:       truncateBody(respBody),
+			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}
 
 		// Rate limited - adjust adaptive limiter and retry
@@ -664,7 +665,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 // using the auth material already resolved in `do()`. Never triggers a network
 // call — the caller is responsible for passing cached auth material only.
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, authHeader string) (json.RawMessage, int, error) {
-	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
+	fmt.Fprintf(os.Stderr, "%s %s\n", method, c.displayURL(targetURL, authHeader))
 	queryPrinted := false
 	if params != nil {
 		keys := make([]string, 0, len(params))
@@ -679,7 +680,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 			if queryPrinted {
 				sep = "&"
 			}
-			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, params[k])
+			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, c.maskCredentialText(params[k], authHeader))
 			queryPrinted = true
 		}
 	}
@@ -866,6 +867,75 @@ func maskToken(token string) string {
 		return "****"
 	}
 	return "****" + token[len(token)-4:]
+}
+
+type maskedError struct {
+	msg string
+}
+
+func (e maskedError) Error() string {
+	return e.msg
+}
+
+func (c *Client) displayURL(rawURL string, extraCredentials ...string) string {
+	return c.maskCredentialText(rawURL, extraCredentials...)
+}
+
+func (c *Client) maskError(err error, extraCredentials ...string) error {
+	if err == nil {
+		return nil
+	}
+	raw := err.Error()
+	msg := c.maskCredentialText(raw, extraCredentials...)
+	if msg == raw {
+		return err
+	}
+	return maskedError{msg: msg}
+}
+
+func (c *Client) maskCredentialText(text string, extraCredentials ...string) string {
+	if text == "" {
+		return text
+	}
+	masked := text
+	seen := map[string]struct{}{}
+	addValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		if escaped := url.QueryEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+		if escaped := url.PathEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+	}
+	addCredential := func(value string) {
+		value = strings.TrimSpace(value)
+		addValue(value)
+		if _, token, ok := strings.Cut(value, " "); ok {
+			addValue(token)
+		}
+	}
+	for _, value := range extraCredentials {
+		addCredential(value)
+	}
+	if c == nil || c.Config == nil {
+		return masked
+	}
+	addCredential(c.Config.AuthHeaderVal)
+	addCredential(c.Config.AuthHeader())
+	addCredential(c.Config.AccessToken)
+	addCredential(c.Config.RefreshToken)
+	addCredential(c.Config.ClientSecret)
+	addCredential(c.Config.PrintingPressGoldenApiKey)
+	return masked
 }
 
 func truncateBody(b []byte) string {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -914,23 +914,34 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	if text == "" {
 		return text
 	}
-	masked := text
+	type credentialMask struct {
+		needle      string
+		replacement string
+	}
+	var masks []credentialMask
 	seen := map[string]struct{}{}
 	addValue := func(value string) {
 		value = strings.TrimSpace(value)
 		if value == "" {
 			return
 		}
-		if _, ok := seen[value]; ok {
-			return
+		replacement := maskToken(value)
+		addMask := func(needle string) {
+			if needle == "" {
+				return
+			}
+			if _, ok := seen[needle]; ok {
+				return
+			}
+			seen[needle] = struct{}{}
+			masks = append(masks, credentialMask{needle: needle, replacement: replacement})
 		}
-		seen[value] = struct{}{}
-		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		addMask(value)
 		if escaped := url.QueryEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 		if escaped := url.PathEscape(value); escaped != value {
-			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+			addMask(escaped)
 		}
 	}
 	addCredential := func(value string) {
@@ -943,15 +954,21 @@ func (c *Client) maskCredentialText(text string, extraCredentials ...string) str
 	for _, value := range extraCredentials {
 		addCredential(value)
 	}
-	if c == nil || c.Config == nil {
-		return masked
+	if c != nil && c.Config != nil {
+		addCredential(c.Config.AuthHeaderVal)
+		addCredential(c.Config.AuthHeader())
+		addCredential(c.Config.AccessToken)
+		addCredential(c.Config.RefreshToken)
+		addCredential(c.Config.ClientSecret)
+		addCredential(c.Config.TierGlobalToken)
 	}
-	addCredential(c.Config.AuthHeaderVal)
-	addCredential(c.Config.AuthHeader())
-	addCredential(c.Config.AccessToken)
-	addCredential(c.Config.RefreshToken)
-	addCredential(c.Config.ClientSecret)
-	addCredential(c.Config.TierGlobalToken)
+	sort.SliceStable(masks, func(i, j int) bool {
+		return len(masks[i].needle) > len(masks[j].needle)
+	})
+	masked := text
+	for _, mask := range masks {
+		masked = strings.ReplaceAll(masked, mask.needle, mask.replacement)
+	}
 	return masked
 }
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -596,7 +597,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return nil, 0, ctxErr
 			}
-			lastErr = fmt.Errorf("%s %s: %w", method, path, err)
+			lastErr = fmt.Errorf("%s %s: %w", method, c.displayURL(path, authHeader), c.maskError(err, authHeader))
 			continue
 		}
 
@@ -632,9 +633,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 
 		apiErr := &APIError{
 			Method:     method,
-			Path:       path,
+			Path:       c.displayURL(path, authHeader),
 			StatusCode: resp.StatusCode,
-			Body:       truncateBody(respBody),
+			Body:       c.maskCredentialText(truncateBody(respBody), authHeader),
 		}
 
 		// Rate limited - adjust adaptive limiter and retry
@@ -673,7 +674,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 func (c *Client) dryRun(method, targetURL, path string, params map[string]string, body []byte, headerOverrides map[string]string, authHeader string) (json.RawMessage, int, error) {
 	authInfo, _ := c.authForRequest(context.Background())
 	authInfo.Value = authHeader
-	fmt.Fprintf(os.Stderr, "%s %s\n", method, targetURL)
+	fmt.Fprintf(os.Stderr, "%s %s\n", method, c.displayURL(targetURL, authHeader))
 	queryPrinted := false
 	if params != nil {
 		keys := make([]string, 0, len(params))
@@ -688,7 +689,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 			if queryPrinted {
 				sep = "&"
 			}
-			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, params[k])
+			fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, k, c.maskCredentialText(params[k], authHeader))
 			queryPrinted = true
 		}
 	}
@@ -883,6 +884,75 @@ func maskToken(token string) string {
 		return "****"
 	}
 	return "****" + token[len(token)-4:]
+}
+
+type maskedError struct {
+	msg string
+}
+
+func (e maskedError) Error() string {
+	return e.msg
+}
+
+func (c *Client) displayURL(rawURL string, extraCredentials ...string) string {
+	return c.maskCredentialText(rawURL, extraCredentials...)
+}
+
+func (c *Client) maskError(err error, extraCredentials ...string) error {
+	if err == nil {
+		return nil
+	}
+	raw := err.Error()
+	msg := c.maskCredentialText(raw, extraCredentials...)
+	if msg == raw {
+		return err
+	}
+	return maskedError{msg: msg}
+}
+
+func (c *Client) maskCredentialText(text string, extraCredentials ...string) string {
+	if text == "" {
+		return text
+	}
+	masked := text
+	seen := map[string]struct{}{}
+	addValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		masked = strings.ReplaceAll(masked, value, maskToken(value))
+		if escaped := url.QueryEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+		if escaped := url.PathEscape(value); escaped != value {
+			masked = strings.ReplaceAll(masked, escaped, maskToken(value))
+		}
+	}
+	addCredential := func(value string) {
+		value = strings.TrimSpace(value)
+		addValue(value)
+		if _, token, ok := strings.Cut(value, " "); ok {
+			addValue(token)
+		}
+	}
+	for _, value := range extraCredentials {
+		addCredential(value)
+	}
+	if c == nil || c.Config == nil {
+		return masked
+	}
+	addCredential(c.Config.AuthHeaderVal)
+	addCredential(c.Config.AuthHeader())
+	addCredential(c.Config.AccessToken)
+	addCredential(c.Config.RefreshToken)
+	addCredential(c.Config.ClientSecret)
+	addCredential(c.Config.TierGlobalToken)
+	return masked
 }
 
 func truncateBody(b []byte) string {


### PR DESCRIPTION
## Summary

This fixes generated client redaction so configured credential values are masked anywhere request URLs or URL-bearing errors are rendered for users. The generator now masks raw and URL-escaped credential values in dry-run URLs, dry-run query previews, APIError paths/bodies, proxy-envelope dry-run paths, and transport errors whose inner `url.Error` includes `req.URL.String()`.

## Verification

- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

Closes #1554
