### PR TITLE
fix(cli): preserve windows exe names in mcpb bundles

### DIFF
--- a/docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md
+++ b/docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md
@@ -1,6 +1,7 @@
 ---
-title: "Windows MCPB companion CLIs need target executable names"
+title: "Windows MCPB bundled executables need target executable names"
 date: 2026-05-23
+last_updated: 2026-05-24
 category: logic-errors
 module: internal/generator/templates/cobratree
 problem_type: logic_error
@@ -12,6 +13,7 @@ symptoms:
   - "Windows MCPB-bundled cobratree shell-out tools reported companion CLI binary not found."
   - "Generated SiblingCLIPath searched for the unsuffixed CLI name even though Windows bundle binaries use .exe."
   - "A template-only fix could still miss the bundled sibling when bundle staging archived the companion under the raw logical name."
+  - "Windows MCPB server bundles could zip and launch the MCP server under an unsuffixed path even when the target platform was Windows."
 root_cause: logic_error
 resolution_type: code_fix
 severity: high
@@ -21,45 +23,51 @@ tags:
   - cobratree
   - executable-names
   - companion-cli
+  - manifest
 ---
 
-# Windows MCPB companion CLIs need target executable names
+# Windows MCPB bundled executables need target executable names
 
 ## Problem
 
-Printed CLI MCP servers shell out to their companion CLI for cobratree-mirrored tools. On Windows MCPB installs, the companion binary must be found as a sibling executable with a `.exe` suffix, or every runtime-mirrored tool fails before it can call the CLI.
+Printed CLI MCPB bundles contain executable binaries that the host launches directly. On Windows MCPB installs, both the MCP server and any companion CLI must be archived and referenced with a `.exe` suffix, or the installed bundle cannot launch the server or mirrored CLI tools.
 
 ## Symptoms
 
 - MCPB-bundled Windows installs failed cobratree shell-out tools with `companion CLI binary not found`.
 - The generated `internal/mcp/cobratree/cli_path.go` built the sibling candidate from the logical CLI name without the Windows suffix.
 - A partial fix in the template was insufficient unless `cli-printing-press bundle` also staged and zipped the companion CLI under the same target executable name.
+- `cli-printing-press bundle --platform windows/<arch>` could package the MCP server as `bin/<api>-pp-mcp` and leave `manifest.json` pointing at the unsuffixed path even when prebuilt inputs were `.exe` files.
 
 ## What Didn't Work
 
 - Patching a generated printed CLI was not durable because `internal/mcp/cobratree/` is generator-owned and overwritten on regen.
 - Updating only `SiblingCLIPath` left a second mismatch: cross-compilation uses the exact `go build -o` path, so the bundle code also has to choose a target-GOOS output and archive name for the companion CLI.
 - Storing the companion CLI path in `manifest.json` is not the right escape hatch. MCPB v0.3 hosts reject unknown manifest keys, so the manifest stays schema-clean and the runtime keeps sibling, env-var, and PATH resolution.
+- Updating the MCP server path by unmarshaling into the typed manifest struct and marshaling it back would silently drop hand-edited MCPB fields that the generator does not model. Bundle-time manifest patching must preserve unknown JSON fields.
 
 ## Solution
 
 Keep logical binary names platform-agnostic, and resolve filesystem/archive executable names at the target boundary:
 
 - Generated `SiblingCLIPath` calls a small `cliExecutableName(runtime.GOOS)` helper so Windows searches for `<api>-pp-cli.exe`, while Linux and macOS keep `<api>-pp-cli`.
-- `cli-printing-press bundle` uses `internal/platform.ExecutablePathForGOOS` when choosing the companion CLI staging path and zip entry for the bundle target platform.
+- `cli-printing-press bundle` uses `internal/platform.ExecutablePathForGOOS` when choosing MCP server and companion CLI staging paths and zip entries for the bundle target platform.
+- The bundle ZIP's `manifest.json` is patched so `server.entry_point` and `server.mcp_config.command` point at the target executable name when it differs from the source manifest.
 - The bundle still passes the raw logical CLI name to `go build` as the package name, and keeps MCPB `manifest.json` free of companion-CLI metadata.
+- Bundle-time manifest patching operates on generic JSON and only changes the launch fields, so unknown top-level, server-level, and launch-level MCPB fields survive.
 
 ## Why This Works
 
-The runtime resolver and the bundle archive now agree on the same target-specific filename. A Windows MCPB bundle contains `bin/<api>-pp-cli.exe`, and the generated MCP server looks for the same sibling before falling back to `<API>_CLI_PATH` or `PATH`.
+The MCPB manifest, ZIP entries, and runtime resolver now agree on the same target-specific filenames. A Windows MCPB bundle contains `bin/<api>-pp-mcp.exe` and, when a companion CLI is present, `bin/<api>-pp-cli.exe`; the manifest launches the suffixed MCP server, and the generated MCP server looks for the suffixed companion before falling back to `<API>_CLI_PATH` or `PATH`.
 
-Separating logical names from executable paths also avoids leaking platform suffixes into package names, manifest identity, or generated command names.
+Separating logical names from executable paths also avoids leaking platform suffixes into package names, manifest identity, generated command names, or non-Windows bundle layouts.
 
 ## Prevention
 
 - For Windows target builds, route filesystem executable paths through `internal/platform.ExecutablePathForGOOS` or an emitted equivalent when generated code cannot import the generator package.
-- When changing cobratree runtime resolution, check bundle staging and archive names in the same pass. The generated resolver and MCPB package layout are one contract.
-- Add tests at both layers: generated cobratree helpers should simulate Windows and non-Windows GOOS values, and bundle tests should assert the companion CLI zip entry uses the target executable name.
+- When changing MCPB runtime resolution, check bundle staging, archive names, and manifest launch fields in the same pass. The generated resolver, bundle manifest, and ZIP package layout are one contract.
+- Add tests at both layers: generated cobratree helpers should simulate Windows and non-Windows GOOS values, and bundle tests should assert MCP server and companion CLI zip entries plus manifest launch fields use the target executable name.
+- When patching MCPB manifests at bundle time, preserve unknown JSON fields so hand-edited upstream MCPB schema extensions are not lost.
 
 ## Related
 

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -80,13 +80,14 @@ from another build pipeline.`,
 				return &ExitError{Code: ExitInputError, Err: err}
 			}
 
+			mcpArchiveName := bundleBinaryArchiveName(manifest.Name, goos)
 			if binaryPath == "" {
-				binaryPath = pipeline.StagedMCPBinaryPath(cliDir, manifest.Name)
+				binaryPath = bundleBinaryPath(cliDir, manifest.Name, goos)
 			}
 			cliName := pipeline.ReadCLIBinaryName(cliDir)
-			cliArchiveName := bundleCLIBinaryArchiveName(cliName, goos)
+			cliArchiveName := bundleBinaryArchiveName(cliName, goos)
 			if cliBinaryPath == "" && cliName != "" {
-				cliBinaryPath = bundleCLIBinaryPath(cliDir, cliName, goos)
+				cliBinaryPath = bundleBinaryPath(cliDir, cliName, goos)
 			}
 			if err := buildBundleBinaries(cliDir, manifest.Name, binaryPath, skipBuild, cliName, cliBinaryPath, cliSkipBuild, goos, goarch); err != nil {
 				return err
@@ -99,6 +100,7 @@ from another build pipeline.`,
 			if err := pipeline.BuildMCPBBundle(pipeline.BundleParams{
 				CLIDir:        cliDir,
 				BinaryPath:    binaryPath,
+				BinaryName:    mcpArchiveName,
 				CLIBinaryName: cliArchiveName,
 				CLIBinaryPath: cliBinaryPath,
 				OutputPath:    output,
@@ -156,12 +158,13 @@ func autoBundleForHost(cliDir string, w io.Writer) {
 	if _, err := os.Stat(filepath.Join(cliDir, "go.sum")); err != nil {
 		return
 	}
-	binaryPath := pipeline.StagedMCPBinaryPath(cliDir, manifest.Name)
+	binaryPath := bundleBinaryPath(cliDir, manifest.Name, runtime.GOOS)
+	mcpArchiveName := bundleBinaryArchiveName(manifest.Name, runtime.GOOS)
 	cliName := pipeline.ReadCLIBinaryName(cliDir)
-	cliArchiveName := bundleCLIBinaryArchiveName(cliName, runtime.GOOS)
+	cliArchiveName := bundleBinaryArchiveName(cliName, runtime.GOOS)
 	cliBinaryPath := ""
 	if cliName != "" {
-		cliBinaryPath = bundleCLIBinaryPath(cliDir, cliName, runtime.GOOS)
+		cliBinaryPath = bundleBinaryPath(cliDir, cliName, runtime.GOOS)
 	}
 	if err := buildBundleBinaries(cliDir, manifest.Name, binaryPath, false, cliName, cliBinaryPath, false, runtime.GOOS, runtime.GOARCH); err != nil {
 		fmt.Fprintf(w, "warning: %v\n", err)
@@ -171,6 +174,7 @@ func autoBundleForHost(cliDir string, w io.Writer) {
 	if err := pipeline.BuildMCPBBundle(pipeline.BundleParams{
 		CLIDir:        cliDir,
 		BinaryPath:    binaryPath,
+		BinaryName:    mcpArchiveName,
 		CLIBinaryName: cliArchiveName,
 		CLIBinaryPath: cliBinaryPath,
 		OutputPath:    output,
@@ -206,18 +210,18 @@ func buildBundleBinaries(cliDir, mcpName, mcpPath string, skipMCP bool, cliName,
 	return g.Wait()
 }
 
-func bundleCLIBinaryPath(cliDir, cliName, goos string) string {
-	if cliName == "" {
+func bundleBinaryPath(cliDir, name, goos string) string {
+	if name == "" {
 		return ""
 	}
-	return pipeline.StagedMCPBinaryPath(cliDir, bundleCLIBinaryArchiveName(cliName, goos))
+	return pipeline.StagedMCPBinaryPath(cliDir, bundleBinaryArchiveName(name, goos))
 }
 
-func bundleCLIBinaryArchiveName(cliName, goos string) string {
-	if cliName == "" {
+func bundleBinaryArchiveName(name, goos string) string {
+	if name == "" {
 		return ""
 	}
-	return platform.ExecutablePathForGOOS(cliName, goos)
+	return platform.ExecutablePathForGOOS(name, goos)
 }
 
 // resolvePlatform parses an optional "<os>/<arch>" string and falls back

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"os"
@@ -43,22 +44,22 @@ func TestResolvePlatform(t *testing.T) {
 	})
 }
 
-func TestBundleCLIBinaryTargetPathUsesWindowsExecutableSuffix(t *testing.T) {
+func TestBundleBinaryTargetPathUsesWindowsExecutableSuffix(t *testing.T) {
 	t.Parallel()
 
 	dir := filepath.Join("tmp", "demo")
 	assert.Equal(t,
 		filepath.Join("tmp", "demo", "build", "stage", "bin", "demo-pp-cli.exe"),
-		bundleCLIBinaryPath(dir, "demo-pp-cli", "windows"),
+		bundleBinaryPath(dir, "demo-pp-cli", "windows"),
 	)
 	assert.Equal(t,
 		filepath.Join("tmp", "demo", "build", "stage", "bin", "demo-pp-cli"),
-		bundleCLIBinaryPath(dir, "demo-pp-cli", "linux"),
+		bundleBinaryPath(dir, "demo-pp-cli", "linux"),
 	)
-	assert.Equal(t, "demo-pp-cli.exe", bundleCLIBinaryArchiveName("demo-pp-cli", "windows"))
-	assert.Equal(t, "demo-pp-cli", bundleCLIBinaryArchiveName("demo-pp-cli", "darwin"))
-	assert.Empty(t, bundleCLIBinaryPath(dir, "", "windows"))
-	assert.Empty(t, bundleCLIBinaryArchiveName("", "windows"))
+	assert.Equal(t, "demo-pp-cli.exe", bundleBinaryArchiveName("demo-pp-cli", "windows"))
+	assert.Equal(t, "demo-pp-cli", bundleBinaryArchiveName("demo-pp-cli", "darwin"))
+	assert.Empty(t, bundleBinaryPath(dir, "", "windows"))
+	assert.Empty(t, bundleBinaryArchiveName("", "windows"))
 }
 
 func TestAutoBundleForHost(t *testing.T) {
@@ -108,11 +109,196 @@ func TestAutoBundleForHost(t *testing.T) {
 	})
 }
 
+func TestNewBundleCmdWindowsPlatformUsesExeNamesInMCPB(t *testing.T) {
+	dir := t.TempDir()
+	writeBundleManifest(t, dir, pipeline.MCPBManifest{
+		ManifestVersion: pipeline.MCPBManifestVersion,
+		Name:            "demo-pp-mcp",
+		Server: pipeline.MCPBServer{
+			Type:       "binary",
+			EntryPoint: "bin/demo-pp-mcp",
+			MCPConfig:  pipeline.MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+		},
+	})
+	writeCLIManifest(t, dir, pipeline.CLIManifest{CLIName: "demo-pp-cli"})
+
+	mcpBinary := filepath.Join(dir, "mcp.exe")
+	cliBinary := filepath.Join(dir, "cli.exe")
+	outPath := filepath.Join(dir, "out.mcpb")
+	require.NoError(t, os.WriteFile(mcpBinary, []byte("mcp"), 0o755))
+	require.NoError(t, os.WriteFile(cliBinary, []byte("cli"), 0o755))
+
+	cmd := newBundleCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{
+		dir,
+		"--platform", "windows/amd64",
+		"--skip-build",
+		"--binary", mcpBinary,
+		"--cli-skip-build",
+		"--cli-binary", cliBinary,
+		"--output", outPath,
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	entries := readBundleZipEntries(t, outPath)
+	assert.Contains(t, entries, "bin/demo-pp-mcp.exe")
+	assert.Contains(t, entries, "bin/demo-pp-cli.exe")
+	assert.NotContains(t, entries, "bin/demo-pp-mcp")
+	assert.NotContains(t, entries, "bin/demo-pp-cli")
+
+	manifest := readBundleZipManifest(t, outPath)
+	assert.Equal(t, "bin/demo-pp-mcp.exe", manifest.Server.EntryPoint)
+	assert.Equal(t, "${__dirname}/bin/demo-pp-mcp.exe", manifest.Server.MCPConfig.Command)
+}
+
+func TestNewBundleCmdWindowsPlatformBuildsToExeStagingPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake go shim uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	writeBundleManifest(t, dir, pipeline.MCPBManifest{
+		ManifestVersion: pipeline.MCPBManifestVersion,
+		Name:            "demo-pp-mcp",
+		Server: pipeline.MCPBServer{
+			Type:       "binary",
+			EntryPoint: "bin/demo-pp-mcp",
+			MCPConfig:  pipeline.MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+		},
+	})
+	writeCLIManifest(t, dir, pipeline.CLIManifest{CLIName: "demo-pp-cli"})
+	installFakeGo(t)
+
+	outPath := filepath.Join(dir, "out.mcpb")
+	cmd := newBundleCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{
+		dir,
+		"--platform", "windows/amd64",
+		"--output", outPath,
+	})
+
+	require.NoError(t, cmd.Execute())
+	require.FileExists(t, filepath.Join(dir, "build", "stage", "bin", "demo-pp-mcp.exe"))
+	require.FileExists(t, filepath.Join(dir, "build", "stage", "bin", "demo-pp-cli.exe"))
+
+	entries := readBundleZipEntries(t, outPath)
+	assert.Contains(t, entries, "bin/demo-pp-mcp.exe")
+	assert.Contains(t, entries, "bin/demo-pp-cli.exe")
+}
+
+func TestAutoBundleForHostSuccessPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake go shim uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	writeBundleManifest(t, dir, pipeline.MCPBManifest{
+		ManifestVersion: pipeline.MCPBManifestVersion,
+		Name:            "demo-pp-mcp",
+		Server: pipeline.MCPBServer{
+			Type:       "binary",
+			EntryPoint: "bin/demo-pp-mcp",
+			MCPConfig:  pipeline.MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+		},
+	})
+	writeCLIManifest(t, dir, pipeline.CLIManifest{CLIName: "demo-pp-cli"})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.sum"), []byte(""), 0o644))
+	installFakeGo(t)
+
+	var out bytes.Buffer
+	autoBundleForHost(dir, &out)
+
+	archiveName := bundleBinaryArchiveName("demo-pp-mcp", runtime.GOOS)
+	outPath := pipeline.DefaultBundleOutputPath(dir, "demo-pp-mcp", runtime.GOOS, runtime.GOARCH)
+	assert.Contains(t, out.String(), "Bundled "+outPath)
+	require.FileExists(t, filepath.Join(dir, "build", "stage", "bin", archiveName))
+
+	entries := readBundleZipEntries(t, outPath)
+	assert.Contains(t, entries, "bin/"+archiveName)
+	manifest := readBundleZipManifest(t, outPath)
+	assert.Equal(t, "bin/"+archiveName, manifest.Server.EntryPoint)
+	assert.Equal(t, "${__dirname}/bin/"+archiveName, manifest.Server.MCPConfig.Command)
+}
+
 func writeBundleManifest(t *testing.T, dir string, m pipeline.MCPBManifest) {
 	t.Helper()
 	data, err := json.Marshal(m)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.MCPBManifestFilename), data, 0o644))
+}
+
+func writeCLIManifest(t *testing.T, dir string, m pipeline.CLIManifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.CLIManifestFilename), data, 0o644))
+}
+
+func readBundleZipEntries(t *testing.T, path string) []string {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = zr.Close() })
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func readBundleZipManifest(t *testing.T, path string) pipeline.MCPBManifest {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = zr.Close() })
+	for _, f := range zr.File {
+		if f.Name != pipeline.MCPBManifestFilename {
+			continue
+		}
+		rc, err := f.Open()
+		require.NoError(t, err)
+		defer func() { _ = rc.Close() }()
+		var manifest pipeline.MCPBManifest
+		require.NoError(t, json.NewDecoder(rc).Decode(&manifest))
+		return manifest
+	}
+	t.Fatalf("%s not found in %s", pipeline.MCPBManifestFilename, path)
+	return pipeline.MCPBManifest{}
+}
+
+func installFakeGo(t *testing.T) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	fakeGo := filepath.Join(fakeBin, "go")
+	script := `#!/bin/sh
+set -eu
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+if [ -z "$out" ]; then
+  echo "missing -o" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$out")"
+printf 'fake binary' > "$out"
+chmod 755 "$out"
+`
+	require.NoError(t, os.WriteFile(fakeGo, []byte(script), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestNewBundleCmdMissingManifest(t *testing.T) {

--- a/internal/pipeline/mcpb_bundle.go
+++ b/internal/pipeline/mcpb_bundle.go
@@ -14,9 +14,11 @@ import (
 
 // BundleParams describes one MCPB bundle build. CLIDir must contain a
 // manifest.json (emitted by WriteMCPBManifest) and a built MCP binary at
-// BinaryPath. OutputPath is where the .mcpb file will be written; the
-// caller is responsible for choosing a path that includes platform
-// information so multi-platform builds don't overwrite each other.
+// BinaryPath. BinaryName optionally names the MCP binary inside the zip;
+// when empty, the manifest's server.entry_point is used as-is. OutputPath
+// is where the .mcpb file will be written; the caller is responsible for
+// choosing a path that includes platform information so multi-platform
+// builds don't overwrite each other.
 //
 // CLIBinaryPath is optional — when set, the bundle includes a second
 // binary at `bin/<CLIBinaryName>` so the MCP server can shell out to its
@@ -29,6 +31,7 @@ import (
 type BundleParams struct {
 	CLIDir        string
 	BinaryPath    string
+	BinaryName    string
 	CLIBinaryName string
 	CLIBinaryPath string
 	OutputPath    string
@@ -58,6 +61,16 @@ func BuildMCPBBundle(params BundleParams) error {
 	}
 	if manifest.Server.EntryPoint == "" {
 		return errors.New("manifest server.entry_point is empty")
+	}
+	if params.BinaryName != "" {
+		entryPoint := "bin/" + params.BinaryName
+		if entryPoint != manifest.Server.EntryPoint {
+			manifest.Server.EntryPoint = entryPoint
+			manifestData, err = rewriteMCPBManifestLaunch(manifestData, entryPoint)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(params.OutputPath), 0o755); err != nil {
@@ -92,6 +105,33 @@ func BuildMCPBBundle(params BundleParams) error {
 		return fmt.Errorf("finalizing bundle archive: %w", err)
 	}
 	return nil
+}
+
+func rewriteMCPBManifestLaunch(data []byte, entryPoint string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing manifest document: %w", err)
+	}
+	server, ok := doc["server"].(map[string]any)
+	if !ok {
+		return nil, errors.New("manifest server must be an object")
+	}
+	server["entry_point"] = entryPoint
+	mcpConfig, ok := server["mcp_config"].(map[string]any)
+	if !ok {
+		mcpConfig = map[string]any{}
+		server["mcp_config"] = mcpConfig
+	}
+	mcpConfig["command"] = "${__dirname}/" + entryPoint
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("marshaling manifest document: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 // zipFile streams srcPath into the zip at name, preserving exec bits.

--- a/internal/pipeline/mcpb_bundle_test.go
+++ b/internal/pipeline/mcpb_bundle_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"archive/zip"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,6 +84,77 @@ func TestBuildMCPBBundle(t *testing.T) {
 
 		entries := readZipEntries(t, out)
 		assert.Contains(t, entries, "bin/demo-pp-cli.exe")
+	})
+
+	t.Run("uses provided MCP archive name in ZIP and bundled manifest", func(t *testing.T) {
+		dir := t.TempDir()
+
+		mData := []byte(`{
+  "manifest_version": "0.3",
+  "name": "demo-pp-mcp",
+  "server": {
+    "type": "binary",
+    "entry_point": "bin/demo-pp-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/bin/demo-pp-mcp",
+      "custom_launch_field": "preserve-me"
+    },
+    "custom_server_field": {"nested": true}
+  },
+  "custom_top_level_field": ["preserve-me"]
+}`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), mData, 0o644))
+
+		mcpPath := filepath.Join(dir, "fake-mcp.exe")
+		require.NoError(t, os.WriteFile(mcpPath, []byte("mcp"), 0o755))
+
+		out := filepath.Join(dir, "demo.mcpb")
+		err := BuildMCPBBundle(BundleParams{
+			CLIDir:     dir,
+			BinaryPath: mcpPath,
+			BinaryName: "demo-pp-mcp.exe",
+			OutputPath: out,
+		})
+		require.NoError(t, err)
+
+		entries := readZipEntries(t, out)
+		assert.Contains(t, entries, "bin/demo-pp-mcp.exe")
+		assert.NotContains(t, entries, "bin/demo-pp-mcp")
+
+		bundledManifest := readZipManifest(t, out)
+		assert.Equal(t, "bin/demo-pp-mcp.exe", bundledManifest.Server.EntryPoint)
+		assert.Equal(t, "${__dirname}/bin/demo-pp-mcp.exe", bundledManifest.Server.MCPConfig.Command)
+		bundledDoc := readZipJSONMap(t, out, MCPBManifestFilename)
+		server := bundledDoc["server"].(map[string]any)
+		mcpConfig := server["mcp_config"].(map[string]any)
+		assert.Equal(t, []any{"preserve-me"}, bundledDoc["custom_top_level_field"])
+		assert.Equal(t, map[string]any{"nested": true}, server["custom_server_field"])
+		assert.Equal(t, "preserve-me", mcpConfig["custom_launch_field"])
+
+		diskManifest := readManifestFile(t, filepath.Join(dir, MCPBManifestFilename))
+		assert.Equal(t, "bin/demo-pp-mcp", diskManifest.Server.EntryPoint)
+		assert.Equal(t, "${__dirname}/bin/demo-pp-mcp", diskManifest.Server.MCPConfig.Command)
+	})
+
+	t.Run("keeps original manifest bytes when MCP archive name is unchanged", func(t *testing.T) {
+		dir := t.TempDir()
+
+		mData := []byte(`{"manifest_version":"0.3","name":"demo-pp-mcp","server":{"type":"binary","entry_point":"bin/demo-pp-mcp","mcp_config":{"command":"${__dirname}/bin/demo-pp-mcp","custom_launch_field":"preserve-me"}},"custom_top_level_field":["preserve-me"]}`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), mData, 0o644))
+
+		mcpPath := filepath.Join(dir, "fake-mcp")
+		require.NoError(t, os.WriteFile(mcpPath, []byte("mcp"), 0o755))
+
+		out := filepath.Join(dir, "demo.mcpb")
+		err := BuildMCPBBundle(BundleParams{
+			CLIDir:     dir,
+			BinaryPath: mcpPath,
+			BinaryName: "demo-pp-mcp",
+			OutputPath: out,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, mData, readZipEntryBytes(t, out, MCPBManifestFilename))
 	})
 
 	t.Run("missing manifest skips silently", func(t *testing.T) {
@@ -179,4 +251,73 @@ func readZipEntryMode(t *testing.T, path, entry string) os.FileMode {
 	}
 	t.Fatalf("entry %q not found in %s", entry, path)
 	return 0
+}
+
+func readZipManifest(t *testing.T, path string) MCPBManifest {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = zr.Close() })
+	for _, f := range zr.File {
+		if f.Name != MCPBManifestFilename {
+			continue
+		}
+		rc, err := f.Open()
+		require.NoError(t, err)
+		defer func() { _ = rc.Close() }()
+		var manifest MCPBManifest
+		require.NoError(t, json.NewDecoder(rc).Decode(&manifest))
+		return manifest
+	}
+	t.Fatalf("%s not found in %s", MCPBManifestFilename, path)
+	return MCPBManifest{}
+}
+
+func readManifestFile(t *testing.T, path string) MCPBManifest {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var manifest MCPBManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	return manifest
+}
+
+func readZipJSONMap(t *testing.T, path, entry string) map[string]any {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = zr.Close() })
+	for _, f := range zr.File {
+		if f.Name != entry {
+			continue
+		}
+		rc, err := f.Open()
+		require.NoError(t, err)
+		defer func() { _ = rc.Close() }()
+		var doc map[string]any
+		require.NoError(t, json.NewDecoder(rc).Decode(&doc))
+		return doc
+	}
+	t.Fatalf("entry %q not found in %s", entry, path)
+	return nil
+}
+
+func readZipEntryBytes(t *testing.T, path, entry string) []byte {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = zr.Close() })
+	for _, f := range zr.File {
+		if f.Name != entry {
+			continue
+		}
+		rc, err := f.Open()
+		require.NoError(t, err)
+		defer func() { _ = rc.Close() }()
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		return data
+	}
+	t.Fatalf("entry %q not found in %s", entry, path)
+	return nil
 }


### PR DESCRIPTION
## Summary

Windows MCPB bundles now launch correctly from the package Claude Desktop installs: `bundle --platform windows/<arch>` stores the MCP server and companion CLI with `.exe` names and writes the bundled manifest to launch the suffixed server path.

The fix keeps Linux and macOS bundle names unchanged, preserves hand-edited MCPB manifest fields while patching only the launch path, and covers both prebuilt `--skip-build` inputs and the normal cross-build staging path.

Closes #1861

## Tests

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/cli ./internal/pipeline -run 'TestBundleBinaryTargetPathUsesWindowsExecutableSuffix|TestNewBundleCmdWindowsPlatformUsesExeNamesInMCPB|TestNewBundleCmdWindowsPlatformBuildsToExeStagingPaths|TestAutoBundleForHostSuccessPath|TestBuildMCPBBundle'`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## Compounded learnings

- Updated `docs/solutions/logic-errors/windows-mcpb-companion-cli-executable-names-2026-05-23.md` to cover MCP server executable naming, bundle manifest launch paths, and unknown-field preservation.
