### PR TITLE
fix(cli): count store helper workflows

### DIFF
--- a/docs/solutions/best-practices/steinberger-scorecard-scoring-architecture-2026-03-27.md
+++ b/docs/solutions/best-practices/steinberger-scorecard-scoring-architecture-2026-03-27.md
@@ -1,7 +1,7 @@
 ---
 title: "Steinberger scorecard scoring system: architecture, conventions, and modification rules"
 date: 2026-03-27
-last_updated: 2026-05-05
+last_updated: 2026-05-23
 category: best-practices
 module: internal/pipeline
 problem_type: best_practice
@@ -191,7 +191,7 @@ The floor ensures no CLI with 91% verify pass rate scores below 72. Static analy
 Both dimensions use **prefix lists** and **structural detection**:
 
 - **Prefix lists**: Filenames matching known prefixes (e.g., `stale`, `agenda`, `stats`, `health`) count automatically.
-- **Structural detection (workflows)**: Any command file containing `/store`, `store.Open`, or `store.New` is a workflow command -- it uses the data layer.
+- **Structural detection (workflows)**: Any registered command file that uses the store directly, or calls a package-local helper that reaches or returns `*store.Store`, is a workflow command -- it uses the data layer.
 - **Structural detection (insights)**: A command that uses the store AND has aggregation patterns (`COUNT(`, `SUM(`, `GROUP BY`, `\brate\b`) is an insight command.
 
 ### Intentional prefix overlap

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -17,11 +17,13 @@ import (
 // behavior - a hand-rolled response, a constant return, or an empty
 // stub that pretends to do work.
 //
-// The check is structural, not semantic. It does not parse Go or try to
-// understand what the function returns. It looks at the file that
+// The check is structural, not semantic. It looks at the file that
 // implements the command and asks: does any part of this file call
-// through the generated client package, or read from the generated
-// store package? If neither, the command is flagged.
+// through the generated client package, read from the generated store package,
+// or call a package-local helper that reaches the store? If none do, the
+// command is flagged. Primitive client/store signals stay regex-based; helper
+// discovery uses Go AST parsing so declarations and comments do not look like
+// real helper calls.
 //
 // SQLite-derived commands (stale, bottleneck, health, reconcile) pass
 // this check because their files call `store.Open` and consult the
@@ -69,10 +71,9 @@ type ReimplementationFinding struct {
 	Reason  string `json:"reason"`
 }
 
-// These signals are intentionally string-match and regex based. AST
-// parsing would be more precise but adds scope and dependency weight
-// this check does not need at v1. If false-positive pressure grows,
-// we upgrade to AST in a follow-up.
+// The primitive store/client signals stay regex-based because they are broad
+// file-level probes. Helper discovery uses Go ASTs so declarations and comments
+// do not look like real helper calls.
 
 var (
 	// storeImportRe catches the generated store package import in any
@@ -172,6 +173,7 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 	// We only index non-infrastructure, non-test source files.
 	leafToFiles := map[string][]string{}
 	fileContent := map[string]string{}
+	helperContent := map[string]string{}
 	infra := map[string]bool{
 		"helpers.go": true,
 		"root.go":    true,
@@ -187,14 +189,15 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 		if strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		if infra[name] {
-			continue
-		}
 		data, readErr := os.ReadFile(filepath.Join(cliFilesDir, name))
 		if readErr != nil {
 			continue
 		}
 		content := string(data)
+		helperContent[name] = content
+		if infra[name] {
+			continue
+		}
 		fileContent[name] = content
 		for _, m := range useLineRe.FindAllStringSubmatch(content, -1) {
 			leaf := m[1]
@@ -203,7 +206,7 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 	}
 
 	result := ReimplementationCheckResult{}
-	storeHelpers := storeHelperNames(fileContent)
+	storeHelpers := storeHelperNames(helperContent)
 	for _, nf := range research.NovelFeatures {
 		leaf := lastPathSegment(commandPath(nf.Command))
 		if leaf == "" {
@@ -346,16 +349,34 @@ func hasStoreSignal(content string) bool {
 
 func storeHelperNames(fileContent map[string]string) map[string]bool {
 	helpers := map[string]bool{}
+	funcContent := map[string]string{}
 	for _, content := range fileContent {
-		if !hasStoreSignal(content) {
-			continue
+		forEachGoFuncContent(content, func(name, body string) {
+			funcContent[name] = body
+			if hasStoreSignal(body) || storeTypeRe.MatchString(body) {
+				helpers[name] = true
+			}
+		})
+	}
+	for {
+		changed := false
+		for name, body := range funcContent {
+			if helpers[name] {
+				continue
+			}
+			if callsStoreHelper(body, helpers) {
+				helpers[name] = true
+				changed = true
+			}
 		}
-		collectStoreHelpers(content, helpers)
+		if !changed {
+			break
+		}
 	}
 	return helpers
 }
 
-func collectStoreHelpers(content string, helpers map[string]bool) {
+func forEachGoFuncContent(content string, visit func(name, body string)) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "", content, 0)
 	if err != nil {
@@ -363,7 +384,7 @@ func collectStoreHelpers(content string, helpers map[string]bool) {
 	}
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name == nil {
+		if !ok || fn.Name == nil || fn.Recv != nil {
 			continue
 		}
 		start := fset.Position(fn.Pos()).Offset
@@ -371,20 +392,39 @@ func collectStoreHelpers(content string, helpers map[string]bool) {
 		if start < 0 || end > len(content) || start >= end {
 			continue
 		}
-		funcText := content[start:end]
-		if storeCallRe.MatchString(funcText) || storeTypeRe.MatchString(funcText) {
-			helpers[fn.Name.Name] = true
-		}
+		visit(fn.Name.Name, content[start:end])
 	}
 }
 
 func callsStoreHelper(content string, helpers map[string]bool) bool {
-	for name := range helpers {
-		if regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\(`).MatchString(content) {
+	if len(helpers) == 0 {
+		return false
+	}
+	source := content
+	if !strings.HasPrefix(strings.TrimSpace(source), "package ") {
+		source = "package cli\n" + source
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
+	if err != nil {
+		return false
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
 			return true
 		}
-	}
-	return false
+		ident, ok := call.Fun.(*ast.Ident)
+		if ok && helpers[ident.Name] {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 func hasClientSignal(content string) bool {

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -123,7 +123,7 @@ func newBottleneckCmd(flags *rootFlags) *cobra.Command {
 
 func TestCheckReimplementation_StoreHelperHop_Exempted(t *testing.T) {
 	files := map[string]string{
-		"types.go": `package cli
+		"helpers.go": `package cli
 
 import "example.com/mod/internal/store"
 

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1386,6 +1386,14 @@ func scoreWorkflows(dir string) int {
 	// also prevents dead-code removal from dropping the score: a file whose
 	// constructor isn't registered isn't counted in the first place.
 	registeredFiles := registeredCommandFiles(cliDir)
+	fileContent := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		fileContent[e.Name()] = readFileContent(filepath.Join(cliDir, e.Name()))
+	}
+	storeHelpers := storeHelperNames(fileContent)
 
 	// Some prefixes overlap with insightPrefixes intentionally — per Steinberger,
 	// analytics/insights ARE compound commands (the visionary research plan lists
@@ -1428,10 +1436,10 @@ func scoreWorkflows(dir string) int {
 			continue
 		}
 
-		content := readFileContent(filepath.Join(cliDir, e.Name()))
+		content := fileContent[e.Name()]
 
 		// A command that uses the local data layer is a workflow command.
-		if hasStoreSignal(content) {
+		if hasStoreSignal(content) || callsStoreHelper(content, storeHelpers) {
 			compoundCommands++
 			continue
 		}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2383,6 +2384,107 @@ func runAvailability() {
 `)
 
 		assert.GreaterOrEqual(t, scoreWorkflows(dir), 4) // 2 compound → 4
+	})
+
+	t.Run("counts commands that call package-local store helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+import "example.com/project/internal/store"
+
+func openLocalStore() (*store.Store, error) {
+	return store.Open("data.db")
+}
+
+func ensureLocalStore() error {
+	db, err := openLocalStore()
+	if err != nil {
+		return err
+	}
+	_ = db
+	return nil
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(
+		newReport1Cmd(nil),
+		newReport2Cmd(nil),
+		newReport3Cmd(nil),
+		newReport4Cmd(nil),
+		newReport5Cmd(nil),
+		newReport6Cmd(nil),
+		newReport7Cmd(nil),
+		newLookupCmd(nil),
+	)
+}
+`)
+		for i := 1; i <= 7; i++ {
+			writeScorecardFixture(t, dir, filepath.Join("internal/cli", fmt.Sprintf("report_%d.go", i)), fmt.Sprintf(`
+package cli
+
+func newReport%dCmd(flags any) {}
+
+func runReport%d() error {
+	return ensureLocalStore()
+}
+`, i, i))
+		}
+		writeScorecardFixture(t, dir, "internal/cli/lookup.go", `package cli
+func newLookupCmd(flags any) {}
+func runLookup() error { return nil }
+`)
+
+		assert.Equal(t, 10, scoreWorkflows(dir))
+	})
+
+	t.Run("does not count commands that do not call store helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+import "example.com/project/internal/store"
+
+func openLocalStore() (*store.Store, error) {
+	return store.Open("data.db")
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(
+		newReport1Cmd(nil),
+		newReport2Cmd(nil),
+		newReport3Cmd(nil),
+		newReport4Cmd(nil),
+		newLookupCmd(nil),
+	)
+}
+`)
+		for i := 1; i <= 4; i++ {
+			writeScorecardFixture(t, dir, filepath.Join("internal/cli", fmt.Sprintf("report_%d.go", i)), fmt.Sprintf(`
+package cli
+
+func newReport%dCmd(flags any) {}
+
+func runReport%d() error {
+	db, err := openLocalStore()
+	if err != nil {
+		return err
+	}
+	_ = db
+	return nil
+}
+`, i, i))
+		}
+		writeScorecardFixture(t, dir, "internal/cli/lookup.go", `package cli
+func newLookupCmd(flags any) {}
+func runLookup() error { return nil }
+`)
+
+		assert.Equal(t, 6, scoreWorkflows(dir))
 	})
 
 	t.Run("counts multi-API-call files", func(t *testing.T) {

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2440,7 +2440,7 @@ func runLookup() error { return nil }
 		assert.Equal(t, 10, scoreWorkflows(dir))
 	})
 
-	t.Run("does not count commands that do not call store helpers", func(t *testing.T) {
+	t.Run("counts direct store-helper calls and excludes non-store commands", func(t *testing.T) {
 		dir := t.TempDir()
 
 		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `

--- a/skills/printing-press/references/scorecard-patterns.md
+++ b/skills/printing-press/references/scorecard-patterns.md
@@ -21,6 +21,8 @@ Run the scorecard: `cli-printing-press scorecard --dir ./<api>-cli`
 | Agent Native | `internal/cli/root.go` + `helpers.go` | `json`(+2) `select`(+2) `dry-run`/`dryRun`/`dry_run`(+2) `non-interactive`/`nonInteractive`(+1) `stdin`(+1) `"yes"`(+1) `409`/`already exists`(+1) `human-friendly`/`humanFriendly`(+1) | 10 |
 | Local Cache | `internal/client/client.go` + `internal/cache/cache.go` | `cacheDir`/`readCache`/`writeCache`(+5) `no-cache`/`NoCache`(+2) `sqlite`/`bolt`/`badger` in cache.go or store.go(+3) | 10 |
 | Breadth | `internal/cli/*.go` file count | Excludes: helpers.go, root.go, doctor.go, auth.go. Thresholds: <5=0, 5-10=3, 11-20=5, 21-40=7, 41-60=9, 60+=10 | 10 |
+| Workflows | `internal/cli/*.go` registered commands | Workflow filename prefixes, direct store use, package-local store helpers, or 2+ client API calls | 10 |
+| Insight | `internal/cli/*.go` registered commands | Insight filename prefixes, store use plus aggregation patterns (`COUNT(`, `SUM(`, `GROUP BY`, rates), or manifest novel-feature hints | 10 |
 
 ## Key Gotchas
 
@@ -29,3 +31,4 @@ Run the scorecard: `cli-printing-press scorecard --dir ./<api>-cli`
 - Auth gives +2 just for `auth.go` existing as a file, regardless of content
 - Local Cache gives +3 for `sqlite`/`bolt`/`badger` strings in `internal/cache/cache.go` or `internal/store/store.go`
 - Breadth counts files, not commands - one file per endpoint beats one file per resource
+- Workflow scoring follows registered Cobra commands and recognizes package-local helpers that reach the store


### PR DESCRIPTION
## Summary

- Count registered workflow command files that call package-local helpers reaching the generated store, including transitive helper hops.
- Share the helper detection with the reimplementation check so helper-backed local-store commands are not falsely treated as hand-rolled responses.
- Update scorecard guidance to document helper-backed workflow detection.

Closes #1608

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
