### PR TITLE
fix(cli): support body wire-name overrides

### DIFF
--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -15,11 +15,11 @@ Decide responsibility explicitly:
 - **Both:** the machine should produce or verify the deterministic substrate, then SKILL.md should direct the agent to inspect the remaining semantic layer. Example pattern: dogfood syncs README/SKILL feature blocks from `novel_features_built`; the skill tells the agent to audit surrounding prose, recipes, trigger phrases, and examples for indirect claims.
 
 Public parameter names follow the "Both" pattern. The agent uses evidence to
-author semantic `flag_name` and compatibility `aliases`; the Printing Press CLI
-inventories suspicious wire names with `public-param-audit`, preserves
-evidence-backed skip decisions in a ledger, and propagates authored fields
-through generated CLI, docs, MCP, and manifest surfaces without inferring names
-itself.
+author semantic `flag_name`, compatibility `aliases`, and wire-only overrides
+such as `url_name` / `body_name`; the Printing Press CLI inventories suspicious
+wire names with `public-param-audit`, preserves evidence-backed skip decisions
+in a ledger, and propagates authored fields through generated CLI, docs, MCP,
+and manifest surfaces without inferring names itself.
 
 For any SKILL.md update, search for the old concept across the skill file, not just the paragraph closest to the code change. Agentic review prompts often duplicate workflow assumptions from earlier phase instructions.
 

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -599,7 +599,8 @@ func buildEndpoint(group EndpointGroup) spec.Endpoint {
 		}
 	}
 
-	body := inferRequestBody(group.Entries)
+	responseFields := InferResponseSchema(responseBodies)
+	body := inferRequestBody(group.Entries, responseFields)
 	params := inferURLParams(group.Entries, group.NormalizedPath)
 	auth := detectAuth(nil, group.Entries, "")
 	if auth.Type == "api_key" && strings.EqualFold(auth.In, "query") && auth.Header != "" {
@@ -607,7 +608,6 @@ func buildEndpoint(group EndpointGroup) spec.Endpoint {
 	}
 
 	responseType := inferResponseType(responseBodies)
-	responseFields := InferResponseSchema(responseBodies)
 	if len(params) == 0 && len(responseFields) > 0 {
 		params = responseFields
 	}
@@ -891,7 +891,9 @@ func htmlChallengeBody(body string) bool {
 	return false
 }
 
-func inferRequestBody(entries []EnrichedEntry) []spec.Param {
+func inferRequestBody(entries []EnrichedEntry, responseFields []spec.Param) []spec.Param {
+	fields := map[string]*inferredField{}
+	sampleCount := 0
 	for _, entry := range entries {
 		body := strings.TrimSpace(entry.RequestBody)
 		if body == "" {
@@ -900,12 +902,66 @@ func inferRequestBody(entries []EnrichedEntry) []spec.Param {
 
 		contentType := getHeaderValue(entry.RequestHeaders, "Content-Type")
 		params := InferRequestSchema(body, contentType)
-		if len(params) > 0 {
-			return params
+		if len(params) == 0 {
+			continue
+		}
+		sampleCount++
+		for _, param := range params {
+			field := fields[param.Name]
+			if field == nil {
+				field = &inferredField{}
+				fields[param.Name] = field
+			}
+			field.count++
+			field.param = param
 		}
 	}
 
-	return nil
+	if len(fields) == 0 {
+		return nil
+	}
+
+	return reconcileObservedBodyCursorNames(buildParams(fields, sampleCount), responseFields)
+}
+
+func reconcileObservedBodyCursorNames(body []spec.Param, response []spec.Param) []spec.Param {
+	responseStartAfter := findParamNameRecursive(response, "startafter")
+	if responseStartAfter == "" || !hasParamName(body, "searchafter") || hasParamName(body, "startafter") {
+		return body
+	}
+
+	out := make([]spec.Param, 0, len(body))
+	for _, param := range body {
+		if strings.ToLower(param.Name) == "searchafter" {
+			param.BodyName = param.Name
+			param.Name = responseStartAfter
+			out = append(out, param)
+			continue
+		}
+		out = append(out, param)
+	}
+	return out
+}
+
+func hasParamName(params []spec.Param, lowerName string) bool {
+	for _, param := range params {
+		if strings.ToLower(param.Name) == lowerName {
+			return true
+		}
+	}
+	return false
+}
+
+func findParamNameRecursive(params []spec.Param, lowerName string) string {
+	for _, param := range params {
+		if strings.ToLower(param.Name) == lowerName {
+			return param.Name
+		}
+		if nested := findParamNameRecursive(param.Fields, lowerName); nested != "" {
+			return nested
+		}
+	}
+	return ""
 }
 
 func inferURLParams(entries []EnrichedEntry, normalizedPath string) []spec.Param {

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -156,6 +156,63 @@ func TestAnalyzeCapture_UsesCapturedCookieAuth(t *testing.T) {
 	assert.Equal(t, []string{"SPOTIFY_COOKIES"}, apiSpec.Auth.EnvVars)
 }
 
+func TestAnalyzeCapture_ReconcilesSearchAfterBodyCursorWireName(t *testing.T) {
+	t.Parallel()
+
+	capture := &EnrichedCapture{
+		TargetURL: "https://services.leadconnectorhq.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "POST",
+				URL:                 "https://services.leadconnectorhq.com/contacts/search",
+				RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+				RequestBody:         `{"locationId":"loc","pageLimit":2,"filters":[]}`,
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"contacts":[{"id":"1"}],"meta":{"startAfter":[1779142892078,"1"],"total":200}}`,
+				Classification:      "api",
+			},
+			{
+				Method:              "POST",
+				URL:                 "https://services.leadconnectorhq.com/contacts/search",
+				RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+				RequestBody:         `{"locationId":"loc","pageLimit":2,"filters":[],"searchAfter":[1779142892078,"1"]}`,
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"contacts":[{"id":"2"}],"meta":{"startAfter":[1779142893000,"2"],"total":200}}`,
+				Classification:      "api",
+			},
+		},
+	}
+
+	apiSpec, err := AnalyzeCapture(capture)
+	require.NoError(t, err)
+
+	endpoint := apiSpec.Resources["contacts"].Endpoints["create_search"]
+	require.NotEmpty(t, endpoint.Body)
+
+	cursor := findBodyParam(endpoint.Body, "startAfter")
+	require.NotNil(t, cursor)
+	assert.Equal(t, "searchAfter", cursor.BodyName)
+	assert.Equal(t, "array", cursor.Type)
+	assert.Nil(t, findBodyParam(endpoint.Body, "searchAfter"))
+}
+
+func TestReconcileObservedBodyCursorNamesKeepsDistinctBodyStartAfter(t *testing.T) {
+	t.Parallel()
+
+	body := []spec.Param{
+		{Name: "searchAfter", Type: "array"},
+		{Name: "startAfter", Type: "string"},
+	}
+	response := []spec.Param{
+		{Name: "meta", Type: "object", Fields: []spec.Param{{Name: "startAfter", Type: "array"}}},
+	}
+
+	got := reconcileObservedBodyCursorNames(body, response)
+	assert.Equal(t, body, got)
+}
+
 func TestAnalyzeCapture_ExpandsGraphQLBFFOperations(t *testing.T) {
 	t.Parallel()
 
@@ -1075,4 +1132,13 @@ func TestWriteEnrichedCaptureUsesPrivatePermissions(t *testing.T) {
 	info, err := os.Stat(outputPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func findBodyParam(params []spec.Param, name string) *spec.Param {
+	for i := range params {
+		if params[i].Name == name {
+			return &params[i]
+		}
+	}
+	return nil
 }

--- a/internal/generator/body_map_test.go
+++ b/internal/generator/body_map_test.go
@@ -167,6 +167,20 @@ func TestBodyMap_IdentName(t *testing.T) {
 	}
 }
 
+func TestBodyMap_BodyNameOverridesJSONKey(t *testing.T) {
+	t.Parallel()
+	got := bodyMap([]spec.Param{{Name: "startAfter", BodyName: "searchAfter", Type: "array"}}, "\t")
+	if !strings.Contains(got, "bodyStartAfter") {
+		t.Errorf("expected public name to drive variable identity, got: %s", got)
+	}
+	if !strings.Contains(got, `body["searchAfter"] = parsedStartAfter`) {
+		t.Errorf("expected body_name to drive JSON key, got: %s", got)
+	}
+	if strings.Contains(got, `body["startAfter"]`) {
+		t.Errorf("public name must not leak as JSON key when body_name is set, got: %s", got)
+	}
+}
+
 // TestBodyMap_NestedObject verifies that body params declaring
 // type=object with non-empty Fields render a nested-map block in
 // place of the JSON-string parse path. The wire key is the parent's

--- a/internal/generator/flag_collision.go
+++ b/internal/generator/flag_collision.go
@@ -304,8 +304,8 @@ func validatePublicFlagEntry(resKey, epName string, entry publicFlagEntry, reser
 // identifiers (via camel) or cobra flag names (via flagName). It is
 // IdentName when populated by the dedup pass and Name otherwise. The
 // resulting string must never be used for wire-side serialization;
-// callers writing URL params read paramWireName, while JSON keys, or
-// path substitutions read Name directly.
+// callers writing URL params read paramWireName, request bodies read
+// BodyWireName, and path substitutions read Name directly.
 func paramIdent(p spec.Param) string {
 	if p.IdentName != "" {
 		return p.IdentName

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3947,7 +3947,7 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 	for _, p := range endpoint.Body {
 		bindings = append(bindings, mcpParamBinding{
 			PublicName:         p.PublicInputName(),
-			WireName:           p.Name,
+			WireName:           p.BodyWireName(),
 			Location:           "body",
 			Format:             multipartBindingFormat(endpoint, p),
 			RequestContentType: requestContentType,
@@ -4087,7 +4087,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			fmt.Fprintf(b, "%s\t%s := map[string]any{}\n", indent, nestedMap)
 			renderBodyMap(b, p.Fields, depth+1, indent+"\t", nestedMap, ident, flag)
 			fmt.Fprintf(b, "%s\tif len(%s) > 0 {\n", indent, nestedMap)
-			fmt.Fprintf(b, "%s\t\t%s[%q] = %s\n", indent, mapVar, p.Name, nestedMap)
+			fmt.Fprintf(b, "%s\t\t%s[%q] = %s\n", indent, mapVar, p.BodyWireName(), nestedMap)
 			fmt.Fprintf(b, "%s\t}\n", indent)
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue
@@ -4106,7 +4106,7 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			fmt.Fprintf(b, "%s\tif err := json.Unmarshal([]byte(body%s), &parsed%s); err != nil {\n", indent, ident, ident)
 			fmt.Fprintf(b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: %%w\", err)\n", indent, flag)
 			fmt.Fprintf(b, "%s\t}\n", indent)
-			fmt.Fprintf(b, "%s\t%s[%q] = %s\n", indent, mapVar, p.Name, rhs)
+			fmt.Fprintf(b, "%s\t%s[%q] = %s\n", indent, mapVar, p.BodyWireName(), rhs)
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue
 		}
@@ -4121,12 +4121,12 @@ func renderBodyMap(b *strings.Builder, body []spec.Param, depth int, indent, map
 			// for POST, PUT, and PATCH. Internal YAML specs use "boolean";
 			// the OpenAPI parser normalizes to "bool".
 			fmt.Fprintf(b, "%sif cmd.Flags().Changed(%q) {\n", indent, flag)
-			fmt.Fprintf(b, "%s\t%s[%q] = body%s\n", indent, mapVar, p.Name, ident)
+			fmt.Fprintf(b, "%s\t%s[%q] = body%s\n", indent, mapVar, p.BodyWireName(), ident)
 			fmt.Fprintf(b, "%s}\n", indent)
 			continue
 		}
 		fmt.Fprintf(b, "%sif body%s != %s {\n", indent, ident, zeroVal(p.Type))
-		fmt.Fprintf(b, "%s\t%s[%q] = body%s\n", indent, mapVar, p.Name, ident)
+		fmt.Fprintf(b, "%s\t%s[%q] = body%s\n", indent, mapVar, p.BodyWireName(), ident)
 		fmt.Fprintf(b, "%s}\n", indent)
 	}
 }
@@ -4355,24 +4355,24 @@ func multipartBodyMaps(body []spec.Param, indent string) string {
 			fmt.Fprintf(&b, "%s\tif !json.Valid([]byte(body%s)) {\n", indent, ident)
 			fmt.Fprintf(&b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: invalid JSON\")\n", indent, flag)
 			fmt.Fprintf(&b, "%s\t}\n", indent)
-			fmt.Fprintf(&b, "%s\tfields[%q] = body%s\n", indent, p.Name, ident)
+			fmt.Fprintf(&b, "%s\tfields[%q] = body%s\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		if isBinaryParam(p) {
 			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
-			fmt.Fprintf(&b, "%s\tfileFields[%q] = body%s\n", indent, p.Name, ident)
+			fmt.Fprintf(&b, "%s\tfileFields[%q] = body%s\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		if p.Type == "string" {
 			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
-			fmt.Fprintf(&b, "%s\tfields[%q] = body%s\n", indent, p.Name, ident)
+			fmt.Fprintf(&b, "%s\tfields[%q] = body%s\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		fmt.Fprintf(&b, "%sif body%s != %s {\n", indent, ident, zeroVal(p.Type))
-		fmt.Fprintf(&b, "%s\tfields[%q] = fmt.Sprintf(\"%%v\", body%s)\n", indent, p.Name, ident)
+		fmt.Fprintf(&b, "%s\tfields[%q] = fmt.Sprintf(\"%%v\", body%s)\n", indent, p.BodyWireName(), ident)
 		fmt.Fprintf(&b, "%s}\n", indent)
 	}
 	return b.String()
@@ -4502,18 +4502,18 @@ func formBodyMaps(body []spec.Param, indent string) string {
 			fmt.Fprintf(&b, "%s\tif !json.Valid([]byte(body%s)) {\n", indent, ident)
 			fmt.Fprintf(&b, "%s\t\treturn fmt.Errorf(\"parsing --%s JSON: invalid JSON\")\n", indent, flag)
 			fmt.Fprintf(&b, "%s\t}\n", indent)
-			fmt.Fprintf(&b, "%s\tfields.Set(%q, body%s)\n", indent, p.Name, ident)
+			fmt.Fprintf(&b, "%s\tfields.Set(%q, body%s)\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		if p.Type == "string" {
 			fmt.Fprintf(&b, "%sif body%s != \"\" {\n", indent, ident)
-			fmt.Fprintf(&b, "%s\tfields.Set(%q, body%s)\n", indent, p.Name, ident)
+			fmt.Fprintf(&b, "%s\tfields.Set(%q, body%s)\n", indent, p.BodyWireName(), ident)
 			fmt.Fprintf(&b, "%s}\n", indent)
 			continue
 		}
 		fmt.Fprintf(&b, "%sif body%s != %s {\n", indent, ident, zeroVal(p.Type))
-		fmt.Fprintf(&b, "%s\tfields.Set(%q, fmt.Sprintf(\"%%v\", body%s))\n", indent, p.Name, ident)
+		fmt.Fprintf(&b, "%s\tfields.Set(%q, fmt.Sprintf(\"%%v\", body%s))\n", indent, p.BodyWireName(), ident)
 		fmt.Fprintf(&b, "%s}\n", indent)
 	}
 	return b.String()

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12839,6 +12839,38 @@ func TestGeneratePublicParamNamesAcrossCLISurfaces(t *testing.T) {
 	assert.Contains(t, skill, `public-params-pp-cli stores create --store-code example-value`)
 }
 
+func TestGenerateBodyNameAcrossCLISurfaces(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("body-wire")
+	delete(apiSpec.Resources, "items")
+	apiSpec.Resources["contacts"] = spec.Resource{
+		Description: "Contacts",
+		Endpoints: map[string]spec.Endpoint{
+			"search": {
+				Method:      "POST",
+				Path:        "/contacts/search",
+				Description: "Search contacts",
+				Body: []spec.Param{
+					{Name: "startAfter", BodyName: "searchAfter", Type: "array", Description: "Pagination cursor"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	searchSource := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_contacts.go")
+	assert.Contains(t, searchSource, `StringVar(&bodyStartAfter, "start-after", "", "Pagination cursor")`)
+	assert.Contains(t, searchSource, `body["searchAfter"] = parsedStartAfter`)
+	assert.NotContains(t, searchSource, `body["startAfter"] = parsedStartAfter`)
+
+	mcpSource := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	assert.Contains(t, mcpSource, `mcplib.WithString("startAfter", mcplib.Description("Pagination cursor"))`)
+	assert.Contains(t, mcpSource, `PublicName: "startAfter", WireName: "searchAfter", Location: "body"`)
+}
+
 // TestMCPHandlerPassesBodyArgsMap pins that POST/PUT/PATCH branches forward
 // the bodyArgs map directly to the client, not via a pre-marshal. The client's
 // do() json.Marshals what it receives; passing []byte causes encoding/json to

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1048,10 +1048,15 @@ func splitSyncPostParams(resource string, params map[string]string) (map[string]
 	if len(bodyParamTypes) == 0 {
 		return params, body
 	}
+	bodyParamWireNames := syncResourceBodyParamWireNames(resource)
 	queryParams := map[string]string{}
 	for key, value := range params {
 		if typ, ok := bodyParamTypes[key]; ok {
-			body[key] = coerceSyncBodyParam(value, typ)
+			bodyKey := bodyParamWireNames[key]
+			if bodyKey == "" {
+				bodyKey = key
+			}
+			body[bodyKey] = coerceSyncBodyParam(value, typ)
 		} else {
 			queryParams[key] = value
 		}
@@ -1103,6 +1108,32 @@ func syncResourceBodyParamTypes(resource string) map[string]string {
 	return nil
 }
 
+func syncResourceBodyParamWireNames(resource string) map[string]string {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if .BodyFields}}
+	case "{{.Name}}":
+		return map[string]string{
+{{- range .BodyFields}}
+			"{{.Name}}": "{{.BodyWireName}}",
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+{{- range .DependentSyncResources}}
+{{- if .BodyFields}}
+	case "{{.Name}}":
+		return map[string]string{
+{{- range .BodyFields}}
+			"{{.Name}}": "{{.BodyWireName}}",
+{{- end}}
+		}
+{{- end}}
+{{- end}}
+	}
+	return nil
+}
+
 func coerceSyncBodyParam(value string, typ string) any {
 	switch typ {
 	case "integer", "int", "int64":
@@ -1132,7 +1163,7 @@ func syncResourceStaticBody(resource string) map[string]any {
 		return map[string]any{
 {{- range .BodyFields}}
 {{- if .HasDefault}}
-			"{{.Name}}": {{goLiteral .Default}},
+			"{{.BodyWireName}}": {{goLiteral .Default}},
 {{- end}}
 {{- end}}
 		}
@@ -1148,7 +1179,7 @@ func syncResourceStaticBody(resource string) map[string]any {
 		return map[string]any{
 {{- range .BodyFields}}
 {{- if .HasDefault}}
-			"{{.Name}}": {{goLiteral .Default}},
+			"{{.BodyWireName}}": {{goLiteral .Default}},
 {{- end}}
 {{- end}}
 		}

--- a/internal/pipeline/merge.go
+++ b/internal/pipeline/merge.go
@@ -76,8 +76,14 @@ func applyParamPatches(params *[]spec.Param, patches []ParamPatch) error {
 				if patch.ClearFlagName {
 					(*params)[i].FlagName = ""
 				}
+				if patch.ClearBodyName {
+					(*params)[i].BodyName = ""
+				}
 				if patch.FlagName != nil {
 					(*params)[i].FlagName = *patch.FlagName
+				}
+				if patch.BodyName != nil {
+					(*params)[i].BodyName = *patch.BodyName
 				}
 				if patch.Aliases != nil {
 					(*params)[i].Aliases = append([]string(nil), (*patch.Aliases)...)

--- a/internal/pipeline/merge_test.go
+++ b/internal/pipeline/merge_test.go
@@ -74,7 +74,7 @@ func TestMergeOverlayPublicParamNames(t *testing.T) {
 							{Name: "c", Type: "string"},
 						},
 						Body: []spec.Param{
-							{Name: "delivery_window", Type: "string", FlagName: "window"},
+							{Name: "delivery_window", Type: "string", FlagName: "window", BodyName: "deliveryWindow"},
 						},
 					},
 				},
@@ -84,6 +84,7 @@ func TestMergeOverlayPublicParamNames(t *testing.T) {
 	address := "address"
 	cityAliases := []string{"c"}
 	bodyAliases := []string{}
+	bodyName := "window"
 	overlay := &SpecOverlay{
 		Resources: map[string]ResourceOverlay{
 			"stores": {
@@ -94,7 +95,7 @@ func TestMergeOverlayPublicParamNames(t *testing.T) {
 							{Name: "c", Aliases: &cityAliases},
 						},
 						Body: []ParamPatch{
-							{Name: "delivery_window", ClearFlagName: true, Aliases: &bodyAliases},
+							{Name: "delivery_window", ClearFlagName: true, BodyName: &bodyName, Aliases: &bodyAliases},
 						},
 					},
 				},
@@ -110,6 +111,7 @@ func TestMergeOverlayPublicParamNames(t *testing.T) {
 	assert.Equal(t, "c", endpoint.Params[1].Name)
 	assert.Equal(t, []string{"c"}, endpoint.Params[1].Aliases)
 	assert.Empty(t, endpoint.Body[0].FlagName)
+	assert.Equal(t, "window", endpoint.Body[0].BodyName)
 	assert.Empty(t, endpoint.Body[0].Aliases)
 }
 

--- a/internal/pipeline/overlay.go
+++ b/internal/pipeline/overlay.go
@@ -24,6 +24,8 @@ type ParamPatch struct {
 	Name          string    `yaml:"name"`
 	Default       *string   `yaml:"default,omitempty"`
 	FlagName      *string   `yaml:"flag_name,omitempty"`
+	BodyName      *string   `yaml:"body_name,omitempty"`
 	ClearFlagName bool      `yaml:"clear_flag_name,omitempty"`
+	ClearBodyName bool      `yaml:"clear_body_name,omitempty"`
 	Aliases       *[]string `yaml:"aliases,omitempty"`
 }

--- a/internal/pipeline/public_param_audit.go
+++ b/internal/pipeline/public_param_audit.go
@@ -117,10 +117,14 @@ func auditPublicParams(resourceName, endpointName, location string, endpoint spe
 }
 
 func publicParamAuditWireName(location string, param spec.Param) string {
-	if location == "params" {
+	switch location {
+	case "body":
+		return param.BodyWireName()
+	case "params":
 		return param.WireName()
+	default:
+		return param.Name
 	}
-	return param.Name
 }
 
 func publicParamAuditPublicName(location string, param spec.Param, wireName string) string {
@@ -128,6 +132,9 @@ func publicParamAuditPublicName(location string, param spec.Param, wireName stri
 		return param.FlagName
 	}
 	if location == "params" && param.URLName != "" && param.Name != wireName {
+		return param.PublicInputName()
+	}
+	if location == "body" && param.BodyName != "" && param.Name != wireName {
 		return param.PublicInputName()
 	}
 	return ""

--- a/internal/pipeline/public_param_audit_test.go
+++ b/internal/pipeline/public_param_audit_test.go
@@ -91,6 +91,31 @@ func TestAuditPublicParamNamesMarksExistingFlagNamesResolved(t *testing.T) {
 	assert.Equal(t, []string{"s"}, street.Aliases)
 }
 
+func TestAuditPublicParamNamesUsesBodyWireName(t *testing.T) {
+	api := &spec.APISpec{
+		Name:    "body-wire",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"stores": {
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method: "POST",
+						Path:   "/stores",
+						Body: []spec.Param{
+							{Name: "street", BodyName: "s", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	findings := AuditPublicParamNames(api)
+	finding := requirePublicParamFinding(t, findings, "stores.create.body.s")
+	assert.Equal(t, "s", finding.WireName)
+}
+
 func TestPublicParamAuditSkipRequiresEvidence(t *testing.T) {
 	findings := []PublicParamAuditFinding{
 		{ID: "stores.find.params.s", WireName: "s", Decision: PublicParamDecisionSkip, SkipReason: "This is a public API field."},

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -402,7 +402,7 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 		name := p.PublicInputName()
 		tool.Params = append(tool.Params, ManifestParam{
 			Name:        name,
-			WireName:    manifestWireName(name, p.Name),
+			WireName:    manifestWireName(name, p.BodyWireName()),
 			Type:        normalizeParamType(p.Type),
 			Location:    "body",
 			Description: describeParam(p),

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -285,7 +285,7 @@ func TestWriteToolsManifest_PublicParamNames(t *testing.T) {
 						Path:        "/stores",
 						Description: "Create store",
 						Body: []spec.Param{
-							{Name: "store_code", FlagName: "store-code", Aliases: []string{"code"}, Type: "string", Required: true, Description: "Store code"},
+							{Name: "store_code", BodyName: "storeCode", FlagName: "store-code", Aliases: []string{"code"}, Type: "string", Required: true, Description: "Store code"},
 						},
 					},
 				},
@@ -314,7 +314,7 @@ func TestWriteToolsManifest_PublicParamNames(t *testing.T) {
 
 	require.Len(t, create.Params, 1)
 	assert.Equal(t, "store-code", create.Params[0].Name)
-	assert.Equal(t, "store_code", create.Params[0].WireName)
+	assert.Equal(t, "storeCode", create.Params[0].WireName)
 	assert.Equal(t, []string{"code"}, create.Params[0].Aliases)
 }
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -62,9 +62,17 @@ type SearchBodyField struct {
 // SyncBodyField describes a request-body field on a syncable POST list endpoint.
 type SyncBodyField struct {
 	Name       string
+	WireName   string
 	Type       string
 	Default    any
 	HasDefault bool
+}
+
+func (f SyncBodyField) BodyWireName() string {
+	if f.WireName != "" {
+		return f.WireName
+	}
+	return f.Name
 }
 
 // FieldSelector describes a query param that asks sparse-response APIs to
@@ -1749,7 +1757,7 @@ func syncBodyFieldsFromEndpoint(endpoint spec.Endpoint) []SyncBodyField {
 	}
 	fields := make([]SyncBodyField, 0, len(endpoint.Body))
 	for _, param := range endpoint.Body {
-		field := SyncBodyField{Name: param.Name, Type: param.Type}
+		field := SyncBodyField{Name: param.Name, WireName: param.BodyWireName(), Type: param.Type}
 		if defaultValue, ok := syncBodyDefault(param); ok {
 			field.Default = defaultValue
 			field.HasDefault = true

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1686,7 +1686,8 @@ func (h *HTMLExtract) EffectiveScriptSelector() string {
 type Param struct {
 	Name        string   `yaml:"name" json:"name"`
 	FlagName    string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
-	URLName     string   `yaml:"url_name,omitempty" json:"url_name,omitempty"` // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
+	URLName     string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
+	BodyName    string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
 	Aliases     []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
 	Type        string   `yaml:"type" json:"type"`
 	Required    bool     `yaml:"required" json:"required"`
@@ -1705,7 +1706,8 @@ type Param struct {
 	FieldSelectorDefault string `yaml:"field_selector_default,omitempty" json:"field_selector_default,omitempty"`
 	// IdentName, when set, overrides Name for Go identifier and CLI flag
 	// derivation (camel/flagName). Name remains the wire-side parameter name
-	// used in URLs, JSON keys, and path substitution. Populated by the
+	// used in URLs unless url_name is set, request-body keys unless body_name
+	// is set, and path substitution. Populated by the
 	// generator's flag-collision dedup pass when two params on the same
 	// endpoint would otherwise produce identical Go identifiers or CLI flag
 	// names — for example Twilio's StartTime/StartTime>/StartTime< all
@@ -1726,6 +1728,16 @@ type Param struct {
 func (p Param) WireName() string {
 	if p.URLName != "" {
 		return p.URLName
+	}
+	return p.Name
+}
+
+// BodyWireName returns the request-body key for this param when emitted in a
+// generated HTTP request body. BodyName takes precedence when set; otherwise
+// Name is used.
+func (p Param) BodyWireName() string {
+	if p.BodyName != "" {
+		return p.BodyName
 	}
 	return p.Name
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -87,6 +87,14 @@ resources:
             aliases: [s]
             type: string
             description: Street address
+      search:
+        method: POST
+        path: /stores/search
+        body:
+          - name: startAfter
+            body_name: searchAfter
+            type: array
+            description: Pagination cursor
 `)
 	s, err := ParseBytes(yamlSpec)
 	require.NoError(t, err)
@@ -94,6 +102,9 @@ resources:
 	assert.Equal(t, "s", param.Name)
 	assert.Equal(t, "address", param.FlagName)
 	assert.Equal(t, []string{"s"}, param.Aliases)
+	bodyParam := s.Resources["stores"].Endpoints["search"].Body[0]
+	assert.Equal(t, "startAfter", bodyParam.Name)
+	assert.Equal(t, "searchAfter", bodyParam.BodyName)
 
 	jsonSpec := []byte(`{
   "name": "public-params-json",
@@ -186,6 +197,11 @@ func TestParamPublicInputName(t *testing.T) {
 	assert.Equal(t, "store_code", Param{Name: "store_code"}.PublicInputName())
 	assert.Equal(t, "id-2", Param{Name: "id", IdentName: "id_2"}.PublicInputName())
 	assert.Equal(t, "start-time-2", Param{Name: "StartTime>", IdentName: "StartTime>_2"}.PublicInputName())
+}
+
+func TestParamBodyWireName(t *testing.T) {
+	assert.Equal(t, "startAfter", Param{Name: "startAfter"}.BodyWireName())
+	assert.Equal(t, "searchAfter", Param{Name: "startAfter", BodyName: "searchAfter"}.BodyWireName())
 }
 
 func TestValidatePublicParamNames(t *testing.T) {

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -233,9 +233,17 @@ types:
 
 ## 3. Public Parameter Names
 
-`name` is the upstream wire key. The generator uses it for query strings, path
-substitution, and JSON body keys. Do not change `name` just to make a prettier
-CLI.
+`name` is the upstream wire key by default and the parameter's public identity
+when no override is set. The generator uses it for path substitution and, unless
+`url_name` or `body_name` says otherwise, query strings and request-body keys.
+Do not change `name` just to make a prettier CLI.
+
+`url_name` is an optional query-string wire override. Use it when the CLI/MCP
+input should keep the `name` spelling but the URL key must differ.
+
+`body_name` is an optional request-body wire override. Use it when the CLI/MCP
+input should keep the `name` spelling but the JSON, form, or multipart body key
+must differ.
 
 `flag_name` is the preferred public name shown in generated CLI flags, examples,
 typed MCP schemas, and `tools-manifest.json`. Add it only when source evidence
@@ -266,6 +274,17 @@ params:
 
 Here `--address` and `--city` are the generated public names, `--s` and `--c`
 remain compatibility aliases, and requests still send upstream keys `s` and `c`.
+
+For body fields where the public cursor name and accepted body key diverge,
+keep the public identity in `name` and set `body_name` to the observed wire key:
+
+```yaml
+body:
+  - name: startAfter
+    body_name: searchAfter
+    type: array
+    description: Pagination cursor
+```
 
 ## 4. Validation Rules
 


### PR DESCRIPTION
## Summary
Generated CLIs can now keep a public cursor like `startAfter` while sending the body key the API actually accepts, such as GoHighLevel's `searchAfter`. The new `body_name` spec/overlay field flows through CLI flags, MCP bindings, tools manifests, sync helpers, and public-param audit; browser-sniff also reconciles the observed `searchAfter` request cursor with `meta.startAfter` responses.

Closes #1694.

## Verification
- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)