### PR TITLE
fix(cli): detect plural wrapper list envelopes

### DIFF
--- a/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
+++ b/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
@@ -1,0 +1,81 @@
+---
+title: Profiler wrapper-array detection must match sync extraction
+date: 2026-05-24
+category: docs/solutions/logic-errors
+module: internal/profiler
+problem_type: logic_error
+component: tooling
+symptoms:
+  - Generated CLIs can omit syncable resources for APIs that return typed object envelopes such as contacts or opportunities arrays.
+  - Runtime sync extraction can support a response envelope shape that the profiler never registers.
+  - Type-name fallbacks can accidentally mark singleton object responses as syncable when field metadata proves they are not lists.
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - internal/generator/templates/sync.go.tmpl
+  - generated-cli-runtime
+tags:
+  - profiler
+  - sync
+  - wrapper-envelope
+  - generated-cli
+  - agent-native
+---
+
+# Profiler wrapper-array detection must match sync extraction
+
+## Problem
+
+The profiler decides which resources become syncable, while generated sync code later extracts items from the chosen endpoint responses. If those two heuristics drift, the generated CLI can either omit usable store-backed resources or advertise local-cache resources that extract the wrong data.
+
+## Symptoms
+
+- APIs with envelopes such as `{"contacts": [...], "meta": {...}}` or `{"opportunities": [...]}` do not get those resources into `defaultSyncResources()`.
+- Generated sync runtime already knows how to extract a single unambiguous array from an envelope, but the profiler rejects the endpoint before generation.
+- Broad type-name fallbacks such as `*Response` or `*Result` can classify a singleton response as list-shaped even when the type fields contain no item array.
+- Multi-array envelopes need a shared tie-breaker list; if the runtime knows `features` but the profiler does not, store and agent surfaces drift.
+
+## What Didn't Work
+
+- **Curated wrapper keys only.** Keys like `data`, `results`, and `items` miss common plural resource envelopes such as `contacts`, `opportunities`, `pipelines`, and `tags`.
+- **Accepting every single array field blindly.** Singleton objects often include relationship arrays, for example `ProfileResponse{roles: []Role}`. Treating those as top-level collections registers the wrong resource for sync.
+- **Leaving type-name fallback after field metadata exists.** Once the parser has a real type definition, field metadata should win. A `SettingsResponse` with no arrays should not become syncable just because the type name contains `Response`.
+- **Fixing only runtime extraction.** Runtime extraction cannot help if the profiler never registers the resource, and profiler registration is unsafe if runtime extraction cannot choose the same item array.
+
+## Solution
+
+Keep three cases distinct in the profiler:
+
+1. Direct array responses are list-shaped.
+2. Known wrapper array keys remain authoritative for ambiguous multi-array envelopes, and the list must stay aligned with generated `extractPageItems`.
+3. A typed object with exactly one array field is list-shaped only when the endpoint context supports that collection interpretation: a collection-shaped endpoint name, or a path segment that matches the array field's resource name.
+
+When a type definition exists and has fields, do not fall through to the type-name fallback after field scanning fails. The fallback is only for missing or empty field metadata.
+
+The regression coverage should include both sides of the heuristic:
+
+```go
+assert.Contains(t, syncNames, "contacts")
+assert.Contains(t, syncNames, "opportunities")
+assert.Contains(t, syncNames, "places") // known features wrapper
+assert.NotContains(t, syncNames, "settings")
+assert.NotContains(t, syncNames, "profile")
+```
+
+## Why This Works
+
+The profiler and generated sync runtime now agree on extractable list envelopes without making every object-with-array a collection. Resource-shaped single arrays unlock SaaS envelopes like contacts and opportunities. Known wrapper keys cover ambiguous cases such as GeoJSON-style `features` plus `bbox`. Existing type metadata prevents list-sounding response names from overriding concrete field evidence.
+
+## Prevention
+
+- When changing generated extraction keys, update profiler wrapper detection in the same change.
+- Add positive and negative profiler tests for every new envelope heuristic.
+- Include singleton-object negative fixtures with list-sounding type names such as `SettingsResponse` or `ProfileResponse`.
+- For generator-owned behavior, test the profiler decision as well as runtime extraction; one green layer does not prove the other is aligned.
+
+## Related Issues
+
+- GitHub issue #1689
+- docs/solutions/logic-errors/html-response-format-sync-extraction.md
+- docs/solutions/logic-errors/paginated-all-needs-advanceable-signal-2026-05-21.md

--- a/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
+++ b/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
@@ -40,7 +40,8 @@ The profiler decides which resources become syncable, while generated sync code 
 
 - **Curated wrapper keys only.** Keys like `data`, `results`, and `items` miss common plural resource envelopes such as `contacts`, `opportunities`, `pipelines`, and `tags`.
 - **Accepting every single array field blindly.** Singleton objects often include relationship arrays, for example `ProfileResponse{roles: []Role}`. Treating those as top-level collections registers the wrong resource for sync.
-- **Leaving type-name fallback after field metadata exists.** Once the parser has a real type definition, field metadata should win. A `SettingsResponse` with no arrays should not become syncable just because the type name contains `Response`.
+- **Trusting collection words without checking the array field.** A `search` endpoint can still return a singleton envelope whose only array is `errors` or `auditLog`. The field name must match the resource context.
+- **Leaving type-name fallback after a type definition exists.** Once the parser has a real type entry, field metadata should win. A `SettingsResponse` with no arrays should not become syncable just because the type name contains `Response`, even if the parsed field list is empty.
 - **Fixing only runtime extraction.** Runtime extraction cannot help if the profiler never registers the resource, and profiler registration is unsafe if runtime extraction cannot choose the same item array.
 
 ## Solution
@@ -49,9 +50,9 @@ Keep three cases distinct in the profiler:
 
 1. Direct array responses are list-shaped.
 2. Known wrapper array keys remain authoritative for ambiguous multi-array envelopes, and the list must stay aligned with generated `extractPageItems`.
-3. A typed object with exactly one array field is list-shaped only when the endpoint context supports that collection interpretation: a collection-shaped endpoint name, or a path segment that matches the array field's resource name.
+3. A typed object with exactly one array field is list-shaped only when the field name matches the endpoint context: the endpoint name or a static path segment must overlap the array field's resource name.
 
-When a type definition exists and has fields, do not fall through to the type-name fallback after field scanning fails. The fallback is only for missing or empty field metadata.
+When a type definition exists, do not fall through to the type-name fallback after field scanning fails. The fallback is only for missing type metadata.
 
 The regression coverage should include both sides of the heuristic:
 
@@ -60,18 +61,21 @@ assert.Contains(t, syncNames, "contacts")
 assert.Contains(t, syncNames, "opportunities")
 assert.Contains(t, syncNames, "places") // known features wrapper
 assert.NotContains(t, syncNames, "settings")
+assert.NotContains(t, syncNames, "empty-settings")
+assert.NotContains(t, syncNames, "audits")
 assert.NotContains(t, syncNames, "profile")
 ```
 
 ## Why This Works
 
-The profiler and generated sync runtime now agree on extractable list envelopes without making every object-with-array a collection. Resource-shaped single arrays unlock SaaS envelopes like contacts and opportunities. Known wrapper keys cover ambiguous cases such as GeoJSON-style `features` plus `bbox`. Existing type metadata prevents list-sounding response names from overriding concrete field evidence.
+The profiler and generated sync runtime now agree on extractable list envelopes without making every object-with-array a collection. Resource-shaped single arrays unlock SaaS envelopes like contacts and opportunities. Known wrapper keys cover ambiguous cases such as GeoJSON-style `features` plus `bbox`. Existing type metadata prevents list-sounding response names from overriding concrete field evidence, including empty parsed field lists.
 
 ## Prevention
 
 - When changing generated extraction keys, update profiler wrapper detection in the same change.
 - Add positive and negative profiler tests for every new envelope heuristic.
 - Include singleton-object negative fixtures with list-sounding type names such as `SettingsResponse` or `ProfileResponse`.
+- Include collection-named endpoint negatives where the single array field is not the resource collection.
 - For generator-owned behavior, test the profiler decision as well as runtime extraction; one green layer does not prove the other is aligned.
 
 ## Related Issues

--- a/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
+++ b/docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
@@ -41,6 +41,7 @@ The profiler decides which resources become syncable, while generated sync code 
 - **Curated wrapper keys only.** Keys like `data`, `results`, and `items` miss common plural resource envelopes such as `contacts`, `opportunities`, `pipelines`, and `tags`.
 - **Accepting every single array field blindly.** Singleton objects often include relationship arrays, for example `ProfileResponse{roles: []Role}`. Treating those as top-level collections registers the wrong resource for sync.
 - **Trusting collection words without checking the array field.** A `search` endpoint can still return a singleton envelope whose only array is `errors` or `auditLog`. The field name must match the resource context.
+- **Counting ancillary arrays as competing item arrays.** Envelopes such as `{"companies": [...], "errors": [...]}` still have one meaningful item array. Error and warning arrays should not make the profiler drop an otherwise clear wrapper.
 - **Leaving type-name fallback after a type definition exists.** Once the parser has a real type entry, field metadata should win. A `SettingsResponse` with no arrays should not become syncable just because the type name contains `Response`, even if the parsed field list is empty.
 - **Fixing only runtime extraction.** Runtime extraction cannot help if the profiler never registers the resource, and profiler registration is unsafe if runtime extraction cannot choose the same item array.
 
@@ -50,7 +51,8 @@ Keep three cases distinct in the profiler:
 
 1. Direct array responses are list-shaped.
 2. Known wrapper array keys remain authoritative for ambiguous multi-array envelopes, and the list must stay aligned with generated `extractPageItems`.
-3. A typed object with exactly one array field is list-shaped only when the field name matches the endpoint context: the endpoint name or a static path segment must overlap the array field's resource name.
+3. A typed object with exactly one meaningful array field is list-shaped only when the field name matches the endpoint context: the endpoint name or a static path segment must overlap the array field's resource name.
+4. Ancillary arrays such as `errors`, `warnings`, and `validation_errors` do not count as item arrays for the single-array heuristic.
 
 When a type definition exists, do not fall through to the type-name fallback after field scanning fails. The fallback is only for missing type metadata.
 
@@ -59,6 +61,8 @@ The regression coverage should include both sides of the heuristic:
 ```go
 assert.Contains(t, syncNames, "contacts")
 assert.Contains(t, syncNames, "opportunities")
+assert.Contains(t, syncNames, "companies")
+assert.Contains(t, syncNames, "open-opportunities")
 assert.Contains(t, syncNames, "places") // known features wrapper
 assert.NotContains(t, syncNames, "settings")
 assert.NotContains(t, syncNames, "empty-settings")
@@ -68,7 +72,7 @@ assert.NotContains(t, syncNames, "profile")
 
 ## Why This Works
 
-The profiler and generated sync runtime now agree on extractable list envelopes without making every object-with-array a collection. Resource-shaped single arrays unlock SaaS envelopes like contacts and opportunities. Known wrapper keys cover ambiguous cases such as GeoJSON-style `features` plus `bbox`. Existing type metadata prevents list-sounding response names from overriding concrete field evidence, including empty parsed field lists.
+The profiler and generated sync runtime now agree on extractable list envelopes without making every object-with-array a collection. Resource-shaped single arrays unlock SaaS envelopes like contacts and opportunities, including envelopes that also contain ancillary error arrays. Known wrapper keys cover ambiguous cases such as GeoJSON-style `features` plus `bbox`. Existing type metadata prevents list-sounding response names from overriding concrete field evidence, including empty parsed field lists.
 
 ## Prevention
 
@@ -76,6 +80,7 @@ The profiler and generated sync runtime now agree on extractable list envelopes 
 - Add positive and negative profiler tests for every new envelope heuristic.
 - Include singleton-object negative fixtures with list-sounding type names such as `SettingsResponse` or `ProfileResponse`.
 - Include collection-named endpoint negatives where the single array field is not the resource collection.
+- Include positive fixtures for compound field names and ancillary arrays, so future tightening does not regress common SaaS response envelopes.
 - For generator-owned behavior, test the profiler decision as well as runtime extraction; one green layer does not prove the other is aligned.
 
 ## Related Issues

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -885,6 +885,13 @@ var wrapperArrayKeys = map[string]bool{
 	"nodes":    true,
 }
 
+var ancillaryArrayKeys = map[string]bool{
+	"errors":            true,
+	"warnings":          true,
+	"validations":       true,
+	"validation_errors": true,
+}
+
 // Field metadata is stronger than type-name guesses: once a type is present,
 // its fields decide whether the response is extractable.
 func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpointName string, path string) bool {
@@ -895,11 +902,15 @@ func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpoi
 			if !strings.EqualFold(field.Type, "array") {
 				continue
 			}
-			arrayFields++
-			arrayField = field.Name
-			if wrapperArrayKeys[strings.ToLower(field.Name)] {
+			fieldKey := normalizedFieldKey(field.Name)
+			if wrapperArrayKeys[fieldKey] {
 				return true
 			}
+			if ancillaryArrayKeys[fieldKey] {
+				continue
+			}
+			arrayFields++
+			arrayField = field.Name
 		}
 		if arrayFields == 1 && singleArrayFieldMatchesCollection(arrayField, endpointName, path) {
 			return true
@@ -942,7 +953,17 @@ func namesOverlap(a, b string) bool {
 			return true
 		}
 	}
+	aTokens := nameTokens(a)
+	for _, bv := range bVariants {
+		if slices.Contains(aTokens, bv) {
+			return true
+		}
+	}
 	return false
+}
+
+func normalizedFieldKey(name string) string {
+	return normalizeName(spec.ToSnakeCase(name))
 }
 
 func nameTokens(name string) []string {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -885,8 +885,8 @@ var wrapperArrayKeys = map[string]bool{
 	"nodes":    true,
 }
 
-// Field metadata is stronger than type-name guesses: a typed non-array
-// *Response object should stay out of sync even though its name sounds listy.
+// Field metadata is stronger than type-name guesses: once a type is present,
+// its fields decide whether the response is extractable.
 func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpointName string, path string) bool {
 	if typeDef, ok := types[typeName]; ok {
 		arrayFields := 0
@@ -904,13 +904,11 @@ func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpoi
 		if arrayFields == 1 && singleArrayFieldMatchesCollection(arrayField, endpointName, path) {
 			return true
 		}
-		if len(typeDef.Fields) > 0 {
-			return false
-		}
+		return false
 	}
 
 	// Fallback: if the type name itself suggests a list wrapper, treat it
-	// as a wrapper even when the types map lacks field definitions.
+	// as a wrapper only when the types map lacks that type definition.
 	nameUpper := strings.ToUpper(typeName)
 	return strings.Contains(nameUpper, "RESPONSE") ||
 		strings.Contains(nameUpper, "LIST") ||
@@ -919,7 +917,7 @@ func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpoi
 }
 
 func singleArrayFieldMatchesCollection(fieldName string, endpointName string, path string) bool {
-	if looksLikeCollectionEndpoint(strings.ToLower(endpointName)) {
+	if namesOverlap(fieldName, endpointName) {
 		return true
 	}
 	for _, segment := range staticPathSegments(path) {
@@ -938,7 +936,27 @@ func namesOverlap(a, b string) bool {
 			return true
 		}
 	}
+	bTokens := nameTokens(b)
+	for _, av := range aVariants {
+		if slices.Contains(bTokens, av) {
+			return true
+		}
+	}
 	return false
+}
+
+func nameTokens(name string) []string {
+	normalized := normalizeName(spec.ToSnakeCase(name))
+	if normalized == "" {
+		return nil
+	}
+	var tokens []string
+	for token := range strings.SplitSeq(normalized, "_") {
+		if token != "" {
+			tokens = append(tokens, nameVariants(token)...)
+		}
+	}
+	return tokens
 }
 
 // findEntityTypeEnum returns the first required enum query param on a list endpoint

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -844,7 +844,7 @@ func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.T
 	if method == "POST" {
 		return endpoint.Pagination != nil &&
 			looksLikeCollectionEndpoint(strings.ToLower(name)) &&
-			hasListShapedResponse(endpoint, types)
+			hasListShapedResponse(name, endpoint, types)
 	}
 
 	if method != "GET" {
@@ -853,52 +853,59 @@ func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.T
 	if endpoint.Pagination != nil {
 		return true
 	}
-	if hasListShapedResponse(endpoint, types) {
+	if hasListShapedResponse(name, endpoint, types) {
 		return true
 	}
 
 	return looksLikeBasicGetListEndpoint(strings.ToLower(name))
 }
 
-func hasListShapedResponse(endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
+func hasListShapedResponse(name string, endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
 	if endpoint.Response.Type == "array" {
 		return true
 	}
 
 	// Check for wrapper-object responses: the endpoint returns type "object"
-	// and the referenced type has a field matching a known wrapper key. These
-	// are list endpoints that wrap their arrays (e.g., {events: [...]}).
-	// The key list matches extractPageItems in sync.go.tmpl plus "events".
+	// and the referenced type has a field that clearly carries the list items.
 	return endpoint.Response.Type == "object" &&
 		endpoint.Response.Item != "" &&
-		hasWrapperArrayField(endpoint.Response.Item, types)
+		hasWrapperArrayField(endpoint.Response.Item, types, name, endpoint.Path)
 }
 
-// wrapperArrayKeys are response object field names that indicate the object
-// wraps a list of items. Kept in sync with extractPageItems in sync.go.tmpl.
-// hasWrapperArrayField lowercases each field name before lookup, so
-// PascalCase variants ("Items", "Data") match the lowercase entries here.
+// Multi-array envelopes need a curated tie-breaker; single-array envelopes are
+// already unambiguous and can use any resource-shaped key.
 var wrapperArrayKeys = map[string]bool{
-	"data":    true,
-	"results": true,
-	"items":   true,
-	"events":  true,
-	"entries": true,
-	"records": true,
-	"nodes":   true,
+	"data":     true,
+	"results":  true,
+	"items":    true,
+	"events":   true,
+	"entries":  true,
+	"features": true,
+	"records":  true,
+	"nodes":    true,
 }
 
-// hasWrapperArrayField checks whether a named type in the spec's types map
-// has any field whose name matches a known wrapper key, or whether the type
-// name itself suggests a list wrapper (contains "Response", "List", "Result",
-// or "Collection"). The type-name heuristic is a fallback for specs where the
-// types map is empty or incomplete.
-func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef) bool {
+// Field metadata is stronger than type-name guesses: a typed non-array
+// *Response object should stay out of sync even though its name sounds listy.
+func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef, endpointName string, path string) bool {
 	if typeDef, ok := types[typeName]; ok {
+		arrayFields := 0
+		var arrayField string
 		for _, field := range typeDef.Fields {
+			if !strings.EqualFold(field.Type, "array") {
+				continue
+			}
+			arrayFields++
+			arrayField = field.Name
 			if wrapperArrayKeys[strings.ToLower(field.Name)] {
 				return true
 			}
+		}
+		if arrayFields == 1 && singleArrayFieldMatchesCollection(arrayField, endpointName, path) {
+			return true
+		}
+		if len(typeDef.Fields) > 0 {
+			return false
 		}
 	}
 
@@ -909,6 +916,29 @@ func hasWrapperArrayField(typeName string, types map[string]spec.TypeDef) bool {
 		strings.Contains(nameUpper, "LIST") ||
 		strings.Contains(nameUpper, "RESULT") ||
 		strings.Contains(nameUpper, "COLLECTION")
+}
+
+func singleArrayFieldMatchesCollection(fieldName string, endpointName string, path string) bool {
+	if looksLikeCollectionEndpoint(strings.ToLower(endpointName)) {
+		return true
+	}
+	for _, segment := range staticPathSegments(path) {
+		if namesOverlap(fieldName, segment) {
+			return true
+		}
+	}
+	return false
+}
+
+func namesOverlap(a, b string) bool {
+	aVariants := nameVariants(a)
+	bVariants := nameVariants(b)
+	for _, av := range aVariants {
+		if slices.Contains(bVariants, av) {
+			return true
+		}
+	}
+	return false
 }
 
 // findEntityTypeEnum returns the first required enum query param on a list endpoint

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -725,6 +725,19 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 					},
 				},
 			},
+			"companies": {
+				Endpoints: map[string]spec.Endpoint{
+					"search": {
+						Method: "POST",
+						Path:   "/companies/search",
+						Pagination: &spec.Pagination{
+							CursorParam: "startAfter",
+							LimitParam:  "limit",
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "CompanyEnvelope"},
+					},
+				},
+			},
 			"tickets": {
 				Endpoints: map[string]spec.Endpoint{
 					"searchTickets": {
@@ -735,6 +748,15 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 							LimitParam:  "limit",
 						},
 						Response: spec.ResponseDef{Type: "object", Item: "TicketEnvelope"},
+					},
+				},
+			},
+			"open-opportunities": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/opportunities/open",
+						Response: spec.ResponseDef{Type: "object", Item: "OpenOpportunityEnvelope"},
 					},
 				},
 			},
@@ -805,9 +827,21 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 					{Name: "meta", Type: "object"},
 				},
 			},
+			"CompanyEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "companies", Type: "array"},
+					{Name: "errors", Type: "array"},
+					{Name: "meta", Type: "object"},
+				},
+			},
 			"TicketEnvelope": {
 				Fields: []spec.TypeField{
 					{Name: "tickets", Type: "array"},
+				},
+			},
+			"OpenOpportunityEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "openOpportunities", Type: "array"},
 				},
 			},
 			"SettingsResponse": {
@@ -846,7 +880,9 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 
 	assert.Contains(t, syncNames, "opportunities", "GET list endpoint with plural wrapper array should be syncable")
 	assert.Contains(t, syncNames, "contacts", "paginated POST search endpoint with plural wrapper array should be syncable")
+	assert.Contains(t, syncNames, "companies", "ancillary errors arrays should not hide one resource-shaped wrapper array")
 	assert.Contains(t, syncNames, "tickets", "single array fields can match the endpoint name when the path is generic")
+	assert.Contains(t, syncNames, "open-opportunities", "compound array field names can match simple path segments")
 	assert.Contains(t, syncNames, "places", "multi-array GeoJSON-style envelope with known features wrapper should be syncable")
 	assert.NotContains(t, syncNames, "settings", "object envelopes without array fields should not be syncable")
 	assert.NotContains(t, syncNames, "empty-settings", "parsed zero-field response types should not fall back to type-name matching")

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -725,12 +725,51 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 					},
 				},
 			},
+			"tickets": {
+				Endpoints: map[string]spec.Endpoint{
+					"searchTickets": {
+						Method: "POST",
+						Path:   "/search",
+						Pagination: &spec.Pagination{
+							CursorParam: "cursor",
+							LimitParam:  "limit",
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "TicketEnvelope"},
+					},
+				},
+			},
 			"settings": {
 				Endpoints: map[string]spec.Endpoint{
 					"get": {
 						Method:   "GET",
 						Path:     "/settings",
 						Response: spec.ResponseDef{Type: "object", Item: "SettingsResponse"},
+					},
+				},
+			},
+			"empty-settings": {
+				Endpoints: map[string]spec.Endpoint{
+					"search": {
+						Method: "POST",
+						Path:   "/settings/search",
+						Pagination: &spec.Pagination{
+							CursorParam: "startAfter",
+							LimitParam:  "limit",
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "EmptySettingsResponse"},
+					},
+				},
+			},
+			"audits": {
+				Endpoints: map[string]spec.Endpoint{
+					"search": {
+						Method: "POST",
+						Path:   "/audits/search",
+						Pagination: &spec.Pagination{
+							CursorParam: "startAfter",
+							LimitParam:  "limit",
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "AuditSearchResponse"},
 					},
 				},
 			},
@@ -766,10 +805,21 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 					{Name: "meta", Type: "object"},
 				},
 			},
+			"TicketEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "tickets", Type: "array"},
+				},
+			},
 			"SettingsResponse": {
 				Fields: []spec.TypeField{
 					{Name: "featureFlags", Type: "object"},
 					{Name: "timezone", Type: "string"},
+				},
+			},
+			"EmptySettingsResponse": {},
+			"AuditSearchResponse": {
+				Fields: []spec.TypeField{
+					{Name: "errors", Type: "array"},
 				},
 			},
 			"ProfileResponse": {
@@ -796,8 +846,11 @@ func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
 
 	assert.Contains(t, syncNames, "opportunities", "GET list endpoint with plural wrapper array should be syncable")
 	assert.Contains(t, syncNames, "contacts", "paginated POST search endpoint with plural wrapper array should be syncable")
+	assert.Contains(t, syncNames, "tickets", "single array fields can match the endpoint name when the path is generic")
 	assert.Contains(t, syncNames, "places", "multi-array GeoJSON-style envelope with known features wrapper should be syncable")
 	assert.NotContains(t, syncNames, "settings", "object envelopes without array fields should not be syncable")
+	assert.NotContains(t, syncNames, "empty-settings", "parsed zero-field response types should not fall back to type-name matching")
+	assert.NotContains(t, syncNames, "audits", "collection-named endpoints should not make unrelated array fields syncable")
 	assert.NotContains(t, syncNames, "profile", "singleton object with one relationship array should not be syncable")
 	assert.Equal(t, "POST", syncByName["contacts"].Method)
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -603,7 +603,7 @@ func TestProfileDateRangeParam(t *testing.T) {
 		Types: map[string]spec.TypeDef{
 			"ScoreboardResponse": {
 				Fields: []spec.TypeField{
-					{Name: "events", Type: "string"},
+					{Name: "events", Type: "array"},
 					{Name: "leagues", Type: "string"},
 				},
 			},
@@ -652,7 +652,7 @@ func TestProfileWrapperObjectDetection(t *testing.T) {
 		Types: map[string]spec.TypeDef{
 			"ScoreboardResponse": {
 				Fields: []spec.TypeField{
-					{Name: "events", Type: "string"},
+					{Name: "events", Type: "array"},
 					{Name: "leagues", Type: "string"},
 				},
 			},
@@ -697,6 +697,109 @@ func TestProfileWrapperObjectDetection_NoFalsePositive(t *testing.T) {
 		syncNames[i] = sr.Name
 	}
 	assert.NotContains(t, syncNames, "settings", "non-wrapper object should not be syncable")
+}
+
+func TestProfilePluralWrapperArrayFieldsAreSyncable(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "saas-crm",
+		Resources: map[string]spec.Resource{
+			"opportunities": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/opportunities",
+						Response: spec.ResponseDef{Type: "object", Item: "OpportunityEnvelope"},
+					},
+				},
+			},
+			"contacts": {
+				Endpoints: map[string]spec.Endpoint{
+					"search": {
+						Method: "POST",
+						Path:   "/contacts/search",
+						Pagination: &spec.Pagination{
+							CursorParam: "startAfter",
+							LimitParam:  "limit",
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "ContactEnvelope"},
+					},
+				},
+			},
+			"settings": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/settings",
+						Response: spec.ResponseDef{Type: "object", Item: "SettingsResponse"},
+					},
+				},
+			},
+			"profile": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/profile",
+						Response: spec.ResponseDef{Type: "object", Item: "ProfileResponse"},
+					},
+				},
+			},
+			"places": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/places",
+						Response: spec.ResponseDef{Type: "object", Item: "GeoFeatureCollection"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"OpportunityEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "opportunities", Type: "array"},
+					{Name: "meta", Type: "object"},
+				},
+			},
+			"ContactEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "contacts", Type: "array"},
+					{Name: "meta", Type: "object"},
+				},
+			},
+			"SettingsResponse": {
+				Fields: []spec.TypeField{
+					{Name: "featureFlags", Type: "object"},
+					{Name: "timezone", Type: "string"},
+				},
+			},
+			"ProfileResponse": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "roles", Type: "array"},
+				},
+			},
+			"GeoFeatureCollection": {
+				Fields: []spec.TypeField{
+					{Name: "features", Type: "array"},
+					{Name: "bbox", Type: "array"},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	syncByName := make(map[string]SyncableResource)
+	for _, sr := range profile.SyncableResources {
+		syncByName[sr.Name] = sr
+	}
+	syncNames := profile.SyncableResourceNames()
+
+	assert.Contains(t, syncNames, "opportunities", "GET list endpoint with plural wrapper array should be syncable")
+	assert.Contains(t, syncNames, "contacts", "paginated POST search endpoint with plural wrapper array should be syncable")
+	assert.Contains(t, syncNames, "places", "multi-array GeoJSON-style envelope with known features wrapper should be syncable")
+	assert.NotContains(t, syncNames, "settings", "object envelopes without array fields should not be syncable")
+	assert.NotContains(t, syncNames, "profile", "singleton object with one relationship array should not be syncable")
+	assert.Equal(t, "POST", syncByName["contacts"].Method)
 }
 
 func TestProfileSimpleListEndpointSyncable(t *testing.T) {


### PR DESCRIPTION
## Summary

Generated CLIs can now register syncable resources when an API returns a typed object envelope with a resource-shaped array such as `contacts`, `opportunities`, or `features`. The profiler now stays aligned with generated sync extraction: it accepts unambiguous resource arrays, keeps curated multi-array wrapper tie-breakers in sync with runtime extraction, and avoids promoting singleton object responses with relationship arrays.

Closes #1689

## What changed

- Broadened profiler wrapper detection beyond the fixed `data` / `results` / `items` style list.
- Added guardrails so typed non-array `*Response` objects and singleton resources like `/profile` with `roles: []` are not marked syncable.
- Added regression coverage for GET plural wrappers, paginated POST search wrappers, GeoJSON-style `features`, non-array `SettingsResponse`, and singleton relationship arrays.

## Compounded learnings

File: docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md
Track: bug
Category: logic-errors
Overlap: low
Instruction-file edit: none needed
Refresh recommendation: none

## Verification

- `go test ./internal/profiler`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `ruby -e 'require "yaml"; require "date"; data = YAML.safe_load(File.read(ARGV[0]), permitted_classes: [Date]); abort("missing title") unless data["title"]; puts data["title"]' docs/solutions/logic-errors/profiler-wrapper-array-detection-sync-alignment-2026-05-24.md`
- `go test ./internal/pipeline -run 'TestRunLiveDogfood(DetectsTruncatedJSONOutput|ProcessTracksOutputTruncation)' -count=1`

`go test ./...` was run after the fix and repeatedly reached unrelated `internal/pipeline` live-dogfood capture-cap timeouts. The exact failing tests passed in isolation, and the profiler/generator-facing gates above passed.
