### PR TITLE
fix(cli): merge spec date-time fields into stale timestamp allowlist

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2503,6 +2503,7 @@ type visionRenderData struct {
 	SyncableResources            []profiler.SyncableResource
 	DependentSyncResources       []profiler.DependentResource
 	PaginationSupportedResources []string
+	SpecTimestampFields          []string
 	SearchableFields             map[string][]string
 	Tables                       []TableDef
 	Pagination                   profiler.PaginationProfile
@@ -2595,6 +2596,56 @@ func paginationSupportedResources(syncable []profiler.SyncableResource, dependen
 	return names
 }
 
+func specDateTimeFieldNames(api *spec.APISpec) []string {
+	if api == nil {
+		return nil
+	}
+
+	fields := map[string]struct{}{}
+	addName := func(name, format string) {
+		if strings.EqualFold(format, "date-time") && strings.TrimSpace(name) != "" {
+			fields[name] = struct{}{}
+		}
+	}
+
+	var walkParams func(params []spec.Param)
+	walkParams = func(params []spec.Param) {
+		for _, p := range params {
+			addName(p.Name, p.Format)
+			if len(p.Fields) > 0 {
+				walkParams(p.Fields)
+			}
+		}
+	}
+
+	var walkResource func(resource spec.Resource)
+	walkResource = func(resource spec.Resource) {
+		for _, endpoint := range resource.Endpoints {
+			walkParams(endpoint.Params)
+			walkParams(endpoint.Body)
+		}
+		for _, sub := range resource.SubResources {
+			walkResource(sub)
+		}
+	}
+
+	for _, typeDef := range api.Types {
+		for _, f := range typeDef.Fields {
+			addName(f.Name, f.Format)
+		}
+	}
+	for _, resource := range api.Resources {
+		walkResource(resource)
+	}
+
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 	gqlFieldPaths := map[string]string{}
 	for rName, r := range g.Spec.Resources {
@@ -2608,6 +2659,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		SyncableResources:            g.profile.SyncableResources,
 		DependentSyncResources:       g.profile.DependentSyncResources,
 		PaginationSupportedResources: paginationSupportedResources(g.profile.SyncableResources, g.profile.DependentSyncResources),
+		SpecTimestampFields:          specDateTimeFieldNames(g.Spec),
 		SearchableFields:             g.profile.SearchableFields,
 		Tables:                       schema,
 		Pagination:                   g.profile.Pagination,
@@ -2692,7 +2744,7 @@ func (g *Generator) renderWorkflowFiles(visionData visionRenderData) ([]string, 
 	for _, tmpl := range g.VisionSet.Workflows {
 		outName := strings.TrimSuffix(filepath.Base(tmpl), ".tmpl")
 		outPath := filepath.Join("internal", "cli", outName)
-		if err := g.renderTemplate(tmpl, outPath, g.Spec); err != nil {
+		if err := g.renderTemplate(tmpl, outPath, visionData); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: skipping workflow template %s: %v\n", tmpl, err)
 			continue
 		}

--- a/internal/generator/stale_spec_fields_test.go
+++ b/internal/generator/stale_spec_fields_test.go
@@ -1,0 +1,95 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaleWorkflowMergesSpecTimestampFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds spec date-time fields", func(t *testing.T) {
+		t.Parallel()
+
+		apiSpec := minimalSpec("stalespecfields")
+		apiSpec.Types = map[string]spec.TypeDef{
+			"Card": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "dateLastActivity", Type: "string", Format: "date-time"},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		gen := New(apiSpec, outputDir)
+		gen.VisionSet = VisionTemplateSet{
+			Store: true,
+			Sync:  true,
+			Workflows: []string{
+				"workflows/pm_stale.go.tmpl",
+			},
+		}
+		require.NoError(t, gen.Generate())
+
+		staleSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "pm_stale.go"))
+		require.NoError(t, err)
+		src := string(staleSrc)
+
+		assert.Contains(t, src, "func init()")
+		assert.Contains(t, src, `"dateLastActivity"`)
+	})
+
+	t.Run("keeps hardcoded fields and emits no init when no spec date-time names", func(t *testing.T) {
+		t.Parallel()
+
+		apiSpec := minimalSpec("stalespecdefaults")
+		apiSpec.Types = map[string]spec.TypeDef{
+			"Item": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "updated_at", Type: "string"},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		gen := New(apiSpec, outputDir)
+		gen.VisionSet = VisionTemplateSet{
+			Store: true,
+			Sync:  true,
+			Workflows: []string{
+				"workflows/pm_stale.go.tmpl",
+			},
+		}
+		require.NoError(t, gen.Generate())
+
+		staleSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "pm_stale.go"))
+		require.NoError(t, err)
+		src := string(staleSrc)
+
+		for _, field := range []string{
+			"updatedAt",
+			"updated_at",
+			"updatedDate",
+			"modifiedAt",
+			"modified_at",
+			"lastModified",
+			"last_modified",
+			"lastEditedTime",
+			"last_edited_time",
+			"updated",
+			"last_updated",
+		} {
+			assert.Contains(t, src, `"`+field+`"`)
+		}
+		assert.False(t, strings.Contains(src, "func init()"), "pm_stale.go should omit init when no date-time fields were collected from the spec")
+	})
+}

--- a/internal/generator/stale_spec_fields_test.go
+++ b/internal/generator/stale_spec_fields_test.go
@@ -47,6 +47,53 @@ func TestStaleWorkflowMergesSpecTimestampFields(t *testing.T) {
 		assert.Contains(t, src, `"dateLastActivity"`)
 	})
 
+	t.Run("dedups spec date-time field already in the hardcoded allowlist", func(t *testing.T) {
+		t.Parallel()
+
+		// updated_at is already hardcoded; declaring it as a spec date-time
+		// field must not produce a duplicate entry after the init() merge.
+		apiSpec := minimalSpec("stalespecdedup")
+		apiSpec.Types = map[string]spec.TypeDef{
+			"Item": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "updated_at", Type: "string", Format: "date-time"},
+				},
+			},
+		}
+
+		outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+		gen := New(apiSpec, outputDir)
+		gen.VisionSet = VisionTemplateSet{
+			Store: true,
+			Sync:  true,
+			Workflows: []string{
+				"workflows/pm_stale.go.tmpl",
+			},
+		}
+		require.NoError(t, gen.Generate())
+
+		// Behavioral: after init() runs, updated_at appears exactly once.
+		testPath := filepath.Join(outputDir, "internal", "cli", "pm_stale_dedup_test.go")
+		require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import "testing"
+
+func TestStaleTimestampFieldsDedup(t *testing.T) {
+	n := 0
+	for _, f := range staleTimestampFields {
+		if f == "updated_at" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("updated_at must appear exactly once after init merge, got %d", n)
+	}
+}
+`), 0o644))
+		runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestStaleTimestampFieldsDedup", "-count=1")
+	})
+
 	t.Run("keeps hardcoded fields and emits no init when no spec date-time names", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -35,6 +35,30 @@ var staleTimestampFields = []string{
 	"last_updated",
 }
 
+{{- if .SpecTimestampFields}}
+
+// init merges spec-declared date-time field names (format: date-time) into
+// staleTimestampFields, additively — the hardcoded entries above always win
+// order and are never removed, so APIs using updated_at keep current behavior
+// while APIs with a custom activity field (e.g. dateLastActivity) are covered.
+func init() {
+	seen := make(map[string]bool, len(staleTimestampFields))
+	for _, f := range staleTimestampFields {
+		seen[f] = true
+	}
+	for _, f := range []string{
+{{- range .SpecTimestampFields}}
+		{{printf "%q" .}},
+{{- end}}
+	} {
+		if !seen[f] {
+			staleTimestampFields = append(staleTimestampFields, f)
+			seen[f] = true
+		}
+	}
+}
+{{- end}}
+
 // buildStaleTimestampPredicate emits SQL clauses that match a row whose
 // modification timestamp is older than cutoff and sort rows by the
 // earliest non-null timestamp the row exposes.


### PR DESCRIPTION
## Intent

Issue: Fixes #1664

The generated `stale` command matched inactivity against a HARDCODED `staleTimestampFields` allowlist. APIs whose activity field isn't on the list (Trello cards use `dateLastActivity`) got a silently-empty `stale` result while the data was clearly stale.

## Approach

Build the stale field set as `hardcoded allowlist ∪ spec-declared date-time property names`, additive only. The generator collects property names declared `format: date-time` (across types, params, body, sub-resources; deduped, sorted) into `visionRenderData.SpecTimestampFields`. `pm_stale.go.tmpl` keeps its hardcoded literal unchanged and adds a conditional `init()` that appends only the spec fields not already present (hardcoded entries keep their order and are never removed — no regression for `updated_at` APIs). A superset of date-time field names is safe because the union is additive and the runtime scan simply won't find absent names on a row.

## Scope

Primary area: generator (`internal/generator/generator.go`, `internal/generator/templates/workflows/pm_stale.go.tmpl`). Machine change. Workflow templates now receive `visionRenderData` (which embeds `*spec.APISpec`, so existing `{{.Owner}}`/`{{.Name}}` references resolve unchanged — confirmed by golden suite showing no workflow-file drift).

## Risk

Low. Additive-only; the hardcoded list is untouched (so `TestStaleTemplateCoversCommonTimestampFields` still passes), and the `init()` is omitted entirely when the spec has no `date-time` fields.

## Output Contract

Generated `internal/cli/pm_stale.go` gains a conditional `init()` merge ONLY when the spec declares `date-time` fields. No golden fixture changed (the fixture specs have no `date-time` fields, so no `init()` is emitted and other workflow files are byte-identical). New unit test covers the positive (`dateLastActivity` merged) and negative (no spurious removals, no `init()`) cases.

## Verification

- `go build`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -short ./...` — all pass (incl. new `TestStaleWorkflowMergesSpecTimestampFields` and the existing `TestStaleTemplateCoversCommonTimestampFields`)
- `scripts/golden.sh verify` — passes unchanged

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change