### PR TITLE
feat(catalog): add IT Glue Printing Press spec

### DIFF
--- a/catalog/itglue.yaml
+++ b/catalog/itglue.yaml
@@ -1,0 +1,21 @@
+name: itglue
+display_name: IT Glue / MyGlue
+description: IT Glue JSON:API surface for organizations, contacts, passwords, configurations, and documents, including the write endpoints needed for MSP automation
+category: productivity
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/itglue-openapi.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: official
+spec_source: docs
+client_pattern: rest
+http_transport: standard
+auth_required: true
+verified_date: "2026-05-24"
+homepage: https://api.itglue.com/developer/
+auth_key_url: https://api.itglue.com/developer/
+auth_instructions: "Use the ITO Key Vault secret ItGlueApiKey. Set the generated CLI base URL to https://api.eu.itglue.com for the ITO EU tenant."
+notes: >
+  Docs-derived wrapper spec from IT Glue's official developer documentation. The
+  API is JSON:API over HTTPS with x-api-key auth. This blueprint intentionally
+  omits DELETE endpoints; contact deactivation should use PATCH with an agreed
+  inactive/contact-state attribute rather than destructive deletion.

--- a/catalog/itglue.yaml
+++ b/catalog/itglue.yaml
@@ -13,7 +13,7 @@ auth_required: true
 verified_date: "2026-05-24"
 homepage: https://api.itglue.com/developer/
 auth_key_url: https://api.itglue.com/developer/
-auth_instructions: "Use the ITO Key Vault secret ItGlueApiKey. Set the generated CLI base URL to https://api.eu.itglue.com for the ITO EU tenant."
+auth_instructions: "Generate an API key in your IT Glue account settings, then choose the base URL for your IT Glue data region."
 notes: >
   Docs-derived wrapper spec from IT Glue's official developer documentation. The
   API is JSON:API over HTTPS with x-api-key auth. This blueprint intentionally

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -9,7 +9,7 @@ info:
     needed for contact sync, password mirroring, configuration creation, and
     onboarding documentation.
   x-auth-key-url: https://api.itglue.com/developer/
-  x-auth-instructions: "Use the ITO Key Vault secret ItGlueApiKey; do not use the read-only ItGlueReadOnlyApiKey for write operations."
+  x-auth-instructions: "Generate an API key in your IT Glue account settings, then choose the base URL for your IT Glue data region."
 externalDocs:
   description: Official IT Glue developer documentation
   url: https://api.itglue.com/developer/
@@ -125,6 +125,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /organizations/{organization_id}/relationships/contacts:
@@ -161,6 +163,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
   /organizations/{organization_id}/relationships/contacts/{id}:
     patch:
       operationId: updateOrganizationContact
@@ -181,6 +185,10 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
   /passwords:
     get:
       operationId: listPasswords
@@ -226,6 +234,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       operationId: updatePassword
       tags: [Passwords]
@@ -302,6 +312,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       operationId: updateConfiguration
       tags: [Configurations]
@@ -353,6 +365,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
   /documents:
     get:
       operationId: listDocuments
@@ -396,6 +410,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       operationId: updateDocument
       tags: [Documents]
@@ -447,6 +463,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
 components:
   securitySchemes:
     ItGlueApiKey:
@@ -459,7 +477,7 @@ components:
           kind: per_call
           required: true
           sensitive: true
-          description: IT Glue read-write API key from the ITO Key Vault secret ItGlueApiKey.
+          description: IT Glue API key with permissions for the requested read and write operations.
   parameters:
     Id:
       name: id
@@ -610,6 +628,7 @@ components:
           additionalProperties: true
     ContactAttributes:
       type: object
+      required: [organization-id, name]
       properties:
         organization-id:
           type: integer
@@ -654,6 +673,7 @@ components:
           additionalProperties: true
     PasswordAttributes:
       type: object
+      required: [organization-id, name]
       properties:
         organization-id:
           type: integer
@@ -702,6 +722,7 @@ components:
           additionalProperties: true
     ConfigurationAttributes:
       type: object
+      required: [organization-id, name]
       properties:
         organization-id:
           type: integer
@@ -758,6 +779,7 @@ components:
           additionalProperties: true
     DocumentAttributes:
       type: object
+      required: [organization-id, name]
       properties:
         organization-id:
           type: integer

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -158,10 +158,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/OrganizationContactRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/OrganizationContactRequest"
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
@@ -368,10 +368,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ConfigurationRequest"
+              $ref: "#/components/schemas/OrganizationConfigurationRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ConfigurationRequest"
+              $ref: "#/components/schemas/OrganizationConfigurationRequest"
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
@@ -472,10 +472,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/DocumentRequest"
+              $ref: "#/components/schemas/OrganizationDocumentRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/DocumentRequest"
+              $ref: "#/components/schemas/OrganizationDocumentRequest"
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
@@ -719,6 +719,49 @@ components:
           type: boolean
           description: Included for non-destructive deactivation where available in the tenant.
       additionalProperties: true
+    OrganizationContactRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [contacts]
+            attributes:
+              $ref: "#/components/schemas/OrganizationContactAttributes"
+          additionalProperties: true
+    OrganizationContactAttributes:
+      type: object
+      required: [name]
+      properties:
+        first-name:
+          type: string
+        last-name:
+          type: string
+        name:
+          type: string
+        title:
+          type: string
+        email:
+          type: string
+          format: email
+        notes:
+          type: string
+          nullable: true
+        important:
+          type: boolean
+        contact-type-id:
+          type: integer
+        location-id:
+          type: integer
+          nullable: true
+        archived:
+          type: boolean
+          description: Included for non-destructive deactivation where available in the tenant.
+      additionalProperties: true
     PasswordRequest:
       type: object
       required: [data]
@@ -923,6 +966,61 @@ components:
           type: string
           nullable: true
       additionalProperties: true
+    OrganizationConfigurationRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [configurations]
+            attributes:
+              $ref: "#/components/schemas/OrganizationConfigurationAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    OrganizationConfigurationAttributes:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        hostname:
+          type: string
+          nullable: true
+        configuration-type-id:
+          type: integer
+        configuration-status-id:
+          type: integer
+        manufacturer-id:
+          type: integer
+          nullable: true
+        model-id:
+          type: integer
+          nullable: true
+        location-id:
+          type: integer
+          nullable: true
+        serial-number:
+          type: string
+          nullable: true
+        asset-tag:
+          type: string
+          nullable: true
+        primary-ip:
+          type: string
+          nullable: true
+        mac-address:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+      additionalProperties: true
     DocumentRequest:
       type: object
       required: [data]
@@ -990,6 +1088,49 @@ components:
       properties:
         organization-id:
           type: integer
+        name:
+          type: string
+        content:
+          type: string
+          nullable: true
+          description: Document body content, typically HTML or rich text from IT Glue.
+        restricted:
+          type: boolean
+          nullable: true
+        archived:
+          type: boolean
+          nullable: true
+        public:
+          type: boolean
+          nullable: true
+        document-folder-id:
+          type: integer
+          nullable: true
+        my-glue:
+          type: boolean
+          nullable: true
+      additionalProperties: true
+    OrganizationDocumentRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [documents]
+            attributes:
+              $ref: "#/components/schemas/OrganizationDocumentAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    OrganizationDocumentAttributes:
+      type: object
+      required: [name]
+      properties:
         name:
           type: string
         content:

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -118,10 +118,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ContactUpdateRequest"
+              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactUpdateRequest"
+              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -738,6 +738,50 @@ components:
     OrganizationContactAttributes:
       type: object
       required: [name]
+      properties:
+        first-name:
+          type: string
+        last-name:
+          type: string
+        name:
+          type: string
+        title:
+          type: string
+        email:
+          type: string
+          format: email
+        notes:
+          type: string
+          nullable: true
+        important:
+          type: boolean
+        contact-type-id:
+          type: integer
+        location-id:
+          type: integer
+          nullable: true
+        archived:
+          type: boolean
+          description: Included for non-destructive deactivation where available in the tenant.
+      additionalProperties: true
+    OrganizationContactUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, id, attributes]
+          properties:
+            type:
+              type: string
+              enum: [contacts]
+            id:
+              type: string
+            attributes:
+              $ref: "#/components/schemas/OrganizationContactUpdateAttributes"
+          additionalProperties: true
+    OrganizationContactUpdateAttributes:
+      type: object
       properties:
         first-name:
           type: string

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -1,0 +1,781 @@
+openapi: 3.0.3
+info:
+  title: IT Glue / MyGlue API
+  version: "2026-05-24"
+  description: >
+    Focused IT Glue REST API wrapper for MSP automation. The API follows the
+    JSON:API media type and uses an x-api-key header. This spec covers the read
+    surface already used by JAIs BOT plus the non-destructive write endpoints
+    needed for contact sync, password mirroring, configuration creation, and
+    onboarding documentation.
+  x-auth-key-url: https://api.itglue.com/developer/
+  x-auth-instructions: "Use the ITO Key Vault secret ItGlueApiKey; do not use the read-only ItGlueReadOnlyApiKey for write operations."
+externalDocs:
+  description: Official IT Glue developer documentation
+  url: https://api.itglue.com/developer/
+servers:
+  - url: https://api.eu.itglue.com
+    description: IT Glue EU data centre
+  - url: https://api.itglue.com
+    description: IT Glue default data centre
+  - url: https://api.au.itglue.com
+    description: IT Glue Australia data centre
+security:
+  - ItGlueApiKey: []
+tags:
+  - name: Organizations
+  - name: Contacts
+  - name: Passwords
+  - name: Configurations
+  - name: Documents
+paths:
+  /organizations:
+    get:
+      operationId: listOrganizations
+      tags: [Organizations]
+      summary: List organizations
+      parameters:
+        - $ref: "#/components/parameters/FilterId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+  /organizations/{id}:
+    get:
+      operationId: getOrganization
+      tags: [Organizations]
+      summary: Retrieve one organization
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /contacts:
+    get:
+      operationId: listContacts
+      tags: [Contacts]
+      summary: List contacts
+      description: Use filter[email] or filter[organization_id] before creating contacts to avoid duplicates.
+      parameters:
+        - $ref: "#/components/parameters/FilterId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/FilterOrganizationId"
+        - name: filter[email]
+          in: query
+          schema:
+            type: string
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createContact
+      tags: [Contacts]
+      summary: Create a contact
+      description: Idempotent callers should first search by organization id and email address.
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /contacts/{id}:
+    get:
+      operationId: getContact
+      tags: [Contacts]
+      summary: Retrieve a contact
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: updateContact
+      tags: [Contacts]
+      summary: Update or deactivate a contact
+      description: Use PATCH for contact deactivation; this spec intentionally does not expose DELETE.
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /organizations/{organization_id}/relationships/contacts:
+    get:
+      operationId: listOrganizationContacts
+      tags: [Contacts]
+      summary: List contacts for an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+        - name: filter[email]
+          in: query
+          schema:
+            type: string
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createOrganizationContact
+      tags: [Contacts]
+      summary: Create a contact under an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+  /organizations/{organization_id}/relationships/contacts/{id}:
+    patch:
+      operationId: updateOrganizationContact
+      tags: [Contacts]
+      summary: Update or deactivate an organization contact
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+        - $ref: "#/components/parameters/Id"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContactRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+  /passwords:
+    get:
+      operationId: listPasswords
+      tags: [Passwords]
+      summary: List passwords
+      description: Use filter[name] plus filter[organization_id] before creating password mirror records.
+      parameters:
+        - $ref: "#/components/parameters/FilterId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/FilterOrganizationId"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createPassword
+      tags: [Passwords]
+      summary: Create a password
+      description: Creates either a general password or an embedded password when resource-id and resource-type are supplied.
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/PasswordRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /passwords/{id}:
+    get:
+      operationId: getPassword
+      tags: [Passwords]
+      summary: Retrieve a password metadata record
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+    patch:
+      operationId: updatePassword
+      tags: [Passwords]
+      summary: Update a password
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/PasswordRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /configurations:
+    get:
+      operationId: listConfigurations
+      tags: [Configurations]
+      summary: List configurations
+      description: Use stable fields such as organization id, name, hostname, serial number, or asset tag before creating records.
+      parameters:
+        - $ref: "#/components/parameters/FilterId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/FilterOrganizationId"
+        - name: filter[serial_number]
+          in: query
+          schema:
+            type: string
+        - name: filter[asset_tag]
+          in: query
+          schema:
+            type: string
+        - name: filter[hostname]
+          in: query
+          schema:
+            type: string
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createConfiguration
+      tags: [Configurations]
+      summary: Create a configuration
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /configurations/{id}:
+    get:
+      operationId: getConfiguration
+      tags: [Configurations]
+      summary: Retrieve a configuration
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+    patch:
+      operationId: updateConfiguration
+      tags: [Configurations]
+      summary: Update a configuration
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /organizations/{organization_id}/relationships/configurations:
+    get:
+      operationId: listOrganizationConfigurations
+      tags: [Configurations]
+      summary: List configurations for an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createOrganizationConfiguration
+      tags: [Configurations]
+      summary: Create a configuration under an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConfigurationRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+  /documents:
+    get:
+      operationId: listDocuments
+      tags: [Documents]
+      summary: List documents
+      parameters:
+        - $ref: "#/components/parameters/FilterId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/FilterOrganizationId"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createDocument
+      tags: [Documents]
+      summary: Create a document
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /documents/{id}:
+    get:
+      operationId: getDocument
+      tags: [Documents]
+      summary: Retrieve a document
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+    patch:
+      operationId: updateDocument
+      tags: [Documents]
+      summary: Update a document
+      parameters:
+        - $ref: "#/components/parameters/Id"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiResource"
+        "422":
+          $ref: "#/components/responses/Unprocessable"
+  /organizations/{organization_id}/relationships/documents:
+    get:
+      operationId: listOrganizationDocuments
+      tags: [Documents]
+      summary: List documents for an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+        - $ref: "#/components/parameters/FilterName"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/JsonApiCollection"
+    post:
+      operationId: createOrganizationDocument
+      tags: [Documents]
+      summary: Create a document under an organization
+      parameters:
+        - $ref: "#/components/parameters/OrganizationId"
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentRequest"
+      responses:
+        "201":
+          $ref: "#/components/responses/JsonApiResource"
+components:
+  securitySchemes:
+    ItGlueApiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: IT Glue read-write API key.
+      x-auth-vars:
+        - name: ITGLUE_API_KEY
+          kind: per_call
+          required: true
+          sensitive: true
+          description: IT Glue read-write API key from the ITO Key Vault secret ItGlueApiKey.
+  parameters:
+    Id:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+    OrganizationId:
+      name: organization_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    FilterId:
+      name: filter[id]
+      in: query
+      schema:
+        type: integer
+    FilterName:
+      name: filter[name]
+      in: query
+      schema:
+        type: string
+      description: Exact match where supported by IT Glue.
+    FilterOrganizationId:
+      name: filter[organization_id]
+      in: query
+      schema:
+        type: integer
+    PageNumber:
+      name: page[number]
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+    PageSize:
+      name: page[size]
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+    Sort:
+      name: sort
+      in: query
+      schema:
+        type: string
+      description: Comma separated sort fields; prefix with - for descending.
+  responses:
+    JsonApiCollection:
+      description: JSON:API collection response.
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JsonApiCollection"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/JsonApiCollection"
+    JsonApiResource:
+      description: JSON:API resource response.
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JsonApiResource"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/JsonApiResource"
+    NotFound:
+      description: Resource not found.
+    Unprocessable:
+      description: Validation failed.
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: "#/components/schemas/JsonApiErrors"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/JsonApiErrors"
+  schemas:
+    JsonApiCollection:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/JsonApiResourceObject"
+        meta:
+          type: object
+          additionalProperties: true
+        links:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    JsonApiResource:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/JsonApiResourceObject"
+        meta:
+          type: object
+          additionalProperties: true
+        links:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    JsonApiResourceObject:
+      type: object
+      required: [type]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          additionalProperties: true
+        relationships:
+          type: object
+          additionalProperties: true
+        links:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    JsonApiErrors:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: true
+    ContactRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [contacts]
+            attributes:
+              $ref: "#/components/schemas/ContactAttributes"
+          additionalProperties: true
+    ContactAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        first-name:
+          type: string
+        last-name:
+          type: string
+        name:
+          type: string
+        title:
+          type: string
+        email:
+          type: string
+          format: email
+        notes:
+          type: string
+          nullable: true
+        important:
+          type: boolean
+        contact-type-id:
+          type: integer
+        location-id:
+          type: integer
+          nullable: true
+        archived:
+          type: boolean
+          description: Included for non-destructive deactivation where available in the tenant.
+      additionalProperties: true
+    PasswordRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [passwords]
+            attributes:
+              $ref: "#/components/schemas/PasswordAttributes"
+          additionalProperties: true
+    PasswordAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+          format: password
+        url:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        password-category-id:
+          type: integer
+          nullable: true
+        password-folder-id:
+          type: integer
+          nullable: true
+        resource-id:
+          type: integer
+          nullable: true
+        resource-type:
+          type: string
+          nullable: true
+      additionalProperties: true
+    ConfigurationRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [configurations]
+            attributes:
+              $ref: "#/components/schemas/ConfigurationAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    ConfigurationAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        hostname:
+          type: string
+          nullable: true
+        configuration-type-id:
+          type: integer
+        configuration-status-id:
+          type: integer
+        manufacturer-id:
+          type: integer
+          nullable: true
+        model-id:
+          type: integer
+          nullable: true
+        location-id:
+          type: integer
+          nullable: true
+        serial-number:
+          type: string
+          nullable: true
+        asset-tag:
+          type: string
+          nullable: true
+        primary-ip:
+          type: string
+          nullable: true
+        mac-address:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+      additionalProperties: true
+    DocumentRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [documents]
+            attributes:
+              $ref: "#/components/schemas/DocumentAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    DocumentAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        restricted:
+          type: boolean
+          nullable: true
+        archived:
+          type: boolean
+          nullable: true
+        public:
+          type: boolean
+          nullable: true
+        document-folder-id:
+          type: integer
+          nullable: true
+        my-glue:
+          type: boolean
+          nullable: true
+      additionalProperties: true

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -118,10 +118,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -182,10 +182,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ContactUpdateRequest"
+              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactUpdateRequest"
+              $ref: "#/components/schemas/OrganizationContactUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -14,10 +14,10 @@ externalDocs:
   description: Official IT Glue developer documentation
   url: https://api.itglue.com/developer/
 servers:
-  - url: https://api.eu.itglue.com
-    description: IT Glue EU data centre
   - url: https://api.itglue.com
     description: IT Glue default data centre
+  - url: https://api.eu.itglue.com
+    description: IT Glue EU data centre
   - url: https://api.au.itglue.com
     description: IT Glue Australia data centre
 security:
@@ -145,6 +145,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiCollection"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       operationId: createOrganizationContact
       tags: [Contacts]
@@ -163,6 +165,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /organizations/{organization_id}/relationships/contacts/{id}:
@@ -351,6 +355,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiCollection"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       operationId: createOrganizationConfiguration
       tags: [Configurations]
@@ -369,6 +375,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /documents:
@@ -451,6 +459,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiCollection"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       operationId: createOrganizationDocument
       tags: [Documents]
@@ -469,6 +479,8 @@ paths:
       responses:
         "201":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
 components:
@@ -791,6 +803,10 @@ components:
           type: integer
         name:
           type: string
+        content:
+          type: string
+          nullable: true
+          description: Document body content, typically HTML or rich text from IT Glue.
         restricted:
           type: boolean
           nullable: true

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: >
     Focused IT Glue REST API wrapper for MSP automation. The API follows the
     JSON:API media type and uses an x-api-key header. This spec covers the read
-    surface already used by JAIs BOT plus the non-destructive write endpoints
+    surface used by existing read-only integrations plus the non-destructive write endpoints
     needed for contact sync, password mirroring, configuration creation, and
     onboarding documentation.
   x-auth-key-url: https://api.itglue.com/developer/
@@ -254,6 +254,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /configurations:
@@ -332,6 +334,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /organizations/{organization_id}/relationships/configurations:
@@ -430,6 +434,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/Unprocessable"
   /organizations/{organization_id}/relationships/documents:

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -118,10 +118,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -182,10 +182,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ContactRequest"
+              $ref: "#/components/schemas/ContactUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -251,10 +251,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/PasswordRequest"
+              $ref: "#/components/schemas/PasswordUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/PasswordRequest"
+              $ref: "#/components/schemas/PasswordUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -331,10 +331,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/ConfigurationRequest"
+              $ref: "#/components/schemas/ConfigurationUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/ConfigurationRequest"
+              $ref: "#/components/schemas/ConfigurationUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -435,10 +435,10 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: "#/components/schemas/DocumentRequest"
+              $ref: "#/components/schemas/DocumentUpdateRequest"
           application/json:
             schema:
-              $ref: "#/components/schemas/DocumentRequest"
+              $ref: "#/components/schemas/DocumentUpdateRequest"
       responses:
         "200":
           $ref: "#/components/responses/JsonApiResource"
@@ -675,6 +675,50 @@ components:
           type: boolean
           description: Included for non-destructive deactivation where available in the tenant.
       additionalProperties: true
+    ContactUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [contacts]
+            attributes:
+              $ref: "#/components/schemas/ContactUpdateAttributes"
+          additionalProperties: true
+    ContactUpdateAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        first-name:
+          type: string
+        last-name:
+          type: string
+        name:
+          type: string
+        title:
+          type: string
+        email:
+          type: string
+          format: email
+        notes:
+          type: string
+          nullable: true
+        important:
+          type: boolean
+        contact-type-id:
+          type: integer
+        location-id:
+          type: integer
+          nullable: true
+        archived:
+          type: boolean
+          description: Included for non-destructive deactivation where available in the tenant.
+      additionalProperties: true
     PasswordRequest:
       type: object
       required: [data]
@@ -692,6 +736,51 @@ components:
     PasswordAttributes:
       type: object
       required: [organization-id, name]
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+          format: password
+        url:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        password-category-id:
+          type: integer
+          nullable: true
+        password-folder-id:
+          type: integer
+          nullable: true
+        resource-id:
+          type: integer
+          nullable: true
+        resource-type:
+          type: string
+          nullable: true
+      additionalProperties: true
+    PasswordUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [passwords]
+            attributes:
+              $ref: "#/components/schemas/PasswordUpdateAttributes"
+          additionalProperties: true
+    PasswordUpdateAttributes:
+      type: object
       properties:
         organization-id:
           type: integer
@@ -778,6 +867,62 @@ components:
           type: string
           nullable: true
       additionalProperties: true
+    ConfigurationUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [configurations]
+            attributes:
+              $ref: "#/components/schemas/ConfigurationUpdateAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    ConfigurationUpdateAttributes:
+      type: object
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        hostname:
+          type: string
+          nullable: true
+        configuration-type-id:
+          type: integer
+        configuration-status-id:
+          type: integer
+        manufacturer-id:
+          type: integer
+          nullable: true
+        model-id:
+          type: integer
+          nullable: true
+        location-id:
+          type: integer
+          nullable: true
+        serial-number:
+          type: string
+          nullable: true
+        asset-tag:
+          type: string
+          nullable: true
+        primary-ip:
+          type: string
+          nullable: true
+        mac-address:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+      additionalProperties: true
     DocumentRequest:
       type: object
       required: [data]
@@ -798,6 +943,50 @@ components:
     DocumentAttributes:
       type: object
       required: [organization-id, name]
+      properties:
+        organization-id:
+          type: integer
+        name:
+          type: string
+        content:
+          type: string
+          nullable: true
+          description: Document body content, typically HTML or rich text from IT Glue.
+        restricted:
+          type: boolean
+          nullable: true
+        archived:
+          type: boolean
+          nullable: true
+        public:
+          type: boolean
+          nullable: true
+        document-folder-id:
+          type: integer
+          nullable: true
+        my-glue:
+          type: boolean
+          nullable: true
+      additionalProperties: true
+    DocumentUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, attributes]
+          properties:
+            type:
+              type: string
+              enum: [documents]
+            attributes:
+              $ref: "#/components/schemas/DocumentUpdateAttributes"
+            relationships:
+              type: object
+              additionalProperties: true
+          additionalProperties: true
+    DocumentUpdateAttributes:
+      type: object
       properties:
         organization-id:
           type: integer

--- a/catalog/specs/itglue-openapi.yaml
+++ b/catalog/specs/itglue-openapi.yaml
@@ -681,11 +681,13 @@ components:
       properties:
         data:
           type: object
-          required: [type, attributes]
+          required: [type, id, attributes]
           properties:
             type:
               type: string
               enum: [contacts]
+            id:
+              type: string
             attributes:
               $ref: "#/components/schemas/ContactUpdateAttributes"
           additionalProperties: true
@@ -814,11 +816,13 @@ components:
       properties:
         data:
           type: object
-          required: [type, attributes]
+          required: [type, id, attributes]
           properties:
             type:
               type: string
               enum: [passwords]
+            id:
+              type: string
             attributes:
               $ref: "#/components/schemas/PasswordUpdateAttributes"
           additionalProperties: true
@@ -916,11 +920,13 @@ components:
       properties:
         data:
           type: object
-          required: [type, attributes]
+          required: [type, id, attributes]
           properties:
             type:
               type: string
               enum: [configurations]
+            id:
+              type: string
             attributes:
               $ref: "#/components/schemas/ConfigurationUpdateAttributes"
             relationships:
@@ -1072,11 +1078,13 @@ components:
       properties:
         data:
           type: object
-          required: [type, attributes]
+          required: [type, id, attributes]
           properties:
             type:
               type: string
               enum: [documents]
+            id:
+              type: string
             attributes:
               $ref: "#/components/schemas/DocumentUpdateAttributes"
             relationships:

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -27,11 +27,11 @@ payments:
   plaid                Banking API for account linking, transactions, identity verification, and income
   stripe               Payment processing and financial infrastructure API
 
-project-management:
-  asana                Work management and project tracking API
-
 productivity:
   itglue               IT Glue JSON:API surface for organizations, contacts, passwords, configurations, and documents, including the write endpoints needed for MSP automation
+
+project-management:
+  asana                Work management and project tracking API
 
 sales-and-crm:
   hubspot              CRM contacts API
@@ -45,3 +45,4 @@ social-and-messaging:
 
 travel:
   google-flights       Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers (krisukox in Go, fli in Python).
+

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -30,6 +30,9 @@ payments:
 project-management:
   asana                Work management and project tracking API
 
+productivity:
+  itglue               IT Glue JSON:API surface for organizations, contacts, passwords, configurations, and documents, including the write endpoints needed for MSP automation
+
 sales-and-crm:
   hubspot              CRM contacts API
   pipedrive            CRM for sales teams - deals, contacts, pipelines, activities, and organizations
@@ -42,4 +45,3 @@ social-and-messaging:
 
 travel:
   google-flights       Flight search via Google Flights. No public API — reached through community-maintained reverse-engineered wrappers (krisukox in Go, fli in Python).
-


### PR DESCRIPTION
## Summary

Adds a docs-derived IT Glue / MyGlue catalog blueprint for Printing Press.

Scope included in this PR:
- `catalog/itglue.yaml` catalog entry
- `catalog/specs/itglue-openapi.yaml` focused OpenAPI 3.0 wrapper for organizations, contacts, passwords, configurations, and documents
- catalog-list golden fixture update for the new `productivity` entry

Review fixes now included:
- global `https://api.itglue.com` is the first/default server, followed by EU and AU regional servers
- organization-scoped contacts/configurations/documents list and create operations include 404 responses
- document attributes include `content` for document body content
- PATCH operations use separate update request schemas so partial updates do not require create-only `organization-id`/`name` fields
- organization-scoped POST operations use dedicated request schemas so `organization-id` is supplied by the path, not duplicated in the body
- PATCH update request schemas require JSON:API `data.id` alongside `type` and `attributes`

## Catalog Justification

Embedded catalog fit: IT Glue is a common MSP documentation platform with a stable REST API, so a reusable Printing Press catalog entry fits the embedded catalog better than a private one-off wrapper.

Distinct blueprint pattern: This blueprint is JSON:API over HTTPS with `x-api-key` auth and region-selectable servers, which is distinct from the existing generic examples and useful for MSP documentation automation.

Closest existing entries checked: The current catalog does not provide an IT Glue/MyGlue entry or a close MSP documentation-system equivalent with organizations, contacts, passwords, configurations, and documents.

Source provenance: The spec is derived from the official IT Glue developer documentation at https://api.itglue.com/developer/ and does not include tenant-private payload samples.

Auth and tenant assumptions: Auth uses an `ITGLUE_API_KEY` environment variable sent as the `x-api-key` header. The default server is the public/global `https://api.itglue.com`; EU and AU regional endpoints are listed as alternatives.

Safe default surface: The blueprint intentionally exposes read/create/update operations and omits DELETE endpoints. Live writes, generated CLI installation, and tenant/client backfills remain out of scope for this PR.

Generation path: Verified with `go test ./internal/catalog ./internal/openapi`, `scripts/golden.sh verify`, and `./printing-press generate --spec catalog/specs/itglue-openapi.yaml --name itglue --output /tmp/itglue-pp-generate-id-required --spec-source docs --transport standard --validate=false --dry-run --json`.

Stale-body check: The PR body has been refreshed after the latest review round and no longer contains tenant-specific Key Vault, EU-default, stale raw-diff wording, or stale schema-review evidence.

## Evidence

Diff stat against `origin/main`:

```text
 catalog/itglue.yaml                              |   21 +
 catalog/specs/itglue-openapi.yaml                | 1163 +++++++++++++++++++++++
 testdata/golden/expected/catalog-list/stdout.txt |    3 +
 3 files changed, 1187 insertions(+)
```

Latest commit: `4d6ae280` (`Require JSON API ids on IT Glue updates`).

Verification run after latest review fixes:

```text
PATH=/home/jason/.local/go/bin:$PATH go test ./internal/catalog ./internal/openapi
ok github.com/mvanhorn/cli-printing-press/v4/internal/catalog (cached)
ok github.com/mvanhorn/cli-printing-press/v4/internal/openapi 2.700s

PATH=/home/jason/.local/go/bin:$PATH scripts/golden.sh verify
Golden verify passed: 19 case(s).

./printing-press generate --spec catalog/specs/itglue-openapi.yaml --name itglue --output /tmp/itglue-pp-generate-id-required --spec-source docs --transport standard --validate=false --dry-run --json
Resources: 6
Endpoints: 25
```

## Source

Official IT Glue developer docs: https://api.itglue.com/developer/

Relevant documented facts used:
- IT Glue uses JSON:API.
- Auth is `x-api-key` header.
- Base URLs include `https://api.itglue.com`, `https://api.eu.itglue.com`, and `https://api.au.itglue.com`; this PR keeps the global URL first as the default.
- Maximum page size is 1000.
- The docs publish contacts, passwords, configurations, and documents create/update endpoints.

## Raw Diff Excerpt

```diff
+servers:
+  - url: https://api.itglue.com
+    description: IT Glue default data centre
+  - url: https://api.eu.itglue.com
+    description: IT Glue EU data centre
+  - url: https://api.au.itglue.com
+    description: IT Glue Australia data centre
```

```diff
+    patch:
+      operationId: updateContact
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/ContactUpdateRequest"
```

```diff
+    ContactUpdateRequest:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: object
+          required: [type, id, attributes]
+          properties:
+            type:
+              type: string
+              enum: [contacts]
+            id:
+              type: string
+            attributes:
+              $ref: "#/components/schemas/ContactUpdateAttributes"
```

```diff
+    post:
+      operationId: createOrganizationContact
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/OrganizationContactRequest"
+
+    OrganizationContactAttributes:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
```

```diff
+        content:
+          type: string
+          nullable: true
+          description: Document body content, typically HTML or rich text from IT Glue.
```

## Boundaries

This PR does not run live IT Glue writes, install the generated CLI, or backfill any tenant/client records. Those should follow after review because they touch client documentation and password-vault surfaces.
