### PR TITLE
fix(cli): render README narrative recipes

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -62,7 +62,7 @@ type QuickStartStep struct {
 	Comment string
 }
 
-// Recipe mirrors pipeline.Recipe for SKILL.md template rendering.
+// Recipe mirrors pipeline.Recipe for README/SKILL template rendering.
 type Recipe struct {
 	Title       string
 	Command     string

--- a/internal/generator/readme_test.go
+++ b/internal/generator/readme_test.go
@@ -165,6 +165,8 @@ func TestReadmeHandlesEmptyButPresentNarrative(t *testing.T) {
 		"empty AuthNarrative should not emit a dangling Authentication header")
 	assert.False(t, strings.Contains(content, "### API-specific"),
 		"empty Troubleshoots should not emit the API-specific subheading")
+	assert.False(t, strings.Contains(content, "## Recipes"),
+		"empty Recipes should not emit the Recipes section")
 	// Falls back to .Description since Headline is empty.
 	assert.True(t, strings.Contains(content, apiSpec.Description) ||
 		strings.Contains(content, "# Emptynarr CLI"),
@@ -475,6 +477,53 @@ func TestReadmeRendersNarrativeQuickStart(t *testing.T) {
 	// narrative quickstart takes over.
 	assert.False(t, strings.Contains(content, "### 1. Install"),
 		"generic numbered steps should be suppressed when narrative quickstart is present")
+}
+
+// TestReadmeRendersNarrativeRecipes asserts the README uses the same
+// narrative.recipes data that already feeds SKILL.md.
+func TestReadmeRendersNarrativeRecipes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("recipes")
+	outputDir := filepath.Join(t.TempDir(), "recipes-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		Recipes: []Recipe{
+			{
+				Title:       "Inspect stale items",
+				Command:     "recipes-pp-cli items list --stale --json",
+				Explanation: "Find items that need review before exporting a report.",
+			},
+			{
+				Title:       "Export a focused item list",
+				Command:     "recipes-pp-cli items list --json --select id,name,status",
+				Explanation: "Return only the fields an agent needs for follow-up work.",
+			},
+			{
+				Title:   "List item names",
+				Command: "recipes-pp-cli items list --json --select name",
+			},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	readme, err := os.ReadFile(filepath.Join(outputDir, "README.md"))
+	require.NoError(t, err)
+	content := string(readme)
+
+	recipesIdx := strings.Index(content, "\n## Recipes\n")
+	require.NotEqual(t, -1, recipesIdx, "Recipes section should render when narrative recipes are present")
+	usageIdx := strings.Index(content[recipesIdx:], "\n## Usage\n")
+	require.NotEqual(t, -1, usageIdx, "Recipes section should appear before Usage")
+	recipesSection := content[recipesIdx : recipesIdx+usageIdx]
+	assert.Contains(t, recipesSection, "### Inspect stale items\n\n```bash\nrecipes-pp-cli items list --stale --json\n```\n\nFind items that need review before exporting a report.",
+		"first recipe should render title, fenced command, and explanation")
+	assert.Contains(t, recipesSection, "### Export a focused item list\n\n```bash\nrecipes-pp-cli items list --json --select id,name,status\n```\n\nReturn only the fields an agent needs for follow-up work.",
+		"second recipe should render title, fenced command, and explanation")
+	assert.Contains(t, recipesSection, "### List item names\n\n```bash\nrecipes-pp-cli items list --json --select name\n```",
+		"recipe without explanation should still render title and fenced command")
+	assert.NotContains(t, recipesSection, "### List item names\n\n```bash\nrecipes-pp-cli items list --json --select name\n```\n\n<",
+		"recipe without explanation should not render placeholder prose")
 }
 
 // TestReadmeAppendsNarrativeTroubleshoots asserts the Troubleshooting

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -323,6 +323,22 @@ These capabilities aren't available in any other tool for this API.
 {{- end}}
 {{- end}}
 {{- end}}
+{{- if and .Narrative .Narrative.Recipes}}
+
+## Recipes
+{{range .Narrative.Recipes}}
+
+### {{.Title}}
+
+```bash
+{{.Command}}
+```
+{{- if .Explanation}}
+
+{{.Explanation}}
+{{- end}}
+{{- end}}
+{{- end}}
 
 ## Usage
 

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -115,8 +115,8 @@ type QuickStartStep struct {
 	Comment string `json:"comment,omitempty"`
 }
 
-// Recipe is a worked example for SKILL.md. Title is rendered as a heading,
-// Command as a fenced code block, Explanation as a paragraph beneath.
+// Recipe is a worked example for README and SKILL.md. Title is rendered as a
+// heading, Command as a fenced code block, Explanation as a paragraph beneath.
 type Recipe struct {
 	Title       string `json:"title"`
 	Command     string `json:"command"`

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -97,7 +97,7 @@ type ReadmeNarrative struct {
 	// WhenToUse is a 2–4 sentence narrative rendered in SKILL.md describing
 	// the CLI's ideal use cases. Not rendered in README.
 	WhenToUse string `json:"when_to_use,omitempty"`
-	// Recipes are worked examples rendered in SKILL.md's Recipes section.
+	// Recipes are worked examples rendered in README/SKILL Recipes sections.
 	// Each recipe is a titled command with an explanation.
 	Recipes []Recipe `json:"recipes,omitempty"`
 	// TriggerPhrases are natural-language phrases that should invoke this

--- a/internal/pipeline/scorecard_readme_test.go
+++ b/internal/pipeline/scorecard_readme_test.go
@@ -1,0 +1,85 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScoreREADMEAwardsTwoPointBonusForRecipesSection(t *testing.T) {
+	t.Parallel()
+
+	withoutRecipes := t.TempDir()
+	writeScorecardFixture(t, withoutRecipes, "README.md", `# Recipe Score CLI
+
+Review item status before follow-up work.
+
+## Quick Start
+
+`+"```bash"+`
+recipe-score-pp-cli items list
+`+"```"+`
+
+## Agent Usage
+
+Use --json and --agent for non-interactive operation.
+
+## Health Check
+
+`+"```bash"+`
+recipe-score-pp-cli doctor
+`+"```"+`
+
+## Troubleshooting
+
+Run doctor before retrying commands.
+`)
+
+	withRecipes := t.TempDir()
+	writeScorecardFixture(t, withRecipes, "README.md", `# Recipe Score CLI
+
+Review item status before follow-up work.
+
+## Quick Start
+
+`+"```bash"+`
+recipe-score-pp-cli items list
+`+"```"+`
+
+## Agent Usage
+
+Use --json and --agent for non-interactive operation.
+
+## Health Check
+
+`+"```bash"+`
+recipe-score-pp-cli doctor
+`+"```"+`
+
+## Troubleshooting
+
+Run doctor before retrying commands.
+
+## Recipes
+
+### Review stale items
+
+`+"```bash"+`
+recipe-score-pp-cli items list --json --select id,status
+`+"```"+`
+
+### Export item names
+
+`+"```bash"+`
+recipe-score-pp-cli items list --json --select id,name
+`+"```"+`
+
+### Inspect one item
+
+`+"```bash"+`
+recipe-score-pp-cli items get --id item_123 --json
+`+"```"+`
+`)
+
+	assert.Equal(t, scoreREADME(withoutRecipes)+2, scoreREADME(withRecipes))
+}


### PR DESCRIPTION
## Summary

Generated README output now includes a `## Recipes` section whenever `narrative.recipes` is populated, so recipe workflows are visible in both human-facing docs and the bundled SKILL surface. Empty or absent recipe narratives still emit no Recipes section.

This fixes the README score gap behind issue #1562 by satisfying the existing `scoreREADME` Recipes/Cookbook bonus from generate-time output instead of relying on post-generation edits.

Closes #1562

## Scope

- Render each narrative recipe as a titled README subsection with one fenced command and optional explanation prose.
- Keep SKILL.md behavior unchanged.
- Update narrative field comments so they no longer describe recipes as SKILL-only.

Deferred: I did not extract a shared README/SKILL recipe partial in this patch. The current generator parses entry templates independently, and introducing shared template machinery would broaden this issue beyond the missing README emission.

## Published Library Coordination

This changes canonical generated README shape. Downstream sweep tracking issue: mvanhorn/printing-press-library#782.

## Verification

- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...` (`0 issues`; same stale sibling-worktree warning as local baseline)
