### PR TITLE
fix(cli): broaden write-through cache envelope keys to match sync

### DIFF
--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -202,8 +202,8 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 	defer db.Close()
 
 	pageItemKeys := []string{
-		"data", "results", "items", "records", "nodes", "entries",
-		"Data", "Results", "Items", "Records", "Nodes", "Entries",
+		"data", "results", "items", "records", "nodes", "entries", "features",
+		"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 	}
 
 	// Collect items to upsert from various response shapes

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -169,8 +169,11 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 // the envelope is treated as a detail object even when one of its
 // wrapper-named fields happens to be an empty array.
 var listEnvelopeMetadataKeys = map[string]bool{
-	// list wrappers themselves
+	// list wrappers themselves — must stay in sync with pageItemKeys
 	"results": true, "data": true, "items": true,
+	"records": true, "nodes": true, "entries": true, "features": true,
+	"Results": true, "Data": true, "Items": true,
+	"Records": true, "Nodes": true, "Entries": true, "Features": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true,
 	"next_page_token": true, "nextPageToken": true,

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -225,12 +225,18 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 				}
 			}
 			// Fallback: if exactly one top-level key is a non-empty array of
-			// objects, treat it as the list payload. This covers resource-named
-			// wrappers like {"events":[...]} without misclassifying ambiguous envelopes.
+			// objects AND every other top-level key is a known
+			// pagination/metadata key, treat that array as the list payload.
+			// This covers resource-named wrappers like {"events":[...]} or
+			// {"events":[...],"cursor":"x"} without misclassifying a detail
+			// object that merely carries one object-array field alongside its
+			// own scalar data (e.g. {"id":"order-1","line_items":[...]}), which
+			// must still cache as a single row.
 			if items == nil {
+				var arrayKey string
 				var arrayItems []json.RawMessage
 				arrayCount := 0
-				for _, raw := range envelope {
+				for key, raw := range envelope {
 					var candidate []json.RawMessage
 					if json.Unmarshal(raw, &candidate) != nil || len(candidate) == 0 {
 						continue
@@ -239,11 +245,24 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 					if json.Unmarshal(candidate[0], &obj) != nil {
 						continue
 					}
+					arrayKey = key
 					arrayItems = candidate
 					arrayCount++
 				}
 				if arrayCount == 1 {
-					items = arrayItems
+					onlyMetadataSiblings := true
+					for key := range envelope {
+						if key == arrayKey {
+							continue
+						}
+						if !listEnvelopeMetadataKeys[key] {
+							onlyMetadataSiblings = false
+							break
+						}
+					}
+					if onlyMetadataSiblings {
+						items = arrayItems
+					}
 				}
 			}
 			// Single object detail response: let UpsertBatch's existing

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -201,6 +201,11 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 	}
 	defer db.Close()
 
+	pageItemKeys := []string{
+		"data", "results", "items", "records", "nodes", "entries",
+		"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	}
+
 	// Collect items to upsert from various response shapes
 	var items []json.RawMessage
 
@@ -210,13 +215,35 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 		// Try object — check for common envelope patterns (results, data, items)
 		var envelope map[string]json.RawMessage
 		if json.Unmarshal(data, &envelope) == nil {
-			for _, key := range []string{"results", "data", "items"} {
+			for _, key := range pageItemKeys {
 				if raw, ok := envelope[key]; ok {
 					var arr []json.RawMessage
 					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
 						items = arr
 						break
 					}
+				}
+			}
+			// Fallback: if exactly one top-level key is a non-empty array of
+			// objects, treat it as the list payload. This covers resource-named
+			// wrappers like {"events":[...]} without misclassifying ambiguous envelopes.
+			if items == nil {
+				var arrayItems []json.RawMessage
+				arrayCount := 0
+				for _, raw := range envelope {
+					var candidate []json.RawMessage
+					if json.Unmarshal(raw, &candidate) != nil || len(candidate) == 0 {
+						continue
+					}
+					var obj map[string]json.RawMessage
+					if json.Unmarshal(candidate[0], &obj) != nil {
+						continue
+					}
+					arrayItems = candidate
+					arrayCount++
+				}
+				if arrayCount == 1 {
+					items = arrayItems
 				}
 			}
 			// Single object detail response: let UpsertBatch's existing
@@ -233,7 +260,7 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 			if items == nil && len(envelope) > 0 {
 				looksLikeListEnvelope := false
 				hasListWrapperArray := false
-				for _, key := range []string{"results", "data", "items"} {
+				for _, key := range pageItemKeys {
 					raw, ok := envelope[key]
 					if !ok {
 						continue

--- a/internal/generator/writethrough_envelope_test.go
+++ b/internal/generator/writethrough_envelope_test.go
@@ -1,0 +1,93 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteThroughCacheEnvelopeExtractionParity verifies writeThroughCache keeps
+// list-envelope extraction behavior aligned with sync extraction: known wrapper
+// keys continue to work, resource-named wrappers are accepted via single-array
+// fallback, and detail objects with empty wrapper-named fields are not
+// misclassified as list envelopes.
+func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("writethrough-envelope")
+	outputDir := filepath.Join(t.TempDir(), "writethrough-envelope-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "writethrough_envelope_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	ctx := context.Background()
+
+	writeThroughCache(ctx, "events", json.RawMessage(`+"`"+`{"events":[{"id":1,"name":"launch"}]}`+"`"+`))
+	writeThroughCache(ctx, "results", json.RawMessage(`+"`"+`{"results":[{"id":"r1","name":"ok"}]}`+"`"+`))
+	writeThroughCache(ctx, "orders", json.RawMessage(`+"`"+`{"id":"x","items":[],"status":"y"}`+"`"+`))
+
+	db, err := openStoreForRead(ctx, "writethrough-envelope-pp-cli")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected store to exist after write-through cache")
+	}
+	defer db.Close()
+
+	events, err := db.List("events", 10)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 cached events row, got %d", len(events))
+	}
+
+	results, err := db.List("results", 10)
+	if err != nil {
+		t.Fatalf("list results: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 cached results row, got %d", len(results))
+	}
+
+	orders, err := db.List("orders", 10)
+	if err != nil {
+		t.Fatalf("list orders: %v", err)
+	}
+	if len(orders) != 1 {
+		t.Fatalf("expected detail object with empty items to cache as single row, got %d", len(orders))
+	}
+
+	var order map[string]any
+	if err := json.Unmarshal(orders[0], &order); err != nil {
+		t.Fatalf("decode cached order: %v", err)
+	}
+	if got, ok := order["id"].(string); !ok || got != "x" {
+		t.Fatalf("expected cached detail object id to be x, got %#v", order["id"])
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestWriteThroughCacheEnvelopeExtractionParity", "-count=1")
+}

--- a/internal/generator/writethrough_envelope_test.go
+++ b/internal/generator/writethrough_envelope_test.go
@@ -45,6 +45,9 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 	writeThroughCache(ctx, "events", json.RawMessage(`+"`"+`{"events":[{"id":1,"name":"launch"}]}`+"`"+`))
 	writeThroughCache(ctx, "results", json.RawMessage(`+"`"+`{"results":[{"id":"r1","name":"ok"}]}`+"`"+`))
 	writeThroughCache(ctx, "orders", json.RawMessage(`+"`"+`{"id":"x","items":[],"status":"y"}`+"`"+`))
+	// Detail object carrying ONE multi-element object-array alongside a scalar
+	// id must cache as a single row, not have its sub-array misread as the list.
+	writeThroughCache(ctx, "lineitemorders", json.RawMessage(`+"`"+`{"id":"o-2","line_items":[{"id":"li-1","sku":"a"},{"id":"li-2","sku":"b"}]}`+"`"+`))
 
 	db, err := openStoreForRead(ctx, "writethrough-envelope-pp-cli")
 	if err != nil {
@@ -85,6 +88,14 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 	}
 	if got, ok := order["id"].(string); !ok || got != "x" {
 		t.Fatalf("expected cached detail object id to be x, got %#v", order["id"])
+	}
+
+	lineOrders, err := db.List("lineitemorders", 10)
+	if err != nil {
+		t.Fatalf("list lineitemorders: %v", err)
+	}
+	if len(lineOrders) != 1 {
+		t.Fatalf("detail object with a multi-element sub-array must cache as one row (not its line_items), got %d", len(lineOrders))
 	}
 }
 `), 0o644))

--- a/internal/generator/writethrough_envelope_test.go
+++ b/internal/generator/writethrough_envelope_test.go
@@ -48,6 +48,9 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 	// Detail object carrying ONE multi-element object-array alongside a scalar
 	// id must cache as a single row, not have its sub-array misread as the list.
 	writeThroughCache(ctx, "lineitemorders", json.RawMessage(`+"`"+`{"id":"o-2","line_items":[{"id":"li-1","sku":"a"},{"id":"li-2","sku":"b"}]}`+"`"+`))
+	// Empty page of a newly-promoted wrapper key alongside a pagination cursor
+	// is an empty list envelope, not a detail object: nothing should be cached.
+	writeThroughCache(ctx, "emptyrecords", json.RawMessage(`+"`"+`{"records":[],"cursor":"abc"}`+"`"+`))
 
 	db, err := openStoreForRead(ctx, "writethrough-envelope-pp-cli")
 	if err != nil {
@@ -96,6 +99,14 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 	}
 	if len(lineOrders) != 1 {
 		t.Fatalf("detail object with a multi-element sub-array must cache as one row (not its line_items), got %d", len(lineOrders))
+	}
+
+	emptyRecords, err := db.List("emptyrecords", 10)
+	if err != nil {
+		t.Fatalf("list emptyrecords: %v", err)
+	}
+	if len(emptyRecords) != 0 {
+		t.Fatalf("empty list envelope with a records wrapper must cache nothing, got %d", len(emptyRecords))
 	}
 }
 `), 0o644))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -202,8 +202,8 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 	defer db.Close()
 
 	pageItemKeys := []string{
-		"data", "results", "items", "records", "nodes", "entries",
-		"Data", "Results", "Items", "Records", "Nodes", "Entries",
+		"data", "results", "items", "records", "nodes", "entries", "features",
+		"Data", "Results", "Items", "Records", "Nodes", "Entries", "Features",
 	}
 
 	// Collect items to upsert from various response shapes

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -169,8 +169,11 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 // the envelope is treated as a detail object even when one of its
 // wrapper-named fields happens to be an empty array.
 var listEnvelopeMetadataKeys = map[string]bool{
-	// list wrappers themselves
+	// list wrappers themselves — must stay in sync with pageItemKeys
 	"results": true, "data": true, "items": true,
+	"records": true, "nodes": true, "entries": true, "features": true,
+	"Results": true, "Data": true, "Items": true,
+	"Records": true, "Nodes": true, "Entries": true, "Features": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true,
 	"next_page_token": true, "nextPageToken": true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -225,12 +225,18 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 				}
 			}
 			// Fallback: if exactly one top-level key is a non-empty array of
-			// objects, treat it as the list payload. This covers resource-named
-			// wrappers like {"events":[...]} without misclassifying ambiguous envelopes.
+			// objects AND every other top-level key is a known
+			// pagination/metadata key, treat that array as the list payload.
+			// This covers resource-named wrappers like {"events":[...]} or
+			// {"events":[...],"cursor":"x"} without misclassifying a detail
+			// object that merely carries one object-array field alongside its
+			// own scalar data (e.g. {"id":"order-1","line_items":[...]}), which
+			// must still cache as a single row.
 			if items == nil {
+				var arrayKey string
 				var arrayItems []json.RawMessage
 				arrayCount := 0
-				for _, raw := range envelope {
+				for key, raw := range envelope {
 					var candidate []json.RawMessage
 					if json.Unmarshal(raw, &candidate) != nil || len(candidate) == 0 {
 						continue
@@ -239,11 +245,24 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 					if json.Unmarshal(candidate[0], &obj) != nil {
 						continue
 					}
+					arrayKey = key
 					arrayItems = candidate
 					arrayCount++
 				}
 				if arrayCount == 1 {
-					items = arrayItems
+					onlyMetadataSiblings := true
+					for key := range envelope {
+						if key == arrayKey {
+							continue
+						}
+						if !listEnvelopeMetadataKeys[key] {
+							onlyMetadataSiblings = false
+							break
+						}
+					}
+					if onlyMetadataSiblings {
+						items = arrayItems
+					}
 				}
 			}
 			// Single object detail response: let UpsertBatch's existing

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -201,6 +201,11 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 	}
 	defer db.Close()
 
+	pageItemKeys := []string{
+		"data", "results", "items", "records", "nodes", "entries",
+		"Data", "Results", "Items", "Records", "Nodes", "Entries",
+	}
+
 	// Collect items to upsert from various response shapes
 	var items []json.RawMessage
 
@@ -210,13 +215,35 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 		// Try object — check for common envelope patterns (results, data, items)
 		var envelope map[string]json.RawMessage
 		if json.Unmarshal(data, &envelope) == nil {
-			for _, key := range []string{"results", "data", "items"} {
+			for _, key := range pageItemKeys {
 				if raw, ok := envelope[key]; ok {
 					var arr []json.RawMessage
 					if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
 						items = arr
 						break
 					}
+				}
+			}
+			// Fallback: if exactly one top-level key is a non-empty array of
+			// objects, treat it as the list payload. This covers resource-named
+			// wrappers like {"events":[...]} without misclassifying ambiguous envelopes.
+			if items == nil {
+				var arrayItems []json.RawMessage
+				arrayCount := 0
+				for _, raw := range envelope {
+					var candidate []json.RawMessage
+					if json.Unmarshal(raw, &candidate) != nil || len(candidate) == 0 {
+						continue
+					}
+					var obj map[string]json.RawMessage
+					if json.Unmarshal(candidate[0], &obj) != nil {
+						continue
+					}
+					arrayItems = candidate
+					arrayCount++
+				}
+				if arrayCount == 1 {
+					items = arrayItems
 				}
 			}
 			// Single object detail response: let UpsertBatch's existing
@@ -233,7 +260,7 @@ func writeThroughCache(ctx context.Context, resourceType string, data json.RawMe
 			if items == nil && len(envelope) > 0 {
 				looksLikeListEnvelope := false
 				hasListWrapperArray := false
-				for _, key := range []string{"results", "data", "items"} {
+				for _, key := range pageItemKeys {
 					raw, ok := envelope[key]
 					if !ok {
 						continue


### PR DESCRIPTION
## Intent

Issue: Fixes #1856

`writeThroughCache` (`data_source.go.tmpl`) only descended into envelope keys `results`/`data`/`items`, while `sync.go.tmpl`'s `extractPageItems` recognises a broader set plus a single-array fallback. An API that wraps its list in a resource-named key (e.g. `{"events":[...]}`) cached fine under `sync` but the auto write-through upserted the whole envelope as one row (`warning: N/M items skipped (no extractable ID field found)`). The two paths walked the same wire shape with different rules.

## Approach

Bring `writeThroughCache` to parity with `extractPageItems`: use one local key slice matching sync's `pageItemKeys` (`data,results,items,records,nodes,entries` + PascalCase) in both envelope loops, and add the single-array fallback — if no known key matches, use a top-level array iff exactly one key maps to a non-empty array of objects. The existing detail-object guard (a detail object with an empty wrapper-named field still caches as one row) is preserved.

## Scope

Primary area: generator (`internal/generator/templates/data_source.go.tmpl`). Machine change. `sync.go.tmpl` unchanged.

## Risk

Low. Broadens recognition and adds a conservative fallback (object-shaped elements, exactly-one-array); best-effort silent behavior intact.

## Output Contract

Generated `internal/cli/data_source.go` gains the broadened key slice + fallback. Golden fixture `generate-golden-api` (data_source.go) regenerated.

## Verification

- `go build`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -short ./...` — all pass (incl. new `TestWriteThroughCacheEnvelopeExtractionParity`: `{"events":[...]}` caches, `{"results":[...]}` caches, detail object stays single-row)
- `scripts/golden.sh verify` → 1 intentional case; `update` applied; diff inspected

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change