### PR TITLE
fix(cli): guard client flag in MCP shellouts

### DIFF
--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -45,12 +45,14 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
-// caller swap auth credentials, redirect the API base URL, load a malicious
-// config file, or change the delivery target — all of which sit outside the
-// per-command surface the agent is supposed to be calling.
+// caller swap auth credentials, redirect the API base URL, select a different
+// per-client filesystem, load a malicious config file, or change the delivery
+// target, all of which sit outside the per-command surface the agent is
+// supposed to be calling.
 var blockedRootFlags = map[string]bool{
 	"args":     true,
 	"base-url": true,
+	"client":   true,
 	"config":   true,
 	"deliver":  true,
 	"profile":  true,

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -46,11 +46,13 @@ func TestSplitShellArgs(t *testing.T) {
 // flag in the structured args map (instead of the free-form "args"
 // string), the root flags listed in blockedRootFlags must be dropped
 // before they reach exec.CommandContext. A regression here would let a
-// caller redirect --base-url, swap --token, or load a malicious --config.
+// caller redirect --base-url, swap --token, switch --client filesystems, or
+// load a malicious --config.
 func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
 		"args":     "contacts",
 		"base-url": "https://evil.example.com",
+		"client":   "attacker-client",
 		"config":   "/tmp/evil.yaml",
 		"deliver":  "fd:3",
 		"profile":  "attacker",
@@ -63,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
-	for _, blocked := range []string{"--base-url", "--config", "--deliver", "--profile", "--token", "--args"} {
+	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--profile", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
 				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -45,12 +45,14 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
-// caller swap auth credentials, redirect the API base URL, load a malicious
-// config file, or change the delivery target — all of which sit outside the
-// per-command surface the agent is supposed to be calling.
+// caller swap auth credentials, redirect the API base URL, select a different
+// per-client filesystem, load a malicious config file, or change the delivery
+// target, all of which sit outside the per-command surface the agent is
+// supposed to be calling.
 var blockedRootFlags = map[string]bool{
 	"args":     true,
 	"base-url": true,
+	"client":   true,
 	"config":   true,
 	"deliver":  true,
 	"profile":  true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -46,11 +46,13 @@ func TestSplitShellArgs(t *testing.T) {
 // flag in the structured args map (instead of the free-form "args"
 // string), the root flags listed in blockedRootFlags must be dropped
 // before they reach exec.CommandContext. A regression here would let a
-// caller redirect --base-url, swap --token, or load a malicious --config.
+// caller redirect --base-url, swap --token, switch --client filesystems, or
+// load a malicious --config.
 func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	in := map[string]any{
 		"args":     "contacts",
 		"base-url": "https://evil.example.com",
+		"client":   "attacker-client",
 		"config":   "/tmp/evil.yaml",
 		"deliver":  "fd:3",
 		"profile":  "attacker",
@@ -63,7 +65,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
 	}
-	for _, blocked := range []string{"--base-url", "--config", "--deliver", "--profile", "--token", "--args"} {
+	for _, blocked := range []string{"--base-url", "--client", "--config", "--deliver", "--profile", "--token", "--args"} {
 		for _, tok := range got {
 			if tok == blocked {
 				t.Errorf("blocked flag %q leaked through cliArgsFromMCP", blocked)


### PR DESCRIPTION
## Intent

Issue: Closes #1582

Prevent generated MCP shellout tools from forwarding a structured `client` argument into the companion CLI as `--client`, which would let an MCP caller select a different per-client filesystem outside the intended per-command surface.

## Approach

Add `client` to the generated cobratree `blockedRootFlags` list and extend the generated unit test that pins root flag filtering. Refresh the golden generated fixture for the changed template output.

## Scope

Primary area: generated MCP cobratree shellout runtime

Why this belongs in this repo: this is generator-owned runtime code emitted into printed CLIs, so the guard needs to be fixed at the Printing Press template layer.

## Risk

Low. This only expands an existing MCP shellout root-control blocklist. A domain command that intentionally exposes a structured `client` flag through the generic shellout walker would now have that parameter dropped, matching the existing treatment of auth, profile, config, base URL, delivery, and args root controls.

## Output Contract

Generated `internal/mcp/cobratree/shellout.go` and `shellout_test.go` now include `client` in the blocked root flag contract.

## Verification

- `scripts/golden.sh verify`
- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
