### PR TITLE
fix(cli): retry live dogfood auth 401s

### DIFF
--- a/docs/solutions/logic-errors/live-dogfood-auth-401-runner-credentials-2026-05-23.md
+++ b/docs/solutions/logic-errors/live-dogfood-auth-401-runner-credentials-2026-05-23.md
@@ -1,0 +1,58 @@
+---
+title: Live dogfood treats runner-auth 401s as credential-unavailable after one retry
+date: 2026-05-23
+category: logic-errors
+module: live dogfood
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "dogfood --live reports HTTP 401 failures for auth-required CLIs"
+  - "direct command invocation succeeds with the same API credential environment"
+  - "missing or stale runner credentials poison the happy_path and json_fidelity matrix"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [dogfood, live-dogfood, auth, credentials, subprocess-env, retry]
+---
+
+# Live dogfood treats runner-auth 401s as credential-unavailable after one retry
+
+## Problem
+
+`dogfood --live` can report auth-shaped HTTP 401 responses as hard matrix failures for auth-required CLIs even after subprocess environment propagation has been ruled out. That makes the live dogfood verdict look like product breakage when the runner credentials are unavailable or a transient upstream auth response succeeds on retry.
+
+## Symptoms
+
+- `happy_path` and `json_fidelity` fail with output such as `HTTP 401` and `Couldn't authenticate you`.
+- The same command succeeds when invoked directly with the same API credential environment.
+- Clearing the API credential produces a normal upstream auth denial instead of a local missing-env error, so the matrix records a 401 fail instead of a credential-unavailable skip.
+
+## What Didn't Work
+
+- Assuming scoped subprocess HOME/XDG handling dropped API credentials. Targeted tests showed arbitrary `*_API_TOKEN` and `*_API_KEY` values survive `scopeSubprocessHome()` and `applyDefaultSubprocessEnv()`.
+- Treating every 401 as a real endpoint failure. For live dogfood, the runner credential state is part of the test harness, and a harness-auth denial should not be mixed into API behavior failures.
+
+## Solution
+
+Keep the subprocess env audit as a guardrail, then handle auth-shaped 401s in the live dogfood runner:
+
+- Retry one auth-shaped HTTP 401 inside the original subprocess timeout budget.
+- Recognize common runner-auth denial text such as `Couldn't authenticate you`, `Could not authenticate you`, `not authenticated`, and `unauthorized`.
+- If the retry still returns the same auth-shaped 401, classify the result as `unavailable for runner credentials` instead of a hard HTTP failure.
+- When `happy_path` establishes that runner credentials are unavailable, skip `json_fidelity` with the same reason rather than executing and retrying the same denied command again.
+
+## Why This Works
+
+The live dogfood matrix is supposed to measure generated CLI behavior against a live API. A runner-auth denial is different from a command implementation bug: it means the harness cannot prove the command against the live service. Classifying persistent auth denial as a skip preserves the existing acceptance floor, which still fails when there is no live happy/json pass, while keeping credential problems out of the HTTP-failure bucket.
+
+The retry covers the narrow transient case without relaxing the command timeout. If the second attempt succeeds, the command contributes a real pass. If it does not, the matrix records the credential limitation and avoids duplicate JSON probes after the happy path already proved the runner cannot authenticate.
+
+## Prevention
+
+- Add env propagation tests whenever subprocess HOME/XDG scoping changes so API credential env vars stay outside the scoped-home filter.
+- Test live dogfood retry behavior through both the raw subprocess helper and the matrix result path.
+- When a harness-level failure mode is expected for auth-required APIs, classify it distinctly from real endpoint failures and keep the acceptance gate responsible for deciding whether enough live signal remains.
+
+## Related Issues
+
+- GitHub issue #1573

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -50,6 +50,7 @@ const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
 // honor a smaller --limit) so the matrix's per-command timeout
 // doesn't kill an otherwise healthy run.
 const dogfoodEnvVar = "PRINTING_PRESS_DOGFOOD"
+const liveDogfoodAuthRetryDelay = time.Second
 
 type LiveDogfoodOptions struct {
 	CLIDir              string
@@ -935,8 +936,6 @@ func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout
 	return result
 }
 
-var liveDogfoodAuthRetryDelay = time.Second
-
 func liveDogfoodRetryableAuth401(run liveDogfoodRun) bool {
 	if run.exitCode == 0 {
 		return false
@@ -1180,8 +1179,7 @@ func liveDogfoodAuth401(run liveDogfoodRun) bool {
 	}
 	return strings.Contains(output, "couldn't authenticate") ||
 		strings.Contains(output, "could not authenticate") ||
-		strings.Contains(output, "not authenticated") ||
-		strings.Contains(output, "unauthorized")
+		strings.Contains(output, "not authenticated")
 }
 
 func commandSupportsDryRun(help string) bool {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1165,13 +1165,16 @@ func validLiveDogfoodJSONOutput(stdout string) bool {
 func liveDogfoodUnavailableForRunner(run liveDogfoodRun) bool {
 	output := strings.ToLower(run.stdout + run.stderr)
 	return strings.Contains(output, "http 403") ||
-		liveDogfoodAuth401(run) ||
+		liveDogfoodAuth401Output(output) ||
 		strings.Contains(output, "permission denied") ||
 		strings.Contains(output, "your credentials are valid but lack access")
 }
 
 func liveDogfoodAuth401(run liveDogfoodRun) bool {
-	output := strings.ToLower(run.stdout + run.stderr)
+	return liveDogfoodAuth401Output(strings.ToLower(run.stdout + run.stderr))
+}
+
+func liveDogfoodAuth401Output(output string) bool {
 	if !strings.Contains(output, "http 401") {
 		return false
 	}

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -728,7 +728,9 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		}
 		results = append(results, happyResult)
 
-		if commandSupportsJSON(command.Help) {
+		if happyResult.Status == LiveDogfoodStatusSkip && happyResult.Reason == reasonUnavailableRunnerCredentials {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonUnavailableRunnerCredentials))
+		} else if commandSupportsJSON(command.Help) {
 			jsonArgs := appendJSONArg(runArgs)
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
@@ -874,6 +876,22 @@ func extractFlagsSection(help string) string {
 }
 
 func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
+	deadline := time.Now().Add(timeout)
+	run := runLiveDogfoodProcessOnce(binaryPath, cliDir, args, timeout)
+	if !liveDogfoodRetryableAuth401(run) || time.Until(deadline) <= liveDogfoodAuthRetryDelay {
+		return run
+	}
+	if liveDogfoodAuthRetryDelay > 0 {
+		time.Sleep(liveDogfoodAuthRetryDelay)
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return run
+	}
+	return runLiveDogfoodProcessOnce(binaryPath, cliDir, args, remaining)
+}
+
+func runLiveDogfoodProcessOnce(binaryPath, cliDir string, args []string, timeout time.Duration) liveDogfoodRun {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -915,6 +933,15 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 		}
 	}
 	return result
+}
+
+var liveDogfoodAuthRetryDelay = time.Second
+
+func liveDogfoodRetryableAuth401(run liveDogfoodRun) bool {
+	if run.exitCode == 0 {
+		return false
+	}
+	return liveDogfoodAuth401(run)
 }
 
 func liveDogfoodInvalidJSONReason(run liveDogfoodRun, fallback string) string {
@@ -1141,8 +1168,20 @@ func validLiveDogfoodJSONOutput(stdout string) bool {
 func liveDogfoodUnavailableForRunner(run liveDogfoodRun) bool {
 	output := strings.ToLower(run.stdout + run.stderr)
 	return strings.Contains(output, "http 403") ||
+		liveDogfoodAuth401(run) ||
 		strings.Contains(output, "permission denied") ||
 		strings.Contains(output, "your credentials are valid but lack access")
+}
+
+func liveDogfoodAuth401(run liveDogfoodRun) bool {
+	output := strings.ToLower(run.stdout + run.stderr)
+	if !strings.Contains(output, "http 401") {
+		return false
+	}
+	return strings.Contains(output, "couldn't authenticate") ||
+		strings.Contains(output, "could not authenticate") ||
+		strings.Contains(output, "not authenticated") ||
+		strings.Contains(output, "unauthorized")
 }
 
 func commandSupportsDryRun(help string) bool {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -882,9 +882,7 @@ func runLiveDogfoodProcess(binaryPath, cliDir string, args []string, timeout tim
 	if !liveDogfoodRetryableAuth401(run) || time.Until(deadline) <= liveDogfoodAuthRetryDelay {
 		return run
 	}
-	if liveDogfoodAuthRetryDelay > 0 {
-		time.Sleep(liveDogfoodAuthRetryDelay)
-	}
+	time.Sleep(liveDogfoodAuthRetryDelay)
 	remaining := time.Until(deadline)
 	if remaining <= 0 {
 		return run

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -263,10 +263,6 @@ func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
 
-	prevDelay := liveDogfoodAuthRetryDelay
-	liveDogfoodAuthRetryDelay = 0
-	t.Cleanup(func() { liveDogfoodAuthRetryDelay = prevDelay })
-
 	dir := t.TempDir()
 	countPath := filepath.Join(dir, "count")
 	binPath := writeStubBinary(t, dir, "flaky-auth", `count_file="count"
@@ -297,10 +293,6 @@ func TestRunLiveDogfoodSkipsPersistentAuth401AsRunnerCredentialUnavailable(t *te
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
-
-	prevDelay := liveDogfoodAuthRetryDelay
-	liveDogfoodAuthRetryDelay = 0
-	t.Cleanup(func() { liveDogfoodAuthRetryDelay = prevDelay })
 
 	dir := t.TempDir()
 	binaryName := "fixture-pp-cli"
@@ -355,6 +347,11 @@ exit 1
 	require.NotNil(t, happy, "expected account show-settings happy_path result")
 	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
 	assert.Equal(t, reasonUnavailableRunnerCredentials, happy.Reason)
+
+	jsonResult := findResultByCommandKind(report, "account show-settings", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult, "expected account show-settings json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, jsonResult.Status)
+	assert.Equal(t, reasonUnavailableRunnerCredentials, jsonResult.Reason)
 
 	count, err := os.ReadFile(filepath.Join(dir, "count"))
 	require.NoError(t, err)

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -258,6 +258,109 @@ func TestRunLiveDogfoodProcessSetsDogfoodEnvVar(t *testing.T) {
 	assert.Equal(t, "1", run.stdout, "live-dogfood subprocess should see PRINTING_PRESS_DOGFOOD=1")
 }
 
+func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	prevDelay := liveDogfoodAuthRetryDelay
+	liveDogfoodAuthRetryDelay = 0
+	t.Cleanup(func() { liveDogfoodAuthRetryDelay = prevDelay })
+
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "count")
+	binPath := writeStubBinary(t, dir, "flaky-auth", `count_file="count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+if [ "$count" -eq 1 ]; then
+  echo 'Error: GET /api/v2/account/settings returned HTTP 401: {"error":"Couldn'\''t authenticate you"}' >&2
+  exit 1
+fi
+printf '{"ok":true}'
+`)
+
+	run := runLiveDogfoodProcess(binPath, dir, nil, 5*time.Second)
+	require.NoError(t, run.err, "fixture: %s", run.stderr)
+	assert.Equal(t, 0, run.exitCode)
+	assert.Equal(t, `{"ok":true}`, run.stdout)
+
+	count, err := os.ReadFile(countPath)
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(count), "auth-shaped 401 should be retried once")
+}
+
+func TestRunLiveDogfoodSkipsPersistentAuth401AsRunnerCredentialUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	prevDelay := liveDogfoodAuthRetryDelay
+	liveDogfoodAuthRetryDelay = 0
+	t.Cleanup(func() { liveDogfoodAuthRetryDelay = prevDelay })
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+	writeStubBinary(t, dir, binaryName, `if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show-settings"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show-settings" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show account settings.
+
+Usage:
+  fixture-pp-cli account show-settings [flags]
+
+Examples:
+  fixture-pp-cli account show-settings
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+count_file="count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+echo 'Error: GET /api/v2/account/settings returned HTTP 401: {"error":"Could not authenticate you"}' >&2
+exit 1
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "account show-settings", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected account show-settings happy_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Equal(t, reasonUnavailableRunnerCredentials, happy.Reason)
+
+	count, err := os.ReadFile(filepath.Join(dir, "count"))
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(count), "persistent auth-shaped 401 should retry once before skip classification")
+}
+
 func TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -642,6 +745,7 @@ func TestLiveDogfoodUnavailableForRunnerDoesNotHideNotFound(t *testing.T) {
 
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 403 permission denied"}))
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "your credentials are valid but lack access"}))
+	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: `HTTP 401: {"error":"Couldn't authenticate you"}`}))
 	assert.False(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 404 NotFound"}))
 }
 

--- a/internal/pipeline/subprocess_env_test.go
+++ b/internal/pipeline/subprocess_env_test.go
@@ -121,6 +121,50 @@ func TestApplyDefaultSubprocessEnvInstallsScopedHome(t *testing.T) {
 	}
 }
 
+func TestSubprocessEnvPreservesAPICredentialsAfterScopedHome(t *testing.T) {
+	t.Setenv("FOO_API_TOKEN", "secret-token")
+	t.Setenv("BAR_API_KEY", "secret-key")
+
+	cleanup, err := scopeSubprocessHome()
+	if err != nil {
+		t.Fatalf("scopeSubprocessHome: %v", err)
+	}
+	defer cleanup()
+
+	env := subprocessEnv()
+	assertEnv(t, env, "FOO_API_TOKEN", "secret-token")
+	assertEnv(t, env, "BAR_API_KEY", "secret-key")
+}
+
+func TestApplyDefaultSubprocessEnvDogfoodAppendPreservesAPICredential(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	t.Setenv("FOO_API_TOKEN", "secret-token")
+
+	dir := t.TempDir()
+	binPath := writeStubBinary(t, dir, "echo-credential", `printf '%s|%s' "${FOO_API_TOKEN:-}" "${PRINTING_PRESS_DOGFOOD:-}"`)
+
+	cleanup, err := scopeSubprocessHome()
+	if err != nil {
+		t.Fatalf("scopeSubprocessHome: %v", err)
+	}
+	defer cleanup()
+
+	cmd := exec.Command(binPath)
+	applyDefaultSubprocessEnv(cmd)
+	cmd.Env = append(cmd.Env, dogfoodEnvVar+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run fixture: %v\n%s", err, out)
+	}
+
+	if string(out) != "secret-token|1" {
+		t.Fatalf("credential or dogfood env missing from subprocess: %q", out)
+	}
+}
+
 // TestSubprocessWriteDoesNotEscapeScopedHome is the acceptance test for
 // issue #1409: a subprocess invoked under a scoped session must not write
 // to the parent's HOME-resolved config dir. The parent's HOME is


### PR DESCRIPTION
## Summary

Live dogfood now distinguishes runner credential problems from generated CLI failures for auth-required APIs. A transient auth-shaped HTTP 401 gets one retry inside the original subprocess timeout budget, while a persistent runner-auth denial becomes a credential-unavailable skip instead of poisoning the matrix as a hard HTTP failure.

The subprocess env audit is pinned with tests so arbitrary API credential env vars survive scoped HOME/XDG handling and the dogfood env append pattern. When happy_path proves runner credentials are unavailable, json_fidelity now skips with the same reason instead of repeating the denied request.

## Compounded learnings

- Added `docs/solutions/logic-errors/live-dogfood-auth-401-runner-credentials-2026-05-23.md` to document the env-audit-then-auth-classification pattern for future live dogfood issues.
- Track: bug
- Category: logic-errors
- Overlap: low
- Instruction-file edit: none needed
- Refresh recommendation: none

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `go test ./internal/pipeline -count=1`
- `go test ./...`
- `git diff --check`

Closes #1573
