### PR TITLE
fix(cli): align MCP remote transport scoring threshold

### DIFF
--- a/internal/pipeline/mcp_scoring.go
+++ b/internal/pipeline/mcp_scoring.go
@@ -32,7 +32,6 @@ type mcpSurface struct {
 	codeOrchPresent bool   // internal/mcp/code_orch.go exists
 	endpointTools   int    // count of endpoint-mirror NewTool(...) registrations
 	intentTools     int    // count of intent tool registrations inside intents.go
-	totalTools      int    // count of agent-visible MCP tools when statically estimable
 }
 
 // mcpMainPath returns the path to the canonical cmd/<cli>-pp-mcp/main.go, or
@@ -93,10 +92,6 @@ func detectMCPSurface(dir string) mcpSurface {
 	if _, err := os.Stat(filepath.Join(dir, "internal", "mcp", "code_orch.go")); err == nil {
 		s.codeOrchPresent = true
 	}
-	s.totalTools = estimateMCPTokens(dir).ToolCount
-	if s.totalTools == 0 {
-		s.totalTools = s.endpointTools + s.intentTools
-	}
 	return s
 }
 
@@ -122,7 +117,14 @@ func scoreMCPRemoteTransport(dir string) (int, bool) {
 	hasStdio := strings.Contains(body, "server.ServeStdio")
 	hasHTTP := strings.Contains(body, "NewStreamableHTTPServer") || strings.Contains(body, "ServeStreamableHTTP")
 	plainEndpointMirror := !s.codeOrchPresent && !s.intentsPresent
-	if hasStdio && !hasHTTP && plainEndpointMirror && s.totalTools < mcpEnrichmentMinEndpoints {
+	totalTools := estimateMCPTokens(dir).ToolCount
+	if totalTools == 0 {
+		totalTools = s.endpointTools + s.intentTools
+	}
+	// Remote reach is about the full agent-visible tool catalog, including
+	// runtime-walked Cobra tools. Tool-design scoring below stays scoped to
+	// endpoint tools because it judges endpoint-mirror grouping specifically.
+	if hasStdio && !hasHTTP && plainEndpointMirror && totalTools < mcpEnrichmentMinEndpoints {
 		return 0, false
 	}
 	switch {

--- a/internal/pipeline/mcp_scoring.go
+++ b/internal/pipeline/mcp_scoring.go
@@ -8,11 +8,12 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 )
 
-// Thresholds for the tool-design dimension. Intent-grouping is only worth
-// scoring when the endpoint mirror would otherwise emit enough tools for
-// agents to feel the pain — small APIs (under ~30 endpoint tools) are fine as a
-// plain mirror and shouldn't be docked for not using intents.
-const toolDesignMinEndpoints = 30
+// Thresholds for MCP endpoint-mirror enrichment dimensions. Intent-grouping
+// and remote-reach pressure are only worth scoring when the endpoint mirror
+// would otherwise emit enough tools for agents to feel the pain — small APIs
+// (under ~30 endpoint tools) are fine as a plain mirror and shouldn't be
+// docked for not using enrichment.
+const mcpEnrichmentMinEndpoints = 30
 
 // Threshold above which an endpoint-mirror surface counts as the article's
 // named anti-pattern for large APIs. Matches the spec's
@@ -31,6 +32,7 @@ type mcpSurface struct {
 	codeOrchPresent bool   // internal/mcp/code_orch.go exists
 	endpointTools   int    // count of endpoint-mirror NewTool(...) registrations
 	intentTools     int    // count of intent tool registrations inside intents.go
+	totalTools      int    // count of agent-visible MCP tools when statically estimable
 }
 
 // mcpMainPath returns the path to the canonical cmd/<cli>-pp-mcp/main.go, or
@@ -91,6 +93,10 @@ func detectMCPSurface(dir string) mcpSurface {
 	if _, err := os.Stat(filepath.Join(dir, "internal", "mcp", "code_orch.go")); err == nil {
 		s.codeOrchPresent = true
 	}
+	s.totalTools = estimateMCPTokens(dir).ToolCount
+	if s.totalTools == 0 {
+		s.totalTools = s.endpointTools + s.intentTools
+	}
 	return s
 }
 
@@ -100,8 +106,9 @@ func detectMCPSurface(dir string) mcpSurface {
 // agents, so they score below the default line. Servers that compile in
 // both transports (stdio for local plus http for hosted) get full marks.
 //
-// Returns (0, false) when the CLI emits no MCP surface so the dimension can
-// be excluded from the tier-1 denominator.
+// Returns (0, false) when the CLI emits no MCP surface, or when a stdio-only
+// plain endpoint mirror is below the enrichment threshold, so the dimension
+// can be excluded from the tier-1 denominator.
 func scoreMCPRemoteTransport(dir string) (int, bool) {
 	s := detectMCPSurface(dir)
 	if !s.present {
@@ -114,6 +121,10 @@ func scoreMCPRemoteTransport(dir string) (int, bool) {
 	body := string(data)
 	hasStdio := strings.Contains(body, "server.ServeStdio")
 	hasHTTP := strings.Contains(body, "NewStreamableHTTPServer") || strings.Contains(body, "ServeStreamableHTTP")
+	plainEndpointMirror := !s.codeOrchPresent && !s.intentsPresent
+	if hasStdio && !hasHTTP && plainEndpointMirror && s.totalTools < mcpEnrichmentMinEndpoints {
+		return 0, false
+	}
 	switch {
 	case hasStdio && hasHTTP:
 		return 10, true
@@ -138,7 +149,7 @@ func scoreMCPRemoteTransport(dir string) (int, bool) {
 //   - intents present + ratio <  0.3: 7  (some coverage)
 //   - endpoint-mirror only: 5 (baseline — works, but leaves value on the table)
 //
-// Endpoint-mirror-only surfaces with endpoint count < toolDesignMinEndpoints
+// Endpoint-mirror-only surfaces with endpoint count < mcpEnrichmentMinEndpoints
 // return (0, false) — the decision doesn't meaningfully affect an agent at
 // small surface sizes.
 func scoreMCPToolDesign(dir string) (int, bool) {
@@ -156,7 +167,7 @@ func scoreMCPToolDesign(dir string) (int, bool) {
 		}
 		return 7, true
 	}
-	if s.endpointTools < toolDesignMinEndpoints {
+	if s.endpointTools < mcpEnrichmentMinEndpoints {
 		return 0, false
 	}
 	return 5, true

--- a/internal/pipeline/mcp_scoring_test.go
+++ b/internal/pipeline/mcp_scoring_test.go
@@ -57,12 +57,36 @@ func TestScoreMCPRemoteTransport(t *testing.T) {
 		assert.Equal(t, 0, score)
 	})
 
-	t.Run("stdio only scores baseline", func(t *testing.T) {
+	t.Run("stdio only is unscored below enrichment threshold", func(t *testing.T) {
+		for _, endpointTools := range []int{17, 29} {
+			dir := t.TempDir()
+			writeMCPFile(t, dir, "cmd/demo-pp-mcp/main.go", stdioOnlyMain)
+			writeMCPFile(t, dir, "internal/mcp/tools.go", buildToolsGo(endpointTools))
+			score, scored := scoreMCPRemoteTransport(dir)
+			assert.False(t, scored, "small endpoint mirrors don't get docked for stdio-only transport")
+			assert.Equal(t, 0, score)
+		}
+	})
+
+	t.Run("large stdio only scores baseline", func(t *testing.T) {
+		for _, endpointTools := range []int{30, 100} {
+			dir := t.TempDir()
+			writeMCPFile(t, dir, "cmd/demo-pp-mcp/main.go", stdioOnlyMain)
+			writeMCPFile(t, dir, "internal/mcp/tools.go", buildToolsGo(endpointTools))
+			score, scored := scoreMCPRemoteTransport(dir)
+			assert.True(t, scored)
+			assert.Equal(t, 5, score, "stdio-only gets middle-low band (remote-unreachable)")
+		}
+	})
+
+	t.Run("runtime-walked tools count toward enrichment threshold", func(t *testing.T) {
 		dir := t.TempDir()
 		writeMCPFile(t, dir, "cmd/demo-pp-mcp/main.go", stdioOnlyMain)
+		writeMCPFile(t, dir, "internal/mcp/tools.go", strings.Replace(buildToolsGo(20), "\n}", "\n\tcobratree.RegisterAll(s, cli.RootCmd(), cobratree.SiblingCLIPath)\n}", 1))
+		writeNovelCommandTree(t, dir, 10)
 		score, scored := scoreMCPRemoteTransport(dir)
-		assert.True(t, scored)
-		assert.Equal(t, 5, score, "stdio-only gets middle-low band (remote-unreachable)")
+		assert.True(t, scored, "endpoint tools plus runtime-walked tools should cross the enrichment threshold")
+		assert.Equal(t, 5, score, "stdio-only remains penalized once the total agent-visible surface reaches the enrichment band")
 	})
 
 	t.Run("http only scores partial", func(t *testing.T) {
@@ -118,6 +142,45 @@ func buildToolsGo(n int) string {
 	}
 	b.WriteString("}\n")
 	return b.String()
+}
+
+func writeNovelCommandTree(t *testing.T, dir string, count int) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(`package cli
+
+import "github.com/spf13/cobra"
+
+func RootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "demo-pp-cli"}
+`)
+	for i := range count {
+		b.WriteString("\trootCmd.AddCommand(newNovel")
+		b.WriteString(string(rune('A' + i%26)))
+		b.WriteString("Cmd())\n")
+	}
+	b.WriteString(`	return rootCmd
+}
+`)
+	for i := range count {
+		suffix := string(rune('A' + i%26))
+		b.WriteString(`
+func newNovel`)
+		b.WriteString(suffix)
+		b.WriteString(`Cmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "novel`)
+		b.WriteString(suffix)
+		b.WriteString(`",
+		Short: "Run novel command `)
+		b.WriteString(suffix)
+		b.WriteString(`.",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+}
+`)
+	}
+	writeMCPCLISource(t, dir, "root.go", b.String())
 }
 
 func TestScoreMCPToolDesign(t *testing.T) {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -64,8 +64,8 @@ type SteinerScore struct {
 	MCPQuality            int `json:"mcp_quality"`              // 0-10
 	MCPDescriptionQuality int `json:"mcp_description_quality"`  // 0-10; unscored when no tools-manifest.json. Penalizes thin per-tool descriptions (the same threshold as `cli-printing-press tools-audit` thin-mcp-description).
 	MCPTokenEff           int `json:"mcp_token_efficiency"`     // 0-10; unscored when no MCP surface
-	MCPRemoteTransport    int `json:"mcp_remote_transport"`     // 0-10; unscored when no MCP surface. Rewards remote-capable servers per Anthropic's 2026-04 MCP guidance.
-	MCPToolDesign         int `json:"mcp_tool_design"`          // 0-10; unscored when no MCP surface or endpoint count below toolDesignMinEndpoints. Rewards intent-grouped tools vs. endpoint mirrors.
+	MCPRemoteTransport    int `json:"mcp_remote_transport"`     // 0-10; unscored when no MCP surface or small endpoint mirrors. Rewards remote-capable MCP servers.
+	MCPToolDesign         int `json:"mcp_tool_design"`          // 0-10; unscored when no MCP surface or endpoint count below mcpEnrichmentMinEndpoints. Rewards intent-grouped tools vs. endpoint mirrors.
 	MCPSurfaceStrategy    int `json:"mcp_surface_strategy"`     // 0-10; unscored unless the endpoint surface exceeds surfaceStrategyLargeThreshold or code-orchestration is explicitly used. Penalizes endpoint-mirror at scale.
 	LocalCache            int `json:"local_cache"`              // 0-10
 	CacheFreshness        int `json:"cache_freshness"`          // 0-10; unscored when the CLI has no local store


### PR DESCRIPTION
## Summary

Small stdio-only endpoint-mirror MCP surfaces no longer get capped at `5/10` on `mcp_remote_transport` when the total agent-visible tool surface is below the enrichment threshold. Once endpoint tools plus runtime-walked tools reach the enrichment band, stdio-only transport still scores `5/10` so larger hosted-agent reach gaps remain visible.

This keeps the remote-transport score aligned with the Printing Press MCP enrichment guidance without weakening the large-surface penalty.

Closes #1571

## Tests

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
