### PR TITLE
fix(ci): let code-owner authors satisfy review gate

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,6 +32,17 @@ queue_rules:
       - check-success = golden
       - check-success = pr-title
       - check-success = test
+      # Mirrors .github/CODEOWNERS for security-sensitive paths, but lets
+      # code-owner-authored PRs enter the queue without requiring a second
+      # code owner to approve their own maintainer work. Non-code-owner PRs
+      # touching these paths still require an explicit approval from tmchow
+      # or mvanhorn.
+      - or:
+        - "-files ~= ^(\\.github/workflows/|\\.github/scripts/|scripts/|\\.github/CODEOWNERS$)"
+        - author = tmchow
+        - author = mvanhorn
+        - approved-reviews-by = tmchow
+        - approved-reviews-by = mvanhorn
       - or:
         - check-success = Greptile Review
         - check-neutral = Greptile Review
@@ -107,6 +118,14 @@ merge_protections:
       - check-success = golden
       - check-success = pr-title
       - check-success = test
+      # Mirrors .github/CODEOWNERS for security-sensitive paths, while
+      # allowing code-owner authors to merge their own maintainer PRs.
+      - or:
+        - "-files ~= ^(\\.github/workflows/|\\.github/scripts/|scripts/|\\.github/CODEOWNERS$)"
+        - author = tmchow
+        - author = mvanhorn
+        - approved-reviews-by = tmchow
+        - approved-reviews-by = mvanhorn
       - or:
         # Source PRs already had to pass Greptile in queue_conditions before
         # Mergify added this label. During merge, checks are evaluated against


### PR DESCRIPTION
## Summary
- move the CODEOWNERS-style maintainer review exception into Mergify queue conditions
- allow PRs authored by tmchow or mvanhorn to satisfy the protected-path review gate directly
- continue requiring approval from tmchow or mvanhorn for non-code-owner PRs touching workflow/script/CODEOWNERS paths

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".mergify.yml"); puts "YAML ok"'\n\n## Follow-up\nAfter this PR merges, GitHub native branch protection still needs `require_code_owner_reviews` disabled on `main`; otherwise GitHub will continue requiring another code-owner approval before Mergify can merge code-owner-authored PRs.