### PR TITLE
fix(cli): warn on novel feature command depth drift

### DIFF
--- a/docs/solutions/logic-errors/novel-feature-command-depth-drift-2026-05-23.md
+++ b/docs/solutions/logic-errors/novel-feature-command-depth-drift-2026-05-23.md
@@ -1,0 +1,71 @@
+---
+title: "Novel feature command-depth drift between docs and Cobra wiring"
+date: 2026-05-23
+category: logic-errors
+module: internal/pipeline
+problem_type: logic_error
+component: tooling
+related_components:
+  - documentation
+  - testing_framework
+symptoms:
+  - "README Unique Features and root help Highlights advertised a novel command at one depth while Cobra registered it at another."
+  - "Dogfood counted the feature as built through leaf fallback and did not warn about the advertised path drift."
+  - "Scorecard output had no corresponding warning when research metadata was available."
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - dogfood
+  - scorecard
+  - novel-features
+  - cobra-tree
+  - readme-drift
+---
+
+# Novel feature command-depth drift between docs and Cobra wiring
+
+## Problem
+
+Novel feature advertising comes from `research.json`, while the final command tree comes from hand-authored Cobra wiring. A feature can be advertised as `grab` in README and root help, then implemented as `assets grab`, and the old dogfood check still counted it as present because the leaf name existed somewhere in the tree.
+
+## Symptoms
+
+- Generated README and root help can claim a copy-paste command shape that is not registered at that path.
+- `novel_features_built` can preserve the feature as shipped even though the advertised path is stale.
+- Scorecard and dogfood do not tell the agent whether the fix is to promote the command or update the research example.
+
+## What Didn't Work
+
+- Leaf-only matching was useful as a compatibility fallback for partially reconstructed command trees, but it erased the difference between `grab` and `assets grab`.
+- Checking only the `command` field missed the user-facing `example` field, which is the exact command shown in docs.
+- Static tree reconstruction that only followed `new*Cmd` factories missed hand-authored helpers such as `assetsGrabSubcmd(flags)`.
+
+## Solution
+
+Keep the existing "is the feature present" matching behavior, then add a second depth-drift diagnostic:
+
+- Parse the advertised path from `example` when it begins with a printed CLI binary, falling back to `command` otherwise.
+- Prefer full command-path matches. When only a leaf match explains the feature, compare the advertised path to all known registered paths with the same leaf.
+- Emit `novel_features_check.depth_mismatches` in dogfood JSON and include the same detail in dogfood human output and issue collection.
+- Add `novel_feature_depth_mismatches` and a gap-report entry to scorecard when a research directory is available.
+- Broaden static command-tree reconstruction to follow arbitrary Cobra factory functions and variable-assigned `AddCommand` calls, not just direct `new*Cmd` calls.
+
+## Why This Works
+
+The feature-presence check and the path-correctness check answer different questions. Leaf fallback can remain permissive so dogfood does not falsely claim a feature is missing when static tree reconstruction is incomplete. The new depth diagnostic only fires when there is a known registered path whose leaf matches the advertised command but whose full path differs.
+
+The broader command-tree reconstruction reduces false depth warnings by recovering common hand-authored Cobra wiring before the checker falls back to leaf evidence. Scorecard reuses the same mismatch logic so agents see the drift whether they run dogfood or inspect scorecard output.
+
+## Prevention
+
+- Treat fallback matchers as lossy: when they preserve compatibility, add a separate diagnostic for what they hide.
+- When generated docs render runnable examples, validate the rendered example path, not only the planner-facing command field.
+- Test both directions of path drift: advertised root vs nested registration, and advertised nested path vs root registration.
+- Include issue-list or gap-report tests for warnings that must guide the remediation path.
+
+## Related Issues
+
+- GitHub issue: #1596
+- Related: `docs/solutions/logic-errors/scorer-dogfood-composed-header-auth-and-example-continuations-2026-05-05.md`
+- Related: `docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md`

--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -269,12 +269,15 @@ func printDogfoodReport(report *pipeline.DogfoodReport) {
 		fmt.Println("Novel Features:    SKIP (none planned)")
 	} else {
 		nfStatus := "PASS"
-		if len(nfc.Missing) > 0 {
+		if len(nfc.Missing) > 0 || len(nfc.DepthMismatches) > 0 {
 			nfStatus = "WARN"
 		}
 		fmt.Printf("Novel Features:    %d/%d survived (%s)\n", nfc.Found, nfc.Planned, nfStatus)
 		for _, cmd := range nfc.Missing {
 			fmt.Printf("  - %s: planned but not found\n", cmd)
+		}
+		for _, mismatch := range nfc.DepthMismatches {
+			fmt.Printf("  - %s: advertised as %q but registered as %q\n", mismatch.Command, mismatch.Advertised, mismatch.Actual)
 		}
 	}
 	fmt.Println()

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -853,15 +853,7 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			continue
 		}
 		src := string(data)
-		vars := commandFactoryVars(src)
-		for _, rm := range rootAddRe.FindAllStringSubmatch(src, -1) {
-			rootFuncs = append(rootFuncs, rm[1])
-		}
-		for _, rm := range rootVarAddRe.FindAllStringSubmatch(src, -1) {
-			if fn := vars[rm[1]]; fn != "" {
-				rootFuncs = append(rootFuncs, fn)
-			}
-		}
+		packageVars := packageCommandFactoryVars(src)
 		for _, u := range useRe.FindAllStringSubmatch(src, -1) {
 			if name := strings.Fields(u[1])[0]; name != "" {
 				leaves[name] = true
@@ -873,6 +865,20 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			if body == "" {
 				continue
 			}
+			bodyVars := commandFactoryVars(body)
+			for _, rm := range rootAddRe.FindAllStringSubmatch(body, -1) {
+				rootFuncs = append(rootFuncs, rm[1])
+			}
+			for _, rm := range rootVarAddRe.FindAllStringSubmatch(body, -1) {
+				fn := bodyVars[rm[1]]
+				if fn == "" {
+					fn = packageVars[rm[1]]
+				}
+				if fn != "" {
+					rootFuncs = append(rootFuncs, fn)
+				}
+			}
+
 			entry := &cmdFunc{}
 			if u := useRe.FindStringSubmatch(body); u != nil {
 				entry.use = strings.Fields(u[1])[0]
@@ -880,11 +886,10 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			for _, cm := range addChildRe.FindAllStringSubmatch(body, -1) {
 				entry.children = append(entry.children, cm[1])
 			}
-			bodyVars := commandFactoryVars(body)
 			for _, cm := range addChildVarRe.FindAllStringSubmatch(body, -1) {
 				fn := bodyVars[cm[1]]
 				if fn == "" {
-					fn = vars[cm[1]]
+					fn = packageVars[cm[1]]
 				}
 				if fn != "" {
 					entry.children = append(entry.children, fn)
@@ -939,6 +944,46 @@ func commandFactoryVars(src string) map[string]string {
 		vars[m[1]] = m[2]
 	}
 	return vars
+}
+
+func packageCommandFactoryVars(src string) map[string]string {
+	vars := map[string]string{}
+	file, err := parser.ParseFile(token.NewFileSet(), "", src, 0)
+	if err != nil {
+		return vars
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if i >= len(valueSpec.Values) {
+					continue
+				}
+				if fn := commandFactoryCallName(valueSpec.Values[i]); fn != "" {
+					vars[name.Name] = fn
+				}
+			}
+		}
+	}
+	return vars
+}
+
+func commandFactoryCallName(expr ast.Expr) string {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	if ident, ok := call.Fun.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
 }
 
 // extractFuncBody returns the balanced-brace body of a Go function given

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -882,7 +882,11 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			}
 			bodyVars := commandFactoryVars(body)
 			for _, cm := range addChildVarRe.FindAllStringSubmatch(body, -1) {
-				if fn := bodyVars[cm[1]]; fn != "" {
+				fn := bodyVars[cm[1]]
+				if fn == "" {
+					fn = vars[cm[1]]
+				}
+				if fn != "" {
 					entry.children = append(entry.children, fn)
 				}
 			}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -571,7 +571,12 @@ func exampleAdvertisedPath(example string, paths map[string]bool) string {
 		candidates = append(candidates, candidates[len(candidates)-1]+" "+token)
 	}
 	for i := len(candidates) - 1; i >= 0; i-- {
-		if matchPath(candidates[i], paths) || len(leafMatchedPaths(candidates[i], paths)) > 0 {
+		if matchPath(candidates[i], paths) {
+			return candidates[i]
+		}
+	}
+	for i := len(candidates) - 1; i >= 0; i-- {
+		if len(leafMatchedPaths(candidates[i], paths)) > 0 {
 			return candidates[i]
 		}
 	}
@@ -920,9 +925,13 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 }
 
 func commandFactoryVars(src string) map[string]string {
-	re := regexp.MustCompile(`\b(\w+)\s*:=\s*(\w+)\s*\(`)
+	shortRe := regexp.MustCompile(`\b(\w+)\s*:=\s*(\w+)\s*\(`)
+	varRe := regexp.MustCompile(`\bvar\s+(\w+)\s*=\s*(\w+)\s*\(`)
 	vars := map[string]string{}
-	for _, m := range re.FindAllStringSubmatch(src, -1) {
+	for _, m := range shortRe.FindAllStringSubmatch(src, -1) {
+		vars[m[1]] = m[2]
+	}
+	for _, m := range varRe.FindAllStringSubmatch(src, -1) {
 		vars[m[1]] = m[2]
 	}
 	return vars

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -100,10 +100,17 @@ type TestPresenceResult struct {
 // NovelFeaturesCheckResult tracks whether transcendence features planned
 // during absorb actually survived the build as registered CLI commands.
 type NovelFeaturesCheckResult struct {
-	Planned int      `json:"planned"`
-	Found   int      `json:"found"`
-	Missing []string `json:"missing,omitempty"`
-	Skipped bool     `json:"skipped,omitempty"`
+	Planned         int                         `json:"planned"`
+	Found           int                         `json:"found"`
+	Missing         []string                    `json:"missing,omitempty"`
+	DepthMismatches []NovelFeatureDepthMismatch `json:"depth_mismatches,omitempty"`
+	Skipped         bool                        `json:"skipped,omitempty"`
+}
+
+type NovelFeatureDepthMismatch struct {
+	Command    string `json:"command"`
+	Advertised string `json:"advertised"`
+	Actual     string `json:"actual"`
 }
 
 type PathCheckResult struct {
@@ -439,6 +446,9 @@ func checkNovelFeatures(cliDir, researchDir string) NovelFeaturesCheckResult {
 		if matched {
 			result.Found++
 			built = append(built, nf)
+			if mismatch := novelFeatureDepthMismatch(nf, paths); mismatch != nil {
+				result.DepthMismatches = append(result.DepthMismatches, *mismatch)
+			}
 		} else {
 			result.Missing = append(result.Missing, nf.Command)
 		}
@@ -515,6 +525,88 @@ func matchNovelFeature(nf NovelFeature, paths, leaves map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+func novelFeatureDepthMismatch(nf NovelFeature, paths map[string]bool) *NovelFeatureDepthMismatch {
+	advertised := advertisedNovelFeaturePath(nf, paths)
+	if advertised == "" || matchPath(advertised, paths) {
+		return nil
+	}
+	actualPaths := leafMatchedPaths(advertised, paths)
+	if len(actualPaths) == 0 {
+		return nil
+	}
+	return &NovelFeatureDepthMismatch{
+		Command:    nf.Command,
+		Advertised: advertised,
+		Actual:     strings.Join(actualPaths, ", "),
+	}
+}
+
+func advertisedNovelFeaturePath(nf NovelFeature, paths map[string]bool) string {
+	if advertised := exampleAdvertisedPath(nf.Example, paths); advertised != "" {
+		return advertised
+	}
+	return commandPath(nf.Command)
+}
+
+func exampleAdvertisedPath(example string, paths map[string]bool) string {
+	tokens := strings.Fields(strings.ToLower(example))
+	if len(tokens) < 2 || !looksLikePrintedCLIBinary(tokens[0]) {
+		return ""
+	}
+	var candidates []string
+	for _, token := range tokens[1:] {
+		token = strings.Trim(token, `"'`)
+		if token == "" {
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			break
+		}
+		if len(candidates) == 0 {
+			candidates = append(candidates, token)
+			continue
+		}
+		candidates = append(candidates, candidates[len(candidates)-1]+" "+token)
+	}
+	for i := len(candidates) - 1; i >= 0; i-- {
+		if matchPath(candidates[i], paths) || len(leafMatchedPaths(candidates[i], paths)) > 0 {
+			return candidates[i]
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+
+func looksLikePrintedCLIBinary(token string) bool {
+	base := filepath.Base(strings.Trim(token, `"'`))
+	return strings.HasSuffix(base, "-pp-cli")
+}
+
+func leafMatchedPaths(plan string, paths map[string]bool) []string {
+	_, leaf := splitCommandPath(plan)
+	if leaf == "" {
+		return nil
+	}
+	var out []string
+	for path := range paths {
+		_, pathLeaf := splitCommandPath(path)
+		if pathLeaf == "" {
+			continue
+		}
+		if commandLeavesMatch(leaf, pathLeaf) {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func commandLeavesMatch(a, b string) bool {
+	return a == b || strings.HasPrefix(a, b+"-") || strings.HasPrefix(b, a+"-")
 }
 
 // matchCrossCuttingFeature handles novel features whose command string
@@ -664,7 +756,7 @@ func matchPath(plan string, paths map[string]bool) bool {
 		if pp != parent || pl == "" {
 			continue
 		}
-		if strings.HasPrefix(pl, leaf+"-") || strings.HasPrefix(leaf, pl+"-") {
+		if commandLeavesMatch(leaf, pl) {
 			return true
 		}
 	}
@@ -682,7 +774,7 @@ func matchLeaf(plan string, leaves map[string]bool) bool {
 		return true
 	}
 	for use := range leaves {
-		if strings.HasPrefix(use, leaf+"-") || strings.HasPrefix(leaf, use+"-") {
+		if commandLeavesMatch(leaf, use) {
 			return true
 		}
 	}
@@ -743,10 +835,12 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 
 	// Root detection scans the full file because the wiring function
 	// (Execute / helpers) isn't a new*Cmd constructor.
-	rootAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(new\w+Cmd)\b`)
-	funcHeaderRe := regexp.MustCompile(`func\s+(new\w+Cmd)\s*\(`)
+	rootAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(\w+)\s*\(`)
+	rootVarAddRe := regexp.MustCompile(`rootCmd\.AddCommand\(\s*(\w+)\b`)
+	funcHeaderRe := regexp.MustCompile(`func\s+(\w+)\s*\(`)
 	useRe := cobraUseLeafRe
-	addChildRe := regexp.MustCompile(`\.AddCommand\(\s*(new\w+Cmd)\b`)
+	addChildRe := regexp.MustCompile(`\.AddCommand\(\s*(\w+)\s*\(`)
+	addChildVarRe := regexp.MustCompile(`\.AddCommand\(\s*(\w+)\b`)
 
 	for _, file := range files {
 		data, err := os.ReadFile(file)
@@ -754,8 +848,14 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			continue
 		}
 		src := string(data)
+		vars := commandFactoryVars(src)
 		for _, rm := range rootAddRe.FindAllStringSubmatch(src, -1) {
 			rootFuncs = append(rootFuncs, rm[1])
+		}
+		for _, rm := range rootVarAddRe.FindAllStringSubmatch(src, -1) {
+			if fn := vars[rm[1]]; fn != "" {
+				rootFuncs = append(rootFuncs, fn)
+			}
 		}
 		for _, u := range useRe.FindAllStringSubmatch(src, -1) {
 			if name := strings.Fields(u[1])[0]; name != "" {
@@ -774,6 +874,12 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 			}
 			for _, cm := range addChildRe.FindAllStringSubmatch(body, -1) {
 				entry.children = append(entry.children, cm[1])
+			}
+			bodyVars := commandFactoryVars(body)
+			for _, cm := range addChildVarRe.FindAllStringSubmatch(body, -1) {
+				if fn := bodyVars[cm[1]]; fn != "" {
+					entry.children = append(entry.children, fn)
+				}
 			}
 			funcs[name] = entry
 		}
@@ -811,6 +917,15 @@ func collectRegisteredCommands(dir string) (paths, leaves map[string]bool) {
 		}
 	}
 	return paths, leaves
+}
+
+func commandFactoryVars(src string) map[string]string {
+	re := regexp.MustCompile(`\b(\w+)\s*:=\s*(\w+)\s*\(`)
+	vars := map[string]string{}
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		vars[m[1]] = m[2]
+	}
+	return vars
 }
 
 // extractFuncBody returns the balanced-brace body of a Go function given
@@ -2037,7 +2152,9 @@ var dogfoodVerdictRules = []dogfoodVerdictRule{
 		return mcpSurfaceCheckActive(r.MCPSurfaceParityCheck) && !r.MCPSurfaceParityCheck.HandEdited && !r.MCPSurfaceParityCheck.Pass
 	}},
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return len(r.WiringCheck.WorkflowComplete.UnmappedSteps) > 0 }},
-	{"WARN", func(r *DogfoodReport, _ bool) bool { return len(r.NovelFeaturesCheck.Missing) > 0 }},
+	{"WARN", func(r *DogfoodReport, _ bool) bool {
+		return len(r.NovelFeaturesCheck.Missing) > 0 || len(r.NovelFeaturesCheck.DepthMismatches) > 0
+	}},
 	{"WARN", func(r *DogfoodReport, _ bool) bool {
 		return mcpSurfaceCheckActive(r.MCPSurfaceParityCheck) && r.MCPSurfaceParityCheck.HandEdited
 	}},
@@ -2114,6 +2231,16 @@ func collectDogfoodIssues(report *DogfoodReport, hasSpec bool) []string {
 			len(report.NovelFeaturesCheck.Missing),
 			report.NovelFeaturesCheck.Planned,
 			strings.Join(report.NovelFeaturesCheck.Missing, ", ")))
+	}
+	if len(report.NovelFeaturesCheck.DepthMismatches) > 0 {
+		parts := make([]string, 0, len(report.NovelFeaturesCheck.DepthMismatches))
+		for _, mismatch := range report.NovelFeaturesCheck.DepthMismatches {
+			parts = append(parts, fmt.Sprintf("%s advertised as %s but registered as %s",
+				mismatch.Command, mismatch.Advertised, mismatch.Actual))
+		}
+		issues = append(issues, fmt.Sprintf("%d novel feature command-depth mismatches: %s",
+			len(report.NovelFeaturesCheck.DepthMismatches),
+			strings.Join(parts, "; ")))
 	}
 	if mcpSurfaceCheckActive(report.MCPSurfaceParityCheck) && !report.MCPSurfaceParityCheck.Pass {
 		issues = append(issues, "MCP surface parity: "+report.MCPSurfaceParityCheck.Detail)

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1443,6 +1443,84 @@ func newHealthCmd() *cobra.Command {
 		assert.Equal(t, "health", (*updated.NovelFeaturesBuilt)[0].Command)
 	})
 
+	t.Run("warns when advertised command depth differs from registered path", func(t *testing.T) {
+		cliDir := t.TempDir()
+		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
+		require.NoError(t, os.MkdirAll(cliCodeDir, 0o755))
+		writeTestFile(t, filepath.Join(cliCodeDir, "root.go"), `package cli
+func Execute() {
+	rootCmd.AddCommand(newAssetsCmd())
+}`)
+		writeTestFile(t, filepath.Join(cliCodeDir, "assets.go"), `package cli
+func newAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "assets"}
+	cmd.AddCommand(newAssetsGrabCmd())
+	return cmd
+}`)
+		writeTestFile(t, filepath.Join(cliCodeDir, "assets_grab.go"), `package cli
+func newAssetsGrabCmd() *cobra.Command {
+	return &cobra.Command{Use: "grab"}
+}`)
+
+		researchDir := t.TempDir()
+		research := &ResearchResult{
+			APIName: "test",
+			NovelFeatures: []NovelFeature{
+				{Name: "Grab asset", Command: "grab", Example: `test-pp-cli grab "sunset"`},
+			},
+		}
+		require.NoError(t, writeResearchJSON(research, researchDir))
+
+		result := checkNovelFeatures(cliDir, researchDir)
+		assert.Equal(t, 1, result.Planned)
+		assert.Equal(t, 1, result.Found)
+		assert.Empty(t, result.Missing)
+		require.Len(t, result.DepthMismatches, 1)
+		assert.Equal(t, NovelFeatureDepthMismatch{
+			Command:    "grab",
+			Advertised: "grab",
+			Actual:     "assets grab",
+		}, result.DepthMismatches[0])
+	})
+
+	t.Run("does not warn when variable wiring resolves the advertised root command", func(t *testing.T) {
+		cliDir := t.TempDir()
+		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
+		require.NoError(t, os.MkdirAll(cliCodeDir, 0o755))
+		writeTestFile(t, filepath.Join(cliCodeDir, "root.go"), `package cli
+func Execute() {
+	grabCmd := rootGrabSubcmd(nil)
+	rootCmd.AddCommand(grabCmd)
+	rootCmd.AddCommand(newAssetsCmd())
+}
+func rootGrabSubcmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "grab"}
+}`)
+		writeTestFile(t, filepath.Join(cliCodeDir, "assets.go"), `package cli
+func newAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "assets"}
+	cmd.AddCommand(assetsGrabSubcmd(nil))
+	return cmd
+}
+func assetsGrabSubcmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "grab"}
+}`)
+
+		researchDir := t.TempDir()
+		research := &ResearchResult{
+			APIName: "test",
+			NovelFeatures: []NovelFeature{
+				{Name: "Grab asset", Command: "grab", Example: `test-pp-cli grab "sunset"`},
+			},
+		}
+		require.NoError(t, writeResearchJSON(research, researchDir))
+
+		result := checkNovelFeatures(cliDir, researchDir)
+		assert.Equal(t, 1, result.Found)
+		assert.Empty(t, result.Missing)
+		assert.Empty(t, result.DepthMismatches)
+	})
+
 	t.Run("syncs README and SKILL to verified subset", func(t *testing.T) {
 		cliDir := t.TempDir()
 		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
@@ -2151,6 +2229,18 @@ func TestDeriveDogfoodVerdict_NovelFeatures(t *testing.T) {
 	base.NovelFeaturesCheck = NovelFeaturesCheckResult{Planned: 3, Found: 1, Missing: []string{"triage", "utilization"}}
 	assert.Equal(t, "WARN", deriveDogfoodVerdict(base, true))
 
+	// Depth mismatches → WARN
+	base.NovelFeaturesCheck = NovelFeaturesCheckResult{
+		Planned: 1,
+		Found:   1,
+		DepthMismatches: []NovelFeatureDepthMismatch{{
+			Command:    "grab",
+			Advertised: "grab",
+			Actual:     "assets grab",
+		}},
+	}
+	assert.Equal(t, "WARN", deriveDogfoodVerdict(base, true))
+
 	// All found → PASS
 	base.NovelFeaturesCheck = NovelFeaturesCheckResult{Planned: 2, Found: 2}
 	assert.Equal(t, "PASS", deriveDogfoodVerdict(base, true))
@@ -2827,6 +2917,23 @@ func TestCollectDogfoodIssues_IncludesMissingTests(t *testing.T) {
 	}
 	issues := collectDogfoodIssues(report, false)
 	assert.Contains(t, issues, "pure-logic packages with no tests: recipes, goat")
+}
+
+func TestCollectDogfoodIssues_IncludesNovelFeatureDepthMismatch(t *testing.T) {
+	report := &DogfoodReport{
+		NovelFeaturesCheck: NovelFeaturesCheckResult{
+			Planned: 1,
+			Found:   1,
+			DepthMismatches: []NovelFeatureDepthMismatch{{
+				Command:    "grab",
+				Advertised: "grab",
+				Actual:     "assets grab",
+			}},
+		},
+	}
+
+	issues := collectDogfoodIssues(report, false)
+	assert.Contains(t, issues, "1 novel feature command-depth mismatches: grab advertised as grab but registered as assets grab")
 }
 
 func TestDeriveDogfoodVerdict_FailsOnMissingTests(t *testing.T) {

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -165,6 +165,13 @@ func TestNovelFeatureDepthMismatch(t *testing.T) {
 			want:    nil,
 		},
 		{
+			name:    "positional argument matching another command leaf is clean",
+			command: "upload",
+			example: `demo-pp-cli upload photo`,
+			paths:   map[string]bool{"upload": true, "photo": true},
+			want:    nil,
+		},
+		{
 			name:    "leaf-only fallback is clean when path is unknown",
 			command: "grab",
 			paths:   map[string]bool{},
@@ -293,13 +300,16 @@ func TestCollectRegisteredCommands_VariableWiring(t *testing.T) {
 
 	writeTestFile(t, filepath.Join(cli, "root.go"), `package cli
 import "github.com/spf13/cobra"
+var listCmd = rootListSubcmd(nil)
 func Execute() {
 	rootCmd := &cobra.Command{Use: "tool"}
 	grabCmd := rootGrabSubcmd(nil)
 	rootCmd.AddCommand(grabCmd)
+	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(newAssetsCmd())
 }
 func rootGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "grab"} }
+func rootListSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "list"} }
 `)
 	writeTestFile(t, filepath.Join(cli, "assets.go"), `package cli
 import "github.com/spf13/cobra"
@@ -313,7 +323,7 @@ func assetsGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "gr
 `)
 
 	paths, _ := collectRegisteredCommands(dir)
-	for _, want := range []string{"grab", "assets", "assets grab"} {
+	for _, want := range []string{"grab", "list", "assets", "assets grab"} {
 		if !paths[want] {
 			t.Errorf("expected path %q, got paths: %v", want, paths)
 		}

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -313,17 +313,20 @@ func rootListSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "list
 `)
 	writeTestFile(t, filepath.Join(cli, "assets.go"), `package cli
 import "github.com/spf13/cobra"
+var assetsListCmd = assetsListSubcmd(nil)
 func newAssetsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "assets"}
 	grabCmd := assetsGrabSubcmd(nil)
 	cmd.AddCommand(grabCmd)
+	cmd.AddCommand(assetsListCmd)
 	return cmd
 }
 func assetsGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "grab"} }
+func assetsListSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "list"} }
 `)
 
 	paths, _ := collectRegisteredCommands(dir)
-	for _, want := range []string{"grab", "list", "assets", "assets grab"} {
+	for _, want := range []string{"grab", "list", "assets", "assets grab", "assets list"} {
 		if !paths[want] {
 			t.Errorf("expected path %q, got paths: %v", want, paths)
 		}

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -310,6 +310,11 @@ func Execute() {
 }
 func rootGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "grab"} }
 func rootListSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "list"} }
+func BuildExtras() {
+	grabCmd := wrongGrabSubcmd(nil)
+	_ = grabCmd
+}
+func wrongGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "wrong"} }
 `)
 	writeTestFile(t, filepath.Join(cli, "assets.go"), `package cli
 import "github.com/spf13/cobra"
@@ -330,5 +335,8 @@ func assetsListSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "li
 		if !paths[want] {
 			t.Errorf("expected path %q, got paths: %v", want, paths)
 		}
+	}
+	if paths["wrong"] {
+		t.Errorf("did not expect same-file local variable collision path, got paths: %v", paths)
 	}
 }

--- a/internal/pipeline/novel_features_matcher_test.go
+++ b/internal/pipeline/novel_features_matcher_test.go
@@ -118,6 +118,80 @@ func TestMatchNovelFeature_FallsBackToLeavesWhenPathsPartial(t *testing.T) {
 	}
 }
 
+func TestNovelFeatureDepthMismatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		example string
+		paths   map[string]bool
+		want    *NovelFeatureDepthMismatch
+	}{
+		{
+			name:    "known nested path mismatches advertised root command",
+			command: "grab",
+			paths:   map[string]bool{"assets": true, "assets grab": true},
+			want: &NovelFeatureDepthMismatch{
+				Command:    "grab",
+				Advertised: "grab",
+				Actual:     "assets grab",
+			},
+		},
+		{
+			name:    "example command wins over command field",
+			command: "assets grab",
+			example: `immich-pp-cli grab "sunset"`,
+			paths:   map[string]bool{"assets": true, "assets grab": true},
+			want: &NovelFeatureDepthMismatch{
+				Command:    "assets grab",
+				Advertised: "grab",
+				Actual:     "assets grab",
+			},
+		},
+		{
+			name:    "multiword example path can mismatch root registration",
+			command: "grab",
+			example: `demo-pp-cli assets grab --json`,
+			paths:   map[string]bool{"grab": true},
+			want: &NovelFeatureDepthMismatch{
+				Command:    "grab",
+				Advertised: "assets grab",
+				Actual:     "grab",
+			},
+		},
+		{
+			name:    "exact registered path is clean",
+			command: "assets grab",
+			paths:   map[string]bool{"assets": true, "assets grab": true},
+			want:    nil,
+		},
+		{
+			name:    "leaf-only fallback is clean when path is unknown",
+			command: "grab",
+			paths:   map[string]bool{},
+			want:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			feature := NovelFeature{Command: tc.command, Example: tc.example}
+			got := novelFeatureDepthMismatch(feature, tc.paths)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("novelFeatureDepthMismatch() = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("novelFeatureDepthMismatch() = nil, want mismatch")
+			}
+			if *got != *tc.want {
+				t.Fatalf("novelFeatureDepthMismatch() = %#v, want %#v", *got, *tc.want)
+			}
+		})
+	}
+}
+
 func TestCommandPath(t *testing.T) {
 	cases := map[string]string{
 		"portfolio perf":                       "portfolio perf",
@@ -206,6 +280,42 @@ func newOptionsChainCmd() *cobra.Command { return &cobra.Command{Use: "options-c
 	for _, w := range wantLeaves {
 		if !leaves[w] {
 			t.Errorf("expected leaf %q, got leaves: %v", w, leaves)
+		}
+	}
+}
+
+func TestCollectRegisteredCommands_VariableWiring(t *testing.T) {
+	dir := t.TempDir()
+	cli := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cli, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestFile(t, filepath.Join(cli, "root.go"), `package cli
+import "github.com/spf13/cobra"
+func Execute() {
+	rootCmd := &cobra.Command{Use: "tool"}
+	grabCmd := rootGrabSubcmd(nil)
+	rootCmd.AddCommand(grabCmd)
+	rootCmd.AddCommand(newAssetsCmd())
+}
+func rootGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "grab"} }
+`)
+	writeTestFile(t, filepath.Join(cli, "assets.go"), `package cli
+import "github.com/spf13/cobra"
+func newAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "assets"}
+	grabCmd := assetsGrabSubcmd(nil)
+	cmd.AddCommand(grabCmd)
+	return cmd
+}
+func assetsGrabSubcmd(flags any) *cobra.Command { return &cobra.Command{Use: "grab"} }
+`)
+
+	paths, _ := collectRegisteredCommands(dir)
+	for _, want := range []string{"grab", "assets", "assets grab"} {
+		if !paths[want] {
+			t.Errorf("expected path %q, got paths: %v", want, paths)
 		}
 	}
 }

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -41,12 +41,13 @@ var quotaDailySignalRE = regexp.MustCompile(`(?i)\b(daily|per[-_\s]+day)\b`)
 
 // Scorecard holds the auto-scored evaluation of a generated CLI against the Steinberger bar.
 type Scorecard struct {
-	APIName            string       `json:"api_name"`
-	Steinberger        SteinerScore `json:"steinberger"`
-	CompetitorScores   []CompScore  `json:"competitor_scores"`
-	OverallGrade       string       `json:"overall_grade"`
-	GapReport          []string     `json:"gap_report"`
-	UnscoredDimensions []string     `json:"unscored_dimensions,omitempty"`
+	APIName                     string                      `json:"api_name"`
+	Steinberger                 SteinerScore                `json:"steinberger"`
+	CompetitorScores            []CompScore                 `json:"competitor_scores"`
+	OverallGrade                string                      `json:"overall_grade"`
+	GapReport                   []string                    `json:"gap_report"`
+	UnscoredDimensions          []string                    `json:"unscored_dimensions,omitempty"`
+	NovelFeatureDepthMismatches []NovelFeatureDepthMismatch `json:"novel_feature_depth_mismatches,omitempty"`
 
 	verifyCalibrationFloor   int
 	browserSessionUnverified bool
@@ -266,6 +267,8 @@ func finalizeScorecard(sc *Scorecard, outputDir, pipelineDir string, verifyRepor
 
 	// Gap report for dimensions below 5
 	sc.GapReport = buildGapReport(sc.Steinberger, sc.UnscoredDimensions)
+	sc.NovelFeatureDepthMismatches = scorecardNovelFeatureDepthMismatches(outputDir, pipelineDir)
+	appendNovelFeatureDepthGaps(sc)
 
 	// MCP tool split from manifest (informational, does not affect score)
 	if manifest, err := loadCLIManifestForScorecard(outputDir); err == nil && manifest.MCPBinary != "" {
@@ -950,6 +953,36 @@ func ApplyLiveCheckToScorecard(sc *Scorecard, live *LiveCheckResult) {
 	applyScorecardCalibration(sc)
 	sc.OverallGrade = computeGrade(sc.Steinberger.Percentage)
 	sc.GapReport = buildGapReport(sc.Steinberger, sc.UnscoredDimensions)
+	appendNovelFeatureDepthGaps(sc)
+}
+
+func scorecardNovelFeatureDepthMismatches(outputDir, pipelineDir string) []NovelFeatureDepthMismatch {
+	if pipelineDir == "" {
+		return nil
+	}
+	research, err := LoadResearch(pipelineDir)
+	if err != nil || len(research.NovelFeatures) == 0 {
+		return nil
+	}
+	paths, leaves := collectRegisteredCommands(outputDir)
+	var mismatches []NovelFeatureDepthMismatch
+	for _, nf := range research.NovelFeatures {
+		if !matchNovelFeature(nf, paths, leaves) {
+			continue
+		}
+		if mismatch := novelFeatureDepthMismatch(nf, paths); mismatch != nil {
+			mismatches = append(mismatches, *mismatch)
+		}
+	}
+	return mismatches
+}
+
+func appendNovelFeatureDepthGaps(sc *Scorecard) {
+	for _, mismatch := range sc.NovelFeatureDepthMismatches {
+		sc.GapReport = append(sc.GapReport, fmt.Sprintf(
+			"novel feature command-depth mismatch: %s advertised as %s but registered as %s",
+			mismatch.Command, mismatch.Advertised, mismatch.Actual))
+	}
 }
 
 func applyScorecardCalibration(sc *Scorecard) {

--- a/internal/pipeline/scorecard_run_test.go
+++ b/internal/pipeline/scorecard_run_test.go
@@ -3,6 +3,8 @@ package pipeline
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -39,4 +41,50 @@ func TestScorecardOnRealCLI(t *testing.T) {
 		}
 	}
 	fmt.Println()
+}
+
+func TestRunScorecardReportsNovelFeatureDepthMismatches(t *testing.T) {
+	outputDir := t.TempDir()
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func Execute() {
+	rootCmd.AddCommand(newAssetsCmd())
+}
+`)
+	writeFile(t, filepath.Join(cliDir, "assets.go"), `package cli
+import "github.com/spf13/cobra"
+func newAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "assets"}
+	cmd.AddCommand(newAssetsGrabCmd())
+	return cmd
+}
+func newAssetsGrabCmd() *cobra.Command {
+	return &cobra.Command{Use: "grab"}
+}
+`)
+
+	pipelineDir := t.TempDir()
+	if err := writeResearchJSON(&ResearchResult{
+		APIName: "test",
+		NovelFeatures: []NovelFeature{
+			{Name: "Grab asset", Command: "grab", Example: `test-pp-cli grab "sunset"`},
+		},
+	}, pipelineDir); err != nil {
+		t.Fatal(err)
+	}
+
+	sc, err := RunScorecard(outputDir, pipelineDir, "", nil)
+	if err != nil {
+		t.Fatalf("RunScorecard: %v", err)
+	}
+	if len(sc.NovelFeatureDepthMismatches) != 1 {
+		t.Fatalf("expected one depth mismatch, got %#v", sc.NovelFeatureDepthMismatches)
+	}
+	want := "novel feature command-depth mismatch: grab advertised as grab but registered as assets grab"
+	if !slices.Contains(sc.GapReport, want) {
+		t.Fatalf("expected gap %q, got %#v", want, sc.GapReport)
+	}
 }


### PR DESCRIPTION
## Summary

Dogfood and scorecard now warn when a novel feature is documented at one command depth but registered at another. This keeps permissive novel-feature survival matching intact while surfacing the actionable drift: promote the command or update the research example so README and root help stop advertising the wrong path.

The check now derives the advertised path from runnable examples when available, reconstructs more Cobra wiring shapes including hand-authored factory helpers and variable-assigned `AddCommand` calls, and reports depth mismatches in dogfood JSON, dogfood human output, dogfood issues, scorecard JSON, and scorecard gap output.

## Tests

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1596

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
