### PR TITLE
fix(cli): include auth flow env vars in mcpb manifests

### DIFF
--- a/docs/solutions/logic-errors/mcpb-auth-env-var-kind-filter-drift-2026-05-24.md
+++ b/docs/solutions/logic-errors/mcpb-auth-env-var-kind-filter-drift-2026-05-24.md
@@ -1,0 +1,69 @@
+---
+title: "MCPB auth env-var kind filters can drift from verifier expectations"
+date: 2026-05-24
+category: logic-errors
+module: internal/pipeline
+problem_type: logic_error
+component: authentication
+symptoms:
+  - "Published-library verify-manifest reports server.mcp_config.env missing auth_flow_input or harvested env vars"
+  - "Generated MCPB manifest user_config only prompts for per_call auth env vars"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - auth
+  - env-vars
+  - mcpb
+  - manifests
+  - verify-manifest
+---
+
+# MCPB auth env-var kind filters can drift from verifier expectations
+
+## Problem
+
+Multi-credential OAuth CLIs can declare `auth.env_var_specs` entries for setup inputs, harvested tokens, and per-call request credentials. The public library verifier compares `.printing-press.json` `auth_env_vars` against MCPB `server.mcp_config.env`, so the MCPB manifest must surface every declared env var, not only the ones used directly on each API request.
+
+## Symptoms
+
+- `verify-manifest` fails a freshly published CLI with `server.mcp_config.env missing entries for [...]`.
+- The generated MCPB `manifest.json` contains only `per_call` env vars in `user_config` and `server.mcp_config.env`.
+- Hand-editing `manifest.json` to add the missing OAuth client or harvested-token env vars makes the downstream verifier pass.
+
+## What Didn't Work
+
+- Treating `auth_flow_input` and `harvested` as non-runtime values inside MCPB manifest generation. That classification is useful for UX copy and auth-flow behavior, but it is the wrong filter for the manifest contract because the host still needs to collect or forward those values.
+- Relying on `.printing-press.json` to record all env vars while MCPB reclassifies and drops some of them. The two artifacts then describe different credential surfaces.
+
+## Solution
+
+Use normalized `EnvVarSpecs` as the authoritative manifest input and include every declared env var kind in MCPB `user_config` plus `server.mcp_config.env`. Preserve kind only to shape the install prompt text:
+
+```go
+for _, envVar := range envVarSpecs {
+    if envVar.Name == "" {
+        continue
+    }
+    envVar.Kind = envVar.EffectiveKind()
+    seen[envVar.Name] = struct{}{}
+    filtered = append(filtered, envVar)
+}
+```
+
+Add regression coverage that asserts `per_call`, `auth_flow_input`, and `harvested` env vars all appear in both MCPB launch env and user_config, including default description text for non-per-call values without explicit prose.
+
+## Why This Works
+
+`auth.env_var_specs.kind` answers "how this credential participates in auth", not "whether the MCPB host must know about it." A setup client secret or harvested refresh token may not be sent with every request, but the installed MCP server still needs a configured value. Emitting all declared specs keeps `.printing-press.json`, MCPB `manifest.json`, and the library verifier on the same credential contract while still allowing kind-aware UX.
+
+## Prevention
+
+- Treat `EnvVarSpecs` as the rich source of truth for generated auth surfaces. Downstream emitters should not independently decide which declared env vars are real.
+- When changing manifest generation, test the emitted artifact fields that downstream verifiers read, not only the helper that builds them.
+- Use kind-aware description defaults instead of kind-based omission when the value should be visible to installers or agents.
+
+## Related Issues
+
+- Issue: [#1945](https://github.com/mvanhorn/cli-printing-press/issues/1945)
+- Related learning: `docs/solutions/design-patterns/auth-envvar-rich-model-2026-05-05.md`

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1098,7 +1098,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.Contains(t, key.Description, "https://fdc.nal.usda.gov/api-key-signup")
 	})
 
-	t.Run("rich auth user_config includes only per-call entries", func(t *testing.T) {
+	t.Run("rich auth user_config includes all declared env vars", func(t *testing.T) {
 		dir := t.TempDir()
 		writeManifest(t, dir, CLIManifest{
 			APIName:     "rich-auth",
@@ -1111,7 +1111,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 				{Name: "RICH_API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Description: "Per-call API key."},
 				{Name: "RICH_OPTIONAL", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: false, Description: "Optional public selector."},
 				{Name: "RICH_CLIENT_SECRET", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: true, Description: "Sensitive setup secret."},
-				{Name: "RICH_SESSION", Kind: spec.AuthEnvVarKindHarvested, Required: false, Sensitive: true, Description: "Harvested browser session."},
+				{Name: "RICH_SESSION", Kind: spec.AuthEnvVarKindHarvested, Required: false, Sensitive: true},
 			},
 		})
 
@@ -1120,8 +1120,8 @@ func TestWriteMCPBManifest(t *testing.T) {
 
 		assert.Equal(t, "${user_config.rich_api_key}", got.Server.MCPConfig.Env["RICH_API_KEY"])
 		assert.Equal(t, "${user_config.rich_optional}", got.Server.MCPConfig.Env["RICH_OPTIONAL"])
-		assert.NotContains(t, got.Server.MCPConfig.Env, "RICH_CLIENT_SECRET")
-		assert.NotContains(t, got.Server.MCPConfig.Env, "RICH_SESSION")
+		assert.Equal(t, "${user_config.rich_client_secret}", got.Server.MCPConfig.Env["RICH_CLIENT_SECRET"])
+		assert.Equal(t, "${user_config.rich_session}", got.Server.MCPConfig.Env["RICH_SESSION"])
 
 		required, ok := got.UserConfig["rich_api_key"]
 		require.True(t, ok)
@@ -1133,8 +1133,18 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.False(t, optional.Required)
 		assert.False(t, optional.Sensitive)
 		assert.Equal(t, "Optional. Optional public selector.", optional.Description)
-		assert.NotContains(t, got.UserConfig, "rich_client_secret")
-		assert.NotContains(t, got.UserConfig, "rich_session")
+
+		secret, ok := got.UserConfig["rich_client_secret"]
+		require.True(t, ok)
+		assert.False(t, secret.Required)
+		assert.True(t, secret.Sensitive)
+		assert.Equal(t, "Optional. Sensitive setup secret.", secret.Description)
+
+		session, ok := got.UserConfig["rich_session"]
+		require.True(t, ok)
+		assert.False(t, session.Required)
+		assert.True(t, session.Sensitive)
+		assert.Equal(t, "Optional. Stores RICH_SESSION after it is harvested by the auth setup flow for the Rich Auth MCP server.", session.Description)
 	})
 
 	t.Run("composed apiKey + bearer surfaces sibling creds in user_config and env", func(t *testing.T) {
@@ -1170,10 +1180,17 @@ func TestWriteMCPBManifest(t *testing.T) {
 
 		assert.Equal(t, "${user_config.st_app_key}", got.Server.MCPConfig.Env["ST_APP_KEY"],
 			"sibling credential must forward through the launch env block")
+		assert.Equal(t, "${user_config.st_client_id}", got.Server.MCPConfig.Env["ST_CLIENT_ID"])
+		assert.Equal(t, "${user_config.st_client_secret}", got.Server.MCPConfig.Env["ST_CLIENT_SECRET"])
 		uc, ok := got.UserConfig["st_app_key"]
 		require.True(t, ok, "user_config must prompt for the sibling apiKey credential")
 		assert.True(t, uc.Required)
 		assert.True(t, uc.Sensitive)
+		clientID, ok := got.UserConfig["st_client_id"]
+		require.True(t, ok, "auth flow inputs must surface in user_config")
+		assert.True(t, clientID.Required)
+		assert.False(t, clientID.Sensitive)
+		assert.Equal(t, "Collects ST_CLIENT_ID for the auth setup flow used by the ServiceTitan Compose MCP server.", clientID.Description)
 	})
 
 	t.Run("sibling header credential surfaces even when primary env vars are absent", func(t *testing.T) {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1106,6 +1106,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 			MCPBinary:   "rich-auth-pp-mcp",
 			MCPReady:    "full",
 			AuthType:    "api_key",
+			AuthKeyURL:  "https://rich-auth.example.com/oauth",
 			AuthEnvVars: []string{"RICH_API_KEY", "RICH_CLIENT_SECRET", "RICH_SESSION"},
 			AuthEnvVarSpecs: []spec.AuthEnvVar{
 				{Name: "RICH_API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Description: "Per-call API key."},
@@ -1145,6 +1146,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.False(t, session.Required)
 		assert.True(t, session.Sensitive)
 		assert.Equal(t, "Optional. Stores RICH_SESSION after it is harvested by the auth setup flow for the Rich Auth MCP server.", session.Description)
+		assert.NotContains(t, session.Description, "Get a credential from")
 	})
 
 	t.Run("composed apiKey + bearer surfaces sibling creds in user_config and env", func(t *testing.T) {
@@ -1191,6 +1193,11 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.True(t, clientID.Required)
 		assert.False(t, clientID.Sensitive)
 		assert.Equal(t, "Collects ST_CLIENT_ID for the auth setup flow used by the ServiceTitan Compose MCP server.", clientID.Description)
+		clientSecret, ok := got.UserConfig["st_client_secret"]
+		require.True(t, ok, "auth flow secrets must surface in user_config")
+		assert.True(t, clientSecret.Required)
+		assert.True(t, clientSecret.Sensitive)
+		assert.Equal(t, "Collects ST_CLIENT_SECRET for the auth setup flow used by the ServiceTitan Compose MCP server.", clientSecret.Description)
 	})
 
 	t.Run("sibling header credential surfaces even when primary env vars are absent", func(t *testing.T) {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -376,14 +376,9 @@ func mcpbUserConfigAuthEnvVars(m CLIManifest) []spec.AuthEnvVar {
 		if envVar.Name == "" {
 			continue
 		}
-		switch envVar.Kind {
-		case "", spec.AuthEnvVarKindPerCall:
-			envVar.Kind = spec.AuthEnvVarKindPerCall
-			seen[envVar.Name] = struct{}{}
-			filtered = append(filtered, envVar)
-		case spec.AuthEnvVarKindAuthFlowInput, spec.AuthEnvVarKindHarvested:
-			continue
-		}
+		envVar.Kind = envVar.EffectiveKind()
+		seen[envVar.Name] = struct{}{}
+		filtered = append(filtered, envVar)
 	}
 	// Sibling-scheme credentials (e.g. an apiKey header alongside an OAuth
 	// bearer) ride the same user_config + env-forwarding path so MCP hosts
@@ -439,7 +434,7 @@ func authUserConfigText(m CLIManifest, envVar spec.AuthEnvVar, required bool, si
 		}
 		return title, description
 	}
-	return title, envVarDescription(m, envVar.Name, required)
+	return title, envVarDescription(m, envVar, required)
 }
 
 func endpointTemplateDefault(m CLIManifest, templateVar string) string {
@@ -455,14 +450,25 @@ func endpointTemplateDefault(m CLIManifest, templateVar string) string {
 // envVarDescription is the help text under each user_config field. The
 // registration URL (when we have one) is what makes the difference between
 // "fill this in" and "I don't know where to get this value."
-func envVarDescription(m CLIManifest, envVar string, required bool) string {
+func envVarDescription(m CLIManifest, envVar spec.AuthEnvVar, required bool) string {
 	var b strings.Builder
 	if !required {
 		b.WriteString("Optional. ")
 	}
-	b.WriteString("Sets ")
-	b.WriteString(envVar)
-	b.WriteString(" for the ")
+	switch envVar.EffectiveKind() {
+	case spec.AuthEnvVarKindAuthFlowInput:
+		b.WriteString("Collects ")
+		b.WriteString(envVar.Name)
+		b.WriteString(" for the auth setup flow used by the ")
+	case spec.AuthEnvVarKindHarvested:
+		b.WriteString("Stores ")
+		b.WriteString(envVar.Name)
+		b.WriteString(" after it is harvested by the auth setup flow for the ")
+	default:
+		b.WriteString("Sets ")
+		b.WriteString(envVar.Name)
+		b.WriteString(" for the ")
+	}
 	if m.DisplayName != "" {
 		b.WriteString(displayNameForConcat(m.DisplayName))
 	} else {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -475,7 +475,7 @@ func envVarDescription(m CLIManifest, envVar spec.AuthEnvVar, required bool) str
 		b.WriteString(m.APIName)
 	}
 	b.WriteString(" MCP server.")
-	if m.AuthKeyURL != "" {
+	if m.AuthKeyURL != "" && envVar.EffectiveKind() != spec.AuthEnvVarKindHarvested {
 		b.WriteString(" Get a credential from ")
 		b.WriteString(m.AuthKeyURL)
 		b.WriteString(".")


### PR DESCRIPTION
## Summary

Multi-credential OAuth CLIs now ship MCPB manifests that expose every declared auth env var to the host. Setup inputs and harvested credentials are no longer dropped from `user_config` or `server.mcp_config.env`, so fresh public-library publishes align with the verifier without hand-editing `manifest.json`.

The manifest prompt text remains kind-aware: request credentials, auth setup inputs, and harvested values get distinct default descriptions when specs do not provide their own prose.

Closes #1945

## Verification

- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

## Compounded learnings

- Added `docs/solutions/logic-errors/mcpb-auth-env-var-kind-filter-drift-2026-05-24.md` for the cross-surface manifest/verifier contract.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
