### PR TITLE
fix(cli): scope traffic-analysis protection evidence

### DIFF
--- a/docs/solutions/logic-errors/third-party-protection-markers-reachability.md
+++ b/docs/solutions/logic-errors/third-party-protection-markers-reachability.md
@@ -1,0 +1,61 @@
+---
+title: Attribute protection markers before deriving reachability
+date: 2026-05-24
+category: logic-errors
+module: browsersniff
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "`traffic-analysis.json` set reachability.mode to browser_required when only third-party scripts contained CAPTCHA or WAF markers"
+  - "Generation refused replayable browser-sniffed CLIs with requires_page_context and requires_protected_client hints"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [browser-sniff, traffic-analysis, reachability, waf]
+---
+
+# Attribute protection markers before deriving reachability
+
+## Problem
+
+Browser-sniff traffic analysis classified protection markers from every captured HAR entry, including third-party script and telemetry hosts. Modern pages commonly load Stripe, reCAPTCHA, DataDome, ad-tech, and WAF helper scripts, so unrelated assets could make a replayable first-party API capture look like it required live browser page context.
+
+## Symptoms
+
+- `protections[].label` included `captcha`, `aws_waf`, `datadome`, or similar labels whose evidence pointed at third-party static assets.
+- `classifyReachability` promoted the whole capture to `browser_required`.
+- `deriveGenerationHints` emitted `requires_page_context` and `requires_protected_client`, causing `generate --traffic-analysis` to reject a CLI even when first-party API endpoints returned 2xx JSON.
+
+## What Didn't Work
+
+- Filtering only by endpoint classification would drop real challenge pages from API hosts, because a 403 HTML challenge response often scores as noise even when the same host also served JSON API traffic.
+- Filtering only by the capture target host would miss split-host APIs where the product page is on one registered domain and the usable API is on another.
+- Counting every protection marker was too broad because third-party fingerprinting scripts are common page noise, not evidence that the target API itself needs a resident browser.
+
+## Solution
+
+Build an allowed protection surface before scanning marker bodies:
+
+- Include the capture target's registered domain only when the target URL has a real HTTP(S) hostname.
+- Include registered domains and exact hosts from entries already classified as API traffic.
+- Analyze protection markers only when the entry is on an allowed registered domain or exact API host.
+
+This keeps first-party challenge scripts and cross-domain API-host challenges load-bearing while dropping third-party script and tracker markers.
+
+## Why This Works
+
+Reachability is a property of the target surface, not the whole browser page. Endpoint classification already identifies which hosts are part of the API surface, but challenge responses from those hosts may themselves be HTML and therefore noise. Carrying both the target registered domain and discovered API hosts into protection detection gives the reachability gate the right attribution boundary.
+
+The hostless-target guard matters for HARs whose first request is `data:` or `about:blank`: do not anchor filtering to parser fallback pseudo-hosts. Infer from real HTTP(S) target/API hosts instead.
+
+## Prevention
+
+- Protection labels that drive `browser_required` or `browser_clearance_http` need attribution tests, not just marker-detection tests.
+- Add paired regressions for third-party marker false positives and first-party/API-host marker false negatives.
+- When optimizing large-HAR scans, precompute target/API registered domains once instead of recomputing public-suffix lookups per entry.
+
+## Related Issues
+
+- GitHub issue #1628
+- GitHub issue #1420
+- `docs/solutions/logic-errors/captcha-precheck-challenge-classification-2026-05-21.md`

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -877,6 +877,8 @@ func detectProtections(entries []EnrichedEntry, targetURL string) []ProtectionOb
 	apiHosts := apiHostsForProtection(entries)
 	for index, entry := range entries {
 		entryHost := normalizedURLHost(entry.URL)
+		// If no real target or API host is known, keep the legacy broad scan
+		// instead of dropping possible protection evidence from a sparse capture.
 		if len(protectionSites) > 0 && !apiHosts[entryHost] && !protectionSites[registeredDomainOrHost(entryHost)] {
 			continue
 		}

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -1291,8 +1291,8 @@ func findSSRStateBlobEntryOnRegisteredDomain(entries []EnrichedEntry, protocols 
 // sameRegisteredDomain compares two hosts at the eTLD+1 level so
 // subdomain splits like api.example.com / www.example.com qualify as
 // "same site." Literal-equality is checked first so private or unknown
-// TLDs (intranet hosts, raw IPs, .test/.local) still match themselves
-// even when publicsuffix can't resolve them.
+// hosts (intranet names, raw IPs) still match themselves even when
+// publicsuffix can't resolve them.
 func sameRegisteredDomain(hostA, hostB string) bool {
 	a := registeredDomainOrHost(hostA)
 	b := registeredDomainOrHost(hostB)

--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -486,7 +486,7 @@ func AnalyzeTraffic(capture *EnrichedCapture) (*TrafficAnalysis, error) {
 		SecondaryHosts:   secondaryHosts,
 		Protocols:        detectProtocols(classifiedEntries),
 		Auth:             detectTrafficAuth(capture, classifiedEntries),
-		Protections:      detectProtections(classifiedEntries),
+		Protections:      detectProtections(classifiedEntries, capture.TargetURL),
 		EndpointClusters: buildEndpointClusters(groups, classifiedEntries),
 		RequestSequences: detectRequestSequences(classifiedEntries),
 		Pagination:       detectPagination(classifiedEntries),
@@ -858,7 +858,7 @@ func detectTrafficAuth(capture *EnrichedCapture, entries []EnrichedEntry) AuthAn
 	}
 }
 
-func detectProtections(entries []EnrichedEntry) []ProtectionObservation {
+func detectProtections(entries []EnrichedEntry, targetURL string) []ProtectionObservation {
 	observations := map[string]*ProtectionObservation{}
 	add := func(label string, confidence float64, entry EnrichedEntry, index int, reason string, notes ...string) {
 		observation := observations[label]
@@ -873,7 +873,13 @@ func detectProtections(entries []EnrichedEntry) []ProtectionObservation {
 		observation.Notes = uniqueStrings(append(observation.Notes, notes...))
 	}
 
+	protectionSites := protectionSitesForEntries(entries, targetURL)
+	apiHosts := apiHostsForProtection(entries)
 	for index, entry := range entries {
+		entryHost := normalizedURLHost(entry.URL)
+		if len(protectionSites) > 0 && !apiHosts[entryHost] && !protectionSites[registeredDomainOrHost(entryHost)] {
+			continue
+		}
 		body := strings.ToLower(entry.ResponseBody)
 		headers := lowerHeaderMap(entry.ResponseHeaders)
 		server := headers["server"]
@@ -925,6 +931,46 @@ func detectProtections(entries []EnrichedEntry) []ProtectionObservation {
 		return out[i].Confidence > out[j].Confidence
 	})
 	return out
+}
+
+func protectionSitesForEntries(entries []EnrichedEntry, targetURL string) map[string]bool {
+	sites := map[string]bool{}
+	if site := registeredDomainOrHost(httpURLHostname(targetURL)); site != "" {
+		sites[site] = true
+	}
+	for _, entry := range entries {
+		if entry.Classification != "api" {
+			continue
+		}
+		if site := registeredDomainOrHost(normalizedURLHost(entry.URL)); site != "" {
+			sites[site] = true
+		}
+	}
+	return sites
+}
+
+func apiHostsForProtection(entries []EnrichedEntry) map[string]bool {
+	hosts := map[string]bool{}
+	for _, entry := range entries {
+		if entry.Classification != "api" {
+			continue
+		}
+		if host := normalizedURLHost(entry.URL); host != "" {
+			hosts[host] = true
+		}
+	}
+	return hosts
+}
+
+func httpURLHostname(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return ""
+	}
+	return strings.ToLower(parsed.Hostname())
 }
 
 func isCaptchaPreflightCandidate(entry EnrichedEntry) bool {
@@ -1246,23 +1292,24 @@ func findSSRStateBlobEntryOnRegisteredDomain(entries []EnrichedEntry, protocols 
 // TLDs (intranet hosts, raw IPs, .test/.local) still match themselves
 // even when publicsuffix can't resolve them.
 func sameRegisteredDomain(hostA, hostB string) bool {
-	a := strings.ToLower(strings.TrimSpace(hostA))
-	b := strings.ToLower(strings.TrimSpace(hostB))
+	a := registeredDomainOrHost(hostA)
+	b := registeredDomainOrHost(hostB)
 	if a == "" || b == "" {
 		return false
 	}
-	if a == b {
-		return true
+	return a == b
+}
+
+func registeredDomainOrHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
 	}
-	aETLD, err := publicsuffix.EffectiveTLDPlusOne(a)
+	registered, err := publicsuffix.EffectiveTLDPlusOne(host)
 	if err != nil {
-		return false
+		return host
 	}
-	bETLD, err := publicsuffix.EffectiveTLDPlusOne(b)
-	if err != nil {
-		return false
-	}
-	return aETLD == bETLD
+	return registered
 }
 
 func hasAPIBrowserRenderedEntry(entries []EnrichedEntry) bool {

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -1854,6 +1854,8 @@ func TestSameRegisteredDomain(t *testing.T) {
 		{"db.local", "db.local", true},
 		{"api.db.local", "www.db.local", true},
 		{"db.local", "other.local", false},
+		{"printer", "printer", true},
+		{"printer", "scanner", false},
 		{"192.168.1.1", "192.168.1.1", true},
 		{"192.168.1.1", "192.168.1.2", false},
 	}

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -1851,6 +1851,11 @@ func TestSameRegisteredDomain(t *testing.T) {
 		{"example.co.uk", "example.com", false},
 		{"", "example.com", false},
 		{"EXAMPLE.com", "example.COM", true},
+		{"db.local", "db.local", true},
+		{"api.db.local", "www.db.local", true},
+		{"db.local", "other.local", false},
+		{"192.168.1.1", "192.168.1.1", true},
+		{"192.168.1.1", "192.168.1.2", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -475,6 +475,144 @@ func TestAnalyzeTraffic_ClassifiesBrowserClearanceReachability(t *testing.T) {
 	assert.Contains(t, analysis.GenerationHints, "requires_browser_auth")
 }
 
+func TestAnalyzeTraffic_IgnoresThirdPartyProtectionMarkersForReachability(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "https://www.skool.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api2.skool.com/self/groups",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"groups":[]}`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://js.stripe.com/v3/fingerprinted/js/controller.js",
+				ResponseStatus:      200,
+				ResponseContentType: "application/javascript",
+				ResponseBody:        `/* recaptcha challenge datadome perimeterx awswaf */`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://017ae153ccc5.edge.sdk.awswaf.com/017ae153ccc5/challenge.js",
+				ResponseStatus:      200,
+				ResponseContentType: "application/javascript",
+				ResponseBody:        `window.awsWafCookieDomainList = ["skool.com"];`,
+			},
+		},
+	}
+
+	analysis, err := AnalyzeTraffic(capture)
+	require.NoError(t, err)
+	require.NotNil(t, analysis.Reachability)
+
+	assert.Equal(t, "standard_http", analysis.Reachability.Mode)
+	assert.NotContains(t, protectionLabels(analysis.Protections), "captcha")
+	assert.NotContains(t, protectionLabels(analysis.Protections), "aws_waf")
+	assert.NotContains(t, analysis.GenerationHints, "requires_page_context")
+	assert.NotContains(t, analysis.GenerationHints, "requires_protected_client")
+}
+
+func TestAnalyzeTraffic_CountsFirstPartyChallengeScriptForReachability(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://assets.example.com/challenge.js",
+				ResponseStatus:      200,
+				ResponseContentType: "application/javascript",
+				ResponseBody:        `window.awsWafCookieDomainList = ["example.com"];`,
+			},
+		},
+	}
+
+	analysis, err := AnalyzeTraffic(capture)
+	require.NoError(t, err)
+	require.NotNil(t, analysis.Reachability)
+
+	assert.Equal(t, "browser_clearance_http", analysis.Reachability.Mode)
+	assert.Contains(t, protectionLabels(analysis.Protections), "aws_waf")
+	assert.Contains(t, analysis.GenerationHints, "browser_clearance_required")
+}
+
+func TestAnalyzeTraffic_CountsProtectionMarkersFromDiscoveredAPIHost(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api.vendor-cdn.com/items",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[]}`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://api.vendor-cdn.com/locked",
+				ResponseStatus:      403,
+				ResponseContentType: "text/html; charset=UTF-8",
+				ResponseHeaders:     map[string]string{"Server": "cloudflare", "CF-Mitigated": "challenge"},
+				ResponseBody:        `<html><title>Just a moment...</title><p>Cloudflare challenge</p></html>`,
+			},
+		},
+	}
+
+	analysis, err := AnalyzeTraffic(capture)
+	require.NoError(t, err)
+	require.NotNil(t, analysis.Reachability)
+
+	assert.Equal(t, "browser_clearance_http", analysis.Reachability.Mode)
+	assert.Contains(t, protectionLabels(analysis.Protections), "bot_challenge")
+	assert.Contains(t, analysis.GenerationHints, "browser_clearance_required")
+}
+
+func TestAnalyzeTraffic_InfersProtectionSiteFromAPIHostWhenTargetIsHostless(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "data:image/png;base64,AAAA",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/items",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[]}`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://www.example.com/challenge.js",
+				ResponseStatus:      200,
+				ResponseContentType: "application/javascript",
+				ResponseBody:        `window.awsWafCookieDomainList = ["example.com"];`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://js.stripe.com/v3/fingerprinted/js/controller.js",
+				ResponseStatus:      200,
+				ResponseContentType: "application/javascript",
+				ResponseBody:        `/* recaptcha challenge datadome */`,
+			},
+		},
+	}
+
+	analysis, err := AnalyzeTraffic(capture)
+	require.NoError(t, err)
+	require.NotNil(t, analysis.Reachability)
+
+	assert.Equal(t, "browser_clearance_http", analysis.Reachability.Mode)
+	assert.Contains(t, protectionLabels(analysis.Protections), "aws_waf")
+	assert.NotContains(t, protectionLabels(analysis.Protections), "captcha")
+}
+
 func TestAnalyzeTraffic_TreatsCaptchaPrecheckAsInformational(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Browser-sniff traffic analysis now ignores CAPTCHA, WAF, and bot-protection markers from unrelated third-party script hosts when deciding whether the target API requires live browser page context.

Protection evidence is now attributed to the captured target's HTTP(S) site and to hosts that actually served API traffic, so first-party challenge scripts and discovered API-host challenges still drive `browser_clearance_http` while Stripe, reCAPTCHA, ad-tech, and tracker assets no longer promote the whole capture to `browser_required`.

Closes #1628

## Compounded learnings

- File: `docs/solutions/logic-errors/third-party-protection-markers-reachability.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with `captcha-precheck-challenge-classification-2026-05-21.md`
- Instruction-file edit: none needed
- Refresh recommendation: none

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/browsersniff -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
