### PR TITLE
fix(cli): harden sniffed auth inference

### DIFF
--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -1909,10 +1909,11 @@ func anyHeaderPrefix(headers map[string]string, prefix string) bool {
 }
 
 func isAuthQueryName(lowerName string) bool {
-	if isPaginationTokenName(lowerName) {
+	lowerName = strings.ToLower(strings.TrimSpace(lowerName))
+	if isSearchInputName(lowerName) || isPaginationTokenName(lowerName) {
 		return false
 	}
-	return strings.Contains(lowerName, "key") || strings.Contains(lowerName, "token") || strings.Contains(lowerName, "auth")
+	return isStrongAuthQueryName(lowerName) || isWeakAuthQueryName(lowerName)
 }
 
 func isPaginationTokenName(lowerName string) bool {

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -354,6 +354,52 @@ func TestAnalyzeTraffic_RedactsAuthSignals(t *testing.T) {
 	assert.Contains(t, authTypes(analysis.Auth.Candidates), "api_key")
 }
 
+func TestAnalyzeTraffic_DoesNotTreatSearchKeywordsAsAuthCandidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "plain keywords",
+			url:  "https://www.example.com/search?keywords=morgan",
+		},
+		{
+			name: "bracketed keywords",
+			url:  "https://www.example.com/search?keywords%5B%5D=morgan",
+		},
+		{
+			name: "compound search keywords",
+			url:  "https://www.example.com/search?search_keywords=morgan",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			capture := &EnrichedCapture{
+				TargetURL: "https://www.example.com",
+				Entries: []EnrichedEntry{
+					{
+						Method:              "GET",
+						URL:                 tc.url,
+						ResponseStatus:      200,
+						ResponseContentType: "application/json",
+						ResponseBody:        `{"results":[{"id":"1"}]}`,
+					},
+				},
+			}
+
+			analysis, err := AnalyzeTraffic(capture)
+			require.NoError(t, err)
+
+			assert.NotContains(t, authTypes(analysis.Auth.Candidates), "api_key")
+		})
+	}
+}
+
 func TestAnalyzeTraffic_DetectsProtocolProtectionAndWarningCategories(t *testing.T) {
 	t.Parallel()
 

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -25,6 +25,8 @@ type graphQLOperationGroup struct {
 	SamplePayload map[string]any
 }
 
+const authInferenceDistinctEndpointThreshold = 3
+
 func Analyze(capturePath string) (*spec.APISpec, error) {
 	capture, err := LoadCapture(capturePath)
 	if err != nil {
@@ -73,9 +75,16 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 		baseURL = normalizeBaseURL(capture.TargetURL)
 	}
 
+	nameSource := capture.TargetURL
+	if normalizeBaseURL(nameSource) == "" {
+		nameSource = baseURL
+	}
+	name := deriveNameFromURL(nameSource)
+	auth, authWarnings := detectAuthWithWarnings(capture, apiEntries, name)
+
 	groups := deduplicateSpecEndpoints(regularEntries, options)
 	for _, group := range groups {
-		endpoint := buildEndpoint(group)
+		endpoint := buildEndpoint(group, auth)
 		if options.PreserveHosts {
 			groupBaseURL := mostCommonBaseURL(group.Entries)
 			if groupBaseURL != "" && groupBaseURL != baseURL {
@@ -104,19 +113,14 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 		resources[resourceKey] = resource
 	}
 
-	nameSource := capture.TargetURL
-	if normalizeBaseURL(nameSource) == "" {
-		nameSource = baseURL
-	}
-	name := deriveNameFromURL(nameSource)
-
 	apiSpec := &spec.APISpec{
-		Name:        name,
-		Description: fmt.Sprintf("Discovered API spec for %s", name),
-		Version:     "0.1.0",
-		BaseURL:     baseURL,
-		SpecSource:  "sniffed",
-		Auth:        detectAuth(capture, apiEntries, name),
+		Name:         name,
+		Description:  fmt.Sprintf("Discovered API spec for %s", name),
+		Version:      "0.1.0",
+		BaseURL:      baseURL,
+		SpecSource:   "sniffed",
+		Auth:         auth,
+		AuthWarnings: authWarnings,
 		Config: spec.ConfigSpec{
 			Format: "toml",
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
@@ -133,7 +137,7 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 			}
 		}
 		if apiSpec.Auth.Type == "" {
-			apiSpec.Auth = spec.AuthConfig{Type: "none"}
+			apiSpec.Auth = spec.AuthConfig{Type: spec.TierAuthTypeNone}
 		}
 		if validateErr := apiSpec.Validate(); validateErr != nil {
 			return nil, fmt.Errorf("validating generated spec: %w", validateErr)
@@ -591,7 +595,7 @@ func DefaultCachePath(name string) string {
 	return filepath.Join(home, ".cache", "printing-press", "sniff", name+"-spec.yaml")
 }
 
-func buildEndpoint(group EndpointGroup) spec.Endpoint {
+func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) spec.Endpoint {
 	responseBodies := make([]string, 0, len(group.Entries))
 	for _, entry := range group.Entries {
 		if strings.TrimSpace(entry.ResponseBody) != "" {
@@ -602,8 +606,7 @@ func buildEndpoint(group EndpointGroup) spec.Endpoint {
 	responseFields := InferResponseSchema(responseBodies)
 	body := inferRequestBody(group.Entries, responseFields)
 	params := inferURLParams(group.Entries, group.NormalizedPath)
-	auth := detectAuth(nil, group.Entries, "")
-	if auth.Type == "api_key" && strings.EqualFold(auth.In, "query") && auth.Header != "" {
+	if auth.Type == spec.TierAuthTypeAPIKey && strings.EqualFold(auth.In, "query") && auth.Header != "" {
 		params = filterAuthQueryParam(params, auth.Header)
 	}
 
@@ -1026,6 +1029,11 @@ func inferURLParams(entries []EnrichedEntry, normalizedPath string) []spec.Param
 }
 
 func detectAuth(capture *EnrichedCapture, entries []EnrichedEntry, name string) spec.AuthConfig {
+	auth, _ := detectAuthWithWarnings(capture, entries, name)
+	return auth
+}
+
+func detectAuthWithWarnings(capture *EnrichedCapture, entries []EnrichedEntry, name string) (spec.AuthConfig, []string) {
 	envPrefix := strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 	auth0SPA := detectAuth0SPAInMemory(entries)
 	if capture != nil && capture.Auth != nil {
@@ -1035,12 +1043,18 @@ func detectAuth(capture *EnrichedCapture, entries []EnrichedEntry, name string) 
 			// gets the subtype annotation so the generator routes to the CDP
 			// extractor; other auth shapes (cookie, composed, api_key) are
 			// reached by their own extractor paths and don't need the hint.
-			if auth0SPA && auth.Type == "bearer_token" {
+			if auth0SPA && auth.Type == spec.TierAuthTypeBearerToken {
 				auth.Subtype = spec.AuthSubtypeAuth0SPAInMemory
 			}
-			return auth
+			return auth, nil
 		}
 	}
+
+	var bearerAuth spec.AuthConfig
+	var headerAPIKeyAuth spec.AuthConfig
+	var strongQueryAuth spec.AuthConfig
+	weakQueryNames := map[string]map[string]bool{}
+	rejectedWarnings := map[string]bool{}
 
 	for _, entry := range entries {
 		for headerName, value := range entry.RequestHeaders {
@@ -1048,20 +1062,24 @@ func detectAuth(capture *EnrichedCapture, entries []EnrichedEntry, name string) 
 			switch {
 			case strings.EqualFold(headerName, "Authorization") && strings.HasPrefix(strings.TrimSpace(value), "Bearer "):
 				auth := spec.AuthConfig{
-					Type:    "bearer_token",
+					Type:    spec.TierAuthTypeBearerToken,
 					Header:  "Authorization",
 					EnvVars: envVarsOrNil(envPrefix, "TOKEN"),
 				}
 				if auth0SPA {
 					auth.Subtype = spec.AuthSubtypeAuth0SPAInMemory
 				}
-				return auth
-			case strings.Contains(lowerHeader, "api-key") || strings.Contains(lowerHeader, "api_key"):
-				return spec.AuthConfig{
-					Type:    "api_key",
-					Header:  headerName,
-					In:      "header",
-					EnvVars: envVarsOrNil(envPrefix, "API_KEY"),
+				if bearerAuth.Type == "" {
+					bearerAuth = auth
+				}
+			case isStrongAuthHeaderName(lowerHeader):
+				if headerAPIKeyAuth.Type == "" {
+					headerAPIKeyAuth = spec.AuthConfig{
+						Type:    spec.TierAuthTypeAPIKey,
+						Header:  headerName,
+						In:      "header",
+						EnvVars: envVarsOrNil(envPrefix, "API_KEY"),
+					}
 				}
 			}
 		}
@@ -1070,20 +1088,136 @@ func detectAuth(capture *EnrichedCapture, entries []EnrichedEntry, name string) 
 		if err != nil {
 			continue
 		}
+		endpointKey := authInferenceEndpointKey(entry)
 		for key := range parsed.Query() {
-			lowerKey := strings.ToLower(key)
-			if strings.Contains(lowerKey, "key") || strings.Contains(lowerKey, "token") {
-				return spec.AuthConfig{
-					Type:    "api_key",
-					Header:  key,
-					In:      "query",
-					EnvVars: envVarsOrNil(envPrefix, "API_KEY"),
+			lowerKey := strings.ToLower(strings.TrimSpace(key))
+			switch {
+			case isPaginationTokenName(lowerKey):
+				rejectedWarnings[authWarning("query", key, "pagination token")] = true
+			case isSearchInputName(lowerKey):
+				rejectedWarnings[authWarning("query", key, "search input")] = true
+			case isStrongAuthQueryName(lowerKey):
+				if strongQueryAuth.Type == "" {
+					strongQueryAuth = spec.AuthConfig{
+						Type:    spec.TierAuthTypeAPIKey,
+						Header:  key,
+						In:      "query",
+						EnvVars: envVarsOrNil(envPrefix, "API_KEY"),
+					}
 				}
+			case isWeakAuthQueryName(lowerKey):
+				if weakQueryNames[key] == nil {
+					weakQueryNames[key] = map[string]bool{}
+				}
+				weakQueryNames[key][endpointKey] = true
+			}
+		}
+
+		for _, param := range InferRequestSchema(entry.RequestBody, getHeaderValue(entry.RequestHeaders, "Content-Type")) {
+			lowerName := strings.ToLower(strings.TrimSpace(param.Name))
+			switch {
+			case isPaginationTokenName(lowerName):
+				rejectedWarnings[authWarning("body", param.Name, "pagination token")] = true
+			case isSearchInputName(lowerName):
+				rejectedWarnings[authWarning("body", param.Name, "search input")] = true
+			case isWeakAuthQueryName(lowerName):
+				rejectedWarnings[authWarning("body", param.Name, "request body field")] = true
 			}
 		}
 	}
 
-	return spec.AuthConfig{Type: "none"}
+	if bearerAuth.Type != "" {
+		return bearerAuth, sortedBoolKeys(rejectedWarnings)
+	}
+	if headerAPIKeyAuth.Type != "" {
+		return headerAPIKeyAuth, sortedBoolKeys(rejectedWarnings)
+	}
+	if strongQueryAuth.Type != "" {
+		return strongQueryAuth, sortedBoolKeys(rejectedWarnings)
+	}
+
+	names := make([]string, 0, len(weakQueryNames))
+	for name := range weakQueryNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, key := range names {
+		endpoints := weakQueryNames[key]
+		if len(endpoints) >= authInferenceDistinctEndpointThreshold {
+			return spec.AuthConfig{
+				Type:    spec.TierAuthTypeAPIKey,
+				Header:  key,
+				In:      "query",
+				EnvVars: envVarsOrNil(envPrefix, "API_KEY"),
+			}, sortedBoolKeys(rejectedWarnings)
+		}
+		rejectedWarnings[authWarning("query", key, "seen on fewer than 3 distinct endpoints")] = true
+	}
+
+	return spec.AuthConfig{Type: spec.TierAuthTypeNone}, sortedBoolKeys(rejectedWarnings)
+}
+
+func isStrongAuthHeaderName(lowerName string) bool {
+	switch lowerName {
+	case "x-api-key", "x_api_key", "api-key", "api_key", "x-auth-token":
+		return true
+	default:
+		return strings.Contains(lowerName, "api-key") || strings.Contains(lowerName, "api_key")
+	}
+}
+
+func isStrongAuthQueryName(lowerName string) bool {
+	switch lowerName {
+	case "key", "api_key", "api-key", "apikey", "x-api-key", "x_api_key", "token", "access_token", "auth_token":
+		return true
+	default:
+		return false
+	}
+}
+
+func isWeakAuthQueryName(lowerName string) bool {
+	return strings.Contains(lowerName, "key") || strings.Contains(lowerName, "token") || strings.Contains(lowerName, "auth")
+}
+
+func isSearchInputName(lowerName string) bool {
+	for _, token := range authCandidateNameTokens(lowerName) {
+		switch token {
+		case "keywords", "keyword", "query", "q", "search", "term", "text", "filter", "sort", "page", "limit", "offset":
+			return true
+		}
+	}
+	return false
+}
+
+func authInferenceEndpointKey(entry EnrichedEntry) string {
+	return strings.ToUpper(strings.TrimSpace(entry.Method)) + " " + normalizeEntryPath(entry.URL)
+}
+
+func authWarning(location string, name string, reason string) string {
+	return fmt.Sprintf("rejected auth candidate %q from %s: %s", name, location, reason)
+}
+
+func authCandidateNameTokens(name string) []string {
+	normalized := strings.NewReplacer(
+		"[", "_",
+		"]", "_",
+		"-", "_",
+		".", "_",
+		" ", "_",
+	).Replace(strings.ToLower(strings.TrimSpace(name)))
+	parts := strings.FieldsFunc(normalized, func(r rune) bool {
+		return r == '_'
+	})
+	tokens := make([]string, 0, len(parts)+1)
+	for _, part := range parts {
+		if part != "" {
+			tokens = append(tokens, part)
+		}
+	}
+	if normalized != "" {
+		tokens = append(tokens, normalized)
+	}
+	return tokens
 }
 
 // observedAuthHeaders returns the sorted set of lowercased request header
@@ -1136,7 +1270,7 @@ func detectCapturedAuth(capture *AuthCapture, envPrefix string) spec.AuthConfig 
 		switch captureType {
 		case "bearer":
 			return spec.AuthConfig{
-				Type:    "bearer_token",
+				Type:    spec.TierAuthTypeBearerToken,
 				Header:  "Authorization",
 				EnvVars: envVarsOrNil(envPrefix, "TOKEN"),
 			}
@@ -1146,7 +1280,7 @@ func detectCapturedAuth(capture *AuthCapture, envPrefix string) spec.AuthConfig 
 				headerName = "X-API-Key"
 			}
 			return spec.AuthConfig{
-				Type:    "api_key",
+				Type:    spec.TierAuthTypeAPIKey,
 				Header:  headerName,
 				In:      "header",
 				EnvVars: envVarsOrNil(envPrefix, "API_KEY"),

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -67,6 +67,7 @@ func TestWriteSpec(t *testing.T) {
 		},
 		Types: map[string]spec.TypeDef{},
 	}
+	apiSpec.AuthWarnings = []string{`rejected auth candidate "keywords" from body: search input`}
 
 	outputPath := filepath.Join(t.TempDir(), "nested", "spec.yaml")
 	err := WriteSpec(apiSpec, outputPath)
@@ -74,11 +75,13 @@ func TestWriteSpec(t *testing.T) {
 
 	data, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
+	assert.Contains(t, string(data), "auth_warnings:")
 
 	parsed, err := spec.ParseBytes(data)
 	require.NoError(t, err)
 	assert.Equal(t, apiSpec.Name, parsed.Name)
 	assert.Equal(t, apiSpec.BaseURL, parsed.BaseURL)
+	assert.Equal(t, apiSpec.AuthWarnings, parsed.AuthWarnings)
 }
 
 func TestDeriveNameFromURL(t *testing.T) {
@@ -651,6 +654,197 @@ func TestDetectAuth_FallsBackToHeaderInference(t *testing.T) {
 
 	assert.Equal(t, "bearer_token", auth.Type)
 	assert.Equal(t, "Authorization", auth.Header)
+}
+
+func TestDetectAuth_FallsBackToAPIKeyHeaderInference(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{
+			Method:         "GET",
+			URL:            "https://www.example.com/v1/users",
+			RequestHeaders: map[string]string{"X-API-Key": "key-123"},
+		},
+		{
+			Method:         "GET",
+			URL:            "https://www.example.com/v1/orders",
+			RequestHeaders: map[string]string{"X-API-Key": "key-123"},
+		},
+		{
+			Method:         "GET",
+			URL:            "https://www.example.com/v1/invoices",
+			RequestHeaders: map[string]string{"X-API-Key": "key-123"},
+		},
+	}, "billing")
+
+	assert.Equal(t, "api_key", auth.Type)
+	assert.Equal(t, "X-API-Key", auth.Header)
+	assert.Equal(t, "header", auth.In)
+}
+
+func TestDetectAuth_DoesNotInferSearchKeywordsAsAPIKey(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{
+			Method: "POST",
+			URL:    "https://www.example.com/resources/services/metadata/coin-explorer-listing/?keywords=morgan",
+			RequestHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			RequestBody: `{"keywords":"morgan"}`,
+		},
+	}, "ngccoin")
+
+	assert.Equal(t, "none", auth.Type)
+}
+
+func TestDetectAuth_DoesNotCorroborateCompoundSearchKeywordsAsAPIKey(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{
+			Method: "GET",
+			URL:    "https://www.example.com/v1/coins?search_keywords=morgan",
+		},
+		{
+			Method: "GET",
+			URL:    "https://www.example.com/v1/notes?search_keywords=morgan",
+		},
+		{
+			Method: "GET",
+			URL:    "https://www.example.com/v1/sets?search_keywords=morgan",
+		},
+	}, "ngccoin")
+
+	assert.Equal(t, "none", auth.Type)
+}
+
+func TestDetectAuth_DoesNotInferBracketedSearchKeywordsAsAPIKey(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{
+			Method: "GET",
+			URL:    "https://www.example.com/v1/coins?keywords%5B%5D=morgan",
+		},
+	}, "ngccoin")
+
+	assert.Equal(t, "none", auth.Type)
+}
+
+func TestAnalyzeCapture_ReportsRejectedSearchAuthCandidates(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "POST",
+				URL:                 "https://www.example.com/resources/services/metadata/coin-explorer-listing/",
+				RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+				RequestBody:         `{"keywords":"morgan"}`,
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"coins":[{"id":"1","name":"Morgan Dollar"}]}`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", apiSpec.Auth.Type)
+	require.Len(t, apiSpec.AuthWarnings, 1)
+	assert.Contains(t, apiSpec.AuthWarnings[0], `auth candidate "keywords"`)
+	assert.Contains(t, apiSpec.AuthWarnings[0], "body")
+	assert.Contains(t, apiSpec.AuthWarnings[0], "search input")
+}
+
+func TestDetectAuth_CorroboratesWeakQueryAuthAcrossDistinctEndpoints(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{Method: "GET", URL: "https://www.example.com/v1/users?session_token=tok"},
+		{Method: "GET", URL: "https://www.example.com/v1/orders?session_token=tok"},
+		{Method: "GET", URL: "https://www.example.com/v1/invoices?session_token=tok"},
+	}, "billing")
+
+	assert.Equal(t, "api_key", auth.Type)
+	assert.Equal(t, "session_token", auth.Header)
+	assert.Equal(t, "query", auth.In)
+}
+
+func TestAnalyzeCapture_FiltersCorroboratedWeakQueryAuthFromEndpointParams(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://www.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://www.example.com/v1/users?session_token=tok&limit=10",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"users":[{"id":"1"}]}`,
+				Classification:      "api",
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://www.example.com/v1/orders?session_token=tok",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"orders":[{"id":"1"}]}`,
+				Classification:      "api",
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://www.example.com/v1/invoices?session_token=tok",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"invoices":[{"id":"1"}]}`,
+				Classification:      "api",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", apiSpec.Auth.Type)
+	assert.Equal(t, "query", apiSpec.Auth.In)
+	assert.Equal(t, "session_token", apiSpec.Auth.Header)
+
+	for _, resource := range apiSpec.Resources {
+		for _, endpoint := range resource.Endpoints {
+			assert.Nil(t, findBodyParam(endpoint.Params, "session_token"))
+		}
+	}
+}
+
+func TestDetectAuth_DoesNotInferWeakQueryAuthFromSingleEndpoint(t *testing.T) {
+	t.Parallel()
+
+	auth := detectAuth(nil, []EnrichedEntry{
+		{Method: "GET", URL: "https://www.example.com/v1/users?session_token=tok"},
+	}, "billing")
+
+	assert.Equal(t, "none", auth.Type)
+}
+
+func TestDetectAuth_WarnsPaginationBeforeSearchInputs(t *testing.T) {
+	t.Parallel()
+
+	auth, warnings := detectAuthWithWarnings(nil, []EnrichedEntry{
+		{
+			Method:         "POST",
+			URL:            "https://www.example.com/v1/search?page_token=abc",
+			RequestHeaders: map[string]string{"Content-Type": "application/json"},
+			RequestBody:    `{"next_page_token":"def"}`,
+		},
+	}, "example")
+
+	assert.Equal(t, "none", auth.Type)
+	assert.Contains(t, warnings, authWarning("query", "page_token", "pagination token"))
+	assert.Contains(t, warnings, authWarning("body", "next_page_token", "pagination token"))
+	assert.NotContains(t, warnings, authWarning("query", "page_token", "search input"))
+	assert.NotContains(t, warnings, authWarning("body", "next_page_token", "search input"))
 }
 
 func TestObservedAuthHeaders(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -184,6 +184,7 @@ type APISpec struct {
 	WebsiteURL                  string              `yaml:"website_url,omitempty" json:"website_url,omitempty"`      // product/company website (not the API base URL)
 	Category                    string              `yaml:"category,omitempty" json:"category,omitempty"`            // catalog category (e.g., productivity, developer-tools) — used for library install path
 	Auth                        AuthConfig          `yaml:"auth" json:"auth"`
+	AuthWarnings                []string            `yaml:"auth_warnings,omitempty" json:"auth_warnings,omitempty"`
 	TierRouting                 TierRoutingConfig   `yaml:"tier_routing,omitempty" json:"tier_routing,omitzero"`
 	RequiredHeaders             []RequiredHeader    `yaml:"required_headers,omitempty" json:"required_headers,omitempty"`
 	Config                      ConfigSpec          `yaml:"config" json:"config"`

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -24,6 +24,7 @@ auth:                             # object (AuthConfig)
     - EXAMPLE_API_TOKEN
   scheme: bearerAuth              # string optional OpenAPI security scheme name
   in: header                      # string optional: header | query | cookie
+auth_warnings:                    # []string optional sniffed-auth rejection notes
 
 config:                           # object (ConfigSpec)
   format: toml                    # string config format: toml | yaml (other values fall back to json tags)


### PR DESCRIPTION
## Summary

Browser-sniffed public search traffic no longer turns ordinary search fields like `keywords`, `keywords[]`, or `search_keywords` into required API-key auth. Sniffed specs now stay `auth.type: none` for search-only captures while preserving strong auth evidence such as bearer headers, API-key headers, and explicit API-key query names.

Rejected auth-shaped search, pagination, and weak one-off candidates are surfaced in `auth_warnings` so agents can inspect why the sniffer declined an auth inference instead of silently losing that context.

Closes #1900

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/browsersniff ./internal/spec -count=1`
- `go test ./internal/pipeline -run 'TestLiveCheck_FailOnIrrelevantOutput|TestLiveCheck_FailOnExitError' -count=1 -v`
- `go test ./internal/pipeline -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
