### PR TITLE
fix(cli): preserve OpenAPI multi-query auth credentials

### DIFF
--- a/docs/solutions/logic-errors/openapi-and-query-apikey-siblings.md
+++ b/docs/solutions/logic-errors/openapi-and-query-apikey-siblings.md
@@ -1,0 +1,66 @@
+---
+title: OpenAPI AND query apiKey siblings must remain required credentials
+date: 2026-05-24
+category: logic-errors
+module: OpenAPI auth generation
+problem_type: logic_error
+component: authentication
+symptoms:
+  - Generated CLIs for Trello-shaped specs sent only the primary query apiKey
+  - Required sibling query credentials were parsed out of the auth model
+  - Scorecard auth_protocol under-scored the newly supported query-sibling shape
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags: [openapi, auth, api-key, query-params, scorecard]
+---
+
+# OpenAPI AND query apiKey siblings must remain required credentials
+
+## Problem
+OpenAPI security requirements can require multiple schemes at once. When a spec declares two `apiKey` schemes in the same requirement, such as query parameters `key` and `token`, the printed CLI must send both credentials on every request.
+
+## Symptoms
+- The parser kept sibling `apiKey` schemes only when they were `in: header`.
+- Trello-shaped specs with `APIKey` plus `APIToken` generated a client that configured and sent `key`, but omitted `token`.
+- The scorecard did not understand exact sibling query-parameter emission, so `auth_protocol` could remain low even after the generator supported the shape.
+
+## What Didn't Work
+- Treating the second scheme as a component-only declaration loses the OpenAPI AND semantics. A sibling scheme in the same security requirement is a required credential, not optional metadata.
+- Blindly promoting query credentials into multi-spec merged auth is unsafe. `Auth.AdditionalHeaders` is global in the generated client, and query credentials are usually origin or endpoint scoped.
+- Scoring generic query plumbing such as `.Query()` is too weak for composed auth. The verifier needs to see the exact required query parameter name.
+
+## Solution
+Allow supported sibling `apiKey` schemes in AND requirements to become additional credentials when their placement is `header` or `query`.
+
+For generation:
+
+- Preserve the scheme placement in `AdditionalAuthHeader.In`.
+- Emit header siblings with `req.Header.Set(...)`.
+- Emit query siblings by updating `req.URL.Query()` and writing `RawQuery`.
+- Load and doctor-check the sibling environment variable the same way as header siblings.
+
+For multi-spec safety:
+
+- Keep query siblings out of merged global auth until auth can be scoped per resource, endpoint, or origin.
+- Continue allowing mergeable header siblings only when existing compatibility predicates pass.
+
+For scoring:
+
+- Parse `x-auth-env-vars` into the scorecard security scheme model.
+- Credit query `apiKey` schemes only when the generated client writes the exact query parameter name, such as `q.Set("token", ...)`.
+- Add positive and negative `auth_protocol` regressions for an AND group of two query apiKeys.
+
+## Why This Works
+OpenAPI OR and AND security meanings are encoded by nesting: separate objects are alternatives, while multiple keys in one object are all required. Keeping header and query sibling credentials in the auth model preserves that contract without inventing product-specific rules.
+
+The multi-spec filter prevents a single-spec fix from reintroducing the known global-auth leak class. Query credentials are correct for the owning spec's generated client path, but they are not safe to union into a combined CLI's global request path.
+
+## Prevention
+- When broadening parser auth support, update both generation tests and dependent verifiers in the same change.
+- Regression tests for composed auth should cover parser output, generated source, generated runtime request behavior, and scorecard scoring.
+- Keep multi-spec negative tests for any auth field that is global at runtime.
+
+## Related Issues
+- GitHub issue #1663
+- `docs/solutions/logic-errors/multi-spec-auth-scope-union-2026-05-22.md`

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1064,6 +1064,22 @@ func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
 		},
 		Types: map[string]spec.TypeDef{},
 	}
+	secondaryQuerySibling := &spec.APISpec{
+		Name:    "secondaryquery",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:   "bearer_token",
+			Header: "Authorization",
+			AdditionalHeaders: []spec.AdditionalAuthHeader{
+				{Header: "secondary_token", In: "query", EnvVar: spec.AuthEnvVar{Name: "SECONDARY_QUERY_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"secondaryquery": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/secondaryquery"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
 	standaloneKey := &spec.APISpec{
 		Name:    "standalone",
 		Version: "0.1.0",
@@ -1165,15 +1181,92 @@ func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
 		Types: map[string]spec.TypeDef{},
 	}
 
-	merged := mergeSpecs([]*spec.APISpec{primary, secondary, standaloneKey, queryKey, ambiguousKey, crossHostKey, foreignOAuth, noFlowOAuth}, "combo")
+	merged := mergeSpecs([]*spec.APISpec{primary, secondary, secondaryQuerySibling, standaloneKey, queryKey, ambiguousKey, crossHostKey, foreignOAuth, noFlowOAuth}, "combo")
 
 	assert.Equal(t, []string{"read.primary", "read.secondary"}, merged.Auth.Scopes)
 	require.Len(t, merged.Auth.AdditionalHeaders, 3)
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Primary-Key", "PRIMARY_KEY")
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Secondary-Key", "SECONDARY_KEY")
 	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Standalone-Key", "STANDALONE_KEY")
+	assertNoAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "secondary_token")
 	assert.Equal(t, " STANDALONE_KEY ", standaloneKey.Auth.EnvVarSpecs[0].Name)
 	assert.Empty(t, standaloneKey.Auth.EnvVarSpecs[0].Kind)
+}
+
+func TestMergeSpecsDropsSelectedQueryAdditionalHeaders(t *testing.T) {
+	t.Parallel()
+
+	trelloShaped := &spec.APISpec{
+		Name:    "trello",
+		Version: "0.1.0",
+		BaseURL: "https://api.trello.com/1",
+		Auth: spec.AuthConfig{
+			Type:   "api_key",
+			Header: "key",
+			In:     "query",
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "TRELLO_API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			},
+			AdditionalHeaders: []spec.AdditionalAuthHeader{
+				{Header: "token", In: "query", EnvVar: spec.AuthEnvVar{Name: "TRELLO_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+				{Header: "X-Mergeable-Key", In: "header", EnvVar: spec.AuthEnvVar{Name: "MERGEABLE_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"cards": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/cards"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	otherOrigin := &spec.APISpec{
+		Name:    "other",
+		Version: "0.1.0",
+		BaseURL: "https://other.example.net",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{trelloShaped, otherOrigin}, "combo")
+
+	assertNoAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "token")
+	assertAdditionalAuthHeader(t, merged.Auth.AdditionalHeaders, "X-Mergeable-Key", "MERGEABLE_KEY")
+
+	noAuthFirst := &spec.APISpec{
+		Name:    "none",
+		Version: "0.1.0",
+		BaseURL: "https://none.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"none": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/none"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	laterSelected := &spec.APISpec{
+		Name:    "oauthquery",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			AuthorizationURL: "https://accounts.example.com/auth",
+			TokenURL:         "https://accounts.example.com/token",
+			AdditionalHeaders: []spec.AdditionalAuthHeader{
+				{Header: "oauth_token_query", In: "query", EnvVar: spec.AuthEnvVar{Name: "OAUTH_QUERY_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+				{Header: "X-OAuth-Key", In: "header", EnvVar: spec.AuthEnvVar{Name: "OAUTH_HEADER_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"oauthquery": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/oauthquery"}}},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	mergedLater := mergeSpecs([]*spec.APISpec{noAuthFirst, laterSelected, otherOrigin}, "combo")
+
+	assertNoAdditionalAuthHeader(t, mergedLater.Auth.AdditionalHeaders, "oauth_token_query")
+	assertAdditionalAuthHeader(t, mergedLater.Auth.AdditionalHeaders, "X-OAuth-Key", "OAUTH_HEADER_KEY")
 }
 
 func TestMergeSpecsUsesLaterOAuthAuthWhenPrimaryHasNoLogin(t *testing.T) {
@@ -1247,6 +1340,16 @@ func assertAdditionalAuthHeader(t *testing.T, headers []spec.AdditionalAuthHeade
 		}
 	}
 	assert.Failf(t, "missing additional auth header", "header %q with env var %q not found in %#v", wantHeader, wantEnvVar, headers)
+}
+
+func assertNoAdditionalAuthHeader(t *testing.T, headers []spec.AdditionalAuthHeader, wantHeader string) {
+	t.Helper()
+	for _, header := range headers {
+		if header.Header == wantHeader {
+			assert.Failf(t, "unexpected additional auth header", "header %q found in %#v", wantHeader, headers)
+			return
+		}
+	}
 }
 
 func TestGenerateMultiSpecUnionsOAuthScopes(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -956,10 +956,10 @@ func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
 			scopeSet[scope] = struct{}{}
 		}
 	}
-	headers := append([]spec.AdditionalAuthHeader(nil), auth.AdditionalHeaders...)
+	headers := mergeableAdditionalAuthHeaders(auth.AdditionalHeaders)
 	seenHeaders := make(map[string]struct{}, len(headers)+1)
 	seenEnvVars := make(map[string]struct{}, len(headers)+len(auth.EnvVarSpecs)+len(auth.EnvVars))
-	seedAuthHeaderDedupe(seenHeaders, seenEnvVars, auth)
+	seedAuthHeaderDedupe(seenHeaders, seenEnvVars, auth, headers)
 
 	for _, s := range specs {
 		if compatibleOAuthScopeAuth(auth, s.Auth) {
@@ -977,7 +977,7 @@ func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
 	return auth
 }
 
-func seedAuthHeaderDedupe(seenHeaders, seenEnvVars map[string]struct{}, auth spec.AuthConfig) {
+func seedAuthHeaderDedupe(seenHeaders, seenEnvVars map[string]struct{}, auth spec.AuthConfig, headers []spec.AdditionalAuthHeader) {
 	if header := strings.TrimSpace(auth.Header); header != "" {
 		seenHeaders[header] = struct{}{}
 	}
@@ -991,7 +991,7 @@ func seedAuthHeaderDedupe(seenHeaders, seenEnvVars map[string]struct{}, auth spe
 			seenEnvVars[name] = struct{}{}
 		}
 	}
-	for _, header := range auth.AdditionalHeaders {
+	for _, header := range headers {
 		if name := strings.TrimSpace(header.Header); name != "" {
 			seenHeaders[name] = struct{}{}
 		}
@@ -1029,6 +1029,9 @@ func appendUniqueAdditionalAuthHeaders(headers []spec.AdditionalAuthHeader, seen
 		}
 	}
 	for _, candidate := range candidates {
+		if !isMergeableAdditionalAuthHeader(candidate) {
+			continue
+		}
 		header := strings.TrimSpace(candidate.Header)
 		envVarName := strings.TrimSpace(candidate.EnvVar.Name)
 		if header == "" || envVarName == "" {
@@ -1045,6 +1048,20 @@ func appendUniqueAdditionalAuthHeaders(headers []spec.AdditionalAuthHeader, seen
 		headers = append(headers, candidate)
 	}
 	return headers
+}
+
+func mergeableAdditionalAuthHeaders(headers []spec.AdditionalAuthHeader) []spec.AdditionalAuthHeader {
+	mergeable := make([]spec.AdditionalAuthHeader, 0, len(headers))
+	for _, header := range headers {
+		if isMergeableAdditionalAuthHeader(header) {
+			mergeable = append(mergeable, header)
+		}
+	}
+	return mergeable
+}
+
+func isMergeableAdditionalAuthHeader(header spec.AdditionalAuthHeader) bool {
+	return !strings.EqualFold(strings.TrimSpace(header.In), "query")
 }
 
 func sortedScopes(scopeSet map[string]struct{}) []string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1076,6 +1076,120 @@ func TestGenerateComposedApiKeyPlusBearerEmitsAdditionalHeader(t *testing.T) {
 		"MCP context must expose sibling apiKey credentials to agents")
 }
 
+// Trello-shaped OpenAPI specs require two apiKey query credentials in the
+// same security requirement. The first key follows the primary auth path; the
+// sibling token must be loaded into config, counted by doctor, and attached to
+// the request URL as its own query parameter.
+func TestGenerateComposedQueryApiKeysEmitAdditionalQueryParam(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Trello Auth
+  version: "1.0.0"
+servers:
+  - url: https://api.trello.com/1
+security:
+  - APIKey: []
+    APIToken: []
+components:
+  securitySchemes:
+    APIKey:
+      type: apiKey
+      in: query
+      name: key
+      x-auth-env-vars:
+        - TRELLO_API_KEY
+    APIToken:
+      type: apiKey
+      in: query
+      name: token
+      x-auth-env-vars:
+        - TRELLO_TOKEN
+paths:
+  /members/me:
+    get:
+      operationId: getMe
+      responses:
+        "200":
+          description: OK
+`))
+	require.NoError(t, err)
+	apiSpec.Name = "trelloauth"
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/trelloauth-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	configBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	configSrc := string(configBytes)
+	assert.Regexp(t, `TrelloToken\s+string`, configSrc,
+		"Config struct must carry a field for the sibling query apiKey env var")
+	assert.Contains(t, configSrc, `os.Getenv("TRELLO_TOKEN")`,
+		"Load() must read TRELLO_TOKEN from env")
+	assert.Contains(t, configSrc, `cfg.TrelloToken = v`,
+		"Load() must assign TRELLO_TOKEN into the Config field")
+
+	clientBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientSrc := string(clientBytes)
+	assert.Contains(t, clientSrc, `q.Set("key", authHeader)`,
+		"client must keep setting the primary API key query parameter")
+	assert.Contains(t, clientSrc, `q.Set("token", v)`,
+		"client must set the sibling token query parameter on every outbound request")
+	assert.NotContains(t, clientSrc, `req.Header.Set("token", v)`,
+		"sibling query credentials must not be emitted as headers")
+
+	doctorBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	doctorSrc := string(doctorBytes)
+	assert.Contains(t, doctorSrc, `recordAdditionalAuthEnv("TRELLO_TOKEN", configuredValue)`,
+		"doctor must check the sibling query apiKey env var")
+	assert.Contains(t, doctorSrc, `OK %d/%d available", len(authEnvSet), 2`,
+		"doctor must include sibling query apiKey credentials in the env-var count")
+
+	clientTest := `package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"trelloauth-pp-cli/internal/config"
+)
+
+func TestGeneratedClientSendsBothQueryCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if got := query.Get("key"); got != "key-value" {
+			t.Fatalf("key query param = %q, want key-value", got)
+		}
+		if got := query.Get("token"); got != "token-value" {
+			t.Fatalf("token query param = %q, want token-value", got)
+		}
+		w.Write([]byte(` + "`" + `{"ok":true}` + "`" + `))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		BaseURL:      server.URL,
+		TrelloApiKey: "key-value",
+		TrelloToken:  "token-value",
+	}
+	c := New(cfg, 5*time.Second, 0)
+	if _, err := c.Get(context.Background(), "/members/me", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "additional_query_auth_test.go"), []byte(clientTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestGeneratedClientSendsBothQueryCredentials")
+}
+
 // OAuth2 client_credentials specs without a sibling apiKey scheme must not
 // emit the additional-header block. Guards against the previous emission
 // regressing into "every OAuth CLI now ships a useless extra Config field".

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1291,16 +1291,22 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- end}}
 		}
 {{- if .Auth.AdditionalHeaders}}
-		// Composed-scheme per-call headers carried by sibling apiKey schemes.
+		// Composed-scheme per-call credentials carried by sibling apiKey schemes.
 		// Sent independently of authHeader: the API requires both the primary
-		// auth header and each sibling header on every request.
+		// auth credential and each sibling credential on every request.
 		if c.Config != nil {
 {{- range .Auth.AdditionalHeaders}}
 			if v := c.Config.{{resolveEnvVarField .EnvVar.Name}}; v != "" {
 				if authHeaderLooksLikePlaceholderCredential(v) {
 					return nil, 0, authPlaceholderCredentialErrorWithSetup(c.Config, "export {{.EnvVar.Name}}=<your-token>")
 				}
+{{- if eq .In "query"}}
+				q := req.URL.Query()
+				q.Set("{{.Header}}", v)
+				req.URL.RawQuery = q.Encode()
+{{- else}}
 				req.Header.Set("{{.Header}}", v)
+{{- end}}
 			}
 {{- end}}
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -982,12 +982,12 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 // header on every Bearer-authenticated request. Only schemes co-located with
 // the winner in a requirement object are promoted.
 //
-// Only apiKey-typed siblings with `in: header` are considered. Rich
+// Only apiKey-typed siblings with `in: header` or `in: query` are considered. Rich
 // x-auth-vars per_call declarations win; legacy x-auth-env-vars supplies the
 // same credential name for specs that do not use the rich shape. For all-apiKey
 // AND groups, missing extension metadata falls back to a deterministic
-// scheme-derived env var so every required header reaches generated config and
-// client code.
+// scheme-derived env var so every required credential reaches generated config
+// and client code.
 func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []spec.AdditionalAuthHeader {
 	if doc == nil || doc.Components == nil || len(doc.Components.SecuritySchemes) <= 1 {
 		return nil
@@ -1008,17 +1008,17 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []s
 		if _, ok := req[winner]; !ok {
 			continue
 		}
-		allHeaderAPIKeys := requirementAllHeaderAPIKeys(doc, req)
+		allSupportedAPIKeys := requirementAllSupportedAPIKeys(doc, req)
 		for name := range req {
 			if name == winner {
 				continue
 			}
 			if _, dup := siblingSet[name]; dup {
-				fallbackEligible[name] = fallbackEligible[name] || allHeaderAPIKeys
+				fallbackEligible[name] = fallbackEligible[name] || allSupportedAPIKeys
 				continue
 			}
 			siblingSet[name] = struct{}{}
-			fallbackEligible[name] = allHeaderAPIKeys
+			fallbackEligible[name] = allSupportedAPIKeys
 			siblings = append(siblings, name)
 		}
 	}
@@ -1038,8 +1038,9 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []s
 			continue
 		}
 		// apiKey schemes must declare `in` per OpenAPI 3.x; an empty value is a
-		// spec authoring mistake and would otherwise silently emit a header.
-		if !strings.EqualFold(strings.TrimSpace(scheme.In), "header") {
+		// spec authoring mistake and would otherwise silently emit a credential.
+		placement := strings.ToLower(strings.TrimSpace(scheme.In))
+		if placement != "header" && placement != "query" {
 			continue
 		}
 		envVars := additionalHeaderEnvVars(scheme, name, envPrefix, fallbackEligible[name])
@@ -1052,7 +1053,7 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []s
 			}
 			headers = append(headers, spec.AdditionalAuthHeader{
 				Header: header,
-				In:     "header",
+				In:     placement,
 				Scheme: name,
 				EnvVar: ev,
 			})
@@ -1230,7 +1231,7 @@ func defaultAuthEnvVars(authType, format, schemeName, envPrefix string) []string
 	}
 }
 
-func requirementAllHeaderAPIKeys(doc *openapi3.T, req openapi3.SecurityRequirement) bool {
+func requirementAllSupportedAPIKeys(doc *openapi3.T, req openapi3.SecurityRequirement) bool {
 	if doc == nil || doc.Components == nil || len(req) == 0 {
 		return false
 	}
@@ -1239,7 +1240,8 @@ func requirementAllHeaderAPIKeys(doc *openapi3.T, req openapi3.SecurityRequireme
 		if scheme == nil {
 			return false
 		}
-		if !strings.EqualFold(scheme.Type, "apiKey") || !strings.EqualFold(strings.TrimSpace(scheme.In), "header") {
+		placement := strings.ToLower(strings.TrimSpace(scheme.In))
+		if !strings.EqualFold(scheme.Type, "apiKey") || (placement != "header" && placement != "query") {
 			return false
 		}
 	}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -4400,38 +4400,37 @@ paths:
 	assert.Empty(t, parsed.Auth.AdditionalHeaders)
 }
 
-// Sibling apiKey-in-query schemes are skipped: the issue this addresses is
-// header-only (ST-App-Key, Stripe-Signature, Atlassian-Token). A query-param
-// sibling would imply mixing query-auth with bearer Authorization, which is
-// not a shape this fix supports, and pretending it works would silently emit
-// broken code.
-func TestSiblingApiKeyInQueryIsSkipped(t *testing.T) {
+// Sibling apiKey-in-query schemes are required credentials just like
+// sibling header schemes. Trello-shaped specs declare two query apiKeys in one
+// AND group; dropping the second one makes every live call unauthenticated.
+func TestSiblingApiKeyInQueryIsCollected(t *testing.T) {
 	t.Parallel()
 
 	yamlSpec := []byte(`openapi: "3.0.3"
 info:
-  title: query-sibling
+  title: trello-shaped
   version: "1.0.0"
 servers:
-  - url: https://api.example.com
+  - url: https://api.trello.com/1
 security:
-  - bearer: []
-    queryKey: []
+  - APIKey: []
+    APIToken: []
 components:
   securitySchemes:
-    bearer:
-      type: http
-      scheme: bearer
-    queryKey:
+    APIKey:
       type: apiKey
       in: query
-      name: api_key
-      x-auth-vars:
-        - name: EXAMPLE_QUERY_KEY
-          kind: per_call
-          required: true
+      name: key
+      x-auth-env-vars:
+        - TRELLO_API_KEY
+    APIToken:
+      type: apiKey
+      in: query
+      name: token
+      x-auth-env-vars:
+        - TRELLO_TOKEN
 paths:
-  /items:
+  /members/me:
     get:
       responses:
         "200":
@@ -4439,7 +4438,20 @@ paths:
 `)
 	parsed, err := Parse(yamlSpec)
 	require.NoError(t, err)
-	assert.Empty(t, parsed.Auth.AdditionalHeaders)
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "APIKey", parsed.Auth.Scheme)
+	assert.Equal(t, "query", parsed.Auth.In)
+	assert.Equal(t, "key", parsed.Auth.Header)
+	assert.Equal(t, []string{"TRELLO_API_KEY"}, parsed.Auth.EnvVars)
+	require.Len(t, parsed.Auth.AdditionalHeaders, 1, "AND-sibling query apiKey scheme must surface as an additional credential")
+	additional := parsed.Auth.AdditionalHeaders[0]
+	assert.Equal(t, "token", additional.Header)
+	assert.Equal(t, "query", additional.In)
+	assert.Equal(t, "APIToken", additional.Scheme)
+	assert.Equal(t, "TRELLO_TOKEN", additional.EnvVar.Name)
+	assert.Equal(t, spec.AuthEnvVarKindPerCall, additional.EnvVar.Kind)
+	assert.True(t, additional.EnvVar.Required)
+	assert.True(t, additional.EnvVar.Sensitive)
 }
 
 func TestOperationLevelHeterogeneousSiblingApiKeysAreSkipped(t *testing.T) {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -2222,6 +2222,7 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 	envMatched := false
 	scoreable := false
 	bearerStyle := false
+	exactQueryParamMatched := false
 
 	if strings.EqualFold(scheme.Type, "apikey") && (scheme.In == "header" || scheme.In == "query") && strings.TrimSpace(scheme.HeaderName) != "" {
 		headerName = scheme.HeaderName
@@ -2262,6 +2263,7 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 		}
 		if scheme.In == "query" && headerName != "" {
 			if queryAssignmentPresent(clientContent, headerName) {
+				exactQueryParamMatched = true
 				authHeaderMatched = true
 				headerNameMatched = true
 				queryMatched = true
@@ -2318,6 +2320,10 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 		strings.Contains(configContent, "chrome-composed") ||
 		strings.Contains(configContent, `"browser"`)) {
 		envMatched = true
+	}
+
+	if strings.EqualFold(scheme.Type, "apikey") && scheme.In == "query" && strings.TrimSpace(headerName) != "" && !exactQueryParamMatched {
+		return 0, true
 	}
 
 	score := 0
@@ -2503,14 +2509,18 @@ func configReadsAPIKeyEnvForScheme(configContent string, scheme openAPISecurityS
 }
 
 func configReadsSchemeEnvVar(configContent string, scheme openAPISecurityScheme) bool {
-	upperConfig := strings.ToUpper(configContent)
 	for _, envVar := range scheme.EnvVars {
 		envVar = strings.TrimSpace(envVar)
-		if envVar != "" && strings.Contains(upperConfig, strings.ToUpper(envVar)) {
+		if envVar != "" && configReadsExactEnvVar(configContent, envVar) {
 			return true
 		}
 	}
 	return false
+}
+
+func configReadsExactEnvVar(configContent, envVar string) bool {
+	callPattern := `\bos\.(?:Getenv|LookupEnv)\(\s*"` + regexp.QuoteMeta(envVar) + `"\s*\)`
+	return regexp.MustCompile(callPattern).MatchString(configContent)
 }
 
 func isGenericAPIKeyScheme(scheme openAPISecurityScheme) bool {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1675,6 +1675,7 @@ type openAPISecurityScheme struct {
 	Scheme     string
 	In         string
 	HeaderName string
+	EnvVars    []string
 	// Prefix mirrors apispec.AuthConfig.Prefix for internal-YAML specs that
 	// override the literal "Bearer" scheme word (e.g., "Token", "PRIVATE-TOKEN").
 	// Empty for OpenAPI-derived schemes; bearer-branch scoring falls back to "Bearer".
@@ -1781,6 +1782,7 @@ func loadOpenAPISpecData(data []byte, specPath string) (*openAPISpecInfo, error)
 					scheme.Scheme = strings.ToLower(asString(fields["scheme"]))
 					scheme.In = strings.ToLower(asString(fields["in"]))
 					scheme.HeaderName = asString(fields["name"])
+					scheme.EnvVars = parseScorecardAuthEnvVars(fields["x-auth-env-vars"])
 				}
 				info.SecuritySchemes[schemeName] = scheme
 			}
@@ -1805,6 +1807,7 @@ func loadOpenAPISpecData(data []byte, specPath string) (*openAPISpecInfo, error)
 						scheme.Type = "apikey"
 						scheme.In = swIn
 						scheme.HeaderName = swName
+						scheme.EnvVars = parseScorecardAuthEnvVars(fields["x-auth-env-vars"])
 						// Detect Bearer-style API key in header with Authorization name.
 						if swIn == "header" && strings.EqualFold(swName, "Authorization") {
 							scheme.Type = "http"
@@ -2122,6 +2125,37 @@ func parseOAuthScopeList(value any) []string {
 	return slices.Compact(scopes)
 }
 
+func parseScorecardAuthEnvVars(value any) []string {
+	switch envVars := value.(type) {
+	case []any:
+		var parsed []string
+		for _, raw := range envVars {
+			envVar := strings.TrimSpace(asString(raw))
+			if envVar != "" {
+				parsed = append(parsed, envVar)
+			}
+		}
+		return parsed
+	case []string:
+		var parsed []string
+		for _, raw := range envVars {
+			envVar := strings.TrimSpace(raw)
+			if envVar != "" {
+				parsed = append(parsed, envVar)
+			}
+		}
+		return parsed
+	case string:
+		envVar := strings.TrimSpace(envVars)
+		if envVar == "" {
+			return nil
+		}
+		return []string{envVar}
+	default:
+		return nil
+	}
+}
+
 func isOAuthSecurityScheme(scheme openAPISecurityScheme) bool {
 	return scheme.Type == "oauth2" || scheme.Type == "openidconnect"
 }
@@ -2189,7 +2223,7 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 	scoreable := false
 	bearerStyle := false
 
-	if strings.EqualFold(scheme.Type, "apikey") && scheme.In == "header" && strings.TrimSpace(scheme.HeaderName) != "" {
+	if strings.EqualFold(scheme.Type, "apikey") && (scheme.In == "header" || scheme.In == "query") && strings.TrimSpace(scheme.HeaderName) != "" {
 		headerName = scheme.HeaderName
 	} else if strings.EqualFold(scheme.Type, "apikey") && scheme.In == "cookie" {
 		headerName = "Cookie"
@@ -2226,6 +2260,13 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 				authHeaderMatched = true
 			}
 		}
+		if scheme.In == "query" && headerName != "" {
+			if queryAssignmentPresent(clientContent, headerName) {
+				authHeaderMatched = true
+				headerNameMatched = true
+				queryMatched = true
+			}
+		}
 	case strings.EqualFold(scheme.Type, "oauth2"), strings.EqualFold(scheme.Type, "openidconnect"):
 		scoreable = true
 		bearerStyle = true
@@ -2255,7 +2296,7 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 	}
 
 	// AuthProtocol pattern: query schemes touch URL query plumbing.
-	if scheme.In == "query" && (strings.Contains(clientContent, ".Query()") || strings.Contains(clientContent, "url.Values") || strings.Contains(clientContent, "RawQuery")) {
+	if scheme.In == "query" && (queryAssignmentPresent(clientContent, headerName) || strings.Contains(clientContent, ".Query()") || strings.Contains(clientContent, "url.Values") || strings.Contains(clientContent, "RawQuery")) {
 		queryMatched = true
 	}
 
@@ -2265,6 +2306,9 @@ func scoreAuthScheme(clientContent, configContent, authContent string, hasStruct
 		envMatched = true
 	}
 	if !envMatched && configReadsAPIKeyEnvForScheme(configContent, scheme) {
+		envMatched = true
+	}
+	if !envMatched && configReadsSchemeEnvVar(configContent, scheme) {
 		envMatched = true
 	}
 	// Browser cookie auth (composed or cookie type) uses Chrome cookie extraction
@@ -2411,6 +2455,17 @@ func headerAssignmentPresent(clientContent, headerName string) bool {
 		strings.Contains(clientContent, `header.add("`+headerName+`"`)
 }
 
+func queryAssignmentPresent(clientContent, queryName string) bool {
+	clientContent = strings.ToLower(clientContent)
+	queryName = strings.ToLower(strings.TrimSpace(queryName))
+	if queryName == "" {
+		return false
+	}
+	return strings.Contains(clientContent, `q.set("`+queryName+`"`) ||
+		strings.Contains(clientContent, `query.set("`+queryName+`"`) ||
+		strings.Contains(clientContent, `params["`+queryName+`"]`)
+}
+
 func inferredAuthHeaderAssignmentPresent(clientContent string) bool {
 	for _, headerName := range []string{"Authorization", "X-Api-Key", "X-Auth-Token", "X-Access-Token", "Cookie"} {
 		if headerAssignmentPresent(clientContent, headerName) {
@@ -2441,6 +2496,17 @@ func configReadsAPIKeyEnvForScheme(configContent string, scheme openAPISecurityS
 		tailEnd := min(len(configContent), tailStart+240)
 		fieldAssignmentRe := regexp.MustCompile(`\.\s*APIKey\s*=\s*` + regexp.QuoteMeta(envVarName) + `\b`)
 		if fieldAssignmentRe.MatchString(configContent[tailStart:tailEnd]) {
+			return true
+		}
+	}
+	return false
+}
+
+func configReadsSchemeEnvVar(configContent string, scheme openAPISecurityScheme) bool {
+	upperConfig := strings.ToUpper(configContent)
+	for _, envVar := range scheme.EnvVars {
+		envVar = strings.TrimSpace(envVar)
+		if envVar != "" && strings.Contains(upperConfig, strings.ToUpper(envVar)) {
 			return true
 		}
 	}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1694,6 +1694,147 @@ func setAutotaskAuth(req *http.Request, userName string, integrationCode string)
 		assert.Less(t, sc.Steinberger.AuthProtocol, 5)
 	})
 
+	t.Run("all apiKey query auth scores every required query parameter", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/client/client.go", `
+package client
+
+import "net/http"
+
+func setTrelloAuth(req *http.Request, key string, token string) {
+	q := req.URL.Query()
+	q.Set("key", key)
+	q.Set("token", token)
+	req.URL.RawQuery = q.Encode()
+}
+`)
+		writeScorecardFixture(t, dir, "internal/config/config.go", `
+package config
+
+import "os"
+
+func Load() {
+	if v := os.Getenv("TRELLO_API_KEY"); v != "" {
+		cfg.TrelloApiKey = v
+	}
+	if v := os.Getenv("TRELLO_TOKEN"); v != "" {
+		cfg.TrelloToken = v
+	}
+}
+`)
+
+		specPath := filepath.Join(dir, "spec-trello-query-composed.json")
+		writeScorecardFixture(t, dir, "spec-trello-query-composed.json", `{
+  "security": [
+    {
+      "APIKey": [],
+      "APIToken": []
+    }
+  ],
+  "paths": {
+    "/members/me": {
+      "get": {
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "APIKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key",
+        "x-auth-env-vars": ["TRELLO_API_KEY"]
+      },
+      "APIToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "token",
+        "x-auth-env-vars": ["TRELLO_TOKEN"]
+      }
+    }
+  }
+}`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
+		assert.NoError(t, err)
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.Equal(t, 10, sc.Steinberger.AuthProtocol)
+	})
+
+	t.Run("all apiKey query auth penalizes missing required query parameter", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/client/client.go", `
+package client
+
+import "net/http"
+
+func setTrelloAuth(req *http.Request, key string) {
+	q := req.URL.Query()
+	q.Set("key", key)
+	req.URL.RawQuery = q.Encode()
+}
+`)
+		writeScorecardFixture(t, dir, "internal/config/config.go", `
+package config
+
+import "os"
+
+func Load() {
+	if v := os.Getenv("TRELLO_API_KEY"); v != "" {
+		cfg.TrelloApiKey = v
+	}
+	if v := os.Getenv("TRELLO_TOKEN"); v != "" {
+		cfg.TrelloToken = v
+	}
+}
+`)
+
+		specPath := filepath.Join(dir, "spec-trello-query-composed-missing.json")
+		writeScorecardFixture(t, dir, "spec-trello-query-composed-missing.json", `{
+  "security": [
+    {
+      "APIKey": [],
+      "APIToken": []
+    }
+  ],
+  "paths": {
+    "/members/me": {
+      "get": {
+        "responses": {
+          "200": { "description": "ok" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "APIKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key",
+        "x-auth-env-vars": ["TRELLO_API_KEY"]
+      },
+      "APIToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "token",
+        "x-auth-env-vars": ["TRELLO_TOKEN"]
+      }
+    }
+  }
+}`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
+		assert.NoError(t, err)
+		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
+		assert.Less(t, sc.Steinberger.AuthProtocol, 8)
+	})
+
 	t.Run("same-prefix standalone header scheme is not pulled into composed auth", func(t *testing.T) {
 		dir := t.TempDir()
 		writeScorecardFixture(t, dir, "internal/client/client.go", `

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1832,7 +1832,7 @@ func Load() {
 		sc, err := RunScorecard(dir, pipelineDir, specPath, nil)
 		assert.NoError(t, err)
 		assert.NotContains(t, sc.UnscoredDimensions, "auth_protocol")
-		assert.Less(t, sc.Steinberger.AuthProtocol, 8)
+		assert.Less(t, sc.Steinberger.AuthProtocol, 6)
 	})
 
 	t.Run("same-prefix standalone header scheme is not pulled into composed auth", func(t *testing.T) {
@@ -3023,6 +3023,33 @@ func Load() {
 	unrelatedScore, unrelatedScoreable := scoreAuthScheme(clientContent, configContent, "", false, unrelatedScheme)
 	assert.True(t, unrelatedScoreable)
 	assert.Equal(t, 0, unrelatedScore)
+}
+
+func TestConfigReadsSchemeEnvVarRequiresExactEnvLookup(t *testing.T) {
+	scheme := openAPISecurityScheme{
+		Key:     "APIToken",
+		Type:    "apikey",
+		In:      "query",
+		EnvVars: []string{"KEY"},
+	}
+
+	assert.True(t, configReadsSchemeEnvVar(`package config
+func Load() {
+	if v := os.Getenv("KEY"); v != "" {
+		cfg.Key = v
+	}
+}`, scheme))
+	assert.True(t, configReadsSchemeEnvVar(`package config
+func Load() {
+	if v, ok := os.LookupEnv("KEY"); ok {
+		cfg.Key = v
+	}
+}`, scheme))
+	assert.False(t, configReadsSchemeEnvVar(`package config
+// KEY is mentioned here, but not read.
+func Load() {
+	cfg.SomeOtherKey = "not-secret"
+}`, scheme))
 }
 
 func TestRunScorecard_APIKeyHeaderUsesCaseInsensitiveHeaderAndGenericAPIKeyEnv(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -840,17 +840,15 @@ type AuthConfig struct {
 	// declare both schemes in components.securitySchemes; selectSecurityScheme
 	// picks one as the primary (Authorization-bearer half) and the parser then
 	// scans the rest for apiKey schemes carrying x-auth-vars[*].kind: per_call,
-	// so the apiKey header gets sent alongside the primary auth. Generator
-	// emits a Config field + os.Getenv loader per entry, plus a req.Header.Set
-	// after the primary auth header on every request.
+	// so the apiKey credential gets sent alongside the primary auth. Generator
+	// emits a Config field + os.Getenv loader per entry, then applies the
+	// credential according to In on every request.
 	AdditionalHeaders []AdditionalAuthHeader `yaml:"additional_headers,omitempty" json:"additional_headers,omitempty"`
 }
 
-// AdditionalAuthHeader pairs a sibling-scheme header destination with the
-// per-call env var that supplies its value. Only In == "header" is emitted by
-// the generator today; the field is serialized so parsed specs round-trip
-// cleanly and validators can distinguish placements without relying on the
-// destination string.
+// AdditionalAuthHeader pairs a sibling-scheme credential destination with the
+// per-call env var that supplies its value. Header stores the OpenAPI apiKey
+// scheme's name field; In distinguishes header and query placements.
 type AdditionalAuthHeader struct {
 	Header string     `yaml:"header" json:"header"`
 	In     string     `yaml:"in,omitempty" json:"in,omitempty"`
@@ -2630,6 +2628,11 @@ func validateAdditionalAuthHeaders(context string, auth AuthConfig) error {
 			return fmt.Errorf("%s.additional_headers contains duplicate header %q", context, header)
 		}
 		seenHeaders[header] = struct{}{}
+		switch strings.ToLower(strings.TrimSpace(ah.In)) {
+		case "", "header", "query":
+		default:
+			return fmt.Errorf("%s.additional_headers[%d].in must be \"header\" or \"query\" (got %q)", context, i, ah.In)
+		}
 		name := strings.TrimSpace(ah.EnvVar.Name)
 		if name == "" {
 			return fmt.Errorf("%s.additional_headers[%d].env_var.name is required", context, i)

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -345,6 +345,17 @@ func TestValidateAdditionalAuthHeadersErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path: per_call sibling with query validates",
+			auth: AuthConfig{
+				Type:   "api_key",
+				Header: "key",
+				In:     "query",
+				AdditionalHeaders: []AdditionalAuthHeader{
+					{Header: "token", In: "query", EnvVar: perCall("TRELLO_TOKEN")},
+				},
+			},
+		},
+		{
 			name: "missing header",
 			auth: AuthConfig{
 				Type: "bearer_token",
@@ -374,6 +385,16 @@ func TestValidateAdditionalAuthHeadersErrors(t *testing.T) {
 				},
 			},
 			wantErr: `auth.additional_headers contains duplicate header "X-Same"`,
+		},
+		{
+			name: "unsupported placement",
+			auth: AuthConfig{
+				Type: "bearer_token",
+				AdditionalHeaders: []AdditionalAuthHeader{
+					{Header: "X-Key", In: "cookie", EnvVar: perCall("COOKIE_KEY")},
+				},
+			},
+			wantErr: `auth.additional_headers[0].in must be "header" or "query" (got "cookie")`,
 		},
 		{
 			name: "duplicate env_var name",


### PR DESCRIPTION
## Summary
Generated CLIs for OpenAPI specs that require multiple query `apiKey` schemes now preserve and send every required credential. This fixes Trello-shaped AND security requirements where the primary `key` was emitted but the sibling `token` was dropped.

The change also keeps query credentials out of multi-spec global auth merges until auth can be scoped safely, and updates `auth_protocol` scoring so the verifier recognizes exact sibling query parameter emission.

Closes #1663

## Verification
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`

## Compounded learnings
- Added `docs/solutions/logic-errors/openapi-and-query-apikey-siblings.md` for the parser/generator/scorer contract and the multi-spec safety boundary.
