### PR TITLE
fix(cli): ignore shell operators in verify-skill positionals

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -705,7 +705,8 @@ def _split_before_shell_operator(line: str) -> str:
             if placeholder:
                 i += placeholder.end()
                 continue
-        if ch in "|;&<>":
+            return line[:_shell_operator_cut_index(line, i)].rstrip()
+        if ch in "|;&>":
             return line[:_shell_operator_cut_index(line, i)].rstrip()
         i += 1
     return line

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -664,6 +664,64 @@ def _cli_invocation_from_tokens(
     return cmd_path, positional, flags
 
 
+def _split_before_shell_operator(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if escaped:
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                escaped = True
+                i += 1
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "<":
+            placeholder = re.match(r"<[A-Za-z][A-Za-z0-9_-]*>", line[i:])
+            if placeholder:
+                i += placeholder.end()
+                continue
+        if ch in "|;&<>":
+            return line[:_shell_operator_cut_index(line, i)].rstrip()
+        i += 1
+    return line
+
+
+def _shell_operator_cut_index(line: str, operator_index: int) -> int:
+    # Redirections may be prefixed by a file descriptor, e.g. `2>err`.
+    if line[operator_index] in "><":
+        j = operator_index - 1
+        while j >= 0 and line[j].isdigit():
+            j -= 1
+        if j < operator_index - 1 and (j < 0 or line[j].isspace()):
+            return j + 1
+    return operator_index
+
+
 def _extract_prose_invocations(
     text: str,
     cli_binary: str,
@@ -758,11 +816,7 @@ def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None =
             # splitting on pipes so we don't mistakenly cut inside a $(...).
             line = re.sub(r"\$\([^)]*\)", "__SUBST__", line)
             line = re.sub(r"`[^`]*`", "__SUBST__", line)
-            # Stop at outer shell operators so we don't parse pipes/redirects
-            for op in [" | ", " && ", " || ", " > ", " >> ", " < "]:
-                if op in line:
-                    line = line.split(op)[0]
-                    break
+            line = _split_before_shell_operator(line)
             after = line[len(cli_binary) + 1 :].strip()
             try:
                 tokens = shlex.split(after, posix=True)

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -168,6 +168,7 @@ func TestVerifySkill_ShellOperatorsDoNotBecomePositionals(t *testing.T) {
 		"fixture-pp-cli export --format json < export.json\n" +
 		"fixture-pp-cli export --format json 2>export.err\n" +
 		"fixture-pp-cli export --filter \"score > 10\"\n" +
+		"fixture-pp-cli export --filter \"score>10\"\n" +
 		"fixture-pp-cli export --filter 'score > 10'\n" +
 		"fixture-pp-cli export --filter 'score \\' > export.json\n" +
 		"```\n"

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -154,6 +154,110 @@ func newSearchCmd() *cobra.Command {
 	require.Contains(t, string(out), "All checks passed")
 }
 
+func TestVerifySkill_ShellOperatorsDoNotBecomePositionals(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\n" +
+		"fixture-pp-cli export --format json > export.json\n" +
+		"fixture-pp-cli export --format json>export.json\n" +
+		"fixture-pp-cli export --format json|jq .\n" +
+		"fixture-pp-cli export --format json; echo done\n" +
+		"fixture-pp-cli export --format json < export.json\n" +
+		"fixture-pp-cli export --format json 2>export.err\n" +
+		"fixture-pp-cli export --filter \"score > 10\"\n" +
+		"fixture-pp-cli export --filter 'score > 10'\n" +
+		"fixture-pp-cli export --filter 'score \\' > export.json\n" +
+		"```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var format string
+	var filter string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&format, "format", "", "Output format")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter expression")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.NoError(t, err, "shell operators must not be counted as positionals: %s", string(out))
+	require.Contains(t, string(out), "All checks passed")
+}
+
+func TestVerifySkill_PositionalArgsStillFailWithoutShellOperator(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export one.json two.json\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	return &cobra.Command{Use: "export"}
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.Error(t, err, "real positional args must still fail verify-skill")
+	require.Contains(t, string(out), "[positional-args]")
+	require.Contains(t, string(out), "got 2 positional args")
+}
+
+func TestVerifySkill_PlaceholderPositionalsStillFail(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export <id>\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	return &cobra.Command{Use: "export"}
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.Error(t, err, "placeholder positionals must still fail verify-skill")
+	require.Contains(t, string(out), "[positional-args]")
+	require.Contains(t, string(out), "got 1 positional args")
+}
+
 // TestVerifySkill_FlagDeclaredViaHelper asserts the verifier accepts a flag
 // declared one level deep through a shared helper invoked with cmd as first
 // arg, e.g. addTargetFlags(cmd, &t) whose body declares the flag.

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -705,7 +705,8 @@ def _split_before_shell_operator(line: str) -> str:
             if placeholder:
                 i += placeholder.end()
                 continue
-        if ch in "|;&<>":
+            return line[:_shell_operator_cut_index(line, i)].rstrip()
+        if ch in "|;&>":
             return line[:_shell_operator_cut_index(line, i)].rstrip()
         i += 1
     return line

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -664,6 +664,64 @@ def _cli_invocation_from_tokens(
     return cmd_path, positional, flags
 
 
+def _split_before_shell_operator(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if escaped:
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                escaped = True
+                i += 1
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "<":
+            placeholder = re.match(r"<[A-Za-z][A-Za-z0-9_-]*>", line[i:])
+            if placeholder:
+                i += placeholder.end()
+                continue
+        if ch in "|;&<>":
+            return line[:_shell_operator_cut_index(line, i)].rstrip()
+        i += 1
+    return line
+
+
+def _shell_operator_cut_index(line: str, operator_index: int) -> int:
+    # Redirections may be prefixed by a file descriptor, e.g. `2>err`.
+    if line[operator_index] in "><":
+        j = operator_index - 1
+        while j >= 0 and line[j].isdigit():
+            j -= 1
+        if j < operator_index - 1 and (j < 0 or line[j].isspace()):
+            return j + 1
+    return operator_index
+
+
 def _extract_prose_invocations(
     text: str,
     cli_binary: str,
@@ -758,11 +816,7 @@ def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None =
             # splitting on pipes so we don't mistakenly cut inside a $(...).
             line = re.sub(r"\$\([^)]*\)", "__SUBST__", line)
             line = re.sub(r"`[^`]*`", "__SUBST__", line)
-            # Stop at outer shell operators so we don't parse pipes/redirects
-            for op in [" | ", " && ", " || ", " > ", " >> ", " < "]:
-                if op in line:
-                    line = line.split(op)[0]
-                    break
+            line = _split_before_shell_operator(line)
             after = line[len(cli_binary) + 1 :].strip()
             try:
                 tokens = shlex.split(after, posix=True)


### PR DESCRIPTION
## Summary

`verify-skill` now accepts realistic bash recipes that redirect, pipe, or sequence CLI output without treating the shell syntax as positional arguments to the printed CLI.

The parser now cuts bash recipes at unescaped shell operators outside quotes, while preserving placeholder arguments like `<id>` so real positional mismatches still fail. The canonical verifier and bundled CLI copy stay synced, with regressions for redirects, compact operators, input redirects, quoted operators, fd redirects, placeholders, and real filename positionals.

`validate-narrative` side-effect UNSUPPORTED handling was already fixed on `main` by #2087, so this PR completes the remaining `verify-skill` half of the issue.

Closes #1835

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/cli -run 'TestVerifySkill_(ShellOperatorsDoNotBecomePositionals|PositionalArgsStillFailWithoutShellOperator|PlaceholderPositionalsStillFail|ScriptInSync)'`
- `go test ./internal/cli`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
- `python3 scripts/verify-skill/test_resolve_command_path.py`
