### PR TITLE
fix(skills): require agent-browser post-install setup

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -123,7 +123,6 @@ func TestAgentBrowserInstallRequiresPostInstallSetup(t *testing.T) {
 		{name: "browser-sniff-capture", content: capture},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Contains(t, tt.content, "! agent-browser install")
 			assert.Contains(t, tt.content, "The leading `!` is intentional")

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -111,6 +111,31 @@ func TestPrintingPressSkillPreflightChecksGoToolchain(t *testing.T) {
 	assert.Contains(t, block, `https://go.dev/dl/`)
 }
 
+func TestAgentBrowserInstallRequiresPostInstallSetup(t *testing.T) {
+	setup := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "setup-checks.md"))
+	capture := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "browser-sniff-capture.md"))
+
+	for name, content := range map[string]string{
+		"setup-checks":          setup,
+		"browser-sniff-capture": capture,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Contains(t, content, "! agent-browser install")
+			assert.Contains(t, content, "The leading `!` is intentional")
+			assert.Contains(t, content, "Do not treat `command -v agent-browser` alone as a complete install")
+		})
+	}
+
+	assert.Contains(t, setup, "Only do this post-install step when this section just installed `agent-browser`; if `PRESS_AGENT_BROWSER_MISSING=false`, skip redundant setup for the already-present binary.")
+	assert.Contains(t, setup, "If the user declines the manual step, it fails, or completion is unclear, do not run it through the agent shell")
+	assert.Contains(t, setup, "If `PRESS_AGENT_BROWSER_MISSING=false`, do not require post-install confirmation for the already-installed binary.")
+	assert.Contains(t, setup, "if a later browser-sniff step reports missing browser binaries, surface `! agent-browser install` then")
+
+	assert.Contains(t, capture, "If the user declines the manual step or completion is unclear, do not run it yourself; fall back to manual HAR.")
+	assert.Contains(t, capture, "do not let a second detection pass select the half-installed binary")
+	assert.Contains(t, capture, "If a pre-existing agent-browser later reports missing browser binaries, surface `! agent-browser install`")
+}
+
 func TestPrintingPressSkillUsesRunstateForBuilds(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -115,14 +115,19 @@ func TestAgentBrowserInstallRequiresPostInstallSetup(t *testing.T) {
 	setup := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "setup-checks.md"))
 	capture := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "browser-sniff-capture.md"))
 
-	for name, content := range map[string]string{
-		"setup-checks":          setup,
-		"browser-sniff-capture": capture,
-	} {
-		t.Run(name, func(t *testing.T) {
-			assert.Contains(t, content, "! agent-browser install")
-			assert.Contains(t, content, "The leading `!` is intentional")
-			assert.Contains(t, content, "Do not treat `command -v agent-browser` alone as a complete install")
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "setup-checks", content: setup},
+		{name: "browser-sniff-capture", content: capture},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.content, "! agent-browser install")
+			assert.Contains(t, tt.content, "The leading `!` is intentional")
+			assert.Contains(t, tt.content, "Do not treat `command -v agent-browser` alone as a complete install")
 		})
 	}
 

--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -80,6 +80,8 @@ if [ -n "$ANTHROPIC_API_KEY" ] || [ -n "$OPENAI_API_KEY" ] || [ -n "$BROWSER_USE
 fi
 ```
 
+Treat `command -v agent-browser` as sufficient only when agent-browser was already present before this step, or when this run just installed it and the user-run `agent-browser install` step completed. This detection step does not launch agent-browser to prove browser-cache readiness for pre-existing installs. If this run attempted the package-manager install but the post-install step was declined, failed, or unclear, set `SNIFF_BACKEND="none"` and fall back to manual HAR; do not let a second detection pass select the half-installed binary. If a pre-existing agent-browser later reports missing browser binaries, surface `! agent-browser install` and use a fallback backend until the user confirms it completed.
+
 If a tool is found, report: "Using **<tool>** for temporary traffic capture during generation (CLI-driven mode — no LLM key needed)." and proceed to Step 1c to verify compatibility.
 
 **Important:** browser-use has two modes: autonomous Agent mode (requires an LLM API key like ANTHROPIC_API_KEY) and CLI mode (open/eval/scroll — no key needed). **Always use CLI mode for browser-sniff.** It is more reliable, version-stable, and does not require the user to provide an additional API key. Do NOT attempt to use browser-use's Python `Agent` class — it requires an LLM key that may not be available.
@@ -143,7 +145,15 @@ else
 fi
 ```
 
-After install, re-run detection. If `agent-browser` is now available, set `SNIFF_BACKEND="agent-browser"` and proceed to Step 1c. If install failed, show the error and fall back to manual HAR.
+After the brew or npm install succeeds, use the same post-install rule as preflight (`references/setup-checks.md` section 5): complete agent-browser's browser-binary setup as a user-run step:
+
+```text
+! agent-browser install
+```
+
+The leading `!` is intentional: surface the command for the user to run manually instead of invoking it through the agent's shell tool. Do not treat `command -v agent-browser` alone as a complete install after the package-manager step; the `agent-browser install` step must complete before browser-sniff flows rely on it. If the user declines the manual step or completion is unclear, do not run it yourself; fall back to manual HAR. If agent-browser was already installed before this Step 1b fallback, do not rerun redundant setup here.
+
+After install, re-run detection. If `agent-browser` is now available and the user-run `agent-browser install` step completed, set `SNIFF_BACKEND="agent-browser"` and proceed to Step 1c. If install failed, show the error and fall back to manual HAR.
 
 **If user picks manual HAR**, ask the user for a HAR file path and skip to Step 3.
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -182,7 +182,15 @@ else
 fi
 ```
 
-After install, verify with `command -v <tool>` and confirm to the user: `"Installed <tool>."` **Continue this current setup run with the newly available tools — do not stop, do not skip the remaining checks (min-binary-version compatibility, etc.).**
+After installing `agent-browser` through brew or npm, complete its browser-binary setup as a user-run step:
+
+```text
+! agent-browser install
+```
+
+The leading `!` is intentional: surface the command for the user to run manually instead of invoking it through the agent's shell tool. Some harness classifiers block installer subcommands from a newly installed tool when the agent runs them directly. Do not treat `command -v agent-browser` alone as a complete install after the package-manager step; the `agent-browser install` step must complete before browser-sniff flows rely on it. Only do this post-install step when this section just installed `agent-browser`; if `PRESS_AGENT_BROWSER_MISSING=false`, skip redundant setup for the already-present binary. This preflight does not launch agent-browser to prove browser-cache readiness for pre-existing installs; if a later browser-sniff step reports missing browser binaries, surface `! agent-browser install` then and use a fallback backend until the user confirms it completed.
+
+After install, verify `browser-use` with `command -v browser-use`. If this section just installed `agent-browser`, verify it with both `command -v agent-browser` and confirmation that the user-run `agent-browser install` step completed. If the user declines the manual step, it fails, or completion is unclear, do not run it through the agent shell; surface the incomplete setup and continue without treating `agent-browser` as available for browser-sniff. If `PRESS_AGENT_BROWSER_MISSING=false`, do not require post-install confirmation for the already-installed binary. Then confirm successful installs to the user: `"Installed <tool>."` **Continue this current setup run with the newly available tools — do not stop, do not skip the remaining checks (min-binary-version compatibility, etc.).**
 
 If an install command fails (no Python, no Node.js, network error), surface the failure to the user and continue without the missing backend. Do not block the run on a failed install — runs using vendor specs, `--spec`, or `--har` do not need these tools, and the lazy Step 1b prompt in `browser-sniff-capture.md` remains as a fallback if browser-sniff is later invoked.
 


### PR DESCRIPTION
## Summary

Fresh setup runs that install `agent-browser` now require the documented user-run `agent-browser install` step before browser-sniff treats the backend as usable. The same guard applies to the lazy browser-sniff install path, and incomplete or declined post-install setup falls back instead of silently selecting a half-installed binary.

The already-present binary path still skips redundant setup; if a pre-existing install later reports missing browser binaries, the skill now surfaces the same manual post-install command and uses a fallback backend until completion is confirmed.

## Tests

- `go fmt ./...`
- `go test ./internal/pipeline -run TestAgentBrowserInstallRequiresPostInstallSetup`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

## Accepted for later

A stronger readiness probe for pre-existing `agent-browser` browser caches would require launching the tool or adding persistent tool-state. This PR keeps the fix scoped to the package-manager install paths and documents the fallback if an older pre-existing install reports missing browser binaries.

Closes #1610
