### PR TITLE
fix(cli): skip live dogfood required-param fixture gaps

### DIFF
--- a/docs/solutions/logic-errors/live-dogfood-required-param-fixture-classification-2026-05-24.md
+++ b/docs/solutions/logic-errors/live-dogfood-required-param-fixture-classification-2026-05-24.md
@@ -1,0 +1,69 @@
+---
+title: Live dogfood required-param 4xx responses need narrow fixture skips
+date: 2026-05-24
+category: logic-errors
+module: live dogfood
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "dogfood --live reports http_4xx failures for endpoints that require input the matrix cannot supply"
+  - "scoped APIs cannot produce a passing live marker even when reachable scoped commands work manually"
+  - "generic 4xx validation errors risk being hidden if skip heuristics are too broad"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [dogfood, live-dogfood, scorer, required-params, fixtures, http-4xx]
+---
+
+# Live dogfood required-param 4xx responses need narrow fixture skips
+
+## Problem
+
+`dogfood --live` can mark healthy scoped APIs as failed when the live matrix invokes a command without an API-required parameter that only a real fixture or operator context can provide. The inverse risk is just as important: a broad 4xx substring heuristic can hide real request-shaping bugs by converting ordinary validation errors into skips.
+
+## Symptoms
+
+- `happy_path` or `json_fidelity` fails with output such as `HTTP 400: {"error":"Please provide email"}`.
+- The same API command works when the required scope or fixture value is supplied manually.
+- The live dogfood failure summary groups the result as `http_4xx`, blocking acceptance even though the runner never had a usable value to send.
+
+## What Didn't Work
+
+- Treating all 4xx responses as command failures. That misclassifies harness-unsuppliable fixture gaps as generated CLI defects.
+- Treating broad phrases like `missing field`, `required field`, or `is required` as fixture gaps. Those phrases also appear in real upstream validation failures and would produce false PASS markers.
+- Fixing a single printed CLI. The issue is in the Printing Press scorer: every printed CLI using live dogfood inherits the same matrix behavior.
+
+## Solution
+
+Classify only narrow required-parameter 400/422 responses as `blocked-fixture: required API parameter` skips:
+
+- Require a non-zero subprocess exit.
+- Require the live response text to look like HTTP 400 or HTTP 422.
+- Match only explicit parameter wording such as `missing parameter`, `missing param`, `required parameter`, or the concrete `Please provide email` shape seen in the Buzz run.
+- Skip the paired JSON-fidelity probe when happy-path already established the same blocked fixture reason.
+- Keep ordinary 4xx responses, auth requirements, subscription requirements, missing fields, and invalid filters as failures.
+
+Regression coverage should include both positive and negative matrix fixtures. The positive fixture proves the blocked happy path skips without invoking `--json`, and that JSON-fidelity skips when only the JSON probe hits the missing-parameter body. The negative fixture proves an ordinary `HTTP 400: invalid filter` still fails the live dogfood verdict.
+
+## Why This Works
+
+The live dogfood runner is a scorer, not an API-specific fixture generator. When the API says a required parameter is missing and the matrix had no value to supply, the correct result is a skipped blocked fixture, not a failed command. But the skip must stay narrow because false skips are worse than false failures: they can promote a CLI while hiding broken examples or request construction.
+
+The fix follows the existing live dogfood classification pattern for runner credentials: separate harness limitations from product failures, preserve specific skip reasons in the report, and keep the acceptance gate responsible for deciding whether enough real live signal remains.
+
+## Prevention
+
+- Pair every scorer skip heuristic with negative fixtures for nearby real failures.
+- Avoid broad substring classifiers when the skipped category has asymmetric risk.
+- Prefer explicit command annotations when an API-specific behavior is known ahead of time; use response heuristics only for portable, narrowly identifiable harness limitations.
+- Keep fixture tests honest by making skipped subprocess paths fail loudly if they are accidentally invoked.
+
+## Related Issues
+
+- GitHub issue #1859
+
+## Related Docs
+
+- `docs/solutions/logic-errors/live-dogfood-auth-401-runner-credentials-2026-05-23.md`
+- `docs/solutions/logic-errors/dogfood-soft-failure-error-path-opt-out-2026-05-22.md`
+- `docs/solutions/logic-errors/scoretypefidelity-flag-decl-regex-and-mark-required-2026-05-22.md`

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -42,6 +42,7 @@ const reasonMutatingErrorPath = "mutating command; error_path would call live AP
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
 const reasonUnavailableRunnerCredentials = "unavailable for runner credentials"
 const reasonFileFixtureRequired = "file fixture required"
+const reasonRequiredParamFixture = "blocked-fixture: required API parameter"
 const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
 
 // dogfoodEnvVar is the env signal every live-dogfood subprocess
@@ -726,11 +727,15 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		} else if liveDogfoodUnavailableForRunner(happyRun) {
 			happyResult.Status = LiveDogfoodStatusSkip
 			happyResult.Reason = reasonUnavailableRunnerCredentials
+		} else if requiredParamReason := liveDogfoodRequiredParamFixtureReason(happyRun); requiredParamReason != "" {
+			happyResult.Status = LiveDogfoodStatusSkip
+			happyResult.Reason = requiredParamReason
 		}
 		results = append(results, happyResult)
 
-		if happyResult.Status == LiveDogfoodStatusSkip && happyResult.Reason == reasonUnavailableRunnerCredentials {
-			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonUnavailableRunnerCredentials))
+		if happyResult.Status == LiveDogfoodStatusSkip &&
+			(happyResult.Reason == reasonUnavailableRunnerCredentials || happyResult.Reason == reasonRequiredParamFixture) {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, happyResult.Reason))
 		} else if commandSupportsJSON(command.Help) {
 			jsonArgs := appendJSONArg(runArgs)
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
@@ -746,6 +751,9 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			} else if liveDogfoodUnavailableForRunner(jsonRun) {
 				jsonResult.Status = LiveDogfoodStatusSkip
 				jsonResult.Reason = reasonUnavailableRunnerCredentials
+			} else if requiredParamReason := liveDogfoodRequiredParamFixtureReason(jsonRun); requiredParamReason != "" {
+				jsonResult.Status = LiveDogfoodStatusSkip
+				jsonResult.Reason = requiredParamReason
 			}
 			results = append(results, jsonResult)
 		} else {
@@ -995,6 +1003,16 @@ const (
 	liveDogfoodMaxOutputBytes  = 10 << 20
 )
 
+var liveDogfoodRequiredParamFixturePhrases = []string{
+	"missing parameter",
+	"missing param",
+	"required parameter",
+	"required param",
+	"must provide parameter",
+	"must provide param",
+	"please provide email",
+}
+
 // destructiveAuthTerms are case-insensitive command or endpoint tokens
 // classifying a command as destructive-at-auth.
 var destructiveAuthTerms = map[string]bool{
@@ -1168,6 +1186,20 @@ func liveDogfoodUnavailableForRunner(run liveDogfoodRun) bool {
 		liveDogfoodAuth401Output(output) ||
 		strings.Contains(output, "permission denied") ||
 		strings.Contains(output, "your credentials are valid but lack access")
+}
+
+func liveDogfoodRequiredParamFixtureReason(run liveDogfoodRun) string {
+	if run.exitCode == 0 {
+		return ""
+	}
+	output := strings.ToLower(run.stdout + " " + run.stderr)
+	if !strings.Contains(output, "http 400") && !strings.Contains(output, "http 422") {
+		return ""
+	}
+	if containsAnyOf(output, liveDogfoodRequiredParamFixturePhrases) {
+		return reasonRequiredParamFixture
+	}
+	return ""
 }
 
 func liveDogfoodAuth401(run liveDogfoodRun) bool {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -690,6 +690,68 @@ func TestRunLiveDogfoodSkipsHappyPathOnMissingFileFixture(t *testing.T) {
 	assert.Equal(t, LiveDogfoodStatusPass, help.Status, "help check must still pass when the only failure is a missing fixture")
 }
 
+func TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodRequiredParamFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "PASS", report.Verdict)
+
+	happy := findResultByCommandKind(report, "reports prospects", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected reports prospects happy_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Equal(t, reasonRequiredParamFixture, happy.Reason)
+
+	json := findResultByCommandKind(report, "reports prospects", LiveDogfoodTestJSON)
+	require.NotNil(t, json, "expected reports prospects json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, json.Status)
+	assert.Equal(t, happy.Reason, json.Reason)
+
+	help := findResultByCommandKind(report, "reports prospects", LiveDogfoodTestHelp)
+	require.NotNil(t, help, "expected reports prospects help result")
+	assert.Equal(t, LiveDogfoodStatusPass, help.Status, "help check must still pass when the only failure is an unsupplied required API parameter")
+
+	summaryHappy := findResultByCommandKind(report, "reports summary", LiveDogfoodTestHappy)
+	require.NotNil(t, summaryHappy, "expected reports summary happy_path result")
+	assert.Equal(t, LiveDogfoodStatusPass, summaryHappy.Status)
+
+	summaryJSON := findResultByCommandKind(report, "reports summary", LiveDogfoodTestJSON)
+	require.NotNil(t, summaryJSON, "expected reports summary json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, summaryJSON.Status)
+	assert.Equal(t, reasonRequiredParamFixture, summaryJSON.Reason)
+}
+
+func TestRunLiveDogfoodKeepsOrdinary4xxFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodOrdinary4xxFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+
+	happy := findResultByCommandKind(report, "reports broken-filter", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected reports broken-filter happy_path result")
+	assert.Equal(t, LiveDogfoodStatusFail, happy.Status)
+	assert.Contains(t, happy.OutputSample, "invalid filter")
+}
+
 func writeLiveDogfoodFileFixtureScript(t *testing.T) (dir string, binaryName string) {
 	t.Helper()
 
@@ -743,6 +805,138 @@ exit 99
 	return dir, binaryName
 }
 
+func writeLiveDogfoodRequiredParamFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	script := `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"reports","subcommands":[
+      {"name":"prospects"},
+      {"name":"summary"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "prospects" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List report prospects.
+
+Usage:
+  fixture-pp-cli reports prospects [flags]
+
+Examples:
+  fixture-pp-cli reports prospects
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "prospects" ] && [ "${3:-}" = "--json" ]; then
+  echo 'unexpected reports prospects --json invocation' >&2
+  exit 9
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "prospects" ]; then
+  echo 'HTTP 400: {"error":"Please provide email"}' >&2
+  exit 1
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "summary" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show report summary.
+
+Usage:
+  fixture-pp-cli reports summary [flags]
+
+Examples:
+  fixture-pp-cli reports summary
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "summary" ] && [ "${3:-}" = "--json" ]; then
+  echo 'HTTP 400: {"error":"missing required parameter: email"}' >&2
+  exit 1
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "summary" ]; then
+  echo 'summary'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	writeStubBinary(t, dir, binaryName, script)
+	return dir, binaryName
+}
+
+func writeLiveDogfoodOrdinary4xxFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	script := `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"reports","subcommands":[
+      {"name":"broken-filter"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "broken-filter" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Run a report with an invalid upstream filter.
+
+Usage:
+  fixture-pp-cli reports broken-filter [flags]
+
+Examples:
+  fixture-pp-cli reports broken-filter
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "broken-filter" ]; then
+  echo 'HTTP 400: {"error":"invalid filter"}' >&2
+  exit 1
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	writeStubBinary(t, dir, binaryName, script)
+	return dir, binaryName
+}
+
 func TestValidLiveDogfoodJSONOutputAcceptsNDJSON(t *testing.T) {
 	t.Parallel()
 
@@ -759,6 +953,64 @@ func TestLiveDogfoodUnavailableForRunnerDoesNotHideNotFound(t *testing.T) {
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "your credentials are valid but lack access"}))
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: `HTTP 401: {"error":"Couldn't authenticate you"}`}))
 	assert.False(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 404 NotFound"}))
+}
+
+func TestLiveDogfoodRequiredParamFixtureReason(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		run  liveDogfoodRun
+		want string
+	}{
+		{
+			name: "missing required parameter 4xx is blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 400: {"error":"missing required parameter: email"}`, exitCode: 1},
+			want: reasonRequiredParamFixture,
+		},
+		{
+			name: "please provide 4xx is blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 400: {"error":"Please provide email"}`, exitCode: 1},
+			want: reasonRequiredParamFixture,
+		},
+		{
+			name: "ordinary 4xx remains a failure",
+			run:  liveDogfoodRun{stderr: "HTTP 404 NotFound", exitCode: 1},
+		},
+		{
+			name: "401 auth requirement is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 401: {"error":"api key is required"}`, exitCode: 1},
+		},
+		{
+			name: "403 subscription requirement is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 403: {"error":"subscription is required"}`, exitCode: 1},
+		},
+		{
+			name: "404 not found requirement is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 404: {"error":"widget id is required"}`, exitCode: 1},
+		},
+		{
+			name: "generic 400 requirement is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 400: {"error":"subscription is required"}`, exitCode: 1},
+		},
+		{
+			name: "generic please provide 400 is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 400: {"error":"Please provide subscription"}`, exitCode: 1},
+		},
+		{
+			name: "422 missing field validation is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 422: {"error":"missing field: status"}`, exitCode: 1},
+		},
+		{
+			name: "successful output is not a blocked fixture",
+			run:  liveDogfoodRun{stderr: `HTTP 400: {"error":"missing required parameter: email"}`, exitCode: 0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, liveDogfoodRequiredParamFixtureReason(tc.run))
+		})
+	}
 }
 
 func TestRunLiveDogfoodSkipsDestructiveByDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

Live dogfood can now distinguish a runner fixture gap from a broken generated command when an upstream API rejects a probe because the matrix could not supply a required parameter. Those required-param 400/422 responses are recorded as `blocked-fixture: required API parameter` skips, while ordinary 4xx validation, auth, subscription, and invalid-filter failures still fail the matrix.

The regression tests cover the happy-path skip, the paired JSON-fidelity skip, the JSON-only required-param case, and negative 4xx cases so the scorer cannot silently turn real failures into passing markers.

Closes #1859

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx|TestRunLiveDogfoodKeepsOrdinary4xxFailures|TestLiveDogfoodRequiredParamFixtureReason' -count=1`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

## Compounded learnings

- File: `docs/solutions/logic-errors/live-dogfood-required-param-fixture-classification-2026-05-24.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with existing live dogfood/scorer classification docs
- Instruction-file edit: none needed
- Refresh recommendation: none
