### PR TITLE
fix(cli): follow one-hop client helpers in reimplementation check

### DIFF
--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -568,6 +568,7 @@ func scanCommandHandler(content, leaf string) commandHandlerScan {
 		return commandHandlerScan{}
 	}
 	imports := clientImportAliases(file)
+	cobraAliases := cobraImportAliases(file)
 	var scan commandHandlerScan
 	ast.Inspect(file, func(n ast.Node) bool {
 		if scan.ok {
@@ -577,7 +578,7 @@ func scanCommandHandler(content, leaf string) commandHandlerScan {
 		if !ok {
 			return true
 		}
-		handler := commandHandlerForLeaf(lit, leaf)
+		handler := commandHandlerForLeaf(lit, leaf, cobraAliases)
 		if handler == nil || handler.Body == nil {
 			return true
 		}
@@ -597,8 +598,8 @@ func scanCommandHandler(content, leaf string) commandHandlerScan {
 	return scan
 }
 
-func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
-	if !isCommandCompositeType(lit.Type) {
+func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string, cobraAliases map[string]bool) *ast.FuncLit {
+	if !isCommandCompositeType(lit.Type, cobraAliases) {
 		return nil
 	}
 	matchesLeaf := false
@@ -635,14 +636,33 @@ func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
 	return nil
 }
 
-func isCommandCompositeType(expr ast.Expr) bool {
+func cobraImportAliases(file *ast.File) map[string]bool {
+	aliases := map[string]bool{}
+	for _, spec := range file.Imports {
+		importPath := strings.Trim(spec.Path.Value, "`\"")
+		if importPath != "github.com/spf13/cobra" {
+			continue
+		}
+		if spec.Name != nil {
+			if spec.Name.Name != "_" {
+				aliases[spec.Name.Name] = true
+			}
+			continue
+		}
+		aliases["cobra"] = true
+	}
+	return aliases
+}
+
+func isCommandCompositeType(expr ast.Expr, cobraAliases map[string]bool) bool {
 	switch e := expr.(type) {
 	case *ast.Ident:
-		return e.Name == "Command"
+		return e.Name == "Command" && cobraAliases["."]
 	case *ast.SelectorExpr:
-		return e.Sel.Name == "Command"
+		id, ok := e.X.(*ast.Ident)
+		return ok && e.Sel.Name == "Command" && cobraAliases[id.Name]
 	case *ast.StarExpr:
-		return isCommandCompositeType(e.X)
+		return isCommandCompositeType(e.X, cobraAliases)
 	default:
 		return false
 	}

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -334,7 +334,7 @@ func classifyReimplementation(leaf string, files []string, fileContent map[strin
 		if callsClientHelper(clientScanContent, clientHelpers) {
 			hasClient = true
 		}
-		if commandScan.ok && hasBlockClientSignal(commandScan.bodyNode, commandScan.imports) {
+		if commandScan.ok && hasBlockClientSignal(commandScan.bodyNode, commandScan.imports, true) {
 			hasClient = true
 		} else if !commandScan.ok && hasClientSignal(content) {
 			hasClient = true
@@ -472,10 +472,10 @@ func importAlias(spec *ast.ImportSpec, importPath string) string {
 }
 
 func hasFunctionClientSignal(fn *ast.FuncDecl, imports map[string]clientImportKind) bool {
-	return hasBlockClientSignal(fn.Body, imports)
+	return hasBlockClientSignal(fn.Body, imports, false)
 }
 
-func hasBlockClientSignal(body *ast.BlockStmt, imports map[string]clientImportKind) bool {
+func hasBlockClientSignal(body *ast.BlockStmt, imports map[string]clientImportKind, allowAnySiblingSelector bool) bool {
 	if body == nil {
 		return false
 	}
@@ -488,7 +488,7 @@ func hasBlockClientSignal(body *ast.BlockStmt, imports map[string]clientImportKi
 		if !ok {
 			return true
 		}
-		if isPrimitiveClientCall(call.Fun) || isImportedClientCall(call.Fun, imports) {
+		if isPrimitiveClientCall(call.Fun) || isImportedClientCall(call.Fun, imports, allowAnySiblingSelector) {
 			found = true
 			return false
 		}
@@ -528,7 +528,7 @@ func isPrimitiveClientCall(expr ast.Expr) bool {
 	return false
 }
 
-func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind) bool {
+func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind, allowAnySiblingSelector bool) bool {
 	parts := selectorParts(expr)
 	if len(parts) < 2 {
 		return false
@@ -538,6 +538,9 @@ func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind) bo
 		return false
 	}
 	if kind == generatedClientImport {
+		return true
+	}
+	if allowAnySiblingSelector {
 		return true
 	}
 	return isSiblingClientSelector(parts[len(parts)-1])

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -20,7 +21,7 @@ import (
 // The check is structural, not semantic. It looks at the file that
 // implements the command and asks: does any part of this file call
 // through the generated client package, read from the generated store package,
-// or call a package-local helper that reaches the store? If none do, the
+// or call a package-local helper that reaches the store or API client? If none do, the
 // command is flagged. Primitive client/store signals stay regex-based; helper
 // discovery uses Go AST parsing so declarations and comments do not look like
 // real helper calls.
@@ -207,6 +208,7 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 
 	result := ReimplementationCheckResult{}
 	storeHelpers := storeHelperNames(helperContent)
+	clientHelpers := clientHelperNames(helperContent)
 	for _, nf := range research.NovelFeatures {
 		leaf := lastPathSegment(commandPath(nf.Command))
 		if leaf == "" {
@@ -222,7 +224,7 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 		// and take the most favorable classification - any single file
 		// with the right signals vindicates the command.
 		result.Checked++
-		finding, kind, ok := classifyReimplementation(files, fileContent, storeHelpers)
+		finding, kind, ok := classifyReimplementation(leaf, files, fileContent, storeHelpers, clientHelpers)
 		switch kind {
 		case exemptStore:
 			result.ExemptedViaStore++
@@ -303,7 +305,7 @@ const (
 //
 // The trivial-body regex is consulted only when rule 5 fires, to pick
 // between "empty stub" and "hand-rolled response" as the reason.
-func classifyReimplementation(files []string, fileContent map[string]string, storeHelpers map[string]bool) (ReimplementationFinding, exemptionKind, bool) {
+func classifyReimplementation(leaf string, files []string, fileContent map[string]string, storeHelpers, clientHelpers map[string]bool) (ReimplementationFinding, exemptionKind, bool) {
 	hasClient := false
 	hasTrivialBody := false
 	primaryFile := files[0]
@@ -324,7 +326,17 @@ func classifyReimplementation(files []string, fileContent map[string]string, sto
 		if callsStoreHelper(content, storeHelpers) {
 			return ReimplementationFinding{File: f}, exemptStore, true
 		}
-		if hasClientSignal(content) {
+		commandScan := scanCommandHandler(content, leaf)
+		clientScanContent := content
+		if commandScan.ok {
+			clientScanContent = commandScan.body
+		}
+		if callsClientHelper(clientScanContent, clientHelpers) {
+			hasClient = true
+		}
+		if commandScan.ok && hasBlockClientSignal(commandScan.bodyNode, commandScan.imports) {
+			hasClient = true
+		} else if !commandScan.ok && hasClientSignal(content) {
 			hasClient = true
 		}
 		if trivialBodyRe.MatchString(content) {
@@ -376,6 +388,273 @@ func storeHelperNames(fileContent map[string]string) map[string]bool {
 	return helpers
 }
 
+type clientImportKind int
+
+const (
+	generatedClientImport clientImportKind = iota + 1
+	siblingClientImport
+)
+
+func clientHelperNames(fileContent map[string]string) map[string]bool {
+	helpers := map[string]bool{}
+	for _, content := range fileContent {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "", content, 0)
+		if err != nil {
+			continue
+		}
+		imports := clientImportAliases(file)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			// Client helper discovery is intentionally one hop: command -> helper
+			// -> client. Deeper chains use the pp:client-call escape hatch.
+			if hasFunctionClientSignal(fn, imports) {
+				helpers[fn.Name.Name] = true
+			}
+		}
+	}
+	return helpers
+}
+
+func clientImportAliases(file *ast.File) map[string]clientImportKind {
+	aliases := map[string]clientImportKind{}
+	for _, spec := range file.Imports {
+		importPath := strings.Trim(spec.Path.Value, "`\"")
+		if importPath == "" {
+			continue
+		}
+		internalName, isInternal := internalPackageName(importPath)
+		kind := clientImportKind(0)
+		switch {
+		case strings.HasSuffix(importPath, "/internal/client"):
+			kind = generatedClientImport
+		case isInternal && !reservedInternalPackages[internalName]:
+			kind = siblingClientImport
+		default:
+			continue
+		}
+		alias := importAlias(spec, importPath)
+		if alias != "" {
+			aliases[alias] = kind
+		}
+	}
+	return aliases
+}
+
+func internalPackageName(importPath string) (string, bool) {
+	_, rest, ok := strings.Cut(importPath, "/internal/")
+	if !ok {
+		return "", false
+	}
+	if rest == "" {
+		return "", false
+	}
+	name, _, _ := strings.Cut(rest, "/")
+	return name, name != ""
+}
+
+func importAlias(spec *ast.ImportSpec, importPath string) string {
+	if spec.Name != nil {
+		switch spec.Name.Name {
+		case ".", "_":
+			return ""
+		default:
+			return spec.Name.Name
+		}
+	}
+	if idx := strings.LastIndex(importPath, "/"); idx >= 0 {
+		return importPath[idx+1:]
+	}
+	return importPath
+}
+
+func hasFunctionClientSignal(fn *ast.FuncDecl, imports map[string]clientImportKind) bool {
+	return hasBlockClientSignal(fn.Body, imports)
+}
+
+func hasBlockClientSignal(body *ast.BlockStmt, imports map[string]clientImportKind) bool {
+	if body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isPrimitiveClientCall(call.Fun) || isImportedClientCall(call.Fun, imports) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isPrimitiveClientCall(expr ast.Expr) bool {
+	parts := selectorParts(expr)
+	if len(parts) < 2 {
+		return false
+	}
+	root := parts[0]
+	last := parts[len(parts)-1]
+	if root == "flags" && last == "newClient" {
+		return true
+	}
+	if root == "http" {
+		switch last {
+		case "Get", "Post", "NewRequest", "NewRequestWithContext", "Do":
+			return true
+		}
+	}
+	if root == "c" {
+		switch last {
+		case "Do", "Get", "Post":
+			return true
+		}
+	}
+	if last == "Do" && len(parts) >= 3 {
+		switch parts[len(parts)-2] {
+		case "HTTPClient", "HTTP":
+			return true
+		}
+	}
+	return false
+}
+
+func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind) bool {
+	parts := selectorParts(expr)
+	if len(parts) < 2 {
+		return false
+	}
+	kind, ok := imports[parts[0]]
+	if !ok {
+		return false
+	}
+	if kind == generatedClientImport {
+		return true
+	}
+	return isSiblingClientSelector(parts[len(parts)-1])
+}
+
+func isSiblingClientSelector(name string) bool {
+	switch name {
+	case "NewClient", "NewRequest", "NewRequestWithContext", "Get", "Post", "Do":
+		return true
+	default:
+		return strings.HasPrefix(name, "Fetch")
+	}
+}
+
+func selectorParts(expr ast.Expr) []string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return []string{e.Name}
+	case *ast.SelectorExpr:
+		parts := selectorParts(e.X)
+		if len(parts) == 0 {
+			return nil
+		}
+		return append(parts, e.Sel.Name)
+	case *ast.ParenExpr:
+		return selectorParts(e.X)
+	default:
+		return nil
+	}
+}
+
+type commandHandlerScan struct {
+	body     string
+	bodyNode *ast.BlockStmt
+	imports  map[string]clientImportKind
+	ok       bool
+}
+
+func scanCommandHandler(content, leaf string) commandHandlerScan {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", content, 0)
+	if err != nil {
+		return commandHandlerScan{}
+	}
+	imports := clientImportAliases(file)
+	var scan commandHandlerScan
+	ast.Inspect(file, func(n ast.Node) bool {
+		if scan.ok {
+			return false
+		}
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		handler := commandHandlerForLeaf(lit, leaf)
+		if handler == nil || handler.Body == nil {
+			return true
+		}
+		start := fset.Position(handler.Body.Pos()).Offset
+		end := fset.Position(handler.Body.End()).Offset
+		if start < 0 || end > len(content) || start >= end {
+			return true
+		}
+		scan = commandHandlerScan{
+			body:     content[start:end],
+			bodyNode: handler.Body,
+			imports:  imports,
+			ok:       true,
+		}
+		return false
+	})
+	return scan
+}
+
+func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
+	matchesLeaf := false
+	var handler *ast.FuncLit
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Use":
+			matchesLeaf = useExprLeaf(kv.Value) == leaf
+		case "Run", "RunE":
+			if fn, ok := kv.Value.(*ast.FuncLit); ok {
+				handler = fn
+			}
+		}
+	}
+	if matchesLeaf {
+		return handler
+	}
+	return nil
+}
+
+func useExprLeaf(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok {
+		return ""
+	}
+	use, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(use)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
 func forEachGoFuncContent(content string, visit func(name, body string)) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "", content, 0)
@@ -396,13 +675,26 @@ func forEachGoFuncContent(content string, visit func(name, body string)) {
 	}
 }
 
+func callsClientHelper(content string, helpers map[string]bool) bool {
+	return callsHelper(content, helpers)
+}
+
 func callsStoreHelper(content string, helpers map[string]bool) bool {
+	return callsHelper(content, helpers)
+}
+
+func callsHelper(content string, helpers map[string]bool) bool {
 	if len(helpers) == 0 {
 		return false
 	}
 	source := content
-	if !strings.HasPrefix(strings.TrimSpace(source), "package ") {
-		source = "package cli\n" + source
+	trimmed := strings.TrimSpace(source)
+	if !strings.HasPrefix(trimmed, "package ") {
+		if strings.HasPrefix(trimmed, "{") {
+			source = "package cli\nfunc _() " + trimmed
+		} else {
+			source = "package cli\n" + source
+		}
 	}
 	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
 	if err != nil {

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -598,6 +598,9 @@ func scanCommandHandler(content, leaf string) commandHandlerScan {
 }
 
 func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
+	if !isCommandCompositeType(lit.Type) {
+		return nil
+	}
 	matchesLeaf := false
 	var runHandler *ast.FuncLit
 	var runEHandler *ast.FuncLit
@@ -630,6 +633,19 @@ func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
 		return runHandler
 	}
 	return nil
+}
+
+func isCommandCompositeType(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "Command"
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "Command"
+	case *ast.StarExpr:
+		return isCommandCompositeType(e.X)
+	default:
+		return false
+	}
 }
 
 func useExprLeaf(expr ast.Expr) string {

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -617,7 +617,8 @@ func scanCommandHandler(content, leaf string) commandHandlerScan {
 
 func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
 	matchesLeaf := false
-	var handler *ast.FuncLit
+	var runHandler *ast.FuncLit
+	var runEHandler *ast.FuncLit
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
@@ -630,14 +631,21 @@ func commandHandlerForLeaf(lit *ast.CompositeLit, leaf string) *ast.FuncLit {
 		switch key.Name {
 		case "Use":
 			matchesLeaf = useExprLeaf(kv.Value) == leaf
-		case "Run", "RunE":
+		case "Run":
 			if fn, ok := kv.Value.(*ast.FuncLit); ok {
-				handler = fn
+				runHandler = fn
+			}
+		case "RunE":
+			if fn, ok := kv.Value.(*ast.FuncLit); ok {
+				runEHandler = fn
 			}
 		}
 	}
 	if matchesLeaf {
-		return handler
+		if runEHandler != nil {
+			return runEHandler
+		}
+		return runHandler
 	}
 	return nil
 }

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -507,25 +507,7 @@ func isPrimitiveClientCall(expr ast.Expr) bool {
 	if root == "flags" && last == "newClient" {
 		return true
 	}
-	if root == "http" {
-		switch last {
-		case "Get", "Post", "NewRequest", "NewRequestWithContext", "Do":
-			return true
-		}
-	}
-	if root == "c" {
-		switch last {
-		case "Do", "Get", "Post":
-			return true
-		}
-	}
-	if last == "Do" && len(parts) >= 3 {
-		switch parts[len(parts)-2] {
-		case "HTTPClient", "HTTP":
-			return true
-		}
-	}
-	return false
+	return outboundHTTPCallRe.MatchString(strings.Join(parts, ".") + "(")
 }
 
 func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind, allowAnySiblingSelector bool) bool {

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -1086,6 +1086,55 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_IgnoresNonCobraCommandLikeLiteral_Passes(t *testing.T) {
+	files := map[string]string{
+		"search.go": `package cli
+
+import (
+	"example.com/mod/internal/algolia"
+	"github.com/spf13/cobra"
+)
+
+type commandExample struct {
+	Use string
+	RunE func(*cobra.Command, []string) error
+}
+
+var misleadingExample = commandExample{
+	Use: "search",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.Println(` + "`" + `{"status":"example"}` + "`" + `)
+		return nil
+	},
+}
+
+func newSearchCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "search",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ac := algolia.New(flags.timeout)
+			rows, err := ac.Search(cmd.Context(), args[0])
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Search", Command: "search"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 // TestCheckReimplementation_WithoutMarker_StillFlagged confirms the
 // F3 fix doesn't silently exempt commands that lack the explicit
 // `// pp:novel-static-reference` marker. Same shape as the test above

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -704,6 +704,313 @@ func newFlightsCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_ClientHelperHop_Passes(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+import "example.com/mod/internal/rappi"
+
+func fetchRestaurantListPage(city, category string) ([]rappi.RestaurantListItem, error) {
+	c := rappi.NewClient()
+	return c.FetchHTML(city, category)
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if got.ExemptedViaClientDirective != 0 {
+		t.Fatalf("ExemptedViaClientDirective: want 0 (no marker needed), got %d", got.ExemptedViaClientDirective)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_HardcodedHelperHop_Flagged(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+type RestaurantListItem struct {
+	Name string
+}
+
+func fetchRestaurantListPage(city, category string) ([]RestaurantListItem, error) {
+	return []RestaurantListItem{{Name: "Hardcoded"}}, nil
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if got.ExemptedViaClientDirective != 0 {
+		t.Fatalf("ExemptedViaClientDirective: want 0, got %d", got.ExemptedViaClientDirective)
+	}
+	if len(got.Suspicious) != 1 {
+		t.Fatalf("Suspicious: want 1, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+	if got.Suspicious[0].Command != "restaurants-top" {
+		t.Fatalf("Command: want restaurants-top, got %s", got.Suspicious[0].Command)
+	}
+}
+
+func TestCheckReimplementation_OutboundHTTPHelperHop_Passes(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+import "net/http"
+
+func fetchRestaurantListPage(city, category string) (*http.Response, error) {
+	return http.Get("https://example.test/restaurants")
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = resp
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_TwoHopClientHelper_Flagged(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+import "example.com/mod/internal/rappi"
+
+func fetchRestaurantListPage(city, category string) ([]rappi.RestaurantListItem, error) {
+	return requestRestaurantListPage(city, category)
+}
+
+func requestRestaurantListPage(city, category string) ([]rappi.RestaurantListItem, error) {
+	c := rappi.NewClient()
+	return c.FetchHTML(city, category)
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 1 {
+		t.Fatalf("Suspicious: want 1 (deeper helper chains need pp:client-call), got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+	if got.Suspicious[0].Command != "restaurants-top" {
+		t.Fatalf("Command: want restaurants-top, got %s", got.Suspicious[0].Command)
+	}
+}
+
+func TestCheckReimplementation_SameFileTwoHopClientHelper_Flagged(t *testing.T) {
+	files := map[string]string{
+		"restaurants_top.go": `package cli
+
+import (
+	"example.com/mod/internal/rappi"
+	"github.com/spf13/cobra"
+)
+
+func fetchRestaurantListPage(city, category string) ([]rappi.RestaurantListItem, error) {
+	return requestRestaurantListPage(city, category)
+}
+
+func requestRestaurantListPage(city, category string) ([]rappi.RestaurantListItem, error) {
+	c := rappi.NewClient()
+	return c.FetchHTML(city, category)
+}
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 1 {
+		t.Fatalf("Suspicious: want 1 (same-file deeper helper chains need pp:client-call), got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_CommentedClientCallInHelper_Flagged(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+type RestaurantListItem struct {
+	Name string
+}
+
+func fetchRestaurantListPage(city, category string) ([]RestaurantListItem, error) {
+	// TODO: replace the hardcoded data with http.Get("https://example.test/restaurants")
+	return []RestaurantListItem{{Name: "Hardcoded"}}, nil
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 1 {
+		t.Fatalf("Suspicious: want 1, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_SiblingInternalUtilityHelper_Flagged(t *testing.T) {
+	files := map[string]string{
+		"novel_helpers.go": `package cli
+
+import "example.com/mod/internal/fixtures"
+
+func fetchRestaurantListPage(city, category string) ([]fixtures.RestaurantListItem, error) {
+	return fixtures.TopRestaurants(), nil
+}
+`,
+		"restaurants_top.go": `package cli
+
+import "github.com/spf13/cobra"
+
+func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "restaurants-top",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rows, err := fetchRestaurantListPage("mx", "pizza")
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Restaurants top", Command: "restaurants-top"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 1 {
+		t.Fatalf("Suspicious: want 1, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 // TestCheckReimplementation_WithoutMarker_StillFlagged confirms the
 // F3 fix doesn't silently exempt commands that lack the explicit
 // `// pp:novel-static-reference` marker. Same shape as the test above

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -1047,6 +1047,45 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_RunEPriorityOverRun_Passes(t *testing.T) {
+	files := map[string]string{
+		"search.go": `package cli
+
+import (
+	"example.com/mod/internal/algolia"
+	"github.com/spf13/cobra"
+)
+
+func newSearchCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "search",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ac := algolia.New(flags.timeout)
+			rows, err := ac.Search(cmd.Context(), args[0])
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println(` + "`" + `{"status":"cached"}` + "`" + `)
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Search", Command: "search"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 // TestCheckReimplementation_WithoutMarker_StillFlagged confirms the
 // F3 fix doesn't silently exempt commands that lack the explicit
 // `// pp:novel-static-reference` marker. Same shape as the test above

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -1011,6 +1011,42 @@ func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_DirectSiblingInternalClient_Passes(t *testing.T) {
+	files := map[string]string{
+		"search.go": `package cli
+
+import (
+	"example.com/mod/internal/algolia"
+	"github.com/spf13/cobra"
+)
+
+func newSearchCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "search",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ac := algolia.New(flags.timeout)
+			rows, err := ac.Search(cmd.Context(), args[0])
+			if err != nil { return err }
+			_ = rows
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Search", Command: "search"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 // TestCheckReimplementation_WithoutMarker_StillFlagged confirms the
 // F3 fix doesn't silently exempt commands that lack the explicit
 // `// pp:novel-static-reference` marker. Same shape as the test above

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -1095,12 +1095,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type commandExample struct {
+type Command struct {
 	Use string
 	RunE func(*cobra.Command, []string) error
 }
 
-var misleadingExample = commandExample{
+var misleadingExample = Command{
 	Use: "search",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.Println(` + "`" + `{"status":"example"}` + "`" + `)


### PR DESCRIPTION
## Summary
Dogfood now recognizes novel command handlers that delegate to a package-local helper making a real client or outbound HTTP call, so helper-backed commands no longer need mechanical `// pp:client-call` annotations just to satisfy `reimplementation_check`.

The check stays bounded to one command-to-helper hop. Deeper helper chains still require the explicit `pp:client-call` assertion, and hardcoded helper responses remain suspicious.

## Verification
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #1643
