### PR TITLE
fix(cli): redact live-check output samples

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -345,7 +345,12 @@ func redactPIIJSONKeyFragments(text string) (string, bool) {
 			return match
 		}
 		changed = true
-		return strings.Replace(match, `"`+pair[2]+`"`, strconv.Quote(PIIRedactedSentinel), 1)
+		target := `"` + pair[2] + `"`
+		valueIdx := strings.LastIndex(match, target)
+		if valueIdx == -1 {
+			return match
+		}
+		return match[:valueIdx] + strconv.Quote(PIIRedactedSentinel) + match[valueIdx+len(target):]
 	})
 	return redacted, changed
 }

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,6 +154,221 @@ var piiDetectors = []piiDetector{
 		// captures surface them, expand with explicit handling.
 		pattern: regexp.MustCompile(`\b\d+\s+[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+){0,3}\s+(?i:ST|STREET|AVE|AVENUE|RD|ROAD|BLVD|BOULEVARD|DR|DRIVE|LN|LANE|CT|COURT|PL|PLACE|WAY)\b`),
 	},
+}
+
+// PIIRedactedSentinel is the stable marker used when artifact text is
+// scrubbed before it can be persisted.
+const PIIRedactedSentinel = "<redacted>"
+
+var piiJSONScalarKeys = map[string]bool{
+	"address":         true,
+	"address1":        true,
+	"address2":        true,
+	"billingaddress":  true,
+	"cardlast4":       true,
+	"customeremail":   true,
+	"customername":    true,
+	"email":           true,
+	"firstname":       true,
+	"fullname":        true,
+	"invoice":         true,
+	"invoicenumber":   true,
+	"lastname":        true,
+	"last4":           true,
+	"mobile":          true,
+	"name":            true,
+	"phone":           true,
+	"phonenumber":     true,
+	"postalcode":      true,
+	"shippingaddress": true,
+	"street":          true,
+	"streetaddress":   true,
+	"zip":             true,
+}
+
+var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:address1?|address2|billing[_ -]?address|card[_ -]?last[_ -]?4|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|phone(?:[_ -]?number)?|postal[_ -]?code|shipping[_ -]?address|street(?:[_ -]?address)?|zip)"\s*:`)
+
+// RedactPIIText returns text with customer-PII shapes replaced before the
+// text is written to durable artifacts. JSON input preserves non-PII fields
+// when redactions are needed and returns the original text unchanged when no
+// PII is found.
+func RedactPIIText(text string) string {
+	if strings.TrimSpace(text) == "" {
+		return text
+	}
+	if redacted, changed := redactPIIJSONText(text); changed {
+		return redacted
+	}
+	if redacted, changed := RedactPIIJSONKeys(text); changed {
+		return redactPIIPatterns(redacted)
+	}
+	return redactPIIPatterns(text)
+}
+
+// RedactPIIJSONKeys redacts values whose JSON keys commonly carry customer
+// PII. It intentionally skips regex value sweeps so callers can apply it to
+// larger captures before truncating, then run RedactPIIText on the bounded
+// persisted sample.
+func RedactPIIJSONKeys(text string) (string, bool) {
+	if strings.TrimSpace(text) == "" {
+		return text, false
+	}
+	if !piiJSONKeyNeedleRE.MatchString(text) {
+		return text, false
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(text)), &parsed); err == nil {
+		redacted, changed := redactPIIJSONValue(parsed, "", false)
+		if !changed {
+			return text, false
+		}
+		out, ok := marshalPIIJSON(redacted)
+		if !ok {
+			return text, false
+		}
+		return out, true
+	}
+
+	if redacted, changed := redactPIIJSONLines(text); changed {
+		return redacted, true
+	}
+	return redactPIIJSONKeyFragments(text)
+}
+
+func redactPIIJSONText(text string) (string, bool) {
+	var parsed any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(text)), &parsed); err != nil {
+		return "", false
+	}
+	redacted, changed := redactPIIJSONValue(parsed, "", true)
+	if !changed {
+		return text, false
+	}
+	out, ok := marshalPIIJSON(redacted)
+	if !ok {
+		return redactPIIPatterns(text), true
+	}
+	return out, true
+}
+
+func marshalPIIJSON(value any) (string, bool) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return "", false
+	}
+	return strings.TrimSuffix(buf.String(), "\n"), true
+}
+
+func redactPIIJSONLines(text string) (string, bool) {
+	var out strings.Builder
+	changed := false
+	for _, line := range strings.SplitAfter(text, "\n") {
+		lineBody := strings.TrimSuffix(line, "\n")
+		lineEnding := line[len(lineBody):]
+		trimmed := strings.TrimSpace(lineBody)
+		if trimmed == "" {
+			out.WriteString(line)
+			continue
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			out.WriteString(line)
+			continue
+		}
+		redacted, lineChanged := redactPIIJSONValue(parsed, "", false)
+		if !lineChanged {
+			out.WriteString(line)
+			continue
+		}
+		marshaled, ok := marshalPIIJSON(redacted)
+		if !ok {
+			out.WriteString(line)
+			continue
+		}
+		out.WriteString(marshaled)
+		out.WriteString(lineEnding)
+		changed = true
+	}
+	return out.String(), changed
+}
+
+func redactPIIJSONValue(value any, key string, redactStringPatterns bool) (any, bool) {
+	if key != "" && piiJSONScalarKeys[normalizePIIJSONKey(key)] {
+		return PIIRedactedSentinel, true
+	}
+
+	switch v := value.(type) {
+	case map[string]any:
+		changed := false
+		for childKey, child := range v {
+			redacted, childChanged := redactPIIJSONValue(child, childKey, redactStringPatterns)
+			if childChanged {
+				v[childKey] = redacted
+				changed = true
+			}
+		}
+		return v, changed
+	case []any:
+		changed := false
+		for i, child := range v {
+			redacted, childChanged := redactPIIJSONValue(child, "", redactStringPatterns)
+			if childChanged {
+				v[i] = redacted
+				changed = true
+			}
+		}
+		return v, changed
+	case string:
+		if !redactStringPatterns {
+			return v, false
+		}
+		redacted := redactPIIPatterns(v)
+		return redacted, redacted != v
+	default:
+		return value, false
+	}
+}
+
+var jsonStringPairRE = regexp.MustCompile(`"((?:[^"\\]|\\.)*)"\s*:\s*"((?:[^"\\]|\\.)*)"`)
+
+func redactPIIJSONKeyFragments(text string) (string, bool) {
+	changed := false
+	redacted := jsonStringPairRE.ReplaceAllStringFunc(text, func(match string) string {
+		pair := jsonStringPairRE.FindStringSubmatch(match)
+		if len(pair) != 3 {
+			return match
+		}
+		key, err := strconv.Unquote(`"` + pair[1] + `"`)
+		if err != nil || !piiJSONScalarKeys[normalizePIIJSONKey(key)] {
+			return match
+		}
+		changed = true
+		return strings.Replace(match, `"`+pair[2]+`"`, strconv.Quote(PIIRedactedSentinel), 1)
+	})
+	return redacted, changed
+}
+
+func normalizePIIJSONKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, "_", "")
+	key = strings.ReplaceAll(key, "-", "")
+	key = strings.ReplaceAll(key, " ", "")
+	return key
+}
+
+func redactPIIPatterns(text string) string {
+	redacted := text
+	for _, det := range piiDetectors {
+		redacted = det.pattern.ReplaceAllStringFunc(redacted, func(match string) string {
+			if isSyntheticPIIPlaceholder(det.kind, match) {
+				return match
+			}
+			return PIIRedactedSentinel
+		})
+	}
+	return redacted
 }
 
 // Scoped to the capture-to-publish leak path: manuscripts, test

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -56,6 +56,14 @@ func TestRedactPIIJSONKeys_RedactsNDJSON(t *testing.T) {
 	require.Contains(t, got, `"status":"active"`)
 }
 
+func TestRedactPIIJSONKeys_FragmentRedactsValueWhenKeyEqualsValue(t *testing.T) {
+	got, changed := RedactPIIJSONKeys(`prefix {"name":"name",`)
+
+	require.True(t, changed)
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.NotContains(t, got, `"<redacted>":"name"`)
+}
+
 func TestRedactPIIText_RedactsPlainTextPatterns(t *testing.T) {
 	got := RedactPIIText("billing email jane@example.com lives at 123 Main Street")
 

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -16,6 +16,54 @@ import (
 // Detector behavior
 // ---------------------------------------------------------------------------
 
+func TestRedactPIIText_RedactsJSONPII(t *testing.T) {
+	got := RedactPIIText(`{"name":"Jane Doe","email":"jane@example.com","address":"123 Main Street","id":42,"status":"active"}`)
+
+	require.NotContains(t, got, "Jane Doe")
+	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "123 Main Street")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, `"email":"<redacted>"`)
+	require.Contains(t, got, `"address":"<redacted>"`)
+	require.Contains(t, got, `"id":42`)
+	require.Contains(t, got, `"status":"active"`)
+}
+
+func TestRedactPIIText_LeavesStructuralJSONUnchanged(t *testing.T) {
+	input := `{"id":42,"status":"active"}`
+
+	require.Equal(t, input, RedactPIIText(input))
+}
+
+func TestRedactPIIJSONKeys_RedactsWithoutPatternSweep(t *testing.T) {
+	got, changed := RedactPIIJSONKeys(`{"name":"Jane Doe","note":"contact jane@example.com","id":42}`)
+
+	require.True(t, changed)
+	require.NotContains(t, got, "Jane Doe")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, "jane@example.com")
+	require.Contains(t, got, `"id":42`)
+}
+
+func TestRedactPIIJSONKeys_RedactsNDJSON(t *testing.T) {
+	got, changed := RedactPIIJSONKeys("{\"name\":\"Jane Doe\"}\n{\"status\":\"active\"}\n{\"invoice_number\":\"INV-12345\"}")
+
+	require.True(t, changed)
+	require.NotContains(t, got, "Jane Doe")
+	require.NotContains(t, got, "INV-12345")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, `"invoice_number":"<redacted>"`)
+	require.Contains(t, got, `"status":"active"`)
+}
+
+func TestRedactPIIText_RedactsPlainTextPatterns(t *testing.T) {
+	got := RedactPIIText("billing email jane@example.com lives at 123 Main Street")
+
+	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "123 Main Street")
+	require.Contains(t, got, PIIRedactedSentinel)
+}
+
 func TestFindPII_CardLast4(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -16,7 +16,9 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
 )
@@ -114,6 +116,10 @@ type LiveCheckBinaryRefresh struct {
 // readable and agentic reviewers don't blow through their context window on
 // one feature's output.
 const outputSampleMaxBytes = 4096
+
+// sampleRedactionLookaheadBytes lets the redactor see short PII spans that
+// start just before the persisted sample cap and end just after it.
+const sampleRedactionLookaheadBytes = 512
 
 // LiveCheckOptions bundles the optional knobs for RunLiveCheck. CLIDir is
 // required; every other field has a sensible zero-value default.
@@ -715,26 +721,67 @@ func sampleOutput(s string) string {
 }
 
 func sampleOutputParts(parts ...string) string {
-	var sample strings.Builder
-	remaining := outputSampleMaxBytes
+	var rawSample strings.Builder
+	captureRemaining := outputSampleMaxBytes + sampleRedactionLookaheadBytes
+	capRemaining := outputSampleMaxBytes
 	truncated := false
 	for _, part := range parts {
-		if remaining <= 0 {
-			truncated = truncated || len(part) > 0
+		if redacted, ok := artifacts.RedactPIIJSONKeys(part); ok {
+			part = redacted
+		}
+		if len(part) > capRemaining {
+			truncated = true
+		}
+		if capRemaining > 0 {
+			if len(part) >= capRemaining {
+				capRemaining = 0
+			} else {
+				capRemaining -= len(part)
+			}
+		}
+		if captureRemaining <= 0 {
 			continue
 		}
-		if len(part) > remaining {
-			sample.WriteString(part[:remaining])
-			truncated = true
-			break
+		if len(part) > captureRemaining {
+			rawSample.WriteString(truncateUTF8(part, captureRemaining))
+			captureRemaining = 0
+			continue
 		}
-		sample.WriteString(part)
-		remaining -= len(part)
+		rawSample.WriteString(part)
+		captureRemaining -= len(part)
+	}
+	sample := artifacts.RedactPIIText(rawSample.String())
+	if len(sample) > outputSampleMaxBytes {
+		sample = truncateUTF8(sample, outputSampleMaxBytes)
+		sample = completePartialRedactionSentinel(sample)
+		truncated = true
 	}
 	if truncated {
-		return sample.String() + "…[truncated]"
+		return sample + "…[truncated]"
 	}
-	return sample.String()
+	return sample
+}
+
+func completePartialRedactionSentinel(sample string) string {
+	const partialSentinelPrefix = "<redact"
+	idx := strings.LastIndex(sample, partialSentinelPrefix)
+	if idx == -1 || strings.Contains(sample[idx:], artifacts.PIIRedactedSentinel) {
+		return sample
+	}
+	return sample[:idx] + artifacts.PIIRedactedSentinel
+}
+
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	for maxBytes > 0 && !utf8.ValidString(s[:maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
 }
 
 // rawHTMLEntityRe matches numeric HTML character references, both decimal
@@ -972,10 +1019,13 @@ func normalizedOutputWords(s string) []string {
 
 func trimOutput(s string) string {
 	s = strings.TrimSpace(s)
-	if len(s) > 300 {
-		s = s[:300] + "..."
+	if redacted, ok := artifacts.RedactPIIJSONKeys(s); ok {
+		s = redacted
 	}
-	return s
+	if len(s) > 300 {
+		s = truncateUTF8(s, 300) + "..."
+	}
+	return artifacts.RedactPIIText(s)
 }
 
 // gracefulEmptyPhrases is the closed vocabulary of stderr substrings that

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -778,7 +778,11 @@ func truncateUTF8(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
 	}
-	for maxBytes > 0 && !utf8.ValidString(s[:maxBytes]) {
+	for maxBytes > 0 {
+		r, size := utf8.DecodeLastRuneInString(s[:maxBytes])
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
 		maxBytes--
 	}
 	return s[:maxBytes]

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -1022,14 +1022,11 @@ func normalizedOutputWords(s string) []string {
 }
 
 func trimOutput(s string) string {
-	s = strings.TrimSpace(s)
-	if redacted, ok := artifacts.RedactPIIJSONKeys(s); ok {
-		s = redacted
-	}
+	s = artifacts.RedactPIIText(strings.TrimSpace(s))
 	if len(s) > 300 {
 		s = truncateUTF8(s, 300) + "..."
 	}
-	return artifacts.RedactPIIText(s)
+	return s
 }
 
 // gracefulEmptyPhrases is the closed vocabulary of stderr substrings that

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -1095,6 +1095,14 @@ exit 7
 	require.Contains(t, result.Reason, `"email":"<redacted>"`)
 }
 
+func TestTrimOutput_RedactsPIIBeforeTruncatingFailureReason(t *testing.T) {
+	got := trimOutput(strings.Repeat("x", 290) + " jane@example.com")
+
+	require.NotContains(t, got, "jane@")
+	require.NotContains(t, got, "example.com")
+	require.Contains(t, got, "<redacted")
+}
+
 func TestSampleOutput_TruncatesLargeCapture(t *testing.T) {
 	// Guard the serialized-sample size so one feature can't bloat the
 	// scorecard JSON or overwhelm an agentic reviewer's context window.

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -1112,6 +1112,16 @@ func TestSampleOutput_TruncatesUTF8Safely(t *testing.T) {
 	require.True(t, utf8.ValidString(got))
 }
 
+func TestTruncateUTF8_PreservesPrefixWithEarlierInvalidByte(t *testing.T) {
+	input := "prefix" + string([]byte{0xff}) + strings.Repeat("a", 32) + "é"
+	got := truncateUTF8(input, len(input)-1)
+
+	require.Contains(t, got, string([]byte{0xff}))
+	require.Contains(t, got, strings.Repeat("a", 32))
+	require.NotContains(t, got, "é")
+	require.Greater(t, len(got), 30)
+}
+
 func TestSampleOutputParts_TruncatesWithoutConcatenatingFullCapture(t *testing.T) {
 	prefix := strings.Repeat("a", outputSampleMaxBytes-2)
 	got := sampleOutputParts(prefix, "bc", strings.Repeat("d", outputSampleMaxBytes))

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/stretchr/testify/assert"
@@ -508,6 +509,54 @@ func TestLiveCheck_OutputCap(t *testing.T) {
 	})
 	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: "stub", Timeout: 10 * time.Second})
 	require.Equal(t, 1, result.Passed, "run should complete despite bounded output")
+}
+
+func TestLiveCheck_OutputSampleRedactsPII(t *testing.T) {
+	got := sampleOutput(`{"name":"Jane Doe","email":"jane@example.com","address":"123 Main Street","id":42,"status":"active"}`)
+
+	require.NotContains(t, got, "Jane Doe")
+	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "123 Main Street")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, `"email":"<redacted>"`)
+	require.Contains(t, got, `"address":"<redacted>"`)
+	require.Contains(t, got, `"id":42`)
+	require.Contains(t, got, `"status":"active"`)
+}
+
+func TestLiveCheck_OutputSampleLeavesStructuralJSONUnchanged(t *testing.T) {
+	input := `{"id":42,"status":"active"}`
+
+	require.Equal(t, input, sampleOutput(input))
+}
+
+func TestLiveCheck_OutputSampleRedactsPIIBeforeTruncatingJSON(t *testing.T) {
+	longNote := strings.Repeat("x", outputSampleMaxBytes)
+	got := sampleOutput(fmt.Sprintf(`{"name":"Jane Doe","email":"jane@example.com","note":%q}`, longNote))
+
+	require.Contains(t, got, "…[truncated]")
+	require.NotContains(t, got, "Jane Doe")
+	require.NotContains(t, got, "jane@example.com")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, `"email":"<redacted>"`)
+}
+
+func TestLiveCheck_OutputSampleRedactsNDJSONAndMixedParts(t *testing.T) {
+	got := sampleOutputParts("{\"name\":\"Jane Doe\"}\n", "{\"invoice_number\":\"INV-12345\"}")
+
+	require.NotContains(t, got, "Jane Doe")
+	require.NotContains(t, got, "INV-12345")
+	require.Contains(t, got, `"name":"<redacted>"`)
+	require.Contains(t, got, `"invoice_number":"<redacted>"`)
+}
+
+func TestLiveCheck_OutputSampleRedactsPIIAcrossTruncationBoundary(t *testing.T) {
+	got := sampleOutput(strings.Repeat("x", outputSampleMaxBytes-8) + " jane@example.com")
+
+	require.Contains(t, got, "…[truncated]")
+	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "jane@")
+	require.Contains(t, got, "<redacted>")
 }
 
 // TestLiveCheck_BinaryAutoDerivation verifies RunLiveCheck finds the binary
@@ -1027,6 +1076,25 @@ printf 'Hello cookie world\n'
 	require.Contains(t, result.OutputSample, "Hello cookie world")
 }
 
+func TestRunOneFeatureCheck_RedactsPIIFromFailureReason(t *testing.T) {
+	binary := buildFakeCLI(t, `#!/usr/bin/env bash
+printf '{"name":"Jane Doe","email":"jane@example.com"}' >&2
+exit 7
+`)
+	feature := NovelFeature{
+		Name:    "demo",
+		Command: "demo",
+		Example: "bin demo",
+	}
+	result := runOneFeatureCheck(t.TempDir(), binary, feature, 5*time.Second)
+
+	require.Equal(t, StatusFail, result.Status)
+	require.NotContains(t, result.Reason, "Jane Doe")
+	require.NotContains(t, result.Reason, "jane@example.com")
+	require.Contains(t, result.Reason, `"name":"<redacted>"`)
+	require.Contains(t, result.Reason, `"email":"<redacted>"`)
+}
+
 func TestSampleOutput_TruncatesLargeCapture(t *testing.T) {
 	// Guard the serialized-sample size so one feature can't bloat the
 	// scorecard JSON or overwhelm an agentic reviewer's context window.
@@ -1034,6 +1102,14 @@ func TestSampleOutput_TruncatesLargeCapture(t *testing.T) {
 	got := sampleOutput(big)
 	require.Contains(t, got, "…[truncated]", "truncation marker missing")
 	require.LessOrEqual(t, len(got), outputSampleMaxBytes+len("…[truncated]"))
+}
+
+func TestSampleOutput_TruncatesUTF8Safely(t *testing.T) {
+	got := sampleOutput(strings.Repeat("a", outputSampleMaxBytes-1) + "é")
+
+	require.Contains(t, got, "…[truncated]")
+	require.NotContains(t, got, "\uFFFD")
+	require.True(t, utf8.ValidString(got))
 }
 
 func TestSampleOutputParts_TruncatesWithoutConcatenatingFullCapture(t *testing.T) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -300,6 +300,21 @@ printf '"}'
 	assert.Equal(t, "output exceeded capture cap", liveDogfoodInvalidJSONReason(run, "invalid JSON"))
 }
 
+func TestLiveDogfoodResultRedactsOutputSamplePII(t *testing.T) {
+	run := liveDogfoodRun{
+		stdout:   "{\"name\":\"Jane Doe\"}\n",
+		stderr:   "{\"email\":\"jane@example.com\"}",
+		exitCode: 0,
+	}
+
+	result := liveDogfoodResult("widgets list", LiveDogfoodTestHappy, []string{"widgets", "list"}, run)
+
+	require.NotContains(t, result.OutputSample, "Jane Doe")
+	require.NotContains(t, result.OutputSample, "jane@example.com")
+	require.Contains(t, result.OutputSample, `"name":"<redacted>"`)
+	require.Contains(t, result.OutputSample, `"email":"<redacted>"`)
+}
+
 func TestRunLiveDogfoodErrorPathAcceptsExpectedNonZeroExit(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")

--- a/skills/printing-press-output-review/SKILL.md
+++ b/skills/printing-press-output-review/SKILL.md
@@ -65,7 +65,7 @@ Use the Agent tool (general-purpose) with this prompt contract:
 
 > Review the sampled outputs from the shipped CLI at `$CLI_DIR`. You have these ground-truth sources:
 >
-> - Sampled command output: read `/tmp/output-review-livecheck.json` and inspect the `live_check.features[]` array. Each entry has the command, example invocation, actual stdout (in `output_sample`, bounded to ~4 KiB), the pass/fail reason, and a `warnings` array (populated by rule-based checks like the raw-HTML-entity detector).
+> - Sampled command output: read `/tmp/output-review-livecheck.json` and inspect the `live_check.features[]` array. Each entry has the command, example invocation, redacted stdout evidence (in `output_sample`, bounded to ~4 KiB), the redacted pass/fail reason, and a `warnings` array (populated by rule-based checks like the raw-HTML-entity detector). Treat `<redacted>` markers as privacy scrubbed values, not format bugs.
 > - **Review only `status: pass` entries.** Entries with `status: fail` either crashed, timed out, or had placeholder args (`<id>`, `<url>`) that never produced real output — their sample is empty and there's nothing for you to judge. Phase 5 dogfood handles test-coverage and exit-code concerns.
 > - `$CLI_DIR/research.json` `novel_features` (planned behavior per feature) and `novel_features_built` (verified built commands).
 > - The CLI binary at `$CLI_DIR/<cli-name>-pp-cli` — you may invoke additional commands to gather more output when a finding needs verification.

--- a/skills/printing-press/references/secret-protection.md
+++ b/skills/printing-press/references/secret-protection.md
@@ -107,6 +107,12 @@ proofs for organization names, email addresses, and full names. The exact-value 
 for API keys (above) catches secrets; this step catches PII that the user's live
 workspace naturally produces.
 
+**When persisting live-check samples:** `scorecard --live-check` and live-dogfood
+sample captures scrub `output_sample` text before it is stored in JSON/proof
+artifacts. Treat archive-time and publish-time scans as defense in depth, not as
+permission to write raw customer names, emails, addresses, invoice numbers, or
+card tails into the run directory.
+
 **Before creating publish PRs:** The publish skill constructs PR descriptions from
 manuscripts and test results. Any live test data quoted in the PR body must be
 scrubbed of workspace PII. The library repo is public.


### PR DESCRIPTION
## Summary

Live-check and live-dogfood samples now scrub customer-identifying output before the sample can be serialized into scorecard JSON or proof artifacts. This closes the gap where archive and publish scans ran after raw API responses had already landed in the run directory.

The redaction keeps structural JSON fields intact, handles NDJSON and mixed stdout/stderr samples, scrubs failure reasons, and applies the final output cap with UTF-8-safe truncation plus a small lookahead so values crossing the cap do not leak partial PII.

Closes #1577

## Output Contract

`live_check.features[].output_sample`, live-dogfood `output_sample`, and live-check failure reasons may now contain `<redacted>` markers instead of raw customer names, emails, addresses, invoice numbers, phone data, or card tails. Non-PII structural fields such as IDs and status values are preserved.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
