### PR TITLE
fix(cli): default sync concurrency by rate class

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -18,6 +18,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-origin` | `info` | Google Discovery resource fallback | No |
 | `x-providerName` | `info` | Google Discovery resource fallback | No |
 | `x-tier-routing` | root or `info` | `APISpec.TierRouting` | No |
+| `x-rate-class` | root or `info` | `APISpec.RateClass` | No |
 | `x-mcp` | root or `info` | `APISpec.MCP` | No |
 | `x-auth-type` | `components.securitySchemes.<name>` | `APISpec.Auth.Type` | No |
 | `x-auth-format` | `components.securitySchemes.<name>` | `APISpec.Auth.Format` | No |
@@ -189,6 +190,33 @@ x-tier-routing:
         in: query
         header: api_key
         env_vars: [EXAMPLE_PAID_KEY]
+```
+
+### `x-rate-class`
+
+Declares the API's rate-limit operating point so generated sync defaults can
+avoid wasteful parallelism on low-total-budget APIs.
+
+Parsed field: `APISpec.RateClass`
+
+Rules:
+- Optional.
+- May be declared at the OpenAPI root or under `info`. Root takes precedence
+  when both are present.
+- Must be a string.
+- Accepted values are `per-second`, `daily`, `monthly`, and `unlimited`.
+- `daily` and `monthly` generate `sync --concurrency` with a default of 1.
+  `per-second`, `unlimited`, and absent keep the default of 4.
+- This only changes generated sync worker defaults. It does not add runtime
+  rate limiting, retries, or backoff.
+
+Example:
+
+```yaml
+info:
+  title: Low Quota API
+  version: "1.0"
+  x-rate-class: monthly
 ```
 
 ### `x-mcp`

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9703,6 +9703,17 @@ func assertVerifyEnvConcurrencyPin(t *testing.T, syncContent, cliutilImportPath,
 		label+": verify-env override must sit after the default-resolution block (as shipped)")
 }
 
+func assertSyncDefaultConcurrency(t *testing.T, syncContent string, want int, label string) {
+	t.Helper()
+	assert.Contains(t, syncContent,
+		fmt.Sprintf(`cmd.Flags().IntVar(&concurrency, "concurrency", %d, "Number of parallel sync workers")`, want),
+		label+": --concurrency flag default must match spec rate class")
+	assert.Regexp(t,
+		fmt.Sprintf(`if concurrency < 1 \{\s*concurrency = %d\s*\}`, want),
+		syncContent,
+		label+": invalid concurrency fallback must match spec rate class")
+}
+
 // TestGeneratedSyncForcesSingleWorkerUnderVerifyEnv pins the verify-mode
 // override in the REST sync template. Without it, the worker pool races on
 // SQLite writes once network latency disappears, tripping SQLITE_BUSY
@@ -9774,6 +9785,23 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestGeneratedGraphQLSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
+	t.Parallel()
+
+	gqlSpec, err := graphql.ParseSDL(filepath.Join("..", "..", "testdata", "graphql", "test.graphql"))
+	require.NoError(t, err)
+	gqlSpec.RateClass = spec.RateClassMonthly
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	gen := New(gqlSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	assertSyncDefaultConcurrency(t, string(syncGo), 1, "GraphQL sync.go")
 }
 
 func TestGeneratedSyncAdvancesOffsetWhenHasMoreWithoutCursor(t *testing.T) {

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -3,6 +3,7 @@
 package generator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,40 @@ func TestGenerateSyncParamPassthrough(t *testing.T) {
 		"sync should validate --resource-param keys against the known resource set")
 	assert.Contains(t, syncSrc, "func knownSyncResourceNames() []string",
 		"knownSyncResourceNames helper must be emitted alongside defaultSyncResources")
+}
+
+func TestGenerateSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		rateClass string
+	}{
+		{name: "absent"},
+		{name: "per-second", rateClass: spec.RateClassPerSecond},
+		{name: "unlimited", rateClass: spec.RateClassUnlimited},
+		{name: "daily", rateClass: spec.RateClassDaily},
+		{name: "monthly", rateClass: spec.RateClassMonthly},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := minimalSpec("sync-" + tc.name)
+			apiSpec.RateClass = tc.rateClass
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+			require.NoError(t, err)
+			syncSrc := string(syncGo)
+
+			wantDefault := apiSpec.SyncDefaultConcurrency()
+			assert.Contains(t, syncSrc, fmt.Sprintf(`cmd.Flags().IntVar(&concurrency, "concurrency", %d, "Number of parallel sync workers")`, wantDefault))
+			assert.Contains(t, syncSrc, fmt.Sprintf("concurrency = %d", wantDefault))
+		})
+	}
 }
 
 // dependentResourceSpec builds a minimal spec with a parent + child

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -3,7 +3,6 @@
 package generator
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,8 +107,7 @@ func TestGenerateSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
 			syncSrc := string(syncGo)
 
 			wantDefault := apiSpec.SyncDefaultConcurrency()
-			assert.Contains(t, syncSrc, fmt.Sprintf(`cmd.Flags().IntVar(&concurrency, "concurrency", %d, "Number of parallel sync workers")`, wantDefault))
-			assert.Contains(t, syncSrc, fmt.Sprintf("concurrency = %d", wantDefault))
+			assertSyncDefaultConcurrency(t, syncSrc, wantDefault, tc.name)
 		})
 	}
 }

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -129,7 +129,7 @@ Exit codes & warnings:
 
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
-				concurrency = 4
+				concurrency = {{.SyncDefaultConcurrency}}
 			}
 			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
 			// reach SQLite without the natural serialization that network
@@ -236,7 +236,7 @@ Exit codes & warnings:
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
-	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
+	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/{{.Name}}-pp-cli/data.db)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -289,7 +289,7 @@ Resource scoping:
 
 			// Worker pool: produce resources, N workers consume
 			if concurrency < 1 {
-				concurrency = 4
+				concurrency = {{.SyncDefaultConcurrency}}
 			}
 			// Under PRINTING_PRESS_VERIFY=1 (mock/dry-run), all goroutines
 			// reach SQLite without the natural serialization that network
@@ -461,7 +461,7 @@ Resource scoping:
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
-	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
+	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/{{.Name}}-pp-cli/data.db)")
 	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -43,6 +43,7 @@ const (
 	extensionSpeakeasyExample      = "x-speakeasy-example"
 	extensionTierRouting           = "x-tier-routing"
 	extensionTier                  = "x-tier"
+	extensionRateClass             = "x-rate-class"
 	extensionMCP                   = "x-mcp"
 	extensionLegacyMCP             = "mcp"
 	extensionSyncWalker            = "x-pp-sync-walker"
@@ -571,6 +572,10 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 	if err != nil {
 		return nil, err
 	}
+	rateClass, err := parseStringOpenAPIExtension(doc, extensionRateClass)
+	if err != nil {
+		return nil, err
+	}
 
 	mcpConfig, err := parseMCPExtension(doc)
 	if err != nil {
@@ -596,6 +601,7 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 		BasePath:                     basePath,
 		WebsiteURL:                   websiteURL,
 		ProxyRoutes:                  proxyRoutes,
+		RateClass:                    rateClass,
 		Auth:                         auth,
 		TierRouting:                  tierRouting,
 		MCP:                          mcpConfig,
@@ -804,6 +810,27 @@ func lookupOpenAPIInfoExtension(doc *openapi3.T, key string) (any, bool) {
 		return raw, ok
 	}
 	return nil, false
+}
+
+func parseStringOpenAPIExtension(doc *openapi3.T, key string) (string, error) {
+	if doc != nil && doc.Extensions != nil {
+		if _, ok := doc.Extensions[key]; ok {
+			return parseStringExtensionValue(doc.Extensions, key)
+		}
+	}
+	if doc != nil && doc.Info != nil && doc.Info.Extensions != nil {
+		if _, ok := doc.Info.Extensions[key]; ok {
+			return parseStringExtensionValue(doc.Info.Extensions, key)
+		}
+	}
+	return "", nil
+}
+
+func parseStringExtensionValue(extensions map[string]any, key string) (string, error) {
+	if _, ok := extensions[key].(string); !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	return stringExtension(extensions, key), nil
 }
 
 func mapAuth(doc *openapi3.T, name string) spec.AuthConfig {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -5198,6 +5198,82 @@ paths:
 	assert.Equal(t, "paid", findEndpointByPath(items, "/items/{id}").Tier)
 }
 
+func TestParseRateClassExtensionFromInfo(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Monthly Quota API
+  version: 1.0.0
+  x-rate-class: monthly
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+	assert.Equal(t, spec.RateClassMonthly, parsed.RateClass)
+	assert.Equal(t, 1, parsed.SyncDefaultConcurrency())
+}
+
+func TestParseRateClassExtensionRootOverridesInfo(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+openapi: 3.0.3
+x-rate-class: daily
+info:
+  title: Root Rate Class API
+  version: 1.0.0
+  x-rate-class: per-second
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+	assert.Equal(t, spec.RateClassDaily, parsed.RateClass)
+	assert.Equal(t, 1, parsed.SyncDefaultConcurrency())
+}
+
+func TestParseRateClassRejectsNonStringExtension(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Bad Rate Class API
+  version: 1.0.0
+  x-rate-class: [monthly]
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: ok
+`)
+
+	_, err := Parse(data)
+	require.ErrorContains(t, err, "x-rate-class must be a string")
+}
+
 func TestParseTierRoutingExtensionFromInfo(t *testing.T) {
 	t.Parallel()
 	data := []byte(`

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -53,6 +53,13 @@ const (
 )
 
 const (
+	RateClassPerSecond = "per-second"
+	RateClassDaily     = "daily"
+	RateClassMonthly   = "monthly"
+	RateClassUnlimited = "unlimited"
+)
+
+const (
 	TierAuthTypeNone        = "none"
 	TierAuthTypeAPIKey      = "api_key"
 	TierAuthTypeBearerToken = "bearer_token"
@@ -170,6 +177,7 @@ type APISpec struct {
 	SpecSource                  string              `yaml:"spec_source,omitempty" json:"spec_source,omitempty"`       // official, community, sniffed, docs — affects generated client defaults
 	ClientPattern               string              `yaml:"client_pattern,omitempty" json:"client_pattern,omitempty"` // rest (default), proxy-envelope — affects generated HTTP client
 	HTTPTransport               string              `yaml:"http_transport,omitempty" json:"http_transport,omitempty"` // standard (default for official APIs), browser-http, browser-chrome, browser-chrome-h2, or browser-chrome-h3
+	RateClass                   string              `yaml:"rate_class,omitempty" json:"rate_class,omitempty"`         // per-second, daily, monthly, or unlimited — affects generated sync concurrency defaults
 	HealthCheckPath             string              `yaml:"health_check_path,omitempty" json:"health_check_path,omitempty"`
 	ProxyRoutes                 map[string]string   `yaml:"proxy_routes,omitempty" json:"proxy_routes,omitempty"`    // path prefix → service name for proxy-envelope routing
 	BearerRefresh               BearerRefreshConfig `yaml:"bearer_refresh,omitempty" json:"bearer_refresh,omitzero"` // live-source metadata for rotating public client bearer tokens
@@ -204,6 +212,22 @@ func (s *APISpec) HasTierRouting() bool {
 		return false
 	}
 	return s.TierRouting.DefaultTier != "" || len(s.TierRouting.Tiers) > 0
+}
+
+func (s *APISpec) EffectiveRateClass() string {
+	if s == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(s.RateClass))
+}
+
+func (s *APISpec) SyncDefaultConcurrency() int {
+	switch s.EffectiveRateClass() {
+	case RateClassDaily, RateClassMonthly:
+		return 1
+	default:
+		return 4
+	}
 }
 
 // EndpointTemplateEnvName returns the env-var name that resolves the given
@@ -2233,6 +2257,11 @@ func (s *APISpec) Validate() error {
 	case "", HTTPTransportStandard, HTTPTransportBrowserHTTP, HTTPTransportBrowserChrome, HTTPTransportBrowserChromeH2, HTTPTransportBrowserChromeH3:
 	default:
 		return fmt.Errorf("http_transport must be one of: standard, browser-http, browser-chrome, browser-chrome-h2, browser-chrome-h3")
+	}
+	switch s.EffectiveRateClass() {
+	case "", RateClassPerSecond, RateClassDaily, RateClassMonthly, RateClassUnlimited:
+	default:
+		return fmt.Errorf("rate_class must be one of: per-second, daily, monthly, unlimited")
 	}
 	if err := validateExtraCommands(s.ExtraCommands); err != nil {
 		return err

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -2870,6 +2870,46 @@ func TestHTTPTransportValidationAndDefaults(t *testing.T) {
 	require.ErrorContains(t, invalid.Validate(), "http_transport must be one of")
 }
 
+func TestRateClassValidationAndSyncConcurrencyDefaults(t *testing.T) {
+	t.Parallel()
+
+	base := APISpec{
+		Name:    "demo",
+		BaseURL: "http://x",
+		Auth:    AuthConfig{Type: "none"},
+		Resources: map[string]Resource{
+			"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		rateClass string
+		want      int
+	}{
+		{name: "absent", want: 4},
+		{name: "per-second", rateClass: RateClassPerSecond, want: 4},
+		{name: "unlimited", rateClass: RateClassUnlimited, want: 4},
+		{name: "daily", rateClass: RateClassDaily, want: 1},
+		{name: "monthly", rateClass: RateClassMonthly, want: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := base
+			s.RateClass = tc.rateClass
+			require.NoError(t, s.Validate())
+			assert.Equal(t, tc.want, s.SyncDefaultConcurrency())
+		})
+	}
+
+	invalid := base
+	invalid.RateClass = "weekly"
+	require.ErrorContains(t, invalid.Validate(), "rate_class must be one of")
+}
+
 func TestUsesBrowserLikeUserAgent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add spec/openapi support for rate_class / x-rate-class
- default generated sync concurrency to 1 for daily/monthly APIs and keep 4 for absent, per-second, and unlimited
- document the new extension and cover parser/spec/generator behavior

## Tests
- GOCACHE=/Users/tmchow/tmp/pp-fix-batch/mvanhorn__cli-printing-press/20260523T103528Z/go-build-cache go test ./internal/spec ./internal/openapi ./internal/generator -run 'Test.*RateClass|Test.*SyncConcurrency|Test.*Concurrency|Test.*rate_class' -count=1\n\n
- 
Closes #1568