### PR TITLE
fix(cli): strip custom auth header on cross-host redirects

### DIFF
--- a/internal/generator/redirect_auth_header_test.go
+++ b/internal/generator/redirect_auth_header_test.go
@@ -1,0 +1,49 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientCheckRedirectDeletesHeaderOnCrossHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("api_key custom header deletes cross-host", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-cross-host-apikey")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "X-Api-Key",
+			EnvVars: []string{"REDIRECT_CROSS_HOST_APIKEY"},
+		}
+
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, `if req.URL.Host == via[0].URL.Host {`)
+		require.Contains(t, closure, `req.Header.Set("X-Api-Key", h)`)
+		require.Contains(t, closure, `} else {`)
+		require.Contains(t, closure, `req.Header.Del("X-Api-Key")`)
+	})
+
+	t.Run("session handshake header deletes cross-host", func(t *testing.T) {
+		t.Parallel()
+		apiSpec := minimalSpec("redirect-cross-host-session-header")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:           "session_handshake",
+			TokenParamIn:   "header",
+			TokenParamName: "X-Kit-Api-Key",
+			EnvVars:        []string{"REDIRECT_CROSS_HOST_SESSION_HEADER"},
+		}
+
+		client := generateClientSource(t, apiSpec)
+		closure := checkRedirectClosureBody(t, client)
+
+		require.Contains(t, closure, `if req.URL.Host == via[0].URL.Host {`)
+		require.Contains(t, closure, `req.Header.Set("X-Kit-Api-Key", h)`)
+		require.Contains(t, closure, `} else {`)
+		require.Contains(t, closure, `req.Header.Del("X-Kit-Api-Key")`)
+	})
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -441,8 +441,13 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		}
 {{- if .HasTierRouting}}
 		// Tier routing picks header vs query at runtime via authForRequest;
-		// re-deriving here would duplicate that selection logic. Cap depth
-		// only and let Go's default header replay handle static credentials.
+		// re-deriving here would duplicate that selection logic, so we cap
+		// depth only. Known limitation: Go strips standard auth headers
+		// (Authorization, Cookie) on cross-host redirects but not custom
+		// header names, so a tier credential carried on a custom header
+		// could still be forwarded on a cross-host hop. Stripping it here
+		// requires the runtime tier selection and is tracked separately
+		// from the static-auth cross-host fix below.
 {{- else if eq .Auth.Type "session_handshake"}}
 {{- if eq .Auth.TokenParamIn "header"}}
 		// Same-host gate mirrors Go's shouldCopyHeaderOnRedirect: a
@@ -453,6 +458,10 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{.Auth.TokenParamName}}", h)
 			}
+		} else {
+			// Cross-host hop: delete the custom auth header so the credential
+			// is not forwarded to the redirect target.
+			req.Header.Del("{{.Auth.TokenParamName}}")
 		}
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
@@ -467,6 +476,11 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
 			}
+		} else {
+			// Cross-host hop: Go strips standard auth headers (Authorization,
+			// Cookie) but not custom ones, so a custom API-key header would be
+			// forwarded verbatim to the redirect target. Delete it explicitly.
+			req.Header.Del("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}")
 		}
 {{- end}}
 		return nil

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -96,6 +96,11 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("Authorization", h)
 			}
+		} else {
+			// Cross-host hop: Go strips standard auth headers (Authorization,
+			// Cookie) but not custom ones, so a custom API-key header would be
+			// forwarded verbatim to the redirect target. Delete it explicitly.
+			req.Header.Del("Authorization")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -90,6 +90,11 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
 				req.Header.Set("X-API-Key", h)
 			}
+		} else {
+			// Cross-host hop: Go strips standard auth headers (Authorization,
+			// Cookie) but not custom ones, so a custom API-key header would be
+			// forwarded verbatim to the redirect target. Delete it explicitly.
+			req.Header.Del("X-API-Key")
 		}
 		return nil
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -185,8 +185,13 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			return errors.New("stopped after 10 redirects")
 		}
 		// Tier routing picks header vs query at runtime via authForRequest;
-		// re-deriving here would duplicate that selection logic. Cap depth
-		// only and let Go's default header replay handle static credentials.
+		// re-deriving here would duplicate that selection logic, so we cap
+		// depth only. Known limitation: Go strips standard auth headers
+		// (Authorization, Cookie) on cross-host redirects but not custom
+		// header names, so a tier credential carried on a custom header
+		// could still be forwarded on a cross-host hop. Stripping it here
+		// requires the runtime tier selection and is tracked separately
+		// from the static-auth cross-host fix below.
 		return nil
 	}
 	return c


### PR DESCRIPTION
## Intent

Issue: Fixes #1672

Go's HTTP client strips `Authorization`/`Cookie` on cross-domain redirects but not custom headers. A printed CLI using a custom API-key header (e.g. `X-Api-Key`) forwarded the credential verbatim to a redirect host on a cross-host 3xx (CDN handoff, partner/open redirect). (Greptile finding on printing-press-library#701.)

## Approach

The `CheckRedirect` closure re-set the auth header only on same-host hops and never removed it cross-host. Add a cross-host `else` that `req.Header.Del(...)` the custom auth header, for the default header-auth scheme and the `session_handshake` header scheme. `Del` on the standard `Authorization` case is a harmless no-op (Go already stripped it); for custom headers it closes the leak.

## Scope

Primary area: generator (`internal/generator/templates/client.go.tmpl`). Machine change — `client.go` is emitted into every printed CLI.

**Known limitation (documented, out of scope):** the `HasTierRouting` branch selects header-vs-query and the header *name* at runtime via `authForRequest`; a tier credential carried on a custom header could still leak cross-host. Stripping it requires the runtime tier selection (a larger change), so this PR only corrects the static-auth schemes and updates the tier-routing comment to state the limitation honestly rather than implying Go handles it. Happy to file/take a follow-up for the tier-routing path.

## Risk

Low. Only adds header deletion on cross-host hops; same-host behavior unchanged. Security-positive (prevents credential forwarding).

## Output Contract

Generated `internal/client/client.go` `CheckRedirect` gains the cross-host `Del`; tier-routing comment reworded. Golden fixtures regenerated for 3 client.go cases (`generate-golden-api`, `generate-golden-api-oauth2-cc`, `generate-tier-routing-api`).

## Verification

- `go build`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -short ./...` — all pass (incl. new `TestClientCheckRedirectDeletesHeaderOnCrossHost`)
- `scripts/golden.sh verify` → 3 intentional cases; `update` applied; diff inspected

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change