### PR TITLE
fix(cli): sync chained dependent resources

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -644,34 +644,9 @@ type HelperFlags struct {
 func computeHelperFlags(s *spec.APISpec) HelperFlags {
 	var flags HelperFlags
 	for _, r := range s.Resources {
-		for _, e := range r.Endpoints {
-			if strings.EqualFold(e.Method, "DELETE") {
-				flags.HasDelete = true
-			}
-			if isMutationMethod(e.Method) {
-				flags.HasMutationEndpoints = true
-			}
-			if endpointNeedsClientLimit(e) {
-				flags.HasClientLimit = true
-			}
-			if len(e.EmbeddedPagedSubresources) > 0 {
-				flags.HasEmbeddedPaged = true
-			}
-			positionalCount := 0
-			for _, p := range e.Params {
-				if p.Positional || p.PathParam {
-					flags.HasPathParams = true
-				}
-				if p.Positional {
-					positionalCount++
-				}
-			}
-			if positionalCount >= 2 {
-				flags.HasMultiPositional = true
-			}
-		}
-		for _, sub := range r.SubResources {
-			for _, e := range sub.Endpoints {
+		var scan func(spec.Resource)
+		scan = func(resource spec.Resource) {
+			for _, e := range resource.Endpoints {
 				if strings.EqualFold(e.Method, "DELETE") {
 					flags.HasDelete = true
 				}
@@ -683,6 +658,9 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 				}
 				if len(e.EmbeddedPagedSubresources) > 0 {
 					flags.HasEmbeddedPaged = true
+				}
+				if strings.Contains(e.Path, "{") {
+					flags.HasPathParams = true
 				}
 				positionalCount := 0
 				for _, p := range e.Params {
@@ -697,7 +675,11 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 					flags.HasMultiPositional = true
 				}
 			}
+			for _, sub := range resource.SubResources {
+				scan(sub)
+			}
 		}
+		scan(r)
 	}
 	return flags
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4463,6 +4463,164 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "-run", "TestSyncDependentResourcePopulatesTypedParentFK", "./internal/cli")
 }
 
+func TestSyncDependentResourceSubstitutesChainedPathParams(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("dependent-chained-params")
+	apiSpec.Resources = map[string]spec.Resource{
+		"channels": {
+			Description: "Channels",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/channels",
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+		"messages": {
+			Description: "Messages",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/channels/{channelId}/messages",
+					Response: spec.ResponseDef{Type: "array"},
+					Params:   []spec.Param{{Name: "channelId", Type: "string", Required: true, Positional: true}},
+				},
+			},
+		},
+		"reactions": {
+			Description: "Reactions",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/channels/{channelId}/messages/{messageId}/reactions",
+					Response: spec.ResponseDef{Type: "array"},
+					Params: []spec.Param{
+						{Name: "channelId", Type: "string", Required: true, Positional: true},
+						{Name: "messageId", Type: "string", Required: true, Positional: true},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "channels", Path: "/channels", Method: "GET"},
+		},
+		DependentSyncResources: []profiler.DependentResource{
+			{
+				Name:           "messages",
+				ParentResource: "channels",
+				ParentIDParam:  "channelId",
+				Path:           "/channels/{channelId}/messages",
+				Method:         "GET",
+				PathParams:     []profiler.DependentPathParam{{Param: "channelId", Field: "id"}},
+			},
+			{
+				Name:           "messages_reactions",
+				ParentResource: "messages",
+				ParentIDParam:  "messageId",
+				Path:           "/channels/{channelId}/messages/{messageId}/reactions",
+				Method:         "GET",
+				PathParams: []profiler.DependentPathParam{
+					{Param: "channelId", Field: "channels_id"},
+					{Param: "messageId", Field: "id"},
+				},
+			},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type dependentChainedParamClient struct {
+	t *testing.T
+}
+
+func (c dependentChainedParamClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	if path != "/channels/chan-1/messages/msg-1/reactions" {
+		c.t.Fatalf("path = %q, want /channels/chan-1/messages/msg-1/reactions", path)
+	}
+	return json.RawMessage(` + "`" + `[{"id":"react-1","emoji":"thumbsup"}]` + "`" + `), nil
+}
+
+func (dependentChainedParamClient) RateLimit() float64 {
+	return 0
+}
+
+func TestSyncDependentResourceSubstitutesChainedPathParams(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("messages", "msg-1", []byte(` + "`" + `{"id":"msg-1","channels_id":"chan-1","text":"hello"}` + "`" + `)); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	res := syncDependentResource(
+		context.Background(),
+		dependentChainedParamClient{t: t},
+		db,
+		dependentResourceDef{
+			Name: "messages_reactions",
+			ParentTable: "messages",
+			ParentIDParam: "messageId",
+			PathTemplate: "/channels/{channelId}/messages/{messageId}/reactions",
+			PathParams: []dependentPathParamDef{
+				{Param: "channelId", Field: "channels_id"},
+				{Param: "messageId", Field: "id"},
+			},
+		},
+		"", false, 1, false, nil, nil,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("synced count = %d, want 1", res.Count)
+	}
+
+	rows, err := db.DB().Query(` + "`" + `SELECT id, json_extract(data, '$.messages_id'), json_extract(data, '$.channels_id') FROM resources WHERE resource_type = 'messages_reactions'` + "`" + `)
+	if err != nil {
+		t.Fatalf("query reactions: %v", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		t.Fatalf("expected one reaction row")
+	}
+	var id, messagesID, channelsID string
+	if err := rows.Scan(&id, &messagesID, &channelsID); err != nil {
+		t.Fatalf("scan reaction: %v", err)
+	}
+	if id != "react-1" || messagesID != "msg-1" || channelsID != "chan-1" {
+		t.Fatalf("row = (%q, %q, %q), want (react-1, msg-1, chan-1)", id, messagesID, channelsID)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "cli", "dependent_chained_params_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestSyncDependentResourceSubstitutesChainedPathParams", "./internal/cli")
+}
+
 func TestGenerateSimilarCommandUsesCompositeResourceKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1210,6 +1210,71 @@ func (s *Store) ListField(resourceType, field string) ([]string, error) {
 	return values, rows.Err()
 }
 
+// ListFieldSets returns row-correlated values from the generic resources
+// table. Dependent sync uses this for multi-placeholder paths where values
+// such as owner/repo or server/webapp must stay paired per parent row.
+func (s *Store) ListFieldSets(resourceType string, fields []string) ([]map[string]string, error) {
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	for _, field := range fields {
+		if !validIdentifierRE.MatchString(field) {
+			return nil, fmt.Errorf("ListFieldSets: invalid field name %q (must match %s)", field, validIdentifierRE.String())
+		}
+	}
+
+	rows, err := s.db.Query(`SELECT id, data FROM resources WHERE resource_type = ?`, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []map[string]string
+	seenRows := map[string]bool{}
+	for rows.Next() {
+		var id string
+		var data []byte
+		if err := rows.Scan(&id, &data); err != nil {
+			return nil, err
+		}
+		var obj map[string]any
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, fmt.Errorf("decode %s parent row %s: %w", resourceType, id, err)
+			}
+		}
+		values := make(map[string]string, len(fields))
+		complete := true
+		for _, field := range fields {
+			var value any
+			if field == "id" {
+				value = id
+			} else {
+				value = LookupFieldValue(obj, field)
+			}
+			valueString := fmt.Sprint(value)
+			if value == nil || valueString == "" {
+				complete = false
+				break
+			}
+			values[field] = valueString
+		}
+		if complete {
+			keyParts := make([]string, 0, len(fields))
+			for _, field := range fields {
+				keyParts = append(keyParts, values[field])
+			}
+			key := strings.Join(keyParts, "\x00")
+			if seenRows[key] {
+				continue
+			}
+			seenRows[key] = true
+			out = append(out, values)
+		}
+	}
+	return out, rows.Err()
+}
+
 // GetLastSyncedAt returns the last sync timestamp for a resource type.
 func (s *Store) GetLastSyncedAt(resourceType string) string {
 	var ts sql.NullString

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1847,19 +1847,29 @@ func syncClientForResource(c *client.Client, resource string) *client.Client {
 // records' KeyField via json_extract rather than from the parent table's primary key.
 // Populated from a spec-declared walker (Endpoint.Walker.KeyField in internal YAML,
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
-// existing parent-primary-key flow byte-for-byte.
+// parent-primary-key flow.
 type dependentResourceDef struct {
 	Name          string
 	ParentTable   string
 	ParentIDParam string
 	PathTemplate  string
 	KeyField      string
+	PathParams    []dependentPathParamDef
+}
+
+type dependentPathParamDef struct {
+	Param string
+	Field string
 }
 
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 {{- range .DependentSyncResources}}
-		{Name: "{{.Name}}", ParentTable: "{{.ParentResource}}", ParentIDParam: "{{.ParentIDParam}}", PathTemplate: "{{.Path}}", KeyField: "{{.KeyField}}"},
+		{Name: "{{.Name}}", ParentTable: "{{.ParentResource}}", ParentIDParam: "{{.ParentIDParam}}", PathTemplate: "{{.Path}}", KeyField: "{{.KeyField}}"{{if .PathParams}}, PathParams: []dependentPathParamDef{
+{{- range .PathParams}}
+			{Param: "{{.Param}}", Field: "{{.Field}}"},
+{{- end}}
+		}{{end}}},
 {{- end}}
 	}
 }
@@ -1912,21 +1922,17 @@ func syncDependentResource(ctx context.Context, c interface {
 		syncEvents = io.Discard
 	}
 
-	// Query parent table for the keys to substitute into the child path.
-	// When KeyField is empty, use the parent's primary key via ListIDs
-	// (the original flat parent-child flow). When KeyField is set, the
-	// spec declared a walker that extracts a non-PK field from each parent
-	// record — ListField looks up the field in the parent's typed column
-	// if present, otherwise json_extract from the generic resources table.
-	var parentIDs []string
-	var err error
-	if dep.KeyField != "" {
-		parentIDs, err = db.ListField(dep.ParentTable, dep.KeyField)
-	} else {
-		parentIDs, err = db.ListIDs(dep.ParentTable)
+	pathParams := dep.PathParams
+	if len(pathParams) == 0 {
+		field := "id"
+		if dep.KeyField != "" {
+			field = dep.KeyField
+		}
+		pathParams = []dependentPathParamDef{{"{{"}}Param: dep.ParentIDParam, Field: field}}
 	}
-	if err != nil || len(parentIDs) == 0 {
-		if len(parentIDs) == 0 {
+	parentRows, err := dependentParentRows(db, dep.ParentTable, pathParams)
+	if err != nil || len(parentRows) == 0 {
+		if len(parentRows) == 0 {
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "  %s: skipping (parent table %s is empty, sync it first)\n", dep.Name, dep.ParentTable)
 			}
@@ -1936,7 +1942,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 
 	if humanFriendly {
-		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentIDs), dep.ParentTable)
+		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentRows), dep.ParentTable)
 	}
 
 	var totalCount int
@@ -1971,13 +1977,19 @@ func syncDependentResource(ctx context.Context, c interface {
 	depAnomalyEmitted := false
 	parentFKKey := dep.ParentTable + "_id"
 
-	for idx, parentID := range parentIDs {
+	for idx, parentRow := range parentRows {
+		parentID := parentRow["id"]
+		if parentID == "" {
+			parentID = parentRow[pathParams[0].Field]
+		}
 		parentIDJSON, _ := json.Marshal(parentID)
-		// Build child endpoint path by replacing the param placeholder
-		path := strings.Replace(dep.PathTemplate, "{"+dep.ParentIDParam+"}", parentID, 1)
+		path := dep.PathTemplate
+		for _, pathParam := range pathParams {
+			path = replacePathParam(path, pathParam.Param, parentRow[pathParam.Field])
+		}
 
 		if humanFriendly {
-			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentIDs))
+			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentRows))
 		}
 
 		cursor := ""
@@ -2102,6 +2114,16 @@ func syncDependentResource(ctx context.Context, c interface {
 					if _, ok := obj[parentFKKey]; !ok {
 						obj[parentFKKey] = parentIDJSON
 					}
+					for _, pathParam := range pathParams {
+						if pathParam.Field == "id" {
+							continue
+						}
+						if _, ok := obj[pathParam.Field]; ok {
+							continue
+						}
+						valueJSON, _ := json.Marshal(parentRow[pathParam.Field])
+						obj[pathParam.Field] = valueJSON
+					}
 					if modified, err := json.Marshal(obj); err == nil {
 						items[i] = modified
 					}
@@ -2210,15 +2232,55 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
-	if deniedParents == len(parentIDs) && totalCount == 0 && firstDenial != nil {
+	if deniedParents == len(parentRows) && totalCount == 0 && firstDenial != nil {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentIDs)),
+			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}
 	return syncResult{Resource: dep.Name, Count: totalCount, Duration: time.Since(started)}
+}
+
+func dependentParentFields(pathParams []dependentPathParamDef) []string {
+	fields := []string{"id"}
+	seen := map[string]bool{"id": true}
+	for _, pathParam := range pathParams {
+		if pathParam.Field == "" || seen[pathParam.Field] {
+			continue
+		}
+		fields = append(fields, pathParam.Field)
+		seen[pathParam.Field] = true
+	}
+	return fields
+}
+
+func dependentParentRows(db *store.Store, parentTable string, pathParams []dependentPathParamDef) ([]map[string]string, error) {
+	fields := dependentParentFields(pathParams)
+	if len(fields) == 1 {
+		values, err := db.ListIDs(parentTable)
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value})
+		}
+		return rows, nil
+	}
+	if len(pathParams) == 1 && len(fields) == 2 && fields[0] == "id" {
+		values, err := db.ListField(parentTable, fields[1])
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value, fields[1]: value})
+		}
+		return rows, nil
+	}
+	return db.ListFieldSets(parentTable, fields)
 }
 {{- end}}
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2,6 +2,7 @@ package profiler
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -155,6 +156,7 @@ type DependentResource struct {
 	Path           string // full path template, e.g. "/channels/{channel_id}/messages"
 	Method         string
 	Tier           string
+	PathParams     []DependentPathParam
 
 	// IDField is the primary-key field name resolved from the spec
 	// (x-resource-id extension or the four-tier fallback chain). Empty when
@@ -206,6 +208,11 @@ type DependentResource struct {
 	// in internal YAML, or the `key_field` key under `x-pp-sync-walker` in
 	// OpenAPI). When empty, the existing parent-primary-key flow runs.
 	KeyField string
+}
+
+type DependentPathParam struct {
+	Param string
+	Field string
 }
 
 // APIProfile describes the shape of an API and what power-user features it warrants.
@@ -444,7 +451,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 						// annotations on a child path-item flow into the override
 						// and critical-resource maps. Store raw names so
 						// detectDependentResources can snake-case downstream.
-						key := parentName + "/" + name
+						key := strings.ToUpper(endpoint.Method) + " " + endpoint.Path
 						if _, ok := parameterized[key]; !ok {
 							parameterized[key] = parameterizedEntry{
 								name:       name,
@@ -1117,60 +1124,213 @@ func sortedKeys[V any](m map[string]V) []string {
 
 // detectDependentResources examines parameterized paths and identifies
 // parent-child relationships. For example, /channels/{channel_id}/messages
-// becomes a dependent resource of "channels" (only one level of nesting).
-// When the same leaf appears under multiple parents (or collides with a
-// top-level resource), each parent emits a sharded Name so its shard syncs
-// to its own table.
+// becomes a dependent resource of "channels", and deeper children can depend
+// on already-detected dependent resources. When the same leaf appears under
+// multiple parents (or collides with a top-level resource), each parent emits
+// a sharded Name so its shard syncs to its own table.
 func detectDependentResources(parameterized map[string]parameterizedEntry, syncable map[string]syncableMeta, shardedSubResources spec.SubResourceShards) []DependentResource {
 	var deps []DependentResource
-	for _, entry := range parameterized {
-		paramName, ok := firstPathParam(entry.meta.Path)
-		if !ok {
-			continue
-		}
-		parentResource := resolveParentResource(entry.parentName, paramName, syncable)
-		if parentResource == "" {
-			continue
-		}
-
-		emittedName := spec.ToSnakeCase(entry.name)
-		if shardedSubResources.IsSharded(entry.name) {
-			// Prefer the spec-walk parent so multi-param paths
-			// (e.g. /repos/{owner}/{repo}/commits) pick the right shard
-			// prefix; the path-param fallback would derive "owner".
-			shardParent := parentResource
-			if entry.parentName != "" {
-				shardParent = entry.parentName
-			}
-			emittedName = spec.ShardedSubResourceTableName(shardParent, entry.name)
-		}
-
-		deps = append(deps, DependentResource{
-			Name:               emittedName,
-			ParentResource:     parentResource,
-			ParentIDParam:      paramName,
-			Path:               entry.meta.Path,
-			Method:             entry.meta.Method,
-			Tier:               entry.meta.Tier,
-			IDField:            entry.meta.IDField,
-			Critical:           entry.meta.Critical,
-			SinceParam:         entry.meta.SinceParam,
-			SupportsPagination: entry.meta.SupportsPagination,
-			UsesHTMLResponse:   entry.meta.UsesHTMLResponse,
-			HTMLExtract:        entry.meta.HTMLExtract,
-			BodyFields:         entry.meta.BodyFields,
-			IDWalkFilterParam:  entry.meta.IDWalkFilterParam,
-			IDWalkLimitParam:   entry.meta.IDWalkLimitParam,
-			IDWalkPageSize:     entry.meta.IDWalkPageSize,
-			FieldSelector:      entry.meta.FieldSelector,
-			Discriminator:      entry.meta.Discriminator,
-		})
+	knownParents := make(map[string]bool, len(syncable)+len(parameterized))
+	for resource := range syncable {
+		knownParents[resource] = true
 	}
-	// Sort for deterministic output
+	depthByResource := map[string]int{}
+
+	keys := sortedKeys(parameterized)
+	for len(keys) > 0 {
+		var next []string
+		progressed := false
+		for _, key := range keys {
+			entry := parameterized[key]
+			dep, ok := dependentResourceFromEntry(entry, knownParents, shardedSubResources)
+			if !ok {
+				next = append(next, key)
+				continue
+			}
+			deps = append(deps, dep)
+			knownParents[dep.Name] = true
+			depthByResource[dep.Name] = depthByResource[dep.ParentResource] + 1
+			if dep.Name == spec.ToSnakeCase(entry.name) {
+				knownParents[spec.ToSnakeCase(entry.name)] = true
+			}
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+		keys = next
+	}
+	sortDependentResources(deps, depthByResource)
+	return deps
+}
+
+func sortDependentResources(deps []DependentResource, knownDepths map[string]int) {
+	depthByResource := make(map[string]int, len(knownDepths)+len(deps))
+	maps.Copy(depthByResource, knownDepths)
+	byName := make(map[string]DependentResource, len(deps))
+	for _, dep := range deps {
+		byName[dep.Name] = dep
+	}
+	var depthOf func(string, map[string]bool) int
+	depthOf = func(name string, visiting map[string]bool) int {
+		if depth, ok := depthByResource[name]; ok {
+			return depth
+		}
+		if visiting[name] {
+			return 1
+		}
+		dep, ok := byName[name]
+		if !ok {
+			return 0
+		}
+		visiting[name] = true
+		depth := depthOf(dep.ParentResource, visiting) + 1
+		delete(visiting, name)
+		depthByResource[name] = depth
+		return depth
+	}
+	for _, dep := range deps {
+		depthOf(dep.Name, map[string]bool{})
+	}
 	sort.Slice(deps, func(i, j int) bool {
+		if depthByResource[deps[i].Name] != depthByResource[deps[j].Name] {
+			return depthByResource[deps[i].Name] < depthByResource[deps[j].Name]
+		}
 		return deps[i].Name < deps[j].Name
 	})
-	return deps
+}
+
+func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[string]bool, shardedSubResources spec.SubResourceShards) (DependentResource, bool) {
+	ctx, ok := dependentPathContext(entry, knownParents, shardedSubResources)
+	if !ok {
+		return DependentResource{}, false
+	}
+
+	return DependentResource{
+		Name:               ctx.name,
+		ParentResource:     ctx.parentResource,
+		ParentIDParam:      dependentParentIDParam(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam),
+		Path:               entry.meta.Path,
+		Method:             entry.meta.Method,
+		Tier:               entry.meta.Tier,
+		PathParams:         dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, ""),
+		IDField:            entry.meta.IDField,
+		Critical:           entry.meta.Critical,
+		SinceParam:         entry.meta.SinceParam,
+		SupportsPagination: entry.meta.SupportsPagination,
+		UsesHTMLResponse:   entry.meta.UsesHTMLResponse,
+		HTMLExtract:        entry.meta.HTMLExtract,
+		BodyFields:         entry.meta.BodyFields,
+		IDWalkFilterParam:  entry.meta.IDWalkFilterParam,
+		IDWalkLimitParam:   entry.meta.IDWalkLimitParam,
+		IDWalkPageSize:     entry.meta.IDWalkPageSize,
+		FieldSelector:      entry.meta.FieldSelector,
+		Discriminator:      entry.meta.Discriminator,
+	}, true
+}
+
+type dependentContext struct {
+	name              string
+	parentResource    string
+	parentPathSegment string
+	firstParam        string
+}
+
+func dependentPathContext(entry parameterizedEntry, knownParents map[string]bool, shardedSubResources spec.SubResourceShards) (dependentContext, bool) {
+	firstParam, ok := firstPathParam(entry.meta.Path)
+	if !ok {
+		return dependentContext{}, false
+	}
+
+	segments := pathSegments(entry.meta.Path)
+	placeholderCount := len(orderedPathPlaceholders(entry.meta.Path))
+	parentSegment := spec.ToSnakeCase(entry.parentName)
+	childName := spec.ToSnakeCase(entry.name)
+	forceShard := false
+	if placeholderCount >= 2 {
+		if childSegment, parent, ok := pathCollectionContext(segments); ok {
+			childName = childSegment
+			parentSegment = parent
+			forceShard = true
+		}
+	}
+	if parentSegment == "" {
+		parentSegment = spec.ToSnakeCase(entry.parentName)
+	}
+
+	parentResource := resolvePathParentResource(parentSegment, segments, knownParents, shardedSubResources)
+	if parentResource == "" {
+		parentResource = resolveParentResourceName(entry.parentName, firstParam, knownParents)
+	}
+	if parentResource == "" {
+		return dependentContext{}, false
+	}
+
+	name := childName
+	if forceShard {
+		name = spec.ShardedSubResourceTableName(parentResource, childName)
+	} else if shardedSubResources.IsSharded(childName) {
+		shardParent := parentResource
+		if entry.parentName != "" {
+			shardParent = entry.parentName
+		}
+		name = spec.ShardedSubResourceTableName(shardParent, childName)
+	}
+	if parentSegment == "" {
+		parentSegment = parentResource
+	}
+
+	return dependentContext{
+		name:              name,
+		parentResource:    parentResource,
+		parentPathSegment: parentSegment,
+		firstParam:        firstParam,
+	}, true
+}
+
+func pathCollectionContext(segments []string) (child, parent string, ok bool) {
+	lastPlaceholder := -1
+	for i, segment := range segments {
+		if isPathPlaceholder(segment) {
+			lastPlaceholder = i
+		}
+	}
+	if lastPlaceholder < 0 {
+		return "", "", false
+	}
+	childIndex := nextStaticSegmentIndex(segments, lastPlaceholder+1)
+	parentIndex := previousStaticSegmentIndex(segments, lastPlaceholder-1)
+	if childIndex < 0 || parentIndex < 0 {
+		return "", "", false
+	}
+	return spec.ToSnakeCase(segments[childIndex]), spec.ToSnakeCase(segments[parentIndex]), true
+}
+
+func resolvePathParentResource(parentSegment string, segments []string, knownParents map[string]bool, shardedSubResources spec.SubResourceShards) string {
+	if parentSegment == "" {
+		return ""
+	}
+	if knownParents[parentSegment] {
+		return parentSegment
+	}
+	parentIndex := lastStaticSegmentIndex(segments, parentSegment)
+	if parentIndex < 0 {
+		return ""
+	}
+	ancestorIndex := previousStaticSegmentIndex(segments, parentIndex-1)
+	if ancestorIndex >= 0 {
+		candidate := spec.ShardedSubResourceTableName(segments[ancestorIndex], parentSegment)
+		if knownParents[candidate] {
+			return candidate
+		}
+	}
+	if shardedSubResources.IsSharded(parentSegment) && ancestorIndex >= 0 {
+		candidate := spec.ShardedSubResourceTableName(segments[ancestorIndex], parentSegment)
+		if knownParents[candidate] {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // applySpecWalkers merges spec-declared walker configs (Endpoint.Walker,
@@ -1256,6 +1416,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 					deps[idx].ParentIDParam = keyParam
 				}
 				deps[idx].KeyField = keyField
+				deps[idx].PathParams = dependentPathParams(e.Path, parent, deps[idx].ParentIDParam, keyField)
 				continue
 			}
 			meta := metaFromEndpoint(s, r, e, types, resourceNameIndex)
@@ -1266,6 +1427,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				Path:               e.Path,
 				Method:             meta.Method,
 				Tier:               meta.Tier,
+				PathParams:         dependentPathParams(e.Path, parent, keyParam, keyField),
 				IDField:            meta.IDField,
 				Critical:           meta.Critical,
 				SinceParam:         meta.SinceParam,
@@ -1289,8 +1451,169 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 	for name, r := range s.Resources {
 		walk(name, r)
 	}
-	sort.Slice(deps, func(i, j int) bool { return deps[i].Name < deps[j].Name })
+	sortDependentResources(deps, nil)
 	return deps
+}
+
+func dependentPathParams(path, parentResource, keyParam, keyField string) []DependentPathParam {
+	placeholders := orderedPathPlaceholders(path)
+	if len(placeholders) == 0 {
+		return nil
+	}
+
+	fields := dependentPathParamFields(path, parentResource)
+	params := make([]DependentPathParam, 0, len(placeholders))
+	for _, placeholder := range placeholders {
+		field := fields[placeholder]
+		if placeholder == keyParam && keyField != "" {
+			field = spec.ToSnakeCase(keyField)
+		}
+		if field == "" {
+			field = spec.ToSnakeCase(placeholder)
+		}
+		params = append(params, DependentPathParam{
+			Param: placeholder,
+			Field: field,
+		})
+	}
+	return params
+}
+
+func dependentParentIDParam(path, parentResource, fallback string) string {
+	for _, pathParam := range dependentPathParams(path, parentResource, fallback, "") {
+		if pathParam.Field == "id" {
+			return pathParam.Param
+		}
+	}
+	return fallback
+}
+
+func dependentPathParamFields(path, parentResource string) map[string]string {
+	fields := map[string]string{}
+	segments := pathSegments(path)
+	parentSegmentIndex := -1
+	childSegmentIndex := -1
+	normalizedParent := spec.ToSnakeCase(parentResource)
+	for i, segment := range segments {
+		if isPathPlaceholder(segment) {
+			continue
+		}
+		if spec.ToSnakeCase(segment) == normalizedParent {
+			parentSegmentIndex = i
+			childSegmentIndex = nextStaticSegmentIndex(segments, i+1)
+		}
+	}
+
+	parentIdentityParams := map[string]bool{}
+	if parentSegmentIndex >= 0 {
+		for i := parentSegmentIndex + 1; i < len(segments); i++ {
+			if i == childSegmentIndex {
+				break
+			}
+			if isPathPlaceholder(segments[i]) {
+				parentIdentityParams[strings.TrimSuffix(strings.TrimPrefix(segments[i], "{"), "}")] = true
+			}
+		}
+	}
+	parentUsesCompositeIdentity := len(parentIdentityParams) > 1
+
+	lastStatic := ""
+	for _, segment := range segments {
+		if isPathPlaceholder(segment) {
+			param := strings.TrimSuffix(strings.TrimPrefix(segment, "{"), "}")
+			switch {
+			case parentIdentityParams[param] && !parentUsesCompositeIdentity:
+				fields[param] = dependentIdentityField(param)
+			case parentIdentityParams[param] && parentUsesCompositeIdentity:
+				fields[param] = spec.ToSnakeCase(param)
+			case lastStatic != "":
+				fields[param] = spec.ToSnakeCase(lastStatic) + "_id"
+			default:
+				fields[param] = spec.ToSnakeCase(param)
+			}
+			continue
+		}
+		lastStatic = segment
+	}
+	return fields
+}
+
+func dependentIdentityField(param string) string {
+	field := spec.ToSnakeCase(param)
+	switch {
+	case field == "id" || strings.HasSuffix(field, "_id") || strings.HasSuffix(param, "Id") || strings.HasSuffix(param, "ID"):
+		return "id"
+	case strings.HasSuffix(field, "_slug"):
+		return "slug"
+	case strings.HasSuffix(field, "_name"):
+		return "name"
+	case strings.HasSuffix(field, "_key"):
+		return "key"
+	default:
+		return field
+	}
+}
+
+func orderedPathPlaceholders(path string) []string {
+	var params []string
+	seen := map[string]bool{}
+	for i := 0; i < len(path); i++ {
+		if path[i] != '{' {
+			continue
+		}
+		j := strings.IndexByte(path[i:], '}')
+		if j < 0 {
+			break
+		}
+		param := path[i+1 : i+j]
+		if param != "" && !seen[param] {
+			params = append(params, param)
+			seen[param] = true
+		}
+		i += j
+	}
+	return params
+}
+
+func isPathPlaceholder(segment string) bool {
+	return strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") && len(segment) > 2
+}
+
+func pathSegments(path string) []string {
+	if strings.Trim(path, "/") == "" {
+		return nil
+	}
+	return strings.Split(strings.Trim(path, "/"), "/")
+}
+
+func nextStaticSegmentIndex(segments []string, start int) int {
+	for i := start; i < len(segments); i++ {
+		if !isPathPlaceholder(segments[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+func previousStaticSegmentIndex(segments []string, start int) int {
+	for i := min(start, len(segments)-1); i >= 0; i-- {
+		if !isPathPlaceholder(segments[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastStaticSegmentIndex(segments []string, normalized string) int {
+	for i := len(segments) - 1; i >= 0; i-- {
+		if isPathPlaceholder(segments[i]) {
+			continue
+		}
+		if spec.ToSnakeCase(segments[i]) == normalized {
+			return i
+		}
+	}
+	return -1
 }
 
 // countPathPlaceholders counts the number of `{name}` substitution slots in
@@ -1323,14 +1646,15 @@ func firstPathParam(path string) (string, bool) {
 	return path[start+1 : end], true
 }
 
-// resolveParentResource picks a parent name that matches a syncable resource.
+// resolveParentResourceName picks a parent name that matches a known flat or
+// already-detected dependent resource.
 // Prefers the spec-walk parent (correct for multi-param paths like
 // /repos/{owner}/{repo}/commits) and falls back to stripping Id/_id from the
 // path param. Returns "" when no candidate matches.
-func resolveParentResource(walkParent, paramName string, syncable map[string]syncableMeta) string {
+func resolveParentResourceName(walkParent, paramName string, knownParents map[string]bool) string {
 	if walkParent != "" {
 		candidate := strings.ToLower(walkParent)
-		if _, ok := syncable[candidate]; ok {
+		if knownParents[candidate] {
 			return candidate
 		}
 	}
@@ -1340,7 +1664,7 @@ func resolveParentResource(walkParent, paramName string, syncable map[string]syn
 	stem = strings.TrimSuffix(stem, "ID")
 	stem = strings.ToLower(stem)
 	for _, candidate := range []string{stem, stem + "s", stem + "es"} {
-		if _, ok := syncable[candidate]; ok {
+		if knownParents[candidate] {
 			return candidate
 		}
 	}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3,6 +3,7 @@ package profiler
 import (
 	"bytes"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -1185,6 +1186,173 @@ func TestProfileDependentResources_MultiParamParentPath(t *testing.T) {
 
 	require.Contains(t, depsByName, "repos_commits", "walk-context parent wins over /repos/{owner}/...'s leading param")
 	assert.Equal(t, "repos", depsByName["repos_commits"].ParentResource)
+	assert.Equal(t, []DependentPathParam{
+		{Param: "owner", Field: "owner"},
+		{Param: "repo", Field: "repo"},
+	}, depsByName["repos_commits"].PathParams)
+}
+
+func TestProfileDependentResources_ChainedParentPathParams(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "nested",
+		Resources: map[string]spec.Resource{
+			"channels": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/channels",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"messages": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/channels/{channelId}/messages",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							},
+						},
+						SubResources: map[string]spec.Resource{
+							"reactions": {
+								Endpoints: map[string]spec.Endpoint{
+									"list": {
+										Method:     "GET",
+										Path:       "/channels/{channelId}/messages/{messageId}/reactions",
+										Response:   spec.ResponseDef{Type: "array"},
+										Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	depsByName := make(map[string]DependentResource)
+	for _, dep := range profile.DependentSyncResources {
+		depsByName[dep.Name] = dep
+	}
+
+	require.Contains(t, depsByName, "messages_reactions")
+	assert.Equal(t, "messages", depsByName["messages_reactions"].ParentResource)
+	assert.Equal(t, []DependentPathParam{
+		{Param: "channelId", Field: "channels_id"},
+		{Param: "messageId", Field: "id"},
+	}, depsByName["messages_reactions"].PathParams)
+}
+
+func TestProfileDependentResources_FlatMultiPlaceholderPathDerivesLeaf(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "runcloud",
+		Resources: map[string]spec.Resource{
+			"servers": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/servers",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"webapps": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/servers/{serverId}/webapps",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+							},
+							"domains": {
+								Method:     "GET",
+								Path:       "/servers/{serverId}/webapps/{webAppId}/domains",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	depsByName := make(map[string]DependentResource)
+	for _, dep := range profile.DependentSyncResources {
+		depsByName[dep.Name] = dep
+	}
+
+	require.Contains(t, depsByName, "webapps")
+	require.Contains(t, depsByName, "webapps_domains")
+	assert.Equal(t, "servers", depsByName["webapps"].ParentResource)
+	assert.Equal(t, "webapps", depsByName["webapps_domains"].ParentResource)
+	assert.Equal(t, "/servers/{serverId}/webapps/{webAppId}/domains", depsByName["webapps_domains"].Path)
+	assert.Equal(t, []DependentPathParam{
+		{Param: "serverId", Field: "servers_id"},
+		{Param: "webAppId", Field: "id"},
+	}, depsByName["webapps_domains"].PathParams)
+}
+
+func TestProfileDependentResources_SlugParentIdentityAndTopoOrder(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "github",
+		Resources: map[string]spec.Resource{
+			"orgs": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/orgs",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"teams": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/orgs/{org}/teams",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+							},
+							"members": {
+								Method:     "GET",
+								Path:       "/orgs/{org}/teams/{team_slug}/members",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "page", LimitParam: "per_page"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	var names []string
+	depsByName := make(map[string]DependentResource)
+	for _, dep := range profile.DependentSyncResources {
+		names = append(names, dep.Name)
+		depsByName[dep.Name] = dep
+	}
+
+	require.Contains(t, depsByName, "teams")
+	require.Contains(t, depsByName, "teams_members")
+	assert.Less(t, slices.Index(names, "teams"), slices.Index(names, "teams_members"))
+	assert.Equal(t, "teams", depsByName["teams_members"].ParentResource)
+	assert.Equal(t, []DependentPathParam{
+		{Param: "org", Field: "orgs_id"},
+		{Param: "team_slug", Field: "slug"},
+	}, depsByName["teams_members"].PathParams)
 }
 
 // TestProfileDependentResources_TopLevelCollisionShards mirrors the schema

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1158,18 +1158,26 @@ func syncResourcePath(resource string) (string, error) {
 // records' KeyField via json_extract rather than from the parent table's primary key.
 // Populated from a spec-declared walker (Endpoint.Walker.KeyField in internal YAML,
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
-// existing parent-primary-key flow byte-for-byte.
+// parent-primary-key flow.
 type dependentResourceDef struct {
 	Name          string
 	ParentTable   string
 	ParentIDParam string
 	PathTemplate  string
 	KeyField      string
+	PathParams    []dependentPathParamDef
+}
+
+type dependentPathParamDef struct {
+	Param string
+	Field string
 }
 
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
-		{Name: "tasks", ParentTable: "projects", ParentIDParam: "projectId", PathTemplate: "/projects/{projectId}/tasks", KeyField: ""},
+		{Name: "tasks", ParentTable: "projects", ParentIDParam: "projectId", PathTemplate: "/projects/{projectId}/tasks", KeyField: "", PathParams: []dependentPathParamDef{
+			{Param: "projectId", Field: "id"},
+		}},
 	}
 }
 
@@ -1205,21 +1213,17 @@ func syncDependentResource(ctx context.Context, c interface {
 		syncEvents = io.Discard
 	}
 
-	// Query parent table for the keys to substitute into the child path.
-	// When KeyField is empty, use the parent's primary key via ListIDs
-	// (the original flat parent-child flow). When KeyField is set, the
-	// spec declared a walker that extracts a non-PK field from each parent
-	// record — ListField looks up the field in the parent's typed column
-	// if present, otherwise json_extract from the generic resources table.
-	var parentIDs []string
-	var err error
-	if dep.KeyField != "" {
-		parentIDs, err = db.ListField(dep.ParentTable, dep.KeyField)
-	} else {
-		parentIDs, err = db.ListIDs(dep.ParentTable)
+	pathParams := dep.PathParams
+	if len(pathParams) == 0 {
+		field := "id"
+		if dep.KeyField != "" {
+			field = dep.KeyField
+		}
+		pathParams = []dependentPathParamDef{{Param: dep.ParentIDParam, Field: field}}
 	}
-	if err != nil || len(parentIDs) == 0 {
-		if len(parentIDs) == 0 {
+	parentRows, err := dependentParentRows(db, dep.ParentTable, pathParams)
+	if err != nil || len(parentRows) == 0 {
+		if len(parentRows) == 0 {
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "  %s: skipping (parent table %s is empty, sync it first)\n", dep.Name, dep.ParentTable)
 			}
@@ -1229,7 +1233,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 
 	if humanFriendly {
-		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentIDs), dep.ParentTable)
+		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentRows), dep.ParentTable)
 	}
 
 	var totalCount int
@@ -1254,13 +1258,19 @@ func syncDependentResource(ctx context.Context, c interface {
 	depAnomalyEmitted := false
 	parentFKKey := dep.ParentTable + "_id"
 
-	for idx, parentID := range parentIDs {
+	for idx, parentRow := range parentRows {
+		parentID := parentRow["id"]
+		if parentID == "" {
+			parentID = parentRow[pathParams[0].Field]
+		}
 		parentIDJSON, _ := json.Marshal(parentID)
-		// Build child endpoint path by replacing the param placeholder
-		path := strings.Replace(dep.PathTemplate, "{"+dep.ParentIDParam+"}", parentID, 1)
+		path := dep.PathTemplate
+		for _, pathParam := range pathParams {
+			path = replacePathParam(path, pathParam.Param, parentRow[pathParam.Field])
+		}
 
 		if humanFriendly {
-			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentIDs))
+			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentRows))
 		}
 
 		cursor := ""
@@ -1335,6 +1345,16 @@ func syncDependentResource(ctx context.Context, c interface {
 					obj["parent_id"] = parentIDJSON
 					if _, ok := obj[parentFKKey]; !ok {
 						obj[parentFKKey] = parentIDJSON
+					}
+					for _, pathParam := range pathParams {
+						if pathParam.Field == "id" {
+							continue
+						}
+						if _, ok := obj[pathParam.Field]; ok {
+							continue
+						}
+						valueJSON, _ := json.Marshal(parentRow[pathParam.Field])
+						obj[pathParam.Field] = valueJSON
 					}
 					if modified, err := json.Marshal(obj); err == nil {
 						items[i] = modified
@@ -1440,15 +1460,55 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
-	if deniedParents == len(parentIDs) && totalCount == 0 && firstDenial != nil {
+	if deniedParents == len(parentRows) && totalCount == 0 && firstDenial != nil {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentIDs)),
+			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}
 	return syncResult{Resource: dep.Name, Count: totalCount, Duration: time.Since(started)}
+}
+
+func dependentParentFields(pathParams []dependentPathParamDef) []string {
+	fields := []string{"id"}
+	seen := map[string]bool{"id": true}
+	for _, pathParam := range pathParams {
+		if pathParam.Field == "" || seen[pathParam.Field] {
+			continue
+		}
+		fields = append(fields, pathParam.Field)
+		seen[pathParam.Field] = true
+	}
+	return fields
+}
+
+func dependentParentRows(db *store.Store, parentTable string, pathParams []dependentPathParamDef) ([]map[string]string, error) {
+	fields := dependentParentFields(pathParams)
+	if len(fields) == 1 {
+		values, err := db.ListIDs(parentTable)
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value})
+		}
+		return rows, nil
+	}
+	if len(pathParams) == 1 && len(fields) == 2 && fields[0] == "id" {
+		values, err := db.ListField(parentTable, fields[1])
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value, fields[1]: value})
+		}
+		return rows, nil
+	}
+	return db.ListFieldSets(parentTable, fields)
 }
 
 // resourceIDFieldOverrides projects per-resource IDField (set by the profiler

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1143,18 +1143,26 @@ func syncResourcePath(resource string) (string, error) {
 // records' KeyField via json_extract rather than from the parent table's primary key.
 // Populated from a spec-declared walker (Endpoint.Walker.KeyField in internal YAML,
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
-// existing parent-primary-key flow byte-for-byte.
+// parent-primary-key flow.
 type dependentResourceDef struct {
 	Name          string
 	ParentTable   string
 	ParentIDParam string
 	PathTemplate  string
 	KeyField      string
+	PathParams    []dependentPathParamDef
+}
+
+type dependentPathParamDef struct {
+	Param string
+	Field string
 }
 
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
-		{Name: "leagues", ParentTable: "games", ParentIDParam: "game_key", PathTemplate: "/games/{game_key}/leagues", KeyField: "game_key"},
+		{Name: "leagues", ParentTable: "games", ParentIDParam: "game_key", PathTemplate: "/games/{game_key}/leagues", KeyField: "game_key", PathParams: []dependentPathParamDef{
+			{Param: "game_key", Field: "game_key"},
+		}},
 	}
 }
 
@@ -1190,21 +1198,17 @@ func syncDependentResource(ctx context.Context, c interface {
 		syncEvents = io.Discard
 	}
 
-	// Query parent table for the keys to substitute into the child path.
-	// When KeyField is empty, use the parent's primary key via ListIDs
-	// (the original flat parent-child flow). When KeyField is set, the
-	// spec declared a walker that extracts a non-PK field from each parent
-	// record — ListField looks up the field in the parent's typed column
-	// if present, otherwise json_extract from the generic resources table.
-	var parentIDs []string
-	var err error
-	if dep.KeyField != "" {
-		parentIDs, err = db.ListField(dep.ParentTable, dep.KeyField)
-	} else {
-		parentIDs, err = db.ListIDs(dep.ParentTable)
+	pathParams := dep.PathParams
+	if len(pathParams) == 0 {
+		field := "id"
+		if dep.KeyField != "" {
+			field = dep.KeyField
+		}
+		pathParams = []dependentPathParamDef{{Param: dep.ParentIDParam, Field: field}}
 	}
-	if err != nil || len(parentIDs) == 0 {
-		if len(parentIDs) == 0 {
+	parentRows, err := dependentParentRows(db, dep.ParentTable, pathParams)
+	if err != nil || len(parentRows) == 0 {
+		if len(parentRows) == 0 {
 			if humanFriendly {
 				fmt.Fprintf(os.Stderr, "  %s: skipping (parent table %s is empty, sync it first)\n", dep.Name, dep.ParentTable)
 			}
@@ -1214,7 +1218,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	}
 
 	if humanFriendly {
-		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentIDs), dep.ParentTable)
+		fmt.Fprintf(os.Stderr, "  %s: syncing for %d %s parents\n", dep.Name, len(parentRows), dep.ParentTable)
 	}
 
 	var totalCount int
@@ -1239,13 +1243,19 @@ func syncDependentResource(ctx context.Context, c interface {
 	depAnomalyEmitted := false
 	parentFKKey := dep.ParentTable + "_id"
 
-	for idx, parentID := range parentIDs {
+	for idx, parentRow := range parentRows {
+		parentID := parentRow["id"]
+		if parentID == "" {
+			parentID = parentRow[pathParams[0].Field]
+		}
 		parentIDJSON, _ := json.Marshal(parentID)
-		// Build child endpoint path by replacing the param placeholder
-		path := strings.Replace(dep.PathTemplate, "{"+dep.ParentIDParam+"}", parentID, 1)
+		path := dep.PathTemplate
+		for _, pathParam := range pathParams {
+			path = replacePathParam(path, pathParam.Param, parentRow[pathParam.Field])
+		}
 
 		if humanFriendly {
-			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentIDs))
+			fmt.Fprintf(os.Stderr, "\r  %s: syncing for %s (%d/%d parents)", dep.Name, dep.ParentTable, idx+1, len(parentRows))
 		}
 
 		cursor := ""
@@ -1320,6 +1330,16 @@ func syncDependentResource(ctx context.Context, c interface {
 					obj["parent_id"] = parentIDJSON
 					if _, ok := obj[parentFKKey]; !ok {
 						obj[parentFKKey] = parentIDJSON
+					}
+					for _, pathParam := range pathParams {
+						if pathParam.Field == "id" {
+							continue
+						}
+						if _, ok := obj[pathParam.Field]; ok {
+							continue
+						}
+						valueJSON, _ := json.Marshal(parentRow[pathParam.Field])
+						obj[pathParam.Field] = valueJSON
 					}
 					if modified, err := json.Marshal(obj); err == nil {
 						items[i] = modified
@@ -1425,15 +1445,55 @@ func syncDependentResource(ctx context.Context, c interface {
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
-	if deniedParents == len(parentIDs) && totalCount == 0 && firstDenial != nil {
+	if deniedParents == len(parentRows) && totalCount == 0 && firstDenial != nil {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentIDs)),
+			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}
 	return syncResult{Resource: dep.Name, Count: totalCount, Duration: time.Since(started)}
+}
+
+func dependentParentFields(pathParams []dependentPathParamDef) []string {
+	fields := []string{"id"}
+	seen := map[string]bool{"id": true}
+	for _, pathParam := range pathParams {
+		if pathParam.Field == "" || seen[pathParam.Field] {
+			continue
+		}
+		fields = append(fields, pathParam.Field)
+		seen[pathParam.Field] = true
+	}
+	return fields
+}
+
+func dependentParentRows(db *store.Store, parentTable string, pathParams []dependentPathParamDef) ([]map[string]string, error) {
+	fields := dependentParentFields(pathParams)
+	if len(fields) == 1 {
+		values, err := db.ListIDs(parentTable)
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value})
+		}
+		return rows, nil
+	}
+	if len(pathParams) == 1 && len(fields) == 2 && fields[0] == "id" {
+		values, err := db.ListField(parentTable, fields[1])
+		if err != nil {
+			return nil, err
+		}
+		rows := make([]map[string]string, 0, len(values))
+		for _, value := range values {
+			rows = append(rows, map[string]string{"id": value, fields[1]: value})
+		}
+		return rows, nil
+	}
+	return db.ListFieldSets(parentTable, fields)
 }
 
 // resourceIDFieldOverrides projects per-resource IDField (set by the profiler

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1090,6 +1090,71 @@ func (s *Store) ListField(resourceType, field string) ([]string, error) {
 	return values, rows.Err()
 }
 
+// ListFieldSets returns row-correlated values from the generic resources
+// table. Dependent sync uses this for multi-placeholder paths where values
+// such as owner/repo or server/webapp must stay paired per parent row.
+func (s *Store) ListFieldSets(resourceType string, fields []string) ([]map[string]string, error) {
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	for _, field := range fields {
+		if !validIdentifierRE.MatchString(field) {
+			return nil, fmt.Errorf("ListFieldSets: invalid field name %q (must match %s)", field, validIdentifierRE.String())
+		}
+	}
+
+	rows, err := s.db.Query(`SELECT id, data FROM resources WHERE resource_type = ?`, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []map[string]string
+	seenRows := map[string]bool{}
+	for rows.Next() {
+		var id string
+		var data []byte
+		if err := rows.Scan(&id, &data); err != nil {
+			return nil, err
+		}
+		var obj map[string]any
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &obj); err != nil {
+				return nil, fmt.Errorf("decode %s parent row %s: %w", resourceType, id, err)
+			}
+		}
+		values := make(map[string]string, len(fields))
+		complete := true
+		for _, field := range fields {
+			var value any
+			if field == "id" {
+				value = id
+			} else {
+				value = LookupFieldValue(obj, field)
+			}
+			valueString := fmt.Sprint(value)
+			if value == nil || valueString == "" {
+				complete = false
+				break
+			}
+			values[field] = valueString
+		}
+		if complete {
+			keyParts := make([]string, 0, len(fields))
+			for _, field := range fields {
+				keyParts = append(keyParts, values[field])
+			}
+			key := strings.Join(keyParts, "\x00")
+			if seenRows[key] {
+				continue
+			}
+			seenRows[key] = true
+			out = append(out, values)
+		}
+	}
+	return out, rows.Err()
+}
+
 // GetLastSyncedAt returns the last sync timestamp for a resource type.
 func (s *Store) GetLastSyncedAt(resourceType string) string {
 	var ts sql.NullString


### PR DESCRIPTION
Sync now populates nested dependent resources whose paths need both ancestor and parent IDs, so fleet/search commands no longer see empty stores for child collections like domains or team members.

What changed:
- derives dependent child and immediate parent resource names from full path templates, including OpenAPI-style flattened paths
- emits parent-prefixed dependent resource types for multi-placeholder fan-outs, such as webapps_domains and teams_members
- carries all required path params from parent rows and preserves parent-before-child sync order
- adds correlated parent field lookup for multi-placeholder paths while keeping ListIDs/ListField fast paths for simple dependents

Verification:
- go test ./internal/profiler ./internal/generator
- scripts/golden.sh verify
- golangci-lint run ./...
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- go test ./...

Closes #1635
