### PR TITLE
fix(cli): recognize literal-format composed auth in dogfood auth_check

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1413,6 +1413,7 @@ type composedAuthLiteralScheme struct {
 }
 
 var composedAuthLiteralSchemes = []composedAuthLiteralScheme{
+	{prefix: "Bot ", label: "bot auth"},
 	{prefix: "Basic ", label: "basic auth"},
 	{prefix: "Bearer ", label: "bearer auth"},
 	{prefix: "Cookie ", label: "cookie auth"},

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1152,6 +1152,38 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	configData, _ := os.ReadFile(filepath.Join(dir, "internal", "config", "config.go"))
 
 	combinedSource := string(clientData) + string(configData)
+
+	// Composed/cookie auth stores the full header value (scheme prefix and
+	// token together) in Config.AuthHeaderVal and writes it to the wire
+	// verbatim. There is no source-level "<Scheme> " + token concat for the
+	// concat detector below to find. Classify by the spec-declared format
+	// instead, but only when the generated source still references
+	// AuthHeaderVal — a hand-stripped client must still surface as a miss.
+	if literalFmt, ok := classifyComposedAuthLiteral(auth, combinedSource); ok {
+		result.GeneratedFmt = literalFmt
+		switch {
+		case expectedPrefix != "" && literalFmt == composedAuthLabelFor(expectedPrefix):
+			result.Match = true
+			result.Detail = fmt.Sprintf(`spec format declares %q and generated client emits Config.AuthHeaderVal verbatim`, strings.TrimSpace(expectedPrefix))
+		case expectedPrefix == "" && literalFmt != composedAuthCustomFmt:
+			// Format-recognized prefix without a corresponding SpecScheme entry
+			// (e.g. composed + "Bearer ...", which the outer switch leaves
+			// expectedPrefix empty because the spec is not bearer_token typed).
+			// Populate SpecScheme from the literal so downstream readers see a
+			// matched pair, and treat the literal classification as the match.
+			result.SpecScheme = fmt.Sprintf(`%s format (composed/cookie literal in spec)`, literalFmt)
+			result.Match = true
+			result.Detail = `composed/cookie auth format declares a recognized scheme prefix and generated client emits Config.AuthHeaderVal verbatim`
+		case literalFmt == composedAuthCustomFmt:
+			result.Match = false
+			result.Detail = fmt.Sprintf(`composed auth format %q does not start with a recognized scheme prefix`, auth.Format)
+		default:
+			result.Match = false
+			result.Detail = fmt.Sprintf(`spec expects %q but composed auth format classifies as %q`, strings.TrimSpace(expectedPrefix), literalFmt)
+		}
+		return result
+	}
+
 	var tokenPreserving bool
 	var invalidDetail string
 	result.GeneratedFmt, tokenPreserving, invalidDetail = detectGeneratedAuthFormat(combinedSource, expectedPrefix)
@@ -1368,6 +1400,61 @@ var authPrefixCandidates = []authPrefixCandidate{
 	{prefix: "Bot ", concatRe: regexp.MustCompile(`"Bot "\s*\+`)},
 	{prefix: "Bearer ", concatRe: regexp.MustCompile(`"Bearer "\s*\+`)},
 	{prefix: "Basic ", concatRe: regexp.MustCompile(`"Basic "\s*\+`)},
+}
+
+// composedAuthLiteralScheme classifies the auth scheme that a composed-auth or
+// cookie-auth spec writes verbatim into Config.AuthHeaderVal. The literal
+// header value never gets a source-level "<Scheme> " + token concat, so the
+// concat-based detector in detectGeneratedAuthFormat returns "unknown" on this
+// path. Spec-side classification covers the gap.
+type composedAuthLiteralScheme struct {
+	prefix string
+	label  string
+}
+
+var composedAuthLiteralSchemes = []composedAuthLiteralScheme{
+	{prefix: "Basic ", label: "basic auth"},
+	{prefix: "Bearer ", label: "bearer auth"},
+	{prefix: "Cookie ", label: "cookie auth"},
+	{prefix: "Token ", label: "token auth"},
+}
+
+const composedAuthCustomFmt = "custom-composed"
+
+// classifyComposedAuthLiteral returns the literal-format classification of a
+// composed/cookie auth spec when the generated source still wires
+// Config.AuthHeaderVal through to the wire. A stripped client (no
+// AuthHeaderVal reference in client.go or config.go) returns ok=false so the
+// caller falls through to the concat detector, which will surface "unknown".
+func classifyComposedAuthLiteral(auth apispec.AuthConfig, source string) (string, bool) {
+	authType := strings.ToLower(strings.TrimSpace(auth.Type))
+	if authType != "composed" && authType != "cookie" {
+		return "", false
+	}
+	if strings.TrimSpace(auth.Format) == "" {
+		return "", false
+	}
+	if !strings.Contains(source, "AuthHeaderVal") {
+		return "", false
+	}
+	for _, scheme := range composedAuthLiteralSchemes {
+		if strings.HasPrefix(auth.Format, scheme.prefix) {
+			return scheme.label, true
+		}
+	}
+	return composedAuthCustomFmt, true
+}
+
+// composedAuthLabelFor maps a concat-detector prefix ("Basic ", "Bearer ", ...)
+// to the composed-auth literal label so the new branch can reuse the existing
+// expectedPrefix value for the match decision.
+func composedAuthLabelFor(prefix string) string {
+	for _, scheme := range composedAuthLiteralSchemes {
+		if scheme.prefix == prefix {
+			return scheme.label
+		}
+	}
+	return ""
 }
 
 var applyAuthFormatInlineMapCallRe = regexp.MustCompile(`(?s)applyAuthFormat\("([^"]*)",\s*map\[string\]string\{(.*?)\}\)`)

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1253,6 +1253,143 @@ func (c *Config) AuthHeader() string {
 	assert.Equal(t, "Bearer ", result.GeneratedFmt)
 }
 
+func TestCheckAuthComposedLiteralFormat(t *testing.T) {
+	// Composed/cookie auth stores the literal Authorization header value in
+	// Config.AuthHeaderVal — no "<Scheme> " + token concat exists in generated
+	// source, so the concat detector returns "unknown". The literal-format
+	// branch classifies by the spec-declared auth.format prefix and confirms
+	// the wiring by checking that generated source still references
+	// Config.AuthHeaderVal.
+	composedAuthHeaderValConfig := `package config
+type Config struct {
+	AuthHeaderVal string
+}
+func (c *Config) AuthHeader() string {
+	if c.AuthHeaderVal != "" {
+		return c.AuthHeaderVal
+	}
+	return ""
+}
+`
+	composedClient := `package client
+func authHeader() string { return configAuthHeader() }
+`
+
+	tests := []struct {
+		name           string
+		auth           apispec.AuthConfig
+		clientGo       string
+		configGo       string
+		wantMatch      bool
+		wantGenerated  string
+		wantDetailLike string
+	}{
+		{
+			name:          "basic literal in composed format matches",
+			auth:          apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "Basic MkFKYjlPeUlBMFZaNUpWNmlkb05vT1VGVWEyOg=="},
+			clientGo:      composedClient,
+			configGo:      composedAuthHeaderValConfig,
+			wantMatch:     true,
+			wantGenerated: "basic auth",
+		},
+		{
+			name:          "bearer literal in composed format matches",
+			auth:          apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "Bearer XYZ"},
+			clientGo:      composedClient,
+			configGo:      composedAuthHeaderValConfig,
+			wantMatch:     true,
+			wantGenerated: "bearer auth",
+		},
+		{
+			name:           "unknown scheme classifies as custom-composed",
+			auth:           apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "FooScheme XYZ"},
+			clientGo:       composedClient,
+			configGo:       composedAuthHeaderValConfig,
+			wantMatch:      false,
+			wantGenerated:  "custom-composed",
+			wantDetailLike: "does not start with a recognized scheme prefix",
+		},
+		{
+			name:          "cookie type with cookie-prefixed format matches",
+			auth:          apispec.AuthConfig{Type: "cookie", Header: "Authorization", Format: "Cookie sessionid=abc"},
+			clientGo:      composedClient,
+			configGo:      composedAuthHeaderValConfig,
+			wantMatch:     true,
+			wantGenerated: "cookie auth",
+		},
+		{
+			name:           "stripped client falls through to concat detector and surfaces unknown",
+			auth:           apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "Basic MkFKYjlPeUlBMFZaNUpWNmlkb05vT1VGVWEyOg=="},
+			clientGo:       `package client` + "\nfunc authHeader() string { return \"\" }\n",
+			configGo:       `package config` + "\ntype Config struct{}\nfunc (c *Config) AuthHeader() string { return \"\" }\n",
+			wantMatch:      false,
+			wantGenerated:  "unknown",
+			wantDetailLike: `spec expects "Basic"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+			writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), tc.clientGo)
+			writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), tc.configGo)
+
+			result := checkAuth(dir, tc.auth)
+			assert.Equal(t, tc.wantMatch, result.Match, "match")
+			assert.Equal(t, tc.wantGenerated, result.GeneratedFmt, "generated_format")
+			if tc.wantDetailLike != "" {
+				assert.Contains(t, result.Detail, tc.wantDetailLike, "detail")
+			}
+		})
+	}
+}
+
+func TestCheckAuthComposedEmptyFormatFallsThrough(t *testing.T) {
+	// auth.type: composed with an empty auth.format must NOT engage the
+	// literal-format branch — fall through to the concat detector so the
+	// existing behavior is preserved.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader() string { return configAuthHeader() }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+type Config struct{ AuthHeaderVal string }
+func (c *Config) AuthHeader() string { return c.AuthHeaderVal }
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "composed", Format: ""})
+	// No expectedPrefix derived; detail should be the existing
+	// "no bot/bearer/basic scheme detected" path.
+	assert.True(t, result.Match)
+	assert.Equal(t, "unknown", result.GeneratedFmt)
+}
+
+func TestCheckAuthAPIKeyTypeUnaffected(t *testing.T) {
+	// Negative-criterion guard: api_key with a "Basic ..." format must keep
+	// the existing concat-detection behavior — the literal-format branch only
+	// fires for composed/cookie types.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader() string { return configAuthHeader() }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+type Config struct{ AuthHeaderVal string }
+func (c *Config) AuthHeader() string {
+	return "Basic " + encode(c.Username+":"+c.Password)
+}
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "api_key", Format: "Basic {username}:{password}"})
+	assert.True(t, result.Match)
+	assert.Equal(t, "Basic ", result.GeneratedFmt)
+}
+
 func TestDeriveDogfoodVerdict_WiringChecks(t *testing.T) {
 	// Test that unregistered commands cause FAIL
 	report := &DogfoodReport{

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1301,6 +1301,14 @@ func authHeader() string { return configAuthHeader() }
 			wantGenerated: "bearer auth",
 		},
 		{
+			name:          "bot literal in composed format matches",
+			auth:          apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "Bot DISCORD_TOKEN"},
+			clientGo:      composedClient,
+			configGo:      composedAuthHeaderValConfig,
+			wantMatch:     true,
+			wantGenerated: "bot auth",
+		},
+		{
 			name:           "unknown scheme classifies as custom-composed",
 			auth:           apispec.AuthConfig{Type: "composed", Header: "Authorization", Format: "FooScheme XYZ"},
 			clientGo:       composedClient,


### PR DESCRIPTION
## Intent

Issue: Closes #1959

Dogfood's `auth_check` derivation false-FAILs composed-auth and cookie-auth CLIs whose `auth.format` carries the scheme literal (e.g., Thrive Market's `format: \"Basic <const>\"`, Pagliacci's `\"PagliacciAuth ...\"`). The detector greps generated client/config source for `\"<Scheme> \" + token` concatenation as scheme evidence, but composed auth stores the full header verbatim in `Config.AuthHeaderVal` and writes it byte-for-byte — there is no concat to find, so the scorer reports `generated_format: \"unknown\"` and `match: false` even when the wire request carries the spec-declared scheme.

## Approach

Add a literal-format branch in `checkAuth` that runs **before** the existing `detectGeneratedAuthFormat` (concat) call. It fires only when `auth.Type ∈ {composed, cookie}` AND `auth.Format` is non-empty. Classification is by `Format` prefix against a typed scheme const slice (`Basic " → \"basic auth\"`, `\"Bearer \" → \"bearer auth\"`, `\"Cookie \" → \"cookie auth\"`, `\"Token \" → \"token auth\"`); a recognized non-matching prefix returns `\"custom-composed\"` — still a better signal than `\"unknown\"`.

The branch only engages when generated source still references `Config.AuthHeaderVal`. A hand-stripped client (no `AuthHeaderVal` in client.go or config.go) falls through to the legacy concat detector and still surfaces as `\"unknown\"`. The `api_key` / `bearer_token` / `oauth2` paths are unchanged (the branch's type guard rejects them).

## Scope

Primary area: scorer (`internal/pipeline/dogfood.go`).

Why this belongs in this repo: every composed/cookie-auth printed CLI in the catalog hits this miss the moment its spec carries a scheme-literal `format`. Pure machine fix — no template / generator change, no spec parser change.

## Risk

N/A — scorer-only change. No template or generated-output impact. The existing concat detection path stays in place for non-composed auth, and existing `TestCheckAuthRecognizesBasicPrefix` / `TestCheckAuthRecognizesBearerApplyAuthFormat*` cases still pass unchanged. The negative criterion (hand-stripped Authorization header) is preserved by the `AuthHeaderVal`-presence gate in the new branch.

## Output Contract

N/A — `scripts/golden.sh verify` clean (23/23 cases pass). The new branch only changes runtime JSON for spec/source combinations that previously produced `match: false` and are not covered by golden fixtures.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — clean
- `go fmt ./...` — clean
- `golangci-lint run ./internal/pipeline/...` — 0 issues
- `go test ./...` — all packages pass (full `internal/pipeline` suite at 94s)
- `scripts/golden.sh verify` — 23/23 pass
- New unit tests in `internal/pipeline/dogfood_test.go`:
  - `TestCheckAuthComposedLiteralFormat` table-driven, sub-cases:
    - `basic_literal_in_composed_format_matches` — `composed` + `\"Basic Mk...\"` → `match: true`, `generated_format: \"basic auth\"`
    - `bearer_literal_in_composed_format_matches` — `composed` + `\"Bearer XYZ\"` → `match: true`, `generated_format: \"bearer auth\"`
    - `unknown_scheme_classifies_as_custom-composed` — `composed` + `\"FooScheme XYZ\"` → `match: false`, `generated_format: \"custom-composed\"`
    - `cookie_type_with_cookie-prefixed_format_matches` — `cookie` + `\"Cookie sessionid=...\"` → `match: true`, `generated_format: \"cookie auth\"`
    - `stripped_client_falls_through_to_concat_detector_and_surfaces_unknown` — `composed` + `\"Basic ...\"`, no `AuthHeaderVal` reference in generated source → `match: false`, `generated_format: \"unknown\"` (negative-criterion guard)
  - `TestCheckAuthComposedEmptyFormatFallsThrough` — `composed` + empty `format` → existing path (`unknown`, no false fire)
  - `TestCheckAuthAPIKeyTypeUnaffected` — `api_key` + `\"Basic {username}:{password}\"` → existing concat path (`Basic `, `match: true`)
- Live regression against Thrive Market spec (`~/printing-press/.runstate/.../thrivemarket-spec.yaml`): regenerated CLI, ran `dogfood --json | jq '.auth_check'` →
  ```json
  {
    \"spec_scheme\": \"basic auth format (expects \\\"Basic \\\" prefix)\",
    \"generated_format\": \"basic auth\",
    \"match\": true,
    \"detail\": \"spec format declares \\\"Basic\\\" and generated client emits Config.AuthHeaderVal verbatim\"
  }
  ```

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change