### PR TITLE
fix(cli): include manuscript narratives in PII polish scan

### DIFF
--- a/docs/solutions/logic-errors/polish-pii-manuscript-ledger-reconciliation-2026-05-24.md
+++ b/docs/solutions/logic-errors/polish-pii-manuscript-ledger-reconciliation-2026-05-24.md
@@ -1,0 +1,62 @@
+---
+title: Polish PII audits must reconcile the same manuscript paths publish scans
+date: 2026-05-24
+category: logic-errors
+module: polish PII audit
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Printing Press polish reports no pending PII findings"
+  - "publish package later fails on .manuscripts/<run-id>/research.json or research/*.md"
+  - "accepted manuscript findings disappear from the ledger during mid-pipeline promote"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+tags: [pii-audit, polish, manuscripts, publish, ledger, runstate]
+---
+
+# Polish PII audits must reconcile the same manuscript paths publish scans
+
+## Problem
+
+Printing Press polish audited the generated CLI tree and wrote `.printing-press-pii-polish.json`, but `publish package` later copied manuscript artifacts into `.manuscripts/<run-id>/` before enforcing the PII gate. PII in `research.json` or top-level `research/*.md` could therefore pass polish and fail only at publish time.
+
+## Symptoms
+
+- `cli-printing-press pii-audit <cli-dir>` reports `no pending findings`.
+- `publish package` fails after staging `.manuscripts/<run-id>/research.json` or `.manuscripts/<run-id>/research/*.md`.
+- A mid-pipeline promote can drop accepted `.manuscripts/<run-id>/...` ledger entries because the promote-time audit runs before staging those files into the working tree.
+
+## What Didn't Work
+
+- Scanning every file under a manuscripts run would overreach. Manuscripts contain proof logs, specs, and other artifacts that publish should not newly classify as polish-blocking narrative PII.
+- Changing only the polish skill catches standalone polish, but mid-pipeline promote still rewrites the ledger before the run archive exists under the published path.
+- Weakening the publish PII gate hides the real mismatch between polish and publish surfaces.
+
+## Solution
+
+Make the optional manuscript scan explicit and path-stable:
+
+- Add `PIIAuditOptions.ManuscriptsDir`.
+- Have `FindPIIWithOptions` scan only `<run>/research.json` and `<run>/research/*.md`.
+- Report those findings as `.manuscripts/<run-id>/...` so accepted ledger entries match the publish-staged tree.
+- Pass `--manuscripts-dir <run-dir>` from the polish skill whenever it resolves a run directory.
+- During `PromoteWorkingCLI`, run the PII gate with the active `PipelineState` run root and stage root `research.json` into `.manuscripts/<run-id>/research.json` before publishing.
+
+The important invariant is that the audit path used for reconciliation must equal the path publish will later scan. For manuscript narratives, that path is the staged `.manuscripts/<run-id>/...` path, not the absolute runstate or archive path.
+
+## Why This Works
+
+`RunPIIAudit` reconciles by finding identity. If an accepted finding exists in the ledger but the current scan omits that file, reconciliation treats it as resolved and rewrites the ledger without the acceptance. Scanning the external run directory with publish-staged relative paths prevents that false resolution before promote, while staging root `research.json` gives the published copy the same file layout publish package already validates.
+
+## Prevention
+
+- When adding audit coverage for files outside the CLI tree, define the publish-visible relative path first and write ledger findings using that path from the start.
+- Keep scan scope narrow when an archive contains mixed artifact types. For this PII path, scan `research.json` and top-level narrative markdown, not proofs or specs.
+- Regression tests should cover both standalone audit output and the promote path that rewrites the ledger.
+- If a skill resolves archived run data, its lookup priority should match the Go publish path: manifest run id first when present, then API slug latest run, then CLI name latest run.
+
+## Related Issues
+
+- GitHub issue #1622
+- `docs/solutions/best-practices/checkout-scoped-printing-press-output-layout-2026-03-28.md`

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -90,6 +90,11 @@ type PIIFinding struct {
 	EvidenceContext string `json:"evidence_context,omitempty"`
 }
 
+// PIIAuditOptions controls optional scan inputs outside the printed CLI tree.
+type PIIAuditOptions struct {
+	ManuscriptsDir string
+}
+
 type piiDetector struct {
 	kind    string
 	pattern *regexp.Regexp
@@ -543,6 +548,33 @@ func FindPII(root string) ([]PIIFinding, error) {
 	if err != nil {
 		return nil, err
 	}
+	sortPIIFindings(findings)
+	return findings, nil
+}
+
+// FindPIIWithOptions walks root plus any explicitly supplied external
+// manuscript run inputs. External manuscript findings are reported using the
+// same .manuscripts/<run-id>/... paths that publish package later stages.
+func FindPIIWithOptions(root string, opts PIIAuditOptions) ([]PIIFinding, error) {
+	findings, err := FindPII(root)
+	if err != nil {
+		return nil, err
+	}
+	if opts.ManuscriptsDir == "" {
+		return findings, nil
+	}
+
+	manuscriptFindings, err := findPIIInManuscriptsRun(opts.ManuscriptsDir)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, manuscriptFindings...)
+	findings = dedupePIIFindings(findings)
+	sortPIIFindings(findings)
+	return findings, nil
+}
+
+func sortPIIFindings(findings []PIIFinding) {
 	sort.Slice(findings, func(i, j int) bool {
 		if findings[i].File != findings[j].File {
 			return findings[i].File < findings[j].File
@@ -555,6 +587,59 @@ func FindPII(root string) ([]PIIFinding, error) {
 		}
 		return findings[i].Kind < findings[j].Kind
 	})
+}
+
+func dedupePIIFindings(findings []PIIFinding) []PIIFinding {
+	seen := make(map[string]bool, len(findings))
+	out := findings[:0]
+	for _, finding := range findings {
+		key := piiFindingKey(finding)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, finding)
+	}
+	return out
+}
+
+func findPIIInManuscriptsRun(runDir string) ([]PIIFinding, error) {
+	info, err := os.Stat(runDir)
+	if err != nil {
+		return nil, fmt.Errorf("manuscripts-dir %q: %w", runDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("manuscripts-dir %q is not a directory", runDir)
+	}
+
+	runID := filepath.Base(filepath.Clean(runDir))
+	candidates := []string{filepath.Join(runDir, "research.json")}
+	researchMarkdown, err := filepath.Glob(filepath.Join(runDir, "research", "*.md"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(researchMarkdown)
+	candidates = append(candidates, researchMarkdown...)
+
+	var findings []PIIFinding
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		rel, err := filepath.Rel(runDir, path)
+		if err != nil {
+			return nil, err
+		}
+		stagedRel := filepath.ToSlash(filepath.Join(manuscriptsDir, runID, rel))
+		fileFindings, err := scanPIIFileWithRel(path, stagedRel)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, fileFindings...)
+	}
 	return findings, nil
 }
 
@@ -594,6 +679,14 @@ func isHighRiskFile(relSlash string) bool {
 // Binary files (null-byte probe) are skipped. Returns findings keyed
 // to the file's path relative to root with forward-slash separators.
 func scanPIIFile(root, path string) ([]PIIFinding, error) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, err
+	}
+	return scanPIIFileWithRel(path, filepath.ToSlash(rel))
+}
+
+func scanPIIFileWithRel(path, relSlash string) ([]PIIFinding, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -608,12 +701,6 @@ func scanPIIFile(root, path string) ([]PIIFinding, error) {
 	if bytes.Contains(probe, []byte{0}) {
 		return nil, nil
 	}
-
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return nil, err
-	}
-	relSlash := filepath.ToSlash(rel)
 
 	// Vendor-published OpenAPI/Swagger source archived under .manuscripts/
 	// carries documentation `example:` values, not customer PII. Mirrors
@@ -1032,18 +1119,29 @@ type PIIAuditResult struct {
 // disk full), the audit result is still returned and a warning is
 // logged to stderr. The gate decision uses the in-memory result.
 func RunPIIAudit(dir string) (PIIAuditResult, error) {
-	return runPIIAudit(dir, true)
+	return RunPIIAuditWithOptions(dir, PIIAuditOptions{})
+}
+
+// RunPIIAuditWithOptions performs a full audit cycle with optional external
+// scan inputs and persists the reconciled ledger.
+func RunPIIAuditWithOptions(dir string, opts PIIAuditOptions) (PIIAuditResult, error) {
+	return runPIIAudit(dir, true, opts)
 }
 
 // ScanPII performs the audit without writing the ledger. The pii-audit
 // CLI's --json path uses this so a read-only probe doesn't have the
 // side effect of touching the filesystem.
 func ScanPII(dir string) (PIIAuditResult, error) {
-	return runPIIAudit(dir, false)
+	return ScanPIIWithOptions(dir, PIIAuditOptions{})
 }
 
-func runPIIAudit(dir string, persist bool) (PIIAuditResult, error) {
-	findings, err := FindPII(dir)
+// ScanPIIWithOptions performs the audit without writing the ledger.
+func ScanPIIWithOptions(dir string, opts PIIAuditOptions) (PIIAuditResult, error) {
+	return runPIIAudit(dir, false, opts)
+}
+
+func runPIIAudit(dir string, persist bool, opts PIIAuditOptions) (PIIAuditResult, error) {
+	findings, err := FindPIIWithOptions(dir, opts)
 	if err != nil {
 		return PIIAuditResult{}, fmt.Errorf("scanning %s for PII: %w", dir, err)
 	}

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -421,6 +421,25 @@ paths:
 		"Swagger 2.0 JSON in manuscripts must be exempt")
 }
 
+func TestFindPIIWithOptions_ManuscriptsVendorSpecExemptUsesStagedPath(t *testing.T) {
+	root := t.TempDir()
+	runDir := filepath.Join(t.TempDir(), "manuscripts", "acme", "run1")
+	openapiJSON := `{
+  "openapi": "3.0.3",
+  "info": {"title": "Calendars"},
+  "paths": {"/users": {"post": {"requestBody": {"content": {"application/json": {"example": {"email": "user1@testemail.com"}}}}}}}
+}`
+	write(t, filepath.Join(runDir, "research.json"), openapiJSON)
+	write(t, filepath.Join(runDir, "research", "brief.md"), "Contact support@example.com for access.\n")
+
+	findings, err := FindPIIWithOptions(root, PIIAuditOptions{ManuscriptsDir: runDir})
+	require.NoError(t, err)
+
+	files := uniqueFiles(findings)
+	assert.NotContains(t, files, ".manuscripts/run1/research.json")
+	assert.Contains(t, files, ".manuscripts/run1/research/brief.md")
+}
+
 // Negative regression: vendor-spec content detection only applies inside
 // .manuscripts/. A file at docs/api.yaml or testdata/openapi.json with
 // OpenAPI markers still scans — those are committed, hand-curated
@@ -678,6 +697,36 @@ func TestRunPIIAudit_RedactsCLIDirInLedger(t *testing.T) {
 	got := ReadPIILedger(dir)
 	require.NotNil(t, got)
 	assert.Equal(t, filepath.Join(CLIDirPlaceholder, filepath.Base(dir)), got.CLIDir)
+}
+
+func TestRunPIIAuditWithOptions_ManuscriptAcceptCarriesIntoStagedPackage(t *testing.T) {
+	cliDir := t.TempDir()
+	runID := "20260517-211252"
+	runDir := filepath.Join(t.TempDir(), "manuscripts", "tenderned", runID)
+	contactLine := `{"narrative":{"auth_narrative":"Contact functioneelbeheer@tenderned.nl"}}` + "\n"
+	write(t, filepath.Join(runDir, "research.json"), contactLine)
+
+	_, err := RunPIIAuditWithOptions(cliDir, PIIAuditOptions{ManuscriptsDir: runDir})
+	require.NoError(t, err)
+	mutatePIILedger(t, cliDir, func(ledger *PIILedger) {
+		require.Len(t, ledger.Findings, 1)
+		ledger.Findings[0].Status = PIIStatusAccepted
+		ledger.Findings[0].Category = PIICategoryAPIProviderData
+		ledger.Findings[0].EvidenceContext = "vendor contact email surfaced in generated auth narrative"
+	})
+
+	stagedDir := t.TempDir()
+	write(t, filepath.Join(stagedDir, ".manuscripts", runID, "research.json"), contactLine)
+	ledgerData, err := os.ReadFile(filepath.Join(cliDir, PIILedgerFilename))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stagedDir, PIILedgerFilename), ledgerData, 0644))
+
+	result, err := RunPIIAudit(stagedDir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+	assert.Equal(t, PIIStatusAccepted, result.Findings[0].Status)
+	assert.Equal(t, ".manuscripts/"+runID+"/research.json", result.Findings[0].File)
+	assert.Equal(t, 0, PIIPendingCount(result.Findings))
 }
 
 func TestReadPIILedger_CorruptDeletesFile(t *testing.T) {
@@ -1014,6 +1063,14 @@ func write(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+}
+
+func mutatePIILedger(t *testing.T, dir string, mutate func(*PIILedger)) {
+	t.Helper()
+	ledger := ReadPIILedger(dir)
+	require.NotNil(t, ledger)
+	mutate(ledger)
+	require.NoError(t, WritePIILedger(dir, ledger))
 }
 
 func scanLine(t *testing.T, line, filename string) []PIIFinding {

--- a/internal/cli/pii_audit.go
+++ b/internal/cli/pii_audit.go
@@ -24,6 +24,7 @@ import (
 func newPIIAuditCmd() *cobra.Command {
 	var asJSON bool
 	var strict bool
+	var manuscriptsDir string
 
 	cmd := &cobra.Command{
 		Use:   "pii-audit <cli-dir>",
@@ -38,7 +39,11 @@ findings and applies judgment per item — fix in source or accept with
 pre-decision fields.
 
 Exit 0 by default (diagnostic). With --strict, exits non-zero when
-pending findings or gate failures remain.`,
+pending findings or gate failures remain.
+
+When --manuscripts-dir points at a manuscripts run directory, pii-audit also
+scans that run's research.json and research/*.md using the publish-staged
+.manuscripts/<run-id>/... paths so accepts carry forward into publish package.`,
 		Example: `  cli-printing-press pii-audit ~/printing-press/library/dub
   cli-printing-press pii-audit ~/printing-press/library/dub --json
   cli-printing-press pii-audit ~/printing-press/library/dub --strict`,
@@ -60,12 +65,13 @@ pending findings or gate failures remain.`,
 				return fmt.Errorf("cli-dir %q is not a directory", cliDir)
 			}
 
+			opts := artifacts.PIIAuditOptions{ManuscriptsDir: manuscriptsDir}
 			var result artifacts.PIIAuditResult
 			if asJSON {
 				// --json is a read-only probe; do not write the ledger.
-				result, err = artifacts.ScanPII(cliDir)
+				result, err = artifacts.ScanPIIWithOptions(cliDir, opts)
 			} else {
-				result, err = artifacts.RunPIIAudit(cliDir)
+				result, err = artifacts.RunPIIAuditWithOptions(cliDir, opts)
 			}
 			if err != nil {
 				return err
@@ -94,6 +100,7 @@ pending findings or gate failures remain.`,
 
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit JSON instead of a human-readable table")
 	cmd.Flags().BoolVar(&strict, "strict", false, "exit non-zero when pending findings or gate failures remain")
+	cmd.Flags().StringVar(&manuscriptsDir, "manuscripts-dir", "", "optional manuscripts run directory; scans research.json and research/*.md using publish-staged paths")
 	return cmd
 }
 

--- a/internal/cli/pii_audit_test.go
+++ b/internal/cli/pii_audit_test.go
@@ -52,6 +52,34 @@ func TestPIIAuditCmd_JSON(t *testing.T) {
 	assert.Equal(t, artifacts.PIIKindEmail, findings[0].Kind)
 }
 
+func TestPIIAuditCmd_ManuscriptsRunDirUsesStagedPackagePaths(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(t.TempDir(), "manuscripts", "tenderned", "20260517-211252")
+	writeFile(t, filepath.Join(runDir, "research.json"), `{"narrative":{"auth_narrative":"Contact functioneelbeheer@tenderned.nl"}}`+"\n")
+	writeFile(t, filepath.Join(runDir, "research", "brief.md"), "Contact functioneelbeheer@tenderned.nl for API access.\n")
+	writeFile(t, filepath.Join(runDir, "research", "vendor-spec.yaml"), "email: functioneelbeheer@tenderned.nl\n")
+	writeFile(t, filepath.Join(runDir, "proofs", "shipcheck.md"), "Contact functioneelbeheer@tenderned.nl\n")
+
+	cmd := newPIIAuditCmd()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{dir, "--manuscripts-dir", runDir, "--json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var findings []artifacts.PIIFinding
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &findings))
+	files := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		files = append(files, finding.File)
+	}
+	assert.ElementsMatch(t, []string{
+		".manuscripts/20260517-211252/research.json",
+		".manuscripts/20260517-211252/research/brief.md",
+	}, files)
+}
+
 func TestPIIAuditCmd_StrictExitsNonZeroOnPending(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -231,7 +231,7 @@ func PromoteWorkingCLI(cliName, workingDir string, state *PipelineState) error {
 	if err := validatePhase5GateForPromote(workingDir, state); err != nil {
 		return err
 	}
-	if err := validatePIIGateForPromote(workingDir); err != nil {
+	if err := validatePIIGateForPromote(workingDir, state); err != nil {
 		return err
 	}
 
@@ -361,6 +361,21 @@ func stageRunstateManuscripts(stagingDir string, state *PipelineState) error {
 		state.DiscoveryDir(),
 	}
 	dstRoot := filepath.Join(stagingDir, ".manuscripts", state.RunID)
+	researchJSON := filepath.Join(state.RunRoot(), "research.json")
+	if info, err := os.Stat(researchJSON); err == nil && !info.IsDir() {
+		target := filepath.Join(dstRoot, "research.json")
+		if _, statErr := os.Stat(target); statErr == nil {
+			// The working copy already has the publish-visible artifact.
+		} else if os.IsNotExist(statErr) {
+			if err := copyFile(researchJSON, target, info.Mode()); err != nil {
+				return fmt.Errorf("copying runstate research.json: %w", err)
+			}
+		} else {
+			return fmt.Errorf("checking %s in staging: %w", target, statErr)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspecting runstate research.json: %w", err)
+	}
 	for _, src := range sources {
 		name := filepath.Base(src)
 		info, err := os.Stat(src)
@@ -421,8 +436,9 @@ func validatePhase5GateForPromote(workingDir string, state *PipelineState) error
 // polish run carry forward and new findings since polish surface as
 // pending. The error message points operators at the ledger file and
 // the pii-polish playbook.
-func validatePIIGateForPromote(workingDir string) error {
-	result, err := artifacts.RunPIIAudit(workingDir)
+func validatePIIGateForPromote(workingDir string, state *PipelineState) error {
+	opts := piiAuditOptionsForPromote(state)
+	result, err := artifacts.RunPIIAuditWithOptions(workingDir, opts)
 	if err != nil {
 		return fmt.Errorf("PII gate failed (scan error): %w", err)
 	}
@@ -448,8 +464,29 @@ func validatePIIGateForPromote(workingDir string) error {
 	}
 	msg += fmt.Sprintf("ledger: %s\n", ledgerPath)
 	msg += "scope: phase-1 detectors (order-id, ASIN, card-last-4, email, phone, ZIP+4, postal-address); standalone names are a future detector class.\n"
-	msg += "run `cli-printing-press pii-audit <dir>` and follow skills/printing-press-polish/references/pii-polish.md"
+	command := "cli-printing-press pii-audit <dir>"
+	if opts.ManuscriptsDir != "" {
+		command += " --manuscripts-dir " + shellQuote(opts.ManuscriptsDir)
+	}
+	msg += fmt.Sprintf("run `%s`", command)
+	msg += " and follow skills/printing-press-polish/references/pii-polish.md"
 	return fmt.Errorf("%s", msg)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func piiAuditOptionsForPromote(state *PipelineState) artifacts.PIIAuditOptions {
+	if state == nil || state.RunID == "" {
+		return artifacts.PIIAuditOptions{}
+	}
+	runRoot := state.RunRoot()
+	info, err := os.Stat(runRoot)
+	if err != nil || !info.IsDir() {
+		return artifacts.PIIAuditOptions{}
+	}
+	return artifacts.PIIAuditOptions{ManuscriptsDir: runRoot}
 }
 
 // IsStale returns true if the lock's heartbeat is too old or its owner

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -645,6 +645,7 @@ func TestPromoteWorkingCLI_StagesRunstateManuscripts(t *testing.T) {
 
 	// Plant research and discovery alongside the phase5 marker so we can
 	// assert the whole runstate triplet gets staged into the published copy.
+	require.NoError(t, os.WriteFile(filepath.Join(state.RunRoot(), "research.json"), []byte(`{"summary":"root research"}`+"\n"), 0o644))
 	require.NoError(t, os.MkdirAll(state.ResearchDir(), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(state.ResearchDir(), "notes.md"), []byte("research notes\n"), 0o644))
 	require.NoError(t, os.MkdirAll(state.DiscoveryDir(), 0o755))
@@ -661,7 +662,11 @@ func TestPromoteWorkingCLI_StagesRunstateManuscripts(t *testing.T) {
 	_, err = os.Stat(filepath.Join(manuRoot, "proofs", Phase5AcceptanceFilename))
 	assert.NoError(t, err, "phase5 acceptance marker should be staged into the published copy")
 
-	data, err := os.ReadFile(filepath.Join(manuRoot, "research", "notes.md"))
+	data, err := os.ReadFile(filepath.Join(manuRoot, "research.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "{\"summary\":\"root research\"}\n", string(data))
+
+	data, err = os.ReadFile(filepath.Join(manuRoot, "research", "notes.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "research notes\n", string(data))
 
@@ -836,6 +841,11 @@ func setLockOwnerAliveForTest(t *testing.T, alive bool) {
 	t.Cleanup(func() { lockOwnerAliveFunc = original })
 }
 
+func TestShellQuote(t *testing.T) {
+	assert.Equal(t, "'/tmp/my project/run1'", shellQuote("/tmp/my project/run1"))
+	assert.Equal(t, "'/tmp/alice'\\''s project/run1'", shellQuote("/tmp/alice's project/run1"))
+}
+
 // ---------------------------------------------------------------------------
 // PII gate (U3)
 // ---------------------------------------------------------------------------
@@ -921,6 +931,57 @@ func TestPromoteWorkingCLI_PIIGatePassesWithValidAccepts(t *testing.T) {
 	// Ledger should be carried into the published library
 	_, statErr = os.Stat(filepath.Join(libDir, artifacts.PIILedgerFilename))
 	assert.NoError(t, statErr, "ledger should travel with the staged copy")
+}
+
+func TestPromoteWorkingCLI_PIIGatePreservesAcceptedRunResearch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "test-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	_, err := AcquireLock("test-pp-cli", "test-scope", false)
+	require.NoError(t, err)
+
+	state := NewStateWithRun("test", workDir, "run-pii-manuscript", "test-scope")
+	writePhase5PassForState(t, state, "none")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(state.RunRoot(), "research.json"),
+		[]byte(`{"narrative":{"auth_narrative":"Contact functioneelbeheer@tenderned.nl for access."}}`+"\n"),
+		0o644,
+	))
+
+	preflight, err := artifacts.FindPIIWithOptions(workDir, artifacts.PIIAuditOptions{ManuscriptsDir: state.RunRoot()})
+	require.NoError(t, err)
+	require.Len(t, preflight, 1)
+	require.Equal(t, ".manuscripts/run-pii-manuscript/research.json", preflight[0].File)
+	preflight[0].Status = artifacts.PIIStatusAccepted
+	preflight[0].Category = artifacts.PIICategoryAPIProviderData
+	preflight[0].EvidenceContext = "research narrative names the API provider's public support email"
+	require.NoError(t, artifacts.WritePIILedger(workDir, &artifacts.PIILedger{
+		Timestamp:           time.Now().UTC(),
+		CLIDir:              workDir,
+		Findings:            preflight,
+		FindingsCountBefore: 1,
+	}))
+
+	err = PromoteWorkingCLI("test-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "test")
+	ledger := artifacts.ReadPIILedger(libDir)
+	require.NotNil(t, ledger)
+	require.Len(t, ledger.Findings, 1)
+	assert.Equal(t, ".manuscripts/run-pii-manuscript/research.json", ledger.Findings[0].File)
+	assert.Equal(t, artifacts.PIIStatusAccepted, ledger.Findings[0].Status)
+
+	result, err := artifacts.RunPIIAudit(libDir)
+	require.NoError(t, err)
+	assert.Zero(t, artifacts.PIIPendingCount(result.Findings))
 }
 
 func TestPromoteWorkingCLI_PIIGateHaltsOnGateFailure(t *testing.T) {

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -170,6 +170,15 @@ fi
 #  2. Post-promote (standalone polish): research.json lives at
 #     manuscripts/<api>/<run-id>/research.json.
 RESEARCH_DIR=""
+MANIFEST_RUN_ID=""
+if [ -f "$CLI_DIR/.printing-press.json" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    MANIFEST_RUN_ID="$(jq -r '.run_id // empty' "$CLI_DIR/.printing-press.json" 2>/dev/null || true)"
+  fi
+  if [ -z "$MANIFEST_RUN_ID" ]; then
+    MANIFEST_RUN_ID="$(sed -nE 's/.*"run_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$CLI_DIR/.printing-press.json" | head -1)"
+  fi
+fi
 case "$CLI_DIR" in
   *.runstate/*)
     _grandparent="$(dirname "$(dirname "$CLI_DIR")")"
@@ -178,12 +187,27 @@ case "$CLI_DIR" in
     fi
     ;;
   *)
-    for d in "$PRESS_HOME/manuscripts/$API_SLUG"/*/research.json "$PRESS_HOME/manuscripts/$CLI_NAME"/*/research.json; do
-      if [ -f "$d" ]; then
-        RESEARCH_DIR="$(dirname "$d")"
-        break
-      fi
-    done
+    if [ -n "$MANIFEST_RUN_ID" ]; then
+      for base in "$PRESS_HOME/manuscripts/$API_SLUG" "$PRESS_HOME/manuscripts/$CLI_NAME"; do
+        if [ -f "$base/$MANIFEST_RUN_ID/research.json" ]; then
+          RESEARCH_DIR="$base/$MANIFEST_RUN_ID"
+          break
+        fi
+      done
+    fi
+    # Match publish package's fallback: API slug first, then CLI name, each
+    # using the lexicographically latest run id when the manifest has none.
+    if [ -z "$RESEARCH_DIR" ]; then
+      for base in "$PRESS_HOME/manuscripts/$API_SLUG" "$PRESS_HOME/manuscripts/$CLI_NAME"; do
+        if [ -d "$base" ]; then
+          _latest="$(find "$base" -mindepth 2 -maxdepth 2 -name research.json -type f 2>/dev/null | sort | tail -1)"
+          if [ -n "$_latest" ]; then
+            RESEARCH_DIR="$(dirname "$_latest")"
+            break
+          fi
+        fi
+      done
+    fi
     ;;
 esac
 
@@ -192,6 +216,15 @@ esac
 RESEARCH_ARGS=()
 if [ -n "$RESEARCH_DIR" ]; then
   RESEARCH_ARGS=(--research-dir "$RESEARCH_DIR")
+fi
+
+# pii-audit runs against the CLI dir, but publish package later copies the
+# same run archive under .manuscripts/<run-id> before enforcing the PII gate.
+# Pass the run dir here so polish sees the narrative manuscript files with
+# the same relative paths publish will scan.
+PII_ARGS=()
+if [ -n "$RESEARCH_DIR" ]; then
+  PII_ARGS=(--manuscripts-dir "$RESEARCH_DIR")
 fi
 ```
 
@@ -268,7 +301,7 @@ fi
 cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
 cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
 cli-printing-press tools-audit "$CLI_DIR" --json > /tmp/polish-tools-audit-before.json 2>&1 || true
-cli-printing-press pii-audit "$CLI_DIR" --json > /tmp/polish-pii-audit-before.json 2>&1 || true
+cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}" --json > /tmp/polish-pii-audit-before.json 2>&1 || true
 go vet ./... 2>&1
 ```
 
@@ -515,7 +548,7 @@ Proceed to "After all fixes" only when the audit's summary line reads `no pendin
 
 Stop and:
 
-1. Run `cli-printing-press pii-audit "$CLI_DIR"` to surface pending findings (or read `/tmp/polish-pii-audit-before.json` from Phase 1's baseline).
+1. Run `cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}"` to surface pending findings (or read `/tmp/polish-pii-audit-before.json` from Phase 1's baseline). When `RESEARCH_DIR` exists, this includes that run's `research.json` and `research/*.md` with `.manuscripts/<run-id>/...` paths so accepts carry forward into `publish package`.
 2. You must read `references/pii-polish.md` and follow its per-finding decision tree — fix real values in source with non-matching placeholders, or accept with the `category` + `evidence_context` pre-decision fields.
 3. **Accepting PII findings carries a strict contract.** Missing fields, 6+ accepts sharing a rationale, or wholesale-accepting ≥10 findings without source fixes all fail the gate. See `references/pii-polish.md` "The accept contract" and "Forbidden accept patterns" for the full rules.
 
@@ -546,7 +579,7 @@ if [ "$STANDALONE_MODE" = "true" ]; then
 fi
 cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
 cli-printing-press tools-audit "$CLI_DIR" 2>&1
-cli-printing-press pii-audit "$CLI_DIR" 2>&1
+cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}" 2>&1
 go vet ./... 2>&1
 ```
 

--- a/skills/printing-press-polish/references/pii-polish.md
+++ b/skills/printing-press-polish/references/pii-polish.md
@@ -10,6 +10,8 @@ cli-printing-press pii-audit <cli-dir>
 
 The audit writes `<cli-dir>/.printing-press-pii-polish.json`. Promote and publish re-run the audit themselves, so the ledger header is the authority — they refuse if pending findings or gate failures remain.
 
+When polish resolved a manuscripts run directory, run the audit with `--manuscripts-dir <run-dir>`. That adds only `<run-dir>/research.json` and `<run-dir>/research/*.md` to the scan and reports them as `.manuscripts/<run-id>/...` paths, matching the publish-staged tree.
+
 ## The accept contract
 
 Every `status: "accepted"` entry must populate:
@@ -92,7 +94,7 @@ Don't manually mark findings as `fixed`. A real source fix makes the finding dis
 
 ## End-state checklist
 
-- [ ] `cli-printing-press pii-audit <cli-dir>` summary reads `no pending findings`, no `incomplete:` block.
+- [ ] `cli-printing-press pii-audit <cli-dir> ${PII_ARGS[@]}` summary reads `no pending findings`, no `incomplete:` block. Outside the polish shell, pass `--manuscripts-dir <run-dir>` when a manuscripts run was resolved.
 - [ ] Every accepted finding has `category` + `evidence_context`. `category: other` also has `note`.
 - [ ] No 6+ accepts share a normalized `note` + `category`.
 - [ ] Real PII fixes landed in source (`git diff`).


### PR DESCRIPTION
## Intent

Polish now sees the same manuscript narrative PII that publish package enforces after staging `.manuscripts/<run-id>/`. This closes the gap where polish could report clean while publish later failed on `research.json` or `research/*.md`.

Issue: Closes #1622

## Approach

The PII audit has an explicit `--manuscripts-dir` path that scans only the run-level narrative files and reports findings using publish-staged `.manuscripts/<run-id>/...` paths. That keeps accepted ledger entries stable across polish, promote, and publish without broadening the scan to every manuscript artifact.

Promote now runs its PII gate with the active run root and stages root `research.json` into the published `.manuscripts` tree before publication. The polish skill resolves the manifest run id first, then falls back to the same latest-run order publish uses.

I also documented the ledger reconciliation pattern in `docs/solutions/logic-errors/` so future audit coverage keeps path identity aligned with the publish-visible tree.

## Scope

Primary area: PII audit, polish workflow, and promote-time manuscript staging.

Why this belongs in this repo: this is Printing Press generator and workflow behavior. The bug affects future printed CLIs and the publish path generally, not a single printed CLI.

## Risk

Medium. The scan scope intentionally stays narrow: `research.json` and top-level `research/*.md` only when a run directory is passed. Promote uses the same optional scan input and preserves prior behavior when no `PipelineState` run id is available.

## Output Contract

The `pii-audit` CLI gains an optional `--manuscripts-dir` flag. Generated CLI output and golden fixtures are unchanged.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/pipeline -run 'TestPromoteWorkingCLI_StagesRunstateManuscripts|TestPromoteWorkingCLI_PIIGate' -count=1`
- `go test ./internal/artifacts ./internal/cli -run 'TestRunPIIAuditWithOptions_ManuscriptAcceptCarriesIntoStagedPackage|TestPIIAuditCmd' -count=1`
- `bash -n <(sed -n '/^```bash$/,/^```$/p' skills/printing-press-polish/SKILL.md | sed '/^```/d')`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
