### PR TITLE
fix(cli): cap wide generated store tables

### DIFF
--- a/docs/solutions/logic-errors/wide-store-tables-need-json-only-fallback.md
+++ b/docs/solutions/logic-errors/wide-store-tables-need-json-only-fallback.md
@@ -1,0 +1,78 @@
+---
+title: "Wide generated store tables need JSON-only fallback"
+date: 2026-05-24
+category: logic-errors
+module: internal/generator/schema_builder
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Generated CLI passes generation and quality gates, then first store open fails with SQLite `too many columns` during migration"
+  - "Wide enterprise config resources flatten thousands of response fields into one CREATE TABLE statement"
+  - "The failure is invisible until a store-backed command runs against a fresh database"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - internal/generator/templates/store.go.tmpl
+  - internal/generator/generator.go
+tags:
+  - schema-builder
+  - sqlite-columns
+  - wide-schema
+  - json-only-fallback
+  - generated-store
+---
+
+# Wide generated store tables need JSON-only fallback
+
+## Problem
+
+The typed-table emitter used one SQLite column per scalar response field for high-gravity resources. On very wide config singleton schemas, that generated a `CREATE TABLE` wider than SQLite's default column limit, so the printed CLI generated cleanly but failed the first time the local store migrated.
+
+## Symptoms
+
+- A generated CLI can pass build, vet, doctor, and verify gates because no database migration runs during generation.
+- First `sync --full --dry-run` or any store-backed command fails while opening the local database.
+- Direct inspection of generated `internal/store/store.go` shows a single resource table with thousands of columns.
+
+## What Didn't Work
+
+- **Hand-removing the pathological resource from one printed CLI.** That unblocks the one API but leaves the generator ready to fail on the next wide config singleton.
+- **Per-column trimming or allowlists.** This creates API-specific policy in a shared generator path and risks silently dropping useful typed columns from ordinary resources.
+- **Only checking `BuildSchema` before dependent columns.** Dependent resources can sit exactly at the safe width before `schemaWithDependentParents` appends `parent_id`; the boundary check must account for generator-added columns too.
+
+## Solution
+
+Keep typed columns for ordinary resources, but mark pathological resources with `JSONOnlyFallback` once their table would exceed the safe width. The fallback keeps the per-resource table and generated `Upsert<Resource>` path, but resets the table to the base `id`, `data`, and `synced_at` columns and drops typed indexes and FTS triggers.
+
+The threshold is intentionally below SQLite's default `SQLITE_MAX_COLUMN=2000` so generated columns and future schema drift have headroom.
+
+```go
+if len(table.Columns) > maxStoreDomainTableColumns {
+    table.JSONOnlyFallback = true
+    table.OriginalColumnCount = len(table.Columns)
+    table.Columns = append([]ColumnDef(nil), baseTableColumns...)
+    table.Indexes = nil
+}
+```
+
+The generator also re-checks the width when adding dependent-resource `parent_id`. If that extra column would cross the threshold, it applies the same JSON-only fallback instead of emitting an over-wide dependent table.
+
+## Why This Works
+
+The local store always writes the full response payload to the `data` JSON column. Typed columns are a query and indexing optimization, not the only copy of the data. Falling back to JSON-only preserves sync, local reads, generic SQL access through `data`, and per-resource dispatch while avoiding a migration that SQLite cannot execute.
+
+The fallback is visible: generation prints a `store-fallback` warning with the resource name and original column count, so operators can distinguish intentional degradation from missing schema inference.
+
+## Prevention
+
+- Generator tests for SQLite DDL bugs must prove the risky SQL is actually emitted. Assert the generated `CREATE TABLE` body, not only `BuildSchema` internals.
+- Boundary tests should include generator-added columns, especially dependent-resource `parent_id`, because post-schema augmentation can cross a width cap.
+- Keep response-schema sourcing separate from fallback policy. Response fields are still the authority for typed columns; JSON-only fallback is a narrow SQLite limit exception.
+- Run `scripts/golden.sh verify` for template predicate changes even when existing goldens do not change.
+
+## Related Issues
+
+- [#1753](https://github.com/mvanhorn/cli-printing-press/issues/1753) — tracked the wide config singleton failure.
+- `docs/solutions/logic-errors/store-columns-sourced-from-request-params-instead-of-response-2026-05-08.md` — adjacent schema-builder invariant: response schema remains the source for typed columns.
+- `docs/solutions/logic-errors/safesqlname-allowlist-misses-strict-reserved-keywords-2026-05-12.md` — adjacent SQLite DDL failure in generated store tables.

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -399,14 +399,15 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"hasDomainUpsert": func(name string) bool {
 			return domainUpsertMethodName(name) != "UpsertBatch"
 		},
-		// hasTypedTable is the single source of truth for "this table gets a
-		// typed Upsert<X>." Table creation, typed-Upsert generation, the
-		// UpsertBatch dispatch switch, and the populated-table tests must all
-		// gate on the same predicate; otherwise dead tables (created but never
-		// written to) leak in for resources whose names hit the framework-cobra
-		// rename and end up with only id/data/synced_at columns.
-		"hasTypedTable": func(t TableDef) bool {
-			return len(t.Columns) > 3 && t.Name != "sync_state" && domainUpsertMethodName(t.Name) != "UpsertBatch"
+		// emitsDomainTable is the single source of truth for "this table gets
+		// a writable per-resource table and Upsert<X>." Table creation,
+		// typed-Upsert generation, the UpsertBatch dispatch switch, and the
+		// populated-table tests must all gate on the same predicate; otherwise
+		// dead tables (created but never written to) leak in for resources whose
+		// names hit the framework-cobra rename. JSONOnlyFallback intentionally
+		// keeps a writable per-resource table while dropping extracted columns.
+		"emitsDomainTable": func(t TableDef) bool {
+			return (len(t.Columns) > 3 || t.JSONOnlyFallback) && t.Name != "sync_state" && domainUpsertMethodName(t.Name) != "UpsertBatch"
 		},
 		"pathContainsParam": func(path, name string) bool {
 			return strings.Contains(path, "{"+name+"}")
@@ -2431,13 +2432,15 @@ func (g *Generator) renderVisionAndRootFiles(promotedCommands []PromotedCommand,
 	return g.renderRootProjectFiles(promotedCommands, promotedResourceNames, workflowConstructors, insightConstructors)
 }
 
-// schemaWithDependentParents adds a parent_id column + index to every
-// dependent resource's table so sync can record which parent each row
-// belongs to. For walker-emitted dependents whose DependentResource.KeyField
-// is non-empty, parent_id stores the value of that field (not strictly a
-// parent's primary key); the column name is retained for backwards
-// compatibility with existing CLIs. The naming caveat is internal — the
-// column is not part of any user-visible API.
+// schemaWithDependentParents adds a parent_id column + index to dependent
+// resource tables so sync can record which parent each row belongs to.
+// JSON-only fallback tables keep only id/data/synced_at; parent context for
+// those rows remains available in the generic resources table. For
+// walker-emitted dependents whose DependentResource.KeyField is non-empty,
+// parent_id stores the value of that field (not strictly a parent's primary
+// key); the column name is retained for backwards compatibility with existing
+// CLIs. The naming caveat is internal — the column is not part of any
+// user-visible API.
 func (g *Generator) schemaWithDependentParents() []TableDef {
 	schema := BuildSchema(g.Spec)
 
@@ -2449,6 +2452,9 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 		}
 		for i, table := range schema {
 			if depSet[table.Name] {
+				if table.JSONOnlyFallback {
+					continue
+				}
 				hasParentID := false
 				for _, col := range table.Columns {
 					if col.Name == "parent_id" {
@@ -2457,6 +2463,16 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 					}
 				}
 				if !hasParentID {
+					if len(table.Columns)+1 > maxStoreDomainTableColumns {
+						schema[i].JSONOnlyFallback = true
+						schema[i].OriginalColumnCount = len(table.Columns) + 1
+						schema[i].Columns = append([]ColumnDef(nil), baseTableColumns...)
+						schema[i].Indexes = nil
+						schema[i].FTS5 = false
+						schema[i].FTS5Fields = nil
+						schema[i].FTS5Triggers = false
+						continue
+					}
 					schema[i].Columns = append(schema[i].Columns, ColumnDef{
 						Name: "parent_id",
 						Type: "TEXT",
@@ -2477,6 +2493,11 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 func (g *Generator) renderStoreFiles(schema []TableDef) error {
 	// Create store directory if needed
 	if g.VisionSet.Store {
+		for _, table := range schema {
+			if table.JSONOnlyFallback {
+				fmt.Fprintf(os.Stderr, "warning: store-fallback: %s (%d cols) -> JSON-only\n", table.Name, table.OriginalColumnCount)
+			}
+		}
 		if err := os.MkdirAll(filepath.Join(g.OutputDir, "internal", "store"), 0755); err != nil {
 			return fmt.Errorf("creating store dir: %w", err)
 		}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14045,6 +14045,111 @@ func TestStoreSkipsDeadTablesForResourcesWithoutTypedUpsert(t *testing.T) {
 		"UpsertBatch must still call upsertGenericResourceTx so renamed resources land in `resources`")
 }
 
+func TestGenerateStoreWideResourceFallsBackToJSONOnlyTable(t *testing.T) {
+	t.Parallel()
+
+	fields := []spec.TypeField{{Name: "id", Type: "string"}}
+	for i := range maxStoreDomainTableColumns {
+		fields = append(fields, spec.TypeField{Name: fmt.Sprintf("setting_%d", i), Type: "string"})
+	}
+
+	apiSpec := &spec.APISpec{
+		Name:    "widecontrol",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/widecontrol-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"control": {
+				Description: "Tenant-wide control settings",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:      "GET",
+						Path:        "/Control",
+						Description: "Get control settings",
+						Response:    spec.ResponseDef{Type: "object", Item: "Control"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Control": {Fields: fields},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	store := string(storeSrc)
+
+	controlCreate := regexp.MustCompile("(?s)`CREATE TABLE IF NOT EXISTS \"control\" \\((.*?)\\)`").FindStringSubmatch(store)
+	require.Len(t, controlCreate, 2, "control table should still be emitted as JSON-only")
+	assert.Contains(t, controlCreate[1], `"id" TEXT PRIMARY KEY`)
+	assert.Contains(t, controlCreate[1], `"data" JSON NOT NULL`)
+	assert.Contains(t, controlCreate[1], `"synced_at" DATETIME DEFAULT CURRENT_TIMESTAMP`)
+	assert.NotContains(t, controlCreate[1], "setting_1499", "wide typed columns must not be emitted")
+	assert.Contains(t, store, "func (s *Store) UpsertControl(", "JSON-only fallback table still needs a typed upsert")
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/store")
+}
+
+func TestSchemaWithDependentParentsFallsBackWhenParentColumnExceedsWideCap(t *testing.T) {
+	t.Parallel()
+
+	scalarFieldCount := maxStoreDomainTableColumns - len(baseTableColumns)
+	fields := []spec.TypeField{}
+	for i := range scalarFieldCount {
+		fields = append(fields, spec.TypeField{Name: fmt.Sprintf("setting_%d", i), Type: "string"})
+	}
+
+	apiSpec := &spec.APISpec{
+		Name:    "widechild",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/widechild-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"control": {
+				Description: "Tenant-wide child settings",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/parents/{parent_id}/control",
+						Description: "List child control settings",
+						Response:    spec.ResponseDef{Type: "array", Item: "Control"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Control": {Fields: fields},
+		},
+	}
+
+	gen := New(apiSpec, t.TempDir())
+	gen.profile = &profiler.APIProfile{
+		DependentSyncResources: []profiler.DependentResource{{Name: "control"}},
+	}
+
+	control := findTable(gen.schemaWithDependentParents(), "control")
+	require.NotNil(t, control)
+	assert.True(t, control.JSONOnlyFallback, "parent_id must not push dependent tables over the wide-table cap")
+	assert.Equal(t, maxStoreDomainTableColumns+1, control.OriginalColumnCount)
+
+	names := make([]string, 0, len(control.Columns))
+	for _, c := range control.Columns {
+		names = append(names, c.Name)
+	}
+	assert.ElementsMatch(t, []string{"id", "data", "synced_at"}, names)
+	assert.Empty(t, control.Indexes)
+	assert.False(t, control.FTS5)
+}
+
 // TestGenerateEndpointTemplateEnvOverridesWireThrough: when the spec
 // declares an explicit env-var name for a template placeholder (e.g.
 // ST_TENANT_ID for {tenant}), every emitted artifact that touches env-var

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -18,6 +18,9 @@ type TableDef struct {
 	FTS5         bool
 	FTS5Fields   []string
 	FTS5Triggers bool
+
+	JSONOnlyFallback    bool
+	OriginalColumnCount int
 }
 
 type ColumnDef struct {
@@ -42,6 +45,10 @@ var baseTableColumns = []ColumnDef{
 	{Name: "data", Type: "JSON", NotNull: true},
 	{Name: "synced_at", Type: "DATETIME DEFAULT CURRENT_TIMESTAMP"},
 }
+
+// SQLite defaults to SQLITE_MAX_COLUMN=2000. Keep typed domain tables below
+// that hard limit with room for generator-added columns and future schema drift.
+const maxStoreDomainTableColumns = 1500
 
 // BuildSchema generates domain-specific table definitions from the API spec.
 // High-gravity entities (many endpoints, text fields, temporal fields) get
@@ -110,10 +117,16 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 					})
 				}
 			}
+			if len(table.Columns) > maxStoreDomainTableColumns {
+				table.JSONOnlyFallback = true
+				table.OriginalColumnCount = len(table.Columns)
+				table.Columns = append([]ColumnDef(nil), baseTableColumns...)
+				table.Indexes = nil
+			}
 		}
 
 		textFields := collectTextFieldNamesFromFields(fields)
-		if len(textFields) >= 2 && gravity >= 2 {
+		if len(textFields) >= 2 && gravity >= 2 && !table.JSONOnlyFallback {
 			table.FTS5 = true
 			table.FTS5Fields = textFields
 			// Only use content-sync triggers when ALL FTS fields are

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -122,6 +122,9 @@ func BuildSchema(s *spec.APISpec) []TableDef {
 				table.OriginalColumnCount = len(table.Columns)
 				table.Columns = append([]ColumnDef(nil), baseTableColumns...)
 				table.Indexes = nil
+				table.FTS5 = false
+				table.FTS5Fields = nil
+				table.FTS5Triggers = false
 			}
 		}
 

--- a/internal/generator/schema_builder_test.go
+++ b/internal/generator/schema_builder_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -291,6 +292,44 @@ func TestBuildSchema_NoResponseTypeFallback(t *testing.T) {
 				"unresolved response type must yield only the base columns; got %v", names)
 		})
 	}
+}
+
+func TestBuildSchema_WideResponseFallsBackToJSONOnlyTable(t *testing.T) {
+	fields := []spec.TypeField{{Name: "id", Type: "string"}}
+	for i := range maxStoreDomainTableColumns {
+		fields = append(fields, spec.TypeField{Name: "setting_" + strconv.Itoa(i), Type: "string"})
+	}
+
+	s := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"control": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:   "GET",
+						Path:     "/Control",
+						Response: spec.ResponseDef{Type: "object", Item: "Control"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Control": {Fields: fields},
+		},
+	}
+
+	control := findTable(BuildSchema(s), "control")
+	require.NotNil(t, control, "control table should be emitted")
+
+	names := make([]string, 0, len(control.Columns))
+	for _, c := range control.Columns {
+		names = append(names, c.Name)
+	}
+	assert.ElementsMatch(t, []string{"id", "data", "synced_at"}, names,
+		"wide resources must fall back to JSON-only columns to stay under SQLite's column cap")
+	assert.True(t, control.JSONOnlyFallback, "wide fallback should still emit a per-resource JSON-only table")
+	assert.Greater(t, control.OriginalColumnCount, maxStoreDomainTableColumns)
+	assert.Empty(t, control.Indexes, "wide fallback must not retain typed-column indexes")
+	assert.False(t, control.FTS5, "wide fallback must not emit typed-table FTS triggers")
 }
 
 // TestBuildSchema_SubResourceCollisionShardsByParent pins the fix for issue

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -788,11 +788,12 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
-// upsert{{pascal .Name}}Tx writes the typed-table portion of a {{.Name}} upsert
-// inside an existing transaction. The caller is responsible for the generic
-// resources insert (via upsertGenericResourceTx) and for committing the tx.
-// Splitting this out lets UpsertBatch dispatch typed inserts per item without
-// opening a per-item transaction.
+// upsert{{pascal .Name}}Tx writes the per-resource domain-table portion of a
+// {{.Name}} upsert inside an existing transaction{{if .JSONOnlyFallback}} (JSON-only fallback:
+// only id/data/synced_at; no typed columns){{end}}. The caller is
+// responsible for the generic resources insert (via upsertGenericResourceTx)
+// and for committing the tx. Splitting this out lets UpsertBatch dispatch
+// domain inserts per item without opening a per-item transaction.
 func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]any, data json.RawMessage) error {
 	if _, err := tx.Exec(
 		`INSERT INTO {{safeName .Name}} ({{columnNames .Columns}})

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -272,10 +272,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		)`,
 		resourcesFTSCreateSQL,
 {{- range .Tables}}
-{{- /* Gate: only create tables that have a typed Upsert. Otherwise the
+{{- /* Gate: only create tables that have a domain Upsert. Otherwise the
        table is dead — UpsertBatch's dispatch skips it and inserts go only
        to the generic `resources` table. */}}
-{{- if hasTypedTable .}}
+{{- if emitsDomainTable .}}
 		`CREATE TABLE IF NOT EXISTS {{safeName .Name}} (
 {{- range $i, $col := .Columns}}
 {{- if $i}},{{end}}
@@ -787,7 +787,7 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 }
 
 {{- range .Tables}}
-{{- if hasTypedTable .}}
+{{- if emitsDomainTable .}}
 // upsert{{pascal .Name}}Tx writes the typed-table portion of a {{.Name}} upsert
 // inside an existing transaction. The caller is responsible for the generic
 // resources insert (via upsertGenericResourceTx) and for committing the tx.
@@ -931,9 +931,9 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 // rollback, so successful API fetches never strand in memory because one
 // downstream typed table is misconfigured. Failures are surfaced via a
 // trailing stderr warning rather than aborting the batch.
-{{- $hasTyped := false }}
+{{- $hasDomainTable := false }}
 {{- range .Tables}}
-{{- if hasTypedTable .}}{{$hasTyped = true}}{{end}}
+{{- if emitsDomainTable .}}{{$hasDomainTable = true}}{{end}}
 {{- end}}
 func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, int, error) {
 	s.writeMu.Lock()
@@ -944,8 +944,8 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	}
 	defer tx.Rollback()
 
-	var stored, skippedCount, extractFailures{{if $hasTyped}}, typedFailures{{end}} int
-	for {{if $hasTyped}}i, {{else}}_, {{end}}item := range items {
+	var stored, skippedCount, extractFailures{{if $hasDomainTable}}, typedFailures{{end}} int
+	for {{if $hasDomainTable}}i, {{else}}_, {{end}}item := range items {
 		var obj map[string]any
 		if err := json.Unmarshal(item, &obj); err != nil {
 			skippedCount++
@@ -969,7 +969,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, id, err)
 		}
 		stored++
-{{- if $hasTyped}}
+{{- if $hasDomainTable}}
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
@@ -979,7 +979,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		var typedErr error
 		switch resourceType {
 {{- range .Tables}}
-{{- if hasTypedTable .}}
+{{- if emitsDomainTable .}}
 		case "{{.Resource}}":
 			typedErr = s.upsert{{pascal .Name}}Tx(tx, id, obj, item)
 {{- end}}
@@ -1007,7 +1007,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
 		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items skipped (no extractable ID field found)\n", skippedCount, len(items), resourceType)
 	}
-{{- if $hasTyped}}
+{{- if $hasDomainTable}}
 	// Surface typed-table failures without aborting the batch. Generic rows
 	// already committed; only the typed projection failed.
 	if typedFailures > 0 {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -258,15 +258,15 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 	}
 }
 
-{{- $hasTyped := false }}
+{{- $hasDomainTable := false }}
 {{- range .Tables}}
-{{- if hasTypedTable .}}
-{{- $hasTyped = true }}
+{{- if emitsDomainTable .}}
+{{- $hasDomainTable = true }}
 {{- end}}
 {{- end}}
-{{- if $hasTyped }}
+{{- if $hasDomainTable }}
 {{- range .Tables}}
-{{- if hasTypedTable .}}
+{{- if emitsDomainTable .}}
 {{- /* $parentFKCol captures buildSubResourceTable's NOT NULL parent FK
        (e.g. "domains_id"). The fixture must populate it or the typed
        insert fails the NOT NULL constraint. The predicate is

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1711,7 +1711,7 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 
 	switch resource {
 {{- range .Tables}}
-{{- if hasTypedTable .}}
+{{- if emitsDomainTable .}}
 	case "{{.Resource}}":
 		return db.Upsert{{pascal .Name}}(data)
 {{- end}}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -740,11 +740,11 @@ func lookupFieldValue(obj map[string]any, snakeKey string) any {
 	return LookupFieldValue(obj, snakeKey)
 }
 
-// upsertLeaguesTx writes the typed-table portion of a leagues upsert
-// inside an existing transaction. The caller is responsible for the generic
-// resources insert (via upsertGenericResourceTx) and for committing the tx.
-// Splitting this out lets UpsertBatch dispatch typed inserts per item without
-// opening a per-item transaction.
+// upsertLeaguesTx writes the per-resource domain-table portion of a
+// leagues upsert inside an existing transaction. The caller is
+// responsible for the generic resources insert (via upsertGenericResourceTx)
+// and for committing the tx. Splitting this out lets UpsertBatch dispatch
+// domain inserts per item without opening a per-item transaction.
 func (s *Store) upsertLeaguesTx(tx *sql.Tx, id string, obj map[string]any, data json.RawMessage) error {
 	if _, err := tx.Exec(
 		`INSERT INTO "leagues" ("id", "data", "synced_at", "parent_id")


### PR DESCRIPTION
## Summary

Wide generated store schemas now stay usable instead of failing the first time SQLite migrations run. When a resource would exceed the safe typed-column width, the generator emits a visible `store-fallback` warning and keeps that resource writable with a JSON-only domain table.

## What changed

- Added a `JSONOnlyFallback` schema path for resources whose generated domain table would exceed the safe column threshold.
- Kept fallback resources in per-resource table/upsert dispatch while dropping typed columns, typed indexes, and FTS triggers.
- Rechecked the same width boundary when dependent-resource `parent_id` would push a table over the cap.
- Renamed the template predicate to `emitsDomainTable` so JSON-only fallback tables are not described as typed-only tables.
- Documented the schema-builder learning in `docs/solutions/logic-errors/wide-store-tables-need-json-only-fallback.md`.

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestBuildSchema_WideResponseFallsBackToJSONOnlyTable|TestGenerateStoreWideResourceFallsBackToJSONOnlyTable|TestSchemaWithDependentParentsFallsBackWhenParentColumnExceedsWideCap|TestStoreSkipsDeadTablesForResourcesWithoutTypedUpsert'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
- Frontmatter helper note: `scripts/validate-frontmatter.py` is not present in this repo; validated the new solution doc's frontmatter delimiter/key shape with a local Python stdlib check.

## Compounded learnings

File: `docs/solutions/logic-errors/wide-store-tables-need-json-only-fallback.md`
Track: bug
Category: logic-errors
Overlap: moderate with existing schema-builder SQLite docs; created a distinct doc because the root cause and fallback policy are different.
Instruction-file edit: none needed; `AGENTS.md` already surfaces `docs/solutions/`.
Refresh recommendation: consider refreshing `docs/solutions/logic-errors/store-columns-sourced-from-request-params-instead-of-response-2026-05-08.md` later to mention JSON-only fallback as the narrow SQLite-cap exception.

Closes #1753
