### PR TITLE
fix(cli): kebab-case resource names in README/SKILL command examples

### DIFF
--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -40,7 +40,10 @@ func firstCommandExample(resources map[string]spec.Resource) string {
 	preferredVerbs := []string{"list", "get", "search", "query"}
 
 	pathFor := func(rName string, r spec.Resource, eName string, ep spec.Endpoint) string {
-		parts := []string{rName}
+		// Kebab the resource segment to match the actual cobra command name
+		// (mirrors toKebab(resourceName) in buildPromotedCommands). PascalCase
+		// or snake_case spec keys would otherwise advertise an unrunnable path.
+		parts := []string{toKebab(rName)}
 		if !isPromotableSingleEndpoint(rName, r) {
 			parts = append(parts, toKebab(eName))
 		}

--- a/internal/generator/first_command_example_test.go
+++ b/internal/generator/first_command_example_test.go
@@ -312,6 +312,35 @@ func TestFirstCommandExampleHonorsPromotion(t *testing.T) {
 			},
 			want: "audio cancel-job",
 		},
+		{
+			// Issue #1853: PascalCase resource keys (sniffed .NET/Java
+			// enterprise APIs) must be kebab-cased to match the actual cobra
+			// command name. Without this the example advertises a phantom
+			// `cli ChangeOrders` path that exits "unknown command".
+			name: "PascalCase resource key is kebab-cased (promoted)",
+			resources: map[string]spec.Resource{
+				"ChangeOrders": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/api/ChangeOrders/Grid"},
+					},
+				},
+			},
+			want: "change-orders",
+		},
+		{
+			// Same kebab pass when the resource is not promoted (multiple
+			// endpoints): both the resource and endpoint segments are kebab.
+			name: "PascalCase resource key is kebab-cased (non-promoted)",
+			resources: map[string]spec.Resource{
+				"PurchaseOrders": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {Method: "GET", Path: "/api/PurchaseOrders"},
+						"get":  {Method: "GET", Path: "/api/PurchaseOrders/{id}"},
+					},
+				},
+			},
+			want: "purchase-orders list",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/generator/skill_endpoint_kebab_test.go
+++ b/internal/generator/skill_endpoint_kebab_test.go
@@ -72,6 +72,53 @@ func TestSkillAndReadmeKebabCaseMultiWordEndpoints(t *testing.T) {
 	}
 }
 
+// TestSkillAndReadmeKebabCasePascalResourceNames covers issue #1853. PascalCase
+// resource keys (sniffed .NET/Java enterprise APIs) must render in the SKILL.md
+// / README.md command lists using the actual cobra command name (kebab), not
+// the raw map key. Otherwise every copy-pasted example exits "unknown command".
+func TestSkillAndReadmeKebabCasePascalResourceNames(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("enterprise")
+	// Single endpoint -> cobra promotes the resource to a top-level command.
+	apiSpec.Resources["ChangeOrders"] = spec.Resource{
+		Description: "Change orders",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {Method: "GET", Path: "/api/ChangeOrders/Grid", Description: "List change orders"},
+		},
+	}
+	// Multiple endpoints -> per-endpoint emission; both segments must kebab.
+	apiSpec.Resources["PurchaseOrders"] = spec.Resource{
+		Description: "Purchase orders",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {Method: "GET", Path: "/api/PurchaseOrders", Description: "List purchase orders"},
+			"get":  {Method: "GET", Path: "/api/PurchaseOrders/{id}", Description: "Get a purchase order"},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "enterprise-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	for _, file := range []string{"SKILL.md", "README.md"} {
+		t.Run(file, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(outputDir, file))
+			require.NoError(t, err)
+			content := string(body)
+
+			assert.Contains(t, content, "enterprise-pp-cli change-orders",
+				"promoted PascalCase resource ChangeOrders must invoke as change-orders")
+			assert.Contains(t, content, "enterprise-pp-cli purchase-orders",
+				"PascalCase resource PurchaseOrders must invoke as purchase-orders")
+
+			assert.NotContains(t, content, "enterprise-pp-cli ChangeOrders",
+				"raw PascalCase key must not appear as an invocation")
+			assert.NotContains(t, content, "enterprise-pp-cli PurchaseOrders",
+				"raw PascalCase key must not appear as an invocation")
+		})
+	}
+}
+
 // TestSkillAndReadmeSingleWordEndpointsUnchanged guards the negative case in
 // issue #1270's acceptance: single-word endpoint keys (list, create, get,
 // check) must pass through the kebab helper unchanged so existing CLIs do not

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -335,9 +335,9 @@ Run `{{.Name}}-pp-cli --help` for the full command reference and flag list.
 {{$resource.Description}}
 {{range $eName, $endpoint := $resource.Endpoints}}
 {{- if index $.PromotedResourceNames $name}}
-- **`{{$.Name}}-pp-cli {{$name}}{{positionalArgs $endpoint}}`** - {{$endpoint.Description}}
+- **`{{$.Name}}-pp-cli {{kebab $name}}{{positionalArgs $endpoint}}`** - {{$endpoint.Description}}
 {{- else}}
-- **`{{$.Name}}-pp-cli {{$name}} {{kebab $eName}}`** - {{$endpoint.Description}}
+- **`{{$.Name}}-pp-cli {{kebab $name}} {{kebab $eName}}`** - {{$endpoint.Description}}
 {{- end}}
 {{- end}}
 {{end}}

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -138,9 +138,9 @@ This CLI was generated with browser-observed traffic context.
 **{{$name}}** — {{$resource.Description}}
 {{range $eName, $endpoint := $resource.Endpoints}}
 {{- if index $.PromotedResourceNames $name}}
-- `{{$.Name}}-pp-cli {{$name}}{{positionalArgs $endpoint}}` — {{oneline $endpoint.Description}}
+- `{{$.Name}}-pp-cli {{kebab $name}}{{positionalArgs $endpoint}}` — {{oneline $endpoint.Description}}
 {{- else}}
-- `{{$.Name}}-pp-cli {{$name}} {{kebab $eName}}` — {{oneline $endpoint.Description}}
+- `{{$.Name}}-pp-cli {{kebab $name}} {{kebab $eName}}` — {{oneline $endpoint.Description}}
 {{- end}}
 {{- end}}
 {{end}}


### PR DESCRIPTION
## Intent

When a spec's resource keys are PascalCase (sniffed .NET/Java enterprise APIs), the generator rendered README/SKILL command examples using the raw key (`cli ChangeOrders`) instead of the actual Cobra command name (`cli change-orders`). Every copy-pasted invocation hits "unknown command".

Issue: Closes #1853

## Approach

The endpoint segment was already kebab-cased (`{{kebab $eName}}`, fixed in #1270); the resource segment was passed raw. Route the resource name through the same `toKebab`/`kebab` helper that `buildPromotedCommands` and the per-endpoint emission use:

- `internal/generator/first_command_example.go` — `parts := []string{toKebab(rName)}`
- `readme.md.tmpl` / `skill.md.tmpl` `## Commands` — `{{kebab $name}}` for the invocation

Display-label headings (`### {{$name}}` / `**{{$name}}**`) are intentionally left as the human-facing resource label, matching how lowercase specs already render.

## Scope

Primary area: generator (example builder + README/SKILL templates).

Why this belongs in this repo: machine change — the bug is in how the generator derives doc examples from spec keys, affecting every CLP printed from a PascalCase-keyed spec.

## Risk

Low. `toKebab`/`kebab` is a no-op on single-word lowercase keys (every existing fixture and published CLI), so existing docs do not drift on regen — confirmed by `scripts/golden.sh verify` passing 23/23 unchanged. This changes example *content* (command casing), not README/SKILL section structure/ordering/headings/frontmatter, so the published-library sweep contract is not triggered.

## Output Contract

Generated README.md / SKILL.md `## Commands` invocations and the Output-Formats example now use the kebab command name for PascalCase/snake_case resource keys. No change for lowercase keys. Golden suite unchanged (23/23).

## Verification

- `go test ./internal/generator/` — pass (new `TestSkillAndReadmeKebabCasePascalResourceNames` + 2 `TestFirstCommandExampleHonorsPromotion` cases)
- `go build ./...` — pass
- `golangci-lint run ./internal/generator/...` — 0 issues
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh verify` — 23/23 pass, no diff

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change