### PR TITLE
fix(cli): derive version-command binary name from cmd.Root().Name()

### DIFF
--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -438,7 +438,7 @@ func newVersionCliCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("{{.Name}}-pp-cli %s\n", version)
+			fmt.Printf("%s %s\n", cmd.Root().Name(), version)
 		},
 	}
 }

--- a/internal/generator/version_cmd_name_test.go
+++ b/internal/generator/version_cmd_name_test.go
@@ -1,0 +1,32 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCommandUsesRootNameInGeneratedRoot(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("version-cmd-name")
+	outputDir := filepath.Join(t.TempDir(), "version-cmd-name-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootPath := filepath.Join(outputDir, "internal", "cli", "root.go")
+	content, err := os.ReadFile(rootPath)
+	require.NoError(t, err)
+	src := string(content)
+
+	re := regexp.MustCompile(`(?s)func newVersionCliCmd\(\) \*cobra.Command \{.*?\n\}`)
+	fn := re.FindString(src)
+	require.NotEmpty(t, fn, "expected generated root.go to contain newVersionCliCmd")
+
+	require.Contains(t, fn, `fmt.Printf("%s %s\n", cmd.Root().Name(), version)`,
+		"newVersionCliCmd must print the root command name at runtime")
+	require.NotContains(t, fn, `fmt.Printf("version-cmd-name-pp-cli %s\n", version)`,
+		"newVersionCliCmd must not hardcode the generated binary literal")
+}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -300,7 +300,7 @@ func newVersionCliCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("fastapi-operationids-golden-pp-cli %s\n", version)
+			fmt.Printf("%s %s\n", cmd.Root().Name(), version)
 		},
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -309,7 +309,7 @@ func newVersionCliCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("printing-press-golden-pp-cli %s\n", version)
+			fmt.Printf("%s %s\n", cmd.Root().Name(), version)
 		},
 	}
 }


### PR DESCRIPTION
## Intent

Issue: Fixes #1585

`newVersionCliCmd` printed the binary name as a hardcoded `"<name>-pp-cli"` literal instead of deriving it from the command tree.

## Approach

Print `cmd.Root().Name()` (the `Run` closure already binds `cmd`). Output is byte-identical for the normal case (root `Use` is `<name>-pp-cli`) and stays correct if the binary is renamed/aliased.

## Scope

Primary area: generator (`internal/generator/templates/root.go.tmpl`). Machine change. Scoped strictly to `newVersionCliCmd`; `SetVersionTemplate` untouched.

## Risk

Low. `version` stdout unchanged in the normal case.

## Output Contract

Generated `internal/cli/root.go` version `Run` uses `cmd.Root().Name()`. Golden fixtures regenerated for 2 cases (root.go). Diff is the one Printf line.

## Verification

- `go build`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -short ./...` — all pass (incl. new `TestVersionCommandUsesRootNameInGeneratedRoot`)
- `scripts/golden.sh verify` → 2 intentional cases; `update` applied; diff inspected

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change