### PR TITLE
fix(cli): refresh stale staged binary before live-check

### DIFF
--- a/docs/solutions/logic-errors/live-check-refreshes-stale-stage-binary-2026-05-23.md
+++ b/docs/solutions/logic-errors/live-check-refreshes-stale-stage-binary-2026-05-23.md
@@ -1,0 +1,56 @@
+---
+title: Live-check refreshes stale staged binaries before sampling
+date: 2026-05-23
+category: logic-errors
+module: scorecard live-check
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "scorecard --live-check reports unknown command for hand-built novel commands"
+  - "shipcheck samples build/stage/bin even after source changes add commands under internal/cli"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: medium
+tags: [scorecard, live-check, shipcheck, staged-binary, novel-commands]
+---
+
+# Live-check refreshes stale staged binaries before sampling
+
+## Problem
+
+`scorecard --live-check` can sample a generated CLI through `build/stage/bin/<cli>`, the binary emitted during generation validation. Phase 3 hand-built novel commands update Go source after that binary is created, so the sample probe can report `unknown command` for commands that are present and working in current source.
+
+## Symptoms
+
+- `scorecard --live-check` reports `0/N` sample probes passing with `unknown command "<novel-command>"`.
+- Rebuilding `build/stage/bin/<cli>` manually makes the same sample probes pass without source changes.
+- Directly invoking a freshly rebuilt root or `bin/` CLI works, while the staged binary remains stale.
+
+## What Didn't Work
+
+- Choosing the freshest binary among existing candidates helps when a root or `bin/` binary was rebuilt, but it does not help when `build/stage/bin/<cli>` is the only runnable candidate.
+- Rebuilding the staged binary unconditionally fixes correctness but adds avoidable work when the staged binary, or a same-name fallback binary, is already current.
+
+## Solution
+
+Make live-check treat the staged binary as a refreshable artifact:
+
+- Find the existing staged binary for the same candidate name live-check would resolve.
+- Compare its mtime to Go sources under `cmd/<cli>/` and `internal/`.
+- Rebuild to a temporary file and replace the staged binary only when the staged binary is older and no same-name runnable fallback is already current.
+- Report the refresh action in `LiveCheckResult` so human and JSON scorecard output can show whether the staged binary was rebuilt, fresh, skipped, or failed.
+- Convert a failed stale-stage refresh into a scorecard error so shipcheck does not pass after the freshness guard fails.
+
+## Why This Works
+
+The root cause is not command registration. It is an artifact freshness gap between generated validation output and later hand-authored source changes. The freshness check belongs in the live-check path because that is the code choosing and sampling the binary. It keeps the no-op case cheap while ensuring the sampled command surface matches the source tree when no fresher binary is available.
+
+## Prevention
+
+- Regression tests should include both `cmd/<cli>/` changes and `internal/` changes, because novel command implementation usually lands under `internal/cli`.
+- Tests should cover no-op paths as well as rebuild paths: fresh staged binary, fresh same-name fallback binary, and stale preferred staged binary with lower-priority fallback.
+- When a verification tool repairs or refreshes an artifact before checking behavior, expose that action in structured output and fail the verification leg if the refresh fails.
+
+## Related Issues
+
+- GitHub issue #1555

--- a/internal/cli/scorecard.go
+++ b/internal/cli/scorecard.go
@@ -76,6 +76,13 @@ func newScorecardCmd() *cobra.Command {
 
 			if live != nil {
 				fmt.Printf("\nSample Output Probe (live command sample)\n")
+				if live.BinaryRefresh != nil {
+					fmt.Printf("  Binary refresh: %s", live.BinaryRefresh.Action)
+					if live.BinaryRefresh.Reason != "" {
+						fmt.Printf(" (%s)", live.BinaryRefresh.Reason)
+					}
+					fmt.Println()
+				}
 				if live.Unable {
 					fmt.Printf("  Unable to run: %s\n", live.Reason)
 				} else {
@@ -114,6 +121,10 @@ func newScorecardCmd() *cobra.Command {
 				}
 			}
 
+			if reason := liveCheckFatalReason(live); reason != "" {
+				return &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("%s", reason)}
+			}
+
 			return nil
 		},
 	}
@@ -126,6 +137,16 @@ func newScorecardCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&liveCheckTimeout, "live-check-timeout", 10*time.Second, "Per-feature timeout for live check invocations")
 
 	return cmd
+}
+
+func liveCheckFatalReason(live *pipeline.LiveCheckResult) string {
+	if live == nil || live.BinaryRefresh == nil || live.BinaryRefresh.Action != "failed" {
+		return ""
+	}
+	if live.Reason != "" {
+		return "live-check staged binary refresh failed: " + live.Reason
+	}
+	return "live-check staged binary refresh failed"
 }
 
 // renderHumanScorecard writes the human-readable scorecard table to w.

--- a/internal/cli/scorecard_test.go
+++ b/internal/cli/scorecard_test.go
@@ -123,6 +123,9 @@ func TestScorecardJSONKeepsLiveCheckSeparateFromLiveVerification(t *testing.T) {
 	live := &pipeline.LiveCheckResult{
 		Passed:   1,
 		PassRate: 1.0,
+		BinaryRefresh: &pipeline.LiveCheckBinaryRefresh{
+			Action: "rebuilt",
+		},
 		Features: []pipeline.LiveFeatureResult{{
 			Name:         "sample",
 			Status:       pipeline.StatusPass,
@@ -136,7 +139,25 @@ func TestScorecardJSONKeepsLiveCheckSeparateFromLiveVerification(t *testing.T) {
 	got := string(data)
 
 	assert.Contains(t, got, `"live_check"`)
+	assert.Contains(t, got, `"binary_refresh"`)
+	assert.Contains(t, got, `"action":"rebuilt"`)
 	assert.Contains(t, got, `"output_sample":"Found 3 brownie recipes"`)
 	assert.Contains(t, got, `"unscored_dimensions":["live_api_verification"]`)
 	assert.Contains(t, got, `"live_api_verification":0`)
+}
+
+func TestLiveCheckFatalReasonReportsFailedBinaryRefresh(t *testing.T) {
+	t.Parallel()
+
+	live := &pipeline.LiveCheckResult{
+		Unable: true,
+		Reason: "rebuilding staged binary: go build failed",
+		BinaryRefresh: &pipeline.LiveCheckBinaryRefresh{
+			Action: "failed",
+		},
+	}
+
+	assert.Contains(t, liveCheckFatalReason(live), "staged binary refresh failed")
+	assert.Contains(t, liveCheckFatalReason(live), "go build failed")
+	assert.Empty(t, liveCheckFatalReason(&pipeline.LiveCheckResult{Unable: true, Reason: "no research.json"}))
 }

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -51,14 +51,15 @@ const (
 // correctness cap on the Insight dimension — a Grade A scorecard with a
 // flagship feature returning wrong data shouldn't be possible.
 type LiveCheckResult struct {
-	Passed   int                 `json:"passed"`
-	Failed   int                 `json:"failed"`
-	Skipped  int                 `json:"skipped"`
-	PassRate float64             `json:"-"` // exposed via pass_rate_pct in MarshalJSON
-	Features []LiveFeatureResult `json:"features"`
-	Unable   bool                `json:"unable,omitempty"`
-	Reason   string              `json:"reason,omitempty"`
-	RanAt    time.Time           `json:"ran_at"`
+	Passed        int                     `json:"passed"`
+	Failed        int                     `json:"failed"`
+	Skipped       int                     `json:"skipped"`
+	PassRate      float64                 `json:"-"` // exposed via pass_rate_pct in MarshalJSON
+	Features      []LiveFeatureResult     `json:"features"`
+	BinaryRefresh *LiveCheckBinaryRefresh `json:"binary_refresh,omitempty"`
+	Unable        bool                    `json:"unable,omitempty"`
+	Reason        string                  `json:"reason,omitempty"`
+	RanAt         time.Time               `json:"ran_at"`
 }
 
 // Checked returns the total number of features that were sampled.
@@ -93,6 +94,15 @@ type LiveFeatureResult struct {
 	Reason       string     `json:"reason,omitempty"`
 	Warnings     []string   `json:"warnings,omitempty"`
 	OutputSample string     `json:"output_sample,omitempty"`
+}
+
+// LiveCheckBinaryRefresh records whether live-check refreshed the canonical
+// staged binary before sampling command examples.
+type LiveCheckBinaryRefresh struct {
+	Action     string `json:"action"`
+	StagePath  string `json:"stage_path,omitempty"`
+	BinaryPath string `json:"binary_path,omitempty"`
+	Reason     string `json:"reason,omitempty"`
 }
 
 // outputSampleMaxBytes caps the captured-output snapshot stored on each
@@ -161,11 +171,24 @@ func RunLiveCheck(opts LiveCheckOptions) *LiveCheckResult {
 		return out
 	}
 
+	refresh, err := refreshLiveCheckStageBinary(opts.CLIDir, opts.BinaryName)
+	if refresh.Action != "" {
+		out.BinaryRefresh = &refresh
+	}
+	if err != nil {
+		out.Unable = true
+		out.Reason = "rebuilding staged binary: " + err.Error()
+		return out
+	}
+
 	binaryPath, binErr := resolveBinaryPath(opts.CLIDir, opts.BinaryName)
 	if binErr != nil {
 		out.Unable = true
 		out.Reason = binErr.Error()
 		return out
+	}
+	if out.BinaryRefresh != nil {
+		out.BinaryRefresh.BinaryPath = binaryPath
 	}
 	features := pickFeatures(research)
 	if len(features) == 0 {
@@ -246,6 +269,169 @@ func findResearchDir(cliDir string) string {
 		dir = parent
 	}
 	return cliDir
+}
+
+func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, error) {
+	stagePath, stageCandidate := liveCheckExistingStageBinaryPath(cliDir, name)
+	if stagePath == "" {
+		return LiveCheckBinaryRefresh{Action: "no_stage", Reason: "no staged binary found"}, nil
+	}
+	refresh := LiveCheckBinaryRefresh{StagePath: stagePath}
+
+	stageInfo, err := os.Stat(stagePath)
+	if err != nil {
+		refresh.Action = "no_stage"
+		refresh.Reason = "staged binary disappeared before stat"
+		return refresh, nil
+	}
+
+	cmdDir, err := findCLICommandDir(cliDir)
+	if err != nil {
+		refresh.Action = "skipped"
+		refresh.Reason = "no CLI command directory found"
+		return refresh, nil
+	}
+
+	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
+	if err != nil {
+		refresh.Action = "failed"
+		return refresh, err
+	}
+	if !ok {
+		refresh.Action = "skipped"
+		refresh.Reason = "no Go source files found"
+		return refresh, nil
+	}
+	if !stageInfo.ModTime().Before(newestSource) {
+		refresh.Action = "fresh"
+		refresh.Reason = "staged binary is newer than Go sources"
+		return refresh, nil
+	}
+	if freshPath := liveCheckFreshRunnableBinaryPath(cliDir, stageCandidate, newestSource); freshPath != "" {
+		refresh.Action = "fresh_fallback"
+		refresh.BinaryPath = freshPath
+		refresh.Reason = "same-name runnable binary is newer than Go sources"
+		return refresh, nil
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(stagePath), "."+filepath.Base(stagePath)+".rebuild-*")
+	if err != nil {
+		refresh.Action = "failed"
+		return refresh, fmt.Errorf("creating staged rebuild temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		refresh.Action = "failed"
+		return refresh, fmt.Errorf("closing staged rebuild temp file: %w", err)
+	}
+	_ = os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := buildCLITo(cliDir, tmpPath); err != nil {
+		refresh.Action = "failed"
+		return refresh, err
+	}
+	if err := replaceLiveCheckStageBinary(tmpPath, stagePath); err != nil {
+		refresh.Action = "failed"
+		return refresh, fmt.Errorf("replacing staged binary: %w", err)
+	}
+	refresh.Action = "rebuilt"
+	refresh.BinaryPath = stagePath
+	refresh.Reason = "staged binary was older than Go sources"
+	return refresh, nil
+}
+
+func replaceLiveCheckStageBinary(src, dst string) error {
+	if runtime.GOOS != "windows" {
+		return os.Rename(src, dst)
+	}
+
+	backup, err := os.CreateTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".old-*")
+	if err != nil {
+		return err
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	_ = os.Remove(backupPath)
+
+	if err := os.Rename(dst, backupPath); err != nil {
+		return err
+	}
+	if err := os.Rename(src, dst); err != nil {
+		_ = os.Rename(backupPath, dst)
+		return err
+	}
+	_ = os.Remove(backupPath)
+	return nil
+}
+
+func liveCheckFreshRunnableBinaryPath(cliDir, name string, newestSource time.Time) string {
+	for _, candidate := range liveCheckBinaryNames(cliDir, name) {
+		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, runtime.GOOS) {
+			info, err := os.Stat(path)
+			if err != nil || !isLiveCheckExecutableForGOOS(path, info.Mode(), runtime.GOOS) {
+				continue
+			}
+			if !info.ModTime().Before(newestSource) {
+				return path
+			}
+		}
+	}
+	return ""
+}
+
+func liveCheckExistingStageBinaryPath(cliDir, name string) (string, string) {
+	stagedDir := filepath.Join(cliDir, "build", "stage", "bin")
+	for _, candidate := range liveCheckBinaryNames(cliDir, name) {
+		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, runtime.GOOS) {
+			cleanPath := filepath.Clean(path)
+			if filepath.Dir(cleanPath) != filepath.Clean(stagedDir) {
+				continue
+			}
+			if runtime.GOOS == "windows" && !strings.EqualFold(filepath.Ext(cleanPath), ".exe") {
+				continue
+			}
+			if _, err := os.Stat(cleanPath); err == nil {
+				return cleanPath, candidate
+			}
+		}
+	}
+	return "", ""
+}
+
+func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error) {
+	var newest time.Time
+	found := false
+	for _, root := range []string{cmdDir, filepath.Join(cliDir, "internal")} {
+		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || filepath.Ext(path) != ".go" {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			if !found || info.ModTime().After(newest) {
+				newest = info.ModTime()
+				found = true
+			}
+			return nil
+		})
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return time.Time{}, false, err
+		}
+	}
+	return newest, found, nil
 }
 
 // resolveBinaryPath returns the absolute path to the CLI binary. When name

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -295,6 +295,7 @@ func refreshLiveCheckStageBinary(cliDir, name string) (LiveCheckBinaryRefresh, e
 	newestSource, ok, err := newestLiveCheckSourceModTime(cliDir, cmdDir)
 	if err != nil {
 		refresh.Action = "failed"
+		refresh.Reason = err.Error()
 		return refresh, err
 	}
 	if !ok {
@@ -407,6 +408,12 @@ func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error
 	var newest time.Time
 	found := false
 	for _, root := range []string{cmdDir, filepath.Join(cliDir, "internal")} {
+		if _, err := os.Stat(root); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return time.Time{}, false, err
+		}
 		err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 			if walkErr != nil {
 				return walkErr
@@ -425,9 +432,6 @@ func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error
 			return nil
 		})
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
 			return time.Time{}, false, err
 		}
 	}

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,6 +38,26 @@ func writeTestResearchJSON(t *testing.T, cliDir string, features []NovelFeature)
 	body, err := json.Marshal(data)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "research.json"), body, 0o644))
+}
+
+func writeLiveCheckGoCLI(t *testing.T, cliDir, binaryName, output string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/live-check-test\n\ngo 1.23\n"), 0o644))
+	cmdDir := filepath.Join(cliDir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	mainSource := fmt.Sprintf(`package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println(%q)
+}
+`, output)
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainSource), 0o644))
+	return mainPath
 }
 
 // TestLiveCheck_UnableWhenNoResearch verifies the check gracefully reports
@@ -667,6 +688,158 @@ func TestLiveCheck_FindsBinaryInBuildStageBin(t *testing.T) {
 	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
 	require.Equal(t, 1, result.Checked())
 	assert.Equal(t, 1, result.Passed, "expected binary at build/stage/bin/ to be found and run")
+}
+
+func TestLiveCheck_RebuildsStaleStageBinaryBeforeSampling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "sample-pp-cli"
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho 'unknown command \"foo\"' >&2\nexit 2\n"), 0o755))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(stub, oldTime, oldTime))
+
+	writeLiveCheckGoCLI(t, dir, binaryName, `{"data":[{"source":"rebuilt"}]}`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: binaryName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: binaryName, Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "rebuilt")
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "rebuilt", result.BinaryRefresh.Action)
+}
+
+func TestLiveCheck_SkipsStageRebuildWhenBinaryIsFresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "sample-pp-cli"
+	mainPath := writeLiveCheckGoCLI(t, dir, binaryName, `{"data":[{"source":"rebuilt"}]}`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho '{\"data\":[{\"source\":\"fresh-stage\"}]}'\n"), 0o755))
+	require.NoError(t, os.Chtimes(stub, time.Now(), time.Now()))
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: binaryName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: binaryName, Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "fresh-stage")
+	require.NotContains(t, result.Features[0].OutputSample, "rebuilt")
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "fresh", result.BinaryRefresh.Action)
+}
+
+func TestLiveCheck_SkipsStageRebuildWhenFreshFallbackBinaryExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "sample-pp-cli"
+	mainPath := writeLiveCheckGoCLI(t, dir, binaryName, `{"data":[{"source":"rebuilt"}]}`)
+	sourceTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(mainPath, sourceTime, sourceTime))
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho 'unknown command \"foo\"' >&2\nexit 2\n"), 0o755))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(stub, oldTime, oldTime))
+	writeStubBinary(t, dir, binaryName, `echo '{"data":[{"source":"fresh-root"}]}'`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: binaryName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: binaryName, Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "fresh-root")
+	require.NotContains(t, result.Features[0].OutputSample, "rebuilt")
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "fresh_fallback", result.BinaryRefresh.Action)
+}
+
+func TestLiveCheck_RebuildsPreferredStageBinaryDespiteFreshLowerPriorityFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "sample")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	sourceName := "sample-pp-cli"
+	mainPath := writeLiveCheckGoCLI(t, dir, sourceName, `{"data":[{"source":"rebuilt"}]}`)
+	sourceTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(mainPath, sourceTime, sourceTime))
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, sourceName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho 'unknown command \"foo\"' >&2\nexit 2\n"), 0o755))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(stub, oldTime, oldTime))
+	writeStubBinary(t, dir, "sample", `echo '{"data":[{"source":"fresh-root"}]}'`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: sourceName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "rebuilt")
+	require.NotContains(t, result.Features[0].OutputSample, "fresh-root")
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "rebuilt", result.BinaryRefresh.Action)
+}
+
+func TestLiveCheck_RebuildsStageBinaryWhenInternalSourceIsNewer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "sample-pp-cli"
+	mainPath := writeLiveCheckGoCLI(t, dir, binaryName, `{"data":[{"source":"rebuilt"}]}`)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(mainPath, oldTime, oldTime))
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho 'unknown command \"foo\"' >&2\nexit 2\n"), 0o755))
+	stageTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(stub, stageTime, stageTime))
+
+	internalPath := filepath.Join(dir, "internal", "cli", "foo.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(internalPath), 0o755))
+	require.NoError(t, os.WriteFile(internalPath, []byte("package cli\n"), 0o644))
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: binaryName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: binaryName, Timeout: 5 * time.Second})
+	require.False(t, result.Unable, "check was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Passed)
+	require.Contains(t, result.Features[0].OutputSample, "rebuilt")
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "rebuilt", result.BinaryRefresh.Action)
 }
 
 func TestLiveCheckBinaryCandidatesIncludeHostExecutableName(t *testing.T) {

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -842,6 +842,41 @@ func TestLiveCheck_RebuildsStageBinaryWhenInternalSourceIsNewer(t *testing.T) {
 	require.Equal(t, "rebuilt", result.BinaryRefresh.Action)
 }
 
+func TestLiveCheck_BinaryRefreshReasonIncludesSourceWalkError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod permission behavior differs on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "sample-pp-cli")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	binaryName := "sample-pp-cli"
+	writeLiveCheckGoCLI(t, dir, binaryName, `{"data":[{"source":"rebuilt"}]}`)
+
+	blockedDir := filepath.Join(dir, "cmd", binaryName, "blocked")
+	require.NoError(t, os.MkdirAll(blockedDir, 0o755))
+	require.NoError(t, os.Chmod(blockedDir, 0))
+	t.Cleanup(func() {
+		_ = os.Chmod(blockedDir, 0o755)
+	})
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stub := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\necho '{\"data\":[{\"source\":\"stale\"}]}'\n"), 0o755))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(stub, oldTime, oldTime))
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Foo", Command: "foo", Example: binaryName + " foo --json"},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: binaryName, Timeout: 5 * time.Second})
+	require.True(t, result.Unable)
+	require.NotNil(t, result.BinaryRefresh)
+	require.Equal(t, "failed", result.BinaryRefresh.Action)
+	require.NotEmpty(t, result.BinaryRefresh.Reason)
+	require.Contains(t, result.Reason, result.BinaryRefresh.Reason)
+}
+
 func TestLiveCheckBinaryCandidatesIncludeHostExecutableName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/runtime_exec.go
+++ b/internal/pipeline/runtime_exec.go
@@ -19,9 +19,16 @@ func buildCLI(dir string) (string, error) {
 		return "", fmt.Errorf("resolving binary path: %w", err)
 	}
 	binaryPath = platform.ExecutablePath(binaryPath)
+	if err := buildCLITo(dir, binaryPath); err != nil {
+		return "", err
+	}
+	return binaryPath, nil
+}
+
+func buildCLITo(dir, binaryPath string) error {
 	cmdDir, err := findCLICommandDir(dir)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -30,9 +37,9 @@ func buildCLI(dir string) (string, error) {
 	cmd.Dir = filepath.Dir(cmdDir)
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("go build: %s\n%s", err, string(out))
+		return fmt.Errorf("go build: %s\n%s", err, string(out))
 	}
-	return binaryPath, nil
+	return nil
 }
 
 func findCLICommandDir(dir string) (string, error) {

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2858,7 +2858,7 @@ cli-printing-press shipcheck \
   --research-dir "$API_RUN_DIR"
 ```
 
-The umbrella defaults to `verify --fix` (auto-repair common failures), `validate-narrative --strict --full-examples` (README/SKILL narrative command validation), and `scorecard --live-check` (sample novel-feature output against real targets). Use `--no-fix` for a read-only pass, `--no-live-check` to skip live sampling, or `--json` for a structured envelope (suppresses per-leg output for clean piping). Pass `--api-key` / `--env-var` through to verify when live testing needs a credential, or `--strict` to make verify-skill treat likely-false-positive findings as failures.
+The umbrella defaults to `verify --fix` (auto-repair common failures), `validate-narrative --strict --full-examples` (README/SKILL narrative command validation), and `scorecard --live-check` (sample novel-feature output against real targets). When Go sources under `cmd/<cli>/` or `internal/` are newer than `build/stage/bin/<cli>`, `scorecard --live-check` rebuilds the staged binary before sampling and reports the refresh action in human and JSON output. Use `--no-fix` for a read-only pass, `--no-live-check` to skip live sampling, or `--json` for a structured envelope (suppresses per-leg output for clean piping). Pass `--api-key` / `--env-var` through to verify when live testing needs a credential, or `--strict` to make verify-skill treat likely-false-positive findings as failures.
 
 If a leg fails, re-run that one leg standalone (e.g., `cli-printing-press verify-skill --dir <CLI_WORK_DIR>`) for focused iteration; once it passes, re-run the full `shipcheck` umbrella to confirm no regression in the others.
 


### PR DESCRIPTION
## Intent

Closes #1555.

`scorecard --live-check` now samples the current generated CLI command surface instead of silently using a stale generation-time staged binary after Phase 3 hand-built novel commands are added.

## Approach

- Refresh `build/stage/bin/<cli>` when Go sources under `cmd/<cli>/` or `internal/` are newer than the staged binary.
- Keep no-op cases cheap by skipping rebuilds when the staged binary is fresh or a same-name fallback binary is already current.
- Report the binary refresh action in live-check JSON and human scorecard output.
- Treat a failed stale-stage refresh as a scorecard failure so shipcheck cannot pass after the freshness guard fails.
- Document the behavior in the Printing Press skill and capture the reusable stale-artifact lesson in `docs/solutions/`.

## Scope

Primary area: scorer live-check behavior.

Why this belongs in this repo: the stale binary is selected by the Printing Press scorecard/shipcheck pipeline, not by one printed CLI.

## Risk

Low. This adds an on-demand rebuild before live sampling only when the staged binary is stale and no current same-name fallback exists. The observable output contract changes by adding live-check binary-refresh metadata.

## Output Contract

`scorecard --live-check --json` includes `live_check.binary_refresh`. Human scorecard output prints a `Binary refresh:` line when live-check evaluated the staged binary refresh path.

## Verification

- `go test ./internal/pipeline -run 'TestLiveCheck_(RebuildsStaleStageBinaryBeforeSampling|SkipsStageRebuildWhenBinaryIsFresh|SkipsStageRebuildWhenFreshFallbackBinaryExists|RebuildsPreferredStageBinaryDespiteFreshLowerPriorityFallback|RebuildsStageBinaryWhenInternalSourceIsNewer|FindsBinaryInBuildStageBin|ResolveBinaryPathPicksNewestCandidate)|TestBuildCLI' -count=1`
- `go test ./internal/cli -run 'TestScorecardJSONKeepsLiveCheckSeparateFromLiveVerification|TestLiveCheckFatalReasonReportsFailedBinaryRefresh|TestShipcheck' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...` (0 issues; warning references a stale sibling worktree path outside this checkout)
- `scripts/golden.sh verify`
- `git diff --check`
- `ruby -e 'require "yaml"; path=ARGV.fetch(0); text=File.read(path); front=text.split(/^---\\s*$/,3)[1]; data=YAML.safe_load(front, permitted_classes: [Date], aliases: false); required=%w[title date category module problem_type component symptoms root_cause resolution_type severity tags]; missing=required.select { |k| !data.key?(k) }; abort("missing #{missing.join(",")}") unless missing.empty?; puts "frontmatter ok"' docs/solutions/logic-errors/live-check-refreshes-stale-stage-binary-2026-05-23.md` (`scripts/validate-frontmatter.py` is not present in this checkout)

## Compounded learnings

File: `docs/solutions/logic-errors/live-check-refreshes-stale-stage-binary-2026-05-23.md`
Track: bug
Category: logic-errors
Overlap: moderate with existing scorer-surface docs, new doc created for stale artifact freshness
Instruction-file edit: none needed, AGENTS.md already surfaces `docs/solutions/`
Refresh recommendation: none
