### PR TITLE
fix(catalog): require catalog PR justification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,26 @@ Why this belongs in this repo:
 
 <!-- Printed-CLI-only fixes belong in the generated CLI or public library repo. If the symptom came from a printed CLI, explain the general Printing Press behavior this changes. -->
 
+## Catalog Justification
+
+<!-- Required when this PR adds or edits catalog/*.yaml or catalog/specs/**. Otherwise write "N/A". -->
+
+Embedded catalog fit:
+
+Distinct blueprint pattern:
+
+Closest existing entries checked:
+
+Source provenance:
+
+Auth and tenant assumptions:
+
+Safe default surface:
+
+Generation path:
+
+Stale-body check:
+
 ## Risk
 
 <!-- What could this break? Include generated output, MCP surface, auth, catalog, publish flow, verifier, scorer, or release behavior if relevant. -->

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -21,6 +21,57 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate catalog PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          body = os.environ.get("PR_BODY") or ""
+          required = [
+              "Embedded catalog fit",
+              "Distinct blueprint pattern",
+              "Closest existing entries checked",
+              "Source provenance",
+              "Auth and tenant assumptions",
+              "Safe default surface",
+              "Generation path",
+              "Stale-body check",
+          ]
+          next_field = "|".join(rf"^{re.escape(label)}:\s*" for label in required)
+
+          def field_has_content(label):
+              match = re.search(
+                  rf"(?ims)^{re.escape(label)}:\s*(.*?)(?={next_field}|^##\s+|\Z)",
+                  body,
+              )
+              if not match:
+                  return False
+              content = match.group(1).strip()
+              return bool(content and content.upper() != "N/A")
+
+          missing = []
+          if not re.search(r"(?im)^## Catalog Justification\s*$", body):
+              missing.append("## Catalog Justification")
+          for label in required:
+              if not field_has_content(label):
+                  missing.append(label)
+
+          if missing:
+              print("FAIL: catalog PRs must complete the Catalog Justification section.")
+              print("Missing or empty fields:")
+              for item in missing:
+                  print(f"  - {item}")
+              sys.exit(1)
+
+          print("PASS: Catalog Justification section is present and complete.")
+          PY
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -45,10 +45,16 @@ jobs:
           ]
           next_field = "|".join(rf"^{re.escape(label)}:\s*" for label in required)
 
+          section_match = re.search(
+              r"(?ims)^## Catalog Justification\s*$(.*?)(?=^##\s+|\Z)",
+              body,
+          )
+          catalog_section = section_match.group(1) if section_match else ""
+
           def field_has_content(label):
               match = re.search(
                   rf"(?ims)^{re.escape(label)}:\s*(.*?)(?={next_field}|^##\s+|\Z)",
-                  body,
+                  catalog_section,
               )
               if not match:
                   return False
@@ -56,7 +62,7 @@ jobs:
               return bool(content and content.upper() != "N/A")
 
           missing = []
-          if not re.search(r"(?im)^## Catalog Justification\s*$", body):
+          if not section_match:
               missing.append("## Catalog Justification")
           for label in required:
               if not field_has_content(label):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ Format: `type(scope): description`. Both type and scope are required.
 
 **Allowed scopes:**
 - `cli` covers the Go binary, commands, flags, embedded catalog, and docs.
+- `catalog` covers embedded catalog entries, catalog specs, catalog fixtures, and catalog-only validation.
 - `skills` covers skill definitions (`SKILL.md`), references, and setup contract.
 - `ci` covers workflows, release config, and goreleaser.
 - `main` is reserved for release-please generated release PRs targeting `main`.
@@ -139,11 +140,17 @@ Format: `type(scope): description`. Both type and scope are required.
 - `refactor` — internal restructuring with no observable behavior change.
 - `chore` — build, tooling, dependency, or housekeeping work outside production code.
 - `test` — test-only additions or corrections.
+- `ci` — workflow and CI configuration changes.
+- `perf` — performance improvements.
+- `build` — build-system changes.
+- `style` — formatting-only changes.
+- `revert` — reverts a prior commit.
 
 **Breaking changes** use `!` after the scope: `feat(cli)!: rename catalog command to registry`. The `!` triggers a major version bump through release-please, so reserve it for changes that *break a downstream contract* — a renamed/removed command, a renamed/removed flag, a removed manifest field, an incompatible config-file shape. **What isn't breaking:** template wording changes, README updates, and generator-output diffs that don't remove or rename a documented surface are `docs(...)` or `fix(...)` — not `feat(...)!`. Even if every printed CLI's output changes on next regen, that alone doesn't qualify as breaking unless something downstream breaks too. The release-versioning consequence of `!` is intentional; if you're unsure, ask before adding it.
 
 **Examples:**
 - `feat(cli): add --select flag to all read commands`
+- `feat(catalog): add maps blueprint entry`
 - `feat(cli)!: rename catalog command to registry`
 - `fix(cli): correct trailing newline in skill.md.tmpl`
 - `docs(cli): clarify install instructions in generated README`
@@ -173,7 +180,10 @@ See [`docs/RELEASE.md`](docs/RELEASE.md) for the merge-the-release-PR flow.
 
 ## Adding Catalog Entries
 When adding or editing `catalog/*.yaml`, first decide whether the entry belongs in the curated blueprint catalog. The embedded catalog is not a public-library index or a shortcut for reprinting existing CLIs; reprint from the current local/public library artifact when that is the source of truth. Add catalog entries only when they represent a distinct, reusable Printing Press pattern and have a real user-facing workflow, a reachable maintained source, and a reproducible generation route: vendor spec, docs-derived in-repo spec, verified sniffed spec, or wrapper-only backing that truthfully describes what the generator can do today. Do not add aspirational entries, dead wrappers, unproven private endpoints, personalized app flows without an auth model, duplicate examples of an already-covered pattern, or scrape ideas without live crawl evidence.
-- Document provenance in the PR: source URL(s), source type (`official`, `docs`, `sniffed`, `community`, or wrapper-only), live smoke evidence, auth requirements, and what is intentionally out of scope.
+- Use the PR template's `Catalog Justification` section when the PR touches `catalog/*.yaml` or `catalog/specs/**`; `validate-catalog.yml` rejects catalog PRs without it.
+- Document why the entry belongs in the embedded catalog, not just why the files belong in this repo. Name the reusable blueprint pattern it adds, the closest existing catalog entries checked, and why this is not a duplicate or a public-library-only reprint.
+- Document provenance in the PR: source URL(s), source type (`official`, `docs`, `sniffed`, `community`, or wrapper-only), live smoke evidence, auth requirements, tenant/region/base-URL assumptions, and what is intentionally out of scope.
+- Refresh the PR body after the final code changes. Do not leave stale raw diff excerpts, tenant-specific instructions, internal secret names, old endpoint counts, or outdated verification claims in the description.
 - If the entry should make `cli-printing-press generate <name>` work, provide a real `spec_url` or in-repo spec; wrapper-only entries are discovery/backing notes unless the generator has a concrete spec path.
 - If catalog output intentionally changes, update `testdata/golden/expected/catalog-list/stdout.txt`.
 - The entry must pass `internal/catalog` validation.

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -45,14 +45,21 @@ If an entry should be directly generatable from the catalog, provide a real `spe
 
 For each catalog PR, include the following in the PR body:
 
+- A `Catalog Justification` section from the PR template. This is required for PRs touching `catalog/*.yaml` or `catalog/specs/**`.
+- Why this entry belongs in the embedded curated catalog instead of only in the local/public library.
+- The distinct reusable blueprint pattern the entry adds, plus the closest existing catalog entries checked and why this is not a near-duplicate.
 - Source URL(s) and source type.
 - Live smoke evidence for the primary source path, with dates or command output summarized.
 - Auth requirements and which commands are public, optional-auth, or auth-required.
+- Tenant, region, base URL, and server-ordering assumptions. If an OpenAPI spec has multiple `servers`, the first one must be the correct generated default for the broadest public use case.
 - Scope boundaries for risky or personalized flows.
 - Whether `testdata/golden/expected/catalog-list/stdout.txt` changed, and why.
 - Verification commands actually run, or a clear reason they were not run.
+- A final body refresh statement. Do not leave stale raw diff excerpts, internal secret names, tenant-specific setup text, old endpoint counts, or outdated verification claims after review fixes.
 
 For HTML or scrape-backed entries, also verify crawlability and extractable data, not just page availability. A `200` on a marketing page is not enough; the PR must show that the data needed for the intended CLI surface is present in public HTML, embedded JSON, sitemaps, or documented endpoints.
+
+Good catalog PR bodies answer the judgment call before listing files. For example: "This belongs in the embedded catalog because it is the first map/routing/VRP blueprint; OpenRouteService was compared against Mapbox, Google, OSRM, and Nominatim; the docs-derived in-repo spec is reproducible from the linked SpringDoc route; auth is API-key based; mutating routes are included only where the generated CLI can surface them safely." File diffs and generation output support that argument, but they do not replace it.
 
 ## Wrapper-only entries
 

--- a/internal/pipeline/conventions_test.go
+++ b/internal/pipeline/conventions_test.go
@@ -7,23 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// conventionalCommitPattern validates the format used in PR titles and
-// commit messages. This pattern is mirrored by the PR title GitHub Action
-// (.github/workflows/pr-title.yml) — keep them in sync.
+// conventionalCommitPattern validates the preferred format used in PR titles
+// and commit messages. The PR title GitHub Action enforces conventional shape;
+// this test keeps the repo's narrower documented scope list honest.
 //
-// Scopes: cli, skills, ci (required on all types).
+// Scopes: cli, catalog, skills, ci, main (required on all types).
 // Breaking changes: ! after scope.
 var conventionalCommitPattern = regexp.MustCompile(
 	`^(feat|fix|docs|chore|refactor|test|ci|perf|build|style|revert)` +
-		`\((cli|skills|ci)\)` +
+		`\((cli|catalog|skills|ci|main)\)` +
 		`!?` +
 		`: .+`)
 
 func TestConventionalCommitPatternAcceptsValid(t *testing.T) {
 	valid := []string{
 		"feat(cli): add catalog subcommands",
+		"feat(catalog): add maps blueprint",
 		"fix(skills): remove repo checkout requirement",
 		"feat(ci): add release-please",
+		"chore(main): release 4.12.0",
 		"feat(cli)!: rename catalog command to registry",
 		"docs(cli): update version flag examples",
 		"chore(ci): bump dependencies",

--- a/internal/pipeline/conventions_test.go
+++ b/internal/pipeline/conventions_test.go
@@ -11,12 +11,14 @@ import (
 // and commit messages. The PR title GitHub Action enforces conventional shape;
 // this test keeps the repo's narrower documented scope list honest.
 //
-// Scopes: cli, catalog, skills, ci, main (required on all types).
+// Scopes: cli, catalog, skills, ci, plus chore(main) release PRs.
 // Breaking changes: ! after scope.
 var conventionalCommitPattern = regexp.MustCompile(
-	`^(feat|fix|docs|chore|refactor|test|ci|perf|build|style|revert)` +
-		`\((cli|catalog|skills|ci|main)\)` +
-		`!?` +
+	`^(` +
+		`(feat|fix|docs|chore|refactor|test|ci|perf|build|style|revert)` +
+		`\((cli|catalog|skills|ci)\)` +
+		`|chore\(main\)` +
+		`)!?` +
 		`: .+`)
 
 func TestConventionalCommitPatternAcceptsValid(t *testing.T) {
@@ -54,6 +56,7 @@ func TestConventionalCommitPatternRejectsInvalid(t *testing.T) {
 		"docs: missing scope",
 		"feat(random): invalid scope",
 		"fix(anything): invalid scope",
+		"feat(main): not a release",
 	}
 
 	for _, msg := range invalid {


### PR DESCRIPTION
## Summary

Catalog-entry PRs now have to explain why a proposed API belongs in the embedded curated catalog before CI will accept them. The PR template, AGENTS guidance, and catalog docs all ask authors to name the reusable blueprint pattern, compare nearby entries, document auth and tenant assumptions, and confirm the body was refreshed after final review fixes.

The catalog validation workflow now checks that PRs touching `catalog/**` complete those justification fields instead of leaving reviewers to infer the argument from file diffs or stale raw excerpts. This also recognizes `catalog` as a documented conventional scope so catalog-only process changes can be titled plainly.

## Validation

- `actionlint .github/workflows/pr-title.yml .github/workflows/validate-catalog.yml`
- `go test ./internal/pipeline -run 'TestConventionalCommitPattern'`
- `go fmt ./...`
- `git diff --check`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
