### PR TITLE
fix(cli): preserve generated auth source provenance

### DIFF
--- a/docs/solutions/logic-errors/auth-header-source-provenance-clobber.md
+++ b/docs/solutions/logic-errors/auth-header-source-provenance-clobber.md
@@ -1,0 +1,81 @@
+---
+title: "AuthHeader must not clobber Load-derived auth provenance"
+date: 2026-05-24
+category: logic-errors
+module: internal/generator
+problem_type: logic_error
+component: authentication
+symptoms:
+  - "doctor --json reports auth_source as env:<NAME> for credentials saved in the config file"
+  - "AuthHeader returns the correct Authorization header while mutating AuthSource to the wrong origin"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - auth
+  - auth-source
+  - config-template
+  - doctor
+  - provenance
+---
+
+# AuthHeader must not clobber Load-derived auth provenance
+
+## Problem
+
+Generated CLIs use `Config.AuthSource` to explain where credentials came from in diagnostics such as `doctor --json`. `Load()` can distinguish env-var credentials from config-file credentials, but `AuthHeader()` also stamped `AuthSource` while returning the header.
+
+That made a disk-stored token look like an env-var token whenever the generated field name was populated, because `AuthHeader()` could not tell whether `Load()` filled that field from the environment or from the config file.
+
+## Symptoms
+
+- `auth set-token` saves a token to `config.toml`, with no env var set.
+- `Load()` labels the credential as `config`.
+- Calling `AuthHeader()` returns the correct header but changes `AuthSource` to `env:<NAME>`.
+- `doctor --json` reports the wrong `auth_source`, which is misleading for humans and agents that use diagnostics to understand credential setup.
+
+## What Didn't Work
+
+- Treating `AuthHeader()` as the place to derive origin from populated credential fields. At that point the field value has already been merged from config and env sources, so field presence is no longer provenance.
+- Guarding every `AuthHeader()` source assignment unconditionally. That preserved config-file provenance, but broke cases where the returned header intentionally came from a higher-priority credential than the source label set during `Load()`, such as bearer-refresh access tokens or OAuth2 access tokens winning over setup env vars.
+
+## Solution
+
+Keep provenance determination in `Load()` and make `AuthHeader()` avoid overwriting a non-empty source when it is returning the same env-backed field:
+
+```go
+if c.TokenField != "" {
+    if c.AuthSource == "" {
+        c.AuthSource = "env:TOKEN_ENV"
+    }
+    return "Bearer " + c.TokenField
+}
+```
+
+For branches where `AuthHeader()` deliberately returns a credential that takes precedence over env-backed fields, let the branch correct stale env labels:
+
+```go
+if c.AccessToken != "" {
+    if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
+        c.AuthSource = "oauth2"
+    }
+    return "Bearer " + c.AccessToken
+}
+```
+
+Bearer-refresh is stricter: a refreshed `AccessToken` always wins over stale generated env-var fields, so the branch stamps `bearer_refresh` even when `Load()` saw an env var.
+
+## Why This Works
+
+`Load()` is the only point that still knows where each credential value came from. Preserving its label fixes normal config-vs-env diagnostics. The explicit exceptions keep `auth_source` aligned with the credential that actually produced the outbound header when runtime precedence intentionally overrides a stale env-backed value.
+
+## Prevention
+
+- When generated getters return credential material, test both the returned header and any diagnostic provenance they mutate.
+- Add generated-runtime tests for config-file credentials with env vars unset, env-over-config credentials, and precedence exceptions where `AccessToken` wins over env setup fields.
+- Update golden fixtures for template changes only after inspecting that the diff matches the intended generated code shape.
+
+## Related Issues
+
+- Issue: [#1970](https://github.com/mvanhorn/cli-printing-press/issues/1970)
+- Related learning: `docs/solutions/design-patterns/auth-envvar-rich-model-2026-05-05.md`

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -56,6 +56,65 @@ func TestAuthHeader_ClientCredentialsDoesNotUseSetupEnvVars(t *testing.T) {
 	require.NotEqual(t, -1, verifyIdx, "mock verification should short-circuit before token minting")
 	require.NotEqual(t, -1, mintIdx, "client_credentials mint path should still be emitted")
 	assert.Less(t, verifyIdx, mintIdx, "mock verification must not dial the real token endpoint")
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClientCredentialsAccessTokenPreservesConfigAuthSource(t *testing.T) {
+	t.Setenv("CC_AUTH_TEST_CLIENT_ID", "")
+	t.Setenv("CC_AUTH_TEST_CLIENT_SECRET", "")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"disk-access-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after Load() = %q, want config", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer disk-access-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer disk-access-token", got)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after AuthHeader() = %q, want config", cfg.AuthSource)
+	}
+}
+
+func TestClientCredentialsAccessTokenCorrectsEnvFlowInputSource(t *testing.T) {
+	t.Setenv("CC_AUTH_TEST_CLIENT_ID", "client-id")
+	t.Setenv("CC_AUTH_TEST_CLIENT_SECRET", "client-secret")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"disk-access-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AuthSource != "env:CC_AUTH_TEST_CLIENT_SECRET" {
+		t.Fatalf("AuthSource after Load() = %q, want env:CC_AUTH_TEST_CLIENT_SECRET", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer disk-access-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer disk-access-token", got)
+	}
+	if cfg.AuthSource != "oauth2" {
+		t.Fatalf("AuthSource after AuthHeader() = %q, want oauth2", cfg.AuthSource)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "client_credentials_source_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestClientCredentialsAccessToken")
 }
 
 func TestClientCredentialsEnvVarsSkipTenantSetupInput(t *testing.T) {
@@ -583,6 +642,77 @@ func TestAuthHeader_EnvVarWinsOverFileToken(t *testing.T) {
 				"env-var check must appear BEFORE AccessToken check for type %q", tc.authType)
 		})
 	}
+}
+
+func TestAuthHeader_PreservesConfigAuthSourceForStoredBearerToken(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-source")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		EnvVars: []string{"BEARER_SOURCE_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-source-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuthHeaderPreservesConfigAuthSourceForStoredBearerToken(t *testing.T) {
+	t.Setenv("BEARER_SOURCE_TOKEN", "")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("source_token = \"disk-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after Load() = %q, want config", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer disk-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer disk-token", got)
+	}
+	if cfg.AuthSource != "config" {
+		t.Fatalf("AuthSource after AuthHeader() = %q, want config", cfg.AuthSource)
+	}
+}
+
+func TestAuthHeaderKeepsEnvAuthSourceWhenEnvOverridesConfig(t *testing.T) {
+	t.Setenv("BEARER_SOURCE_TOKEN", "env-token")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("source_token = \"disk-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AuthSource != "env:BEARER_SOURCE_TOKEN" {
+		t.Fatalf("AuthSource after Load() = %q, want env:BEARER_SOURCE_TOKEN", cfg.AuthSource)
+	}
+	if got := cfg.AuthHeader(); got != "Bearer env-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer env-token", got)
+	}
+	if cfg.AuthSource != "env:BEARER_SOURCE_TOKEN" {
+		t.Fatalf("AuthSource after AuthHeader() = %q, want env:BEARER_SOURCE_TOKEN", cfg.AuthSource)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "auth_source_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestAuthHeader")
 }
 
 // TestAuthHeader_BearerTokenPrefixOverride pins that a bearer_token spec

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -962,6 +962,16 @@ func TestBearerRefreshSavedTokenWinsOverEnvBackedField(t *testing.T) {
 	}
 }
 
+func TestBearerRefreshSavedTokenCorrectsStaleEnvSource(t *testing.T) {
+	cfg := &Config{AccessToken: "fresh-token", RefreshbearerPublicBearer: "stale-token", AuthSource: "env:REFRESHBEARER_PUBLIC_BEARER"}
+	if got := cfg.AuthHeader(); got != "Bearer fresh-token" {
+		t.Fatalf("AuthHeader() = %q, want refreshed token", got)
+	}
+	if cfg.AuthSource != "bearer_refresh" {
+		t.Fatalf("AuthSource = %q, want bearer_refresh", cfg.AuthSource)
+	}
+}
+
 func TestSaveBearerTokenClearsEnvBackedField(t *testing.T) {
 	cfg := &Config{
 		Path:                filepath.Join(t.TempDir(), "config.toml"),

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -369,7 +369,9 @@ func (c *Config) AuthHeader() string {
 	// win. Sending the client_id as Authorization: Bearer surfaces as
 	// token_rejected at the API.
 	if c.AccessToken != "" {
-		c.AuthSource = "oauth2"
+		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
+			c.AuthSource = "oauth2"
+		}
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
@@ -395,7 +397,9 @@ func (c *Config) AuthHeader() string {
 {{- if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		{{- if $.Auth.Format}}
 		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
@@ -412,7 +416,9 @@ func (c *Config) AuthHeader() string {
 {{- else}}
 	{{- with $canonicalEnvVar}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		{{- if $.Auth.Format}}
 		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
@@ -429,7 +435,9 @@ func (c *Config) AuthHeader() string {
 {{- end}}
 {{- if not .BearerRefresh.Enabled}}
 	if c.AccessToken != "" {
-		c.AuthSource = "oauth2"
+		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
+			c.AuthSource = "oauth2"
+		}
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
@@ -444,20 +452,26 @@ func (c *Config) AuthHeader() string {
 {{- if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
 	{{- with $canonicalEnvVar}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
 	if c.AccessToken != "" {
-		c.AuthSource = "browser"
+		if c.AuthSource == "" {
+			c.AuthSource = "browser"
+		}
 		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
 	}
 	return ""
@@ -466,20 +480,26 @@ func (c *Config) AuthHeader() string {
 {{- if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
 	{{- with $canonicalEnvVar}}
 	if c.{{resolveEnvVarField .Name}} != "" {
-		c.AuthSource = "env:{{.Name}}"
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
 		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
 	if c.AccessToken != "" {
-		c.AuthSource = "chrome-composed"
+		if c.AuthSource == "" {
+			c.AuthSource = "chrome-composed"
+		}
 		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
 	}
 	return ""

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -368,6 +368,9 @@ func TestEnsureAuthSchemeAppliesBearerPrefix(t *testing.T) {
 	if got := c.AuthHeader(); got != "Bearer eyJxxx" {
 		t.Fatalf("expected Bearer-prefixed header, got %q", got)
 	}
+	if c.AuthSource != "env:` + tt.envVar + `" {
+		t.Fatalf("AuthSource = %q, want env:` + tt.envVar + `", c.AuthSource)
+	}
 }
 
 func TestEnsureAuthSchemeDoesNotDoublePrefix(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -103,7 +103,9 @@ func (c *Config) AuthHeader() string {
 	// win. Sending the client_id as Authorization: Bearer surfaces as
 	// token_rejected at the API.
 	if c.AccessToken != "" {
-		c.AuthSource = "oauth2"
+		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
+			c.AuthSource = "oauth2"
+		}
 		return "Bearer " + c.AccessToken
 	}
 	return ""


### PR DESCRIPTION
## Summary

Generated CLIs now preserve the credential provenance that `Load()` determined, so `doctor --json` reports config-file tokens as `config` instead of relabeling them as env vars when `AuthHeader()` is called.

This fixes the generator template rather than one printed CLI. `AuthHeader()` still stamps a source for manually constructed configs, and the OAuth2 / bearer-refresh precedence exceptions now correct stale env labels only when the returned header actually comes from an access token.

## What changed

- Guard generated `AuthHeader()` env/browser/composed source stamps so they do not clobber an existing `AuthSource` from `Load()`.
- Keep OAuth2 and bearer-refresh source labels aligned with the credential that actually produces the outbound header.
- Add generated-runtime regression tests for config-file bearer tokens, env-over-config bearer tokens, OAuth2 access tokens with setup env vars present, bearer-refresh stale-env correction, and composed/cookie manual source stamping.
- Refresh the OAuth2 client-credentials golden fixture for the intended generated `config.go` shape.
- Document the provenance pattern in `docs/solutions/logic-errors/auth-header-source-provenance-clobber.md`.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `git diff --check`

Closes #1970
