### PR TITLE
fix(cli): suppress phantom [] MCP/CLI parameters

### DIFF
--- a/internal/generator/phantom_param_e2e_test.go
+++ b/internal/generator/phantom_param_e2e_test.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPhantomBracketParamAbsentFromMCPSurface is the end-to-end companion to
+// the mapParameters unit test for issue #1670: it parses a real OpenAPI doc
+// whose operation declares a phantom "[]" query parameter, generates the CLI,
+// and asserts the emitted MCP tool schemas (which the tools-manifest.json is
+// built from) never expose it — while a legitimate sibling param survives.
+func TestPhantomBracketParamAbsentFromMCPSurface(t *testing.T) {
+	t.Parallel()
+
+	const doc = `
+openapi: 3.0.0
+info:
+  title: Phantom API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /broadcasts:
+    get:
+      operationId: listBroadcasts
+      tags: [broadcasts]
+      parameters:
+        - name: "[]"
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ok
+`
+	apiSpec, err := openapi.Parse([]byte(doc))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "phantom-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	toolsSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	content := string(toolsSrc)
+
+	// The quoted param name "[]" must never appear (Go slice literals like
+	// []mcpParamBinding{ contain unquoted [] and are not matched here).
+	assert.NotContains(t, content, `"[]"`,
+		"phantom []-named param must not reach the MCP tool surface")
+	assert.True(t, strings.Contains(content, `"limit"`),
+		"the legitimate sibling param must still be emitted")
+}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3524,6 +3524,12 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 		if strings.HasPrefix(paramName, "$") || strings.HasPrefix(paramName, ".") {
 			continue
 		}
+		// Skip phantom names ("" / "[]") that some specs emit for unnamed
+		// array query params. They are not usable MCP/CLI arguments and would
+		// send "?[]=value" on the wire. Legitimate "foo[]" names are kept.
+		if trimmed := strings.TrimSpace(paramName); trimmed == "" || trimmed == "[]" {
+			continue
+		}
 		description := strings.TrimSpace(parameter.Description)
 		if description == "" {
 			description = humanizeFieldName(paramName)

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -411,6 +411,35 @@ func TestMapParametersOnlyMarksQueryFieldSelectors(t *testing.T) {
 	assert.Equal(t, spec.ParamPurposeFieldSelector, byName["opt_fields"].Purpose)
 }
 
+// TestMapParametersDropsPhantomBracketName covers issue #1670. A spec
+// parameter literally named "[]" (or empty) is not a usable MCP/CLI argument
+// and would emit "?[]=value" on the wire. It must be dropped before reaching
+// CLI flags, MCP tool schemas, and tools-manifest.json. Legitimate
+// array-style names like "tags[]" must be preserved.
+func TestMapParametersDropsPhantomBracketName(t *testing.T) {
+	t.Parallel()
+
+	pathItem := &openapi3.PathItem{}
+	op := &openapi3.Operation{
+		Parameters: openapi3.Parameters{
+			{Value: &openapi3.Parameter{Name: "[]", In: openapi3.ParameterInQuery, Schema: openapi3.NewStringSchema().NewRef()}},
+			{Value: &openapi3.Parameter{Name: "  ", In: openapi3.ParameterInQuery, Schema: openapi3.NewStringSchema().NewRef()}},
+			{Value: &openapi3.Parameter{Name: "tags[]", In: openapi3.ParameterInQuery, Schema: openapi3.NewStringSchema().NewRef()}},
+			{Value: &openapi3.Parameter{Name: "limit", In: openapi3.ParameterInQuery, Schema: openapi3.NewInt64Schema().NewRef()}},
+		},
+	}
+
+	byName := make(map[string]bool)
+	for _, p := range mapParameters(pathItem, op) {
+		byName[p.Name] = true
+	}
+
+	assert.False(t, byName["[]"], "phantom []-named param must be dropped")
+	assert.False(t, byName["  "], "whitespace-only param name must be dropped")
+	assert.True(t, byName["tags[]"], "legitimate array-style param must be kept")
+	assert.True(t, byName["limit"], "normal param must be kept")
+}
+
 func readAICLargeSpec(tb testing.TB) []byte {
 	tb.Helper()
 	data, err := os.ReadFile(filepath.Join("..", "..", "testdata", "openapi", "artic-openapi.json"))

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -411,11 +411,12 @@ func TestMapParametersOnlyMarksQueryFieldSelectors(t *testing.T) {
 	assert.Equal(t, spec.ParamPurposeFieldSelector, byName["opt_fields"].Purpose)
 }
 
-// TestMapParametersDropsPhantomBracketName covers issue #1670. A spec
-// parameter literally named "[]" (or empty) is not a usable MCP/CLI argument
-// and would emit "?[]=value" on the wire. It must be dropped before reaching
-// CLI flags, MCP tool schemas, and tools-manifest.json. Legitimate
-// array-style names like "tags[]" must be preserved.
+// TestMapParametersDropsPhantomBracketName verifies that phantom parameter
+// names are dropped (issue #1670). A spec parameter literally named "[]" (or
+// empty) is not a usable MCP/CLI argument and would emit "?[]=value" on the
+// wire, so it must be dropped before reaching CLI flags, MCP tool schemas, and
+// tools-manifest.json. Legitimate array-style names like "tags[]" must be
+// preserved.
 func TestMapParametersDropsPhantomBracketName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

Some OpenAPI specs declare an unnamed array query parameter as literally `[]`. Greptile flagged a generated MCP tool (`broadcasts_get`) exposing a `[]` argument, which is not meaningful for MCP clients and would send `?[]=value` if used.

Issue: Closes #1670

## Approach

`mapParameters` is the single chokepoint that turns OpenAPI parameters into `spec.Param` (which feeds CLI flags, MCP tool schemas/bindings, and `tools-manifest.json`). It already skips names that can't be Go identifiers (`$`/`.` prefixes). Extend that guard to also drop parameters whose trimmed name is empty or exactly `[]`.

Legitimate array-style names like `tags[]` are preserved — only the empty-base `[]` (and whitespace-only/empty) cases are dropped.

## Scope

Primary area: openapi-parser (`internal/openapi/parser.go`).

Why this belongs in this repo: machine change — fixes the spec-shape-to-surface emission so no printed CLI exposes the phantom parameter; dropping at the parser covers CLI, MCP, and manifest at once.

## Risk

Low. Only the exact `[]`/empty/whitespace names are dropped; real parameters (including `foo[]`) are unaffected. No golden fixture contains a `[]` param, so `scripts/golden.sh verify` is unchanged (23/23).

## Output Contract

A source parameter named `[]` (or empty) no longer appears as a CLI flag, MCP tool argument, binding, or `tools-manifest.json` entry. No change for any other parameter shape.

## Verification

- `go test ./internal/openapi/` — pass (new `TestMapParametersDropsPhantomBracketName`)
- `go build ./...` — pass
- `golangci-lint run ./internal/openapi/...` — 0 issues
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh verify` — 23/23 pass, no diff

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change