### PR TITLE
fix(cli): chomp trailing newline from auth setup instructions

### DIFF
--- a/internal/generator/auth_instructions_newline_test.go
+++ b/internal/generator/auth_instructions_newline_test.go
@@ -1,0 +1,36 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthSetupInstructionsNoRedundantNewline pins that a multi-line
+// (YAML block-scalar) auth.instructions value does not produce an Fprintln
+// whose string literal ends in \n. Fprintln appends its own newline, so a
+// trailing-\n literal trips `go vet`'s redundant-newline check and fails the
+// post-generation quality gate (#1946).
+func TestAuthSetupInstructionsNoRedundantNewline(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("blockscalar")
+	// Trailing newline mimics a YAML block scalar ("instructions: |").
+	apiSpec.Auth.Instructions = "1. Visit the console\n2. Create a client\n3. Copy the token\n"
+
+	outputDir := filepath.Join(t.TempDir(), "blockscalar-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	content := string(authSrc)
+
+	require.Contains(t, content, "3. Copy the token", "instructions should render")
+	assert.NotContains(t, content, `3. Copy the token\n")`,
+		"instructions Fprintln literal must not end in \\n (go vet redundant-newline)")
+	assert.Contains(t, content, `3. Copy the token")`,
+		"chomped instructions should end the Fprintln literal cleanly")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -254,6 +254,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"effectiveTier":          effectiveTier,
 		"effectiveSubTier":       effectiveSubTier,
 		"add":                    func(a, b int) int { return a + b },
+		"chomp":                  func(s string) string { return strings.TrimRight(s, "\r\n") },
 		"oneline":                naming.OneLine,
 		"composeMCPDesc":         composeMCPDesc,
 		"composeMCPSubDesc":      composeMCPSubDesc,

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -54,7 +54,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
 {{- if .Auth.Instructions}}
-			fmt.Fprintln(w, {{printf "%q" (printf "  %s" .Auth.Instructions)}})
+			fmt.Fprintln(w, {{printf "%q" (printf "  %s" (chomp .Auth.Instructions))}})
 {{- end}}
 {{- if .Auth.EnvVarSpecs}}
 			fmt.Fprintln(w, "")


### PR DESCRIPTION
## Intent

A multi-line (YAML block-scalar) `auth.instructions` value makes the generated `auth setup` command fail `go vet` — the post-generation quality gate — with `fmt.Fprintln arg list ends with redundant newline`.

Issue: Closes #1946

## Approach

`auth_simple.go.tmpl` rendered the instructions via `{{printf "%q" (printf "  %s" .Auth.Instructions)}}` into `fmt.Fprintln`. A block scalar (`instructions: |`) ends in `\n`, so the quoted literal ended in `\n` and `Fprintln` appended a second one.

Added a `chomp` template func (`strings.TrimRight(s, "\r\n")`) and applied it before quoting. Single-line instructions are unaffected (no-op); multi-line instructions keep interior newlines and lose only the trailing one, so `Fprintln` emits exactly one.

## Scope

Primary area: generator (`internal/generator/templates/auth_simple.go.tmpl`, funcMap in `generator.go`).

Why this belongs in this repo: machine change — every printed CLI whose spec uses block-scalar `auth.instructions` would otherwise fail the `go vet` gate on first generation. The embedded catalog all uses single-line instructions, so this is "next-agent insurance" for rich multi-step setup flows.

## Risk

Low. `chomp` only trims trailing newline characters; single-line instructions (the only shape in the existing catalog/goldens) are unchanged, confirmed by `scripts/golden.sh verify` showing no diff.

## Output Contract

Generated `internal/cli/auth.go`: the instructions `Fprintln` literal no longer ends in `\n` when instructions are multi-line. No change for single-line instructions. Golden suite unaffected (23/23 pass unchanged).

## Verification

- `go test ./internal/generator/` — pass (incl. new `TestAuthSetupInstructionsNoRedundantNewline`)
- `go build ./...` — pass
- `go fmt ./internal/generator/` — clean
- `golangci-lint run ./internal/generator/...` — 0 issues
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh verify` — 23/23 pass, no diff

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change