### PR TITLE
docs(skills): clarify internal spec authoring constraints

### DIFF
--- a/skills/printing-press/references/browser-sniff-capture.md
+++ b/skills/printing-press/references/browser-sniff-capture.md
@@ -1019,6 +1019,12 @@ Two fields trip up hand-edits often enough to call out:
 - **`version`** is the literal string `"1"` — not semver, not `"1.0.0"`. The downstream parser rejects any other value with `unsupported traffic analysis version`.
 - **Confidence fields** are numbers from `0` to `1`, not strings such as `"high"`.
 
+Before hand-writing or repairing the sniffed YAML spec, check
+`spec-format.md`; two common traps are `types.X.fields` list shape (`- name:`
+items, not a map) and the `response_format` enum (`json`, `html`, or `binary`;
+use `html` only for GET/HEAD HTML and embedded-JSON surfaces, with
+`html_extract` when the built-in page, links, or embedded-json modes fit).
+
 #### Step 4: Report and update spec source
 
 Report: "Browser-Sniff discovered **N endpoints** across **M resources**. [X new endpoints not in the original spec.]"

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -69,6 +69,11 @@ resources:                        # map[string]Resource (REQUIRED: at least one 
           type: cursor            # string pagination style: cursor | offset | page_token
           cursor_field: cursor    # string response field containing next cursor
           has_more_field: data.has_more # string response field indicating more results
+        response_format: json     # string optional: json | html | binary; defaults to json
+        html_extract:             # object optional, only with response_format: html
+          mode: page              # string optional: page | links | embedded-json
+          script_selector: ""     # string optional for embedded-json; defaults to script#__NEXT_DATA__
+          json_path: ""           # string optional for embedded-json; empty returns the full JSON
         response_path: data       # string optional path to extract list payload from wrapper response
 
 types:                            # map[string]TypeDef named response/body models
@@ -77,6 +82,18 @@ types:                            # map[string]TypeDef named response/body model
       - name: user_id             # string field name
         type: string              # string field type (typically string/int/bool/float)
 ```
+
+**`response_format` must be one of `json`, `html`, or `binary`.** Use `json`
+when the response body is JSON and can be parsed directly. Use `html` only for
+GET/HEAD HTML documents, including HTML pages with embedded JSON such as
+Next.js `__NEXT_DATA__` or schema.org JSON-LD; prefer `html_extract` modes
+`page`, `links`, or `embedded-json` before writing custom extraction code. Use
+`binary` for opaque byte payloads.
+
+**`types.X.fields` is a list, not a map.** Each field is an item with
+`- name: <field-name>` followed by `type:`, `description:`, and other field
+metadata. Map shape such as `field-name: {type: string}` fails to parse with
+`cannot unmarshal !!map into []spec.TypeField`.
 
 ## 2. Annotated Example (`testdata/stytch.yaml`)
 


### PR DESCRIPTION
## Summary

Spec authors now see the two internal YAML constraints that were causing avoidable generation failures: `types.X.fields` must use list items, and `response_format` is limited to `json`, `html`, or `binary`.

The browser-sniff repair workflow also points authors back to the canonical spec reference and names the same two traps at the moment a sniffed YAML spec is hand-written or repaired.

## Validation

- `bash .github/scripts/validate-skill-docs.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`

Closes #1646
