### PR TITLE
fix(cli): support query wire-name overrides

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -862,6 +862,57 @@ components:
             read: Read access
 ```
 
+### `x-url-name` and `x-param-url-names`
+
+Overrides the URL query key for a parameter without changing the public
+CLI/MCP input name. Use this for APIs whose documented flag name or shared
+OpenAPI component name differs from the exact wire query key a specific
+endpoint accepts.
+
+Parsed field: `Param.URLName`
+
+Rules:
+
+- `x-url-name` is allowed on an OpenAPI Parameter Object and applies wherever
+  that parameter object is used.
+- `x-param-url-names` is allowed on a Path Item Object or Operation Object. It
+  is an object mapping parameter names to URL query keys. Operation entries
+  override path-item entries.
+- The parameter's `name` remains the public input identity used for generated
+  Go identifiers, CLI flags, MCP public names, and manifest public names.
+- The override only changes generated URL query emission, MCP `WireName`, and
+  manifest `wire_name`.
+- Empty names, empty URL keys, and non-string override values are ignored with
+  warnings.
+
+Example:
+
+```yaml
+paths:
+  /opportunities/search:
+    get:
+      x-param-url-names:
+        locationId: location_id
+      parameters:
+        - $ref: "#/components/parameters/LocationId"
+
+  /opportunities/pipelines:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/LocationId"
+
+components:
+  parameters:
+    LocationId:
+      name: locationId
+      in: query
+      schema:
+        type: string
+```
+
+In this example both endpoints keep the same public `locationId` input, but
+only `/opportunities/search` sends `?location_id=` on the wire.
+
 ## Path Item Extensions
 
 Path item extensions are read from a path object, beside its HTTP operations.

--- a/internal/cli/public_param_audit_test.go
+++ b/internal/cli/public_param_audit_test.go
@@ -158,6 +158,46 @@ types:
 	require.NoError(t, cmd.Execute())
 }
 
+func TestPublicParamAuditOpenAPIURLNameOverrideInventoriesWireName(t *testing.T) {
+	specPath := writePublicParamAuditSpec(t, `
+openapi: 3.0.3
+info:
+  title: Public Param URL Name API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /records:
+    get:
+      operationId: queryRecords
+      x-param-url-names:
+        limit: "$limit"
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+`)
+
+	var out bytes.Buffer
+	cmd := newPublicParamAuditCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--spec", specPath, "--json"})
+	require.NoError(t, cmd.Execute())
+
+	var ledger pipeline.PublicParamAuditLedger
+	require.NoError(t, json.Unmarshal(out.Bytes(), &ledger))
+	require.Len(t, ledger.Findings, 1)
+	assert.Equal(t, pipeline.PublicParamAuditSummary{Total: 1, Resolved: 1}, ledger.Summary)
+	assert.Equal(t, "records.query.params.$limit", ledger.Findings[0].ID)
+	assert.Equal(t, "$limit", ledger.Findings[0].WireName)
+	assert.Equal(t, "limit", ledger.Findings[0].CurrentPublicName)
+	assert.Equal(t, []string{"operator-like-wire-name"}, ledger.Findings[0].Reasons)
+}
+
 func TestPublicParamAuditStrictRefsDisablesLenientLocalSchemaStubs(t *testing.T) {
 	specPath := writePublicParamAuditSpec(t, `
 openapi: 3.0.3

--- a/internal/generator/code_orch_query_split_test.go
+++ b/internal/generator/code_orch_query_split_test.go
@@ -43,18 +43,24 @@ func TestCodeOrchRoutesQueryParamsOnWriteMethods(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 	src := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
 
-	// Struct carries the new field.
-	require.Regexp(t, `QueryParams\s+\[\]string`, src,
+	// Struct carries the public-to-wire query binding field.
+	require.Regexp(t, `QueryParams\s+\[\]codeOrchParamBinding`, src,
 		"codeOrchEndpoint must declare a QueryParams field")
 	// The PUT endpoint emits its in:query param into QueryParams.
-	require.Regexp(t, `QueryParams:\s*\[\]string\{\s*"sendToLedger"\s*,?\s*\}`, src,
+	require.Regexp(t, `QueryParams:\s*\[\]codeOrchParamBinding\{\s*\{PublicName: "sendToLedger", WireName: "sendToLedger"\}\s*,?\s*\}`, src,
 		"PUT endpoint must list sendToLedger in QueryParams")
 	// A body param must never be classified as a query param.
-	require.NotRegexp(t, `QueryParams:\s*\[\]string\{[^}]*voucherDescription[^}]*\}`, src,
+	require.NotRegexp(t, `QueryParams:\s*\[\]codeOrchParamBinding\{[^}]*voucherDescription[^}]*\}`, src,
 		"body param must not appear inside any QueryParams literal")
+	// GET/DELETE params and write-method split both translate public names
+	// to wire names before calling the client.
+	require.Contains(t, src, "codeOrchWireQueryName(ep.QueryParams, k)",
+		"GET/DELETE query routing must translate public query names")
 	// The split helper exists and is wired into the write path.
 	require.Contains(t, src, "func codeOrchSplitQuery(",
 		"codeOrchSplitQuery helper must be emitted")
 	require.Contains(t, src, "codeOrchSplitQuery(ep.QueryParams, params)",
 		"the write branch must route query params via codeOrchSplitQuery")
+	require.NotContains(t, src, "delete(params, q.WireName)",
+		"query routing must not delete a same-named body field when the public query name was consumed")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3859,9 +3859,13 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		if strings.Contains(pathTemplate, "{"+p.Name+"}") {
 			loc = "path"
 		}
+		wireName := p.WireName()
+		if loc == "path" {
+			wireName = p.Name
+		}
 		bindings = append(bindings, mcpParamBinding{
 			PublicName:         p.PublicInputName(),
-			WireName:           p.Name,
+			WireName:           wireName,
 			Location:           loc,
 			RequestContentType: requestContentType,
 		})

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -262,11 +262,11 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -321,11 +321,11 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -369,11 +369,11 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -419,11 +419,11 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
-				params["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -60,11 +60,11 @@ type codeOrchEndpoint struct {
 	Tier        string
 	Summary     string
 	Positional  []string
-	// QueryParams carries the wire names of spec-declared in:query
+	// QueryParams carries public-to-wire bindings for spec-declared in:query
 	// parameters. Write methods (POST/PUT/PATCH) route these to the query
 	// string instead of dumping them into the JSON body. Derived from the
 	// same mcpParamBindings location data the per-endpoint tools use.
-	QueryParams []string
+	QueryParams []codeOrchParamBinding
 	// HeaderOverrides carries per-endpoint request headers (e.g. an
 	// Accept override for binary-only response endpoints). Without
 	// threading these through, the code-orchestration execute path
@@ -77,6 +77,11 @@ type codeOrchEndpoint struct {
 	// root with HTTP 422 "Invalid json".
 	BodyIsArray bool
 	keywords    []string
+}
+
+type codeOrchParamBinding struct {
+	PublicName string
+	WireName   string
 }
 
 // codeOrchEndpoints is the generator-populated registry covering every
@@ -95,7 +100,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 {{- end}}
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
-		QueryParams: []string{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{{printf "%q" .WireName}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -117,7 +122,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 {{- end}}
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
 		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
-		QueryParams: []string{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{{printf "%q" .WireName}},{{end}}{{end}} },
+		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
@@ -269,7 +274,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
 		for k, v := range params {
-			query[k] = fmt.Sprintf("%v", v)
+			query[codeOrchWireQueryName(ep.QueryParams, k)] = fmt.Sprintf("%v", v)
 		}
 	} else {
 		// Route spec-declared in:query params to the query string for write
@@ -373,13 +378,28 @@ func codeOrchArrayBody(params map[string]any) any {
 // entries stay in the map for codeOrchWriteBody (the JSON body), so a write
 // method's query parameters never get buried in the body. Mutates params by
 // design (deletes the consumed query keys).
-func codeOrchSplitQuery(queryParams []string, params map[string]any) string {
+func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]any) string {
 	uv := neturl.Values{}
 	for _, q := range queryParams {
-		if v, ok := params[q]; ok {
-			uv.Set(q, fmt.Sprintf("%v", v))
-			delete(params, q)
+		for _, key := range []string{q.PublicName, q.WireName} {
+			if key == "" {
+				continue
+			}
+			if v, ok := params[key]; ok {
+				uv.Set(q.WireName, fmt.Sprintf("%v", v))
+				delete(params, key)
+				break
+			}
 		}
 	}
 	return uv.Encode()
+}
+
+func codeOrchWireQueryName(queryParams []codeOrchParamBinding, name string) string {
+	for _, q := range queryParams {
+		if q.PublicName == name || q.WireName == name {
+			return q.WireName
+		}
+	}
+	return name
 }

--- a/internal/generator/url_name_test.go
+++ b/internal/generator/url_name_test.go
@@ -89,6 +89,51 @@ func TestParamWithoutURLNameUnchanged(t *testing.T) {
 	require.Contains(t, content, `params["owner"]`, "plain Name owner must emit as URL key when URLName unset")
 }
 
+func TestParamURLNameOverridesWriteMethodQueryKeys(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("write-url-name")
+	apiSpec.Resources["records"] = spec.Resource{
+		Description: "Records",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/records",
+				Description: "Create record",
+				Params:      []spec.Param{{Name: "dry_run", URLName: "$dry_run", Type: "boolean", Description: "Preview"}},
+				Body:        []spec.Param{{Name: "name", Type: "string", Description: "Name"}},
+			},
+			"delete": {
+				Method:      "DELETE",
+				Path:        "/records",
+				Description: "Delete records",
+				Params:      []spec.Param{{Name: "dry_run", URLName: "$dry_run", Type: "boolean", Description: "Preview"}},
+			},
+			"update": {
+				Method:      "PUT",
+				Path:        "/records",
+				Description: "Update records",
+				Params:      []spec.Param{{Name: "dry_run", URLName: "$dry_run", Type: "boolean", Description: "Preview"}},
+				Body:        []spec.Param{{Name: "name", Type: "string", Description: "Name"}},
+			},
+			"patch": {
+				Method:      "PATCH",
+				Path:        "/records",
+				Description: "Patch records",
+				Params:      []spec.Param{{Name: "dry_run", URLName: "$dry_run", Type: "boolean", Description: "Preview"}},
+				Body:        []spec.Param{{Name: "name", Type: "string", Description: "Name"}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "write-url-name-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	content := readGeneratedCLIHandlers(t, outputDir)
+	require.Equal(t, 4, strings.Count(content, `params["$dry_run"]`), "all write-method query maps must use URLName")
+	require.NotContains(t, content, `params["dry_run"]`, "plain Name must not be used as the URL key when URLName is set")
+}
+
 // readGeneratedHandler returns the contents of the generated CLI handler for a
 // resource. The generator may emit it as either `<resource>.go` (multi-endpoint
 // resource) or `promoted_<resource>.go` (single-endpoint promoted pattern), so
@@ -108,6 +153,25 @@ func readGeneratedHandler(t *testing.T, outputDir, resource string) string {
 	return ""
 }
 
+func readGeneratedCLIHandlers(t *testing.T, outputDir string) string {
+	t.Helper()
+	var out strings.Builder
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+	require.NoError(t, filepath.WalkDir(cliDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".go" {
+			return err
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out.Write(src)
+		out.WriteByte('\n')
+		return nil
+	}))
+	return out.String()
+}
+
 // TestParamWireNameUnit exercises the spec.Param.WireName() method directly.
 func TestParamWireNameUnit(t *testing.T) {
 	t.Parallel()
@@ -125,4 +189,63 @@ func TestParamWireNameUnit(t *testing.T) {
 			require.Equal(t, c.want, p.WireName())
 		})
 	}
+}
+
+func TestMCPParamBindingsUseParamWireName(t *testing.T) {
+	t.Parallel()
+
+	bindings := mcpParamBindings(spec.Endpoint{
+		Params: []spec.Param{
+			{Name: "locationId", URLName: "location_id", Type: "string"},
+		},
+	}, "/opportunities/search")
+
+	require.Len(t, bindings, 1)
+	require.Equal(t, "locationId", bindings[0].PublicName)
+	require.Equal(t, "location_id", bindings[0].WireName)
+	require.Equal(t, "query", bindings[0].Location)
+}
+
+func TestCodeOrchQueryParamsUseParamWireName(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("code-orch-url-name")
+	apiSpec.MCP = spec.MCPConfig{Orchestration: "code"}
+	apiSpec.Resources["opportunities"] = spec.Resource{
+		Description: "Opportunities",
+		Endpoints: map[string]spec.Endpoint{
+			"search": {
+				Method:      "GET",
+				Path:        "/opportunities/search",
+				Description: "Search opportunities",
+				Params: []spec.Param{
+					{Name: "locationId", URLName: "location_id", Type: "string", Description: "Location id"},
+				},
+			},
+			"create": {
+				Method:      "POST",
+				Path:        "/opportunities",
+				Description: "Create opportunity",
+				Params: []spec.Param{
+					{Name: "locationId", URLName: "location_id", Type: "string", Description: "Location id"},
+				},
+				Body: []spec.Param{
+					{Name: "name", Type: "string", Description: "Opportunity name"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "code-orch-url-name-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	content := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+	require.Contains(t, content, `QueryParams []codeOrchParamBinding`,
+		"code-orch endpoints must retain public-to-wire query bindings")
+	require.Equal(t, 2, strings.Count(content, `{PublicName: "locationId", WireName: "location_id"}`),
+		"GET and POST code-orch endpoints must preserve both public and wire query names")
+	require.Contains(t, content, `query[codeOrchWireQueryName(ep.QueryParams, k)]`,
+		"GET/DELETE code-orch routing must translate public names to wire names")
+	require.Contains(t, content, `uv.Set(q.WireName, fmt.Sprintf("%v", v))`,
+		"write-method code-orch routing must append wire query names")
 }

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -48,6 +48,8 @@ const (
 	extensionLegacyMCP             = "mcp"
 	extensionCache                 = "x-cache"
 	extensionSyncWalker            = "x-pp-sync-walker"
+	extensionParamURLName          = "x-url-name"
+	extensionParamURLNames         = "x-param-url-names"
 	extensionAPIName               = "x-api-name"
 	extensionDisplayName           = "x-display-name"
 	extensionWebsite               = "x-website"
@@ -3518,6 +3520,8 @@ func hasPathParams(path string) bool {
 
 func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.Param {
 	merged := mergeParameters(pathItem, op)
+	var urlNameOverrides map[string]string
+	urlNameOverridesRead := false
 	params := make([]spec.Param, 0, len(merged))
 	for _, parameter := range merged {
 		if parameter == nil {
@@ -3546,6 +3550,13 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 			Enum:        schemaEnum(schema),
 			Format:      schemaFormat(schema),
 		}
+		if parameter.In == openapi3.ParameterInQuery {
+			if !urlNameOverridesRead {
+				urlNameOverrides = readParamURLNameOverrides(pathItem, op)
+				urlNameOverridesRead = true
+			}
+			param.URLName = paramURLName(paramName, parameter.Extensions, urlNameOverrides)
+		}
 		if parameter.In == openapi3.ParameterInQuery && isFieldSelectorParameter(paramName, description) {
 			param.Purpose = spec.ParamPurposeFieldSelector
 		}
@@ -3564,6 +3575,72 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 	reclassifyPathParamModifiers(params)
 
 	return params
+}
+
+func readParamURLNameOverrides(pathItem *openapi3.PathItem, op *openapi3.Operation) map[string]string {
+	var out map[string]string
+	add := func(extensions map[string]any, context string) {
+		if len(extensions) == 0 {
+			return
+		}
+		raw, ok := extensions[extensionParamURLNames]
+		if !ok || raw == nil {
+			return
+		}
+		values, ok := raw.(map[string]any)
+		if !ok {
+			warnf("%s: %s must be an object mapping parameter names to URL names; ignoring", context, extensionParamURLNames)
+			return
+		}
+		for name, value := range values {
+			paramName := strings.TrimSpace(name)
+			urlName, ok := value.(string)
+			if !ok {
+				warnf("%s: %s.%s must be a string; ignoring", context, extensionParamURLNames, name)
+				continue
+			}
+			urlName = strings.TrimSpace(urlName)
+			if paramName == "" || urlName == "" {
+				warnf("%s: %s entries must have non-empty parameter and URL names; ignoring %q", context, extensionParamURLNames, name)
+				continue
+			}
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[paramName] = urlName
+		}
+	}
+	if pathItem != nil {
+		add(pathItem.Extensions, "path")
+	}
+	if op != nil {
+		add(op.Extensions, "operation")
+	}
+	return out
+}
+
+func paramURLName(paramName string, extensions map[string]any, overrides map[string]string) string {
+	if urlName, ok := overrides[paramName]; ok {
+		return urlName
+	}
+	if len(extensions) == 0 {
+		return ""
+	}
+	raw, ok := extensions[extensionParamURLName]
+	if !ok || raw == nil {
+		return ""
+	}
+	urlName, ok := raw.(string)
+	if !ok {
+		warnf("parameter %q: %s must be a string; ignoring", paramName, extensionParamURLName)
+		return ""
+	}
+	urlName = strings.TrimSpace(urlName)
+	if urlName == "" {
+		warnf("parameter %q: %s must be non-empty; ignoring", paramName, extensionParamURLName)
+		return ""
+	}
+	return urlName
 }
 
 func isFieldSelectorParameter(name, description string) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7281,6 +7281,105 @@ paths:
 	assert.False(t, byName["client_secret"].Required)
 }
 
+func TestParseQueryParamURLNameOverrides(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Param Override API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /opportunities/search:
+    get:
+      operationId: searchOpportunities
+      x-param-url-names:
+        " locationId ": location_id
+      parameters:
+        - $ref: "#/components/parameters/LocationId"
+        - name: pipeline_id
+          in: query
+          schema:
+            type: string
+        - name: contactId
+          in: query
+          x-url-name: contact_id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+  /opportunities/pipelines:
+    get:
+      operationId: listPipelines
+      parameters:
+        - $ref: "#/components/parameters/LocationId"
+      responses:
+        "200":
+          description: ok
+  /shared:
+    x-param-url-names:
+      accountId: account_id
+    get:
+      operationId: getShared
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+    delete:
+      operationId: deleteShared
+      x-param-url-names:
+        accountId: acct_id
+      parameters:
+        - name: accountId
+          in: query
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+components:
+  parameters:
+    LocationId:
+      name: locationId
+      in: query
+      required: true
+      schema:
+        type: string
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+
+	search := findParsedEndpointByPath(t, parsed, "GET", "/opportunities/search")
+	require.Len(t, search.Params, 3)
+	assert.Equal(t, "locationId", search.Params[0].Name)
+	assert.Equal(t, "location_id", search.Params[0].URLName)
+	assert.Equal(t, "locationId", search.Params[0].PublicInputName())
+	assert.Equal(t, "location_id", search.Params[0].WireName())
+	assert.Equal(t, "contactId", search.Params[2].Name)
+	assert.Equal(t, "contact_id", search.Params[2].URLName)
+
+	pipelines := findParsedEndpointByPath(t, parsed, "GET", "/opportunities/pipelines")
+	require.Len(t, pipelines.Params, 1)
+	assert.Equal(t, "locationId", pipelines.Params[0].Name)
+	assert.Empty(t, pipelines.Params[0].URLName)
+	assert.Equal(t, "locationId", pipelines.Params[0].WireName())
+
+	sharedGet := findParsedEndpointByPath(t, parsed, "GET", "/shared")
+	require.Len(t, sharedGet.Params, 1)
+	assert.Equal(t, "account_id", sharedGet.Params[0].URLName)
+
+	sharedDelete := findParsedEndpointByPath(t, parsed, "DELETE", "/shared")
+	require.Len(t, sharedDelete.Params, 1)
+	assert.Equal(t, "acct_id", sharedDelete.Params[0].URLName)
+}
+
 // TestParseJSONPreferredOverFormUrlencoded asserts the parser still picks
 // application/json when the spec offers both content types — keeping JSON-
 // declared specs byte-identical and letting form-only OAuth/legacy endpoints

--- a/internal/pipeline/public_param_audit.go
+++ b/internal/pipeline/public_param_audit.go
@@ -92,17 +92,18 @@ func auditPublicParams(resourceName, endpointName, location string, endpoint spe
 		if param.Positional {
 			continue
 		}
-		reasons := publicParamAuditReasons(param)
+		wireName := publicParamAuditWireName(location, param)
+		reasons := publicParamAuditReasons(wireName)
 		if len(reasons) == 0 {
 			continue
 		}
 		findings = append(findings, PublicParamAuditFinding{
-			ID:                  publicParamAuditID(resourceName, endpointName, location, param.Name),
+			ID:                  publicParamAuditID(resourceName, endpointName, location, wireName),
 			Resource:            resourceName,
 			Endpoint:            endpointName,
 			Location:            location,
-			WireName:            param.Name,
-			CurrentPublicName:   param.FlagName,
+			WireName:            wireName,
+			CurrentPublicName:   publicParamAuditPublicName(location, param, wireName),
 			Aliases:             append([]string(nil), param.Aliases...),
 			Type:                param.Type,
 			Required:            param.Required,
@@ -115,8 +116,25 @@ func auditPublicParams(resourceName, endpointName, location string, endpoint spe
 	return findings
 }
 
-func publicParamAuditReasons(param spec.Param) []string {
-	wire := strings.TrimSpace(param.Name)
+func publicParamAuditWireName(location string, param spec.Param) string {
+	if location == "params" {
+		return param.WireName()
+	}
+	return param.Name
+}
+
+func publicParamAuditPublicName(location string, param spec.Param, wireName string) string {
+	if param.FlagName != "" {
+		return param.FlagName
+	}
+	if location == "params" && param.URLName != "" && param.Name != wireName {
+		return param.PublicInputName()
+	}
+	return ""
+}
+
+func publicParamAuditReasons(wireName string) []string {
+	wire := strings.TrimSpace(wireName)
 	if wire == "" {
 		return nil
 	}

--- a/internal/pipeline/public_param_audit_test.go
+++ b/internal/pipeline/public_param_audit_test.go
@@ -39,6 +39,34 @@ func TestAuditPublicParamNamesFindsDecisionRequiredCrypticParams(t *testing.T) {
 	assert.Equal(t, "s", requirePublicParamFinding(t, findings, "stores.find.params.s").WireName)
 }
 
+func TestAuditPublicParamNamesUsesURLNameForQueryWireName(t *testing.T) {
+	api := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"records": {
+				Endpoints: map[string]spec.Endpoint{
+					"query": {
+						Path: "/records",
+						Params: []spec.Param{
+							{Name: "limit", URLName: "$limit", Type: "integer", Description: "Max rows"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := AuditPublicParamNames(api)
+
+	require.Len(t, findings, 1)
+	finding := requirePublicParamFinding(t, findings, "records.query.params.$limit")
+	assert.Equal(t, "$limit", finding.WireName)
+	assert.Equal(t, "limit", finding.CurrentPublicName)
+	assert.Equal(t, []string{"operator-like-wire-name"}, finding.Reasons)
+
+	ledger := NewPublicParamAuditLedger(findings)
+	assert.Equal(t, PublicParamAuditSummary{Total: 1, Resolved: 1}, ledger.Summary)
+}
+
 func TestAuditPublicParamNamesMarksExistingFlagNamesResolved(t *testing.T) {
 	api := &spec.APISpec{
 		Resources: map[string]spec.Resource{

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -382,9 +382,13 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 			loc = "path"
 		}
 		name := p.PublicInputName()
+		wireName := p.WireName()
+		if loc == "path" {
+			wireName = p.Name
+		}
 		tool.Params = append(tool.Params, ManifestParam{
 			Name:        name,
-			WireName:    manifestWireName(name, p.Name),
+			WireName:    manifestWireName(name, wireName),
 			Type:        normalizeParamType(p.Type),
 			Location:    loc,
 			Description: describeParam(p),

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -318,6 +318,37 @@ func TestWriteToolsManifest_PublicParamNames(t *testing.T) {
 	assert.Equal(t, []string{"code"}, create.Params[0].Aliases)
 }
 
+func TestWriteToolsManifest_ParamURLNameUsesWireName(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "param-url-name",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"opportunities": {
+				Endpoints: map[string]spec.Endpoint{
+					"search": {
+						Method: "GET",
+						Path:   "/opportunities/search",
+						Params: []spec.Param{
+							{Name: "locationId", URLName: "location_id", Type: "string", Required: true, Description: "Location ID"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+
+	require.Len(t, got.Tools, 1)
+	require.Len(t, got.Tools[0].Params, 1)
+	assert.Equal(t, "locationId", got.Tools[0].Params[0].Name)
+	assert.Equal(t, "location_id", got.Tools[0].Params[0].WireName)
+}
+
 func TestWriteToolsManifest_IdentNamePublicParamName(t *testing.T) {
 	dir := t.TempDir()
 	parsed := &spec.APISpec{

--- a/testdata/golden/cases/generate-public-param-names/artifacts.txt
+++ b/testdata/golden/cases/generate-public-param-names/artifacts.txt
@@ -1,5 +1,6 @@
 public-param-golden/internal/cli/stores_find.go
 public-param-golden/internal/cli/stores_create.go
 public-param-golden/internal/mcp/tools.go
+public-param-golden/tools-manifest.json
 public-param-golden/README.md
 public-param-golden/SKILL.md

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -60,11 +60,11 @@ type codeOrchEndpoint struct {
 	Tier       string
 	Summary    string
 	Positional []string
-	// QueryParams carries the wire names of spec-declared in:query
+	// QueryParams carries public-to-wire bindings for spec-declared in:query
 	// parameters. Write methods (POST/PUT/PATCH) route these to the query
 	// string instead of dumping them into the JSON body. Derived from the
 	// same mcpParamBindings location data the per-endpoint tools use.
-	QueryParams []string
+	QueryParams []codeOrchParamBinding
 	// HeaderOverrides carries per-endpoint request headers (e.g. an
 	// Accept override for binary-only response endpoints). Without
 	// threading these through, the code-orchestration execute path
@@ -79,6 +79,11 @@ type codeOrchEndpoint struct {
 	keywords    []string
 }
 
+type codeOrchParamBinding struct {
+	PublicName string
+	WireName   string
+}
+
 // codeOrchEndpoints is the generator-populated registry covering every
 // endpoint declared in the spec. Kept flat on purpose — the agent queries
 // via <api>_search, so hierarchy shows up as dotted IDs, not nested maps.
@@ -89,7 +94,7 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Path:        "/items",
 		Summary:     "List items",
 		Positional:  []string{},
-		QueryParams: []string{},
+		QueryParams: []codeOrchParamBinding{},
 		keywords:    codeOrchKeywords("items", "list", "List items", "/items"),
 	},
 }
@@ -226,7 +231,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
 		for k, v := range params {
-			query[k] = fmt.Sprintf("%v", v)
+			query[codeOrchWireQueryName(ep.QueryParams, k)] = fmt.Sprintf("%v", v)
 		}
 	} else {
 		// Route spec-declared in:query params to the query string for write
@@ -330,13 +335,28 @@ func codeOrchArrayBody(params map[string]any) any {
 // entries stay in the map for codeOrchWriteBody (the JSON body), so a write
 // method's query parameters never get buried in the body. Mutates params by
 // design (deletes the consumed query keys).
-func codeOrchSplitQuery(queryParams []string, params map[string]any) string {
+func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]any) string {
 	uv := neturl.Values{}
 	for _, q := range queryParams {
-		if v, ok := params[q]; ok {
-			uv.Set(q, fmt.Sprintf("%v", v))
-			delete(params, q)
+		for _, key := range []string{q.PublicName, q.WireName} {
+			if key == "" {
+				continue
+			}
+			if v, ok := params[key]; ok {
+				uv.Set(q.WireName, fmt.Sprintf("%v", v))
+				delete(params, key)
+				break
+			}
 		}
 	}
 	return uv.Encode()
+}
+
+func codeOrchWireQueryName(queryParams []codeOrchParamBinding, name string) string {
+	for _, q := range queryParams {
+		if q.PublicName == name || q.WireName == name {
+			return q.WireName
+		}
+	}
+	return name
 }

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -13,6 +13,7 @@ import (
 )
 
 func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
+	var flagDryRun bool
 	var bodyStoreCode string
 	var stdinBody bool
 
@@ -34,6 +35,9 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/stores"
 			params := map[string]string{}
+			if flagDryRun != false {
+				params["$dry_run"] = fmt.Sprintf("%v", flagDryRun)
+			}
 			var body map[string]any
 			if stdinBody {
 				stdinData, err := io.ReadAll(os.Stdin)
@@ -184,6 +188,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Preview without writing")
 	cmd.Flags().StringVar(&bodyStoreCode, "store-code", "", "Store code")
 	cmd.Flags().StringVar(&bodyStoreCode, "code", "", "Store code")
 	_ = cmd.Flags().MarkHidden("code")

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -14,11 +14,12 @@ import (
 func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	var flagS string
 	var flagC string
+	var flagLocationId string
 
 	cmd := &cobra.Command{
 		Use:         "find",
 		Short:       "Find nearby stores by address",
-		Example:     "  public-param-golden-pp-cli stores find --address example-value --city example-value",
+		Example:     "  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "stores.find", "pp:method": "GET", "pp:path": "/power/store-locator", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun {
@@ -26,6 +27,9 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			}
 			if !(cmd.Flags().Changed("city") || cmd.Flags().Changed("c")) && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "city")
+			}
+			if !cmd.Flags().Changed("location-id") && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "location-id")
 			}
 			c, err := flags.newClient()
 			if err != nil {
@@ -39,6 +43,9 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			}
 			if flagC != "" {
 				params["c"] = fmt.Sprintf("%v", flagC)
+			}
+			if flagLocationId != "" {
+				params["location_id"] = fmt.Sprintf("%v", flagLocationId)
 			}
 			data, err := c.Get(cmd.Context(), path, params)
 			if err != nil {
@@ -65,6 +72,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&flagC, "city", "", "City, state, zip")
 	cmd.Flags().StringVar(&flagC, "c", "", "City, state, zip")
 	_ = cmd.Flags().MarkHidden("c")
+	cmd.Flags().StringVar(&flagLocationId, "location-id", "", "Location identifier sent with this endpoint's snake-case query key")
 
 	return cmd
 }

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -25,23 +25,25 @@ import (
 func RegisterTools(s *server.MCPServer) {
 	s.AddTool(
 		mcplib.NewTool("stores_create",
-			mcplib.WithDescription("Create a store record. Required: store-code. Returns the new Store."),
+			mcplib.WithDescription("Create a store record. Required: store-code. Optional: dry_run. Returns the new Store."),
+			mcplib.WithBoolean("dry_run", mcplib.Description("Preview without writing")),
 			mcplib.WithString("store-code", mcplib.Required(), mcplib.Description("Store code")),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/stores", false, false, nil, []mcpParamBinding{{PublicName: "store-code", WireName: "store_code", Location: "body"}}, []string{}),
+		makeAPIHandler("POST", "/stores", false, false, nil, []mcpParamBinding{{PublicName: "dry_run", WireName: "$dry_run", Location: "query"}, {PublicName: "store-code", WireName: "store_code", Location: "body"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("stores_find",
-			mcplib.WithDescription("Find nearby stores by address. Required: address, city. Returns array of Store."),
+			mcplib.WithDescription("Find nearby stores by address. Required: address, city, locationId. Returns array of Store."),
 			mcplib.WithString("address", mcplib.Required(), mcplib.Description("Street address")),
 			mcplib.WithString("city", mcplib.Required(), mcplib.Description("City, state, zip")),
+			mcplib.WithString("locationId", mcplib.Required(), mcplib.Description("Location identifier sent with this endpoint's snake-case query key")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/power/store-locator", true, false, nil, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}}, []string{}),
+		makeAPIHandler("GET", "/power/store-locator", true, false, nil, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}, {PublicName: "locationId", WireName: "location_id", Location: "query"}}, []string{}),
 	)
 
 	// Context tool — front-loaded domain knowledge for agents.

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/tools-manifest.json
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/tools-manifest.json
@@ -1,0 +1,79 @@
+{
+  "api_name": "public-param-golden",
+  "auth": {
+    "type": "none"
+  },
+  "base_url": "https://api.public-param.example/v1",
+  "description": "Public parameter name golden fixture",
+  "http_transport": "standard",
+  "mcp_ready": "full",
+  "required_headers": [],
+  "tools": [
+    {
+      "description": "Create a store record. Required: store-code. Optional: dry_run. Returns the new Store.",
+      "method": "POST",
+      "name": "stores_create",
+      "no_auth": true,
+      "params": [
+        {
+          "description": "Preview without writing",
+          "location": "query",
+          "name": "dry_run",
+          "type": "boolean",
+          "wire_name": "$dry_run"
+        },
+        {
+          "aliases": [
+            "code"
+          ],
+          "description": "Store code",
+          "location": "body",
+          "name": "store-code",
+          "required": true,
+          "type": "string",
+          "wire_name": "store_code"
+        }
+      ],
+      "path": "/stores"
+    },
+    {
+      "description": "Find nearby stores by address. Required: address, city, locationId. Returns array of Store.",
+      "method": "GET",
+      "name": "stores_find",
+      "no_auth": true,
+      "params": [
+        {
+          "aliases": [
+            "s"
+          ],
+          "description": "Street address",
+          "location": "query",
+          "name": "address",
+          "required": true,
+          "type": "string",
+          "wire_name": "s"
+        },
+        {
+          "aliases": [
+            "c"
+          ],
+          "description": "City, state, zip",
+          "location": "query",
+          "name": "city",
+          "required": true,
+          "type": "string",
+          "wire_name": "c"
+        },
+        {
+          "description": "Location identifier sent with this endpoint's snake-case query key",
+          "location": "query",
+          "name": "locationId",
+          "required": true,
+          "type": "string",
+          "wire_name": "location_id"
+        }
+      ],
+      "path": "/power/store-locator"
+    }
+  ]
+}

--- a/testdata/golden/fixtures/public-param-names.yaml
+++ b/testdata/golden/fixtures/public-param-names.yaml
@@ -25,6 +25,11 @@ resources:
             type: string
             required: true
             description: City, state, zip
+          - name: locationId
+            url_name: location_id
+            type: string
+            required: true
+            description: Location identifier sent with this endpoint's snake-case query key
         response:
           type: array
           item: Store
@@ -32,6 +37,11 @@ resources:
         method: POST
         path: /stores
         description: Create a store record
+        params:
+          - name: dry_run
+            url_name: $dry_run
+            type: boolean
+            description: Preview without writing
         body:
           - name: store_code
             flag_name: store-code


### PR DESCRIPTION
## Summary
- Preserve public CLI and MCP names while allowing OpenAPI query params to specify wire-side URL keys via `x-url-name` or `x-param-url-names`.
- Thread `Param.URLName` through generated CLI handlers, typed MCP bindings, code-orchestration MCP, tools manifests, and public-param audit output.
- Expand parser, generator, pipeline, CLI, docs, and golden coverage for `locationId` to `location_id` style APIs.

Closes #1687

## Verification
- `go test ./...`
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh verify`
- `golangci-lint run ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`