### PR TITLE
fix(cli): write feedback.jsonl to XDG data dir

### DIFF
--- a/internal/generator/feedback_path_test.go
+++ b/internal/generator/feedback_path_test.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeedbackPath_UsesLocalShareDir(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("feedback-path")
+	outputDir := filepath.Join(t.TempDir(), "feedback-path-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	feedbackPath := filepath.Join(outputDir, "internal", "cli", "feedback.go")
+	feedbackContent, err := os.ReadFile(feedbackPath)
+	require.NoError(t, err)
+	feedbackSrc := string(feedbackContent)
+
+	require.Contains(t, feedbackSrc,
+		`dir := filepath.Join(home, ".local", "share", "feedback-path-pp-cli")`,
+		"feedbackFilePath should use ~/.local/share/<name> like defaultDBPath")
+	require.NotContains(t, feedbackSrc,
+		`dir := filepath.Join(home, ".feedback-path-pp-cli")`,
+		"feedbackFilePath must not use the legacy ~/.<name> dotdir")
+	require.Contains(t, feedbackSrc,
+		"Feedback is captured locally first at ~/.local/share/feedback-path-pp-cli/feedback.jsonl.",
+		"feedback command help text should reference the new local ledger path")
+
+	skillPath := filepath.Join(outputDir, "SKILL.md")
+	skillContent, err := os.ReadFile(skillPath)
+	require.NoError(t, err)
+	require.Contains(t, string(skillContent),
+		"Entries are stored locally at `~/.local/share/feedback-path-pp-cli/feedback.jsonl`.",
+		"generated SKILL.md should reference the new local ledger path")
+}

--- a/internal/generator/templates/feedback.go.tmpl
+++ b/internal/generator/templates/feedback.go.tmpl
@@ -35,7 +35,7 @@ func feedbackFilePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving home dir: %w", err)
 	}
-	dir := filepath.Join(home, ".{{.Name}}-pp-cli")
+	dir := filepath.Join(home, ".local", "share", "{{.Name}}-pp-cli")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("creating state dir: %w", err)
 	}
@@ -100,7 +100,7 @@ func newFeedbackCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feedback [text]",
 		Short: "Record feedback about this CLI (local by default; upstream opt-in)",
-		Long: `Feedback is captured locally first at ~/.{{.Name}}-pp-cli/feedback.jsonl.
+		Long: `Feedback is captured locally first at ~/.local/share/{{.Name}}-pp-cli/feedback.jsonl.
 When ` + "`{{envName .Name}}_FEEDBACK_ENDPOINT`" + ` is set and either --send is
 passed or ` + "`{{envName .Name}}_FEEDBACK_AUTO_SEND=true`" + `, the entry is
 POSTed as JSON after the local write.

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -307,7 +307,7 @@ When you (or the agent) notice something off about this CLI, record it:
 {{.Name}}-pp-cli feedback list --json --limit 10
 ```
 
-Entries are stored locally at `~/.{{.Name}}-pp-cli/feedback.jsonl`. They are never POSTed unless `{{envName .Name}}_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `{{envName .Name}}_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+Entries are stored locally at `~/.local/share/{{.Name}}-pp-cli/feedback.jsonl`. They are never POSTed unless `{{envName .Name}}_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `{{envName .Name}}_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
 
 Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -101,7 +101,7 @@ printing-press-rich-pp-cli feedback --stdin < notes.txt
 printing-press-rich-pp-cli feedback list --json --limit 10
 ```
 
-Entries are stored locally at `~/.printing-press-rich-pp-cli/feedback.jsonl`. They are never POSTed unless `PRINTING_PRESS_RICH_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PRINTING_PRESS_RICH_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+Entries are stored locally at `~/.local/share/printing-press-rich-pp-cli/feedback.jsonl`. They are never POSTed unless `PRINTING_PRESS_RICH_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PRINTING_PRESS_RICH_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
 
 Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -110,7 +110,7 @@ printing-press-golden-pp-cli feedback --stdin < notes.txt
 printing-press-golden-pp-cli feedback list --json --limit 10
 ```
 
-Entries are stored locally at `~/.printing-press-golden-pp-cli/feedback.jsonl`. They are never POSTed unless `PRINTING_PRESS_GOLDEN_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PRINTING_PRESS_GOLDEN_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+Entries are stored locally at `~/.local/share/printing-press-golden-pp-cli/feedback.jsonl`. They are never POSTed unless `PRINTING_PRESS_GOLDEN_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PRINTING_PRESS_GOLDEN_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
 
 Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
@@ -35,7 +35,7 @@ func feedbackFilePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving home dir: %w", err)
 	}
-	dir := filepath.Join(home, ".printing-press-golden-pp-cli")
+	dir := filepath.Join(home, ".local", "share", "printing-press-golden-pp-cli")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("creating state dir: %w", err)
 	}
@@ -100,7 +100,7 @@ func newFeedbackCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feedback [text]",
 		Short: "Record feedback about this CLI (local by default; upstream opt-in)",
-		Long: `Feedback is captured locally first at ~/.printing-press-golden-pp-cli/feedback.jsonl.
+		Long: `Feedback is captured locally first at ~/.local/share/printing-press-golden-pp-cli/feedback.jsonl.
 When ` + "`PRINTING_PRESS_GOLDEN_FEEDBACK_ENDPOINT`" + ` is set and either --send is
 passed or ` + "`PRINTING_PRESS_GOLDEN_FEEDBACK_AUTO_SEND=true`" + `, the entry is
 POSTed as JSON after the local write.

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -79,7 +79,7 @@ public-param-golden-pp-cli feedback --stdin < notes.txt
 public-param-golden-pp-cli feedback list --json --limit 10
 ```
 
-Entries are stored locally at `~/.public-param-golden-pp-cli/feedback.jsonl`. They are never POSTed unless `PUBLIC_PARAM_GOLDEN_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PUBLIC_PARAM_GOLDEN_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
+Entries are stored locally at `~/.local/share/public-param-golden-pp-cli/feedback.jsonl`. They are never POSTed unless `PUBLIC_PARAM_GOLDEN_FEEDBACK_ENDPOINT` is set AND either `--send` is passed or `PUBLIC_PARAM_GOLDEN_FEEDBACK_AUTO_SEND=true`. Default behavior is local-only.
 
 Write what *surprised* you, not a bug report. Short, specific, one line: that is the part that compounds.
 


### PR DESCRIPTION
## Intent

Issue: Fixes #1640

`feedbackFilePath` wrote `feedback.jsonl` to the legacy `~/.<name>-pp-cli/` dotdir, while the SQLite cache uses `~/.local/share/<name>-pp-cli/` (`defaultDBPath`) and config uses `~/.config/`. The feedback ledger was the lone off-policy outlier.

## Approach

Move the feedback dir to `~/.local/share/{{.Name}}-pp-cli`, mirroring `defaultDBPath` exactly (no `XDG_DATA_HOME` env handling, since `defaultDBPath` doesn't read it either — consistency with the sibling). Update the feedback `Long:` help and the generated `SKILL.md` path mention to match.

## Scope

Primary area: generator (`internal/generator/templates/feedback.go.tmpl`, `skill.md.tmpl`). Machine change. The `skill.md.tmpl` edit is a path-string change only — not a section/frontmatter/install-block shape change — so the published-library canonical-shape sweep contract does not fire.

## Risk

Low. A user with an existing legacy `~/.<name>-pp-cli/feedback.jsonl` will start a fresh ledger at the new path; feedback is append-only local telemetry (never POSTed by default), so the only impact is that prior local entries aren't migrated. No automatic migration is included by design.

## Output Contract

Generated `internal/cli/feedback.go` (dir + Long help) and `SKILL.md` reference the new path. Golden fixtures regenerated for the affected cases (feedback.go + SKILL.md). Diff is the path string only.

## Verification

- `go build`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -short ./...` — all pass (incl. new `TestFeedbackPath_UsesLocalShareDir`)
- `scripts/golden.sh verify` → 3 intentional cases; `update` applied; diff inspected

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change