### PR TITLE
fix(cli): exempt sentinel parent groupers from tools audit

### DIFF
--- a/docs/solutions/logic-errors/parent-nosubcommand-rune-tools-audit-exemption.md
+++ b/docs/solutions/logic-errors/parent-nosubcommand-rune-tools-audit-exemption.md
@@ -1,0 +1,75 @@
+---
+title: "Tools-audit parent grouper exemptions must recognize generated sentinels"
+date: 2026-05-23
+category: logic-errors
+module: internal/cli
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Generated parent commands with parentNoSubcommandRunE triggered thin-short findings even though they only route users to subcommands"
+  - "Polish runs repeatedly accepted or rewrote parent-group Short text instead of fixing the scorer boundary"
+  - "Real hand-authored RunE commands still needed thin-short and missing-read-only findings"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - tools-audit
+  - scorecard
+  - cobra
+  - parent-grouper
+  - mcp
+---
+
+# Tools-audit parent grouper exemptions must recognize generated sentinels
+
+## Problem
+
+`tools-audit` treated any Cobra command literal with `Run` or `RunE` as an actionable shell-out command. Generated parent groupers now use `RunE: parentNoSubcommandRunE(flags)` so invoking the parent without a subcommand returns a structured "subcommand required" envelope. That sentinel made parent containers look like ordinary commands, causing `thin-short` findings on boilerplate Shorts such as `Manage mints`.
+
+## Symptoms
+
+- Generated parent groupers surfaced `thin-short` findings even when their leaf subcommands carried the actionable descriptions.
+- Polish runs spent time accepting repeated parent findings or hand-editing generated files that regen would overwrite.
+- The old exemption model, "no RunE means parent grouper", no longer matched generated Cobra source.
+
+## What Didn't Work
+
+- Rewriting generated parent Shorts during polish only fixed one printed CLI until the next regen.
+- Broadly exempting all `RunE` commands would hide real hand-authored shell-out tools with poor descriptions or missing `mcp:read-only` annotations.
+- Relying on runtime command behavior alone was not enough for `tools-audit`, which works from source literals and needs to distinguish the generated sentinel from ordinary closures.
+
+## Solution
+
+Preserve the sentinel identity while extracting Cobra command fields:
+
+```go
+case "Run", "RunE":
+    f.hasRunE = true
+    if key.Name == "RunE" && isParentNoSubcommandRunE(kv.Value) {
+        f.hasParentNoSubcommandRunE = true
+    }
+```
+
+Then exclude only that generated parent sentinel from the Cobra-side audit eligibility check. Keep ordinary `Run` and `RunE` command literals in scope so `thin-short` and `missing-read-only` still fire for real shell-out commands.
+
+The regression coverage should include both layers:
+
+- An extraction test proving `RunE: parentNoSubcommandRunE(flags)` sets the sentinel flag.
+- A source-level audit test proving the sentinel parent emits no findings while a parsed real `RunE: func(...)` command with the same thin Short still emits `thin-short` and `missing-read-only`.
+
+## Why This Works
+
+The scorer exemption is tied to the generator-owned parent-grouper sentinel instead of the broad presence or absence of `RunE`. That matches the actual source shape that caused the false positive while preserving the audit for hand-authored commands where the Cobra Short and annotations are still the agent-facing quality surface.
+
+## Prevention
+
+- When generator code changes a parent command from non-runnable to sentinel-runnable, update source-based scorers that previously keyed on `RunE == nil`.
+- Pair every audit exemption with a negative test for a nearby real command shape so the exemption cannot silently widen.
+- Keep polish playbooks aligned with scorer skip rules; otherwise agents will keep accepting or rewriting findings that the machine now owns.
+
+## Related Issues
+
+- GitHub issue #1565
+- `docs/solutions/logic-errors/cobratree-framework-command-depth-parity.md`
+- `docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md`
+- `docs/solutions/security-issues/mcp-sql-search-readonly-bypass-2026-05-08.md`

--- a/internal/cli/tools_audit.go
+++ b/internal/cli/tools_audit.go
@@ -284,9 +284,10 @@ type commandFields struct {
 	// missing-read-only finding fires only when the annotation is
 	// genuinely absent — an author who has explicitly opted out by
 	// writing "false" has done the right thing and shouldn't be flagged.
-	hasExplicitReadOnly bool
-	hasEndpoint         bool
-	hasRunE             bool // true when the literal declares Run or RunE; parent groupers omit both
+	hasExplicitReadOnly       bool
+	hasEndpoint               bool
+	hasRunE                   bool
+	hasParentNoSubcommandRunE bool
 }
 
 func isCobraCommandType(expr ast.Expr) bool {
@@ -326,9 +327,21 @@ func extractCommandFields(lit *ast.CompositeLit) commandFields {
 			f.hasExplicitReadOnly, f.hasEndpoint = inspectAnnotations(kv.Value)
 		case "Run", "RunE":
 			f.hasRunE = true
+			if key.Name == "RunE" && isParentNoSubcommandRunE(kv.Value) {
+				f.hasParentNoSubcommandRunE = true
+			}
 		}
 	}
 	return f
+}
+
+func isParentNoSubcommandRunE(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	fn, ok := call.Fun.(*ast.Ident)
+	return ok && fn.Name == "parentNoSubcommandRunE"
 }
 
 func stringLit(e ast.Expr) string {
@@ -378,11 +391,12 @@ func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFind
 	}
 	name := cmdName[0]
 
-	// The Cobra-side checks only apply to commands that actually become
-	// shell-out MCP tools at runtime. The cobratree walker skips:
+	// The Cobra-side checks only apply when the command's own Short is
+	// meaningful agent-facing description material. The audit exempts:
 	//   - pp:endpoint commands (registered as typed tools with
 	//     spec-derived descriptions; the manifest audit covers those)
-	//   - parent groupers (no Run/RunE means not actionable)
+	//   - parent groupers (no Run/RunE, or the generated
+	//     parentNoSubcommandRunE sentinel, means not actionable)
 	//   - top-level framework command files (auth, doctor, version,
 	//     etc.) — including their true framework subtree. Generated CLIs
 	//     put children (e.g. `auth status`, `profile list`) in the same
@@ -391,12 +405,13 @@ func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFind
 	//     match a framework name. A nested domain command named `search`
 	//     in a non-framework file still becomes a shell-out MCP tool and
 	//     must be audited.
-	// For all of these, the Cobra Short isn't the MCP tool description
-	// the agent will see, so flagging it would be noise.
-	isShellOut := !f.hasEndpoint && f.hasRunE && !inFrameworkSubtree(file)
+	// For all of these, Cobra Short quality is either covered by another
+	// surface or describes a non-leaf grouping affordance, so flagging it
+	// here would be noise.
+	shouldAuditShort := !f.hasEndpoint && f.hasRunE && !f.hasParentNoSubcommandRunE && !inFrameworkSubtree(file)
 
 	var out []ToolsAuditFinding
-	if isShellOut {
+	if shouldAuditShort {
 		switch {
 		case f.short == "":
 			out = append(out, ToolsAuditFinding{
@@ -410,10 +425,10 @@ func auditCommandFields(file string, line int, f commandFields) []ToolsAuditFind
 			})
 		}
 	}
-	// missing-read-only applies only to commands that become shell-out
-	// MCP tools (typed endpoint tools get classification from the spec
-	// method; framework commands don't register at all).
-	if isShellOut && !f.hasExplicitReadOnly && readShapedName(name) {
+	// missing-read-only follows the same audit eligibility as Short
+	// quality: parent groupers and generated typed endpoints are not
+	// places for hand-authored command safety annotations.
+	if shouldAuditShort && !f.hasExplicitReadOnly && readShapedName(name) {
 		out = append(out, ToolsAuditFinding{
 			Kind: kindMissingReadOnly, Command: name, File: file, Line: line,
 			Evidence: "name matches read heuristic; no mcp:read-only annotation",

--- a/internal/cli/tools_audit.go
+++ b/internal/cli/tools_audit.go
@@ -335,13 +335,17 @@ func extractCommandFields(lit *ast.CompositeLit) commandFields {
 	return f
 }
 
+// Must match the generated helper name in
+// internal/generator/templates/cobratree/classify.go.tmpl.
+const parentNoSubcommandRunESentinel = "parentNoSubcommandRunE"
+
 func isParentNoSubcommandRunE(e ast.Expr) bool {
 	call, ok := e.(*ast.CallExpr)
 	if !ok {
 		return false
 	}
 	fn, ok := call.Fun.(*ast.Ident)
-	return ok && fn.Name == "parentNoSubcommandRunE"
+	return ok && fn.Name == parentNoSubcommandRunESentinel
 }
 
 func stringLit(e ast.Expr) string {

--- a/internal/cli/tools_audit_test.go
+++ b/internal/cli/tools_audit_test.go
@@ -5,6 +5,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -579,6 +581,18 @@ func TestAuditCommandFieldsThinShortStillFlagsShellOutCommands(t *testing.T) {
 	}
 }
 
+func TestAuditCommandFieldsParentNoSubcommandRunESkipsParentFindings(t *testing.T) {
+	findings := auditCommandFields("internal/cli/reports.go", 1, commandFields{
+		use:                       "report",
+		short:                     "Manage reports",
+		hasRunE:                   true,
+		hasParentNoSubcommandRunE: true,
+	})
+	if len(findings) != 0 {
+		t.Fatalf("parentNoSubcommandRunE parent findings = %+v, want none", findings)
+	}
+}
+
 func TestAuditCommandFieldsFrameworkNamesOnlySkippedInFrameworkSubtrees(t *testing.T) {
 	t.Run("nested framework-named domain command is audited", func(t *testing.T) {
 		findings := auditCommandFields("items.go", 1, commandFields{
@@ -611,6 +625,102 @@ func TestAuditCommandFieldsFrameworkNamesOnlySkippedInFrameworkSubtrees(t *testi
 			t.Fatalf("top-level framework search findings = %+v, want none", findings)
 		}
 	})
+}
+
+func TestExtractCommandFieldsDetectsParentNoSubcommandRunE(t *testing.T) {
+	src := `package x
+import "github.com/spf13/cobra"
+func newMintsCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mints",
+		Short: "Manage mints",
+		RunE:  parentNoSubcommandRunE(flags),
+	}
+}`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "mints.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var lit *ast.CompositeLit
+	ast.Inspect(file, func(n ast.Node) bool {
+		c, ok := n.(*ast.CompositeLit)
+		if !ok || !isCobraCommandType(c.Type) {
+			return true
+		}
+		lit = c
+		return false
+	})
+	if lit == nil {
+		t.Fatalf("no cobra command literal found")
+	}
+
+	fields := extractCommandFields(lit)
+	if !fields.hasRunE {
+		t.Fatalf("hasRunE = false, want true")
+	}
+	if !fields.hasParentNoSubcommandRunE {
+		t.Fatalf("hasParentNoSubcommandRunE = false, want true")
+	}
+}
+
+func TestAuditCobraSourceDistinguishesSentinelFromRealRunE(t *testing.T) {
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatalf("mkdir cli dir: %v", err)
+	}
+	sentinelSrc := `package cli
+import "github.com/spf13/cobra"
+func newReportCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "report",
+		Short: "Manage reports",
+		RunE:  parentNoSubcommandRunE(flags),
+	}
+}`
+	realRunESrc := `package cli
+import "github.com/spf13/cobra"
+func newReportRealCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "report",
+		Short: "Manage reports",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+}`
+	if err := os.WriteFile(filepath.Join(cliDir, "report.go"), []byte(sentinelSrc), 0o644); err != nil {
+		t.Fatalf("write sentinel source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cliDir, "report_real.go"), []byte(realRunESrc), 0o644); err != nil {
+		t.Fatalf("write real RunE source: %v", err)
+	}
+
+	findings, err := auditCobraSource(root)
+	if err != nil {
+		t.Fatalf("auditCobraSource: %v", err)
+	}
+	var sentinelFindings, realThinShort, realMissingReadOnly int
+	for _, f := range findings {
+		switch f.File {
+		case "report.go":
+			sentinelFindings++
+		case "report_real.go":
+			switch f.Kind {
+			case kindThinShort:
+				realThinShort++
+			case kindMissingReadOnly:
+				realMissingReadOnly++
+			}
+		}
+	}
+	if sentinelFindings != 0 {
+		t.Fatalf("sentinel parent findings = %d in %+v, want none", sentinelFindings, findings)
+	}
+	if realThinShort != 1 || realMissingReadOnly != 1 {
+		t.Fatalf("real RunE findings thin=%d missing-read-only=%d in %+v, want 1 each", realThinShort, realMissingReadOnly, findings)
+	}
 }
 
 // TestInspectAnnotationsExplicitReadOnlyFalse pins the AST-level

--- a/skills/printing-press-polish/references/tools-polish.md
+++ b/skills/printing-press-polish/references/tools-polish.md
@@ -24,7 +24,7 @@ The audit emits findings on two surfaces:
 - **Cobra source** (`internal/cli/*.go`) — `empty-short`, `thin-short`, `missing-read-only`. These check shell-out tools the runtime walker registers from Cobra metadata.
 - **Tools manifest** (`tools-manifest.json`) — `empty-mcp-description`, `thin-mcp-description`. These check the descriptions agents actually see for typed endpoint tools, where the source is the OpenAPI spec rather than the Cobra Short.
 
-The audit exempts `pp:endpoint`-annotated commands, parent groupers (no `RunE`), and framework-skipped commands (`auth`, `doctor`, `version`, …) from the Cobra-side checks — those don't become MCP tools the way Cobra Short would describe them.
+The audit exempts `pp:endpoint`-annotated commands, parent groupers (no `RunE`, or the generated `parentNoSubcommandRunE(flags)` sentinel), and framework-skipped commands (`auth`, `doctor`, `version`, …) from the Cobra-side checks — those are not actionable leaf tool descriptions for the Cobra Short audit.
 
 A finding here means the description is mechanically thin enough that there's no chance it's adequate. Fix it. But absence of a finding does NOT mean the description is good — the threshold is a floor, not a ceiling. That's what Pass 2 is for.
 


### PR DESCRIPTION
## Summary

Teach `tools-audit` to recognize generated parent groupers that wire `RunE: parentNoSubcommandRunE(flags)` and exempt those parent containers from Cobra-side `thin-short` and `missing-read-only` findings.

The fix preserves the negative path for real `RunE` commands: parsed hand-authored command literals with thin Shorts still emit `thin-short`, and read-shaped names without `mcp:read-only` still emit `missing-read-only`.

Closes #1565

## Validation

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/cli`
- `go test ./...`
- `golangci-lint run ./...` (0 issues; emitted one stale sibling-worktree generated-file-filter warning)
- `scripts/golden.sh verify`
- `python3 /Users/tmchow/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.8.4/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/logic-errors/parent-nosubcommand-rune-tools-audit-exemption.md`

## Compounded learnings

- File: `docs/solutions/logic-errors/parent-nosubcommand-rune-tools-audit-exemption.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with existing cobratree/tools-audit scorer-boundary docs
- Instruction-file edit: none needed
- Refresh recommendation: none
