### PR TITLE
fix(cli): preserve templated server URL schemes

### DIFF
--- a/docs/solutions/logic-errors/openapi-server-template-scheme-separator.md
+++ b/docs/solutions/logic-errors/openapi-server-template-scheme-separator.md
@@ -1,0 +1,80 @@
+---
+title: "OpenAPI server template schemes need separator-aware normalization"
+date: 2026-05-24
+category: logic-errors
+module: internal/openapi
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "OpenAPI servers such as {protocol}://{hostpath} parsed as a relative base path instead of an absolute base URL"
+  - "Generated dry-run output showed GET /http:/localhost:41184/notes instead of GET http://localhost:41184/notes"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - openapi
+  - server-url
+  - endpoint-template-vars
+  - url-normalization
+  - generator
+---
+
+# OpenAPI server template schemes need separator-aware normalization
+
+## Problem
+
+OpenAPI specs can declare server URLs whose scheme and host are both template variables, such as `{protocol}://{host}/v1`. The parser preserved the variables for runtime substitution, but slash normalization collapsed the separator to `{protocol}:/{host}/v1`, causing the generated client to treat the eventual request URL as relative.
+
+## Symptoms
+
+- A spec declaring `servers: [{url: "{protocol}://{hostpath}"}]` produced dry-run output like `GET /http:/localhost:41184/notes`.
+- Literal server URLs and templated hosts with literal schemes, such as `https://{domain}/api/v2`, still worked, which made the failure look narrower than the server-template path really was.
+
+## What Didn't Work
+
+- Treating the problem as only a runtime `buildURL` issue would miss the parser classification bug. Once `resolveServerURLTemplate` stores `{protocol}:/{host}` as `BasePath`, the generated client has already lost the absolute-URL shape.
+- Preserving every `://` substring naively creates a legacy compatibility regression: dangling scheme placeholders without `variables:` strip to `://host`, and that empty-scheme shape must still fall through to the older slash cleanup.
+
+## Solution
+
+Make URL slash normalization separator-aware when the substring before `://` is non-empty, and separately classify a full runtime placeholder scheme as an absolute templated base URL.
+
+```go
+func hasRuntimeTemplateScheme(s string, defaults map[string]string) bool {
+    scheme, _, ok := strings.Cut(s, "://")
+    if !ok {
+        return false
+    }
+    matches := templateVarPattern.FindStringSubmatch(scheme)
+    if len(matches) != 2 || matches[0] != scheme {
+        return false
+    }
+    _, ok = defaults[matches[1]]
+    return ok
+}
+```
+
+The parser coverage should pin three cases together:
+
+- `{protocol}://{host}/v1` with declared variables remains a `BaseURL`.
+- `{stage}/{version}` remains a relative `BasePath`.
+- A dangling `{protocol}://host` with no declared variable follows legacy strip-and-normalize behavior instead of preserving an empty scheme.
+
+Generated-runtime coverage should also exercise `buildURL("{protocol}://{host}", "/notes", vars)` so parser success is tied to the URL that the printed CLI actually sends.
+
+## Why This Works
+
+The literal `://` separator is part of the URL grammar, not just duplicate slash noise. Normalization can collapse duplicate slashes in the rest of the URL, but it must not collapse the separator once a real or runtime-templated scheme exists.
+
+`hasRuntimeTemplateScheme` keeps the absolute-vs-relative decision explicit. It only upgrades a templated server URL to `BaseURL` when the scheme is exactly one preserved runtime placeholder backed by a server variable, so adjacent path placeholders remain relative and unresolved placeholders keep legacy behavior.
+
+## Prevention
+
+- When normalizing URLs that may still contain runtime placeholders, preserve grammar separators before doing broad string cleanup.
+- Pair parser tests with generated-runtime tests for URL-template bugs. A correct `BaseURL` parse is not enough unless the emitted client builds the same absolute URL after substitution.
+- Keep negative tests for legacy unresolved placeholders when broadening template-variable support. OpenAPI permits placeholders that this generator intentionally strips when no runtime substitution path exists.
+
+## Related Issues
+
+- [#1962](https://github.com/mvanhorn/cli-printing-press/issues/1962) - original issue.
+- [#1383](https://github.com/mvanhorn/cli-printing-press/issues/1383) - related server URL parsing area, different symptom.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11678,6 +11678,21 @@ func TestBuildURLPassthroughWhenNoPlaceholders(t *testing.T) {
 	}
 }
 
+func TestBuildURLSubstitutesTemplatedSchemeAndHost(t *testing.T) {
+	vars := map[string]string{
+		"protocol": "http",
+		"host":     "localhost:41184",
+	}
+	got, err := buildURL("{protocol}://{host}", "/notes", vars)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	const want = "http://localhost:41184/notes"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestBuildURLEmptyVarValueIsTreatedAsUnset(t *testing.T) {
 	// An env var that exists but is empty must produce the same actionable
 	// error as one that's not set — otherwise a stray "export FOO=" silently

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11679,6 +11679,13 @@ func TestBuildURLPassthroughWhenNoPlaceholders(t *testing.T) {
 }
 
 func TestBuildURLSubstitutesTemplatedSchemeAndHost(t *testing.T) {
+	templateVarEnvNames["protocol"] = "SHOPIFY_PROTOCOL"
+	templateVarEnvNames["host"] = "SHOPIFY_HOST"
+	t.Cleanup(func() {
+		delete(templateVarEnvNames, "protocol")
+		delete(templateVarEnvNames, "host")
+	})
+
 	vars := map[string]string{
 		"protocol": "http",
 		"host":     "localhost:41184",
@@ -11690,6 +11697,33 @@ func TestBuildURLSubstitutesTemplatedSchemeAndHost(t *testing.T) {
 	const want = "http://localhost:41184/notes"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		vars    map[string]string
+		wantErr string
+	}{
+		{
+			name:    "missing protocol",
+			vars:    map[string]string{"host": "localhost:41184"},
+			wantErr: "SHOPIFY_PROTOCOL not set",
+		},
+		{
+			name:    "missing host",
+			vars:    map[string]string{"protocol": "http"},
+			wantErr: "SHOPIFY_HOST not set",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildURL("{protocol}://{host}", "/notes", tc.vars)
+			if err == nil {
+				t.Fatal("expected missing template variable error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error to contain %q; got %q", tc.wantErr, err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2961,6 +2961,9 @@ func hasRuntimeTemplateScheme(s string, defaults map[string]string) bool {
 		return false
 	}
 	matches := templateVarPattern.FindStringSubmatch(scheme)
+	// Only a single bare placeholder is an absolute runtime-template scheme.
+	// Compound schemes fall through to the legacy relative-path handling so
+	// malformed or intentionally relative inputs are not broadened silently.
 	if len(matches) != 2 || matches[0] != scheme {
 		return false
 	}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2943,7 +2943,9 @@ func resolveServerURLTemplate(server *openapi3.Server) (baseURL, basePath string
 		return "", "", placeholders, defaults
 	}
 	lowerURL := strings.ToLower(serverURL)
-	if strings.HasPrefix(lowerURL, "http://") || strings.HasPrefix(lowerURL, "https://") {
+	if strings.HasPrefix(lowerURL, "http://") ||
+		strings.HasPrefix(lowerURL, "https://") ||
+		hasRuntimeTemplateScheme(serverURL, defaults) {
 		return serverURL, "", placeholders, defaults
 	}
 	return "", serverURL, placeholders, defaults
@@ -2953,7 +2955,25 @@ func resolveServerURLTemplate(server *openapi3.Server) (baseURL, basePath string
 // so the parser and the runtime substitute the same set of placeholder names.
 var templateVarPattern = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 
+func hasRuntimeTemplateScheme(s string, defaults map[string]string) bool {
+	scheme, _, ok := strings.Cut(s, "://")
+	if !ok {
+		return false
+	}
+	matches := templateVarPattern.FindStringSubmatch(scheme)
+	if len(matches) != 2 || matches[0] != scheme {
+		return false
+	}
+	_, ok = defaults[matches[1]]
+	return ok
+}
+
 func normalizeURLSlashes(s string) string {
+	if scheme, rest, ok := strings.Cut(s, "://"); ok {
+		if scheme != "" {
+			return scheme + "://" + strings.ReplaceAll(rest, "//", "/")
+		}
+	}
 	s = strings.ReplaceAll(s, "//", "/")
 	s = strings.Replace(s, "http:/", "http://", 1)
 	s = strings.Replace(s, "https:/", "https://", 1)

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8336,6 +8336,32 @@ paths:
 		assert.Equal(t, "api.example.com", parsed.EndpointTemplateVarDefaults["host"])
 	})
 
+	t.Run("partial scheme host variables document malformed triple slash", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Partial Scheme Host API
+  version: 1.0.0
+servers:
+  - url: "{protocol}://{host}/v1"
+    variables:
+      protocol:
+        default: https
+paths:
+  /items:
+    get:
+      responses:
+        "200": {description: ok}
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, "{protocol}:///v1", parsed.BaseURL,
+			"malformed specs with an undeclared host placeholder keep the runtime scheme URL shape")
+		assert.Empty(t, parsed.BasePath)
+		assert.Equal(t, []string{"protocol"}, parsed.EndpointTemplateVars)
+		assert.Equal(t, "https", parsed.EndpointTemplateVarDefaults["protocol"])
+	})
+
 	t.Run("adjacent path placeholders without scheme stay relative", func(t *testing.T) {
 		data := []byte(`
 openapi: 3.0.3

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8307,6 +8307,84 @@ paths:
 		assert.Equal(t, "v1", parsed.EndpointTemplateVarDefaults["version"])
 	})
 
+	t.Run("scheme and host placeholders preserve URL separator", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Scheme Host API
+  version: 1.0.0
+servers:
+  - url: "{protocol}://{host}/v1"
+    variables:
+      protocol:
+        default: "https"
+      host:
+        default: "api.example.com"
+paths:
+  /items:
+    get:
+      responses:
+        "200": {description: ok}
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Equal(t, "{protocol}://{host}/v1", parsed.BaseURL,
+			"server URL normalization must preserve :// when the scheme is a runtime placeholder")
+		assert.Empty(t, parsed.BasePath)
+		assert.Equal(t, []string{"protocol", "host"}, parsed.EndpointTemplateVars)
+		assert.Equal(t, "https", parsed.EndpointTemplateVarDefaults["protocol"])
+		assert.Equal(t, "api.example.com", parsed.EndpointTemplateVarDefaults["host"])
+	})
+
+	t.Run("adjacent path placeholders without scheme stay relative", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Relative Var API
+  version: 1.0.0
+servers:
+  - url: "{stage}/{version}"
+    variables:
+      stage:
+        default: "api"
+      version:
+        default: "v1"
+paths:
+  /items:
+    get:
+      responses:
+        "200": {description: ok}
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Empty(t, parsed.BaseURL)
+		assert.Equal(t, "{stage}/{version}", parsed.BasePath,
+			"only a preserved :// separator should make a templated server URL absolute")
+		assert.Equal(t, []string{"stage", "version"}, parsed.EndpointTemplateVars)
+	})
+
+	t.Run("dangling scheme placeholder strips without preserving empty scheme", func(t *testing.T) {
+		data := []byte(`
+openapi: 3.0.3
+info:
+  title: Dangling Scheme API
+  version: 1.0.0
+servers:
+  - url: "{protocol}://api.example.com/v1"
+paths:
+  /items:
+    get:
+      responses:
+        "200": {description: ok}
+`)
+		parsed, err := Parse(data)
+		require.NoError(t, err)
+		assert.Empty(t, parsed.BaseURL)
+		assert.Equal(t, ":/api.example.com/v1", parsed.BasePath,
+			"dangling scheme placeholders must follow legacy strip-and-normalize behavior, not preserve ://")
+		assert.Empty(t, parsed.EndpointTemplateVars)
+	})
+
 	t.Run("placeholder with empty default registers var but no default entry", func(t *testing.T) {
 		data := []byte(`
 openapi: 3.0.3


### PR DESCRIPTION
## Summary

OpenAPI server templates can now use a runtime-resolved scheme and host, such as `{protocol}://{host}`, without collapsing the URL separator. The parser keeps that shape as an absolute templated `BaseURL`, and generated clients substitute it into request URLs like `http://localhost:41184/notes` instead of treating `http:/...` as a relative path.

The fix keeps adjacent placeholder paths relative and preserves legacy behavior for dangling scheme placeholders that have no declared runtime variable.

## Compounded learnings

- Added `docs/solutions/logic-errors/openapi-server-template-scheme-separator.md` to capture the parser/runtime lesson: URL grammar separators need to survive placeholder-aware normalization, and parser coverage should be paired with generated-runtime URL coverage.

## Verification

- `go fmt ./...`
- `go test ./internal/openapi -run TestParseServerURLVariablesAsTemplateVars -count=1`
- `go test ./internal/generator -run TestGenerateEndpointTemplateVarsRuntimeSubstitution -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `go test ./...`
- `git diff --check`

Closes #1962
