### PR TITLE
feat(installer): add repo bootstrap script

### DIFF
--- a/.github/scripts/validate-printing-press-skill-list.mjs
+++ b/.github/scripts/validate-printing-press-skill-list.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const expected = readdirSync(join(root, "skills"), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .filter((entry) => {
+    try {
+      readFileSync(join(root, "skills", entry.name, "SKILL.md"), "utf8");
+      return true;
+    } catch {
+      return false;
+    }
+  })
+  .map((entry) => entry.name)
+  .sort();
+
+function assertList(name, actual) {
+  assert.deepEqual(
+    actual,
+    expected,
+    `${name} is out of sync with skills/*/SKILL.md. Update the named skill list when adding, renaming, or removing a Printing Press skill.`,
+  );
+}
+
+function updateBlock(text, marker) {
+  const start = `# ${marker}_START`;
+  const end = `# ${marker}_END`;
+  const startIndex = text.indexOf(start);
+  const endIndex = text.indexOf(end);
+  assert.notEqual(startIndex, -1, `${marker} start marker missing`);
+  assert.notEqual(endIndex, -1, `${marker} end marker missing`);
+  assert.ok(endIndex > startIndex, `${marker} end marker must follow start marker`);
+  return text.slice(startIndex + start.length, endIndex);
+}
+
+function listedSkillsFromBlock(block) {
+  return block
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/\\$/, "").trim())
+    .filter((line) => line.startsWith("printing-press"))
+    .sort();
+}
+
+const setupChecks = readFileSync(join(root, "skills/printing-press/references/setup-checks.md"), "utf8");
+assertList(
+  "setup-checks skill update list",
+  listedSkillsFromBlock(updateBlock(setupChecks, "PRINTING_PRESS_SKILL_UPDATE")),
+);

--- a/.github/scripts/validate-skill-docs.sh
+++ b/.github/scripts/validate-skill-docs.sh
@@ -44,4 +44,6 @@ for skill in skills/*/SKILL.md; do
   fi
 done
 
+node .github/scripts/validate-printing-press-skill-list.mjs || status=1
+
 exit "$status"

--- a/README.md
+++ b/README.md
@@ -26,29 +26,54 @@ You need both the **binary** and the **Claude Code skills**. The skills (`/print
 
 The binary alone works (research, generation, verification, scoring) but skips the curated agent loop. The skills alone have nothing to call. Install both.
 
-**Prerequisites:** [Go 1.26.3 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code), and Node/npm for `npx skills`. The skills are tested with Claude Code; other harnesses like Codex may work but aren't tested. **Use Claude Code for the best experience.**
+**Prerequisites:** [Go 1.26.3 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code), and Node/npm for `npx`. The skills are tested with Claude Code; other harnesses like Codex may work but aren't tested. **Use Claude Code for the best experience.**
 
-### 1. Install the binary
+### 1. Install
 
 ```bash
-go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
 ```
 
-Verify with `cli-printing-press --version`. If `go install` fails, confirm Go 1.26.3 or newer is installed and `$GOPATH/bin` is on your `PATH`.
+The installer runs `go install` for the generator binary, then refreshes all Printing Press skills through `skills@latest add --skill '*'`. Restart Claude Code after it completes so the refreshed skills are loaded.
+
+Use `--cli-only` or `--skills-only` when you only want one side:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --cli-only
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
+```
+
+Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.3 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
 
 Older releases installed a generator binary named `printing-press`. That legacy
 entrypoint still works for compatibility, but the canonical generator command is
 now `cli-printing-press` so the public catalog installer can own
 `printing-press list`, `printing-press search`, and `printing-press install`.
 
-### 2. Install the skills
+<details>
+<summary><b>Manual install</b></summary>
+
+Install or update the binary:
+
+```bash
+go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
+```
 
 Use Vercel's [open-agent-skills](https://www.npmjs.com/package/skills) CLI to install the Printing Press skills from this repo into Claude Code:
 
 ```bash
-npx skills add mvanhorn/cli-printing-press/skills --skill '*' -g -a claude-code -y
-npx skills update                              # update later
+npx -y skills@latest add mvanhorn/cli-printing-press/skills --skill '*' -g -a claude-code -y
 ```
+
+To refresh the skills later without naming individual skills, rerun the installer in skills-only mode:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
+```
+
+Restart Claude Code after refreshing skills so the new skill text is loaded.
+
+</details>
 
 Once installed, you can start Claude Code from any folder.
 
@@ -66,7 +91,7 @@ claude --plugin-dir . -w       # ...in a new git worktree (parallel runs)
 
 </details>
 
-### 3. Start a printing session
+### 2. Start a printing session
 
 ```bash
 claude
@@ -471,7 +496,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 
 ## Troubleshooting
 
-**`/printing-press` slash command doesn't appear in Claude Code.** Restart your Claude Code session after installing the skills. Run `npx skills list -g -a claude-code` to verify the install. If you're developing from a clone, confirm `claude --plugin-dir .` was run from the cloned repo root.
+**`/printing-press` slash command doesn't appear in Claude Code.** Restart your Claude Code session after installing the skills. Run `npx -y skills@latest list -g -a claude-code` to verify the install. If you're developing from a clone, confirm `claude --plugin-dir .` was run from the cloned repo root.
 
 **`cli-printing-press: command not found` after a successful `go install`.** `$GOPATH/bin` (default `~/go/bin`) isn't on your `PATH`. Add it to your shell profile.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s lastpipe 2>/dev/null || true
+umask 022
+
+# CLI Printing Press installer
+#
+# One-line install:
+#   curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
+#
+# Options:
+#   --cli-only          Install or update only the Go generator binary.
+#   --skills-only       Install or refresh only the Claude Code skills.
+#   -a, --agent NAME    Install skills for an agent supported by `skills`.
+#                       May be repeated. Defaults to claude-code.
+#   --dry-run           Print commands without executing them.
+#   --quiet             Suppress non-error output.
+#   --no-gum            Disable gum formatting even when gum is installed.
+#   -h, --help          Show help.
+
+readonly PROJECT_NAME="CLI Printing Press"
+readonly BINARY_NAME="cli-printing-press"
+readonly GO_MIN_VERSION="1.26.3"
+readonly GO_INSTALL_TARGET="github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
+readonly SKILL_SOURCE="mvanhorn/cli-printing-press/skills"
+readonly SKILLS_PACKAGE="skills@latest"
+readonly DEFAULT_AGENT="claude-code"
+
+INSTALL_CLI=1
+INSTALL_SKILLS=1
+DRY_RUN=0
+QUIET=0
+NO_GUM=0
+AGENTS=()
+PROXY_ARGS=()
+TMP_DIR=""
+LOCK_DIR=""
+CLI_STATUS="skipped"
+SKILLS_STATUS="skipped"
+
+cleanup() {
+  if [[ -n "${LOCK_DIR:-}" && -d "$LOCK_DIR" ]]; then
+    rm -f "$LOCK_DIR/pid" 2>/dev/null || true
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+  if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'USAGE'
+CLI Printing Press installer
+
+Usage:
+  bash scripts/install.sh [options]
+  curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --cli-only
+
+Options:
+  --cli-only          Install or update only the Go generator binary.
+  --skills-only       Install or refresh only the Claude Code skills.
+  -a, --agent NAME    Install skills for an agent supported by `skills`.
+                       May be repeated. Defaults to claude-code.
+  --dry-run           Print commands without executing them.
+  --quiet             Suppress non-error output.
+  --no-gum            Disable gum formatting even when gum is installed.
+  -h, --help          Show this help.
+USAGE
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --cli-only)
+      INSTALL_SKILLS=0
+      ;;
+    --skills-only)
+      INSTALL_CLI=0
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --quiet)
+      QUIET=1
+      ;;
+    --no-gum)
+      NO_GUM=1
+      ;;
+    --agent=*)
+      AGENTS+=("${arg#--agent=}")
+      ;;
+    -a=*)
+      AGENTS+=("${arg#-a=}")
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      # Handled below so "-a value" and "--agent value" can consume the next arg.
+      ;;
+  esac
+done
+
+# Re-parse options that consume a following value.
+if (($# > 0)); then
+  while (($# > 0)); do
+    case "$1" in
+      -a|--agent)
+        shift
+        if (($# == 0)); then
+          echo "error: --agent requires a value" >&2
+          exit 1
+        fi
+        AGENTS+=("$1")
+        ;;
+      --cli-only|--skills-only|--dry-run|--quiet|--no-gum|-h|--help|--agent=*|-a=*)
+        ;;
+      *)
+        echo "error: unknown option: $1" >&2
+        exit 1
+        ;;
+    esac
+    shift || true
+  done
+fi
+
+if [[ "$INSTALL_CLI" -eq 0 && "$INSTALL_SKILLS" -eq 0 ]]; then
+  echo "error: choose only one of --cli-only or --skills-only" >&2
+  exit 1
+fi
+
+if [[ "${#AGENTS[@]}" -eq 0 ]]; then
+  AGENTS=("$DEFAULT_AGENT")
+fi
+
+HAS_GUM=0
+if command -v gum >/dev/null 2>&1 && [[ -t 1 && "$NO_GUM" -eq 0 ]]; then
+  HAS_GUM=1
+fi
+
+info() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    gum style --foreground 39 "-> $*"
+  else
+    printf '\033[0;34m->\033[0m %s\n' "$*"
+  fi
+}
+
+ok() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    gum style --foreground 42 "✓ $*"
+  else
+    printf '\033[0;32m✓\033[0m %s\n' "$*"
+  fi
+}
+
+warn() {
+  [[ "$QUIET" -eq 1 ]] && return 0
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    gum style --foreground 214 "! $*"
+  else
+    printf '\033[1;33m!\033[0m %s\n' "$*"
+  fi
+}
+
+err() {
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    gum style --foreground 196 "✗ $*" >&2
+  else
+    printf '\033[0;31m✗\033[0m %s\n' "$*" >&2
+  fi
+}
+
+strip_ansi() {
+  sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g'
+}
+
+draw_box() {
+  local color="$1"
+  shift
+  local lines=("$@")
+  local width=0
+  local line clean len
+  for line in "${lines[@]}"; do
+    clean="$(printf '%s' "$line" | strip_ansi)"
+    len=${#clean}
+    ((len > width)) && width=$len
+  done
+  ((width < 24)) && width=24
+  [[ "$QUIET" -eq 1 ]] && return 0
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    printf '%s\n' "${lines[@]}" | gum style --border double --border-foreground "$color" --padding "0 1"
+    return 0
+  fi
+  printf '╔'
+  printf '═%.0s' $(seq 1 $((width + 2)))
+  printf '╗\n'
+  for line in "${lines[@]}"; do
+    clean="$(printf '%s' "$line" | strip_ansi)"
+    printf '║ %s%*s ║\n' "$line" $((width - ${#clean})) ''
+  done
+  printf '╚'
+  printf '═%.0s' $(seq 1 $((width + 2)))
+  printf '╝\n'
+}
+
+run_with_spinner() {
+  local title="$1"
+  shift
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    local quoted=()
+    local arg
+    for arg in "$@"; do
+      printf -v arg '%q' "$arg"
+      quoted+=("$arg")
+    done
+    info "[dry-run] ${quoted[*]}"
+    return 0
+  fi
+  if [[ "$HAS_GUM" -eq 1 && "$QUIET" -eq 0 ]]; then
+    gum spin --spinner dot --title "$title" -- "$@"
+  else
+    info "$title"
+    "$@"
+  fi
+}
+
+setup_proxy() {
+  PROXY_ARGS=()
+  if [[ -n "${HTTPS_PROXY:-}" ]]; then
+    PROXY_ARGS=(--proxy "$HTTPS_PROXY")
+  elif [[ -n "${HTTP_PROXY:-}" ]]; then
+    PROXY_ARGS=(--proxy "$HTTP_PROXY")
+  fi
+}
+
+detect_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) arch="x86_64" ;;
+    arm64|aarch64) arch="aarch64" ;;
+  esac
+  case "$os" in
+    darwin|linux) ;;
+    *)
+      err "Unsupported OS: $os"
+      exit 1
+      ;;
+  esac
+  case "$arch" in
+    x86_64|aarch64) ;;
+    *)
+      err "Unsupported architecture: $arch"
+      exit 1
+      ;;
+  esac
+  if [[ "$os" == "linux" ]] && grep -qi microsoft /proc/version 2>/dev/null; then
+    warn "WSL detected; continuing with Linux install."
+  fi
+}
+
+check_disk_space() {
+  local path="${TMPDIR:-/tmp}"
+  local available
+  available="$(df -Pk "$path" | awk 'NR==2 {print $4}')"
+  if [[ -n "$available" && "$available" -lt 10240 ]]; then
+    err "At least 10MB of free space is required in $path."
+    exit 1
+  fi
+}
+
+check_write_permissions() {
+  local probe
+  probe="$(mktemp "${TMPDIR:-/tmp}/cli-printing-press-install.XXXXXX")"
+  rm -f "$probe"
+}
+
+check_network() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return 0
+  fi
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --connect-timeout 5 "${PROXY_ARGS[@]}" https://github.com >/dev/null || {
+      err "Network check failed: could not reach github.com."
+      exit 1
+    }
+    if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
+      curl -fsSL --connect-timeout 5 "${PROXY_ARGS[@]}" https://registry.npmjs.org/skills >/dev/null || {
+        err "Network check failed: could not reach registry.npmjs.org."
+        exit 1
+      }
+    fi
+  fi
+}
+
+acquire_lock() {
+  local lock_base="${XDG_STATE_HOME:-$HOME/.local/state}/cli-printing-press"
+  mkdir -p "$lock_base"
+  LOCK_DIR="$lock_base/install.lock"
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' "$$" > "$LOCK_DIR/pid"
+    return 0
+  fi
+  if [[ -f "$LOCK_DIR/pid" ]]; then
+    local pid
+    pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+      warn "Removing stale installer lock."
+      rm -rf "$LOCK_DIR"
+      mkdir "$LOCK_DIR"
+      printf '%s\n' "$$" > "$LOCK_DIR/pid"
+      return 0
+    fi
+  fi
+  err "Another CLI Printing Press installer appears to be running."
+  exit 1
+}
+
+parse_go_version() {
+  sed -nE 's/^go version go([0-9]+(\.[0-9]+){1,2}).*/\1/p'
+}
+
+version_ge() {
+  local left="$1"
+  local right="$2"
+  local IFS=.
+  local -a l r
+  read -r -a l <<< "$left"
+  read -r -a r <<< "$right"
+  local i lv rv
+  for i in 0 1 2; do
+    lv="${l[$i]:-0}"
+    rv="${r[$i]:-0}"
+    if ((10#$lv > 10#$rv)); then return 0; fi
+    if ((10#$lv < 10#$rv)); then return 1; fi
+  done
+  return 0
+}
+
+check_go() {
+  if ! command -v go >/dev/null 2>&1; then
+    err "Go $GO_MIN_VERSION or newer is required."
+    err "Install Go from https://go.dev/dl/, then re-run this installer."
+    exit 1
+  fi
+  local version
+  version="$(go version | parse_go_version)"
+  if [[ -z "$version" ]]; then
+    err "Could not determine the installed Go version. Ensure Go $GO_MIN_VERSION or newer is installed."
+    exit 1
+  fi
+  if ! version_ge "$version" "$GO_MIN_VERSION"; then
+    err "Go $GO_MIN_VERSION or newer is required; found Go $version."
+    err "Install Go from https://go.dev/dl/, then re-run this installer."
+    exit 1
+  fi
+}
+
+check_node() {
+  if ! command -v npm >/dev/null 2>&1 || ! command -v npx >/dev/null 2>&1; then
+    err "Node/npm is required for skill installation."
+    err "Install Node.js from https://nodejs.org/, then re-run this installer."
+    exit 1
+  fi
+}
+
+installed_cli_version() {
+  if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+    "$BINARY_NAME" --version 2>/dev/null || true
+  fi
+}
+
+install_cli() {
+  local current
+  current="$(installed_cli_version)"
+  if [[ -n "$current" ]]; then
+    info "Existing $BINARY_NAME detected: $current"
+  fi
+  run_with_spinner "Installing $BINARY_NAME with go install" go install "$GO_INSTALL_TARGET"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    CLI_STATUS="planned"
+  else
+    CLI_STATUS="installed"
+    ok "Installed $BINARY_NAME"
+  fi
+}
+
+install_skills() {
+  local cmd=(npx -y "$SKILLS_PACKAGE" add "$SKILL_SOURCE" --skill "*" -g -y)
+  local agent
+  for agent in "${AGENTS[@]}"; do
+    cmd+=(-a "$agent")
+  done
+  run_with_spinner "Installing Printing Press skills" "${cmd[@]}"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    SKILLS_STATUS="planned"
+  else
+    SKILLS_STATUS="installed"
+    ok "Installed Printing Press skills for ${AGENTS[*]}"
+  fi
+}
+
+preflight_checks() {
+  info "Running preflight checks"
+  detect_platform
+  setup_proxy
+  check_disk_space
+  check_write_permissions
+  check_network
+  if [[ "$INSTALL_CLI" -eq 1 ]]; then
+    check_go
+  fi
+  if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
+    check_node
+  fi
+}
+
+print_header() {
+  if [[ "$QUIET" -eq 1 ]]; then
+    return 0
+  fi
+  if [[ "$HAS_GUM" -eq 1 ]]; then
+    gum style \
+      --border normal --border-foreground 39 \
+      --padding "0 1" --margin "1 0" \
+      "$(gum style --foreground 42 --bold "$PROJECT_NAME installer")" \
+      "$(gum style --foreground 245 "Install the generator binary and Claude Code skills")"
+  else
+    printf '\033[1;32m%s installer\033[0m\n' "$PROJECT_NAME"
+    printf '\033[0;90mInstall the generator binary and Claude Code skills\033[0m\n\n'
+  fi
+}
+
+print_summary() {
+  local lines=()
+  lines+=("CLI: $CLI_STATUS")
+  lines+=("Skills: $SKILLS_STATUS")
+  if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
+    lines+=("Agents: ${AGENTS[*]}")
+    lines+=("Restart Claude Code so refreshed skills are loaded.")
+  fi
+  draw_box 42 "${lines[@]}"
+}
+
+main() {
+  TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cli-printing-press-install.XXXXXX")"
+  print_header
+  acquire_lock
+  preflight_checks
+  if [[ "$INSTALL_CLI" -eq 1 ]]; then
+    install_cli
+  fi
+  if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
+    install_skills
+  fi
+  print_summary
+}
+
+main "$@"

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -154,7 +154,7 @@ elif ! _resolve_press_bin >/dev/null; then
     export PATH="$HOME/go/bin:$PATH"
   else
     # Refuse: the cli-printing-press binary is required and we will not auto-install
-    # it. The README's two-step install (binary + plugin) is the source of truth;
+    # it. The README's install flow is the source of truth;
     # silent auto-install hides failure modes (network, wrong GOPATH) inside an
     # opaque skill invocation.
     echo ""
@@ -204,6 +204,7 @@ else
   PRINTING_PRESS_BIN="$(_resolve_press_bin 2>/dev/null || true)"
 fi
 echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
+echo "PRESS_REPO_MODE=$_press_repo"
 
 # Shadow detector (advisory). When a local build is in use, surface any
 # differing global so the user can see at a glance that the two binaries
@@ -387,11 +388,11 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles six signals the contract emits to stdout: `[setup-error]` (refuse to run, surface the install instructions), `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
 
 **Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `cli-printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `cli-printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/cli-printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `cli-printing-press generate ...` for readability — replace `cli-printing-press` with the captured absolute path each time you actually run one.
 
-Only after preflight completes successfully (no `[setup-error]`; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user; `PRINTING_PRESS_BIN` is captured) should you proceed to the Orientation & Briefing section below.
+Only after preflight completes successfully (no `[setup-error]`; no global skill update that requires restart; any `[repo-upgrade-available]`, `[upgrade-available]`, or `[browser-tools-missing]` was offered to the user; `PRINTING_PRESS_BIN` is captured) should you proceed to the Orientation & Briefing section below.
 
 ## Orientation & Briefing
 

--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -101,7 +101,7 @@ If either MCP flag is true, extend the status report:
 
 #### Step 1b: Install capture tool (fallback — preflight should have prompted first)
 
-Preflight (`references/setup-checks.md` section 5) offers to install browser-use and agent-browser on every run, so most users arrive at Step 1 with one or both already installed. This step is a fallback for the case where the user declined the preflight prompt and the current run actually needs a browser backend.
+Preflight (`references/setup-checks.md` section 6) offers to install browser-use and agent-browser on every run, so most users arrive at Step 1 with one or both already installed. This step is a fallback for the case where the user declined the preflight prompt and the current run actually needs a browser backend.
 
 If neither tool is installed, offer to install via `AskUserQuestion`. Do not install automatically:
 
@@ -145,7 +145,7 @@ else
 fi
 ```
 
-After the brew or npm install succeeds, use the same post-install rule as preflight (`references/setup-checks.md` section 5): complete agent-browser's browser-binary setup as a user-run step:
+After the brew or npm install succeeds, use the same post-install rule as preflight (`references/setup-checks.md` section 6): complete agent-browser's browser-binary setup as a user-run step:
 
 ```text
 ! agent-browser install

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,12 +1,14 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle six signals the contract emits to stdout: `[setup-error]`, `[repo-upgrade-available]`, the `min-binary-version` compatibility check, `[upgrade-available]`, `[browser-tools-missing]`, and the always-emitted `PRINTING_PRESS_BIN=<abs-path>` marker (with optional `[binary-shadow]` advisory).
+Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
 
 Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
 
 ## Preamble: Capture the absolute binary path (unconditional)
 
-Before applying any numbered section below, capture the `PRINTING_PRESS_BIN=<absolute path to the binary>` line the contract emitted to stdout. Every generator invocation referenced anywhere below — including the `version --json` calls in sections 3 and 4 — must be made using that absolute path (substitute the captured value, not the literal `$PRINTING_PRESS_BIN` token). The contract's `export PATH=...` line only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells where bare `cli-printing-press` or legacy bare `printing-press` resolves against the user's default `PATH`, and a stale globally-installed binary (`$HOME/go/bin/cli-printing-press` from an earlier `go install`, a Homebrew copy, etc.) or the public catalog installer can silently shadow the local repo build the contract selected. Using the absolute path eliminates the shadow.
+Before applying any numbered section below, capture the `PRINTING_PRESS_BIN=<absolute path to the binary>` line the contract emitted to stdout. Every generator invocation referenced anywhere below — including the `version --json` calls in sections 4 and 5 — must be made using that absolute path (substitute the captured value, not the literal `$PRINTING_PRESS_BIN` token). The contract's `export PATH=...` line only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells where bare `cli-printing-press` or legacy bare `printing-press` resolves against the user's default `PATH`, and a stale globally-installed binary (`$HOME/go/bin/cli-printing-press` from an earlier `go install`, a Homebrew copy, etc.) or the public catalog installer can silently shadow the local repo build the contract selected. Using the absolute path eliminates the shadow.
+
+Also capture `PRESS_REPO_MODE=<true|false>`. When it is `true`, the current session is running from a repo checkout/plugin-dir and should use the checkout's skill files, not mutate the user's global skill install as part of this run. When it is `false`, run the global open-agent-skills freshness check in section 3, but treat a missing global open-agent-skills entry as a non-blocking signal that this skill may have been loaded from another install surface.
 
 If `PRINTING_PRESS_BIN` was emitted as an empty value (`PRINTING_PRESS_BIN=`), the contract was unable to resolve a binary; this should have already been surfaced as `[setup-error]` (handled in section 1 below). Treat an empty value here as a setup-error fallback and stop.
 
@@ -18,7 +20,7 @@ If the setup contract output contains a line starting with `[setup-error]`, a re
 
 **Stop the skill immediately.** Do not proceed to research, generation, or any other work. Surface the message the contract printed (it includes the exact install command or download URL) verbatim to the user.
 
-The user must install the missing prerequisite in their terminal before re-running. Do not offer to auto-install — the README's two-step install is the source of truth for the binary, and silent auto-install hides failure modes (network, wrong GOPATH, no Go toolchain) inside an opaque skill invocation.
+The user must install the missing prerequisite in their terminal before re-running. Do not offer to auto-install — the README's install flow is the source of truth for the binary, and silent auto-install hides failure modes (network, wrong GOPATH, no Go toolchain) inside an opaque skill invocation.
 
 ## 2. Interactive repo upgrade prompt
 
@@ -63,7 +65,52 @@ Prompt again only when `origin/main` advances to a different SHA.
 
 If no `[repo-upgrade-available]` line was emitted, skip this section entirely.
 
-## 3. Min-binary-version compatibility
+## 3. Global open-agent-skills freshness check
+
+If `PRESS_REPO_MODE=true`, skip this section entirely. The repo checkout/plugin-dir is the source of truth for skill files in that mode, and section 2 already handles updating the checkout from `origin/main`.
+
+If `PRESS_REPO_MODE=false`, run the targeted global open-agent-skills updater before continuing:
+
+```bash
+# PRINTING_PRESS_SKILL_UPDATE_START
+npx -y skills@latest update -g \
+  printing-press \
+  printing-press-amend \
+  printing-press-catalog \
+  printing-press-import \
+  printing-press-output-review \
+  printing-press-polish \
+  printing-press-publish \
+  printing-press-reprint \
+  printing-press-retro \
+  printing-press-score
+# PRINTING_PRESS_SKILL_UPDATE_END
+```
+
+Interpret the output as follows:
+
+- If it reports `✓ Updated N skill(s)` with `N > 0`, stop immediately. Tell the user:
+
+  > "Updated N Printing Press skill(s) on disk. This agent session may still have the old skill text loaded. Restart the agent session, then re-run `/printing-press` before continuing."
+
+  Do not proceed to research, generation, scoring, publishing, or any other workflow after a skill update.
+- If it reports `All global skills are up to date` or otherwise completes without an updated-skill summary, continue.
+- If it reports `No installed skills found matching: ...`, continue without blocking. The current skill is already running, so absence from the global open-agent-skills registry usually means this session was loaded from another install surface, such as the Claude Code plugin/marketplace channel, a project-scoped skill install, or a local plugin directory. Do not tell the user to reinstall through `npx skills` as a prerequisite. If they explicitly ask how to move to the global open-agent-skills install path, give them the skills-only installer command so they do not have to name individual skills:
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
+  ```
+
+  Then tell them to restart the agent session.
+- If it reports one or more `Failed to update ...` lines or exits non-zero, stop and surface the failure. For manual repair, tell the user to run the skills-only installer command below, then restart the agent session. Do not continue with potentially mixed skill files.
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
+  ```
+
+This command mutates global skill files, so never run it silently after user work has started. It belongs in preflight before any user-facing prompt.
+
+## 4. Min-binary-version compatibility
 
 Check binary version compatibility against the skill's declared minimum. Read the `min-binary-version` field from the skill's YAML frontmatter. Run `<PRINTING_PRESS_BIN> version --json` (using the absolute path captured in the preamble — not bare `cli-printing-press` or legacy bare `printing-press`, which would resolve against the user's default `PATH` and could interrogate a stale global or the public catalog installer) and parse the version from the output. Compare it to `min-binary-version` using semver rules.
 
@@ -73,7 +120,7 @@ If the installed binary is older than the minimum, stop the skill immediately an
 
 Do not proceed to research, scoring, publishing, or any other workflow when the binary is below `min-binary-version`. This is the compatibility floor, not a freshness advisory.
 
-## 4. Interactive standalone binary upgrade prompt
+## 5. Interactive standalone binary upgrade prompt
 
 If the setup contract output contains a line starting with `[upgrade-available]`, parse the two follow-up lines for the version values:
 
@@ -111,27 +158,13 @@ else
 fi
 ```
 
-Capture the new `PRINTING_PRESS_BIN=<abs-path>` value and use it for every subsequent generator invocation in the rest of this run, overriding the value captured in the preamble. Then confirm with `<PRINTING_PRESS_BIN> version --json` and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).**
-
-Separately, as out-of-band advice for the user's *next* session (not a stop signal for this run), tell them they can also refresh their installed skill files outside the repo checkout by running one of:
-
-```bash
-gh skill update
-```
-
-or:
-
-```bash
-npx skills update
-```
-
-These two commands update skill files that live outside the repo; they only take effect after the user reloads or restarts the agent session, which they should do *after* the current run finishes. Frame this clearly to the user as "for next time" guidance, then continue setup with the newly installed binary.
+Capture the new `PRINTING_PRESS_BIN=<abs-path>` value and use it for every subsequent generator invocation in the rest of this run, overriding the value captured in the preamble. Then confirm with `<PRINTING_PRESS_BIN> version --json` and tell the user `"Upgraded to v<new>."` **Continue this current setup run with the freshly installed binary on disk — do not stop, do not reload the session, do not skip the remaining checks (min-binary-version compatibility, etc.).** Skill freshness was already handled by section 3, so this binary-only update does not require a session restart.
 
 If the upgrade command fails (network error, auth error, etc.), surface the failure to the user and continue with the current binary — do not block the run on a failed upgrade. The user can re-run later.
 
 If no `[upgrade-available]` line was emitted, skip this section entirely.
 
-## 5. Interactive browser-sniff backend install prompt
+## 6. Interactive browser-sniff backend install prompt
 
 If the setup contract output contains a line starting with `[browser-tools-missing]`, parse the follow-up lines:
 
@@ -199,7 +232,7 @@ If the user picks **Skip for this run**, continue without prompting further this
 
 If no `[browser-tools-missing]` line was emitted, skip this section entirely.
 
-## 6. Optional shadow advisory
+## 7. Optional shadow advisory
 
 If the setup contract output contains a line starting with `[binary-shadow]`, parse the follow-up lines:
 


### PR DESCRIPTION
## Summary

Printing Press now has a repo-owned one-command installer script instead of an unpublished npm bootstrap package. The README makes the script the primary install path:

```bash
curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
```

The script installs or updates the Go generator with `go install`, then refreshes all Printing Press skills through `skills@latest add ... --skill '*'`. It also supports `--cli-only`, `--skills-only`, repeated `--agent` flags, `--dry-run`, `--quiet`, and `--no-gum`. This gives us a unified install and repair path without needing Matt to publish or administer an npm package.

The user-facing skill refresh path is now the same script in skills-only mode, so users never have to name each Printing Press skill manually:

```bash
curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
```

The preflight skill freshness check remains conservative. It uses targeted `skills update -g <printing-press skills...>` internally so an ordinary `/printing-press` run can detect global open-agent-skills updates without reinstalling from the repo or disturbing users who loaded the skill from the Claude Code plugin/marketplace channel, a local plugin directory, or a project-scoped install. If `skills update -g` reports `No installed skills found matching: ...`, the skill treats that as non-blocking; if manual repair is needed, it points users to `install.sh --skills-only`.

A new drift validator ties the internal preflight update list back to the actual `skills/*/SKILL.md` directories, so adding, renaming, or deleting a Printing Press skill fails validation until the setup preflight list is reconciled.

## Test Plan

- `bash -n scripts/install.sh`
- `bash scripts/install.sh --help`
- `bash scripts/install.sh --dry-run --no-gum`
- `bash scripts/install.sh --dry-run --no-gum --cli-only`
- `bash scripts/install.sh --dry-run --no-gum --skills-only`
- `bash scripts/install.sh --dry-run --no-gum --skills-only --agent codex --agent claude-code`
- `bash .github/scripts/validate-skill-docs.sh`
- `node .github/scripts/validate-printing-press-skill-list.mjs`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
