### PR TITLE
fix(skills): require fresh publish turn after polish

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -396,6 +396,58 @@ func TestPolishSkillHardGatesPublishValidate(t *testing.T) {
 	assert.Contains(t, skill, "ship cannot fire while publish validate fails")
 }
 
+func TestPolishPublishOfferRequiresFreshUserTurn(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
+	reference := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "references", "publish-turn-boundary.md"))
+
+	assert.Contains(t, skill, "references/publish-turn-boundary.md")
+	assert.Contains(t, skill, "fresh user-authored message")
+	assert.Contains(t, skill, "Do not invoke `/printing-press-publish <cli-name>` from this same turn")
+	assert.Contains(t, skill, "After printing the handoff, stop")
+	assert.Contains(t, skill, "**Publish separately** (recommended)")
+	assert.Contains(t, skill, "show the publish command for the next user message")
+	assert.Contains(t, skill, "/printing-press-publish <cli-name> --from-polish")
+	assert.Contains(t, skill, "post-publish retro offer")
+	assert.Contains(t, reference, "--from-polish")
+	assert.Contains(t, reference, "Treat the menu answer as intent to hand off, not permission to execute")
+	assert.NotContains(t, skill, "Then invoke `/printing-press-publish <cli-name>`")
+	assert.NotContains(t, skill, "**Publish now** (recommended)")
+	assert.NotContains(t, skill, "validate, package, and open a PR")
+	assert.NotContains(t, reference, "Publish now")
+}
+
+func TestPublishSkillRejectsChainedPublishInvocations(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+	guardStart := strings.Index(skill, "## Direct User Invocation Required")
+	setupStart := strings.Index(skill, "## Setup")
+	require.NotEqual(t, -1, guardStart)
+	require.NotEqual(t, -1, setupStart)
+	require.Less(t, guardStart, setupStart)
+	guardBlock := skill[guardStart:setupStart]
+
+	assert.Contains(t, guardBlock, "chained continuation from `printing-press-polish`'s")
+	assert.Contains(t, guardBlock, "auto-resolved")
+	assert.Contains(t, guardBlock, "recommendation")
+	assert.Contains(t, guardBlock, "stop immediately")
+	assert.Contains(t, guardBlock, "fresh user-authored")
+	assert.Contains(t, guardBlock, "--from-polish")
+	assert.Contains(t, guardBlock, "POLISH_HANDOFF=true")
+	assert.Contains(t, guardBlock, "ignore that marker when")
+}
+
+func TestPublishSkillOffersRetroForPolishHandoff(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+	terminalStart := strings.Index(skill, "### Terminal state")
+	require.NotEqual(t, -1, terminalStart)
+	terminalBlock := skill[terminalStart:]
+
+	assert.Contains(t, terminalBlock, "direct human invocation without `--from-polish` just ends here")
+	assert.Contains(t, terminalBlock, "If `POLISH_HANDOFF=true`, offer retro")
+	assert.Contains(t, terminalBlock, "standalone polish")
+	assert.Contains(t, terminalBlock, "AskUserQuestion")
+	assert.Contains(t, terminalBlock, "/printing-press-retro")
+}
+
 func TestPublishSkillPRBodyIncludesStableNovelCommands(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -709,6 +709,8 @@ Set `no` when another invocation would re-tread the same ground:
 
 **Skip this entire section unless `STANDALONE_MODE` is true.** `STANDALONE_MODE` is set in the "Resolve CLI" block above based on the caller mode: true for slash-command invocations (`/printing-press-polish ...`) or Skill-tool invocations that pass `--standalone` in `args`; false otherwise. When false, polish is being called from main SKILL Phase 5.5 or hold-path "Polish to retry," and the working CLI has not been promoted to library yet. `/printing-press-publish <slug>` would resolve to `$PRESS_LIBRARY/<slug>/`, which is either empty or holds a stale prior run — invoking publish here would either fail to resolve or ship the wrong copy. The parent skill owns the publish flow on that path; just emit the result block and return.
 
+Apply the publish turn-boundary rule: the `AskUserQuestion` answer may authorize only a handoff message, not a same-turn publish. Publishing opens or updates a public-library PR, so it requires a fresh user-authored message after polish completes. See `references/publish-turn-boundary.md` for rationale.
+
 A simple check:
 
 ```bash
@@ -750,7 +752,7 @@ Present via `AskUserQuestion`. Two example shapes:
 >
 > Recommendation: Publish.
 >
-> 1. **Publish now** (recommended) — validate, package, and open a PR
+> 1. **Publish separately** (recommended) — show the publish command for the next user message
 > 2. **Done for now** — CLI is at $PRESS_LIBRARY/<cli-name>"
 
 **Polish thinks another pass would help** (`remaining_issues` non-empty, `further_polish_recommended: yes`):
@@ -762,30 +764,22 @@ Present via `AskUserQuestion`. Two example shapes:
 > Recommendation: Polish again before publishing.
 >
 > 1. **Polish again** (recommended) — close the remaining <N> issues
-> 2. **Publish now** — ship as-is
+> 2. **Publish separately** — show the publish command to ship as-is in the next user message
 > 3. **Done for now** — CLI is at $PRESS_LIBRARY/<cli-name>"
 
 The recommended option leads, carries the `(recommended)` label, and the leading `Recommendation:` line states the agent's call explicitly. Three reinforcing channels so the user does not have to infer from ordering.
 
-### If "Publish now"
+### If "Publish separately"
 
-Check for existing PR:
-```bash
-gh pr list --repo mvanhorn/printing-press-library --head "feat/$CLI_NAME" --state open --author @me --json number,url --jq '.[0]' 2>/dev/null
-```
+Do not invoke `/printing-press-publish <cli-name>` from this same turn, and do not check or create public-library PRs here. Print a handoff that requires an explicit fresh user-authored message. Include the `--from-polish` marker so publish can offer the same post-publish retro tail that polish used to offer after a successful inline publish:
 
-Then invoke `/printing-press-publish <cli-name>`.
-
-**After publish returns success**, offer retro as a soft tail. This mirrors the main `/printing-press` skill's Phase 6 behavior so users who reach publish through polish (mid-pipeline → polish-again → publish, or standalone polish → publish) get the same retro opportunity as users who reach publish directly through Phase 6.
-
-Present via `AskUserQuestion`:
-
-> "PR opened: <PR_URL>. Run a retro? It surfaces systemic gaps from this session (generator misses, scorer bugs, skill-doc drift) as a GitHub issue for the Printing Press maintainers. Every retro filed raises the floor for the next CLI — and your session context is freshest right now."
+> "Publishing requires a separate user confirmation because it can fork `mvanhorn/printing-press-library`, push a branch, and open or update a PR.
 >
-> 1. **No — I'm done** (default)
-> 2. **Yes — run retro now**
+> To publish, send this as your next message:
+>
+> `/printing-press-publish <cli-name> --from-polish`"
 
-If the user picks yes, invoke `/printing-press-retro`.
+After printing the handoff, stop. If the user sends the command in a later message, the publish skill owns validation, packaging, public-library PR creation or update, and the `--from-polish` post-publish retro offer.
 
 (When `STANDALONE_MODE` is false this whole section is unreachable — the Publish Offer guard at the top of this section returns early — so no extra check is needed here.)
 

--- a/skills/printing-press-polish/references/publish-turn-boundary.md
+++ b/skills/printing-press-polish/references/publish-turn-boundary.md
@@ -1,0 +1,23 @@
+# Publish Turn Boundary
+
+Publishing a printed CLI opens or updates a pull request in
+`mvanhorn/printing-press-library`, a repository outside the current local CLI
+workspace. An `AskUserQuestion` answer inside polish is not enough authority to
+perform that cross-repo side effect in the same model turn, especially in Auto
+Mode where the model may auto-select the recommended option.
+
+When polish offers **Publish separately**, it must:
+
+1. Treat the menu answer as intent to hand off, not permission to execute.
+2. Print the exact `/printing-press-publish <cli-name> --from-polish` command
+   for the user, preserving the post-publish retro offer for this handoff.
+3. Stop after printing that command.
+
+The publish action may run only after a fresh user-authored message explicitly
+asks to publish or invokes `/printing-press-publish`. Do not chain from polish's
+Publish Offer directly into `/printing-press-publish`, and do not open a public
+library PR from an auto-resolved polish menu option.
+
+For polish, this rule covers the **Publish separately** handoff. Other skills
+should define their own fresh-user boundary when they perform cross-repo side
+effects.

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -20,8 +20,26 @@ Publish a generated CLI from your local library to the [printing-press-library](
 ```bash
 /printing-press publish notion-pp-cli
 /printing-press publish notion
+/printing-press publish notion --from-polish
 /printing-press publish
 ```
+
+## Direct User Invocation Required
+
+Publishing can fork `mvanhorn/printing-press-library`, push a branch, and open or
+update a PR. Before setup or validation, check the invocation context. If this
+skill was invoked as a chained continuation from `printing-press-polish`'s
+Publish Offer, including an `AskUserQuestion` answer or auto-resolved polish
+recommendation, stop immediately and tell the user to send
+`/printing-press-publish <cli-name> --from-polish` in a fresh message. A fresh
+user-authored request that explicitly asks to publish is sufficient; do not add
+another confirmation prompt on top of a direct publish request.
+
+If the fresh user-authored request includes `--from-polish`, record
+`POLISH_HANDOFF=true` for the terminal-state step and ignore that marker when
+resolving the CLI name. The marker is not a second confirmation and is not
+passed to `cli-printing-press`; it only preserves standalone polish's old
+post-publish retro offer after the fresh-turn publish completes.
 
 The public library treats `library/<category>/<api-slug>/.printing-press.json`
 and `manifest.json` as the source of truth for registry-display fields. Do not
@@ -1030,7 +1048,18 @@ Read `access` from `$PUBLISH_CONFIG` (`jq -r .access "$PUBLISH_CONFIG"`) to dete
   ```
 - **If `access` is `fork`** (community contributor): you cannot merge or label the upstream PR. There is nothing more to do once it's green.
 
-Then **report the terminal state and return control to the caller.** Do not offer a retro or any follow-up menu from this skill — that decision belongs to whoever invoked publish. The `printing-press` pipeline offers retro as its own post-publish tail; a direct human invocation just ends here.
+Then **report the terminal state and return control to the caller.** Do not offer a retro or any follow-up menu from this skill by default — that decision belongs to whoever invoked publish. The `printing-press` pipeline offers retro as its own post-publish tail; a direct human invocation without `--from-polish` just ends here.
+
+If `POLISH_HANDOFF=true`, offer retro as a soft tail after the PR is green. This preserves the standalone polish -> publish workflow without allowing polish's same-turn `AskUserQuestion` answer to create or update a public-library PR.
+
+Present via `AskUserQuestion`:
+
+> "PR opened: <PR_URL>. Run a retro? It surfaces systemic gaps from this session (generator misses, scorer bugs, skill-doc drift) as a GitHub issue for the Printing Press maintainers. Every retro filed raises the floor for the next CLI, and your session context is freshest right now."
+>
+> 1. **No, I'm done** (default)
+> 2. **Yes, run retro now**
+
+If the user picks yes, invoke `/printing-press-retro`.
 
 ## Secret & PII Protection
 


### PR DESCRIPTION
## Summary

Polish now treats a shippable result's publish option as a handoff, not permission to open or update a public-library PR in the same model turn. Selecting the option prints `/printing-press-publish <cli-name> --from-polish` and stops, so publishing only proceeds after a fresh user-authored request.

The publish skill rejects chained continuations from polish before setup or validation, while preserving direct publish requests. The `--from-polish` marker also preserves standalone polish's old post-publish retro offer after the fresh-turn publish completes.

Closes #1917

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `bash .github/scripts/validate-skill-docs.sh`
- `./cli-printing-press verify-internal-skill --dir skills/printing-press-polish && ./cli-printing-press verify-internal-skill --dir skills/printing-press-publish`
- `go test ./internal/pipeline -run 'TestPolishPublishOfferRequiresFreshUserTurn|TestPublishSkillRejectsChainedPublishInvocations|TestPublishSkillOffersRetroForPolishHandoff|TestPolishSkillHardGatesPublishValidate' -count=1`
- `go test ./internal/pressauth -run TestCaptureTimeoutCleansTempDir -count=1`
- `golangci-lint run ./...`
- `go test ./...`
