### PR TITLE
fix(cli): skip JSON cache for binary responses

### DIFF
--- a/internal/generator/client_binary_cache_test.go
+++ b/internal/generator/client_binary_cache_test.go
@@ -1,0 +1,128 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientBinaryResponseHeaderBypassesJSONCache(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("binary-cache")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const behaviorTest = `package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"binary-cache-pp-cli/internal/config"
+)
+
+func TestBinaryResponseHeaderBypassesJSONCache(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte{0x1f, 0x8b, 0x08, 0x00})
+	}))
+	defer server.Close()
+
+	c := New(&config.Config{BaseURL: server.URL}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	headers := map[string]string{BinaryResponseHeader: "true"}
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, headers); err != nil {
+		t.Fatalf("first binary GetWithHeaders returned error: %v", err)
+	}
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, headers); err != nil {
+		t.Fatalf("second binary GetWithHeaders returned error: %v", err)
+	}
+	if _, err := c.GetWithHeadersNoCache(context.Background(), "/blob", nil, headers); err != nil {
+		t.Fatalf("binary GetWithHeadersNoCache returned error: %v", err)
+	}
+	if seen != 3 {
+		t.Fatalf("server saw %d requests, want 3 because binary responses bypass cache reads and writes", seen)
+	}
+	if matches, err := filepath.Glob(filepath.Join(c.cacheDir, "*.json")); err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	} else if len(matches) != 0 {
+		t.Fatalf("binary response wrote JSON cache files: %v", matches)
+	}
+}
+
+func TestConfigBinaryResponseHeaderBypassesJSONCache(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte{0x1f, 0x8b, 0x08, 0x00})
+	}))
+	defer server.Close()
+
+	c := New(&config.Config{
+		BaseURL: server.URL,
+		Headers: map[string]string{
+			BinaryResponseHeader: "true",
+		},
+	}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, nil); err != nil {
+		t.Fatalf("first config-header binary GetWithHeaders returned error: %v", err)
+	}
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, nil); err != nil {
+		t.Fatalf("second config-header binary GetWithHeaders returned error: %v", err)
+	}
+	if seen != 2 {
+		t.Fatalf("server saw %d requests, want 2 because config binary responses bypass cache", seen)
+	}
+	if matches, err := filepath.Glob(filepath.Join(c.cacheDir, "*.json")); err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	} else if len(matches) != 0 {
+		t.Fatalf("config binary response wrote JSON cache files: %v", matches)
+	}
+}
+
+func TestJSONResponseStillUsesJSONCache(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	defer server.Close()
+
+	c := New(&config.Config{BaseURL: server.URL}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	if _, err := c.GetWithHeaders(context.Background(), "/items", nil, nil); err != nil {
+		t.Fatalf("first JSON GetWithHeaders returned error: %v", err)
+	}
+	if _, err := c.GetWithHeaders(context.Background(), "/items", nil, nil); err != nil {
+		t.Fatalf("second JSON GetWithHeaders returned error: %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("server saw %d requests, want 1 because JSON response should be cached", seen)
+	}
+	if matches, err := filepath.Glob(filepath.Join(c.cacheDir, "*.json")); err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	} else if len(matches) != 1 {
+		t.Fatalf("JSON response wrote %d cache files, want 1: %v", len(matches), matches)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "binary_cache_test.go"), []byte(behaviorTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/client")
+}

--- a/internal/generator/client_binary_cache_test.go
+++ b/internal/generator/client_binary_cache_test.go
@@ -84,13 +84,53 @@ func TestConfigBinaryResponseHeaderBypassesJSONCache(t *testing.T) {
 	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, nil); err != nil {
 		t.Fatalf("second config-header binary GetWithHeaders returned error: %v", err)
 	}
-	if seen != 2 {
-		t.Fatalf("server saw %d requests, want 2 because config binary responses bypass cache", seen)
+	if _, err := c.GetWithHeadersNoCache(context.Background(), "/blob", nil, nil); err != nil {
+		t.Fatalf("config-header binary GetWithHeadersNoCache returned error: %v", err)
+	}
+	if seen != 3 {
+		t.Fatalf("server saw %d requests, want 3 because config binary responses bypass cache", seen)
 	}
 	if matches, err := filepath.Glob(filepath.Join(c.cacheDir, "*.json")); err != nil {
 		t.Fatalf("glob cache files: %v", err)
 	} else if len(matches) != 0 {
 		t.Fatalf("config binary response wrote JSON cache files: %v", matches)
+	}
+}
+
+func TestCaseVariantBinaryResponseHeadersAreDeterministic(t *testing.T) {
+	var seen int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen++
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte{0x1f, 0x8b, 0x08, 0x00})
+	}))
+	defer server.Close()
+
+	c := New(&config.Config{
+		BaseURL: server.URL,
+		Headers: map[string]string{
+			BinaryResponseHeader:               "false",
+			"x-printing-press-binary-response": "true",
+		},
+	}, time.Second, 0)
+	c.cacheDir = t.TempDir()
+
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, nil); err != nil {
+		t.Fatalf("case-variant config binary GetWithHeaders returned error: %v", err)
+	}
+	if _, err := c.GetWithHeaders(context.Background(), "/blob", nil, map[string]string{
+		BinaryResponseHeader:               "false",
+		"x-printing-press-binary-response": "true",
+	}); err != nil {
+		t.Fatalf("case-variant call binary GetWithHeaders returned error: %v", err)
+	}
+	if seen != 2 {
+		t.Fatalf("server saw %d requests, want 2 because case-variant binary headers bypass cache", seen)
+	}
+	if matches, err := filepath.Glob(filepath.Join(c.cacheDir, "*.json")); err != nil {
+		t.Fatalf("glob cache files: %v", err)
+	} else if len(matches) != 0 {
+		t.Fatalf("case-variant binary response wrote JSON cache files: %v", matches)
 	}
 }
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -485,8 +485,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
+	binaryResponse := c.wantsBinaryResponse(headers)
+	cacheEnabled := c.responseCacheEnabled(binaryResponse)
 	// Check cache for GET requests
-	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if cacheEnabled {
 {{- if .HasHTMLExtraction}}
 		if cached, contentType, ok := c.readCache(path, params); ok {
 			c.lastContentType = contentType
@@ -499,7 +501,7 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	{{- end}}
 	}
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && cacheEnabled {
 		c.writeCache(path, params, result{{if .HasHTMLExtraction}}, c.lastContentType{{end}})
 	}
 	return result, err
@@ -518,15 +520,39 @@ func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]
 	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
-// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
-// still writes the fresh response on success. See GetNoCache for when to
+// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but still
+// writes cacheable fresh responses on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
 func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	binaryResponse := c.wantsBinaryResponse(headers)
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && c.responseCacheEnabled(binaryResponse) {
 		c.writeCache(path, params, result{{if .HasHTMLExtraction}}, c.lastContentType{{end}})
 	}
 	return result, err
+}
+
+func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
+	return !binaryResponse && !c.NoCache && !c.DryRun && c.cacheDir != ""
+}
+
+// The response cache stores text/JSON bodies as <hash>.json. Binary callers
+// opt out so opaque blobs do not land under a misleading extension.
+func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
+	binaryResponse := false
+	if c != nil && c.Config != nil {
+		for k, v := range c.Config.Headers {
+			if strings.EqualFold(k, BinaryResponseHeader) {
+				binaryResponse = strings.EqualFold(v, "true")
+			}
+		}
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			binaryResponse = strings.EqualFold(v, "true")
+		}
+	}
+	return binaryResponse
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -541,18 +541,27 @@ func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
 func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
 	binaryResponse := false
 	if c != nil && c.Config != nil {
-		for k, v := range c.Config.Headers {
-			if strings.EqualFold(k, BinaryResponseHeader) {
-				binaryResponse = strings.EqualFold(v, "true")
+		if value, ok := binaryResponseHeaderValue(c.Config.Headers); ok {
+			binaryResponse = value
+		}
+	}
+	if value, ok := binaryResponseHeaderValue(headers); ok {
+		binaryResponse = value
+	}
+	return binaryResponse
+}
+
+func binaryResponseHeaderValue(headers map[string]string) (bool, bool) {
+	found := false
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			found = true
+			if strings.EqualFold(v, "true") {
+				return true, true
 			}
 		}
 	}
-	for k, v := range headers {
-		if strings.EqualFold(k, BinaryResponseHeader) {
-			binaryResponse = strings.EqualFold(v, "true")
-		}
-	}
-	return binaryResponse
+	return false, found
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -164,18 +164,27 @@ func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
 func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
 	binaryResponse := false
 	if c != nil && c.Config != nil {
-		for k, v := range c.Config.Headers {
-			if strings.EqualFold(k, BinaryResponseHeader) {
-				binaryResponse = strings.EqualFold(v, "true")
+		if value, ok := binaryResponseHeaderValue(c.Config.Headers); ok {
+			binaryResponse = value
+		}
+	}
+	if value, ok := binaryResponseHeaderValue(headers); ok {
+		binaryResponse = value
+	}
+	return binaryResponse
+}
+
+func binaryResponseHeaderValue(headers map[string]string) (bool, bool) {
+	found := false
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			found = true
+			if strings.EqualFold(v, "true") {
+				return true, true
 			}
 		}
 	}
-	for k, v := range headers {
-		if strings.EqualFold(k, BinaryResponseHeader) {
-			binaryResponse = strings.EqualFold(v, "true")
-		}
-	}
-	return binaryResponse
+	return false, found
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -115,14 +115,16 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
+	binaryResponse := c.wantsBinaryResponse(headers)
+	cacheEnabled := c.responseCacheEnabled(binaryResponse)
 	// Check cache for GET requests
-	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if cacheEnabled {
 		if cached, ok := c.readCache(path, params); ok {
 			return cached, nil
 		}
 	}
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && cacheEnabled {
 		c.writeCache(path, params, result)
 	}
 	return result, err
@@ -141,15 +143,39 @@ func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]
 	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
-// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
-// still writes the fresh response on success. See GetNoCache for when to
+// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but still
+// writes cacheable fresh responses on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
 func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	binaryResponse := c.wantsBinaryResponse(headers)
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && c.responseCacheEnabled(binaryResponse) {
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
+	return !binaryResponse && !c.NoCache && !c.DryRun && c.cacheDir != ""
+}
+
+// The response cache stores text/JSON bodies as <hash>.json. Binary callers
+// opt out so opaque blobs do not land under a misleading extension.
+func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
+	binaryResponse := false
+	if c != nil && c.Config != nil {
+		for k, v := range c.Config.Headers {
+			if strings.EqualFold(k, BinaryResponseHeader) {
+				binaryResponse = strings.EqualFold(v, "true")
+			}
+		}
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			binaryResponse = strings.EqualFold(v, "true")
+		}
+	}
+	return binaryResponse
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -110,14 +110,16 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
+	binaryResponse := c.wantsBinaryResponse(headers)
+	cacheEnabled := c.responseCacheEnabled(binaryResponse)
 	// Check cache for GET requests
-	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if cacheEnabled {
 		if cached, ok := c.readCache(path, params); ok {
 			return cached, nil
 		}
 	}
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && cacheEnabled {
 		c.writeCache(path, params, result)
 	}
 	return result, err
@@ -136,15 +138,39 @@ func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]
 	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
-// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
-// still writes the fresh response on success. See GetNoCache for when to
+// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but still
+// writes cacheable fresh responses on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
 func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	binaryResponse := c.wantsBinaryResponse(headers)
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && c.responseCacheEnabled(binaryResponse) {
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
+	return !binaryResponse && !c.NoCache && !c.DryRun && c.cacheDir != ""
+}
+
+// The response cache stores text/JSON bodies as <hash>.json. Binary callers
+// opt out so opaque blobs do not land under a misleading extension.
+func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
+	binaryResponse := false
+	if c != nil && c.Config != nil {
+		for k, v := range c.Config.Headers {
+			if strings.EqualFold(k, BinaryResponseHeader) {
+				binaryResponse = strings.EqualFold(v, "true")
+			}
+		}
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			binaryResponse = strings.EqualFold(v, "true")
+		}
+	}
+	return binaryResponse
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -159,18 +159,27 @@ func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
 func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
 	binaryResponse := false
 	if c != nil && c.Config != nil {
-		for k, v := range c.Config.Headers {
-			if strings.EqualFold(k, BinaryResponseHeader) {
-				binaryResponse = strings.EqualFold(v, "true")
+		if value, ok := binaryResponseHeaderValue(c.Config.Headers); ok {
+			binaryResponse = value
+		}
+	}
+	if value, ok := binaryResponseHeaderValue(headers); ok {
+		binaryResponse = value
+	}
+	return binaryResponse
+}
+
+func binaryResponseHeaderValue(headers map[string]string) (bool, bool) {
+	found := false
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			found = true
+			if strings.EqualFold(v, "true") {
+				return true, true
 			}
 		}
 	}
-	for k, v := range headers {
-		if strings.EqualFold(k, BinaryResponseHeader) {
-			binaryResponse = strings.EqualFold(v, "true")
-		}
-	}
-	return binaryResponse
+	return false, found
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -206,14 +206,16 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	if err := c.validateCachedRequestAuth(ctx); err != nil {
 		return nil, err
 	}
+	binaryResponse := c.wantsBinaryResponse(headers)
+	cacheEnabled := c.responseCacheEnabled(binaryResponse)
 	// Check cache for GET requests
-	if !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if cacheEnabled {
 		if cached, ok := c.readCache(path, params); ok {
 			return cached, nil
 		}
 	}
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && cacheEnabled {
 		c.writeCache(path, params, result)
 	}
 	return result, err
@@ -232,15 +234,39 @@ func (c *Client) GetNoCache(ctx context.Context, path string, params map[string]
 	return c.GetWithHeadersNoCache(ctx, path, params, nil)
 }
 
-// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but
-// still writes the fresh response on success. See GetNoCache for when to
+// GetWithHeadersNoCache is GetWithHeaders that skips the cache read but still
+// writes cacheable fresh responses on success. See GetNoCache for when to
 // prefer this over Get/GetWithHeaders.
 func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error) {
+	binaryResponse := c.wantsBinaryResponse(headers)
 	result, _, err := c.do(ctx, "GET", path, params, nil, headers)
-	if err == nil && !c.NoCache && !c.DryRun && c.cacheDir != "" {
+	if err == nil && c.responseCacheEnabled(binaryResponse) {
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
+	return !binaryResponse && !c.NoCache && !c.DryRun && c.cacheDir != ""
+}
+
+// The response cache stores text/JSON bodies as <hash>.json. Binary callers
+// opt out so opaque blobs do not land under a misleading extension.
+func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
+	binaryResponse := false
+	if c != nil && c.Config != nil {
+		for k, v := range c.Config.Headers {
+			if strings.EqualFold(k, BinaryResponseHeader) {
+				binaryResponse = strings.EqualFold(v, "true")
+			}
+		}
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			binaryResponse = strings.EqualFold(v, "true")
+		}
+	}
+	return binaryResponse
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -255,18 +255,27 @@ func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
 func (c *Client) wantsBinaryResponse(headers map[string]string) bool {
 	binaryResponse := false
 	if c != nil && c.Config != nil {
-		for k, v := range c.Config.Headers {
-			if strings.EqualFold(k, BinaryResponseHeader) {
-				binaryResponse = strings.EqualFold(v, "true")
+		if value, ok := binaryResponseHeaderValue(c.Config.Headers); ok {
+			binaryResponse = value
+		}
+	}
+	if value, ok := binaryResponseHeaderValue(headers); ok {
+		binaryResponse = value
+	}
+	return binaryResponse
+}
+
+func binaryResponseHeaderValue(headers map[string]string) (bool, bool) {
+	found := false
+	for k, v := range headers {
+		if strings.EqualFold(k, BinaryResponseHeader) {
+			found = true
+			if strings.EqualFold(v, "true") {
+				return true, true
 			}
 		}
 	}
-	for k, v := range headers {
-		if strings.EqualFold(k, BinaryResponseHeader) {
-			binaryResponse = strings.EqualFold(v, "true")
-		}
-	}
-	return binaryResponse
+	return false, found
 }
 
 func (c *Client) validateCachedRequestAuth(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Binary response requests no longer read from or write to the generated client's `.json` response cache. The cache decision now follows the same effective `X-Printing-Press-Binary-Response` header precedence used by the request path, so per-call and configured binary sentinels both bypass misleading JSON cache files while normal JSON GETs still cache as before.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1557
