### PR TITLE
fix(cli): count helper-backed workflow client calls

### DIFF
--- a/docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md
+++ b/docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md
@@ -1,7 +1,7 @@
 ---
 title: "Scorecard scorers must follow reachable command surfaces"
 date: 2026-05-21
-last_updated: 2026-05-23
+last_updated: 2026-05-24
 category: logic-errors
 module: internal/pipeline
 problem_type: logic_error
@@ -11,6 +11,7 @@ symptoms:
   - "Dead generic REST scaffolding can look like the only scored surface"
   - "Re-adding dead scaffold would improve scores without improving the printed CLI"
   - "Capability-equivalent resource-grouped or generic-store commands score lower than literal-pattern command files"
+  - "Workflow scores stay low when registered command files delegate API calls to same-package helpers"
 root_cause: logic_error
 resolution_type: code_fix
 severity: medium
@@ -21,6 +22,7 @@ tags:
   - reachability
   - dead-code
   - json-rpc
+  - helper-indirection
 ---
 
 # Scorecard scorers must follow reachable command surfaces
@@ -31,6 +33,8 @@ Several scorecard dimensions assumed generated REST scaffolding was the canonica
 
 The same failure mode applies when a REST CLI exposes equivalent capability through a different reachable shape: resource-grouped subcommands instead of top-level literal filenames, generic `resources` SQL queries instead of typed store search methods, or quota-aware cache designs that intentionally omit auto-refresh.
 
+It also applies inside `internal/cli` when a registered command delegates real API work to a same-package helper. The scorer should not require `c.Get` or `c.Post` to appear in the command file itself when the reachable helper performs the client calls.
+
 ## Symptoms
 
 - Error handling, output modes, and sync correctness were under-scored even when a registered command delegated to richer sibling-package code.
@@ -38,6 +42,7 @@ The same failure mode applies when a REST CLI exposes equivalent capability thro
 - Nested Cobra subcommands were invisible when only the parent command's first `Use:` literal was scanned.
 - Broad scans risked rewarding unregistered command files or dead files inside imported sibling packages.
 - Generic resources SQL searches could be under-scored when the command used the local store directly instead of a typed `SearchX` wrapper.
+- Compound workflow commands could be under-scored when they called shared helpers such as `pxcommon.go` functions that performed multiple generated-client or sibling-client calls.
 
 ## What Didn't Work
 
@@ -53,6 +58,7 @@ Build scorer evidence from the registered command surface:
 - Reuse the local-data signal used by the reimplementation check, including raw `database/sql` access paired with `sql.Open` or `sql.OpenDB`.
 - Run sync correctness and pagination AST checks against the same reachable files used by output and error scoring.
 - When adding a new capability-equivalent heuristic, evaluate it against registered command content or reachable files. For paired signals such as SQL text plus `Query` execution, require the evidence to live in the same command file unless cross-file matching is explicitly designed and covered by tests.
+- For workflow scoring, count one-hop same-package helper calls from registered command files when the helper contains generated-client calls or calls into a recognized sibling internal client. Exclude helpers defined in the same command file from the helper credit so normal Cobra handler-to-runner wiring does not double-count a single inline API call.
 
 ## Why This Works
 
@@ -61,6 +67,8 @@ The scorer now evaluates behavior a user or agent can actually reach. It gives n
 ## Prevention
 
 When adding scorecard heuristics, prefer registered-command reachability over hardcoded filenames. If a dimension needs paired signals, keep those pairs within the same source unit unless cross-file matching is deliberately justified. Add both positive reachable-package tests and negative dead-code tests so future broadening does not reintroduce scorer inflation. For equivalent-capability scoring, pair each positive fixture with a negative fixture for copied SQL, split-file evidence, or unregistered command files so the scorer rewards real capability rather than plausible-looking source text.
+
+For helper-following heuristics, cover both sides of the boundary: a registered command that calls a shared helper should score when the helper performs real client/store work, while an unregistered command file or same-file runner wrapper should not inflate the score. Include sibling-internal-client fixtures when the blast radius includes combo or non-REST CLIs.
 
 ## Related
 

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -712,10 +712,31 @@ func callsStoreHelper(content string, helpers map[string]bool) bool {
 	return callsHelper(content, helpers)
 }
 
+func countWeightedHelperCallsFiltered(content string, helpers map[string]int, include func(string) bool) int {
+	if len(helpers) == 0 {
+		return 0
+	}
+	return countHelperCalls(content, func(name string) int {
+		if include != nil && !include(name) {
+			return 0
+		}
+		return helpers[name]
+	})
+}
+
 func callsHelper(content string, helpers map[string]bool) bool {
 	if len(helpers) == 0 {
 		return false
 	}
+	return countHelperCalls(content, func(name string) int {
+		if helpers[name] {
+			return 1
+		}
+		return 0
+	}) > 0
+}
+
+func countHelperCalls(content string, weight func(string) int) int {
 	source := content
 	trimmed := strings.TrimSpace(source)
 	if !strings.HasPrefix(trimmed, "package ") {
@@ -727,25 +748,21 @@ func callsHelper(content string, helpers map[string]bool) bool {
 	}
 	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
 	if err != nil {
-		return false
+		return 0
 	}
-	found := false
+	count := 0
 	ast.Inspect(file, func(n ast.Node) bool {
-		if found {
-			return false
-		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
 		ident, ok := call.Fun.(*ast.Ident)
-		if ok && helpers[ident.Name] {
-			found = true
-			return false
+		if ok {
+			count += weight(ident.Name)
 		}
 		return true
 	})
-	return found
+	return count
 }
 
 func hasClientSignal(content string) bool {

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -712,15 +712,23 @@ func callsStoreHelper(content string, helpers map[string]bool) bool {
 	return callsHelper(content, helpers)
 }
 
-func countWeightedHelperCallsFiltered(content string, helpers map[string]int, include func(string) bool) int {
+func countWeightedHelperCallsFiltered(content string, helpers map[string]int, include func(string, string) bool) int {
 	if len(helpers) == 0 {
 		return 0
 	}
 	return countHelperCalls(content, func(name string) int {
-		if include != nil && !include(name) {
-			return 0
+		count := 0
+		for key, weight := range helpers {
+			fileName, funcName := splitHelperKey(key)
+			if funcName != name {
+				continue
+			}
+			if include != nil && !include(fileName, funcName) {
+				continue
+			}
+			count += weight
 		}
-		return helpers[name]
+		return count
 	})
 }
 

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1293,9 +1293,8 @@ func countClientAPICalls(content string) int {
 	return len(clientAPICallRE.FindAllString(content, -1))
 }
 
-func clientHelperCallCounts(fileContent map[string]string) (map[string]int, map[string]string) {
+func clientHelperCallCounts(fileContent map[string]string) map[string]int {
 	helpers := map[string]int{}
-	helperFiles := map[string]string{}
 	for fileName, content := range fileContent {
 		fset := token.NewFileSet()
 		file, err := parser.ParseFile(fset, "", content, 0)
@@ -1316,12 +1315,23 @@ func clientHelperCallCounts(fileContent map[string]string) (map[string]int, map[
 			body := content[start:end]
 			calls := countClientAPICalls(body) + countImportedClientCalls(fn.Body, imports, false)
 			if calls > 0 {
-				helpers[fn.Name.Name] = calls
-				helperFiles[fn.Name.Name] = fileName
+				helpers[helperKey(fileName, fn.Name.Name)] = calls
 			}
 		}
 	}
-	return helpers, helperFiles
+	return helpers
+}
+
+func helperKey(fileName, funcName string) string {
+	return fileName + ":" + funcName
+}
+
+func splitHelperKey(key string) (string, string) {
+	i := strings.LastIndexByte(key, ':')
+	if i < 0 {
+		return "", key
+	}
+	return key[:i], key[i+1:]
 }
 
 func countImportedClientCalls(body *ast.BlockStmt, imports map[string]clientImportKind, allowAnySiblingSelector bool) int {
@@ -1479,7 +1489,7 @@ func scoreWorkflows(dir string) int {
 		fileContent[e.Name()] = readFileContent(filepath.Join(cliDir, e.Name()))
 	}
 	storeHelpers := storeHelperNames(fileContent)
-	clientHelpers, clientHelperFiles := clientHelperCallCounts(fileContent)
+	clientHelpers := clientHelperCallCounts(fileContent)
 
 	// Some prefixes overlap with insightPrefixes intentionally — per Steinberger,
 	// analytics/insights ARE compound commands (the visionary research plan lists
@@ -1532,8 +1542,8 @@ func scoreWorkflows(dir string) int {
 
 		// Count files that make 2+ API calls (total occurrences, not unique methods).
 		// A command calling c.Get 3 times is a compound workflow even if it never uses POST.
-		apiCalls := countClientAPICalls(content) + countWeightedHelperCallsFiltered(content, clientHelpers, func(name string) bool {
-			return clientHelperFiles[name] != e.Name()
+		apiCalls := countClientAPICalls(content) + countWeightedHelperCallsFiltered(content, clientHelpers, func(fileName, name string) bool {
+			return fileName != e.Name()
 		})
 		if strings.Contains(content, "store.") {
 			apiCalls++

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1290,6 +1293,55 @@ func countClientAPICalls(content string) int {
 	return len(clientAPICallRE.FindAllString(content, -1))
 }
 
+func clientHelperCallCounts(fileContent map[string]string) (map[string]int, map[string]string) {
+	helpers := map[string]int{}
+	helperFiles := map[string]string{}
+	for fileName, content := range fileContent {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "", content, 0)
+		if err != nil {
+			continue
+		}
+		imports := clientImportAliases(file)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			start := fset.Position(fn.Body.Pos()).Offset
+			end := fset.Position(fn.Body.End()).Offset
+			if start < 0 || end > len(content) || start >= end {
+				continue
+			}
+			body := content[start:end]
+			calls := countClientAPICalls(body) + countImportedClientCalls(fn.Body, imports, false)
+			if calls > 0 {
+				helpers[fn.Name.Name] = calls
+				helperFiles[fn.Name.Name] = fileName
+			}
+		}
+	}
+	return helpers, helperFiles
+}
+
+func countImportedClientCalls(body *ast.BlockStmt, imports map[string]clientImportKind, allowAnySiblingSelector bool) int {
+	if body == nil {
+		return 0
+	}
+	count := 0
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isImportedClientCall(call.Fun, imports, allowAnySiblingSelector) {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
 // cobraUseLeafRe extracts the leaf command name from a Cobra Use: literal.
 // Accepts both Go string forms — double-quoted and backtick raw-string —
 // because authors reach for backticks when the value contains a literal
@@ -1427,6 +1479,7 @@ func scoreWorkflows(dir string) int {
 		fileContent[e.Name()] = readFileContent(filepath.Join(cliDir, e.Name()))
 	}
 	storeHelpers := storeHelperNames(fileContent)
+	clientHelpers, clientHelperFiles := clientHelperCallCounts(fileContent)
 
 	// Some prefixes overlap with insightPrefixes intentionally — per Steinberger,
 	// analytics/insights ARE compound commands (the visionary research plan lists
@@ -1479,7 +1532,9 @@ func scoreWorkflows(dir string) int {
 
 		// Count files that make 2+ API calls (total occurrences, not unique methods).
 		// A command calling c.Get 3 times is a compound workflow even if it never uses POST.
-		apiCalls := countClientAPICalls(content)
+		apiCalls := countClientAPICalls(content) + countWeightedHelperCallsFiltered(content, clientHelpers, func(name string) bool {
+			return clientHelperFiles[name] != e.Name()
+		})
 		if strings.Contains(content, "store.") {
 			apiCalls++
 		}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2671,6 +2671,31 @@ func runReport%d(c apiClient) error {
 		assert.Equal(t, 6, scoreWorkflows(dir))
 	})
 
+	t.Run("counts package-local client helper weights greater than one", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+	package cli
+	
+	func fetchBundle(c apiClient) error {
+		if _, err := c.Get("/bundle/meta"); err != nil {
+			return err
+		}
+		_, err := c.Get("/bundle/items")
+		return err
+	}
+	`)
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+	package cli
+	
+	func runReport(c apiClient) error {
+		return fetchBundle(c)
+	}
+	`)
+
+		assert.Equal(t, 2, scoreWorkflows(dir))
+	})
+
 	t.Run("ignores unregistered commands that call package-local client helpers", func(t *testing.T) {
 		dir := t.TempDir()
 

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2628,6 +2628,191 @@ func runLookup() error { return nil }
 		assert.Equal(t, 6, scoreWorkflows(dir))
 	})
 
+	t.Run("counts commands that call package-local client helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+func fetchMeta(c apiClient) error {
+	_, err := c.Get("/meta")
+	return err
+}
+
+func runQuery(c apiClient) error {
+	_, err := c.Post("/query", nil)
+	return err
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(
+		newReport1Cmd(nil),
+		newReport2Cmd(nil),
+		newReport3Cmd(nil),
+	)
+}
+`)
+		for i := 1; i <= 3; i++ {
+			writeScorecardFixture(t, dir, filepath.Join("internal/cli", fmt.Sprintf("report_%d.go", i)), fmt.Sprintf(`
+package cli
+
+func newReport%dCmd(flags any) {}
+
+func runReport%d(c apiClient) error {
+	if err := fetchMeta(c); err != nil {
+		return err
+	}
+	return runQuery(c)
+}
+`, i, i))
+		}
+
+		assert.Equal(t, 6, scoreWorkflows(dir))
+	})
+
+	t.Run("ignores unregistered commands that call package-local client helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/pxcommon.go", `
+package cli
+
+func runQuery(c apiClient) error {
+	_, err := c.Post("/query", nil)
+	return err
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(newLookupCmd(nil))
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/lookup.go", `package cli
+func newLookupCmd(flags any) {}
+func runLookup() error { return nil }
+`)
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+package cli
+
+func newReportCmd(flags any) {}
+
+func runReport(c apiClient) error {
+	return runQuery(c)
+}
+`)
+
+		assert.Equal(t, 0, scoreWorkflows(dir))
+	})
+
+	t.Run("counts package-local helpers using other generated client verbs", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+func updateThing(c apiClient) error {
+	_, err := c.Put("/thing", nil)
+	return err
+}
+
+func deleteThing(c apiClient) error {
+	_, err := c.Delete("/thing")
+	return err
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+package cli
+
+func runReport(c apiClient) error {
+	if err := updateThing(c); err != nil {
+		return err
+	}
+	return deleteThing(c)
+}
+`)
+
+		assert.Equal(t, 2, scoreWorkflows(dir))
+	})
+
+	t.Run("counts package-local helpers that call sibling internal clients", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/pxcommon.go", `
+package cli
+
+import "example.com/project/internal/phgraphql"
+
+func fetchMeta() error {
+	_, err := phgraphql.FetchMeta()
+	return err
+}
+
+func runQuery() error {
+	_, err := phgraphql.Post()
+	return err
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(newReportCmd(nil))
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+package cli
+
+func newReportCmd(flags any) {}
+
+func runReport() error {
+	if err := fetchMeta(); err != nil {
+		return err
+	}
+	return runQuery()
+}
+`)
+
+		assert.Equal(t, 2, scoreWorkflows(dir))
+	})
+
+	t.Run("does not count commands that only call non-client helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/helpers.go", `
+package cli
+
+func staticRows() []string {
+	return []string{"cached"}
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+package cli
+
+func runReport() []string {
+	return staticRows()
+}
+`)
+
+		assert.Equal(t, 0, scoreWorkflows(dir))
+	})
+
+	t.Run("does not double-count same-file command runners as helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/report.go", `
+package cli
+
+func newReportCmd(flags any) {
+	runReport(flags)
+}
+
+func runReport(c apiClient) error {
+	_, err := c.Get("/report")
+	return err
+}
+`)
+
+		assert.Equal(t, 0, scoreWorkflows(dir))
+	})
+
 	t.Run("counts multi-API-call files", func(t *testing.T) {
 		dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Workflow scoring now credits registered commands that delegate real API work to same-package helpers, so compound commands that share `pxcommon`-style fetch/query logic are no longer under-scored just because the client calls are factored out of the command file.

The scorer keeps the anti-inflation guardrails in place: helper credit is limited to calls from registered command files, same-file runner wrappers do not double-count inline API calls, non-client helpers stay at zero, and sibling internal clients are recognized through the same import-aware signal used by the reimplementation check.

Closes #1725

## Tests

- `go test ./internal/pipeline -run 'TestScoreWorkflows' -count=1`
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodDetectsTruncatedJSONOutput|TestRunLiveDogfoodProcessTracksOutputTruncation' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `python3 /Users/tmchow/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.8.4/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md`

Local `go test ./...` twice hit the existing live-dogfood truncation timeout assertions (`TestRunLiveDogfoodDetectsTruncatedJSONOutput`, `TestRunLiveDogfoodProcessTracksOutputTruncation`); those exact tests pass when isolated, and the scorer package tests pass for this change.

## Compounded learnings

- File: `docs/solutions/logic-errors/reachable-scorer-surfaces-non-rest-clis-2026-05-21.md`
- Track: bug
- Category: logic-errors
- Overlap: high, existing scorer reachability doc updated
- Instruction-file edit: none needed
- Refresh recommendation: none

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
