### PR TITLE
fix(cli): normalize verify directories

### DIFF
--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -431,6 +431,11 @@ Each leg remains callable standalone — this command is additive orchestration.
 			if err := validateShipcheckDir(opts.dir); err != nil {
 				return &ExitError{Code: ExitInputError, Err: err}
 			}
+			absDir, err := filepath.Abs(opts.dir)
+			if err != nil {
+				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("resolving --dir: %w", err)}
+			}
+			opts.dir = absDir
 
 			binPath, err := resolveSelfBinary()
 			if err != nil {

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -280,6 +280,26 @@ func TestShipcheck_DefaultArgvIncludesFixAndLiveCheck(t *testing.T) {
 	}
 }
 
+func TestShipcheck_NormalizesRelativeDirForLegs(t *testing.T) {
+	h := newShipcheckHarness(t)
+	t.Chdir(h.dir)
+
+	if err := runShipcheckCmd(t, "--dir", "."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	verifyArgs := findInvocation(readStubLog(t, h.logFile), "verify")
+	for i, arg := range verifyArgs {
+		if arg == "--dir" && i+1 < len(verifyArgs) {
+			if verifyArgs[i+1] != h.dir {
+				t.Fatalf("verify --dir = %q; want %q", verifyArgs[i+1], h.dir)
+			}
+			return
+		}
+	}
+	t.Fatalf("verify argv missing --dir: %v", verifyArgs)
+}
+
 // TestShipcheck_PassesSpecAndResearchDir: when --spec and --research-dir
 // are set, dogfood and scorecard receive both; verify receives --spec.
 func TestShipcheck_PassesSpecAndResearchDir(t *testing.T) {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -75,6 +75,11 @@ Use --fix to auto-patch common failures and re-test (max 3 iterations).`,
   # Structural verification without an API spec (plan-driven CLIs)
   cli-printing-press verify --dir ./agent-capture-pp-cli --no-spec`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			absDir, err := filepath.Abs(dir)
+			if err != nil {
+				return fmt.Errorf("resolving --dir: %w", err)
+			}
+			dir = absDir
 			cfg := pipeline.VerifyConfig{
 				Dir:       dir,
 				SpecPath:  specPath,

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -132,3 +132,27 @@ func TestVerifyCmdTextFailExitsWithLegacyCode(t *testing.T) {
 	assert.Equal(t, 1, *exitCode)
 	assert.Contains(t, output, "Verdict: FAIL")
 }
+
+func TestVerifyCmdNormalizesRelativeDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	var gotDir string
+	cmd := newVerifyCmdWithOptions(verifyCmdOptions{
+		runVerify: func(cfg pipeline.VerifyConfig) (*pipeline.VerifyReport, error) {
+			gotDir = cfg.Dir
+			return &pipeline.VerifyReport{
+				Mode:     "mock",
+				Total:    1,
+				Passed:   1,
+				PassRate: 100,
+				Verdict:  "PASS",
+				Binary:   filepath.Join(cfg.Dir, "sample-cli"),
+			}, nil
+		},
+	})
+	cmd.SetArgs([]string{"--dir", "."})
+
+	_, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+	assert.Equal(t, dir, gotDir)
+}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -91,6 +91,11 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 		return nil, err
 	}
 	defer releaseHome()
+	absDir, err := filepath.Abs(cfg.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving CLI directory: %w", err)
+	}
+	cfg.Dir = absDir
 	if cfg.NoSpec {
 		return runStructuralVerify(cfg)
 	}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -91,6 +91,8 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 		return nil, err
 	}
 	defer releaseHome()
+	// Keep this boundary safe for programmatic callers; CLI commands also
+	// normalize earlier when they need the stable path for follow-on argv.
 	absDir, err := filepath.Abs(cfg.Dir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving CLI directory: %w", err)

--- a/internal/pipeline/runtime_exec.go
+++ b/internal/pipeline/runtime_exec.go
@@ -14,7 +14,7 @@ import (
 )
 
 func buildCLI(dir string) (string, error) {
-	dir, err := resolveCLIDir(dir)
+	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", fmt.Errorf("resolving CLI directory: %w", err)
 	}
@@ -43,7 +43,7 @@ func buildCLITo(dir, binaryPath string) error {
 }
 
 func findCLICommandDir(dir string) (string, error) {
-	dir, err := resolveCLIDir(dir)
+	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", fmt.Errorf("resolving CLI directory: %w", err)
 	}
@@ -93,10 +93,6 @@ func findCLICommandDir(dir string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cannot find CLI cmd entry point in %s", dir)
-}
-
-func resolveCLIDir(dir string) (string, error) {
-	return filepath.Abs(dir)
 }
 
 func runCLI(binary string, args []string, env []string, timeout time.Duration) error {

--- a/internal/pipeline/runtime_exec.go
+++ b/internal/pipeline/runtime_exec.go
@@ -14,11 +14,11 @@ import (
 )
 
 func buildCLI(dir string) (string, error) {
-	binaryPath, err := filepath.Abs(filepath.Join(dir, filepath.Base(dir)))
+	dir, err := resolveCLIDir(dir)
 	if err != nil {
-		return "", fmt.Errorf("resolving binary path: %w", err)
+		return "", fmt.Errorf("resolving CLI directory: %w", err)
 	}
-	binaryPath = platform.ExecutablePath(binaryPath)
+	binaryPath := platform.ExecutablePath(filepath.Join(dir, filepath.Base(dir)))
 	if err := buildCLITo(dir, binaryPath); err != nil {
 		return "", err
 	}
@@ -43,6 +43,10 @@ func buildCLITo(dir, binaryPath string) error {
 }
 
 func findCLICommandDir(dir string) (string, error) {
+	dir, err := resolveCLIDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving CLI directory: %w", err)
+	}
 	name := filepath.Base(dir)
 	apiName := naming.TrimCLISuffix(name)
 	candidates := []string{
@@ -89,6 +93,10 @@ func findCLICommandDir(dir string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cannot find CLI cmd entry point in %s", dir)
+}
+
+func resolveCLIDir(dir string) (string, error) {
+	return filepath.Abs(dir)
 }
 
 func runCLI(binary string, args []string, env []string, timeout time.Duration) error {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -62,6 +62,20 @@ func main() {
 	assert.FileExists(t, existingBinary)
 }
 
+func TestFindCLICommandDirResolvesRelativeDirFromCLIRoot(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "sample-cli")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "sample-cli"), 0o755))
+	writeTestFile(t, filepath.Join(dir, "cmd", "sample-cli", "main.go"), `package main
+func main() {}
+`)
+
+	t.Chdir(dir)
+
+	cmdDir, err := findCLICommandDir(".")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "cmd", "sample-cli"), cmdDir)
+}
+
 func TestRunFreshnessContractTestPassesGeneratedSurface(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))


### PR DESCRIPTION
## Summary
- Normalize `verify --dir` before building `VerifyConfig` so `.` and other relative paths stay stable through verify and the fix loop.
- Normalize `shipcheck --dir` before constructing leg argv so internal verify, dogfood, workflow, skill, and scorecard legs all receive the same absolute CLI directory.
- Normalize runtime CLI build/discovery paths before probing `cmd/<name>` candidates so `findCLICommandDir(".")` cannot resolve to the bare `cmd` directory.

## Verification
- `go test ./internal/pipeline -run 'TestFindCLICommandDirResolvesRelativeDirFromCLIRoot|TestRunVerify_CleansTransientArtifactsButKeepsCache|TestRunVerify_KeepsExistingBinaryWhenRebuildFails|TestRunLiveDogfoodProcessTracksOutputTruncation'`
- `go test ./internal/cli -run 'TestVerifyCmdNormalizesRelativeDir|TestShipcheck_NormalizesRelativeDirForLegs|TestShipcheck_DefaultArgvIncludesFixAndLiveCheck'`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `go test ./...` passed once before rebase, then hit the existing flaky 5s timeout in `TestRunLiveDogfoodProcessTracksOutputTruncation` after rebase; that test passes in isolation.

Closes #1579
