### PR TITLE
fix(cli): treat side-effect narrative skips as warnings

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -7,15 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrintingPressSkillQuickstartFirstStepIsVerifySafe(t *testing.T) {
+func TestPrintingPressSkillSideEffectNarrativeGuidance(t *testing.T) {
 	t.Parallel()
 
 	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
 	require.NoError(t, err)
 
 	content := string(data)
-	require.Contains(t, content, "Step 1 of `quickstart` MUST be verify-safe")
+	require.Contains(t, content, "Step 1 of `quickstart` should usually be verify-safe")
 	require.Contains(t, content, "Use `<cli> doctor --dry-run` as step 1")
-	require.Contains(t, content, "Do not use `<cli> auth set-token <token>` as step 1")
-	require.Contains(t, content, "Auth setup instructions belong in `auth_narrative` prose only")
+	require.Contains(t, content, "reports each as an `UNSUPPORTED` warning instead of executing it")
+	require.Contains(t, content, "These warnings do not fail strict aggregation")
+	require.Contains(t, content, "Non-side-effect unsupported examples still fail strict mode")
 }

--- a/internal/cli/validate_narrative.go
+++ b/internal/cli/validate_narrative.go
@@ -134,7 +134,7 @@ func printHumanReport(w io.Writer, report *narrativecheck.Report) {
 			fmt.Fprintf(w, "UNSUPPORTED [%s]: %s → %s\n", r.Section, r.Command, r.Error)
 		}
 	}
-	if !report.HasFailures() && !report.ResearchEmpty {
+	if !report.HasFailures() && !report.ResearchEmpty && report.Unsupported == 0 {
 		if report.FrameworkOnly {
 			if report.Walked == 0 {
 				fmt.Fprintln(w, "N/A: no framework-command narrative examples found; static framework check skipped")

--- a/internal/cli/validate_narrative_test.go
+++ b/internal/cli/validate_narrative_test.go
@@ -69,6 +69,66 @@ func TestValidateNarrativeCmd_StrictExitCode(t *testing.T) {
 	}
 }
 
+func TestValidateNarrativeCmd_StrictFullExamplesAllowsSideEffectUnsupported(t *testing.T) {
+	t.Parallel()
+
+	research := filepath.Join(t.TempDir(), "research.json")
+	if err := os.WriteFile(research, []byte(`{"narrative":{
+		"quickstart":[{"command":"stub auth login --client-id abc --client-secret def"}],
+		"recipes":[{"command":"stub tickets age-out --status stale --apply"}]
+	}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binary := buildShipcheckStub(t)
+
+	cmd := newValidateNarrativeCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetArgs([]string{"--strict", "--full-examples", "--research", research, "--binary", binary})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("side-effectful unsupported examples should not fail strict mode, got %v", err)
+	}
+	got := stdout.String() + stderr.String()
+	if count := strings.Count(got, "UNSUPPORTED"); count != 2 {
+		t.Fatalf("expected 2 unsupported warnings, got %d in %q", count, got)
+	}
+	if !strings.Contains(got, "2 unsupported") {
+		t.Fatalf("output = %q, want summary with 2 unsupported warnings", got)
+	}
+}
+
+func TestValidateNarrativeCmd_JSONReportsStrictFailureForUnsupported(t *testing.T) {
+	t.Parallel()
+
+	research := filepath.Join(t.TempDir(), "research.json")
+	if err := os.WriteFile(research, []byte(`{"narrative":{
+		"quickstart":[{"command":"stub auth login --client-id abc --client-secret def"}],
+		"recipes":[{"command":"stub widgets list"}]
+	}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binary := buildShipcheckStub(t)
+
+	cmd := newValidateNarrativeCmd()
+	var stdout bytes.Buffer
+	cmd.SetArgs([]string{"--json", "--full-examples", "--research", research, "--binary", binary})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(new(bytes.Buffer))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected JSON report to succeed without --strict, got %v", err)
+	}
+	got := stdout.String()
+	if count := strings.Count(got, `"status":"unsupported"`); count != 2 {
+		t.Fatalf("expected 2 unsupported JSON results, got %d in %s", count, got)
+	}
+	if count := strings.Count(got, `"strict_failure":true`); count != 1 {
+		t.Fatalf("expected only the dry-run-unavailable unsupported result to be strict_failure, got %d in %s", count, got)
+	}
+}
+
 func TestValidateNarrativeCmd_MissingResearchIsNotApplicable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -259,10 +259,11 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 	segments, err := splitShellChain(command)
 	if err != nil {
 		return Result{
-			Section: section,
-			Command: command,
-			Status:  StatusExampleFailed,
-			Error:   err.Error(),
+			Section:       section,
+			Command:       command,
+			Status:        StatusExampleFailed,
+			Error:         err.Error(),
+			StrictFailure: true,
 		}
 	}
 
@@ -299,9 +300,10 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 		// is no runnable head. Surface this as empty-words so the author
 		// notices, but keep the pipe-skipped notes for context.
 		return finish(Result{
-			Section: section,
-			Status:  StatusEmptyWords,
-			Error:   "command has no runnable segment (every chained segment is pipe-skipped)",
+			Section:       section,
+			Status:        StatusEmptyWords,
+			Error:         "command has no runnable segment (every chained segment is pipe-skipped)",
+			StrictFailure: true,
 		})
 	}
 

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -47,10 +47,11 @@ const (
 	// StatusExampleFailed means the command path resolved, but the full
 	// narrative example failed when executed under the verify environment.
 	StatusExampleFailed Status = "example-failed"
-	// StatusUnsupported means full-example validation could not safely run
-	// because the command does not advertise --dry-run.
+	// StatusUnsupported means full-example validation could not safely run.
 	StatusUnsupported Status = "unsupported"
 )
+
+const sideEffectfulExampleSkipReason = "full-example validation skipped: command is side-effectful (auth/launch/apply)"
 
 type Result struct {
 	Section Section `json:"section"`
@@ -66,6 +67,10 @@ type Result struct {
 	// e.g. `pipe-skipped: jq '.items[]'` or `redirect-stripped: <
 	// keywords.txt`. Empty when the recipe is plain (no pipes, no redirects).
 	Notes []string `json:"notes,omitempty"`
+	// StrictFailure tells JSON consumers whether this result is part of
+	// Report.HasFailures. Some unsupported examples are warnings because the
+	// validator intentionally skips side-effectful commands.
+	StrictFailure bool `json:"strict_failure,omitempty"`
 }
 
 type Report struct {
@@ -170,10 +175,36 @@ func validateFrameworkOnly(commands []sectionCommand) *Report {
 	return report
 }
 
-// HasFailures reports whether the run found any missing or empty-words
-// entries. Callers gate --strict exit codes on this.
+func (r Result) isStrictFailure() bool {
+	switch r.Status {
+	case StatusMissing, StatusEmptyWords, StatusExampleFailed:
+		return true
+	case StatusUnsupported:
+		return r.StrictFailure
+	default:
+		return false
+	}
+}
+
+// HasFailures reports whether the run found entries that should fail strict
+// validation. Side-effectful full examples are intentionally skipped and remain
+// warnings so narratives can document real auth/login/apply flows.
 func (r *Report) HasFailures() bool {
-	return r.Missing > 0 || r.Empty > 0 || r.ExampleFailed > 0 || r.Unsupported > 0
+	if r == nil {
+		return false
+	}
+	if r.Missing > 0 || r.Empty > 0 || r.ExampleFailed > 0 {
+		return true
+	}
+	if r.Unsupported == 0 {
+		return false
+	}
+	for _, result := range r.Results {
+		if result.isStrictFailure() {
+			return true
+		}
+	}
+	return false
 }
 
 type sectionCommand struct {
@@ -275,15 +306,27 @@ func classify(ctx context.Context, binaryPath string, section Section, command s
 	}
 
 	var last Result
+	var warning Result
+	hasWarning := false
 	for i, seg := range runnable {
 		sub := classifySegment(ctx, binaryPath, section, seg.cleaned, opts, templateVarAssignments)
 		if sub.Status != StatusOK {
 			if len(runnable) > 1 {
 				sub.Error = fmt.Sprintf("segment %d (%q): %s", i+1, seg.cleaned, sub.Error)
 			}
+			if !sub.isStrictFailure() {
+				if !hasWarning {
+					warning = sub
+					hasWarning = true
+				}
+				continue
+			}
 			return finish(sub)
 		}
 		last = sub
+	}
+	if hasWarning {
+		return finish(warning)
 	}
 	return finish(last)
 }
@@ -533,6 +576,7 @@ func classifySegment(ctx context.Context, binaryPath string, section Section, co
 	if len(words) == 0 {
 		r.Status = StatusEmptyWords
 		r.Error = "command has no subcommand words to verify (bare binary or pure-flag invocation)"
+		r.StrictFailure = true
 		return r
 	}
 
@@ -541,6 +585,7 @@ func classifySegment(ctx context.Context, binaryPath string, section Section, co
 		if err := exec.CommandContext(ctx, binaryPath, helpArgs...).Run(); err != nil {
 			r.Status = StatusMissing
 			r.Error = fmt.Sprintf("%s %s --help failed: %v", binaryPath, r.Words, err)
+			r.StrictFailure = true
 			return r
 		}
 
@@ -552,6 +597,7 @@ func classifySegment(ctx context.Context, binaryPath string, section Section, co
 	if err != nil {
 		r.Status = StatusMissing
 		r.Error = fmt.Sprintf("%s %s --help failed: %v", binaryPath, r.Words, err)
+		r.StrictFailure = true
 		return r
 	}
 	return classifyFullExample(ctx, binaryPath, command, helpOut, r, templateVarAssignments)
@@ -562,24 +608,27 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 	if err != nil {
 		r.Status = StatusExampleFailed
 		r.Error = err.Error()
+		r.StrictFailure = true
 		return r
 	}
 	if len(tokens) <= 1 {
 		r.Status = StatusEmptyWords
 		r.Error = "command has no arguments to execute after the binary name"
+		r.StrictFailure = true
 		return r
 	}
 
 	args := append([]string(nil), tokens[1:]...)
 	if isSideEffectfulNarrativeExample(args) {
 		r.Status = StatusUnsupported
-		r.Error = "full-example validation skipped: command is side-effectful (auth/launch/apply)"
+		r.Error = sideEffectfulExampleSkipReason
 		return r
 	}
 	if !hasEnabledBoolFlag(args, "--dry-run") {
 		if !helpAdvertisesDryRun(helpOut) {
 			r.Status = StatusUnsupported
 			r.Error = "full-example validation skipped: command help does not advertise --dry-run"
+			r.StrictFailure = true
 			return r
 		}
 		args = append(args, "--dry-run")
@@ -602,6 +651,7 @@ func classifyFullExample(ctx context.Context, binaryPath, command string, helpOu
 			err,
 			formatOutputSuffix(out),
 		)
+		r.StrictFailure = true
 		return r
 	}
 

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -212,8 +212,40 @@ func TestValidateWithOptions_FullExamplesCatchesInvalidFlag(t *testing.T) {
 	if got.Status != StatusExampleFailed {
 		t.Fatalf("Status = %q, want %q", got.Status, StatusExampleFailed)
 	}
+	if !got.StrictFailure {
+		t.Fatal("failed full example should be marked as a strict failure")
+	}
 	if !strings.Contains(got.Error, "--bad-flag") {
 		t.Errorf("Error %q should mention the invalid flag", got.Error)
+	}
+}
+
+func TestValidateWithOptions_FullExamplesMarksParseErrorAsStrictFailure(t *testing.T) {
+	t.Parallel()
+
+	binary := buildStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub widgets list --message \"open"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.HasFailures() {
+		t.Fatal("parse errors should fail strict aggregation")
+	}
+	if report.ExampleFailed != 1 {
+		t.Fatalf("ExampleFailed = %d, want 1", report.ExampleFailed)
+	}
+	got := report.Results[0]
+	if got.Status != StatusExampleFailed {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusExampleFailed)
+	}
+	if !got.StrictFailure {
+		t.Fatal("parse error should be marked as a strict failure")
 	}
 }
 
@@ -774,6 +806,35 @@ func TestValidate_PipeRecipeValidatesLeadingSegment(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.Notes, wantNotes) {
 		t.Errorf("Notes = %q, want %q", got.Notes, wantNotes)
+	}
+}
+
+func TestValidate_PipeOnlyRecipeMarksEmptyWordsAsStrictFailure(t *testing.T) {
+	t.Parallel()
+
+	binary := buildStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"recipes":[
+			{"command":"| jq '.'"}
+		]
+	}}`)
+
+	report, err := Validate(context.Background(), research, binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.HasFailures() {
+		t.Fatal("pipe-only recipes should fail strict aggregation")
+	}
+	if report.Empty != 1 {
+		t.Fatalf("Empty = %d, want 1", report.Empty)
+	}
+	got := report.Results[0]
+	if got.Status != StatusEmptyWords {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusEmptyWords)
+	}
+	if !got.StrictFailure {
+		t.Fatal("pipe-only empty-words result should be marked as a strict failure")
 	}
 }
 

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -217,6 +217,37 @@ func TestValidateWithOptions_FullExamplesCatchesInvalidFlag(t *testing.T) {
 	}
 }
 
+func TestValidateWithOptions_FullExamplesTreatsSideEffectSkipsAsWarnings(t *testing.T) {
+	t.Parallel()
+
+	binary := buildStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"quickstart":[
+			{"command":"stub widgets list --launch"}
+		],
+		"recipes":[
+			{"command":"stub widgets show 42 --apply"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.Unsupported != 2 {
+		t.Fatalf("Unsupported = %d, want 2; results=%+v", report.Unsupported, report.Results)
+	}
+	if report.HasFailures() {
+		t.Fatalf("side-effectful full examples should warn without failing strict aggregation, got %+v", report)
+	}
+	for _, result := range report.Results {
+		if result.StrictFailure {
+			t.Fatalf("side-effectful unsupported result should serialize as non-strict-failure warning, got %+v", result)
+		}
+	}
+}
+
 func TestValidateWithOptions_FrameworkOnlyCatchesInventedFrameworkFlags(t *testing.T) {
 	t.Parallel()
 
@@ -420,6 +451,13 @@ func TestClassifyFullExample_ReportsUnsupportedWhenDryRunUnavailable(t *testing.
 	if !strings.Contains(got.Error, "does not advertise --dry-run") {
 		t.Errorf("Error %q should explain why the full example was not run", got.Error)
 	}
+	if !got.StrictFailure {
+		t.Fatal("dry-run-unavailable unsupported result should be marked as a strict failure")
+	}
+	report := &Report{Unsupported: 1, Results: []Result{got}}
+	if !report.HasFailures() {
+		t.Fatal("dry-run-unavailable unsupported examples should still fail strict aggregation")
+	}
 }
 
 func TestRunFullExample_SkipsAuthSetToken(t *testing.T) {
@@ -468,6 +506,11 @@ func TestIsSideEffectfulNarrativeExample_UsesExactFlagMatches(t *testing.T) {
 		args []string
 		want bool
 	}{
+		{
+			name: "auth login is side effectful",
+			args: []string{"auth", "login", "--client-id", "abc"},
+			want: true,
+		},
 		{
 			name: "launch flag is side effectful",
 			args: []string{"widgets", "create", "--launch"},
@@ -644,6 +687,32 @@ func TestValidateWithOptions_ChainedRecipeRunsBothFullExamples(t *testing.T) {
 	}
 	if report.Walked != 1 || report.HasFailures() {
 		t.Fatalf("chained full-example recipe should pass, got %+v", report)
+	}
+}
+
+func TestValidateWithOptions_ChainedSideEffectWarningDoesNotHideLaterFailure(t *testing.T) {
+	t.Parallel()
+
+	binary := buildStubBinary(t)
+	research := writeFile(t, `{"narrative":{
+		"recipes":[
+			{"command":"stub widgets list --launch && stub typo-here"}
+		]
+	}}`)
+
+	report, err := ValidateWithOptions(context.Background(), research, binary, Options{FullExamples: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Missing != 1 {
+		t.Fatalf("later hard failure should win over earlier side-effect warning, got %+v", report)
+	}
+	if !report.HasFailures() {
+		t.Fatal("later hard failure should still fail strict aggregation")
+	}
+	got := report.Results[0]
+	if !strings.Contains(got.Error, "segment 2") {
+		t.Errorf("error should attribute failure to segment 2: %s", got.Error)
 	}
 }
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1593,7 +1593,7 @@ For each tool, fill in what you know from the research. Stars and command_count 
 3. `value_prop` expands the headline to 2–3 sentences. Name specific novel features by command where helpful.
 4. `auth_narrative` tells the real auth story for this API (crumb handshake, cookie session, OAuth device flow). Omit for standard API-key auth where the generic branch is fine.
 5. `quickstart` is a 3–6 step flow using REAL arguments (symbols, IDs, resource names an agent can actually pass). Each step's `comment` explains *why* it runs. This replaces the generic "resource list" first-command fallback.
-   - Step 1 of `quickstart` MUST be verify-safe: it must exit 0 when `validate-narrative --full-examples` appends `--dry-run` in a no-credentials environment.
+   - Step 1 of `quickstart` should usually be verify-safe: it should exit 0 when `validate-narrative --full-examples` appends `--dry-run` in a no-credentials environment.
    - Use `<cli> doctor --dry-run` as step 1 (health check, works without auth). Do not use `<cli> auth set-token <token>` as step 1 because it requires a positional token and is not a verify-safe runnable first step. Auth setup instructions belong in `auth_narrative` prose only, not as an executable quickstart command.
 6. `troubleshoots` captures API-specific failure modes (rate-limit mitigation, cookie expiry, paginated quirks). Each `fix` must be actionable — a command or a concrete setting change.
 7. `when_to_use` is SKILL-only narrative. 2–4 sentences describing the kinds of agent tasks this CLI is the right choice for. Not rendered in README.
@@ -1601,7 +1601,7 @@ For each tool, fill in what you know from the research. Stars and command_count 
 9. `trigger_phrases` are natural-language phrases a user might say that should invoke this CLI's skill. Include 3–5 domain-specific phrases (e.g. for a finance CLI: "quote AAPL", "check my portfolio", "options for TSLA") and 2 generic phrases ("use <api-name>", "run <api-name>"). Domain verbs vary — don't just template "use X" variants.
 10. All `narrative` fields are optional. Omit fields you can't populate honestly rather than emit filler. The generator falls back to generic content gracefully.
 11. **Avoid hardcoded counts in narrative copy when the count tracks a runtime list.** A number embedded in `headline` or `value_prop` ("across N trusted sources", "from N retailers", "queries N vendors") propagates into root.go's Short/Long, the README, the SKILL, the MCP tools description, and `which.go` — every output surface that reads the narrative. When the underlying registry grows or shrinks, the count goes stale across all of those surfaces simultaneously, and a single-line edit to add a source requires hunting down ~10 hardcoded copies. Prefer plural-without-count phrasing ("across the major sources", "from a curated set of retailers") or describe the breadth qualitatively ("dozens of vendors") rather than committing to a specific integer. If a count is load-bearing for the value prop, keep the brief's narrative count-free and have the printed-CLI's README/SKILL author write the count once into a single hand-edited paragraph after generation — accepting that it will need a manual update whenever the registry changes.
-12. **Don't put side-effectful auth setup in `quickstart[0]`.** `validate-narrative --strict --full-examples` classifies `auth login`, `auth set-token`, `auth logout`, and `auth setup` as side-effectful for every auth type (see `isSideEffectfulNarrativeExample` in `internal/narrativecheck/narrativecheck.go`) and counts each as a strict-mode failure via `Report.HasFailures()`, so any quickstart whose step 0 is `<cli> auth login --chrome` or `<cli> auth set-token $KEY` guarantees a Phase 4 shipcheck round-trip. This applies unconditionally across every auth type the Printing Press supports — `api_key`, `bearer_token`, `cookie`, `composed`, `session_handshake`, and `oauth2` alike. Use `doctor` (or another read-only invocation like `account get` if auth-required-and-cookie-already-imported is the onboarding entry point) as the first quickstart step, and mention the one-time auth-setup step in that step's `comment` field. The auth flow itself belongs in `auth_narrative` prose, not in `quickstart`.
+12. **Use side-effectful examples only when they are the truthful workflow.** `validate-narrative --strict --full-examples` classifies `auth login`, `auth set-token`, `auth logout`, `auth setup`, `--launch`, and mutating `--apply` examples as side-effectful (see `isSideEffectfulNarrativeExample` in `internal/narrativecheck/narrativecheck.go`) and reports each as an `UNSUPPORTED` warning instead of executing it. These warnings do not fail strict aggregation, so it is valid to show an auth or apply command when that is the honest onboarding or bulk-operation shape. Prefer `doctor` or another read-only invocation as `quickstart[0]` when it teaches the same workflow, but do not strip a real auth or apply step just to appease shipcheck. Non-side-effect unsupported examples still fail strict mode when they cannot dry-run, and missing commands, empty command paths, and failed full examples remain failures.
 
 **Pre-render framework-command check.** Before running `generate --research-dir`,
 validate the framework command examples already present in `research.json`.
@@ -2496,9 +2496,11 @@ cli-printing-press validate-narrative --strict --full-examples \
 
 `--strict` exits non-zero on any missing command, empty subcommand-words entry, or
 empty narrative (both sections omitted). With `--full-examples`, it also fails on full
-examples that cannot dry-run or whose full invocation fails. Drop `--strict` to get a
-warn-only report, omit `--full-examples` only when you intentionally want the old
-offline path check, or add `--json` for machine-readable output.
+examples that cannot dry-run or whose full invocation fails. Side-effectful auth,
+launch, and mutating apply examples are reported as `UNSUPPORTED` warnings and do not
+fail strict aggregation. Drop `--strict` to get a warn-only report, omit
+`--full-examples` only when you intentionally want the old offline path check, or add
+`--json` for machine-readable output.
 
 If any commands are reported missing, fix them in `research.json` before continuing.
 Common causes:


### PR DESCRIPTION
## Summary

Narrative validation can now document the real auth and bulk-operation workflows without making shipcheck fail just because the validator safely skipped a side-effectful example.

This keeps `auth`, `--launch`, and mutating `--apply` examples classified as `UNSUPPORTED`, but marks those skips as non-strict warnings. Unsupported examples that should have been runnable, missing command paths, empty command paths, and failed full examples still fail strict validation. The JSON report now exposes `strict_failure` so downstream tooling can distinguish unsupported warnings from strict failures without parsing prose.

The Printing Press skill guidance is updated so agents stop deleting truthful auth or apply examples solely to satisfy `validate-narrative --strict --full-examples`.

Closes #1752

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
