### PR TITLE
fix(cli): route GraphQL reads around verify gate

### DIFF
--- a/internal/generator/cost_throttling_test.go
+++ b/internal/generator/cost_throttling_test.go
@@ -155,6 +155,16 @@ func TestGenerateCostThrottlingPrimitives(t *testing.T) {
 		"graphql.go must parse extensions.cost via updateThrottleFromBody")
 	assert.Contains(t, graphqlGo, "throttleStatus",
 		"graphql.go cost parser must read throttleStatus")
+	queryWithThrottleBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) queryWithThrottle(")
+	assert.Contains(t, queryWithThrottleBody, "c.PostQueryWithParams(ctx, graphqlEndpointPath",
+		"throttle-aware GraphQL reads must use the read-only POST helper")
+	assert.NotContains(t, queryWithThrottleBody, "c.Post(ctx, graphqlEndpointPath",
+		"throttle-aware GraphQL reads must not use the verify-gated POST helper")
+	mutateWithThrottleBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) mutateWithThrottle(")
+	assert.Contains(t, mutateWithThrottleBody, "c.Post(ctx, graphqlEndpointPath",
+		"throttle-aware GraphQL mutations must keep the verify-gated POST helper")
+	assert.Contains(t, mutateWithThrottleBody, "c.graphqlWithThrottle",
+		"throttle-aware GraphQL mutations must preserve cost-budget handling")
 
 	// root.go must register --throttle-mode and validate its value.
 	rootGoBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))

--- a/internal/generator/cost_throttling_test.go
+++ b/internal/generator/cost_throttling_test.go
@@ -163,6 +163,8 @@ func TestGenerateCostThrottlingPrimitives(t *testing.T) {
 	mutateWithThrottleBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) mutateWithThrottle(")
 	assert.Contains(t, mutateWithThrottleBody, "c.Post(ctx, graphqlEndpointPath",
 		"throttle-aware GraphQL mutations must keep the verify-gated POST helper")
+	assert.NotContains(t, mutateWithThrottleBody, "c.PostQueryWithParams(ctx, graphqlEndpointPath",
+		"throttle-aware GraphQL mutations must not use the read-only POST helper")
 	assert.Contains(t, mutateWithThrottleBody, "c.graphqlWithThrottle",
 		"throttle-aware GraphQL mutations must preserve cost-budget handling")
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11495,6 +11495,8 @@ func TestGenerateGraphQLEndpointPathRendersTemplatedURL(t *testing.T) {
 	mutateBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) Mutate(")
 	assert.Contains(t, mutateBody, "c.Post(ctx, graphqlEndpointPath",
 		"GraphQL mutations must stay on the verify-gated POST helper")
+	assert.NotContains(t, mutateBody, "c.PostQueryWithParams(ctx, graphqlEndpointPath",
+		"GraphQL mutations must not use the read-only POST helper")
 
 	// The config struct must carry the templated BaseURL through unchanged so
 	// PR-2 can resolve {shop} against SHOPIFY_SHOP at Load() time without

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11486,8 +11486,15 @@ func TestGenerateGraphQLEndpointPathRendersTemplatedURL(t *testing.T) {
 		"graphql.go must render GraphQLEndpointPath into a const")
 	assert.NotContains(t, graphqlGo, `c.Post("/graphql"`,
 		"graphql.go must not retain the hardcoded /graphql path after PR-1")
-	assert.Contains(t, graphqlGo, "c.Post(ctx, graphqlEndpointPath",
-		"Query/Mutate must post against the rendered constant, not a literal")
+	queryBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) Query(")
+	assert.Contains(t, queryBody, "c.PostQueryWithParams(ctx, graphqlEndpointPath",
+		"Query must use the read-only POST helper against the rendered constant")
+	assert.NotContains(t, queryBody, "c.Post(ctx, graphqlEndpointPath",
+		"GraphQL reads must not use the verify-gated POST helper")
+
+	mutateBody := generatedFunctionBody(t, graphqlGo, "func (c *Client) Mutate(")
+	assert.Contains(t, mutateBody, "c.Post(ctx, graphqlEndpointPath",
+		"GraphQL mutations must stay on the verify-gated POST helper")
 
 	// The config struct must carry the templated BaseURL through unchanged so
 	// PR-2 can resolve {shop} against SHOPIFY_SHOP at Load() time without
@@ -11508,6 +11515,20 @@ func TestGenerateGraphQLEndpointPathRendersTemplatedURL(t *testing.T) {
 	).Replace(rawURL)
 	assert.Equal(t, expectedFinalURL, resolved,
 		"BaseURL + GraphQLEndpointPath must resolve to the Shopify Admin endpoint after env substitution")
+}
+
+func generatedFunctionBody(t *testing.T, src, signature string) string {
+	t.Helper()
+
+	start := strings.Index(src, signature)
+	require.NotEqual(t, -1, start, "generated source must contain %s", signature)
+
+	rest := src[start:]
+	next := strings.Index(rest[1:], "\nfunc ")
+	if next == -1 {
+		return rest
+	}
+	return rest[:next+1]
 }
 
 // shopifyTemplateVarsTestSpec returns a Shopify-shape APISpec used by

--- a/internal/generator/templates/graphql_client.go.tmpl
+++ b/internal/generator/templates/graphql_client.go.tmpl
@@ -137,7 +137,7 @@ func (c *Client) throttleModeOrDefault() string {
 // awaitBudget consults the throttle mode and either blocks on
 // WaitForBudget (strict), warns to stderr without blocking (lenient), or
 // returns immediately (off / no throttle state). The graphql Query path
-// calls this before every Post; novel commands can call it directly when
+// calls this before every request; novel commands can call it directly when
 // composing multi-query workflows.
 func (c *Client) awaitBudget(ctx context.Context, cost float64) error {
 	if c == nil || c.Throttle == nil {
@@ -167,54 +167,45 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]a
 	return c.queryWithThrottle(ctx, query, variables)
 {{- else}}
 	req := GraphQLRequest{Query: query, Variables: variables}
-	raw, _, err := c.Post(ctx, graphqlEndpointPath, req)
+	raw, _, err := c.PostQueryWithParams(ctx, graphqlEndpointPath, nil, req)
 	if err != nil {
 		return nil, err
 	}
-
-	var resp GraphQLResponse
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("decoding graphql response: %w", err)
-	}
-	if len(resp.Errors) > 0 {
-		msgs := make([]string, len(resp.Errors))
-		codes := make([]string, 0, len(resp.Errors))
-		allDenial := true
-		for i, e := range resp.Errors {
-			msgs[i] = e.Message
-			if e.Extensions.Code != "" {
-				codes = append(codes, e.Extensions.Code)
-			}
-			if !isGraphQLAccessDenialCode(e.Extensions.Code) {
-				allDenial = false
-			}
-		}
-		if allDenial && len(codes) > 0 {
-			return nil, &GraphQLAccessDeniedError{Codes: codes, Messages: msgs}
-		}
-		return nil, fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
-	}
-	return resp.Data, nil
+	return decodeGraphQLData(raw)
 {{- end}}
 }
 
 {{- if .HasCostThrottling}}
 
-// queryWithThrottle is the throttle-aware Query path. Wraps the bare Post
-// call with WaitForBudget (mode-gated), parses extensions.cost from every
-// response (including error responses, since Shopify reports the bucket
-// even when the query was rejected), and retries on THROTTLED extension
-// codes via HandleThrottleError. HTTP 429s are still handled by the
-// Client.do() layer's existing AdaptiveLimiter retry — this path stacks
-// on top of that without double-handling.
+// queryWithThrottle is the throttle-aware Query path. Wraps the read-only
+// POST helper with WaitForBudget (mode-gated), parses extensions.cost from
+// every response (including error responses, since Shopify reports the bucket
+// even when the query was rejected), and retries on THROTTLED extension codes
+// via HandleThrottleError.
 func (c *Client) queryWithThrottle(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
 	req := GraphQLRequest{Query: query, Variables: variables}
+	return c.graphqlWithThrottle(ctx, req, func(ctx context.Context, req GraphQLRequest) (json.RawMessage, int, error) {
+		return c.PostQueryWithParams(ctx, graphqlEndpointPath, nil, req)
+	})
+}
+
+// mutateWithThrottle is the throttle-aware Mutate path. It keeps the gated
+// mutation transport while preserving the same cost-budget behavior that Mutate
+// had when it delegated to Query.
+func (c *Client) mutateWithThrottle(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	req := GraphQLRequest{Query: query, Variables: variables}
+	return c.graphqlWithThrottle(ctx, req, func(ctx context.Context, req GraphQLRequest) (json.RawMessage, int, error) {
+		return c.Post(ctx, graphqlEndpointPath, req)
+	})
+}
+
+func (c *Client) graphqlWithThrottle(ctx context.Context, req GraphQLRequest, post func(context.Context, GraphQLRequest) (json.RawMessage, int, error)) (json.RawMessage, error) {
 	mode := c.throttleModeOrDefault()
 	for attempt := 0; ; attempt++ {
 		if err := c.awaitBudget(ctx, defaultThrottleQueryCost); err != nil {
 			return nil, err
 		}
-		raw, _, err := c.Post(ctx, graphqlEndpointPath, req)
+		raw, _, err := post(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -247,31 +238,54 @@ func (c *Client) queryWithThrottle(ctx context.Context, query string, variables 
 			}
 		}
 
-		msgs := make([]string, len(resp.Errors))
-		codes := make([]string, 0, len(resp.Errors))
-		allDenial := true
-		for i, e := range resp.Errors {
-			msgs[i] = e.Message
-			if e.Extensions.Code != "" {
-				codes = append(codes, e.Extensions.Code)
-			}
-			if !isGraphQLAccessDenialCode(e.Extensions.Code) {
-				allDenial = false
-			}
-		}
-		if allDenial && len(codes) > 0 {
-			return nil, &GraphQLAccessDeniedError{Codes: codes, Messages: msgs}
-		}
-		return nil, fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
+		return nil, graphqlResponseError(resp.Errors)
 	}
 }
 {{- end}}
 
 // Mutate executes a GraphQL mutation via POST against graphqlEndpointPath and
-// returns the raw data payload. Identical transport to Query; separate method
-// for clarity.
+// returns the raw data payload.
 func (c *Client) Mutate(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
-	return c.Query(ctx, query, variables)
+{{- if .HasCostThrottling}}
+	return c.mutateWithThrottle(ctx, query, variables)
+{{- else}}
+	req := GraphQLRequest{Query: query, Variables: variables}
+	raw, _, err := c.Post(ctx, graphqlEndpointPath, req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeGraphQLData(raw)
+{{- end}}
+}
+
+func decodeGraphQLData(raw json.RawMessage) (json.RawMessage, error) {
+	var resp GraphQLResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decoding graphql response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, graphqlResponseError(resp.Errors)
+	}
+	return resp.Data, nil
+}
+
+func graphqlResponseError(errors []GraphQLError) error {
+	msgs := make([]string, len(errors))
+	codes := make([]string, 0, len(errors))
+	allDenial := true
+	for i, e := range errors {
+		msgs[i] = e.Message
+		if e.Extensions.Code != "" {
+			codes = append(codes, e.Extensions.Code)
+		}
+		if !isGraphQLAccessDenialCode(e.Extensions.Code) {
+			allDenial = false
+		}
+	}
+	if allDenial && len(codes) > 0 {
+		return &GraphQLAccessDeniedError{Codes: codes, Messages: msgs}
+	}
+	return fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
 }
 
 // PaginatedQuery fetches all pages of a Connection field using first/after pagination.


### PR DESCRIPTION
## Summary

Generated GraphQL read queries now reach the real transport under `PRINTING_PRESS_VERIFY=1` instead of being mistaken for mutating POSTs and returning the synthetic noop envelope. This fixes GraphQL sync paths that could otherwise report a clean zero-row sync without ever exercising the mock or live read response.

The GraphQL mutation helper remains on the verify-gated POST path. Cost-throttled GraphQL clients keep their budget/update/retry behavior for both reads and mutations, with only the read transport using the read-only POST helper.

Closes #1955

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator ./internal/pipeline`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Note: `go test ./...` was also run once and hit a transient 5s timeout in `internal/pipeline TestRunLiveDogfoodProcessRetriesTransientAuth401`; rerunning that exact test passed, and the focused `internal/pipeline` package run passed afterward.
