### PR TITLE
fix(cli): infer template vars from base URLs

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -166,6 +166,7 @@ type Generator struct {
 }
 
 func New(s *spec.APISpec, outputDir string) *Generator {
+	s.InferEndpointTemplateVarsFromBaseURLs()
 	if s.Owner == "" {
 		s.Owner = resolveOwnerForExisting(outputDir)
 	}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11352,6 +11352,25 @@ func TestCacheKeyIncludesTemplateVars(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestBuildURL")
 }
 
+func TestGenerateInfersEndpointTemplateVarsFromBaseURL(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("tenant-api")
+	apiSpec.BaseURL = "https://{tenant}.api.example.com"
+	require.Empty(t, apiSpec.EndpointTemplateVars)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.Equal(t, []string{"tenant"}, apiSpec.EndpointTemplateVars)
+	require.NoError(t, gen.Generate())
+
+	_, err := os.Stat(filepath.Join(outputDir, "internal", "client", "url.go"))
+	require.NoError(t, err, "url.go should be generated when BaseURL contains a placeholder")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 // TestGenerateEndpointTemplateVarsVerifyPlaceholderFallback covers the
 // PRINTING_PRESS_VERIFY=1 fallback in config.Load(): when a spec declares
 // EndpointTemplateVars and the runtime env var (e.g. SHOPIFY_SHOP) is unset,

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -274,6 +275,141 @@ func (s *APISpec) IsEndpointTemplateVar(placeholder string) bool {
 		return false
 	}
 	return slices.Contains(s.EndpointTemplateVars, placeholder)
+}
+
+// InferEndpointTemplateVarsFromBaseURLs preserves existing explicit
+// placeholders, then appends placeholders found in URL-bearing spec fields.
+// It intentionally ignores endpoint paths: ordinary path params are command
+// inputs, while BaseURL placeholders need runtime config/env substitution.
+func (s *APISpec) InferEndpointTemplateVarsFromBaseURLs() {
+	if s == nil {
+		return
+	}
+	if len(s.EndpointTemplateVars) == 0 && !s.hasURLTemplateVars() {
+		return
+	}
+	seen := make(map[string]bool, len(s.EndpointTemplateVars))
+	out := make([]string, 0, len(s.EndpointTemplateVars))
+	add := func(raw string) {
+		for _, match := range pathParamRe.FindAllStringSubmatch(raw, -1) {
+			if len(match) < 2 || seen[match[1]] {
+				continue
+			}
+			seen[match[1]] = true
+			out = append(out, match[1])
+		}
+	}
+	for _, name := range s.EndpointTemplateVars {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+
+	add(s.BaseURL)
+	s.visitURLTemplateSources(true, func(raw string) bool {
+		add(raw)
+		return true
+	})
+
+	s.EndpointTemplateVars = out
+}
+
+func (s *APISpec) hasURLTemplateVars() bool {
+	return !s.visitURLTemplateSources(false, func(raw string) bool {
+		return !pathParamRe.MatchString(raw)
+	})
+}
+
+func (s *APISpec) visitURLTemplateSources(deterministic bool, visit func(string) bool) bool {
+	if !visit(s.BaseURL) || !visit(s.BasePath) || !visit(s.GraphQLEndpointPath) {
+		return false
+	}
+
+	visitTier := func(tier TierConfig) bool {
+		return visit(tier.BaseURL)
+	}
+	if deterministic {
+		for _, name := range sortedStringKeys(s.TierRouting.Tiers) {
+			if !visitTier(s.TierRouting.Tiers[name]) {
+				return false
+			}
+		}
+	} else {
+		for _, tier := range s.TierRouting.Tiers {
+			if !visitTier(tier) {
+				return false
+			}
+		}
+	}
+
+	visitResource := func(resource Resource) bool {
+		return visitResourceURLTemplateSources(resource, deterministic, visit)
+	}
+	if deterministic {
+		for _, name := range sortedStringKeys(s.Resources) {
+			if !visitResource(s.Resources[name]) {
+				return false
+			}
+		}
+	} else {
+		for _, resource := range s.Resources {
+			if !visitResource(resource) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func visitResourceURLTemplateSources(r Resource, deterministic bool, visit func(string) bool) bool {
+	if !visit(r.BaseURL) {
+		return false
+	}
+
+	visitEndpoint := func(endpoint Endpoint) bool {
+		return visit(endpoint.BaseURL)
+	}
+	if deterministic {
+		for _, name := range sortedStringKeys(r.Endpoints) {
+			if !visitEndpoint(r.Endpoints[name]) {
+				return false
+			}
+		}
+	} else {
+		for _, endpoint := range r.Endpoints {
+			if !visitEndpoint(endpoint) {
+				return false
+			}
+		}
+	}
+
+	if deterministic {
+		for _, name := range sortedStringKeys(r.SubResources) {
+			if !visitResourceURLTemplateSources(r.SubResources[name], deterministic, visit) {
+				return false
+			}
+		}
+	} else {
+		for _, subResource := range r.SubResources {
+			if !visitResourceURLTemplateSources(subResource, deterministic, visit) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func sortedStringKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (s *APISpec) EffectiveTier(resource Resource, endpoint Endpoint) string {
@@ -2231,6 +2367,7 @@ func singularize(s string) string {
 
 func (s *APISpec) Validate() error {
 	s.NormalizeAuthEnvVarSpecs()
+	s.InferEndpointTemplateVarsFromBaseURLs()
 	if s.Name == "" {
 		return fmt.Errorf("name is required")
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"unicode"
 
@@ -307,7 +306,6 @@ func (s *APISpec) InferEndpointTemplateVarsFromBaseURLs() {
 		out = append(out, name)
 	}
 
-	add(s.BaseURL)
 	s.visitURLTemplateSources(true, func(raw string) bool {
 		add(raw)
 		return true
@@ -408,7 +406,7 @@ func sortedStringKeys[V any](m map[string]V) []string {
 	for key := range m {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3809,6 +3809,140 @@ resources:
 	assert.Equal(t, "paid", s.EffectiveTier(s.Resources["results"], s.Resources["results"].Endpoints["premium"]))
 }
 
+func TestInferEndpointTemplateVarsFromBaseURLs(t *testing.T) {
+	t.Parallel()
+
+	s := &APISpec{
+		Name:                 "templated",
+		BaseURL:              "https://{tenant}.api.example.com",
+		BasePath:             "/{base_path}",
+		GraphQLEndpointPath:  "/admin/{version}/graphql",
+		EndpointTemplateVars: []string{"explicit", "tenant"},
+		TierRouting: TierRoutingConfig{Tiers: map[string]TierConfig{
+			"z": {BaseURL: "https://{tier_z}.api.example.com"},
+			"a": {BaseURL: "https://{tier_a}.api.example.com"},
+		}},
+		Resources: map[string]Resource{
+			"z_resource": {
+				BaseURL: "https://{resource_z}.api.example.com",
+				Endpoints: map[string]Endpoint{
+					"z_endpoint": {BaseURL: "https://{endpoint_z}.api.example.com"},
+					"a_endpoint": {BaseURL: "https://{endpoint_a}.api.example.com"},
+				},
+				SubResources: map[string]Resource{
+					"z_sub": {BaseURL: "https://{sub_z}.api.example.com"},
+					"a_sub": {BaseURL: "https://{sub_a}.api.example.com"},
+				},
+			},
+			"a_resource": {
+				BaseURL: "https://{resource_a}.api.example.com/{tenant}",
+			},
+		},
+	}
+
+	s.InferEndpointTemplateVarsFromBaseURLs()
+
+	assert.Equal(t, []string{
+		"explicit",
+		"tenant",
+		"base_path",
+		"version",
+		"tier_a",
+		"tier_z",
+		"resource_a",
+		"resource_z",
+		"endpoint_a",
+		"endpoint_z",
+		"sub_a",
+		"sub_z",
+	}, s.EndpointTemplateVars)
+}
+
+func TestInferEndpointTemplateVarsFromBaseURLsFastPathSources(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*APISpec)
+		want   string
+	}{
+		{
+			name: "base path",
+			mutate: func(s *APISpec) {
+				s.BasePath = "/{base_path}"
+			},
+			want: "base_path",
+		},
+		{
+			name: "graphql endpoint path",
+			mutate: func(s *APISpec) {
+				s.GraphQLEndpointPath = "/admin/{version}/graphql"
+			},
+			want: "version",
+		},
+		{
+			name: "tier base url",
+			mutate: func(s *APISpec) {
+				s.TierRouting = TierRoutingConfig{Tiers: map[string]TierConfig{
+					"paid": {BaseURL: "https://{tier}.api.example.com"},
+				}}
+			},
+			want: "tier",
+		},
+		{
+			name: "resource base url",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				resource.BaseURL = "https://{resource}.api.example.com"
+				s.Resources["items"] = resource
+			},
+			want: "resource",
+		},
+		{
+			name: "endpoint base url",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				resource.Endpoints["list"] = Endpoint{Method: "GET", Path: "/items", BaseURL: "https://{endpoint}.api.example.com"}
+				s.Resources["items"] = resource
+			},
+			want: "endpoint",
+		},
+		{
+			name: "subresource base url",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				resource.SubResources = map[string]Resource{
+					"children": {BaseURL: "https://{subresource}.api.example.com"},
+				}
+				s.Resources["items"] = resource
+			},
+			want: "subresource",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &APISpec{
+				Name:    "templated",
+				BaseURL: "https://api.example.com",
+				Resources: map[string]Resource{
+					"items": {
+						Endpoints: map[string]Endpoint{
+							"list": {Method: "GET", Path: "/items"},
+						},
+					},
+				},
+			}
+			tc.mutate(s)
+
+			s.InferEndpointTemplateVarsFromBaseURLs()
+
+			assert.Equal(t, []string{tc.want}, s.EndpointTemplateVars)
+		})
+	}
+}
+
 func TestValidateTierRouting(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
## Summary

- Infer endpoint template vars from spec, tier, resource, endpoint, and sub-resource BaseURL-style fields when specs omit `endpoint_template_vars`.
- Normalize that inference before generator templates render so `url.go`, `config.TemplateVars`, client `buildURL`, sync path-context, README, and agent metadata all use the existing template-var pipeline.
- Add package-level and generator regression coverage for placeholder inference and the no-placeholder byte-compat fast path.

Closes #1581

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/spec -run TestInferEndpointTemplateVarsFromBaseURLs -count=1`
- `go test ./internal/generator -run 'TestGenerateInfersEndpointTemplateVarsFromBaseURL|TestGenerateNoEndpointTemplateVarsByteCompat' -count=1`
- `go test ./internal/generator ./internal/spec`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
