### PR TITLE
fix(cli): fall back synthetic anchors to local lists

### DIFF
--- a/docs/solutions/logic-errors/synthetic-anchor-endpoints-need-local-list-fallback-2026-05-24.md
+++ b/docs/solutions/logic-errors/synthetic-anchor-endpoints-need-local-list-fallback-2026-05-24.md
@@ -45,7 +45,7 @@ Synthetic specs use anchor resources to define local store shape, but those reso
 Keep the endpoint command, but make the generated read path encode both pieces of information the local resolver needs:
 
 1. Synthetic specs, and specs whose placeholder base URL ends in `.local`, emit a generated fallback reason of `synthetic_anchor_fallback`.
-2. Non-paginated GET endpoints whose response type is an array are passed to `resolveRead` as list reads only when the endpoint has no path scope.
+2. Non-paginated GET endpoints whose response type is an array are passed to `resolveRead` as list reads only when the endpoint has no path scope and either has the canonical `list` endpoint name or belongs to a synthetic / `.local` spec.
 
 The generator-level helpers make the invariant explicit:
 
@@ -64,7 +64,7 @@ func networkFallbackReason(s *spec.APISpec) string {
     return "api_unreachable"
 }
 
-func localReadIsList(supportsAllPagination bool, endpointName string, endpoint spec.Endpoint) bool {
+func localReadIsList(supportsAllPagination bool, apiSpec *spec.APISpec, endpointName string, endpoint spec.Endpoint) bool {
     if supportsAllPagination {
         return true
     }
@@ -74,7 +74,7 @@ func localReadIsList(supportsAllPagination bool, endpointName string, endpoint s
     if strings.EqualFold(endpointName, "list") {
         return true
     }
-    return strings.EqualFold(endpoint.Response.Type, "array")
+    return networkFallbackReason(apiSpec) == "synthetic_anchor_fallback" && strings.EqualFold(endpoint.Response.Type, "array")
 }
 ```
 
@@ -88,7 +88,7 @@ The bug was not just that synthetic specs used a placeholder host. It was that l
 
 ## Prevention
 
-- When generated fallback code crosses from API transport to local store, carry the response shape and scope. Returning every cached row is correct for top-level synthetic anchors, but unsafe for path-scoped child collections.
+- When generated fallback code crosses from API transport to local store, carry response shape, scope, and spec kind. Returning every cached row is correct for top-level synthetic anchors, but unsafe for path-scoped child collections or non-synthetic search/filter endpoints.
 - Regression tests should execute a generated CLI command after seeding the local store, not only assert template text. This catches the `Get` vs `List` distinction.
 - Keep synthetic fallback metadata separate from fallback mechanics. `meta.reason` is an observability contract; `isList` is the data access contract.
 - Include a negative fixture for live APIs so fallback labels do not accidentally reclassify ordinary network failures as synthetic behavior.

--- a/docs/solutions/logic-errors/synthetic-anchor-endpoints-need-local-list-fallback-2026-05-24.md
+++ b/docs/solutions/logic-errors/synthetic-anchor-endpoints-need-local-list-fallback-2026-05-24.md
@@ -1,0 +1,103 @@
+---
+title: "Synthetic anchor endpoints need local list fallback semantics"
+date: 2026-05-24
+category: logic-errors
+module: internal/generator
+problem_type: logic_error
+component: tooling
+related_components:
+  - testing_framework
+symptoms:
+  - "Synthetic-kind generated CLIs tried to dial placeholder .local base URLs for anchor list commands."
+  - "After sync populated the local store, endpoint-mirror commands still reported no local data."
+  - "Dogfood happy_path and json_fidelity failed for synthetic anchor resources that should have read synced rows."
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - synthetic-specs
+  - local-store
+  - endpoint-mirror
+  - fallback
+  - generated-cli
+---
+
+# Synthetic anchor endpoints need local list fallback semantics
+
+## Problem
+
+Synthetic specs use anchor resources to define local store shape, but those resources do not have a real upstream REST origin. The generator still emitted normal endpoint-mirror commands, so a command like `<cli> products --json` tried to call `https://<api>.local/products` and failed before returning the synced local data agents expected.
+
+## Symptoms
+
+- Synthetic anchor commands failed with `API unreachable and no local data` even after sync had inserted rows for the resource.
+- The JSON envelope never exposed `meta.source: "local"` or a synthetic-specific fallback reason, so agents could not tell the fallback path was intentional.
+- Dogfood correctly flagged happy-path and JSON-fidelity failures for synthetic CLIs, forcing per-CLI hand shims.
+
+## What Didn't Work
+
+- Only changing the fallback reason. A synthetic-specific `meta.reason` is useful, but it does not fix the no-data failure if the generated command tells `resolveLocal` that a list endpoint is a single-object lookup.
+- Suppressing endpoint command emission for synthetic specs. That avoids the bad network call but removes a useful typed surface from generated CLIs.
+- Treating this as a dogfood or scorer problem. The verifier was catching real generated runtime behavior.
+
+## Solution
+
+Keep the endpoint command, but make the generated read path encode both pieces of information the local resolver needs:
+
+1. Synthetic specs, and specs whose placeholder base URL ends in `.local`, emit a generated fallback reason of `synthetic_anchor_fallback`.
+2. Non-paginated GET endpoints whose response type is an array are passed to `resolveRead` as list reads only when the endpoint has no path scope.
+
+The generator-level helpers make the invariant explicit:
+
+```go
+func networkFallbackReason(s *spec.APISpec) string {
+    if s == nil {
+        return "api_unreachable"
+    }
+    if s.IsSynthetic() {
+        return "synthetic_anchor_fallback"
+    }
+    u, err := url.Parse(strings.TrimSpace(s.BaseURL))
+    if err == nil && strings.HasSuffix(strings.ToLower(u.Hostname()), ".local") {
+        return "synthetic_anchor_fallback"
+    }
+    return "api_unreachable"
+}
+
+func localReadIsList(supportsAllPagination bool, endpointName string, endpoint spec.Endpoint) bool {
+    if supportsAllPagination {
+        return true
+    }
+    if endpointHasPathScope(endpoint) {
+        return false
+    }
+    if strings.EqualFold(endpointName, "list") {
+        return true
+    }
+    return strings.EqualFold(endpoint.Response.Type, "array")
+}
+```
+
+The endpoint and promoted-command templates now pass `true` for top-level list-shaped local fallback reads even when the endpoint is not paginated. `data_source.go.tmpl` uses the generated `networkFallbackReason` constant for network-error fallback envelopes.
+
+## Why This Works
+
+`resolveRead` has two jobs: try the live API first, then fall back to the local store for network errors. The second step is shape-sensitive. When `isList` is false, `resolveLocal` treats the URL path tail as an ID and calls `Get(resourceType, id)`. For `/products`, that means looking for an ID literally named `products`, so the fallback reports no data even though `List(resourceType)` would return synced rows.
+
+The bug was not just that synthetic specs used a placeholder host. It was that list-shaped, non-paginated endpoint mirrors were classified as single-object fallbacks. Marking array responses as local list reads lets the existing store path return synced rows while preserving live API behavior for non-synthetic specs.
+
+## Prevention
+
+- When generated fallback code crosses from API transport to local store, carry the response shape and scope. Returning every cached row is correct for top-level synthetic anchors, but unsafe for path-scoped child collections.
+- Regression tests should execute a generated CLI command after seeding the local store, not only assert template text. This catches the `Get` vs `List` distinction.
+- Keep synthetic fallback metadata separate from fallback mechanics. `meta.reason` is an observability contract; `isList` is the data access contract.
+- Include a negative fixture for live APIs so fallback labels do not accidentally reclassify ordinary network failures as synthetic behavior.
+
+## Related Issues
+
+- [#1717](https://github.com/mvanhorn/cli-printing-press/issues/1717) - synthetic-spec anchor commands fail because endpoint-mirror tries `.local` base URL.
+
+## Related Docs
+
+- `docs/solutions/logic-errors/store-columns-sourced-from-request-params-instead-of-response-2026-05-08.md` - adjacent generator lesson: local surfaces must derive from response shape, not request-side or path-side hints.
+- `docs/solutions/logic-errors/dogfood-soft-failure-error-path-opt-out-2026-05-22.md` - dogfood should reflect generated runtime behavior rather than pushing per-CLI semantic shims.

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5432,6 +5432,9 @@ func networkFallbackReason(s *spec.APISpec) string {
 		return "synthetic_anchor_fallback"
 	}
 	u, err := url.Parse(strings.TrimSpace(s.BaseURL))
+	// In Printing Press specs, .local base URLs are synthetic placeholders.
+	// Real mDNS/private hosts should use a non-.local alias to avoid being
+	// classified as synthetic fallback surfaces.
 	if err == nil && strings.HasSuffix(strings.ToLower(u.Hostname()), ".local") {
 		return "synthetic_anchor_fallback"
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5438,7 +5438,7 @@ func networkFallbackReason(s *spec.APISpec) string {
 	return "api_unreachable"
 }
 
-func localReadIsList(supportsAllPagination bool, endpointName string, endpoint spec.Endpoint) bool {
+func localReadIsList(supportsAllPagination bool, apiSpec *spec.APISpec, endpointName string, endpoint spec.Endpoint) bool {
 	if supportsAllPagination {
 		return true
 	}
@@ -5448,10 +5448,13 @@ func localReadIsList(supportsAllPagination bool, endpointName string, endpoint s
 	if strings.EqualFold(endpointName, "list") {
 		return true
 	}
-	return strings.EqualFold(endpoint.Response.Type, "array")
+	return networkFallbackReason(apiSpec) == "synthetic_anchor_fallback" && strings.EqualFold(endpoint.Response.Type, "array")
 }
 
 func endpointHasPathScope(endpoint spec.Endpoint) bool {
+	// Parsed specs and hand-authored fixtures may disagree between the path
+	// string and normalized Param flags; either signal means local List would
+	// over-return rows across parents.
 	if strings.Contains(endpoint.Path, "{") {
 		return true
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -290,13 +290,15 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"graphqlFieldSelection": func(typeName string, types map[string]spec.TypeDef) []string {
 			return graphqlFieldSelection(typeName, types)
 		},
-		"isGraphQL":           isGraphQLSpec,
-		"exportableResources": exportableResources,
-		"backtick":            func() string { return "`" },
-		"kebab":               toKebab,
-		"humanName":           naming.HumanName,
-		"envPrefix":           naming.EnvPrefix,
-		"mcpToolName":         naming.SnakeIdentifier,
+		"isGraphQL":             isGraphQLSpec,
+		"localReadIsList":       localReadIsList,
+		"networkFallbackReason": networkFallbackReason,
+		"exportableResources":   exportableResources,
+		"backtick":              func() string { return "`" },
+		"kebab":                 toKebab,
+		"humanName":             naming.HumanName,
+		"envPrefix":             naming.EnvPrefix,
+		"mcpToolName":           naming.SnakeIdentifier,
 		"lookupEndpoint": func(api *spec.APISpec, ref string) templateEndpoint {
 			e, _ := lookupEndpointForTemplate(api, ref)
 			return e
@@ -5405,6 +5407,9 @@ func sortedEndpointNames(endpoints map[string]spec.Endpoint) []string {
 // isGraphQLSpec returns true if the spec was produced by a GraphQL SDL parser.
 // Detection heuristic: all list endpoints have path "/graphql".
 func isGraphQLSpec(s *spec.APISpec) bool {
+	if s == nil {
+		return false
+	}
 	hasListEndpoint := false
 	for _, r := range s.Resources {
 		for eName, ep := range r.Endpoints {
@@ -5417,6 +5422,45 @@ func isGraphQLSpec(s *spec.APISpec) bool {
 		}
 	}
 	return hasListEndpoint
+}
+
+func networkFallbackReason(s *spec.APISpec) string {
+	if s == nil {
+		return "api_unreachable"
+	}
+	if s.IsSynthetic() {
+		return "synthetic_anchor_fallback"
+	}
+	u, err := url.Parse(strings.TrimSpace(s.BaseURL))
+	if err == nil && strings.HasSuffix(strings.ToLower(u.Hostname()), ".local") {
+		return "synthetic_anchor_fallback"
+	}
+	return "api_unreachable"
+}
+
+func localReadIsList(supportsAllPagination bool, endpointName string, endpoint spec.Endpoint) bool {
+	if supportsAllPagination {
+		return true
+	}
+	if endpointHasPathScope(endpoint) {
+		return false
+	}
+	if strings.EqualFold(endpointName, "list") {
+		return true
+	}
+	return strings.EqualFold(endpoint.Response.Type, "array")
+}
+
+func endpointHasPathScope(endpoint spec.Endpoint) bool {
+	if strings.Contains(endpoint.Path, "{") {
+		return true
+	}
+	for _, p := range endpoint.Params {
+		if p.PathParam {
+			return true
+		}
+	}
+	return false
 }
 
 // graphqlQueryField extracts the GraphQL query field name from a ResponsePath.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
@@ -13477,6 +13478,282 @@ func TestPMWorkflowCommandEmitsSyncHints(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "pm_sync_hint_command_test.go"), []byte(commandTest), 0o644))
 
 	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func TestNetworkFallbackReason(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "api_unreachable", networkFallbackReason(nil))
+
+	cases := []struct {
+		name    string
+		kind    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "synthetic kind",
+			kind:    spec.KindSynthetic,
+			baseURL: "https://example.com",
+			want:    "synthetic_anchor_fallback",
+		},
+		{
+			name:    "local placeholder host",
+			baseURL: "https://example.local",
+			want:    "synthetic_anchor_fallback",
+		},
+		{
+			name:    "live api",
+			baseURL: "https://api.example.com",
+			want:    "api_unreachable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := adsCampaignSpec()
+			apiSpec.Name = "fallback-" + strings.ReplaceAll(tc.name, " ", "-")
+			apiSpec.Kind = tc.kind
+			apiSpec.BaseURL = tc.baseURL
+			assert.Equal(t, tc.want, networkFallbackReason(apiSpec))
+		})
+	}
+}
+
+func TestLocalReadIsList(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                  string
+		supportsAllPagination bool
+		endpointName          string
+		endpoint              spec.Endpoint
+		want                  bool
+	}{
+		{
+			name:         "top-level list endpoint",
+			endpointName: "list",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns", Response: spec.ResponseDef{Type: "array"}},
+			want:         true,
+		},
+		{
+			name:         "top-level array response",
+			endpointName: "search",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/search", Response: spec.ResponseDef{Type: "array"}},
+			want:         true,
+		},
+		{
+			name:         "path-scoped array response stays out of unscoped fallback",
+			endpointName: "list",
+			endpoint: spec.Endpoint{
+				Method:   "GET",
+				Path:     "/teams/{team_id}/users",
+				Params:   []spec.Param{{Name: "team_id", Type: "string", Positional: true, PathParam: true}},
+				Response: spec.ResponseDef{Type: "array"},
+			},
+			want: false,
+		},
+		{
+			name:                  "existing paginated local fallback behavior is preserved",
+			supportsAllPagination: true,
+			endpointName:          "list",
+			endpoint: spec.Endpoint{
+				Method:   "GET",
+				Path:     "/teams/{team_id}/users",
+				Params:   []spec.Param{{Name: "team_id", Type: "string", Positional: true, PathParam: true}},
+				Response: spec.ResponseDef{Type: "array"},
+			},
+			want: true,
+		},
+		{
+			name:         "single-object endpoint",
+			endpointName: "get",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/{id}", Response: spec.ResponseDef{Type: "object"}},
+			want:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, localReadIsList(tc.supportsAllPagination, tc.endpointName, tc.endpoint))
+		})
+	}
+}
+
+func TestGeneratedSyntheticAnchorCommandFallsBackToLocalStore(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := adsCampaignSpec()
+	apiSpec.Name = "syntheticanchors"
+	apiSpec.Kind = spec.KindSynthetic
+	apiSpec.BaseURL = "http://127.0.0.1:1"
+	campaigns := apiSpec.Resources["campaigns"]
+	listEndpoint := campaigns.Endpoints["list"]
+	listEndpoint.Params = append(listEndpoint.Params, spec.Param{Name: "limit", Type: "int"})
+	campaigns.Endpoints["list"] = listEndpoint
+	apiSpec.Resources["campaigns"] = campaigns
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"syntheticanchors-pp-cli/internal/store"
+)
+
+func TestSyntheticAnchorCommandFallsBackToLocalStore(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("syntheticanchors-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := db.DB().Exec(` + "`" + `INSERT INTO resources(resource_type, id, data) VALUES
+		(?, ?, ?),
+		(?, ?, ?),
+		(?, ?, ?),
+		(?, ?, ?)` + "`" + `,
+		"campaigns", "camp_1", ` + "`" + `{"id":"camp_1","name":"Launch","status":"active","account_id":"acct_1"}` + "`" + `,
+		"campaigns", "camp_2", ` + "`" + `{"id":"camp_2","name":"Sustain","status":"paused","account_id":"acct_1"}` + "`" + `,
+		"campaigns", "camp_3", ` + "`" + `{"id":"camp_3","name":"Winback","status":"active","account_id":"acct_2"}` + "`" + `,
+		"campaigns", "camp_4", ` + "`" + `{"id":"camp_4","name":"Nurture","status":"active","account_id":"acct_2"}` + "`" + `,
+	); err != nil {
+		t.Fatalf("seed campaigns: %v", err)
+	}
+	if err := db.SaveSyncState("campaigns", "", 1); err != nil {
+		t.Fatalf("save sync state: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"campaigns", "--limit", "3", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute campaigns: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Meta struct {
+			Source       string ` + "`" + `json:"source"` + "`" + `
+			Reason       string ` + "`" + `json:"reason"` + "`" + `
+			ResourceType string ` + "`" + `json:"resource_type"` + "`" + `
+		} ` + "`" + `json:"meta"` + "`" + `
+		Results []json.RawMessage ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if payload.Meta.Source != "local" || payload.Meta.Reason != "synthetic_anchor_fallback" || payload.Meta.ResourceType != "campaigns" {
+		t.Fatalf("meta = %+v, want local synthetic_anchor_fallback campaigns", payload.Meta)
+	}
+	if len(payload.Results) != 3 {
+		t.Fatalf("results = %d, want 3; stdout=%s", len(payload.Results), stdout.String())
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "synthetic_anchor_fallback_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestSyntheticAnchorCommandFallsBackToLocalStore", "./internal/cli")
+}
+
+func TestGeneratedLiveCommandPrefersAPIOverLocalStore(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		assert.Equal(t, "/campaigns", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"live_1","name":"Live","status":"active","account_id":"acct_live"}]`))
+	}))
+	defer server.Close()
+
+	apiSpec := adsCampaignSpec()
+	apiSpec.Name = "livefallback"
+	apiSpec.BaseURL = server.URL
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"livefallback-pp-cli/internal/store"
+)
+
+func TestLiveCommandPrefersAPIOverLocalStore(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	db, err := store.OpenWithContext(context.Background(), defaultDBPath("livefallback-pp-cli"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := db.DB().Exec(` + "`" + `INSERT INTO resources(resource_type, id, data) VALUES (?, ?, ?)` + "`" + `,
+		"campaigns", "local_1", ` + "`" + `{"id":"local_1","name":"Local","status":"paused","account_id":"acct_local"}` + "`" + `,
+	); err != nil {
+		t.Fatalf("seed campaigns: %v", err)
+	}
+	if err := db.SaveSyncState("campaigns", "", 1); err != nil {
+		t.Fatalf("save sync state: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"campaigns", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute campaigns: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Meta struct {
+			Source string ` + "`" + `json:"source"` + "`" + `
+			Reason string ` + "`" + `json:"reason"` + "`" + `
+		} ` + "`" + `json:"meta"` + "`" + `
+		Results []map[string]any ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if payload.Meta.Source != "live" || payload.Meta.Reason != "" {
+		t.Fatalf("meta = %+v, want live with no fallback reason", payload.Meta)
+	}
+	if len(payload.Results) != 1 || payload.Results[0]["id"] != "live_1" {
+		t.Fatalf("results = %#v, want live payload only", payload.Results)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "live_preferred_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "-run", "TestLiveCommandPrefersAPIOverLocalStore", "./internal/cli")
+	assert.Greater(t, requestCount.Load(), int32(0), "generated command should call the live API in auto mode")
 }
 
 // TestSearchTemplateEmptyTypeQueriesGenericFTS pins #1390 — the

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13598,9 +13599,15 @@ func TestGeneratedSyntheticAnchorCommandFallsBackToLocalStore(t *testing.T) {
 	apiSpec := adsCampaignSpec()
 	apiSpec.Name = "syntheticanchors"
 	apiSpec.Kind = spec.KindSynthetic
-	apiSpec.BaseURL = "http://127.0.0.1:1"
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	unreachableAddr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	apiSpec.BaseURL = "http://" + unreachableAddr
 	campaigns := apiSpec.Resources["campaigns"]
 	listEndpoint := campaigns.Endpoints["list"]
+	// This exercises endpointNeedsClientLimit and truncateJSONArray after
+	// resolveRead falls back to the local store.
 	listEndpoint.Params = append(listEndpoint.Params, spec.Param{Name: "limit", Type: "int"})
 	campaigns.Endpoints["list"] = listEndpoint
 	apiSpec.Resources["campaigns"] = campaigns

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13528,6 +13528,7 @@ func TestLocalReadIsList(t *testing.T) {
 	cases := []struct {
 		name                  string
 		supportsAllPagination bool
+		apiSpec               *spec.APISpec
 		endpointName          string
 		endpoint              spec.Endpoint
 		want                  bool
@@ -13539,7 +13540,14 @@ func TestLocalReadIsList(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "top-level array response",
+			name:         "non-synthetic array response without list name",
+			endpointName: "search",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/search", Response: spec.ResponseDef{Type: "array"}},
+			want:         false,
+		},
+		{
+			name:         "synthetic array response without list name",
+			apiSpec:      &spec.APISpec{Kind: spec.KindSynthetic},
 			endpointName: "search",
 			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/search", Response: spec.ResponseDef{Type: "array"}},
 			want:         true,
@@ -13579,7 +13587,7 @@ func TestLocalReadIsList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tc.want, localReadIsList(tc.supportsAllPagination, tc.endpointName, tc.endpoint))
+			assert.Equal(t, tc.want, localReadIsList(tc.supportsAllPagination, tc.apiSpec, tc.endpointName, tc.endpoint))
 		})
 	}
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -4,7 +4,7 @@
 {{- $isMultipart := endpointUsesMultipart .Endpoint}}
 {{- $isForm := endpointUsesForm .Endpoint}}
 {{- $hasJSONBody := and (or .Endpoint.Body .Endpoint.BodyJSONFallback) (not $isMultipart) (not $isForm)}}
-{{- $supportsAllPagination := and .Endpoint.Pagination (ne .Endpoint.Pagination.Type "id_walk")}}
+{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk")}}
 
 package cli
 
@@ -249,7 +249,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{if $supportsAllPagination}}true{{else}}false{{end}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -249,7 +249,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -9,7 +9,7 @@
 {{- $isReadVerb := or (eq $method "GET") (eq $method "HEAD") (eq $method "OPTIONS")}}
 {{- $isWriteVerb := or (eq $method "POST") (eq $method "PUT") (eq $method "PATCH")}}
 {{- $canWriteBack := and .HasStore $isWriteVerb (not .IsReadOnly) (not .Endpoint.UsesBinaryResponse)}}
-{{- $supportsAllPagination := and .Endpoint.Pagination (ne .Endpoint.Pagination.Type "id_walk")}}
+{{- $supportsAllPagination := and (ne .Endpoint.Pagination nil) (ne .Endpoint.Pagination.Type "id_walk")}}
 
 package cli
 
@@ -188,7 +188,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{if $supportsAllPagination}}true{{else}}false{{end}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else if eq $method "GET"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -188,7 +188,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else if eq $method "GET"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			data, err := c.GetWithHeaders(cmd.Context(), path, params, headerOverrides)

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -21,6 +21,8 @@ import (
 	"{{modulePath}}/internal/store"
 )
 
+const networkFallbackReason = "{{networkFallbackReason .APISpec}}"
+
 // isNetworkError returns true for errors caused by network connectivity issues
 // (DNS, connection refused, timeout). HTTP 4xx/5xx errors are NOT network errors.
 func isNetworkError(err error) bool {
@@ -119,7 +121,7 @@ func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resour
 			return nil, DataProvenance{}, err
 		}
 		// Network error — try local fallback
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, isList, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, isList, path, params, networkFallbackReason)
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run '{{.Name}}-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -153,7 +155,7 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 		if !isNetworkError(err) {
 			return nil, DataProvenance{}, err
 		}
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, networkFallbackReason)
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run '{{.Name}}-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -21,6 +21,8 @@ import (
 	"printing-press-golden-pp-cli/internal/store"
 )
 
+const networkFallbackReason = "api_unreachable"
+
 // isNetworkError returns true for errors caused by network connectivity issues
 // (DNS, connection refused, timeout). HTTP 4xx/5xx errors are NOT network errors.
 func isNetworkError(err error) bool {
@@ -119,7 +121,7 @@ func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resour
 			return nil, DataProvenance{}, err
 		}
 		// Network error — try local fallback
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, isList, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, isList, path, params, networkFallbackReason)
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'printing-press-golden-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}
@@ -153,7 +155,7 @@ func resolvePaginatedRead(ctx context.Context, c *client.Client, flags *rootFlag
 		if !isNetworkError(err) {
 			return nil, DataProvenance{}, err
 		}
-		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, "api_unreachable")
+		fallbackData, fallbackProv, fallbackErr := resolveLocal(ctx, flags, hintWriter, resourceType, true, path, params, networkFallbackReason)
 		if fallbackErr != nil {
 			return nil, DataProvenance{}, fmt.Errorf("API unreachable and no local data. Run 'printing-press-golden-pp-cli sync' to enable offline access.\n\nOriginal error: %w", err)
 		}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -27,7 +27,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/games"
 			params := map[string]string{}
-			data, prov, err := resolveRead(cmd.Context(), c, flags, "games", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveRead(cmd.Context(), c, flags, "games", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}


### PR DESCRIPTION
## Intent

Synthetic anchor commands now return synced local data instead of failing on placeholder `.local` base URLs.

Issue: Closes #1717

## Approach

The generator now labels synthetic and `.local` network fallbacks as `synthetic_anchor_fallback`, and treats top-level list-shaped GET endpoints as local list reads when auto fallback is needed. Path-scoped collection endpoints stay out of the new list fallback so they do not return every cached child row across parents.

## Scope

Primary area: generator templates and generated CLI data-source behavior.

Why this belongs in this repo: the failure comes from generated endpoint-mirror commands, so fixing the Printing Press generator prevents each synthetic printed CLI from needing a hand-written shim.

## Risk

Generated read-command output changes for store-backed top-level array endpoints when the live API is unreachable and local data exists. Path-scoped non-paginated lists intentionally remain single-object fallback attempts to avoid unscoped cached reads.

## Output Contract

Generated `data_source.go` now emits a fallback reason constant. Generated top-level list-shaped endpoint commands can pass `isList=true` into `resolveRead`; path-scoped list commands remain guarded.

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestNetworkFallbackReason|TestLocalReadIsList|TestGeneratedSyntheticAnchorCommandFallsBackToLocalStore|TestGeneratedLiveCommandPrefersAPIOverLocalStore' -count=1`
- `go test ./internal/generator -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change