### PR TITLE
fix(cli): report malformed research json during publish

### DIFF
--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -491,6 +491,9 @@ func loadMatchingResearch(candidates []researchCandidate, apiName string) (*Rese
 			}
 			continue
 		}
+		if r == nil {
+			continue
+		}
 		if apiName != "" && r.APIName != "" && r.APIName != apiName {
 			continue
 		}

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -208,9 +208,8 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 
 	// Carry forward metadata from the generated manifest when publish-time
 	// parsing is unavailable or lossy for the original spec format. NovelFeatures
-	// is carried forward as a defensive fallback in case the loadResearchForState
-	// lookup below misses (e.g., research.json moved or absent); when both are
-	// available, research.json wins as the post-dogfood source of truth.
+	// is carried forward as a defensive fallback in case research.json is absent;
+	// when both are available, research.json wins as the post-dogfood source of truth.
 	if existingData, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename)); err == nil {
 		var existing CLIManifest
 		if json.Unmarshal(existingData, &existing) == nil {
@@ -339,15 +338,12 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	// check passes without manual patching.
 	//
 	// Lookup order:
-	//   1. loadResearchForState — checks <RunRoot>/research.json (skill-flow
-	//      convention) then <state.PipelineDir>/research.json (generate-flow
-	//      convention). Covers both write conventions (cal-com retro #334 F2,
-	//      and food52 retro #337 F4 once #340 recovers RunID in NewMinimalState).
-	//   2. Minimal-state fallback: when loadResearchForState fails AND
-	//      state.RunID is empty (NewMinimalState had no registered runstate
-	//      to recover RunID from), glob the scoped runstate root for any
-	//      run whose research.json names this APIName and pick the most
-	//      recent by mtime. Backstop for orphaned plan-driven promotes.
+	//   1. Check <RunRoot>/research.json (skill-flow convention), then
+	//      <state.PipelineDir>/research.json (generate-flow convention).
+	//   2. With a RunID, glob matching run IDs across scopes as a recovery
+	//      path for recovered/minimal state.
+	//   3. Without a RunID, glob the scoped runstate root for the most recent
+	//      research.json whose APIName matches this API.
 	//
 	// Within the loaded ResearchResult, prefer NovelFeaturesBuilt
 	// (dogfood-verified subset) over NovelFeatures (planned list) — if
@@ -355,7 +351,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	// Falling back to the planned list when dogfood didn't run (or wrote
 	// an empty NovelFeaturesBuilt) keeps first-publish from failing the
 	// transcendence check on a CLI that genuinely shipped novel features.
-	research, source := loadResearchForPromote(state)
+	research, source, researchErr := loadResearchForPromote(state)
 	if research != nil {
 		nfs := pickNovelFeaturesForManifest(research)
 		// Override the existing-manifest carry-forward (line 221) with
@@ -371,6 +367,11 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 			// user when novel_features came from the glob fallback.
 			fmt.Fprintf(os.Stderr, "publish: hydrated %d novel_features from %s\n", len(m.NovelFeatures), source)
 		}
+	} else if researchErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"debug: %v; skipping novel_features enrichment (state.RunID=%q)\n",
+			researchErr,
+			state.RunID)
 	} else {
 		// No research.json found by any lookup path. Emit a debug
 		// breadcrumb naming the canonical paths so the silent dropout
@@ -421,28 +422,31 @@ func applyPublishCatalogMetadata(parsed *spec.APISpec, apiName string) {
 // for non-canonical-source stderr visibility).
 //
 // Lookup order:
-//   - Delegate to loadResearchForState first (RunRoot then PipelineDir).
-//     This is the dominant path; with #340's NewMinimalState recovery,
-//     even plan-driven promotes hit this branch.
-//   - When loadResearchForState fails AND RunID is empty (the registry
-//     recovery had no prior runstate to borrow from), glob the scoped
-//     runstate root for any research.json whose APIName matches and
-//     pick the most recent by mtime. Backstop for orphaned promotes.
+//   - Check the canonical run-root path, then the pipeline path.
+//   - When RunID is set, glob matching run IDs across scopes.
+//   - When RunID is empty, glob the scoped runstate root for any
+//     research.json whose APIName matches and pick the most recent by mtime.
 //
-// Returns (nil, "") when neither lookup finds a usable research.json.
-func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
-	if r, err := loadResearchForState(state); err == nil {
-		// loadResearchForState is the canonical loader; report the
-		// path it tried first (run-root) when RunID is set, since the
-		// caller's "is this a non-canonical source?" check compares
-		// against state.PipelineDir() and RunRoot(state.RunID).
-		if state.RunID != "" {
-			if _, statErr := os.Stat(filepath.Join(state.RunRoot(), "research.json")); statErr == nil {
-				return r, state.RunRoot()
-			}
-			return r, state.PipelineDir()
+// Returns (nil, "", nil) when neither lookup finds a usable research.json.
+func loadResearchForPromote(state *PipelineState) (*ResearchResult, string, error) {
+	canonicalCandidates := []struct {
+		path   string
+		source string
+	}{
+		{path: filepath.Join(state.RunRoot(), "research.json"), source: state.RunRoot()},
+		{path: filepath.Join(state.PipelineDir(), "research.json"), source: state.PipelineDir()},
+	}
+	for _, candidate := range canonicalCandidates {
+		r, err := loadResearchPath(candidate.path)
+		if err != nil {
+			return nil, "", err
 		}
-		return r, ""
+		if r != nil {
+			if state.RunID == "" {
+				return r, "", nil
+			}
+			return r, candidate.source, nil
+		}
 	}
 
 	if state.RunID != "" {
@@ -454,7 +458,7 @@ func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
 	// files matching this APIName and pick the most recent.
 	candidates, err := globResearchCandidates(ScopedRunstateRoot())
 	if err != nil || len(candidates) == 0 {
-		return nil, ""
+		return nil, "", nil
 	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return candidates[i].mtime.After(candidates[j].mtime)
@@ -462,18 +466,40 @@ func loadResearchForPromote(state *PipelineState) (*ResearchResult, string) {
 	return loadMatchingResearch(candidates, state.APIName)
 }
 
-func loadMatchingResearch(candidates []researchCandidate, apiName string) (*ResearchResult, string) {
+func loadResearchPath(path string) (*ResearchResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("research.json at %s read failed: %w", path, err)
+	}
+	r, err := decodeResearch(data)
+	if err != nil {
+		return nil, fmt.Errorf("research.json at %s failed to parse: %w", path, err)
+	}
+	return r, nil
+}
+
+func loadMatchingResearch(candidates []researchCandidate, apiName string) (*ResearchResult, string, error) {
+	var loadErr error
 	for _, c := range candidates {
-		r, err := LoadResearch(filepath.Dir(c.path))
+		r, err := loadResearchPath(c.path)
 		if err != nil {
+			if loadErr == nil {
+				loadErr = err
+			}
 			continue
 		}
 		if apiName != "" && r.APIName != "" && r.APIName != apiName {
 			continue
 		}
-		return r, c.path
+		return r, c.path, nil
 	}
-	return nil, ""
+	if loadErr != nil {
+		return nil, "", loadErr
+	}
+	return nil, "", nil
 }
 
 func globResearchCandidatesForRunID(runID string) []researchCandidate {

--- a/internal/pipeline/publish_novelfeatures_test.go
+++ b/internal/pipeline/publish_novelfeatures_test.go
@@ -81,7 +81,8 @@ func TestLoadResearchForPromote_PipelineDir(t *testing.T) {
 	data, _ := json.Marshal(r)
 	require.NoError(t, os.WriteFile(filepath.Join(pipelineDir, "research.json"), data, 0o644))
 
-	got, source := loadResearchForPromote(state)
+	got, source, err := loadResearchForPromote(state)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "From pipeline", got.NovelFeatures[0].Name)
 	assert.Equal(t, pipelineDir, source)
@@ -107,7 +108,8 @@ func TestLoadResearchForPromote_RunRoot(t *testing.T) {
 	data, _ := json.Marshal(r)
 	require.NoError(t, os.WriteFile(filepath.Join(runRoot, "research.json"), data, 0o644))
 
-	got, source := loadResearchForPromote(state)
+	got, source, err := loadResearchForPromote(state)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "From run root", got.NovelFeatures[0].Name)
 	assert.Equal(t, runRoot, source)
@@ -148,7 +150,8 @@ func TestLoadResearchForPromote_MinimalStateGlob(t *testing.T) {
 	state := NewMinimalState("myapi-pp-cli", "/some/working/dir")
 	require.Empty(t, state.RunID, "NewMinimalState should not set RunID")
 
-	got, source := loadResearchForPromote(state)
+	got, source, err := loadResearchForPromote(state)
+	require.NoError(t, err)
 	require.NotNil(t, got, "should find a research.json via glob")
 	assert.Equal(t, "Recent myapi feature", got.NovelFeatures[0].Name,
 		"should pick the most recent matching API")
@@ -173,7 +176,8 @@ func TestLoadResearchForPromote_MinimalStateNoMatch(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(runDir, "research.json"), data, 0o644))
 
 	state := NewMinimalState("myapi-pp-cli", "/some/dir")
-	got, source := loadResearchForPromote(state)
+	got, source, err := loadResearchForPromote(state)
+	require.NoError(t, err)
 	assert.Nil(t, got, "no match for myapi should return nil")
 	assert.Empty(t, source)
 }
@@ -186,7 +190,25 @@ func TestLoadResearchForPromote_NoRunstateRoot(t *testing.T) {
 	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
 
 	state := NewMinimalState("myapi-pp-cli", "/some/dir")
-	got, source := loadResearchForPromote(state)
+	got, source, err := loadResearchForPromote(state)
+	require.NoError(t, err)
 	assert.Nil(t, got)
 	assert.Empty(t, source)
+}
+
+func TestLoadResearchForPromote_MinimalStateGlobReportsMalformedResearch(t *testing.T) {
+	t.Setenv("PRINTING_PRESS_HOME", t.TempDir())
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+
+	runDir := RunRoot("run-bad")
+	require.NoError(t, os.MkdirAll(runDir, 0o755))
+	path := filepath.Join(runDir, "research.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"api_name":"myapi","novel_features":[{"name":1}]}`), 0o644))
+
+	state := NewMinimalState("myapi-pp-cli", "/some/dir")
+	got, source, err := loadResearchForPromote(state)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, source)
+	assert.Contains(t, err.Error(), "research.json at "+path+" failed to parse:")
 }

--- a/internal/pipeline/publish_novelfeatures_test.go
+++ b/internal/pipeline/publish_novelfeatures_test.go
@@ -212,3 +212,27 @@ func TestLoadResearchForPromote_MinimalStateGlobReportsMalformedResearch(t *test
 	assert.Empty(t, source)
 	assert.Contains(t, err.Error(), "research.json at "+path+" failed to parse:")
 }
+
+func TestLoadMatchingResearchSkipsVanishedCandidate(t *testing.T) {
+	dir := t.TempDir()
+	missingPath := filepath.Join(dir, "missing", "research.json")
+	validDir := filepath.Join(dir, "valid")
+	require.NoError(t, os.MkdirAll(validDir, 0o755))
+
+	r := ResearchResult{
+		APIName:       "myapi",
+		NovelFeatures: []NovelFeature{{Name: "From remaining candidate", Command: "cmd"}},
+	}
+	data, _ := json.Marshal(r)
+	validPath := filepath.Join(validDir, "research.json")
+	require.NoError(t, os.WriteFile(validPath, data, 0o644))
+
+	got, source, err := loadMatchingResearch([]researchCandidate{
+		{path: missingPath, mtime: time.Now()},
+		{path: validPath, mtime: time.Now().Add(-time.Minute)},
+	}, "myapi")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "From remaining candidate", got.NovelFeatures[0].Name)
+	assert.Equal(t, validPath, source)
+}

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -635,8 +635,50 @@ func TestWriteCLIManifestForPublish_NoResearchNoExistingManifest(t *testing.T) {
 	_, state := publishManifestEnvSetup(t, "20260427-empty-everything")
 
 	// No research.json, no existing manifest in WorkingDir.
-	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+	var stderr string
+	require.NoError(t, captureStderr(t, &stderr, func() error {
+		return writeCLIManifestForPublish(state, state.WorkingDir)
+	}))
 
 	m := readPublishedManifest(t, state.WorkingDir)
 	assert.Empty(t, m.NovelFeatures, "no novel_features when neither research nor prior manifest has any")
+	assert.Contains(t, stderr, "debug: research.json not found at "+
+		filepath.Join(state.RunRoot(), "research.json")+" or "+
+		filepath.Join(state.PipelineDir(), "research.json"))
+	assert.NotContains(t, stderr, "read failed")
+	assert.NotContains(t, stderr, "failed to parse")
+}
+
+func TestWriteCLIManifestForPublishReportsMalformedResearchJSON(t *testing.T) {
+	_, state := publishManifestEnvSetup(t, "20260427-bad-research")
+
+	runRoot := RunRoot(state.RunID)
+	require.NoError(t, os.MkdirAll(runRoot, 0o755))
+	path := filepath.Join(runRoot, "research.json")
+	body := []byte(`{"api_name":"test-api","novel_features":[{"name":1}]}`)
+	require.NoError(t, os.WriteFile(path, body, 0o644))
+
+	var stderr string
+	require.NoError(t, captureStderr(t, &stderr, func() error {
+		return writeCLIManifestForPublish(state, state.WorkingDir)
+	}))
+
+	assert.Contains(t, stderr, "debug: research.json at "+path+" failed to parse:")
+	assert.NotContains(t, stderr, "research.json not found at")
+}
+
+func TestWriteCLIManifestForPublishReportsUnreadableResearchJSON(t *testing.T) {
+	_, state := publishManifestEnvSetup(t, "20260427-unreadable-research")
+
+	runRoot := RunRoot(state.RunID)
+	path := filepath.Join(runRoot, "research.json")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+
+	var stderr string
+	require.NoError(t, captureStderr(t, &stderr, func() error {
+		return writeCLIManifestForPublish(state, state.WorkingDir)
+	}))
+
+	assert.Contains(t, stderr, "debug: research.json at "+path+" read failed:")
+	assert.NotContains(t, stderr, "research.json not found at")
 }

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -40,6 +40,69 @@ type ResearchResult struct {
 	Narrative *ReadmeNarrative `json:"narrative,omitempty"`
 }
 
+func (r *ResearchResult) UnmarshalJSON(data []byte) error {
+	type researchResultAlias ResearchResult
+	var decoded struct {
+		*researchResultAlias
+		Gaps     flexibleResearchStrings `json:"gaps"`
+		Patterns flexibleResearchStrings `json:"patterns"`
+	}
+	decoded.researchResultAlias = (*researchResultAlias)(r)
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	r.Gaps = []string(decoded.Gaps)
+	r.Patterns = []string(decoded.Patterns)
+	return nil
+}
+
+type flexibleResearchStrings []string
+
+func (f *flexibleResearchStrings) UnmarshalJSON(data []byte) error {
+	var items []json.RawMessage
+	if err := json.Unmarshal(data, &items); err != nil {
+		return err
+	}
+
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		var text string
+		if err := json.Unmarshal(item, &text); err == nil {
+			out = append(out, text)
+			continue
+		}
+
+		var structured struct {
+			Name   string `json:"name"`
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal(item, &structured); err != nil {
+			return err
+		}
+		rendered := renderResearchString(structured.Name, structured.Reason)
+		if rendered == "" {
+			return fmt.Errorf("expected research list item to be a string or object with name/reason")
+		}
+		out = append(out, rendered)
+	}
+
+	*f = out
+	return nil
+}
+
+func renderResearchString(name, reason string) string {
+	name = strings.TrimSpace(name)
+	reason = strings.TrimSpace(reason)
+	switch {
+	case name != "" && reason != "":
+		return name + ": " + reason
+	case name != "":
+		return name
+	default:
+		return reason
+	}
+}
+
 // NovelFeature represents a transcendence feature invented during the absorb
 // phase — a capability not found in any existing tool for this API.
 type NovelFeature struct {
@@ -261,28 +324,15 @@ func LoadResearch(pipelineDir string) (*ResearchResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	return decodeResearch(data)
+}
+
+func decodeResearch(data []byte) (*ResearchResult, error) {
 	var r ResearchResult
 	if err := json.Unmarshal(data, &r); err != nil {
 		return nil, err
 	}
 	return &r, nil
-}
-
-// loadResearchForState reads research.json from the run directory, supporting
-// both write conventions: the printing-press skill writes to RunRoot/research.json
-// directly, while cli-printing-press print writes to RunRoot/pipeline/research.json
-// alongside its phase artifacts. Tries the run-root path first (the dominant
-// case), falls back to pipeline-dir.
-//
-// The two-location lookup matters at promote/publish time, when downstream code
-// needs research.json to populate the published manifest's novel_features.
-// Without this fallback the publish-time read silently misses skill-flow runs
-// and ships manifests with empty novel_features (cal-com retro #334 F2).
-func loadResearchForState(state *PipelineState) (*ResearchResult, error) {
-	if r, err := LoadResearch(state.RunRoot()); err == nil {
-		return r, nil
-	}
-	return LoadResearch(state.PipelineDir())
 }
 
 // WriteNovelFeaturesBuilt updates research.json with the verified list of

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -66,6 +67,9 @@ func (f *flexibleResearchStrings) UnmarshalJSON(data []byte) error {
 
 	out := make([]string, 0, len(items))
 	for _, item := range items {
+		if bytes.Equal(bytes.TrimSpace(item), []byte("null")) {
+			return fmt.Errorf("expected research list item to be a string or object with name/reason, got null")
+		}
 		var text string
 		if err := json.Unmarshal(item, &text); err == nil {
 			out = append(out, text)

--- a/internal/pipeline/research_test.go
+++ b/internal/pipeline/research_test.go
@@ -136,6 +136,7 @@ func TestLoadResearchRejectsMalformedGapsAndPatterns(t *testing.T) {
 	}{
 		{name: "empty structured gap", body: `{"gaps":[{}]}`},
 		{name: "numeric pattern", body: `{"patterns":[42]}`},
+		{name: "null gap", body: `{"gaps":[null]}`},
 		{name: "non-array gaps", body: `{"gaps":{"name":"No JSON output"}}`},
 	}
 	for _, tt := range tests {

--- a/internal/pipeline/research_test.go
+++ b/internal/pipeline/research_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,53 @@ func TestWriteAndLoadResearch(t *testing.T) {
 	assert.Equal(t, "proceed", loaded.Recommendation)
 	assert.Len(t, loaded.Alternatives, 1)
 	assert.Equal(t, "alt-1", loaded.Alternatives[0].Name)
+}
+
+func TestLoadResearchAcceptsStructuredGapsAndPatterns(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`{
+		"api_name": "test-api",
+		"gaps": [
+			{"name": "No JSON output", "reason": "Agents need structured responses"},
+			"limited auth support"
+		],
+		"patterns": [
+			{"name": "Workflow commands", "reason": "Competitors compose common tasks"},
+			"standard CRUD"
+		]
+	}`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "research.json"), body, 0o644))
+
+	loaded, err := LoadResearch(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"No JSON output: Agents need structured responses",
+		"limited auth support",
+	}, loaded.Gaps)
+	assert.Equal(t, []string{
+		"Workflow commands: Competitors compose common tasks",
+		"standard CRUD",
+	}, loaded.Patterns)
+}
+
+func TestLoadResearchRejectsMalformedGapsAndPatterns(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty structured gap", body: `{"gaps":[{}]}`},
+		{name: "numeric pattern", body: `{"patterns":[42]}`},
+		{name: "non-array gaps", body: `{"gaps":{"name":"No JSON output"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "research.json"), []byte(tt.body), 0o644))
+
+			_, err := LoadResearch(dir)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestParseGitHubURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Promote now tells operators when `research.json` exists but cannot be read or parsed, instead of reporting it as missing and silently skipping `novel_features` enrichment. Research payloads also accept `gaps` and `patterns` as either plain strings or `{name, reason}` objects, so skill-authored research files keep feeding publish manifests when those fields use the same structured shape as nearby research data.

Closes #1600

## Approach

The publish loader now checks canonical and fallback research candidates through a single diagnostic-aware path. Missing files still produce the existing not-found breadcrumb, while unreadable or malformed files emit path-specific read/parse diagnostics.

The research decoder normalizes structured `gaps` and `patterns` entries into prose strings at load time, preserving downstream renderers and manifest code.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/pipeline`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- headless review pass against `origin/main`
