### PR TITLE
fix(cli): clarify live dogfood output truncation

### DIFF
--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -39,6 +39,9 @@ const (
 	// Relevance matching only needs a few hundred bytes; a 1 MiB cap keeps a
 	// misbehaving feature from exhausting the scorecard process's memory.
 	MaxOutputBytes = 1 << 20
+	// MaxErrorOutputBytes keeps diagnostic stderr captures bounded separately
+	// from stdout.
+	MaxErrorOutputBytes = 1 << 20
 )
 
 // LiveCheckResult summarizes a live-behavior sampling of a printed CLI's
@@ -106,10 +109,10 @@ type LiveCheckBinaryRefresh struct {
 }
 
 // outputSampleMaxBytes caps the captured-output snapshot stored on each
-// LiveFeatureResult. The raw capture buffer allows up to MaxOutputBytes
-// (1 MiB) but the serialized sample is bounded much tighter so scorecard
-// JSON files stay readable and agentic reviewers don't blow through their
-// context window on one feature's output.
+// LiveFeatureResult. The raw capture buffer allows up to MaxOutputBytes but
+// the serialized sample is bounded much tighter so scorecard JSON files stay
+// readable and agentic reviewers don't blow through their context window on
+// one feature's output.
 const outputSampleMaxBytes = 4096
 
 // LiveCheckOptions bundles the optional knobs for RunLiveCheck. CLIDir is
@@ -657,7 +660,7 @@ func runOneFeatureCheck(cliDir, binaryPath string, f NovelFeature, timeout time.
 	stdoutCap := &bytes.Buffer{}
 	stderrCap := &bytes.Buffer{}
 	cmd.Stdout = &limitedWriter{w: stdoutCap, remaining: MaxOutputBytes}
-	cmd.Stderr = &limitedWriter{w: stderrCap, remaining: MaxOutputBytes}
+	cmd.Stderr = &limitedWriter{w: stderrCap, remaining: MaxErrorOutputBytes}
 	runErr := cmd.Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		return fail(fmt.Sprintf("timed out after %s", timeout))
@@ -704,14 +707,34 @@ func runOneFeatureCheck(cliDir, binaryPath string, f NovelFeature, timeout time.
 	return result
 }
 
-// sampleOutput truncates captured stdout to outputSampleMaxBytes for
+// sampleOutput truncates captured output to outputSampleMaxBytes for
 // persistence on LiveFeatureResult.OutputSample. An ellipsis marker at the
 // boundary tells downstream readers the snapshot is truncated.
 func sampleOutput(s string) string {
-	if len(s) <= outputSampleMaxBytes {
-		return s
+	return sampleOutputParts(s)
+}
+
+func sampleOutputParts(parts ...string) string {
+	var sample strings.Builder
+	remaining := outputSampleMaxBytes
+	truncated := false
+	for _, part := range parts {
+		if remaining <= 0 {
+			truncated = truncated || len(part) > 0
+			continue
+		}
+		if len(part) > remaining {
+			sample.WriteString(part[:remaining])
+			truncated = true
+			break
+		}
+		sample.WriteString(part)
+		remaining -= len(part)
 	}
-	return s[:outputSampleMaxBytes] + "…[truncated]"
+	if truncated {
+		return sample.String() + "…[truncated]"
+	}
+	return sample.String()
 }
 
 // rawHTMLEntityRe matches numeric HTML character references, both decimal
@@ -775,10 +798,14 @@ func detectRawHTMLEntities(output string, args []string) string {
 type limitedWriter struct {
 	w         io.Writer
 	remaining int
+	truncated bool
 }
 
 func (lw *limitedWriter) Write(p []byte) (int, error) {
 	if lw.remaining <= 0 {
+		if len(p) > 0 {
+			lw.truncated = true
+		}
 		return len(p), nil
 	}
 	n := min(len(p), lw.remaining)
@@ -786,6 +813,9 @@ func (lw *limitedWriter) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	lw.remaining -= n
+	if n < len(p) {
+		lw.truncated = true
+	}
 	return len(p), nil
 }
 

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -497,13 +497,12 @@ esac
 }
 
 // TestLiveCheck_OutputCap guards against OOM from a runaway feature that
-// streams megabytes of output. The cap is MaxOutputBytes (1 MiB); the test
-// writes 2 MiB so the limitedWriter has to truncate without blowing up the
-// process. The Example has only one positional so no relevance check fires
-// against the (mostly 'x') output.
+// streams megabytes of output. The test writes past MaxOutputBytes so the
+// limitedWriter has to truncate without blowing up the process. The Example
+// has only one positional so no relevance check fires against the output.
 func TestLiveCheck_OutputCap(t *testing.T) {
 	dir := t.TempDir()
-	writeStubBinary(t, dir, "stub", `head -c 2097152 /dev/zero | tr '\0' 'x'`)
+	writeStubBinary(t, dir, "stub", fmt.Sprintf(`head -c %d /dev/zero | tr '\0' 'x'`, MaxOutputBytes+1024))
 	writeTestResearchJSON(t, dir, []NovelFeature{
 		{Name: "Noisy", Command: "n", Example: `stub n`},
 	})
@@ -1035,6 +1034,12 @@ func TestSampleOutput_TruncatesLargeCapture(t *testing.T) {
 	got := sampleOutput(big)
 	require.Contains(t, got, "…[truncated]", "truncation marker missing")
 	require.LessOrEqual(t, len(got), outputSampleMaxBytes+len("…[truncated]"))
+}
+
+func TestSampleOutputParts_TruncatesWithoutConcatenatingFullCapture(t *testing.T) {
+	prefix := strings.Repeat("a", outputSampleMaxBytes-2)
+	got := sampleOutputParts(prefix, "bc", strings.Repeat("d", outputSampleMaxBytes))
+	require.Equal(t, prefix+"bc"+"…[truncated]", got)
 }
 
 func TestSampleOutput_ShortCapturePassesThrough(t *testing.T) {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -733,10 +733,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
 			if jsonRun.exitCode == 0 {
-				if jsonRun.stdoutTruncated {
-					jsonResult.Status = LiveDogfoodStatusFail
-					jsonResult.Reason = liveDogfoodInvalidJSONReason(jsonRun, "invalid JSON")
-				} else if !validLiveDogfoodJSONOutput(jsonRun.stdout) {
+				if jsonRun.stdoutTruncated || !validLiveDogfoodJSONOutput(jsonRun.stdout) {
 					jsonResult.Status = LiveDogfoodStatusFail
 					jsonResult.Reason = liveDogfoodInvalidJSONReason(jsonRun, "invalid JSON")
 				} else {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -95,10 +95,11 @@ type liveDogfoodCommand struct {
 }
 
 type liveDogfoodRun struct {
-	stdout   string
-	stderr   string
-	exitCode int
-	err      error
+	stdout          string
+	stderr          string
+	stdoutTruncated bool
+	exitCode        int
+	err             error
 }
 
 func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
@@ -732,9 +733,12 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
 			if jsonRun.exitCode == 0 {
-				if !validLiveDogfoodJSONOutput(jsonRun.stdout) {
+				if jsonRun.stdoutTruncated {
 					jsonResult.Status = LiveDogfoodStatusFail
-					jsonResult.Reason = "invalid JSON"
+					jsonResult.Reason = liveDogfoodInvalidJSONReason(jsonRun, "invalid JSON")
+				} else if !validLiveDogfoodJSONOutput(jsonRun.stdout) {
+					jsonResult.Status = LiveDogfoodStatusFail
+					jsonResult.Reason = liveDogfoodInvalidJSONReason(jsonRun, "invalid JSON")
 				} else {
 					jsonResult.Status = LiveDogfoodStatusPass
 					jsonResult.Reason = ""
@@ -795,9 +799,12 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 				case errorRun.exitCode != 0:
 					errorResult.Status = LiveDogfoodStatusPass
 					errorResult.Reason = ""
+				case suppliedJSON && errorRun.stdoutTruncated:
+					errorResult.Status = LiveDogfoodStatusFail
+					errorResult.Reason = liveDogfoodInvalidJSONReason(errorRun, "invalid JSON under --json")
 				case suppliedJSON && !json.Valid([]byte(errorRun.stdout)):
 					errorResult.Status = LiveDogfoodStatusFail
-					errorResult.Reason = "invalid JSON under --json"
+					errorResult.Reason = liveDogfoodInvalidJSONReason(errorRun, "invalid JSON under --json")
 				default:
 					errorResult.Status = LiveDogfoodStatusPass
 					errorResult.Reason = ""
@@ -884,15 +891,18 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 	cmd.Env = append(cmd.Env, dogfoodEnvVar+"=1")
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	cmd.Stdout = &limitedWriter{w: stdout, remaining: MaxOutputBytes}
-	cmd.Stderr = &limitedWriter{w: stderr, remaining: MaxOutputBytes}
+	stdoutCap := &limitedWriter{w: stdout, remaining: liveDogfoodMaxOutputBytes}
+	stderrCap := &limitedWriter{w: stderr, remaining: MaxErrorOutputBytes}
+	cmd.Stdout = stdoutCap
+	cmd.Stderr = stderrCap
 
 	err := cmd.Run()
 	result := liveDogfoodRun{
-		stdout:   stdout.String(),
-		stderr:   stderr.String(),
-		exitCode: 0,
-		err:      err,
+		stdout:          stdout.String(),
+		stderr:          stderr.String(),
+		stdoutTruncated: stdoutCap.truncated,
+		exitCode:        0,
+		err:             err,
 	}
 	if ctx.Err() == context.DeadlineExceeded {
 		result.exitCode = -1
@@ -910,6 +920,13 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 	return result
 }
 
+func liveDogfoodInvalidJSONReason(run liveDogfoodRun, fallback string) string {
+	if run.stdoutTruncated {
+		return "output exceeded capture cap"
+	}
+	return fallback
+}
+
 func liveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, run liveDogfoodRun) LiveDogfoodTestResult {
 	result := LiveDogfoodTestResult{
 		Command:      command,
@@ -917,7 +934,7 @@ func liveDogfoodResult(command string, kind LiveDogfoodTestKind, args []string, 
 		Args:         append([]string{}, args...),
 		Status:       LiveDogfoodStatusFail,
 		ExitCode:     run.exitCode,
-		OutputSample: sampleOutput(run.stdout + run.stderr),
+		OutputSample: sampleOutputParts(run.stdout, run.stderr),
 	}
 	if run.exitCode != 0 {
 		result.Reason = fmt.Sprintf("exit %d", run.exitCode)
@@ -954,6 +971,7 @@ const (
 	mcpReadOnlyAnnotation      = "mcp:read-only"
 	destructiveAuthAnnotation  = "pp:destructive-auth"
 	noErrorPathProbeAnnotation = "pp:no-error-path-probe"
+	liveDogfoodMaxOutputBytes  = 10 << 20
 )
 
 // destructiveAuthTerms are case-insensitive command or endpoint tokens

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -43,6 +44,26 @@ func TestRunLiveDogfoodDetectsJSONParseFailure(t *testing.T) {
 	require.NotNil(t, jsonFailure)
 	assert.Equal(t, LiveDogfoodStatusFail, jsonFailure.Status)
 	assert.Contains(t, jsonFailure.Reason, "invalid JSON")
+}
+
+func TestRunLiveDogfoodDetectsTruncatedJSONOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodLargeJSONFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	result := findResultByCommandKind(report, "widgets large", LiveDogfoodTestJSON)
+	require.NotNil(t, result)
+	assert.Equal(t, LiveDogfoodStatusFail, result.Status)
+	assert.Equal(t, "output exceeded capture cap", result.Reason)
 }
 
 func TestRunLiveDogfoodWritesAcceptanceMarkerOnPass(t *testing.T) {
@@ -235,6 +256,47 @@ func TestRunLiveDogfoodProcessSetsDogfoodEnvVar(t *testing.T) {
 	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second)
 	require.NoError(t, run.err, "fixture: %s", run.stderr)
 	assert.Equal(t, "1", run.stdout, "live-dogfood subprocess should see PRINTING_PRESS_DOGFOOD=1")
+}
+
+func TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "large-json")
+	script := `#!/bin/sh
+printf '{"data":"'
+head -c 2097152 /dev/zero | tr '\0' 'x'
+printf '"}'
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o700))
+
+	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second)
+	require.NoError(t, run.err)
+	assert.False(t, run.stdoutTruncated)
+	assert.True(t, validLiveDogfoodJSONOutput(run.stdout))
+}
+
+func TestRunLiveDogfoodProcessTracksOutputTruncation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "huge-json")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '{"data":"'
+head -c %d /dev/zero | tr '\0' 'x'
+printf '"}'
+`, liveDogfoodMaxOutputBytes+1024)
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o700))
+
+	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second)
+	require.NoError(t, run.err)
+	assert.True(t, run.stdoutTruncated)
+	assert.False(t, validLiveDogfoodJSONOutput(run.stdout))
+	assert.Equal(t, "output exceeded capture cap", liveDogfoodInvalidJSONReason(run, "invalid JSON"))
 }
 
 func TestRunLiveDogfoodErrorPathAcceptsExpectedNonZeroExit(t *testing.T) {
@@ -1398,6 +1460,63 @@ fi
 echo "unexpected args: $*" >&2
 exit 99
 `
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
+func writeLiveDogfoodLargeJSONFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	binPath := filepath.Join(dir, binaryName)
+	script := fmt.Sprintf(`#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"widgets","subcommands":[{"name":"large"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "large" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Large widgets.
+
+Usage:
+  fixture-pp-cli widgets large [flags]
+
+Examples:
+  fixture-pp-cli widgets large --json
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "large" ]; then
+  if [ "${3:-}" = "--json" ]; then
+    printf '{"id":"first"}\n'
+    printf '{"data":"'
+    head -c %d /dev/zero | tr '\0' 'x'
+    printf '"}\n'
+    exit 0
+  fi
+  echo 'large widgets'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`, liveDogfoodMaxOutputBytes+1024)
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
 	return dir, binaryName
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -265,9 +265,10 @@ func TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap(t *testing.T) {
 
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "large-json")
+	payloadBytes := liveDogfoodMaxOutputBytes / 5
 	script := `#!/bin/sh
 printf '{"data":"'
-head -c 2097152 /dev/zero | tr '\0' 'x'
+head -c ` + fmt.Sprint(payloadBytes) + ` /dev/zero | tr '\0' 'x'
 printf '"}'
 `
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o700))


### PR DESCRIPTION
## Summary
- track stdout truncation in live dogfood subprocess captures
- report output exceeded capture cap instead of invalid JSON when the scorer truncated otherwise valid output
- keep diagnostics bounded while raising live dogfood stdout capture to 10 MiB

## Tests
- GOCACHE=/Users/tmchow/tmp/pp-fix-batch/mvanhorn__cli-printing-press/20260523T103528Z/go-build-cache go test ./internal/pipeline -run 'Test(LiveDogfood|RunLiveDogfood|SampleOutput|RunOneFeatureCheck)' -count=1\n\nCloses #1564