### PR TITLE
fix(cli): skip auth-tagged resources in sync defaults

### DIFF
--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -134,6 +134,14 @@ func TestGenerateSyncDefaultsSkipAuthTaggedResources(t *testing.T) {
 			Description: "OAuth token endpoint",
 			Endpoints:   map[string]spec.Endpoint{"list": paginated("/oauth_token", "OAuth")},
 		},
+		"oauth2-token": {
+			Description: "OAuth2 token endpoint",
+			Endpoints:   map[string]spec.Endpoint{"list": paginated("/oauth2_token", "OAuth2")},
+		},
+		"authorization-grant": {
+			Description: "Authorization grant endpoint",
+			Endpoints:   map[string]spec.Endpoint{"list": paginated("/authorization_grant", "Billing", "Authorization")},
+		},
 	}
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	require.NoError(t, New(apiSpec, outputDir).Generate())
@@ -146,10 +154,14 @@ func TestGenerateSyncDefaultsSkipAuthTaggedResources(t *testing.T) {
 	defaultsBlock := syncSrc[defaultsStart:knownStart]
 	assert.Contains(t, defaultsBlock, `"items"`)
 	assert.NotContains(t, defaultsBlock, `"oauth-token"`)
+	assert.NotContains(t, defaultsBlock, `"oauth2-token"`)
+	assert.NotContains(t, defaultsBlock, `"authorization-grant"`)
 
 	knownBlock := syncSrc[knownStart:]
 	assert.Contains(t, knownBlock, `"items"`)
 	assert.Contains(t, knownBlock, `"oauth-token"`, "explicit --resources should still accept auth-tagged sync endpoints")
+	assert.Contains(t, knownBlock, `"oauth2-token"`, "explicit --resources should still accept auth-tagged sync endpoints")
+	assert.Contains(t, knownBlock, `"authorization-grant"`, "explicit --resources should still accept auth-tagged sync endpoints")
 
 	workflowSrc := readGeneratedFile(t, outputDir, "internal", "cli", "channel_workflow.go")
 	archiveIdx := strings.Index(workflowSrc, "resources := []string")
@@ -157,6 +169,8 @@ func TestGenerateSyncDefaultsSkipAuthTaggedResources(t *testing.T) {
 	archiveBlock := workflowSrc[archiveIdx:]
 	assert.Contains(t, archiveBlock, `"items"`)
 	assert.NotContains(t, archiveBlock, `"oauth-token"`)
+	assert.NotContains(t, archiveBlock, `"oauth2-token"`)
+	assert.NotContains(t, archiveBlock, `"authorization-grant"`)
 }
 
 // dependentResourceSpec builds a minimal spec with a parent + child

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -112,6 +112,53 @@ func TestGenerateSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
 	}
 }
 
+func TestGenerateSyncDefaultsSkipAuthTaggedResources(t *testing.T) {
+	t.Parallel()
+
+	paginated := func(path string, tags ...string) spec.Endpoint {
+		return spec.Endpoint{
+			Method:     "GET",
+			Path:       path,
+			Tags:       tags,
+			Response:   spec.ResponseDef{Type: "array"},
+			Pagination: &spec.Pagination{Type: "cursor", LimitParam: "limit", CursorParam: "after"},
+		}
+	}
+	apiSpec := minimalSpec("sync-auth")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Items",
+			Endpoints:   map[string]spec.Endpoint{"list": paginated("/items")},
+		},
+		"oauth-token": {
+			Description: "OAuth token endpoint",
+			Endpoints:   map[string]spec.Endpoint{"list": paginated("/oauth_token", "OAuth")},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	defaultsStart := strings.Index(syncSrc, "func defaultSyncResources() []string")
+	knownStart := strings.Index(syncSrc, "func knownSyncResourceNames() []string")
+	require.NotEqual(t, -1, defaultsStart)
+	require.NotEqual(t, -1, knownStart)
+	defaultsBlock := syncSrc[defaultsStart:knownStart]
+	assert.Contains(t, defaultsBlock, `"items"`)
+	assert.NotContains(t, defaultsBlock, `"oauth-token"`)
+
+	knownBlock := syncSrc[knownStart:]
+	assert.Contains(t, knownBlock, `"items"`)
+	assert.Contains(t, knownBlock, `"oauth-token"`, "explicit --resources should still accept auth-tagged sync endpoints")
+
+	workflowSrc := readGeneratedFile(t, outputDir, "internal", "cli", "channel_workflow.go")
+	archiveIdx := strings.Index(workflowSrc, "resources := []string")
+	require.NotEqual(t, -1, archiveIdx)
+	archiveBlock := workflowSrc[archiveIdx:]
+	assert.Contains(t, archiveBlock, `"items"`)
+	assert.NotContains(t, archiveBlock, `"oauth-token"`)
+}
+
 // dependentResourceSpec builds a minimal spec with a parent + child
 // resource so syncDependentResource is actually emitted. The
 // dependent-resource profiler requires paginated list endpoints (not

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -276,7 +276,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 			defer s.Close()
 
-			resources := []string{ {{- range .SyncableResources}}"{{.Name}}", {{end}} }
+			resources := []string{ {{- range .SyncableResources}}{{if not .SkipDefaultSync}}"{{.Name}}", {{end}}{{end}} }
 			totalSynced := 0
 
 			// --full clears the cursor here because syncResource reads

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -443,7 +443,9 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 func defaultSyncResources() []string {
 	return []string{
 {{- range .SyncableResources}}
+{{- if not .SkipDefaultSync}}
 		"{{.Name}}",
+{{- end}}
 {{- end}}
 	}
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1716,7 +1716,9 @@ func parseSinceDuration(s string) (time.Time, error) {
 func defaultSyncResources() []string {
 	return []string{
 {{- range .SyncableResources}}
+{{- if not .SkipDefaultSync}}
 		"{{.Name}}",
+{{- end}}
 {{- end}}
 	}
 }
@@ -1725,7 +1727,11 @@ func defaultSyncResources() []string {
 // flat resources plus any parent-child dependents. Used by --resource-param
 // validation to reject misspellings before they become silent no-ops.
 func knownSyncResourceNames() []string {
-	names := defaultSyncResources()
+	names := []string{
+{{- range .SyncableResources}}
+		"{{.Name}}",
+{{- end}}
+	}
 {{- if .DependentSyncResources}}
 	for _, dep := range dependentResourceDefs() {
 		names = append(names, dep.Name)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2741,6 +2741,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 				BodyRequired:       bodyRequired,
 				BodyIsArray:        bodyIsArray,
 				RequestContentType: requestContentType,
+				Tags:               append([]string{}, op.Tags...),
 			}
 			endpoint.Tier = readTierExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
 			if endpoint.Tier == "" {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8487,3 +8487,35 @@ func TestDetectPaginationOffsetBeatsPage(t *testing.T) {
 	assert.Equal(t, "offset", pag.CursorParam)
 	assert.Equal(t, "offset", pag.Type)
 }
+
+func TestParsePreservesOperationTags(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.0
+info:
+  title: Tagged API
+  version: "1.0"
+paths:
+  /oauth_token:
+    get:
+      operationId: listOAuthToken
+      tags: [OAuth]
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+`))
+	require.NoError(t, err)
+	require.Contains(t, parsed.Resources, "oauth-token")
+	require.Contains(t, parsed.Resources["oauth-token"].Endpoints, "list")
+	assert.Equal(t, []string{"OAuth"}, parsed.Resources["oauth-token"].Endpoints["list"].Tags)
+}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -93,6 +93,9 @@ type SyncableResource struct {
 	Path   string
 	Method string
 	Tier   string
+	// SkipDefaultSync keeps resources callable via --resources while excluding
+	// auth-flow endpoints from generated "sync all" defaults.
+	SkipDefaultSync bool
 	// IDField is the resolved primary-key field name for items returned by the
 	// list endpoint, populated from the chosen endpoint's resolved value (in
 	// turn populated by the OpenAPI parser's `x-resource-id` extension or the
@@ -1351,6 +1354,7 @@ type syncableMeta struct {
 	Path               string
 	Method             string
 	Tier               string
+	SkipDefaultSync    bool
 	IDField            string
 	Critical           bool
 	SinceParam         string
@@ -1389,6 +1393,7 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		Path:               e.Path,
 		Method:             strings.ToUpper(e.Method),
 		Tier:               s.EffectiveTier(resource, e),
+		SkipDefaultSync:    isAuthTaggedEndpoint(e),
 		IDField:            e.IDField,
 		Critical:           e.Critical,
 		SinceParam:         detectEndpointSinceParam(e.Params),
@@ -1401,6 +1406,18 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		IDWalkPageSize:     idWalkPageSize,
 		FieldSelector:      detectEndpointFieldSelector(e),
 		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
+	}
+}
+
+func isAuthTaggedEndpoint(endpoint spec.Endpoint) bool {
+	if len(endpoint.Tags) == 0 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(endpoint.Tags[0])) {
+	case "auth", "authentication", "oauth":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1734,6 +1751,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			Path:               meta.Path,
 			Method:             meta.Method,
 			Tier:               meta.Tier,
+			SkipDefaultSync:    meta.SkipDefaultSync,
 			IDField:            meta.IDField,
 			Critical:           meta.Critical,
 			SinceParam:         meta.SinceParam,

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1410,15 +1410,13 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 }
 
 func isAuthTaggedEndpoint(endpoint spec.Endpoint) bool {
-	if len(endpoint.Tags) == 0 {
-		return false
+	for _, tag := range endpoint.Tags {
+		switch strings.ToLower(strings.TrimSpace(tag)) {
+		case "auth", "authentication", "authorization", "oauth", "oauth2":
+			return true
+		}
 	}
-	switch strings.ToLower(strings.TrimSpace(endpoint.Tags[0])) {
-	case "auth", "authentication", "oauth":
-		return true
-	default:
-		return false
-	}
+	return false
 }
 
 func syncBodyFieldsFromEndpoint(endpoint spec.Endpoint) []SyncBodyField {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1391,6 +1391,7 @@ type Endpoint struct {
 	RequestContentType string       `yaml:"request_content_type,omitempty" json:"request_content_type,omitempty"`
 	Response           ResponseDef  `yaml:"response" json:"response"`
 	ResponseFormat     string       `yaml:"response_format,omitempty" json:"response_format,omitempty"` // json (default) or html
+	Tags               []string     `yaml:"tags,omitempty" json:"tags,omitempty"`                       // source operation tags; used for generated defaults, not command grouping
 	HTMLExtract        *HTMLExtract `yaml:"html_extract,omitempty" json:"html_extract,omitempty"`       // extraction options when response_format is html
 	Pagination         *Pagination  `yaml:"pagination" json:"pagination"`
 	// EmbeddedPagedSubresources names paged-envelope properties nested

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1123,7 +1123,10 @@ func defaultSyncResources() []string {
 // flat resources plus any parent-child dependents. Used by --resource-param
 // validation to reject misspellings before they become silent no-ops.
 func knownSyncResourceNames() []string {
-	names := defaultSyncResources()
+	names := []string{
+		"currencies",
+		"projects",
+	}
 	for _, dep := range dependentResourceDefs() {
 		names = append(names, dep.Name)
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1110,7 +1110,9 @@ func defaultSyncResources() []string {
 // flat resources plus any parent-child dependents. Used by --resource-param
 // validation to reject misspellings before they become silent no-ops.
 func knownSyncResourceNames() []string {
-	names := defaultSyncResources()
+	names := []string{
+		"games",
+	}
 	for _, dep := range dependentResourceDefs() {
 		names = append(names, dep.Name)
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1077,7 +1077,9 @@ func defaultSyncResources() []string {
 // flat resources plus any parent-child dependents. Used by --resource-param
 // validation to reject misspellings before they become silent no-ops.
 func knownSyncResourceNames() []string {
-	names := defaultSyncResources()
+	names := []string{
+		"items",
+	}
 	return names
 }
 


### PR DESCRIPTION
## Summary
- preserve OpenAPI operation tags on parsed endpoints
- mark OAuth/Auth/Authentication first-tagged sync resources as skipped from generated sync-all defaults
- keep those resources accepted by explicit --resources while omitting them from workflow archive defaults

## Tests
- GOCACHE=/Users/tmchow/tmp/pp-fix-batch/mvanhorn__cli-printing-press/20260523T103528Z/go-build-cache go test ./internal/openapi ./internal/generator -run 'TestParsePreservesOperationTags|TestGenerateSyncDefaultsSkipAuthTaggedResources' -count=1\n- GOCACHE=/Users/tmchow/tmp/pp-fix-batch/mvanhorn__cli-printing-press/20260523T103528Z/go-build-cache scripts/golden.sh verify\n\nCloses #1566