### PR TITLE
fix(cli): require quoted shell variables in skill bash blocks

### DIFF
--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -1169,6 +1169,8 @@ import "github.com/spf13/cobra"
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "test-pp-cli"}
+	var agent bool
+	cmd.PersistentFlags().BoolVar(&agent, "agent", false, "Agent mode")
 	cmd.AddCommand(newInsightCmd())
 	return cmd
 }

--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -214,13 +214,14 @@ func newVerifySkillCmd() *cobra.Command {
 		Short:         "Verify SKILL.md matches the shipped CLI source",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Long: `Run five checks against a printed CLI's SKILL.md:
+		Long: `Run six checks against a printed CLI's SKILL.md:
 
   1. flag-names — every --flag used on a <cli> ... invocation in SKILL.md is declared in internal/cli/*.go
   2. flag-commands — every --flag used on a specific command is declared on that command (or persistent)
   3. positional-args — positional args in bash recipes match the command's Use: field
-  4. unknown-command — every referenced command path maps to a cobra Use: declaration
-  5. canonical-sections — the Prerequisites: Install the CLI section matches what the generator would emit (defends against post-publish edits to generator-owned text)
+  4. shell-var-quotes — every shell variable expanded in generated bash code blocks is double-quoted
+  5. unknown-command — every referenced command path maps to a cobra Use: declaration
+  6. canonical-sections — the Prerequisites: Install the CLI section matches what the generator would emit (defends against post-publish edits to generator-owned text)
 
 Fails when the SKILL advertises commands, flags, or arguments that the binary
 doesn't actually provide — which is how the recipe-goat "search --max-time"
@@ -229,9 +230,9 @@ has been hand-edited away from the canonical generator output, which is the
 failure mode that produced fabricated /ppl install slash commands and
 mangled fallback blocks during polish loops.
 
-Checks 1-4 run via the bundled scripts/verify-skill/verify_skill.py; check 5
+Checks 1-5 run via the bundled scripts/verify-skill/verify_skill.py; check 6
 runs in Go using the CLI manifest (.printing-press.json) and go.mod.
-Requires python3 on PATH for checks 1-4.`,
+Requires python3 on PATH for checks 1-5.`,
 		Example: `  # Run all checks against a generated CLI
   cli-printing-press verify-skill --dir ./my-api-pp-cli
 
@@ -240,6 +241,7 @@ Requires python3 on PATH for checks 1-4.`,
 
   # Only check a specific category
   cli-printing-press verify-skill --dir ./my-api-pp-cli --only flag-commands
+  cli-printing-press verify-skill --dir ./my-api-pp-cli --only shell-var-quotes
   cli-printing-press verify-skill --dir ./my-api-pp-cli --only canonical-sections`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dir == "" {
@@ -311,7 +313,7 @@ Requires python3 on PATH for checks 1-4.`,
 	}
 
 	cmd.Flags().StringVar(&dir, "dir", "", "Path to the printed CLI directory (contains SKILL.md + internal/cli/)")
-	cmd.Flags().StringSliceVar(&only, "only", nil, "Run only the named check(s): flag-names, flag-commands, positional-args, unknown-command, canonical-sections (repeatable)")
+	cmd.Flags().StringSliceVar(&only, "only", nil, "Run only the named check(s): flag-names, flag-commands, positional-args, shell-var-quotes, unknown-command, canonical-sections (repeatable)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Treat likely-false-positive findings as failures")
 

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """verify_skill.py — validate that SKILL.md and README.md match the shipped CLI source.
 
-Four checks run in sequence:
+Five checks run in sequence:
 
   1. flag-names — every `--flag` used on a `<cli_binary> ...` invocation in
      a prose source (SKILL.md, plus README.md when present) is declared as

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -12,7 +12,9 @@ Four checks run in sequence:
      on that command (or as a persistent/root flag).
   3. positional-args — positional args in bash recipes match the command's
      `Use:` field signature (required + optional + variadic).
-  4. unknown-command — every command path referenced in a prose source (in
+  4. shell-var-quotes — every shell variable expanded inside a generated bash
+     code block is wrapped in double quotes.
+  5. unknown-command — every command path referenced in a prose source (in
      bash recipes from SKILL.md and README.md, plus inline backticks under
      SKILL.md's `## Command Reference`) maps to a real cobra `Use:`
      declaration in internal/cli/*.go. Catches docs that promise commands
@@ -35,6 +37,7 @@ USAGE
     python3 verify_skill.py --dir <cli-dir> --json
     python3 verify_skill.py --dir <cli-dir> --only flag-names
     python3 verify_skill.py --dir <cli-dir> --only unknown-command
+    python3 verify_skill.py --dir <cli-dir> --only shell-var-quotes
     python3 verify_skill.py --dir <cli-dir> --strict  # treat known-FPs as failures
 
 Exit codes:
@@ -67,9 +70,10 @@ def read_utf8(path: Path) -> str:
 # copy-paste examples cannot hide missing flags behind this whitelist.
 COMMON_FLAGS = {"help", "version"}
 
-CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
+CODEBLOCK_BASH = re.compile(r"^[ \t]*```bash[^\n]*\n(.*?)\n[ \t]*```[ \t]*$", re.DOTALL | re.MULTILINE)
 FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 INLINE_CODE = re.compile(r"`[^`\n]*`")
+SHELL_VAR_RE = re.compile(r"\$(?:\{[^}\n]+\}|[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?])")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
     re.DOTALL | re.MULTILINE | re.IGNORECASE,
@@ -782,9 +786,76 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
     ]
 
 
+def _bash_blocks_with_line_numbers(text: str) -> Iterable[tuple[int, str]]:
+    for match in CODEBLOCK_BASH.finditer(text):
+        first_line = text[:match.start(1)].count("\n") + 1
+        yield first_line, match.group(1)
+
+
+def _unquoted_shell_variables(line: str) -> list[str]:
+    vars_found: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if ch == "\\" and i + 1 < len(line):
+                i += 2
+                continue
+            if ch == '"':
+                quote = None
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < len(line):
+            i += 2
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
+            break
+        if ch == "$":
+            match = SHELL_VAR_RE.match(line, i)
+            if match:
+                vars_found.append(match.group(0))
+                i = match.end()
+                continue
+        i += 1
+    return vars_found
+
+
 # ---------------------------------------------------------------------------
 # Checks
 # ---------------------------------------------------------------------------
+
+
+def check_shell_var_quotes(sources: list[Path], report: Report) -> None:
+    for src in sources:
+        text = read_utf8(src)
+        seen: set[tuple[int, str]] = set()
+        for first_line, block in _bash_blocks_with_line_numbers(text):
+            for offset, raw_line in enumerate(block.splitlines()):
+                line_no = first_line + offset
+                for var in _unquoted_shell_variables(raw_line):
+                    key = (line_no, var)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    report.findings.append(
+                        Finding(
+                            check="shell-var-quotes",
+                            severity="error",
+                            command=f"(file: {src.name})",
+                            detail=f"{var} is expanded in a bash code block without double quotes",
+                            evidence=f"{src.name}:{line_no}: {raw_line.strip()}",
+                        )
+                    )
 
 
 def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
@@ -1079,7 +1150,7 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     report = Report(cli_dir=str(cli_dir), skill_path=str(skill))
     sources = prose_sources(cli_dir)
 
-    checks = only or {"flag-names", "flag-commands", "positional-args", "unknown-command"}
+    checks = only or {"flag-names", "flag-commands", "positional-args", "shell-var-quotes", "unknown-command"}
     if "flag-names" in checks:
         report.checks_run.append("flag-names")
         check_flag_names(cli_dir, sources, cli_binary, report)
@@ -1089,6 +1160,9 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     if "positional-args" in checks:
         report.checks_run.append("positional-args")
         check_positional_args(cli_dir, sources, cli_binary, report)
+    if "shell-var-quotes" in checks:
+        report.checks_run.append("shell-var-quotes")
+        check_shell_var_quotes(sources, report)
     if "unknown-command" in checks:
         report.checks_run.append("unknown-command")
         check_unknown_commands(cli_dir, sources, cli_binary, report)
@@ -1156,7 +1230,7 @@ def main():
     p.add_argument("--dir", required=True, help="CLI directory (contains SKILL.md + internal/cli/)")
     p.add_argument(
         "--only",
-        choices=["flag-names", "flag-commands", "positional-args", "unknown-command"],
+        choices=["flag-names", "flag-commands", "positional-args", "shell-var-quotes", "unknown-command"],
         action="append",
         help="Run only the named check(s). Pass multiple times to include multiple.",
     )

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -323,6 +323,139 @@ func Execute() error {
 	require.NotContains(t, string(out), "--cli-only", "verifier must not mention an external-tool flag")
 }
 
+// TestVerifySkill_DetectsUnquotedShellVariable is the regression guard for
+// generated bash blocks teaching agents to expand shell variables without
+// double quotes.
+func TestVerifySkill_DetectsUnquotedShellVariable(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export --output $OUT_FILE\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&output, "output", "", "Output file")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "shell-var-quotes").CombinedOutput()
+	require.Error(t, err, "unquoted shell variables in bash blocks must fail verify-skill")
+	require.Contains(t, string(out), "shell-var-quotes")
+	require.Contains(t, string(out), "$OUT_FILE")
+}
+
+func TestVerifySkill_DefaultChecksIncludeShellVarQuotes(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export --output $OUT_FILE\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&output, "output", "", "Output file")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir).CombinedOutput()
+	require.Error(t, err, "default verify-skill run must include shell-var-quotes")
+	require.Contains(t, string(out), "shell-var-quotes")
+	require.Contains(t, string(out), "$OUT_FILE")
+}
+
+func TestVerifySkill_DetectsUnquotedShellVariableInIndentedFence(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n1. Export a file:\n   ```bash\n   fixture-pp-cli export --output $OUT_FILE\n   ```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&output, "output", "", "Output file")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "shell-var-quotes").CombinedOutput()
+	require.Error(t, err, "indented bash fences must still be scanned")
+	require.Contains(t, string(out), "$OUT_FILE")
+}
+
+func TestVerifySkill_AllowsQuotedShellVariable(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export --output \"$OUT_FILE\"\nrm -f \"${TMPDIR:-/tmp}/fixture-output.json\"\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&output, "output", "", "Output file")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "shell-var-quotes").CombinedOutput()
+	require.NoError(t, err, "quoted shell variables should pass verify-skill: %s", string(out))
+	require.Contains(t, string(out), "All checks passed")
+}
+
 // TestVerifySkill_CanonicalSectionsPassesOnFreshFixture confirms the
 // canonical-sections check exits 0 when a fixture's SKILL.md install
 // section matches what the generator would emit. The fixture is built

--- a/scripts/verify-skill/README.md
+++ b/scripts/verify-skill/README.md
@@ -1,8 +1,8 @@
 # verify-skill
 
 Static verifier for `SKILL.md` files that ship alongside printed CLIs. Checks
-that every command, flag, and positional-arg signature referenced in a
-SKILL.md actually exists in the shipped CLI's `internal/cli/*.go` source.
+that every command, flag, positional-arg signature, and shell-variable bash
+example referenced in a SKILL.md matches the shipped CLI contract.
 
 ## Why
 
@@ -14,7 +14,7 @@ in production.
 
 This verifier was built after hand-authoring SKILLs for the 11 launch
 CLIs and discovering **23 invented / wrong-command / wrong-arg-count
-errors** across 7 of them. Three tiers of checks catch different error
+errors** across 7 of them. Five tiers of checks catch different error
 classes; the earlier tier is strictest and the later tiers cover what
 the earlier ones miss.
 
@@ -35,14 +35,24 @@ compatible with the command's `Use:` field (`<required>` + `[optional]` +
 `variadic`) and its `Args:` validator (`cobra.ExactArgs(N)`,
 `MinimumNArgs(N)`, etc.). Catches wrong-arity invocations.
 
+**4. shell-var-quotes** — each shell variable expanded inside a bash code
+block is wrapped in double quotes. Catches examples like `--output $FILE`
+that break on whitespace or glob characters in agent-provided paths.
+
+**5. unknown-command** — every command path referenced in a bash recipe or
+the SKILL command reference resolves to a Cobra command.
+
 ## Usage
 
 ```bash
-# Run all three checks against a CLI directory
+# Run all checks against a CLI directory
 python3 verify_skill.py --dir /path/to/my-pp-cli
 
 # Run only the flag-command check
 python3 verify_skill.py --dir /path/to/my-pp-cli --only flag-commands
+
+# Run only the shell-variable quoting check
+python3 verify_skill.py --dir /path/to/my-pp-cli --only shell-var-quotes
 
 # JSON output for CI
 python3 verify_skill.py --dir /path/to/my-pp-cli --json

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """verify_skill.py — validate that SKILL.md and README.md match the shipped CLI source.
 
-Four checks run in sequence:
+Five checks run in sequence:
 
   1. flag-names — every `--flag` used on a `<cli_binary> ...` invocation in
      a prose source (SKILL.md, plus README.md when present) is declared as

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -12,7 +12,9 @@ Four checks run in sequence:
      on that command (or as a persistent/root flag).
   3. positional-args — positional args in bash recipes match the command's
      `Use:` field signature (required + optional + variadic).
-  4. unknown-command — every command path referenced in a prose source (in
+  4. shell-var-quotes — every shell variable expanded inside a generated bash
+     code block is wrapped in double quotes.
+  5. unknown-command — every command path referenced in a prose source (in
      bash recipes from SKILL.md and README.md, plus inline backticks under
      SKILL.md's `## Command Reference`) maps to a real cobra `Use:`
      declaration in internal/cli/*.go. Catches docs that promise commands
@@ -35,6 +37,7 @@ USAGE
     python3 verify_skill.py --dir <cli-dir> --json
     python3 verify_skill.py --dir <cli-dir> --only flag-names
     python3 verify_skill.py --dir <cli-dir> --only unknown-command
+    python3 verify_skill.py --dir <cli-dir> --only shell-var-quotes
     python3 verify_skill.py --dir <cli-dir> --strict  # treat known-FPs as failures
 
 Exit codes:
@@ -67,9 +70,10 @@ def read_utf8(path: Path) -> str:
 # copy-paste examples cannot hide missing flags behind this whitelist.
 COMMON_FLAGS = {"help", "version"}
 
-CODEBLOCK_BASH = re.compile(r"```bash\n(.*?)\n```", re.DOTALL)
+CODEBLOCK_BASH = re.compile(r"^[ \t]*```bash[^\n]*\n(.*?)\n[ \t]*```[ \t]*$", re.DOTALL | re.MULTILINE)
 FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 INLINE_CODE = re.compile(r"`[^`\n]*`")
+SHELL_VAR_RE = re.compile(r"\$(?:\{[^}\n]+\}|[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?])")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
     re.DOTALL | re.MULTILINE | re.IGNORECASE,
@@ -782,9 +786,76 @@ def extract_recipes(skill: Path, cli_binary: str, cli_dir: Path | None = None) -
     ]
 
 
+def _bash_blocks_with_line_numbers(text: str) -> Iterable[tuple[int, str]]:
+    for match in CODEBLOCK_BASH.finditer(text):
+        first_line = text[:match.start(1)].count("\n") + 1
+        yield first_line, match.group(1)
+
+
+def _unquoted_shell_variables(line: str) -> list[str]:
+    vars_found: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if ch == "\\" and i + 1 < len(line):
+                i += 2
+                continue
+            if ch == '"':
+                quote = None
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < len(line):
+            i += 2
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
+            break
+        if ch == "$":
+            match = SHELL_VAR_RE.match(line, i)
+            if match:
+                vars_found.append(match.group(0))
+                i = match.end()
+                continue
+        i += 1
+    return vars_found
+
+
 # ---------------------------------------------------------------------------
 # Checks
 # ---------------------------------------------------------------------------
+
+
+def check_shell_var_quotes(sources: list[Path], report: Report) -> None:
+    for src in sources:
+        text = read_utf8(src)
+        seen: set[tuple[int, str]] = set()
+        for first_line, block in _bash_blocks_with_line_numbers(text):
+            for offset, raw_line in enumerate(block.splitlines()):
+                line_no = first_line + offset
+                for var in _unquoted_shell_variables(raw_line):
+                    key = (line_no, var)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    report.findings.append(
+                        Finding(
+                            check="shell-var-quotes",
+                            severity="error",
+                            command=f"(file: {src.name})",
+                            detail=f"{var} is expanded in a bash code block without double quotes",
+                            evidence=f"{src.name}:{line_no}: {raw_line.strip()}",
+                        )
+                    )
 
 
 def check_flag_names(cli_dir: Path, sources: list[Path], cli_binary: str, report: Report) -> None:
@@ -1079,7 +1150,7 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     report = Report(cli_dir=str(cli_dir), skill_path=str(skill))
     sources = prose_sources(cli_dir)
 
-    checks = only or {"flag-names", "flag-commands", "positional-args", "unknown-command"}
+    checks = only or {"flag-names", "flag-commands", "positional-args", "shell-var-quotes", "unknown-command"}
     if "flag-names" in checks:
         report.checks_run.append("flag-names")
         check_flag_names(cli_dir, sources, cli_binary, report)
@@ -1089,6 +1160,9 @@ def run_checks(cli_dir: Path, only: set[str] | None) -> Report:
     if "positional-args" in checks:
         report.checks_run.append("positional-args")
         check_positional_args(cli_dir, sources, cli_binary, report)
+    if "shell-var-quotes" in checks:
+        report.checks_run.append("shell-var-quotes")
+        check_shell_var_quotes(sources, report)
     if "unknown-command" in checks:
         report.checks_run.append("unknown-command")
         check_unknown_commands(cli_dir, sources, cli_binary, report)
@@ -1156,7 +1230,7 @@ def main():
     p.add_argument("--dir", required=True, help="CLI directory (contains SKILL.md + internal/cli/)")
     p.add_argument(
         "--only",
-        choices=["flag-names", "flag-commands", "positional-args", "unknown-command"],
+        choices=["flag-names", "flag-commands", "positional-args", "shell-var-quotes", "unknown-command"],
         action="append",
         help="Run only the named check(s). Pass multiple times to include multiple.",
     )


### PR DESCRIPTION
## Summary

Adds a `shell-var-quotes` verifier pass so generated `SKILL.md` and README bash blocks fail verification when they expand shell variables without double quotes.

This makes `verify-skill` catch examples like `--output $OUT_FILE` before they ship, while preserving quoted forms like `"$OUT_FILE"` and `"${TMPDIR:-/tmp}/file"`. It also teaches the bash-fence scanner to handle indented Markdown fences so list-nested install/example blocks are parsed correctly.

Closes #1584

## Verification

- `go test ./internal/cli -run 'TestVerifySkill|TestPublishPackageDoesNotStageCompiledBinary' -count=1`
- `python3 scripts/verify-skill/test_resolve_command_path.py`
- `cmp -s scripts/verify-skill/verify_skill.py internal/cli/verify_skill_bundled.py`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
