### PR TITLE
fix(cli): route analytics output through cobra writer

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13447,6 +13447,7 @@ func TestProjectManagementWorkflowsEmitSyncHints(t *testing.T) {
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13456,12 +13457,20 @@ import (
 )
 
 func runPMHintCommand(t *testing.T, dbPath string, args ...string) (string, string) {
+	return runPMCommand(t, dbPath, true, args...)
+}
+
+func runPMCommand(t *testing.T, dbPath string, asJSON bool, args ...string) (string, string) {
 	t.Helper()
 	root := RootCmd()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
-	root.SetArgs(append(args, "--db", dbPath, "--json"))
+	fullArgs := append(args, "--db", dbPath)
+	if asJSON {
+		fullArgs = append(fullArgs, "--json")
+	}
+	root.SetArgs(fullArgs)
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute %v: %v; stderr=%s", args, err, stderr.String())
 	}
@@ -13505,6 +13514,62 @@ func TestPMWorkflowCommandEmitsSyncHints(t *testing.T) {
 	_, stderr = runPMHintCommand(t, dbPath, "load", "--max-age", "0")
 	if strings.Contains(stderr, "older than --max-age") {
 		t.Fatalf("stderr = %q, want max-age 0 to disable stale hint", stderr)
+	}
+}
+
+func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	db, err := store.OpenWithContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	for _, raw := range []string{
+		` + "`" + `{"id":"issue-1","status":"open"}` + "`" + `,
+		` + "`" + `{"id":"issue-2","status":"open"}` + "`" + `,
+	} {
+		var payload json.RawMessage = []byte(raw)
+		var obj map[string]any
+		if err := json.Unmarshal(payload, &obj); err != nil {
+			t.Fatalf("unmarshal seed: %v", err)
+		}
+		id, _ := obj["id"].(string)
+		if err := db.Upsert("issues", id, payload); err != nil {
+			t.Fatalf("upsert seed: %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	stdout, _ := runPMCommand(t, dbPath, false, "analytics")
+	for _, want := range []string{"Resource Type\tCount", "issues\t2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("analytics text summary stdout = %q, want %q in configured output", stdout, want)
+		}
+	}
+
+	stdout, _ = runPMCommand(t, dbPath, false, "analytics", "--type", "issues")
+	if !strings.Contains(stdout, "issues: 2 records") {
+		t.Fatalf("analytics text count stdout = %q, want issues count in configured output", stdout)
+	}
+
+	stdout, _ = runPMCommand(t, dbPath, false, "analytics", "--type", "issues", "--group-by", "status")
+	for _, want := range []string{"status\tCount", "open\t2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("analytics text group-by stdout = %q, want %q in configured output", stdout, want)
+		}
+	}
+
+	stdout, _ = runPMHintCommand(t, dbPath, "analytics")
+	if !strings.Contains(stdout, ` + "`" + `"issues": 2` + "`" + `) {
+		t.Fatalf("analytics summary stdout = %q, want issues count in configured output", stdout)
+	}
+
+	stdout, _ = runPMHintCommand(t, dbPath, "analytics", "--type", "issues", "--group-by", "status")
+	for _, want := range []string{` + "`" + `"value": "open"` + "`" + `, ` + "`" + `"count": 2` + "`" + `} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("analytics group-by stdout = %q, want %q in configured output", stdout, want)
+		}
 	}
 }
 `

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -6,7 +6,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"sort"
 
 	"{{modulePath}}/internal/store"
@@ -34,6 +34,7 @@ Data must be synced first with the sync command.`,
   # Top 10 most frequent values
   {{.Name}}-pp-cli analytics --type messages --group-by channel_id --limit 10 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
 			if dbPath == "" {
 				dbPath = defaultDBPath("{{.Name}}-pp-cli")
 			}
@@ -53,20 +54,20 @@ Data must be synced first with the sync command.`,
 					return fmt.Errorf("getting status: %w", err)
 				}
 				if flags.asJSON {
-					enc := json.NewEncoder(os.Stdout)
+					enc := json.NewEncoder(out)
 					enc.SetIndent("", "  ")
 					return enc.Encode(status)
 				}
-				fmt.Println("Resource Type\tCount")
-				fmt.Println("-------------\t-----")
+				fmt.Fprintln(out, "Resource Type\tCount")
+				fmt.Fprintln(out, "-------------\t-----")
 				for rt, count := range status {
-					fmt.Printf("%s\t%d\n", rt, count)
+					fmt.Fprintf(out, "%s\t%d\n", rt, count)
 				}
 				return nil
 			}
 
 			if groupBy != "" {
-				return runGroupBy(db, resourceType, groupBy, limit, flags)
+				return runGroupBy(out, db, resourceType, groupBy, limit, flags)
 			}
 
 			count, err := db.Count(resourceType)
@@ -76,12 +77,12 @@ Data must be synced first with the sync command.`,
 
 			if flags.asJSON {
 				result := map[string]any{"resource_type": resourceType, "count": count}
-				enc := json.NewEncoder(os.Stdout)
+				enc := json.NewEncoder(out)
 				enc.SetIndent("", "  ")
 				return enc.Encode(result)
 			}
 
-			fmt.Printf("%s: %d records\n", resourceType, count)
+			fmt.Fprintf(out, "%s: %d records\n", resourceType, count)
 			return nil
 		},
 	}
@@ -94,7 +95,7 @@ Data must be synced first with the sync command.`,
 	return cmd
 }
 
-func runGroupBy(db *store.Store, resourceType, field string, limit int, flags *rootFlags) error {
+func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limit int, flags *rootFlags) error {
 	items, err := db.List(resourceType, 0)
 	if err != nil {
 		return err
@@ -124,15 +125,15 @@ func runGroupBy(db *store.Store, resourceType, field string, limit int, flags *r
 	}
 
 	if flags.asJSON {
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(sorted)
 	}
 
-	fmt.Printf("%s\tCount\n", field)
-	fmt.Println("---\t-----")
+	fmt.Fprintf(out, "%s\tCount\n", field)
+	fmt.Fprintln(out, "---\t-----")
 	for _, kv := range sorted {
-		fmt.Printf("%s\t%d\n", kv.Key, kv.Count)
+		fmt.Fprintf(out, "%s\t%d\n", kv.Key, kv.Count)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Generated `analytics` commands now honor Cobra's configured output writer, so `--deliver file:...` captures summaries and group-by results instead of leaving the target empty while printing to the terminal.

The template now captures `cmd.OutOrStdout()` once and threads that writer into every analytics output path, including the helper used by grouped results. The generated-CLI regression seeds a local store and verifies both default text output and JSON output are written through `root.SetOut()`.

Closes #1964

## Verification

- `go test ./internal/generator -run TestProjectManagementWorkflowsEmitSyncHints -count=1`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run ./...`
