### PR TITLE
fix(cli): support Entra client credentials generation

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -58,6 +58,334 @@ func TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars(t *testing.T) {
 	assert.Less(t, verifyIdx, mintIdx, "mock verification must not dial the real token endpoint")
 }
 
+func TestClientCredentialsEnvVarsSkipTenantSetupInput(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("entra-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://login.microsoftonline.com/COMMON/oauth2/v2.0/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "ENTRA_CC_TENANT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: false},
+			{Name: "ENTRA_CC_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "ENTRA_CC_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "entra-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	authContent := string(authSrc)
+	require.Contains(t, authContent, `clientID = os.Getenv("ENTRA_CC_CLIENT_ID")`)
+	require.Contains(t, authContent, `clientSecret = os.Getenv("ENTRA_CC_CLIENT_SECRET")`)
+	require.NotContains(t, authContent, `clientID = os.Getenv("ENTRA_CC_TENANT_ID")`)
+	require.Contains(t, authContent, `resolveClientCredentialsTokenURL(tokenURL, cfg.`+resolveEnvVarField("ENTRA_CC_TENANT_ID")+`)`)
+	require.Contains(t, authContent, `os.Getenv("ENTRA_CC_OAUTH_SCOPE")`)
+	require.Contains(t, authContent, `strings.ReplaceAll("api://{client_id}/.default", "{client_id}", clientID)`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `id = os.Getenv("ENTRA_CC_CLIENT_ID")`)
+	require.Contains(t, clientContent, `secret = os.Getenv("ENTRA_CC_CLIENT_SECRET")`)
+	require.NotContains(t, clientContent, `id = os.Getenv("ENTRA_CC_TENANT_ID")`)
+	require.Contains(t, clientContent, `tenant = c.Config.`+resolveEnvVarField("ENTRA_CC_TENANT_ID"))
+	require.Contains(t, clientContent, `resolveClientCredentialsTokenURL(tokenURL, tenant)`)
+	require.Contains(t, clientContent, `form.Set("scope", scope)`)
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"entra-cc-pp-cli/internal/config"
+)
+
+func TestClientCredentialsRuntimeEntraTenantAndScope(t *testing.T) {
+	var gotPath string
+	var gotScope string
+	var gotClientID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		gotScope = r.Form.Get("scope")
+		gotClientID = r.Form.Get("client_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ` + "`" + `{"access_token":"minted-token","expires_in":3600}` + "`" + `)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{TokenURL: server.URL + "/COMMON/oauth2/v2.0/token", Path: filepath.Join(t.TempDir(), "config.toml")}
+	cfg.{{TENANT_FIELD}} = "contoso"
+	c := &Client{Config: cfg, HTTPClient: server.Client()}
+	if err := c.mintClientCredentials(context.Background(), "client-123", "secret-456"); err != nil {
+		t.Fatalf("mintClientCredentials() error = %v", err)
+	}
+	if gotPath != "/contoso/oauth2/v2.0/token" {
+		t.Fatalf("token request path = %q, want /contoso/oauth2/v2.0/token", gotPath)
+	}
+	if gotScope != "api://client-123/.default" {
+		t.Fatalf("scope = %q, want api://client-123/.default", gotScope)
+	}
+	if gotClientID != "client-123" {
+		t.Fatalf("client_id = %q, want client-123", gotClientID)
+	}
+
+	t.Setenv("ENTRA_CC_OAUTH_SCOPE", "https://override.example/.default")
+	if err := c.mintClientCredentials(context.Background(), "client-789", "secret-456"); err != nil {
+		t.Fatalf("mintClientCredentials() with scope override error = %v", err)
+	}
+	if gotScope != "https://override.example/.default" {
+		t.Fatalf("override scope = %q, want https://override.example/.default", gotScope)
+	}
+}
+
+func TestClientCredentialsRuntimeEntraRequiresTenant(t *testing.T) {
+	cfg := &config.Config{TokenURL: "https://login.microsoftonline.com/COMMON/oauth2/v2.0/token"}
+	c := &Client{Config: cfg, HTTPClient: http.DefaultClient}
+	if err := c.mintClientCredentials(context.Background(), "client-123", "secret-456"); err == nil {
+		t.Fatalf("mintClientCredentials() error = nil, want tenant-required error")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "client", "entra_runtime_test.go"),
+		[]byte(strings.ReplaceAll(runtimeTest, "{{TENANT_FIELD}}", resolveEnvVarField("ENTRA_CC_TENANT_ID"))),
+		0o644,
+	))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestClientCredentialsRuntimeEntra")
+}
+
+func TestClientCredentialsStaticTokenURLDoesNotEmitTenantSubstitution(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("static-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://auth.example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "STATIC_CC_TENANT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+			{Name: "STATIC_CC_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "STATIC_CC_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "static-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(authSrc), `resolveClientCredentialsTokenURL(tokenURL`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(clientSrc), `resolveClientCredentialsTokenURL(tokenURL`)
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"static-cc-pp-cli/internal/config"
+)
+
+func TestClientCredentialsRuntimeStaticTokenURLDoesNotSendDefaultScope(t *testing.T) {
+	var hasScope bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		_, hasScope = r.Form["scope"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ` + "`" + `{"access_token":"minted-token","expires_in":3600}` + "`" + `)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{TokenURL: server.URL, Path: filepath.Join(t.TempDir(), "config.toml")}
+	c := &Client{Config: cfg, HTTPClient: server.Client()}
+	if err := c.mintClientCredentials(context.Background(), "client-123", "secret-456"); err != nil {
+		t.Fatalf("mintClientCredentials() error = %v", err)
+	}
+	if hasScope {
+		t.Fatalf("unexpected scope form value for static non-Microsoft token URL")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "static_runtime_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestClientCredentialsRuntimeStatic")
+}
+
+func TestClientCredentialsLegacyEnvVarsSubstituteTenantTokenURL(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("legacy-entra-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+		EnvVars: []string{
+			"LEGACY_ENTRA_TENANT_ID",
+			"LEGACY_ENTRA_CLIENT_ID",
+			"LEGACY_ENTRA_CLIENT_SECRET",
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "legacy-entra-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	authContent := string(authSrc)
+	require.Contains(t, authContent, `clientID = os.Getenv("LEGACY_ENTRA_CLIENT_ID")`)
+	require.Contains(t, authContent, `clientSecret = os.Getenv("LEGACY_ENTRA_CLIENT_SECRET")`)
+	require.Contains(t, authContent, `resolveClientCredentialsTokenURL(tokenURL, cfg.`+resolveEnvVarField("LEGACY_ENTRA_TENANT_ID")+`)`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `id = os.Getenv("LEGACY_ENTRA_CLIENT_ID")`)
+	require.Contains(t, clientContent, `secret = os.Getenv("LEGACY_ENTRA_CLIENT_SECRET")`)
+	require.Contains(t, clientContent, `tenant = c.Config.`+resolveEnvVarField("LEGACY_ENTRA_TENANT_ID"))
+	require.Contains(t, clientContent, `resolveClientCredentialsTokenURL(tokenURL, tenant)`)
+}
+
+func TestClientCredentialsTenantPrefixDoesNotHideClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("multitenant-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://auth.example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "MULTITENANT_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: false},
+			{Name: "MULTITENANT_CLIENT_SECRET", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "multitenant-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	authContent := string(authSrc)
+	require.Contains(t, authContent, `clientID = os.Getenv("MULTITENANT_CLIENT_ID")`)
+	require.Contains(t, authContent, `clientSecret = os.Getenv("MULTITENANT_CLIENT_SECRET")`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `id = os.Getenv("MULTITENANT_CLIENT_ID")`)
+	require.Contains(t, clientContent, `secret = os.Getenv("MULTITENANT_CLIENT_SECRET")`)
+}
+
+func TestClientCredentialsDeclaredScopesSuppressMicrosoftDefaultScope(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("scoped-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://login.microsoftonline.com/COMMON/oauth2/v2.0/token",
+		Scopes:      []string{"https://graph.microsoft.com/.default"},
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "SCOPED_CC_TENANT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+			{Name: "SCOPED_CC_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "SCOPED_CC_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "scoped-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `return "https://graph.microsoft.com/.default"`)
+	require.NotContains(t, clientContent, `api://{client_id}/.default`)
+}
+
+func TestClientCredentialsMixedKindEnvVarsPreserveClientRoles(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mixed-kind-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://auth.example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "MIXED_KIND_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: false},
+			{Name: "MIXED_KIND_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "mixed-kind-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	authContent := string(authSrc)
+	require.Contains(t, authContent, `clientID = os.Getenv("MIXED_KIND_CLIENT_ID")`)
+	require.Contains(t, authContent, `clientSecret = os.Getenv("MIXED_KIND_CLIENT_SECRET")`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `id = os.Getenv("MIXED_KIND_CLIENT_ID")`)
+	require.Contains(t, clientContent, `secret = os.Getenv("MIXED_KIND_CLIENT_SECRET")`)
+}
+
+func TestClientCredentialsHostileScopeEmitsValidGo(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("hostile-scope-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://auth.example.com/oauth/token",
+		Scopes:      []string{"read\"with\\escapes\nwrite"},
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "HOSTILE_SCOPE_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "HOSTILE_SCOPE_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "hostile-scope-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	runGoCommand(t, outputDir, "test", "./internal/client")
+	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
 // TestAuthHeader_OAuth2DoesNotUseSetupEnvVars pins that for every OAuth2
 // grant (authorization_code via the default, client_credentials via explicit
 // OAuth2Grant) the configured env vars (e.g. CLIENT_ID / CLIENT_SECRET) are

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -251,6 +251,12 @@ func TestClientCredentialsLegacyEnvVarsSubstituteTenantTokenURL(t *testing.T) {
 			"LEGACY_ENTRA_CLIENT_SECRET",
 		},
 	}
+	ccEnvVars := clientCredentialsEnvVars(apiSpec.Auth)
+	require.Len(t, ccEnvVars, 2)
+	require.Equal(t, "LEGACY_ENTRA_CLIENT_ID", ccEnvVars[0].Name)
+	require.False(t, ccEnvVars[0].Sensitive, "legacy client ID must not be synthesized as sensitive")
+	require.Equal(t, "LEGACY_ENTRA_CLIENT_SECRET", ccEnvVars[1].Name)
+	require.True(t, ccEnvVars[1].Sensitive, "legacy client secret must stay sensitive")
 
 	outputDir := filepath.Join(t.TempDir(), "legacy-entra-cc-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
@@ -301,6 +307,35 @@ func TestClientCredentialsTenantPrefixDoesNotHideClientCredentials(t *testing.T)
 	clientContent := string(clientSrc)
 	require.Contains(t, clientContent, `id = os.Getenv("MULTITENANT_CLIENT_ID")`)
 	require.Contains(t, clientContent, `secret = os.Getenv("MULTITENANT_CLIENT_SECRET")`)
+}
+
+func TestClientCredentialsPerCallTenantIDDoesNotTriggerConfigBackedTenantSubstitution(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("per-call-tenant-cc")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "PER_CALL_TENANT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "PER_CALL_CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false},
+			{Name: "PER_CALL_CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "per-call-tenant-cc-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(authSrc), `resolveClientCredentialsTokenURL(tokenURL`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(clientSrc), `resolveClientCredentialsTokenURL(tokenURL`)
 }
 
 func TestClientCredentialsDeclaredScopesSuppressMicrosoftDefaultScope(t *testing.T) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -233,39 +233,44 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return zeroVal(t)
 		},
-		"positionalArgs":         positionalArgs,
-		"configTag":              configTag,
-		"camelToJSON":            camelToJSON,
-		"columnNames":            columnNames,
-		"columnPlaceholders":     columnPlaceholders,
-		"updateSet":              updateSet,
-		"envVarField":            envVarField,
-		"envVarPlaceholder":      naming.EnvVarPlaceholder,
-		"envVarIsBuiltinField":   envVarIsBuiltinField,
-		"envVarBuiltinFieldName": envVarBuiltinFieldName,
-		"resolveEnvVarField":     resolveEnvVarField,
-		"authPlacement":          authPlacement,
-		"authParameterName":      authParameterName,
-		"authCommandShort":       authCommandShort,
-		"authHarvestedEnvHint":   authHarvestedEnvHint,
-		"basicAuthEnvVars":       basicAuthEnvVars,
-		"authAgentEnvVars":       authAgentEnvVars,
-		"hasAuthEnvVarKind":      hasAuthEnvVarKind,
-		"isRequestAuthEnvVar":    isRequestAuthEnvVar,
-		"effectiveTier":          effectiveTier,
-		"effectiveSubTier":       effectiveSubTier,
-		"add":                    func(a, b int) int { return a + b },
-		"chomp":                  func(s string) string { return strings.TrimRight(s, "\r\n") },
-		"staleAfterExpr":         staleAfterExpr,
-		"oneline":                naming.OneLine,
-		"composeMCPDesc":         composeMCPDesc,
-		"composeMCPSubDesc":      composeMCPSubDesc,
-		"mcpParamDesc":           g.mcpParamDescription,
-		"flagName":               flagName,
-		"paramIdent":             paramIdent,
-		"paramWireName":          paramWireName,
-		"typeFieldIdent":         typeFieldIdent,
-		"safeTypeName":           safeTypeName,
+		"positionalArgs":                     positionalArgs,
+		"configTag":                          configTag,
+		"camelToJSON":                        camelToJSON,
+		"columnNames":                        columnNames,
+		"columnPlaceholders":                 columnPlaceholders,
+		"updateSet":                          updateSet,
+		"envVarField":                        envVarField,
+		"envVarPlaceholder":                  naming.EnvVarPlaceholder,
+		"envVarIsBuiltinField":               envVarIsBuiltinField,
+		"envVarBuiltinFieldName":             envVarBuiltinFieldName,
+		"resolveEnvVarField":                 resolveEnvVarField,
+		"authPlacement":                      authPlacement,
+		"authParameterName":                  authParameterName,
+		"authCommandShort":                   authCommandShort,
+		"authHarvestedEnvHint":               authHarvestedEnvHint,
+		"basicAuthEnvVars":                   basicAuthEnvVars,
+		"clientCredentialsEnvVars":           clientCredentialsEnvVars,
+		"clientCredentialsScope":             clientCredentialsScope,
+		"clientCredentialsScopeUsesClientID": clientCredentialsScopeUsesClientID,
+		"clientCredentialsTenantEnvVar":      clientCredentialsTenantEnvVar,
+		"clientCredentialsTokenURLHasTenant": clientCredentialsTokenURLHasTenant,
+		"authAgentEnvVars":                   authAgentEnvVars,
+		"hasAuthEnvVarKind":                  hasAuthEnvVarKind,
+		"isRequestAuthEnvVar":                isRequestAuthEnvVar,
+		"effectiveTier":                      effectiveTier,
+		"effectiveSubTier":                   effectiveSubTier,
+		"add":                                func(a, b int) int { return a + b },
+		"chomp":                              func(s string) string { return strings.TrimRight(s, "\r\n") },
+		"staleAfterExpr":                     staleAfterExpr,
+		"oneline":                            naming.OneLine,
+		"composeMCPDesc":                     composeMCPDesc,
+		"composeMCPSubDesc":                  composeMCPSubDesc,
+		"mcpParamDesc":                       g.mcpParamDescription,
+		"flagName":                           flagName,
+		"paramIdent":                         paramIdent,
+		"paramWireName":                      paramWireName,
+		"typeFieldIdent":                     typeFieldIdent,
+		"safeTypeName":                       safeTypeName,
 		"hasNonScalarType": func(types map[string]spec.TypeDef) bool {
 			for _, td := range types {
 				for _, f := range td.Fields {
@@ -1033,6 +1038,123 @@ func basicAuthEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
 		return envVars
 	}
 	return envVars[:2]
+}
+
+func clientCredentialsEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
+	if auth.EffectiveOAuth2Grant() != spec.OAuth2GrantClientCredentials {
+		return nil
+	}
+	if len(auth.EnvVarSpecs) > 0 {
+		var candidates []spec.AuthEnvVar
+		tenantEnvVar := clientCredentialsTenantEnvVar(auth)
+		for _, envVar := range auth.EnvVarSpecs {
+			name := strings.TrimSpace(envVar.Name)
+			if name == "" || name == tenantEnvVar || envVar.EffectiveKind() == spec.AuthEnvVarKindHarvested {
+				continue
+			}
+			candidates = append(candidates, envVar)
+		}
+		clientID, clientSecret := clientCredentialsNamedPair(candidates)
+		if clientID.Name != "" && clientSecret.Name != "" {
+			return []spec.AuthEnvVar{clientID, clientSecret}
+		}
+		if len(candidates) >= 2 {
+			return candidates[:2]
+		}
+		return nil
+	}
+	var envVars []spec.AuthEnvVar
+	tenantEnvVar := clientCredentialsTenantEnvVar(auth)
+	for _, name := range auth.EnvVars {
+		if strings.TrimSpace(name) == "" || name == tenantEnvVar {
+			continue
+		}
+		envVars = append(envVars, spec.AuthEnvVar{
+			Name:      name,
+			Kind:      spec.AuthEnvVarKindPerCall,
+			Required:  true,
+			Sensitive: true,
+		})
+	}
+	if len(envVars) < 2 {
+		return nil
+	}
+	clientID, clientSecret := clientCredentialsNamedPair(envVars)
+	if clientID.Name != "" && clientSecret.Name != "" {
+		return []spec.AuthEnvVar{clientID, clientSecret}
+	}
+	return envVars[:2]
+}
+
+func clientCredentialsNamedPair(envVars []spec.AuthEnvVar) (spec.AuthEnvVar, spec.AuthEnvVar) {
+	var clientID spec.AuthEnvVar
+	var clientSecret spec.AuthEnvVar
+	for _, envVar := range envVars {
+		placeholder := naming.EnvVarPlaceholder(envVar.Name)
+		switch {
+		case clientID.Name == "" && (placeholder == "client_id" || strings.HasSuffix(placeholder, "_client_id")):
+			clientID = envVar
+		case clientSecret.Name == "" && (placeholder == "client_secret" || strings.HasSuffix(placeholder, "_client_secret")):
+			clientSecret = envVar
+		}
+	}
+	return clientID, clientSecret
+}
+
+func clientCredentialsTenantEnvVar(auth spec.AuthConfig) string {
+	if auth.EffectiveOAuth2Grant() != spec.OAuth2GrantClientCredentials {
+		return ""
+	}
+	for _, envVar := range auth.EnvVarSpecs {
+		if envVar.EffectiveKind() == spec.AuthEnvVarKindAuthFlowInput && isTenantAuthEnvVar(envVar.Name) {
+			return envVar.Name
+		}
+	}
+	for _, envVar := range auth.EnvVarSpecs {
+		if envVar.EffectiveKind() != spec.AuthEnvVarKindHarvested && isTenantAuthEnvVar(envVar.Name) {
+			return envVar.Name
+		}
+	}
+	for _, name := range auth.EnvVars {
+		if isTenantAuthEnvVar(name) {
+			return name
+		}
+	}
+	return ""
+}
+
+func clientCredentialsTokenURLHasTenant(auth spec.AuthConfig) bool {
+	return clientCredentialsTenantEnvVar(auth) != "" && isMicrosoftEntraTokenURL(auth.TokenURL) && strings.Contains(strings.ToLower(auth.TokenURL), "/common/")
+}
+
+func clientCredentialsScope(auth spec.AuthConfig) string {
+	if auth.EffectiveOAuth2Grant() != spec.OAuth2GrantClientCredentials {
+		return ""
+	}
+	if len(auth.Scopes) > 0 {
+		return strings.Join(auth.Scopes, " ")
+	}
+	if isMicrosoftEntraTokenURL(auth.TokenURL) {
+		return "api://{client_id}/.default"
+	}
+	return ""
+}
+
+func clientCredentialsScopeUsesClientID(scope string) bool {
+	return strings.Contains(scope, "{client_id}")
+}
+
+func isMicrosoftEntraTokenURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Host, "login.microsoftonline.com")
+}
+
+func isTenantAuthEnvVar(name string) bool {
+	placeholder := naming.EnvVarPlaceholder(name)
+	return placeholder == "tenant_id" || strings.HasSuffix(placeholder, "_tenant_id")
 }
 
 func authAgentEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1073,7 +1073,7 @@ func clientCredentialsEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {
 			Name:      name,
 			Kind:      spec.AuthEnvVarKindPerCall,
 			Required:  true,
-			Sensitive: true,
+			Sensitive: !isClientIDAuthEnvVar(name),
 		})
 	}
 	if len(envVars) < 2 {
@@ -1110,14 +1110,11 @@ func clientCredentialsTenantEnvVar(auth spec.AuthConfig) string {
 			return envVar.Name
 		}
 	}
-	for _, envVar := range auth.EnvVarSpecs {
-		if envVar.EffectiveKind() != spec.AuthEnvVarKindHarvested && isTenantAuthEnvVar(envVar.Name) {
-			return envVar.Name
-		}
-	}
-	for _, name := range auth.EnvVars {
-		if isTenantAuthEnvVar(name) {
-			return name
+	if len(auth.EnvVarSpecs) == 0 || spec.AllAuthEnvVarSpecsInferred(auth.EnvVarSpecs) {
+		for _, name := range auth.EnvVars {
+			if isTenantAuthEnvVar(name) {
+				return name
+			}
 		}
 	}
 	return ""
@@ -1155,6 +1152,11 @@ func isMicrosoftEntraTokenURL(raw string) bool {
 func isTenantAuthEnvVar(name string) bool {
 	placeholder := naming.EnvVarPlaceholder(name)
 	return placeholder == "tenant_id" || strings.HasSuffix(placeholder, "_tenant_id")
+}
+
+func isClientIDAuthEnvVar(name string) bool {
+	placeholder := naming.EnvVarPlaceholder(name)
+	return placeholder == "client_id" || strings.HasSuffix(placeholder, "_client_id")
 }
 
 func authAgentEnvVars(auth spec.AuthConfig) []spec.AuthEnvVar {

--- a/internal/generator/templates/auth_client_credentials.go.tmpl
+++ b/internal/generator/templates/auth_client_credentials.go.tmpl
@@ -17,6 +17,10 @@ import (
 	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
+{{- $ccEnvVars := clientCredentialsEnvVars .Auth}}
+{{- $ccTenantEnvVar := clientCredentialsTenantEnvVar .Auth}}
+{{- $ccScope := clientCredentialsScope .Auth}}
+{{- $ccScopeUsesClientID := clientCredentialsScopeUsesClientID $ccScope}}
 
 // OAuth2 client_credentials grant: 2-legged server-to-server flow.
 // POST to TokenURL with form-encoded client_id/client_secret. No user
@@ -51,7 +55,7 @@ Mint an OAuth2 bearer token via POST {{.Auth.TokenURL}} with
 grant_type=client_credentials and cache it on disk. Subsequent commands
 auto-refresh the token before expiry.
 
-Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID){{if gt (len .Auth.EnvVars) 1}} and {{index .Auth.EnvVars 1}} (Client Secret){{end}}{{else}}your project's Client ID and Client Secret{{end}} environment variables.
+Credentials default to {{if $ccEnvVars}}{{(index $ccEnvVars 0).Name}} (Client ID){{if gt (len $ccEnvVars) 1}} and {{(index $ccEnvVars 1).Name}} (Client Secret){{end}}{{else}}your project's Client ID and Client Secret{{end}} environment variables.
 `),
 		Example: strings.Trim(`
   # Use env vars
@@ -68,18 +72,18 @@ Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID)
 			}
 
 			if clientID == "" {
-{{- if .Auth.EnvVars}}
-				clientID = os.Getenv("{{index .Auth.EnvVars 0}}")
+{{- if $ccEnvVars}}
+				clientID = os.Getenv("{{(index $ccEnvVars 0).Name}}")
 {{- end}}
 			}
 			if clientSecret == "" {
-{{- if gt (len .Auth.EnvVars) 1}}
-				clientSecret = os.Getenv("{{index .Auth.EnvVars 1}}")
+{{- if gt (len $ccEnvVars) 1}}
+				clientSecret = os.Getenv("{{(index $ccEnvVars 1).Name}}")
 {{- end}}
 			}
 			if clientID == "" || clientSecret == "" {
-{{- if gt (len .Auth.EnvVars) 1}}
-				return authErr(fmt.Errorf("client ID and secret required (set --client-id/--client-secret or {{index .Auth.EnvVars 0}}/{{index .Auth.EnvVars 1}})"))
+{{- if gt (len $ccEnvVars) 1}}
+				return authErr(fmt.Errorf("client ID and secret required (set --client-id/--client-secret or {{(index $ccEnvVars 0).Name}}/{{(index $ccEnvVars 1).Name}})"))
 {{- else}}
 				return authErr(fmt.Errorf("client ID and secret required (set --client-id and --client-secret)"))
 {{- end}}
@@ -94,6 +98,12 @@ Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID)
 			if tokenURL == "" {
 				tokenURL = "{{.Auth.TokenURL}}"
 			}
+{{- if clientCredentialsTokenURLHasTenant .Auth}}
+			tokenURL, err = resolveClientCredentialsTokenURL(tokenURL, cfg.{{resolveEnvVarField $ccTenantEnvVar}})
+			if err != nil {
+				return authErr(err)
+			}
+{{- end}}
 			tok, err := mintClientCredentialsToken(http.DefaultClient, tokenURL, clientID, clientSecret)
 			if err != nil {
 				return authErr(err)
@@ -121,10 +131,10 @@ Credentials default to {{if .Auth.EnvVars}}{{index .Auth.EnvVars 0}} (Client ID)
 		},
 	}
 
-{{- if .Auth.EnvVars}}
-	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth2 Client ID; defaults to ${{index .Auth.EnvVars 0}}")
-{{- if gt (len .Auth.EnvVars) 1}}
-	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth2 Client Secret; defaults to ${{index .Auth.EnvVars 1}}")
+{{- if $ccEnvVars}}
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth2 Client ID; defaults to ${{(index $ccEnvVars 0).Name}}")
+{{- if gt (len $ccEnvVars) 1}}
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth2 Client Secret; defaults to ${{(index $ccEnvVars 1).Name}}")
 {{- else}}
 	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth2 Client Secret")
 {{- end}}
@@ -141,6 +151,36 @@ type tokenResponse struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
+func resolveClientCredentialsScope({{if $ccScopeUsesClientID}}clientID string{{end}}) string {
+	if scope := os.Getenv("{{envName .Name}}_OAUTH_SCOPE"); scope != "" {
+		return scope
+	}
+{{- if $ccScope}}
+{{- if $ccScopeUsesClientID}}
+	return strings.ReplaceAll({{printf "%q" $ccScope}}, "{client_id}", clientID)
+{{- else}}
+	return {{printf "%q" $ccScope}}
+{{- end}}
+{{- else}}
+	return ""
+{{- end}}
+}
+
+{{- if clientCredentialsTokenURLHasTenant .Auth}}
+func resolveClientCredentialsTokenURL(tokenURL, tenant string) (string, error) {
+	idx := strings.Index(strings.ToLower(tokenURL), "/common/")
+	if idx < 0 {
+		return tokenURL, nil
+	}
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return "", fmt.Errorf("tenant required for token URL; set {{$ccTenantEnvVar}}")
+	}
+	return tokenURL[:idx] + "/" + url.PathEscape(tenant) + "/" + tokenURL[idx+len("/common/"):], nil
+}
+
+{{- end}}
+
 // mintClientCredentialsToken POSTs grant_type=client_credentials to the
 // token endpoint and returns the parsed token response.
 func mintClientCredentialsToken(httpClient *http.Client, tokenURL, clientID, clientSecret string) (*tokenResponse, error) {
@@ -148,6 +188,9 @@ func mintClientCredentialsToken(httpClient *http.Client, tokenURL, clientID, cli
 		"grant_type":    {"client_credentials"},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
+	}
+	if scope := resolveClientCredentialsScope({{if $ccScopeUsesClientID}}clientID{{end}}); scope != "" {
+		form.Set("scope", scope)
 	}
 	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -211,10 +254,10 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				fmt.Fprintln(w, red("Not authenticated"))
 				fmt.Fprintln(w, "")
 				fmt.Fprintln(w, "Mint a token:")
-{{- if .Auth.EnvVars}}
-				fmt.Fprintln(w, "  export {{index .Auth.EnvVars 0}}=\"<client-id>\"")
-{{- if gt (len .Auth.EnvVars) 1}}
-				fmt.Fprintln(w, "  export {{index .Auth.EnvVars 1}}=\"<client-secret>\"")
+{{- if $ccEnvVars}}
+				fmt.Fprintln(w, "  export {{(index $ccEnvVars 0).Name}}=\"<client-id>\"")
+{{- if gt (len $ccEnvVars) 1}}
+				fmt.Fprintln(w, "  export {{(index $ccEnvVars 1).Name}}=\"<client-secret>\"")
 {{- end}}
 {{- end}}
 				fmt.Fprintf(w, "  {{.Name}}-pp-cli auth login\n")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -38,6 +38,10 @@ import (
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
 )
+{{- $ccEnvVars := clientCredentialsEnvVars .Auth}}
+{{- $ccTenantEnvVar := clientCredentialsTenantEnvVar .Auth}}
+{{- $ccScope := clientCredentialsScope .Auth}}
+{{- $ccScopeUsesClientID := clientCredentialsScopeUsesClientID $ccScope}}
 
 const BinaryResponseHeader = "X-Printing-Press-Binary-Response"
 
@@ -1878,18 +1882,48 @@ func needsClientCredentialsMint(cfg *config.Config) bool {
 func resolveClientCredentials(cfg *config.Config) (string, string) {
 	id := cfg.ClientID
 	secret := cfg.ClientSecret
-{{- if .Auth.EnvVars}}
+{{- if $ccEnvVars}}
 	if id == "" {
-		id = os.Getenv("{{index .Auth.EnvVars 0}}")
+		id = os.Getenv("{{(index $ccEnvVars 0).Name}}")
 	}
-{{- if gt (len .Auth.EnvVars) 1}}
+{{- if gt (len $ccEnvVars) 1}}
 	if secret == "" {
-		secret = os.Getenv("{{index .Auth.EnvVars 1}}")
+		secret = os.Getenv("{{(index $ccEnvVars 1).Name}}")
 	}
 {{- end}}
 {{- end}}
 	return id, secret
 }
+
+func resolveClientCredentialsScope({{if $ccScopeUsesClientID}}clientID string{{end}}) string {
+	if scope := os.Getenv("{{envName .Name}}_OAUTH_SCOPE"); scope != "" {
+		return scope
+	}
+{{- if $ccScope}}
+{{- if $ccScopeUsesClientID}}
+	return strings.ReplaceAll({{printf "%q" $ccScope}}, "{client_id}", clientID)
+{{- else}}
+	return {{printf "%q" $ccScope}}
+{{- end}}
+{{- else}}
+	return ""
+{{- end}}
+}
+
+{{- if clientCredentialsTokenURLHasTenant .Auth}}
+func resolveClientCredentialsTokenURL(tokenURL, tenant string) (string, error) {
+	idx := strings.Index(strings.ToLower(tokenURL), "/common/")
+	if idx < 0 {
+		return tokenURL, nil
+	}
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return "", fmt.Errorf("tenant required for token URL; set {{$ccTenantEnvVar}}")
+	}
+	return tokenURL[:idx] + "/" + url.PathEscape(tenant) + "/" + tokenURL[idx+len("/common/"):], nil
+}
+
+{{- end}}
 
 func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error {
 	tokenURL := ""
@@ -1904,10 +1938,23 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 	if tokenURL == "" {
 		return nil
 	}
+{{- if clientCredentialsTokenURLHasTenant .Auth}}
+	tenant := ""
+	if c.Config != nil {
+		tenant = c.Config.{{resolveEnvVarField $ccTenantEnvVar}}
+	}
+	tokenURL, err := resolveClientCredentialsTokenURL(tokenURL, tenant)
+	if err != nil {
+		return err
+	}
+{{- end}}
 	form := url.Values{
 		"grant_type":    {"client_credentials"},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
+	}
+	if scope := resolveClientCredentialsScope({{if $ccScopeUsesClientID}}clientID{{end}}); scope != "" {
+		form.Set("scope", scope)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/cli/auth.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/cli/auth.go
@@ -123,6 +123,13 @@ type tokenResponse struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
+func resolveClientCredentialsScope() string {
+	if scope := os.Getenv("PRINTING_PRESS_OAUTH2_OAUTH_SCOPE"); scope != "" {
+		return scope
+	}
+	return "read write"
+}
+
 // mintClientCredentialsToken POSTs grant_type=client_credentials to the
 // token endpoint and returns the parsed token response.
 func mintClientCredentialsToken(httpClient *http.Client, tokenURL, clientID, clientSecret string) (*tokenResponse, error) {
@@ -130,6 +137,9 @@ func mintClientCredentialsToken(httpClient *http.Client, tokenURL, clientID, cli
 		"grant_type":    {"client_credentials"},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
+	}
+	if scope := resolveClientCredentialsScope(); scope != "" {
+		form.Set("scope", scope)
 	}
 	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -777,6 +777,13 @@ func resolveClientCredentials(cfg *config.Config) (string, string) {
 	return id, secret
 }
 
+func resolveClientCredentialsScope() string {
+	if scope := os.Getenv("PRINTING_PRESS_OAUTH2_OAUTH_SCOPE"); scope != "" {
+		return scope
+	}
+	return "read write"
+}
+
 func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecret string) error {
 	tokenURL := ""
 	if c.Config != nil {
@@ -792,6 +799,9 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 		"grant_type":    {"client_credentials"},
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
+	}
+	if scope := resolveClientCredentialsScope(); scope != "" {
+		form.Set("scope", scope)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Generated OAuth2 client_credentials CLIs now handle Microsoft Entra tenant token URLs and default scopes without hand patches.
- Client ID and secret env fallbacks are selected by role instead of raw position, so tenant setup inputs no longer displace credentials.
- Scope literals are Go-quoted before template emission and covered by generated runtime tests.

## Review Notes
- The Entra `.default` fallback is guarded to `login.microsoftonline.com` client_credentials token URLs with empty declared scopes. Static token URLs and declared scopes remain unchanged.
- Tenant URL substitution only activates for strict `*_TENANT_ID` style env vars and `/common/` Entra token URLs.

Closes #1833

## Tests
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator -run 'TestClientCredentials(EnvVarsSkipTenantSetupInput|StaticTokenURLDoesNotEmitTenantSubstitution|LegacyEnvVarsSubstituteTenantTokenURL|TenantPrefixDoesNotHideClientCredentials|DeclaredScopesSuppressMicrosoftDefaultScope|MixedKindEnvVarsPreserveClientRoles|HostileScopeEmitsValidGo)'`\n- `go test ./...`\n- `golangci-lint run ./...`\n- `scripts/golden.sh verify`\n- `git diff --check`