### PR TITLE
fix(skills): honor PRINTING_PRESS_HOME in setup paths

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -68,7 +68,7 @@ func TestSkillSetupBlocksMatchWorkspaceContract(t *testing.T) {
 			assert.Contains(t, block, `pwd -P`)
 
 			// Core workspace variables
-			assert.Contains(t, block, `PRESS_HOME="$HOME/printing-press"`)
+			assert.Contains(t, block, `PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"`)
 			assert.Contains(t, block, `PRESS_SCOPE=`)
 			assert.Contains(t, block, `PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"`)
 			assert.Contains(t, block, `PRESS_LIBRARY="$PRESS_HOME/library"`)
@@ -87,6 +87,83 @@ func TestSkillSetupBlocksMatchWorkspaceContract(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSkillFilesHonorPrintingPressHomeEnv(t *testing.T) {
+	skillPaths, err := filepath.Glob(filepath.Join("..", "..", "skills", "*", "SKILL.md"))
+	require.NoError(t, err)
+	require.NotEmpty(t, skillPaths)
+
+	referencePaths, err := filepath.Glob(filepath.Join("..", "..", "skills", "*", "references", "*"))
+	require.NoError(t, err)
+
+	for _, path := range append(skillPaths, referencePaths...) {
+		t.Run(filepath.Base(filepath.Dir(path)), func(t *testing.T) {
+			full := readContractFile(t, path)
+			assert.NotContains(t, full, `PRESS_HOME="$HOME/printing-press"`)
+			assert.NotContains(t, full, `$HOME/printing-press/`)
+			assert.NotContains(t, full, `"$HOME/printing-press"`)
+			assert.NotContains(t, full, `~/printing-press/manuscripts/`)
+		})
+	}
+}
+
+func TestPrintingPressImportScriptsHonorPrintingPressHomeEnv(t *testing.T) {
+	pressHome := t.TempDir()
+	home := t.TempDir()
+	apiSlug := "fixture-api"
+
+	staging := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "README.md"), []byte("# fixture\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(staging, ".manuscripts", "run-1"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, ".manuscripts", "run-1", "research.json"), []byte("{}\n"), 0o644))
+
+	placeScript := filepath.Join("..", "..", "skills", "printing-press-import", "references", "import-place.sh")
+	runContractScript(t, placeScript, []string{
+		"PRINTING_PRESS_HOME=" + pressHome,
+		"HOME=" + home,
+	}, staging, apiSlug)
+
+	assert.FileExists(t, filepath.Join(pressHome, "library", apiSlug, "README.md"))
+	assert.FileExists(t, filepath.Join(pressHome, "manuscripts", apiSlug, "run-1", "research.json"))
+	assert.NoDirExists(t, filepath.Join(home, "printing-press"))
+
+	defaultHome := t.TempDir()
+	defaultStaging := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(defaultStaging, "README.md"), []byte("# default\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(defaultStaging, ".manuscripts", "run-1"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(defaultStaging, ".manuscripts", "run-1", "research.json"), []byte("{}\n"), 0o644))
+	runContractScript(t, placeScript, []string{
+		"PRINTING_PRESS_HOME=",
+		"HOME=" + defaultHome,
+	}, defaultStaging, apiSlug)
+
+	assert.FileExists(t, filepath.Join(defaultHome, "printing-press", "library", apiSlug, "README.md"))
+	assert.FileExists(t, filepath.Join(defaultHome, "printing-press", "manuscripts", apiSlug, "run-1", "research.json"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(pressHome, "library", apiSlug, "state.json"), []byte("{}\n"), 0o644))
+	fakeBin := t.TempDir()
+	fakeZip := filepath.Join(fakeBin, "zip")
+	require.NoError(t, os.WriteFile(fakeZip, []byte("#!/usr/bin/env bash\nset -euo pipefail\ntouch \"$2\"\n"), 0o755))
+
+	backupScript := filepath.Join("..", "..", "skills", "printing-press-import", "references", "import-backup.sh")
+	out := runContractScript(t, backupScript, []string{
+		"PRINTING_PRESS_HOME=" + pressHome,
+		"HOME=" + home,
+		"PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}, apiSlug)
+
+	assert.Contains(t, out, "/tmp/printing-press/"+apiSlug+"-")
+	assert.NoDirExists(t, filepath.Join(home, "printing-press"))
+}
+
+func TestPrintingPressSetupChecksSkipSnippetIsSelfContained(t *testing.T) {
+	setupChecks := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "references", "setup-checks.md"))
+	skipSnippet := substringBetween(t, setupChecks, "If the user picks **Skip**", "Prompt again only when")
+
+	assert.Contains(t, skipSnippet, `PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"`)
+	assert.Contains(t, skipSnippet, `> "$PRESS_HOME/.version-check"`)
+	assert.NotContains(t, skipSnippet, `> "$HOME/printing-press/.version-check"`)
 }
 
 func TestPrintingPressSkillUsesRunRootStateFile(t *testing.T) {
@@ -364,4 +441,14 @@ func runGoContractCommand(t *testing.T, dir string, args ...string) {
 	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(dir, ".cache", "go-build"))
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
+}
+
+func runContractScript(t *testing.T, path string, env []string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(path, args...)
+	cmd.Env = append(os.Environ(), env...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return string(output)
 }

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -103,6 +103,7 @@ func TestSkillFilesHonorPrintingPressHomeEnv(t *testing.T) {
 			assert.NotContains(t, full, `PRESS_HOME="$HOME/printing-press"`)
 			assert.NotContains(t, full, `$HOME/printing-press/`)
 			assert.NotContains(t, full, `"$HOME/printing-press"`)
+			assert.NotContains(t, full, `~/printing-press/library/`)
 			assert.NotContains(t, full, `~/printing-press/manuscripts/`)
 		})
 	}
@@ -155,6 +156,20 @@ func TestPrintingPressImportScriptsHonorPrintingPressHomeEnv(t *testing.T) {
 
 	assert.Contains(t, out, "/tmp/printing-press/"+apiSlug+"-")
 	assert.NoDirExists(t, filepath.Join(home, "printing-press"))
+
+	defaultBackupHome := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(defaultBackupHome, "printing-press", "library", apiSlug), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(defaultBackupHome, "printing-press", "library", apiSlug, "state.json"), []byte("{}\n"), 0o644))
+	defaultFakeBin := t.TempDir()
+	defaultFakeZip := filepath.Join(defaultFakeBin, "zip")
+	require.NoError(t, os.WriteFile(defaultFakeZip, []byte("#!/usr/bin/env bash\nset -euo pipefail\ntouch \"$2\"\n"), 0o755))
+	defaultOut := runContractScript(t, backupScript, []string{
+		"PRINTING_PRESS_HOME=",
+		"HOME=" + defaultBackupHome,
+		"PATH=" + defaultFakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}, apiSlug)
+
+	assert.Contains(t, defaultOut, "/tmp/printing-press/"+apiSlug+"-")
 }
 
 func TestPrintingPressSetupChecksSkipSnippetIsSelfContained(t *testing.T) {

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -36,7 +36,7 @@ Turn a dogfood session into a PR for a printed CLI in the public library.
 /printing-press-amend                 # auto-detect target CLI from session
 /printing-press-amend superhuman      # explicit short name
 /printing-press-amend superhuman-pp-cli
-/printing-press-amend ~/printing-press/library/superhuman
+/printing-press-amend "$PRESS_LIBRARY/superhuman"
 ```
 
 This skill lives in this repo (the machine) and acts on a printed CLI in the public library. It is sibling to `/printing-press-publish` (adds a new CLI), `/printing-press-polish` (improves a CLI pre-publish), and `/printing-press-retro` (reflects on the machine itself). None of those cover post-publish CLI amendments driven by real-session friction.

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -91,7 +91,7 @@ if [ -z "$PRESS_BASE" ]; then
 fi
 
 PRESS_SCOPE="$PRESS_BASE-$(printf '%s' "$_scope_dir" | shasum -a 256 | cut -c1-8)"
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"

--- a/skills/printing-press-amend/references/transcript-parsing.md
+++ b/skills/printing-press-amend/references/transcript-parsing.md
@@ -70,9 +70,9 @@ When the user explicitly passed a target as the skill argument, skip auto-detect
 ### Path resolution for the chosen target
 
 Accept any of:
-- short name: `superhuman` → `~/printing-press/library/superhuman/`
+- short name: `superhuman` → `$PRESS_LIBRARY/superhuman/`
 - full name: `superhuman-pp-cli` → strip `-pp-cli`, resolve as short name
-- absolute path: `~/printing-press/library/superhuman` → use as-is
+- absolute path: `$PRESS_LIBRARY/superhuman` → use as-is
 
 If the resolved path doesn't exist locally, search `~/printing-press-library/library/*/` for a directory whose name matches the slug, and fall back to that as the target. The skill operates on the managed clone (per the Pre-Implementation Decisions in the plan), so the local-library path is informational; the actual edits land in the managed clone created in U7.
 
@@ -89,7 +89,7 @@ Phase 1 emits a structured finding list to the next phase:
 
 ```yaml
 target_cli: superhuman-pp-cli
-target_dir: ~/printing-press/library/superhuman   # may be informational; managed-clone path resolved later
+target_dir: $PRESS_LIBRARY/superhuman   # may be informational; managed-clone path resolved later
 target_category: productivity                      # resolved from the public library, used by U7
 findings:
   - id: F1

--- a/skills/printing-press-catalog/SKILL.md
+++ b/skills/printing-press-catalog/SKILL.md
@@ -81,7 +81,7 @@ if [ -z "$PRESS_BASE" ]; then
 fi
 
 PRESS_SCOPE="$PRESS_BASE-$(printf '%s' "$_scope_dir" | shasum -a 256 | cut -c1-8)"
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools:
 
 Bring a published CLI from the public library
 ([`mvanhorn/printing-press-library`](https://github.com/mvanhorn/printing-press-library))
-into the internal library at `~/printing-press/library/` so it matches
+into the internal library at `$PRESS_LIBRARY/` so it matches
 the form the generator would produce. Manuscripts ride along.
 
 ```bash

--- a/skills/printing-press-import/SKILL.md
+++ b/skills/printing-press-import/SKILL.md
@@ -45,7 +45,7 @@ library" or "from the repo", suggest running this skill first.
 ## Setup
 
 ```bash
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]:-$0}")/references"

--- a/skills/printing-press-import/references/import-backup.sh
+++ b/skills/printing-press-import/references/import-backup.sh
@@ -6,8 +6,8 @@
 #   import-backup.sh <api-slug>
 #
 # Backs up:
-#   $HOME/printing-press/library/<api-slug>/
-#   $HOME/printing-press/manuscripts/<api-slug>/  (if present)
+#   ${PRINTING_PRESS_HOME:-$HOME/printing-press}/library/<api-slug>/
+#   ${PRINTING_PRESS_HOME:-$HOME/printing-press}/manuscripts/<api-slug>/  (if present)
 #
 # Output: prints the absolute path of the resulting zip on stdout.
 
@@ -20,8 +20,9 @@ BACKUP_DIR="/tmp/printing-press"
 TS=$(date -u +%Y%m%dT%H%M%SZ)
 ZIP_PATH="$BACKUP_DIR/${API_SLUG}-${TS}.zip"
 
-LIBRARY_DIR="$HOME/printing-press/library/$API_SLUG"
-MANUSCRIPTS_DIR="$HOME/printing-press/manuscripts/$API_SLUG"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
+LIBRARY_DIR="$PRESS_HOME/library/$API_SLUG"
+MANUSCRIPTS_DIR="$PRESS_HOME/manuscripts/$API_SLUG"
 
 if [[ ! -d "$LIBRARY_DIR" && ! -d "$MANUSCRIPTS_DIR" ]]; then
   echo "nothing to backup for $API_SLUG" >&2

--- a/skills/printing-press-import/references/import-place.sh
+++ b/skills/printing-press-import/references/import-place.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # import-place.sh — atomically move a staged CLI + its manuscripts into
-# the internal library at $HOME/printing-press/.
+# the internal library at ${PRINTING_PRESS_HOME:-$HOME/printing-press}/.
 #
 # Layout:
 #   <staging>/                      (CLI files at root)
 #   <staging>/.manuscripts/<run>/   (one or more run-id dirs)
 #
 # Lands as:
-#   $HOME/printing-press/library/<api-slug>/             (CLI files)
-#   $HOME/printing-press/manuscripts/<api-slug>/<run>/   (each run dir)
+#   ${PRINTING_PRESS_HOME:-$HOME/printing-press}/library/<api-slug>/             (CLI files)
+#   ${PRINTING_PRESS_HOME:-$HOME/printing-press}/manuscripts/<api-slug>/<run>/   (each run dir)
 #
 # Any pre-existing target dirs are removed first; back them up with
 # import-backup.sh before invoking this.
@@ -25,8 +25,9 @@ API_SLUG="$2"
 
 [[ -d "$STAGING" ]] || { echo "staging dir not found: $STAGING" >&2; exit 1; }
 
-LIB_TARGET="$HOME/printing-press/library/$API_SLUG"
-MAN_TARGET_ROOT="$HOME/printing-press/manuscripts/$API_SLUG"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
+LIB_TARGET="$PRESS_HOME/library/$API_SLUG"
+MAN_TARGET_ROOT="$PRESS_HOME/manuscripts/$API_SLUG"
 
 # Move manuscripts out of the staging dir before placing the CLI. This
 # keeps the CLI subtree clean (no .manuscripts/ inside the library dir).

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -5,7 +5,7 @@ description: >
   diagnostics (dogfood, verify, scorecard, go vet), automatically fixes all
   issues (verify failures, dead code, descriptions, README, MCP tool quality),
   reports the before/after delta, and offers to publish. Use after any
-  /printing-press run, or on any CLI in ~/printing-press/library/. Trigger
+  /printing-press run, or on any CLI in $PRESS_LIBRARY/. Trigger
   phrases: "polish", "improve the CLI", "fix verify", "make it publish-ready",
   "clean up the CLI", "get this ready to ship".
 context: fork
@@ -29,7 +29,7 @@ The retro improves the Printing Press. Polish improves the generated CLI. This s
 ```bash
 /printing-press-polish redfin
 /printing-press-polish redfin-pp-cli
-/printing-press-polish ~/printing-press/library/redfin
+/printing-press-polish "$PRESS_LIBRARY/redfin"
 ```
 
 ## When to run
@@ -40,7 +40,7 @@ After any `/printing-press` generation, especially when:
 - The scorecard is below 85
 - You want the CLI publish-ready in one pass
 
-Can also be run standalone on any CLI in `~/printing-press/library/`.
+Can also be run standalone on any CLI in `$PRESS_LIBRARY/`.
 
 ## Setup
 
@@ -82,7 +82,7 @@ The argument string can contain a `--standalone` flag plus one positional value 
 The positional value can be:
 - A short name: `redfin` (looks up `$PRESS_LIBRARY/redfin`)
 - A full name: `redfin-pp-cli` (strips suffix, looks up `$PRESS_LIBRARY/redfin`)
-- A path: `~/printing-press/library/redfin` (used directly)
+- A path: `$PRESS_LIBRARY/redfin` (used directly)
 
 Resolution order for the positional value:
 1. If it is an absolute or `~`-prefixed path and exists, use it
@@ -94,7 +94,7 @@ Resolution order for the positional value:
 
 - **Standalone (user-invoked, `/printing-press-polish redfin`).** Invoked via the slash command. Treat as `STANDALONE_MODE=true` unconditionally — the slash-command form is the publish-intent surface, even when the user omits the flag. The arg is a slug or binary name; resolution lands on `$PRESS_LIBRARY/<slug>/`. This is the published copy and the right target.
 - **Mid-pipeline (main printing-press skill Phase 5.5, hold-path "Polish to retry").** Invoked via the Skill tool with `args: "$CLI_WORK_DIR"`. The arg is an absolute path to `~/printing-press/.runstate/.../runs/.../working/<api>-pp-cli/`; resolution must hit rule 1. `STANDALONE_MODE=false` by default — main SKILL owns the publish flow on this path, so polish defers. **Do not paraphrase the arg to the slug** — Phase 5.5 fires before the working CLI is promoted, so `$PRESS_LIBRARY/<slug>/` either doesn't exist or holds the *prior* run's stale CLI.
-- **Skill-tool standalone override.** A non-slash caller that genuinely wants polish to publish must opt in explicitly by including `--standalone` in `args` (e.g., `args: "--standalone ~/printing-press/library/redfin"`). Without that token, polish never publishes from a Skill-tool invocation — even if the resolved path happens to live under `$PRESS_LIBRARY/`. The flag is the contract; the path is not.
+- **Skill-tool standalone override.** A non-slash caller that genuinely wants polish to publish must opt in explicitly by including `--standalone` in `args` (e.g., `args: "--standalone $PRESS_LIBRARY/redfin"`). Without that token, polish never publishes from a Skill-tool invocation — even if the resolved path happens to live under `$PRESS_LIBRARY/`. The flag is the contract; the path is not.
 
 This caller-mode-driven gate replaces the older path-substring heuristic (`*.runstate/*`). The heuristic broke when the main SKILL's Phase 5.5/5.6 ordering inverted, or when polish was invoked from a non-`.runstate` scratch layout: polish would see a `$PRESS_LIBRARY/<slug>/` path, conclude "standalone," and fire its Publish Offer (fork, global git config, public PR) inside a mid-pipeline run. The flag is unambiguous and the safer default is no-publish.
 
@@ -718,7 +718,7 @@ Present via `AskUserQuestion`. Two example shapes:
 > Recommendation: Publish.
 >
 > 1. **Publish now** (recommended) — validate, package, and open a PR
-> 2. **Done for now** — CLI is at ~/printing-press/library/<cli-name>"
+> 2. **Done for now** — CLI is at $PRESS_LIBRARY/<cli-name>"
 
 **Polish thinks another pass would help** (`remaining_issues` non-empty, `further_polish_recommended: yes`):
 
@@ -730,7 +730,7 @@ Present via `AskUserQuestion`. Two example shapes:
 >
 > 1. **Polish again** (recommended) — close the remaining <N> issues
 > 2. **Publish now** — ship as-is
-> 3. **Done for now** — CLI is at ~/printing-press/library/<cli-name>"
+> 3. **Done for now** — CLI is at $PRESS_LIBRARY/<cli-name>"
 
 The recommended option leads, carries the `(recommended)` label, and the leading `Recommendation:` line states the agent's call explicitly. Three reinforcing channels so the user does not have to infer from ordering.
 

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -47,7 +47,7 @@ Can also be run standalone on any CLI in `~/printing-press/library/`.
 ```bash
 # min-binary-version: 4.0.0
 
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 
 if ! command -v cli-printing-press >/dev/null 2>&1; then
@@ -419,7 +419,7 @@ sections, expect the next dogfood resync or regeneration to clobber the change.
 To find the manuscript source:
 
 ```bash
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 API_SLUG="${CLI_NAME%-pp-cli}"
 RESEARCH_JSON=""
 for f in "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json \

--- a/skills/printing-press-polish/references/tools-polish.md
+++ b/skills/printing-press-polish/references/tools-polish.md
@@ -371,4 +371,4 @@ After applying fixes, before declaring the polish complete:
 
 The ledger file persists until it ages out (24h). Once the polish PR merges and the CLI is rebuilt, the file is no longer load-bearing — the next `tools-audit` run can start fresh.
 
-If you're polishing a CLI inside a clone of the public library repo (not the internal `~/printing-press/library/`), add `.printing-press-tools-polish.json` to that repo's root `.gitignore` before committing — the ledger is local working state, not part of the published CLI.
+If you're polishing a CLI inside a clone of the public library repo (not the internal `$PRESS_LIBRARY/`), add `.printing-press-tools-polish.json` to that repo's root `.gitignore` before committing — the ledger is local working state, not part of the published CLI.

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -80,7 +80,7 @@ if [ -z "$PRESS_BASE" ]; then
 fi
 
 PRESS_SCOPE="$PRESS_BASE-$(printf '%s' "$_scope_dir" | shasum -a 256 | cut -c1-8)"
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"

--- a/skills/printing-press-reprint/SKILL.md
+++ b/skills/printing-press-reprint/SKILL.md
@@ -48,7 +48,7 @@ redo research or rebuild the manuscript.
 ## Setup
 
 ```bash
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 ```

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -88,7 +88,7 @@ different PRs.
 _scope_dir="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
 _scope_dir="$(cd "$_scope_dir" && pwd -P)"
 
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
 PRESS_LIBRARY="$PRESS_HOME/library"
 RETRO_SCRATCH_DIR="/tmp/printing-press/retro"
@@ -373,7 +373,7 @@ For each candidate, ask in order:
    Don't re-raise at the same priority. Either drop it (the cost-benefit math has
    been "no" twice and the retro is becoming a wishlist), or reframe as a smaller
    incremental fix that addresses part of the friction. Search:
-   `grep -l "<finding keywords>" ~/printing-press/manuscripts/*/proofs/*-retro-*.md`
+   `grep -l "<finding keywords>" "$PRESS_MANUSCRIPTS"/*/proofs/*-retro-*.md`
 
 Survivors of these five questions go to Phase 3. Dropped candidates are recorded
 as one-line entries in the retro's "Dropped at triage" section — they exist for
@@ -455,7 +455,7 @@ correctness; it stays P2 only because it's gated on profiler-detected absence of
 paginator. Without that guard the same finding is unsafe to land.
 
 **Step D: Recurrence-cost check.** Search prior retros under
-`~/printing-press/manuscripts/*/proofs/*-retro-*.md` for the same finding. If the same
+`$PRESS_MANUSCRIPTS/*/proofs/*-retro-*.md` for the same finding. If the same
 finding has been raised in 2+ prior retros without being implemented, the prior cost-
 benefit math has been "no" twice. Don't re-raise it at the same priority — either move
 to P3 with a "raised N times, still not justified" annotation, or reframe the finding

--- a/skills/printing-press-retro/SKILL.md
+++ b/skills/printing-press-retro/SKILL.md
@@ -356,7 +356,7 @@ For each candidate, ask in order:
 
 1. **Was this iteration noise?** Normal trial-and-error during generation —
    one-off retry, typo recovery, agent forgetting a flag, transient network blip. Drop.
-2. **Is this a printed-CLI fix?** The fix lives in `~/printing-press/library/<api>/`
+2. **Is this a printed-CLI fix?** The fix lives in `$PRESS_LIBRARY/<api>/`
    and helps only this one CLI. If the proposed change is "edit this command in
    this CLI" or "regenerate after fixing the spec," it's not a retro finding — it's
    a polish pass on that CLI. Drop.
@@ -439,7 +439,7 @@ RPC-style) and input methods (OpenAPI, crowd-sniffed, HAR-sniffed, no spec).
 
 **Step B: Name three concrete APIs from the catalog with direct evidence.** Not "every
 API with multi-word resources" or "any browser-sniffed CLI." Name three specific APIs
-already in `~/printing-press/library/` (or the embedded `catalog/` directory) where you
+already in `$PRESS_LIBRARY/` (or the embedded `catalog/` directory) where you
 can point to evidence the pattern exists: a path in their spec, a known endpoint shape,
 a header the vendor documents, an output you can reproduce. "Stripe, Notion, GitHub
 probably have this" is hand-waving; "Stripe (Stripe-Version header in spec line N),

--- a/skills/printing-press-score/SKILL.md
+++ b/skills/printing-press-score/SKILL.md
@@ -77,7 +77,7 @@ if [ -z "$PRESS_BASE" ]; then
 fi
 
 PRESS_SCOPE="$PRESS_BASE-$(printf '%s' "$_scope_dir" | shasum -a 256 | cut -c1-8)"
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -403,7 +403,7 @@ If the user typed `/printing-press` with no arguments (no API name, no `--spec`,
 
 > The Printing Press generates a fully functional CLI for any API. You give it an API name, a spec file, or a URL. It researches the landscape, catalogs every feature that exists in any competing tool, invents novel features of its own, then generates a Go CLI that matches and beats everything out there — with offline search, agent-native output, and a local SQLite data layer.
 >
-> By the end, you'll have a working CLI in `~/printing-press/library/` that you can use for yourself, ship on your own, or apply to add to the printing-press library.
+> By the end, you'll have a working CLI in `$PRESS_LIBRARY/` that you can use for yourself, ship on your own, or apply to add to the printing-press library.
 >
 > The process takes 30-60 minutes depending on API complexity. Simple APIs with official specs (Stripe, GitHub) are faster. Undocumented APIs that need discovery (ESPN, Domino's) take longer.
 
@@ -456,7 +456,7 @@ Print as prose, matching the style of the example below:
 > 3. I shall present what I found and what I invented — you will have a chance to add your own ideas or adjust the plan before I build
 > 4. I shall generate a Go CLI, build every feature from the plan, then verify quality through dogfood, runtime verification, and scoring
 >
-> **What you will have at the end:** A fully functional CLI at `~/printing-press/library/<api>` that you can use yourself, ship on your own, or apply to add to the printing-press library.
+> **What you will have at the end:** A fully functional CLI at `$PRESS_LIBRARY/<api>` that you can use yourself, ship on your own, or apply to add to the printing-press library.
 >
 > **Time:** 30-60 minutes depending on API complexity.
 >
@@ -595,7 +595,7 @@ Short-lived command captures may use `/tmp/printing-press/` with unique `mktemp`
 paths and must be deleted after use.
 
 Examples of the current naming/layout:
-- `~/printing-press/library/notion/` — published CLI directory (keyed by API slug)
+- `$PRESS_LIBRARY/notion/` — published CLI directory (keyed by API slug)
 - `notion-pp-cli` — the binary name inside the directory
 - `/printing-press emboss notion` — emboss accepts both slug and CLI name
 - `discord-pp-cli/internal/store/store.go` — internal source paths still use CLI name

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -237,7 +237,7 @@ if [ -z "$PRESS_BASE" ]; then
 fi
 
 PRESS_SCOPE="$PRESS_BASE-$(printf '%s' "$_scope_dir" | shasum -a 256 | cut -c1-8)"
-PRESS_HOME="$HOME/printing-press"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -54,8 +54,9 @@ If the pull fails, surface the failure to the user and continue with the current
 If the user picks **Skip**, record the skipped target SHA so the same update is not prompted again:
 
 ```bash
-mkdir -p "$HOME/printing-press"
-printf "last_check=%s\nmode=repo\nskipped_repo_main=%s\n" "$(date +%s)" "$PRESS_REPO_MAIN" > "$HOME/printing-press/.version-check"
+PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
+mkdir -p "$PRESS_HOME"
+printf "last_check=%s\nmode=repo\nskipped_repo_main=%s\n" "$(date +%s)" "$PRESS_REPO_MAIN" > "$PRESS_HOME/.version-check"
 ```
 
 Prompt again only when `origin/main` advances to a different SHA.


### PR DESCRIPTION
## Intent

Skill setup and helper paths now honor `PRINTING_PRESS_HOME`, matching the Go binary's existing `PressHome()` behavior. Users can relocate the Printing Press home tree without keeping a symlink at `~/printing-press`.

Issue: Closes #1612

## Approach

The skill setup contracts now derive `PRESS_HOME` from `PRINTING_PRESS_HOME` with the existing default path as fallback. Related helper scripts and setup-check snippets use the same `PRESS_HOME` convention, and retro recurrence searches now read from `$PRESS_MANUSCRIPTS` instead of a fixed manuscripts path.

The contract tests now guard the canonical setup block, scan skill/reference files for the old hardcoded home paths, and execute the import place/backup helpers with both override and default-home behavior.

## Scope

Primary area: Printing Press skills and their setup/reference contracts.

Why this belongs in this repo: these skills are part of the Printing Press system surface, and the bug was a mismatch between the repo's Go path helper and the skill shell layer.

## Risk

Low. The fallback keeps current behavior for users without `PRINTING_PRESS_HOME`; the changed paths only affect where skill-side files are read or written.

## Output Contract

N/A

## Verification

- `go test ./internal/pipeline -run 'TestSkill|TestPrintingPressImportScripts|TestPrintingPressSetupChecks'`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
