### PR TITLE
fix(cli): sync narrative docs after dogfood

### DIFF
--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -17,6 +17,77 @@ type syncedArtifact struct {
 	Detail string
 }
 
+// SyncCLINarrativeDocs rewrites generated README/SKILL narrative blocks from
+// the current research.json narrative. Empty narrative fields remove only the
+// narrative-owned subsections; generic fallback prose is left intact.
+func SyncCLINarrativeDocs(dir, apiName string, narrative *ReadmeNarrative) ([]syncedArtifact, error) {
+	if narrative == nil {
+		return nil, nil
+	}
+
+	var synced []syncedArtifact
+	if len(narrative.QuickStart) > 0 {
+		changed, err := syncMarkdownFeatureSection(
+			filepath.Join(dir, "README.md"),
+			"## Quick Start",
+			renderQuickStartSection(narrative.QuickStart),
+			[]string{"## Unique Features", "## Usage"},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			synced = append(synced, syncedArtifact{Path: "README.md", Detail: "Quick Start"})
+		}
+	}
+
+	if strings.TrimSpace(narrative.AuthNarrative) != "" {
+		changed, err := syncReadmeAuthNarrative(filepath.Join(dir, "README.md"), narrative.AuthNarrative)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			synced = append(synced, syncedArtifact{Path: "README.md", Detail: "Authentication"})
+		}
+
+		changed, err = syncMarkdownFeatureSection(
+			filepath.Join(dir, "SKILL.md"),
+			"## Auth Setup",
+			renderSkillAuthSetupSection(apiName, narrative.AuthNarrative),
+			[]string{"## Agent Mode", "## Command Reference"},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			synced = append(synced, syncedArtifact{Path: "SKILL.md", Detail: "Auth Setup"})
+		}
+	}
+
+	changed, err := syncReadmeTroubleshoots(filepath.Join(dir, "README.md"), narrative.Troubleshoots)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		synced = append(synced, syncedArtifact{Path: "README.md", Detail: "Troubleshooting"})
+	}
+
+	changed, err = syncMarkdownFeatureSection(
+		filepath.Join(dir, "SKILL.md"),
+		"## Recipes",
+		renderRecipesSection(narrative.Recipes),
+		[]string{"## Auth Setup", "## Agent Mode", "## Command Reference"},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		synced = append(synced, syncedArtifact{Path: "SKILL.md", Detail: "Recipes"})
+	}
+
+	return synced, nil
+}
+
 // SyncCLITranscendenceDocs rewrites generated README/SKILL transcendence
 // blocks from dogfood-verified features. Empty verified sets remove the blocks.
 func SyncCLITranscendenceDocs(dir string, features []NovelFeature) ([]syncedArtifact, error) {
@@ -49,6 +120,106 @@ func SyncCLITranscendenceDocs(dir string, features []NovelFeature) ([]syncedArti
 	return synced, nil
 }
 
+func syncReadmeAuthNarrative(path, authNarrative string) (bool, error) {
+	return syncMarkdownFile(path, func(content string) string {
+		heading := "## Authentication"
+		if findMarkdownHeading(content, "## Optional: API Key") >= 0 {
+			heading = "## Optional: API Key"
+		}
+		return replaceMarkdownSection(content, heading, renderAuthNarrativeSection(heading, authNarrative), []string{"## Quick Start"})
+	})
+}
+
+func syncReadmeTroubleshoots(path string, troubleshoots []TroubleshootTip) (bool, error) {
+	return syncMarkdownFile(path, func(content string) string {
+		return replaceMarkdownSubsection(content, "## Troubleshooting", "### API-specific", renderTroubleshootSubsection(troubleshoots))
+	})
+}
+
+func renderQuickStartSection(steps []QuickStartStep) string {
+	if len(steps) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Quick Start\n\n```bash\n")
+	for _, step := range steps {
+		if step.Comment != "" {
+			b.WriteString("# ")
+			b.WriteString(step.Comment)
+			b.WriteString("\n")
+		}
+		b.WriteString(step.Command)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("```")
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderAuthNarrativeSection(heading, authNarrative string) string {
+	authNarrative = strings.TrimSpace(authNarrative)
+	if authNarrative == "" {
+		return ""
+	}
+	if heading == "## Optional: API Key" {
+		return heading + "\n\n**All core commands work without setup.** The API key below is only needed to unlock additional features.\n\n" + authNarrative
+	}
+	return heading + "\n\n" + authNarrative
+}
+
+func renderSkillAuthSetupSection(apiName, authNarrative string) string {
+	authNarrative = strings.TrimSpace(authNarrative)
+	if authNarrative == "" {
+		return ""
+	}
+	cliName := strings.TrimSpace(apiName)
+	if cliName == "" {
+		cliName = "<cli>"
+	} else if !strings.HasSuffix(cliName, "-pp-cli") {
+		cliName += "-pp-cli"
+	}
+	return "## Auth Setup\n\n" + authNarrative + "\n\nRun `" + cliName + " doctor` to verify setup."
+}
+
+func renderTroubleshootSubsection(troubleshoots []TroubleshootTip) string {
+	if len(troubleshoots) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("### API-specific\n")
+	for _, tip := range troubleshoots {
+		b.WriteString("- **")
+		b.WriteString(tip.Symptom)
+		b.WriteString("** \u2014 ")
+		b.WriteString(tip.Fix)
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderRecipesSection(recipes []Recipe) string {
+	if len(recipes) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Recipes\n")
+	for _, recipe := range recipes {
+		b.WriteString("\n### ")
+		b.WriteString(recipe.Title)
+		b.WriteString("\n\n```bash\n")
+		b.WriteString(recipe.Command)
+		b.WriteString("\n```")
+		if recipe.Explanation != "" {
+			b.WriteString("\n\n")
+			b.WriteString(recipe.Explanation)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
 // SyncCLIRootHighlights rewrites root --help Highlights from dogfood-verified
 // features. It edits only the generated Long-string section so hand-authored
 // command registration changes in root.go are left intact.
@@ -72,6 +243,12 @@ func SyncCLIRootHighlights(dir string, features []NovelFeature) (bool, error) {
 }
 
 func syncMarkdownFeatureSection(path, heading, replacement string, insertBefore []string) (bool, error) {
+	return syncMarkdownFile(path, func(content string) string {
+		return replaceMarkdownSection(content, heading, replacement, insertBefore)
+	})
+}
+
+func syncMarkdownFile(path string, rewrite func(string) string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -80,8 +257,9 @@ func syncMarkdownFeatureSection(path, heading, replacement string, insertBefore 
 		return false, fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	updated := replaceMarkdownSection(string(data), heading, replacement, insertBefore)
-	if updated == string(data) {
+	content := string(data)
+	updated := rewrite(content)
+	if updated == content {
 		return false, nil
 	}
 	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
@@ -198,6 +376,25 @@ func replaceMarkdownSection(content, heading, replacement string, insertBefore [
 	return joinMarkdownParts(content[:insertAt], replacement, content[insertAt:])
 }
 
+func replaceMarkdownSubsection(content, parentHeading, subsectionHeading, replacement string) string {
+	parentStart := findMarkdownHeading(content, parentHeading)
+	if parentStart < 0 {
+		return content
+	}
+
+	parentEnd := findNextLevelTwoHeading(content, parentStart+len(parentHeading))
+	subStart := findMarkdownHeadingInRange(content, subsectionHeading, parentStart+len(parentHeading), parentEnd)
+	if subStart >= 0 {
+		subEnd := findNextMarkdownHeadingAtMost(content, subStart+len(subsectionHeading), 3, parentEnd)
+		return joinMarkdownParts(content[:subStart], replacement, content[subEnd:])
+	}
+
+	if strings.TrimSpace(replacement) == "" {
+		return content
+	}
+	return joinMarkdownParts(content[:parentEnd], replacement, content[parentEnd:])
+}
+
 func joinMarkdownParts(prefix, middle, suffix string) string {
 	prefix = strings.TrimRight(prefix, "\n")
 	middle = strings.Trim(middle, "\n")
@@ -227,31 +424,117 @@ func joinMarkdownParts(prefix, middle, suffix string) string {
 }
 
 func findMarkdownHeading(content, heading string) int {
-	offset := 0
-	for {
-		idx := strings.Index(content[offset:], heading)
-		if idx == -1 {
-			return -1
+	for _, candidate := range markdownHeadings(content, 0, len(content), 1, 6) {
+		if candidate.Text == heading {
+			return candidate.Start
 		}
-		idx += offset
-		beforeOK := idx == 0 || content[idx-1] == '\n'
-		after := idx + len(heading)
-		afterOK := after == len(content) || content[after] == '\n' || content[after] == '\r'
-		if beforeOK && afterOK {
-			return idx
-		}
-		offset = idx + len(heading)
 	}
+	return -1
+}
+
+func findMarkdownHeadingInRange(content, heading string, start, end int) int {
+	for _, candidate := range markdownHeadings(content, start, end, 1, 6) {
+		if candidate.Text == heading {
+			return candidate.Start
+		}
+	}
+	return -1
 }
 
 func findNextLevelTwoHeading(content string, after int) int {
-	if after >= len(content) {
-		return len(content)
-	}
-	if idx := strings.Index(content[after:], "\n## "); idx >= 0 {
-		return after + idx + 1
+	if heading := firstMarkdownHeading(content, after, len(content), 2, 2); heading.Start >= 0 {
+		return heading.Start
 	}
 	return len(content)
+}
+
+func findNextMarkdownHeadingAtMost(content string, after, maxLevel, limit int) int {
+	if heading := firstMarkdownHeading(content, after, limit, 1, maxLevel); heading.Start >= 0 {
+		return heading.Start
+	}
+	if limit > len(content) {
+		return len(content)
+	}
+	return limit
+}
+
+type markdownHeading struct {
+	Start int
+	Level int
+	Text  string
+}
+
+func firstMarkdownHeading(content string, start, end, minLevel, maxLevel int) markdownHeading {
+	for _, heading := range markdownHeadings(content, start, end, minLevel, maxLevel) {
+		return heading
+	}
+	return markdownHeading{Start: -1}
+}
+
+func markdownHeadings(content string, start, end, minLevel, maxLevel int) []markdownHeading {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(content) {
+		end = len(content)
+	}
+	if start > end {
+		return nil
+	}
+
+	var headings []markdownHeading
+	inFence := false
+	fenceMarker := ""
+	for lineStart := 0; lineStart < len(content); {
+		lineEnd := strings.IndexByte(content[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(content)
+		} else {
+			lineEnd += lineStart
+		}
+
+		if lineStart >= end {
+			break
+		}
+
+		line := content[lineStart:lineEnd]
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			marker := trimmed[:3]
+			if !inFence {
+				inFence = true
+				fenceMarker = marker
+			} else if marker == fenceMarker {
+				inFence = false
+				fenceMarker = ""
+			}
+		} else if !inFence && lineStart >= start {
+			if heading, ok := parseMarkdownHeading(line, lineStart, minLevel, maxLevel); ok {
+				headings = append(headings, heading)
+			}
+		}
+
+		if lineEnd == len(content) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return headings
+}
+
+func parseMarkdownHeading(line string, start, minLevel, maxLevel int) (markdownHeading, bool) {
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level < minLevel || level > maxLevel || level >= len(line) || line[level] != ' ' {
+		return markdownHeading{}, false
+	}
+	return markdownHeading{
+		Start: start,
+		Level: level,
+		Text:  strings.TrimRight(line, " \t\r"),
+	}, true
 }
 
 const rootHighlightsHeading = "Highlights (not in the official API docs):"

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -123,10 +123,16 @@ func SyncCLITranscendenceDocs(dir string, features []NovelFeature) ([]syncedArti
 func syncReadmeAuthNarrative(path, authNarrative string) (bool, error) {
 	return syncMarkdownFile(path, func(content string) string {
 		heading := "## Authentication"
+		staleHeading := ""
 		if findMarkdownHeading(content, "## Optional: API Key") >= 0 {
 			heading = "## Optional: API Key"
+			staleHeading = "## Authentication"
 		}
-		return replaceMarkdownSection(content, heading, renderAuthNarrativeSection(heading, authNarrative), []string{"## Quick Start"})
+		content = replaceMarkdownSection(content, heading, renderAuthNarrativeSection(heading, authNarrative), []string{"## Quick Start"})
+		if staleHeading != "" {
+			content = replaceMarkdownSection(content, staleHeading, "", nil)
+		}
+		return content
 	})
 }
 
@@ -178,7 +184,24 @@ func renderSkillAuthSetupSection(apiName, authNarrative string) string {
 	} else if !strings.HasSuffix(cliName, "-pp-cli") {
 		cliName += "-pp-cli"
 	}
+	if authNarrativeMentionsDoctor(authNarrative, cliName) {
+		return "## Auth Setup\n\n" + authNarrative
+	}
 	return "## Auth Setup\n\n" + authNarrative + "\n\nRun `" + cliName + " doctor` to verify setup."
+}
+
+func authNarrativeMentionsDoctor(authNarrative, cliName string) bool {
+	lower := strings.ToLower(authNarrative)
+	cliName = strings.ToLower(strings.TrimSpace(cliName))
+	for _, candidate := range []string{
+		"`" + cliName + " doctor`",
+		"`<cli> doctor`",
+	} {
+		if strings.Contains(lower, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func renderTroubleshootSubsection(troubleshoots []TroubleshootTip) string {
@@ -499,12 +522,11 @@ func markdownHeadings(content string, start, end, minLevel, maxLevel int) []mark
 
 		line := content[lineStart:lineEnd]
 		trimmed := strings.TrimLeft(line, " \t")
-		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			marker := trimmed[:3]
+		if marker, ok := markdownFenceMarker(trimmed); ok {
 			if !inFence {
 				inFence = true
 				fenceMarker = marker
-			} else if marker == fenceMarker {
+			} else if marker[0] == fenceMarker[0] && len(marker) >= len(fenceMarker) {
 				inFence = false
 				fenceMarker = ""
 			}
@@ -520,6 +542,24 @@ func markdownHeadings(content string, start, end, minLevel, maxLevel int) []mark
 		lineStart = lineEnd + 1
 	}
 	return headings
+}
+
+func markdownFenceMarker(trimmedLine string) (string, bool) {
+	if len(trimmedLine) < 3 {
+		return "", false
+	}
+	ch := trimmedLine[0]
+	if ch != '`' && ch != '~' {
+		return "", false
+	}
+	end := 1
+	for end < len(trimmedLine) && trimmedLine[end] == ch {
+		end++
+	}
+	if end < 3 {
+		return "", false
+	}
+	return trimmedLine[:end], true
 }
 
 func parseMarkdownHeading(line string, start, minLevel, maxLevel int) (markdownHeading, bool) {

--- a/internal/pipeline/docsync_test.go
+++ b/internal/pipeline/docsync_test.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncReadmeAuthNarrativeRemovesStaleAuthenticationWhenOptionalExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(path, []byte(strings.Join([]string{
+		"# Example",
+		"",
+		"## Optional: API Key",
+		"",
+		"Old optional setup.",
+		"",
+		"## Authentication",
+		"",
+		"Old required setup.",
+		"",
+		"## Quick Start",
+		"",
+		"Run the CLI.",
+		"",
+	}, "\n")), 0o600))
+
+	changed, err := syncReadmeAuthNarrative(path, "Use `example-pp-cli oauth-token` for protected calls.")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	readme := string(data)
+	assert.Contains(t, readme, "## Optional: API Key\n\n**All core commands work without setup.**")
+	assert.Contains(t, readme, "Use `example-pp-cli oauth-token` for protected calls.")
+	assert.NotContains(t, readme, "## Authentication")
+	assert.NotContains(t, readme, "Old required setup.")
+	assert.Contains(t, readme, "## Quick Start")
+}
+
+func TestRenderSkillAuthSetupSectionDoesNotDuplicateDoctorInstruction(t *testing.T) {
+	section := renderSkillAuthSetupSection(
+		"test",
+		"Use `test-pp-cli oauth-token` before protected calls.\n\nRun `test-pp-cli doctor` to verify setup.",
+	)
+
+	assert.Equal(t, 1, strings.Count(section, "Run `test-pp-cli doctor` to verify setup."))
+}
+
+func TestMarkdownHeadingsRequiresMatchingFenceLength(t *testing.T) {
+	content := strings.Join([]string{
+		"````",
+		"## Fenced",
+		"```",
+		"## Still fenced",
+		"````",
+		"## Real",
+		"",
+	}, "\n")
+
+	assert.Equal(t, -1, findMarkdownHeading(content, "## Fenced"))
+	assert.Equal(t, -1, findMarkdownHeading(content, "## Still fenced"))
+	assert.GreaterOrEqual(t, findMarkdownHeading(content, "## Real"), 0)
+}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -461,6 +461,13 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 				fmt.Fprintf(os.Stderr, "dogfood: synced %s (%s) from novel_features_built\n", artifact.Path, artifact.Detail)
 			}
 		}
+		if artifacts, err := SyncCLINarrativeDocs(cliDir, research.APIName, research.Narrative); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not sync narrative docs: %v\n", err)
+		} else {
+			for _, artifact := range artifacts {
+				fmt.Fprintf(os.Stderr, "dogfood: synced %s (%s) from research.json narrative\n", artifact.Path, artifact.Detail)
+			}
+		}
 		if changed, err := SyncCLIRootHighlights(cliDir, built); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not sync root highlights: %v\n", err)
 		} else if changed {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1565,6 +1565,148 @@ func newHealthCmd() *cobra.Command {
 		assert.Contains(t, stderr, "dogfood: synced internal/cli/root.go (Highlights) from novel_features_built")
 	})
 
+	t.Run("syncs narrative README and SKILL blocks from research", func(t *testing.T) {
+		cliDir := t.TempDir()
+		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
+		require.NoError(t, os.MkdirAll(cliCodeDir, 0o755))
+		writeTestFile(t, filepath.Join(cliCodeDir, "health.go"),
+			`package cli
+func newHealthCmd() *cobra.Command {
+	return &cobra.Command{Use: "health"}
+}`)
+		writeTestFile(t, filepath.Join(cliDir, "README.md"), strings.Join([]string{
+			"# Test CLI",
+			"",
+			"## Authentication",
+			"",
+			"Use the old auth command.",
+			"",
+			"## Quick Start",
+			"",
+			"```bash",
+			"test-pp-cli old quickstart",
+			"```",
+			"",
+			"## Unique Features",
+			"",
+			"These capabilities aren't available in any other tool for this API.",
+			"- **`health`** \u2014 planned health",
+			"",
+			"## Usage",
+			"",
+			"Run help.",
+			"",
+			"## Troubleshooting",
+			"",
+			"**Not found errors (exit code 3)**",
+			"- Check the resource ID is correct",
+			"",
+			"### API-specific",
+			"- **Old symptom** \u2014 Old fix",
+			"",
+			"## HTTP Transport",
+			"",
+			"Standard transport.",
+			"",
+		}, "\n"))
+		writeTestFile(t, filepath.Join(cliDir, "SKILL.md"), strings.Join([]string{
+			"# Test Skill",
+			"",
+			"## Unique Capabilities",
+			"",
+			"These capabilities aren't available in any other tool for this API.",
+			"- **`health`** \u2014 planned health",
+			"",
+			"## Recipes",
+			"",
+			"### Old recipe",
+			"",
+			"```bash",
+			"test-pp-cli old recipe",
+			"```",
+			"",
+			"## Auth Setup",
+			"",
+			"Use the old auth command.",
+			"",
+			"Run `test-pp-cli doctor` to verify setup.",
+			"",
+			"## Agent Mode",
+			"",
+			"Use --agent.",
+			"",
+		}, "\n"))
+
+		researchDir := t.TempDir()
+		research := &ResearchResult{
+			APIName: "test",
+			NovelFeatures: []NovelFeature{
+				{Name: "Health dashboard", Command: "health", Description: "See scheduling health metrics at a glance"},
+			},
+			Narrative: &ReadmeNarrative{
+				AuthNarrative: "Use `test-pp-cli oauth-token --grant-type client_credentials` before protected calls.",
+				QuickStart: []QuickStartStep{
+					{Comment: "Check credentials", Command: "test-pp-cli doctor"},
+					{Comment: "Inspect health", Command: "test-pp-cli health --agent"},
+				},
+				Troubleshoots: []TroubleshootTip{
+					{Symptom: "OAuth scope rejected", Fix: "Run `test-pp-cli oauth-token --grant-type client_credentials --scope view_collection`.\n```text\n### not a section\n```"},
+				},
+				Recipes: []Recipe{
+					{Title: "Inspect health", Command: "test-pp-cli health --agent", Explanation: "Returns the verified health summary."},
+				},
+			},
+		}
+		require.NoError(t, writeResearchJSON(research, researchDir))
+
+		var stderr string
+		result := captureStderr(t, &stderr, func() NovelFeaturesCheckResult {
+			return checkNovelFeatures(cliDir, researchDir)
+		})
+		assert.Equal(t, 1, result.Found)
+
+		readmeData, err := os.ReadFile(filepath.Join(cliDir, "README.md"))
+		require.NoError(t, err)
+		readme := string(readmeData)
+		assert.Contains(t, readme, "## Authentication\n\nUse `test-pp-cli oauth-token --grant-type client_credentials` before protected calls.")
+		assert.Contains(t, readme, "# Check credentials\ntest-pp-cli doctor")
+		assert.Contains(t, readme, "# Inspect health\ntest-pp-cli health --agent")
+		assert.Contains(t, readme, "- **OAuth scope rejected** \u2014 Run `test-pp-cli oauth-token --grant-type client_credentials --scope view_collection`.\n```text\n### not a section\n```")
+		assert.NotContains(t, readme, "old quickstart")
+		assert.NotContains(t, readme, "Old symptom")
+		requireBefore(t, readme, "## Quick Start", "## Unique Features")
+		requireBefore(t, readme, "### API-specific", "## HTTP Transport")
+
+		skillData, err := os.ReadFile(filepath.Join(cliDir, "SKILL.md"))
+		require.NoError(t, err)
+		skill := string(skillData)
+		assert.Contains(t, skill, "## Recipes")
+		assert.Contains(t, skill, "### Inspect health")
+		assert.Contains(t, skill, "test-pp-cli health --agent")
+		assert.Contains(t, skill, "Returns the verified health summary.")
+		assert.Contains(t, skill, "## Auth Setup\n\nUse `test-pp-cli oauth-token --grant-type client_credentials` before protected calls.")
+		assert.Contains(t, skill, "Run `test-pp-cli doctor` to verify setup.")
+		assert.NotContains(t, skill, "Old recipe")
+		requireBefore(t, skill, "## Recipes", "## Auth Setup")
+
+		assert.Contains(t, stderr, "dogfood: synced README.md (Quick Start) from research.json narrative")
+		assert.Contains(t, stderr, "dogfood: synced README.md (Authentication) from research.json narrative")
+		assert.Contains(t, stderr, "dogfood: synced README.md (Troubleshooting) from research.json narrative")
+		assert.Contains(t, stderr, "dogfood: synced SKILL.md (Recipes) from research.json narrative")
+		assert.Contains(t, stderr, "dogfood: synced SKILL.md (Auth Setup) from research.json narrative")
+
+		beforeReadme := readme
+		beforeSkill := skill
+		result = checkNovelFeatures(cliDir, researchDir)
+		assert.Equal(t, 1, result.Found)
+		afterReadme, err := os.ReadFile(filepath.Join(cliDir, "README.md"))
+		require.NoError(t, err)
+		afterSkill, err := os.ReadFile(filepath.Join(cliDir, "SKILL.md"))
+		require.NoError(t, err)
+		assert.Equal(t, beforeReadme, string(afterReadme), "unchanged narrative should not rewrite README content")
+		assert.Equal(t, beforeSkill, string(afterSkill), "unchanged narrative should not rewrite SKILL content")
+	})
+
 	t.Run("inserts README and SKILL sections when absent", func(t *testing.T) {
 		cliDir := t.TempDir()
 		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
@@ -1979,6 +2121,16 @@ func captureStderr[T any](t *testing.T, captured *string, fn func() T) T {
 	require.NoError(t, r.Close())
 	*captured = string(out)
 	return result
+}
+
+func requireBefore(t *testing.T, content, before, after string) {
+	t.Helper()
+
+	beforeIdx := strings.Index(content, before)
+	require.NotEqual(t, -1, beforeIdx, "missing expected content %q", before)
+	afterIdx := strings.Index(content, after)
+	require.NotEqual(t, -1, afterIdx, "missing expected content %q", after)
+	require.Less(t, beforeIdx, afterIdx, "%q should appear before %q", before, after)
 }
 
 func TestDeriveDogfoodVerdict_NovelFeatures(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfood now propagates post-generate `research.json` narrative corrections back into the generated README and SKILL surfaces. Corrections to Quick Start commands, auth guidance, troubleshooting tips, and SKILL recipes no longer need manual substitutions after validate-narrative or verify-skill catches drift.

The sync keeps generic fallback docs intact when narrative fields are absent, updates narrative-owned sections when they are present, and uses fence-aware Markdown heading detection so examples containing heading-like text do not corrupt section boundaries.

Closes #1567

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
