### PR TITLE
fix(cli): honor absolute endpoint paths

### DIFF
--- a/internal/generator/client_basepath_test.go
+++ b/internal/generator/client_basepath_test.go
@@ -161,6 +161,8 @@ func TestEndpointPathWithBaseLeavesAbsolutePathAlone(t *testing.T) {
 		endpointPathWithBase("https://gamma.example.com", "http://clob.example.com/book"))
 	assert.Equal(t, "https://gamma.example.com/v1/book",
 		endpointPathWithBase("https://gamma.example.com/v1/", "/book"))
+	// Protocol-relative URLs remain relative paths for this fix. Only
+	// explicit http:// and https:// endpoint paths select another host.
 	assert.Equal(t, "https://gamma.example.com//cdn.example.com/book",
 		endpointPathWithBase("https://gamma.example.com", "//cdn.example.com/book"))
 }

--- a/internal/generator/client_basepath_test.go
+++ b/internal/generator/client_basepath_test.go
@@ -151,3 +151,114 @@ func TestClientBasePathLiveRequest(t *testing.T) {
 	assert.Contains(t, gotPaths, "/api/v1/things",
 		"the things.list endpoint should hit /api/v1/things, not /things")
 }
+
+func TestEndpointPathWithBaseLeavesAbsolutePathAlone(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "https://clob.example.com/book",
+		endpointPathWithBase("https://gamma.example.com", "https://clob.example.com/book"))
+	assert.Equal(t, "http://clob.example.com/book",
+		endpointPathWithBase("https://gamma.example.com", "http://clob.example.com/book"))
+	assert.Equal(t, "https://gamma.example.com/v1/book",
+		endpointPathWithBase("https://gamma.example.com/v1/", "/book"))
+	assert.Equal(t, "https://gamma.example.com//cdn.example.com/book",
+		endpointPathWithBase("https://gamma.example.com", "//cdn.example.com/book"))
+}
+
+// TestClientAbsoluteEndpointPathLiveRequest proves internal YAML specs can
+// declare a full URL directly in endpoints[].path. The generated client must
+// use that URL as-is instead of prepending the CLI's default BaseURL.
+func TestClientAbsoluteEndpointPathLiveRequest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		targetMu    sync.Mutex
+		targetPaths []string
+	)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetMu.Lock()
+		targetPaths = append(targetPaths, r.URL.Path)
+		targetMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items": []}`))
+	}))
+	t.Cleanup(target.Close)
+
+	var (
+		fallbackMu    sync.Mutex
+		fallbackPaths []string
+	)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackMu.Lock()
+		fallbackPaths = append(fallbackPaths, r.URL.Path)
+		fallbackMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items": []}`))
+	}))
+	t.Cleanup(fallback.Close)
+
+	apiSpec := minimalSpec("abspathlive")
+	apiSpec.BaseURL = fallback.URL
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"markets": {
+			Description: "Market data",
+			Endpoints: map[string]spec.Endpoint{
+				"book":   {Method: "GET", Path: target.URL + "/book", Description: "Fetch order book"},
+				"ticker": {Method: "GET", Path: "/ticker", Description: "Fetch ticker"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "abspathlive-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	client := string(clientSrc)
+	assert.Contains(t, client, "func isAbsoluteURL(path string) bool",
+		"absolute endpoint paths must emit the absolute-URL helper")
+	assert.Contains(t, client, "if isAbsoluteURL(path) {",
+		"client.do() must branch before concatenating BaseURL")
+
+	handlerSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "markets_book.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(handlerSrc), `path := "`+target.URL+`/book"`,
+		"generated command should preserve the absolute endpoint path")
+	relativeHandlerSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "markets_ticker.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(relativeHandlerSrc), `path := "/ticker"`,
+		"sibling relative endpoint should stay relative")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "abspathlive-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/abspathlive-pp-cli")
+
+	cmd := exec.Command(binaryPath, "markets", "book", "--json")
+	cmd.Env = append(os.Environ(), "ABSPATHLIVE_BASE_URL="+fallback.URL)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	var resp any
+	require.NoError(t, json.Unmarshal(out, &resp), string(out))
+
+	cmd = exec.Command(binaryPath, "markets", "ticker", "--json")
+	cmd.Env = append(os.Environ(), "ABSPATHLIVE_BASE_URL="+fallback.URL)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, json.Unmarshal(out, &resp), string(out))
+
+	targetMu.Lock()
+	defer targetMu.Unlock()
+	assert.Contains(t, targetPaths, "/book",
+		"absolute endpoint request should reach the endpoint host")
+	assert.NotContains(t, targetPaths, "/ticker",
+		"relative sibling endpoint should not hit the absolute endpoint host")
+
+	fallbackMu.Lock()
+	defer fallbackMu.Unlock()
+	assert.Contains(t, fallbackPaths, "/ticker",
+		"relative sibling endpoint should still hit the default BaseURL host")
+	assert.NotContains(t, fallbackPaths, "/book",
+		"default BaseURL host must not receive requests for absolute endpoint paths")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -748,23 +748,21 @@ type configTemplateData struct {
 	HasAuthCommand bool
 }
 
-// endpointTemplateData is the data passed to command_endpoint.go.tmpl
-// for both top-level resource endpoints and sub-resource endpoints.
-// ResourceBaseURL carries the endpoint's effective BaseURL override. The
-// template prepends it to Endpoint.Path so per-request hosts produce absolute
-// URLs.
+// endpointTemplateData is the data passed to command_endpoint.go.tmpl for both
+// top-level resource endpoints and sub-resource endpoints. EffectivePath is
+// either the relative endpoint path or a full URL when the endpoint declares
+// one directly or inherits a per-resource/per-endpoint BaseURL override.
 type endpointTemplateData struct {
-	ResourceName    string
-	ResourceBaseURL string
-	EffectivePath   string
-	EffectiveTier   string
-	FuncPrefix      string
-	CommandPath     string
-	EndpointName    string
-	Endpoint        spec.Endpoint
-	HasStore        bool
-	IsAsync         bool
-	Async           AsyncJobInfo
+	ResourceName  string
+	EffectivePath string
+	EffectiveTier string
+	FuncPrefix    string
+	CommandPath   string
+	EndpointName  string
+	Endpoint      spec.Endpoint
+	HasStore      bool
+	IsAsync       bool
+	Async         AsyncJobInfo
 	// IsReadOnly mirrors !endpointIsWriteCommand(endpoint, name). The
 	// emitted command sets Annotations["mcp:read-only"] = "true" when
 	// it's true so the cobratree MCP walker marks the tool with
@@ -2367,19 +2365,18 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 			}
 			asyncInfo, isAsync := g.AsyncJobs[name+"/"+eName]
 			epData := endpointTemplateData{
-				ResourceName:    name,
-				ResourceBaseURL: effectiveEndpointBaseURL(resource, endpoint),
-				EffectivePath:   effectiveEndpointPath(resource, endpoint),
-				EffectiveTier:   g.Spec.EffectiveTier(resource, endpoint),
-				FuncPrefix:      name,
-				CommandPath:     name,
-				EndpointName:    eName,
-				Endpoint:        endpoint,
-				HasStore:        g.VisionSet.Store,
-				IsAsync:         isAsync,
-				Async:           asyncInfo,
-				IsReadOnly:      endpointIsReadCommand(endpoint, eName),
-				APISpec:         g.Spec,
+				ResourceName:  name,
+				EffectivePath: effectiveEndpointPath(resource, endpoint),
+				EffectiveTier: g.Spec.EffectiveTier(resource, endpoint),
+				FuncPrefix:    name,
+				CommandPath:   name,
+				EndpointName:  eName,
+				Endpoint:      endpoint,
+				HasStore:      g.VisionSet.Store,
+				IsAsync:       isAsync,
+				Async:         asyncInfo,
+				IsReadOnly:    endpointIsReadCommand(endpoint, eName),
+				APISpec:       g.Spec,
 			}
 			epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+eName)+".go")
 			if err := g.renderTemplate("command_endpoint.go.tmpl", epPath, epData); err != nil {
@@ -2419,19 +2416,18 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 					effectiveResource.Tier = resource.Tier
 				}
 				epData := endpointTemplateData{
-					ResourceName:    subName,
-					ResourceBaseURL: effectiveSubEndpointBaseURL(resource, subResource, endpoint),
-					EffectivePath:   effectiveSubEndpointPath(resource, subResource, endpoint),
-					EffectiveTier:   g.Spec.EffectiveTier(effectiveResource, endpoint),
-					FuncPrefix:      name + "-" + subName,
-					CommandPath:     name + " " + subName,
-					EndpointName:    eName,
-					Endpoint:        endpoint,
-					HasStore:        g.VisionSet.Store,
-					IsAsync:         isAsync,
-					Async:           asyncInfo,
-					IsReadOnly:      endpointIsReadCommand(endpoint, eName),
-					APISpec:         g.Spec,
+					ResourceName:  subName,
+					EffectivePath: effectiveSubEndpointPath(resource, subResource, endpoint),
+					EffectiveTier: g.Spec.EffectiveTier(effectiveResource, endpoint),
+					FuncPrefix:    name + "-" + subName,
+					CommandPath:   name + " " + subName,
+					EndpointName:  eName,
+					Endpoint:      endpoint,
+					HasStore:      g.VisionSet.Store,
+					IsAsync:       isAsync,
+					Async:         asyncInfo,
+					IsReadOnly:    endpointIsReadCommand(endpoint, eName),
+					APISpec:       g.Spec,
 				}
 				epPath := filepath.Join("internal", "cli", safeResourceFileStem(name+"_"+subName+"_"+eName)+".go")
 				if err := g.renderTemplate("command_endpoint.go.tmpl", epPath, epData); err != nil {
@@ -3327,37 +3323,31 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 	// promotedCommands was computed earlier so promoted resources can replace their raw parents.
 	for _, pc := range promotedCommands {
 		// Look up the full resource to pass sibling endpoints/sub-resources.
-		// Trim trailing slash on BaseURL so the promoted handler's
-		// `path := <ResourceBaseURL><Endpoint.Path>` concat doesn't
-		// produce `https://x.com/v1//search`.
 		resource := g.Spec.Resources[pc.ResourceName]
-		resourceBaseURL := effectiveEndpointBaseURL(resource, pc.Endpoint)
 		promotedData := struct {
-			PromotedName    string
-			ResourceName    string
-			EndpointName    string
-			ResourceBaseURL string
-			EffectivePath   string
-			Endpoint        spec.Endpoint
-			EffectiveTier   string
-			HasStore        bool
-			Resource        spec.Resource
-			FuncPrefix      string
-			IsReadOnly      bool
+			PromotedName  string
+			ResourceName  string
+			EndpointName  string
+			EffectivePath string
+			Endpoint      spec.Endpoint
+			EffectiveTier string
+			HasStore      bool
+			Resource      spec.Resource
+			FuncPrefix    string
+			IsReadOnly    bool
 			*spec.APISpec
 		}{
-			PromotedName:    pc.PromotedName,
-			ResourceName:    pc.ResourceName,
-			EndpointName:    pc.EndpointName,
-			ResourceBaseURL: resourceBaseURL,
-			EffectivePath:   effectiveEndpointPath(resource, pc.Endpoint),
-			Endpoint:        pc.Endpoint,
-			EffectiveTier:   g.Spec.EffectiveTier(resource, pc.Endpoint),
-			HasStore:        g.VisionSet.Store,
-			Resource:        resource,
-			FuncPrefix:      pc.ResourceName,
-			IsReadOnly:      endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
-			APISpec:         g.Spec,
+			PromotedName:  pc.PromotedName,
+			ResourceName:  pc.ResourceName,
+			EndpointName:  pc.EndpointName,
+			EffectivePath: effectiveEndpointPath(resource, pc.Endpoint),
+			Endpoint:      pc.Endpoint,
+			EffectiveTier: g.Spec.EffectiveTier(resource, pc.Endpoint),
+			HasStore:      g.VisionSet.Store,
+			Resource:      resource,
+			FuncPrefix:    pc.ResourceName,
+			IsReadOnly:    endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
+			APISpec:       g.Spec,
 		}
 		promotedPath := filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+pc.PromotedName)+".go")
 		if err := g.renderTemplate("command_promoted.go.tmpl", promotedPath, promotedData); err != nil {
@@ -5752,7 +5742,7 @@ func effectiveSubEndpointBaseURL(parent spec.Resource, sub spec.Resource, endpoi
 
 func endpointPathWithBase(baseURL, path string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
-	if baseURL == "" {
+	if baseURL == "" || strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
 		return path
 	}
 	return baseURL + path

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1110,10 +1110,10 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- end}}
 {{- else}}
 {{- if .EndpointTemplateVars}}
-{{- if .HasResourceBaseURLOverride}}
-	// Resource and endpoint BaseURL overrides flow through as absolute paths
-	// (https:// or http://); buildURL still substitutes any
-	// {placeholder} markers, but the relative-path concat with
+{{- if .HasAbsoluteRequestPath}}
+	// Resource and endpoint BaseURL overrides, plus absolute endpoint paths,
+	// flow through as absolute paths (https:// or http://). buildURL still
+	// substitutes any {placeholder} markers, but the relative-path concat with
 	// c.BaseURL must be skipped for absolute paths.
 	var targetURL string
 	var urlErr error
@@ -1132,10 +1132,10 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	}
 {{- end}}
 {{- else}}
-{{- if .HasResourceBaseURLOverride}}
-	// Resource and endpoint BaseURL overrides flow through as absolute paths
-	// (https:// or http://); the resource template emits the full URL
-	// in `path` and we skip the c.BaseURL concat for those.
+{{- if .HasAbsoluteRequestPath}}
+	// Resource and endpoint BaseURL overrides, plus absolute endpoint paths,
+	// flow through as absolute paths (https:// or http://). Skip the
+	// c.BaseURL concat for those calls.
 	var targetURL string
 	if isAbsoluteURL(path) {
 		targetURL = path
@@ -2065,10 +2065,10 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 }
 {{- end}}
 
-{{if .HasResourceBaseURLOverride -}}
-// isAbsoluteURL reports whether path is already a full URL (resource or
-// endpoint BaseURL override emits the full URL into path; the relative-path
-// concat with c.BaseURL must be skipped for those calls).
+{{if .HasAbsoluteRequestPath -}}
+// isAbsoluteURL reports whether path is already a full URL. Resource or
+// endpoint BaseURL overrides and absolute endpoint paths emit full URLs into
+// path; the relative-path concat with c.BaseURL must be skipped for those calls.
 func isAbsoluteURL(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -123,7 +123,7 @@ func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra
 			c = c.WithTier({{printf "%q" .EffectiveTier}})
 {{- end}}
 
-			path := "{{.ResourceBaseURL}}{{.Endpoint.Path}}"{{/* ResourceBaseURL is empty unless the resource or endpoint declares an override; when set it makes path absolute and the client skips the c.BaseURL concat. */}}
+			path := "{{.EffectivePath}}"
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -96,7 +96,7 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			c = c.WithTier({{printf "%q" .EffectiveTier}})
 {{- end}}
 
-			path := "{{.ResourceBaseURL}}{{.Endpoint.Path}}"{{/* ResourceBaseURL is empty unless the resource or endpoint declares an override; when set it makes path absolute and the client skips the c.BaseURL concat. */}}
+			path := "{{.EffectivePath}}"
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -374,7 +374,7 @@ func visitResourceURLTemplateSources(r Resource, deterministic bool, visit func(
 			return false
 		}
 		if isAbsoluteRequestPath(endpoint.Path) {
-			return visit(endpoint.Path)
+			return visit(absoluteRequestPathTemplateSource(endpoint.Path))
 		}
 		return true
 	}
@@ -1478,20 +1478,6 @@ func DefaultResourceDescription(name string) string {
 	return "Manage " + strings.ReplaceAll(strings.ReplaceAll(name, "_", "-"), "-", " ")
 }
 
-// HasResourceBaseURLOverride reports whether any resource or endpoint declares
-// a BaseURL override.
-func (s *APISpec) HasResourceBaseURLOverride() bool {
-	if s == nil {
-		return false
-	}
-	for _, resource := range s.Resources {
-		if resourceHasBaseURLOverride(resource) {
-			return true
-		}
-	}
-	return false
-}
-
 // HasAbsoluteRequestPath reports whether generated commands can pass a full
 // URL to the HTTP client instead of a path relative to BaseURL. Resource or
 // endpoint BaseURL overrides synthesize absolute paths at generation time, and
@@ -1502,23 +1488,6 @@ func (s *APISpec) HasAbsoluteRequestPath() bool {
 	}
 	for _, resource := range s.Resources {
 		if resourceHasAbsoluteRequestPath(resource) {
-			return true
-		}
-	}
-	return false
-}
-
-func resourceHasBaseURLOverride(resource Resource) bool {
-	if resource.BaseURL != "" {
-		return true
-	}
-	for _, endpoint := range resource.Endpoints {
-		if endpoint.BaseURL != "" {
-			return true
-		}
-	}
-	for _, sub := range resource.SubResources {
-		if resourceHasBaseURLOverride(sub) {
 			return true
 		}
 	}
@@ -1544,6 +1513,18 @@ func resourceHasAbsoluteRequestPath(resource Resource) bool {
 
 func isAbsoluteRequestPath(path string) bool {
 	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
+}
+
+func absoluteRequestPathTemplateSource(path string) string {
+	for _, scheme := range []string{"https://", "http://"} {
+		if rest, ok := strings.CutPrefix(path, scheme); ok {
+			if authority, _, ok := strings.Cut(rest, "/"); ok {
+				return scheme + authority
+			}
+			return path
+		}
+	}
+	return path
 }
 
 type Endpoint struct {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2510,6 +2510,9 @@ func (s *APISpec) Validate() error {
 			if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q endpoint %q base_url", name, eName), e.BaseURL); err != nil {
 				return err
 			}
+			if e.BaseURL != "" && isAbsoluteRequestPath(e.Path) {
+				return fmt.Errorf("resource %q endpoint %q declares both base_url and an absolute endpoint path; choose one routing source", name, eName)
+			}
 			if err := validateEndpointPublicParamNames(e); err != nil {
 				return fmt.Errorf("resource %q endpoint %q: %w", name, eName, err)
 			}
@@ -2536,6 +2539,9 @@ func (s *APISpec) Validate() error {
 				}
 				if err := validateReservedPlaceholderHost(fmt.Sprintf("resource %q sub-resource %q endpoint %q base_url", name, subName, eName), e.BaseURL); err != nil {
 					return err
+				}
+				if e.BaseURL != "" && isAbsoluteRequestPath(e.Path) {
+					return fmt.Errorf("resource %q sub-resource %q endpoint %q declares both base_url and an absolute endpoint path; choose one routing source", name, subName, eName)
 				}
 				if err := validateEndpointPublicParamNames(e); err != nil {
 					return fmt.Errorf("resource %q sub-resource %q endpoint %q: %w", name, subName, eName, err)

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -280,7 +280,8 @@ func (s *APISpec) IsEndpointTemplateVar(placeholder string) bool {
 // InferEndpointTemplateVarsFromBaseURLs preserves existing explicit
 // placeholders, then appends placeholders found in URL-bearing spec fields.
 // It intentionally ignores endpoint paths: ordinary path params are command
-// inputs, while BaseURL placeholders need runtime config/env substitution.
+// inputs, while BaseURL placeholders and absolute endpoint-path placeholders
+// need runtime config/env substitution.
 func (s *APISpec) InferEndpointTemplateVarsFromBaseURLs() {
 	if s == nil {
 		return
@@ -369,7 +370,13 @@ func visitResourceURLTemplateSources(r Resource, deterministic bool, visit func(
 	}
 
 	visitEndpoint := func(endpoint Endpoint) bool {
-		return visit(endpoint.BaseURL)
+		if !visit(endpoint.BaseURL) {
+			return false
+		}
+		if isAbsoluteRequestPath(endpoint.Path) {
+			return visit(endpoint.Path)
+		}
+		return true
 	}
 	if deterministic {
 		for _, name := range sortedStringKeys(r.Endpoints) {
@@ -1472,14 +1479,29 @@ func DefaultResourceDescription(name string) string {
 }
 
 // HasResourceBaseURLOverride reports whether any resource or endpoint declares
-// a BaseURL override. Used by the client template to gate the absolute-URL
-// detection branch — specs that don't opt in regenerate byte-identically.
+// a BaseURL override.
 func (s *APISpec) HasResourceBaseURLOverride() bool {
 	if s == nil {
 		return false
 	}
 	for _, resource := range s.Resources {
 		if resourceHasBaseURLOverride(resource) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAbsoluteRequestPath reports whether generated commands can pass a full
+// URL to the HTTP client instead of a path relative to BaseURL. Resource or
+// endpoint BaseURL overrides synthesize absolute paths at generation time, and
+// internal YAML specs may also declare absolute endpoint paths directly.
+func (s *APISpec) HasAbsoluteRequestPath() bool {
+	if s == nil {
+		return false
+	}
+	for _, resource := range s.Resources {
+		if resourceHasAbsoluteRequestPath(resource) {
 			return true
 		}
 	}
@@ -1501,6 +1523,27 @@ func resourceHasBaseURLOverride(resource Resource) bool {
 		}
 	}
 	return false
+}
+
+func resourceHasAbsoluteRequestPath(resource Resource) bool {
+	if resource.BaseURL != "" {
+		return true
+	}
+	for _, endpoint := range resource.Endpoints {
+		if endpoint.BaseURL != "" || isAbsoluteRequestPath(endpoint.Path) {
+			return true
+		}
+	}
+	for _, sub := range resource.SubResources {
+		if resourceHasAbsoluteRequestPath(sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAbsoluteRequestPath(path string) bool {
+	return strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://")
 }
 
 type Endpoint struct {
@@ -2460,8 +2503,8 @@ func (s *APISpec) Validate() error {
 	if err := validateTierRouting(s); err != nil {
 		return err
 	}
-	if s.ClientPattern == "proxy-envelope" && s.HasResourceBaseURLOverride() {
-		return fmt.Errorf("resource or endpoint base_url overrides are incompatible with client_pattern=proxy-envelope; the proxy POSTs every request to the spec-level BaseURL, so per-request overrides would be silently ignored")
+	if s.ClientPattern == "proxy-envelope" && s.HasAbsoluteRequestPath() {
+		return fmt.Errorf("resource or endpoint base_url overrides and absolute endpoint paths are incompatible with client_pattern=proxy-envelope; the proxy POSTs every request to the spec-level BaseURL, so per-request hosts would be silently ignored")
 	}
 	if s.ClientPattern == "proxy-envelope" && s.BasePath != "" {
 		return fmt.Errorf("base_path is incompatible with client_pattern=proxy-envelope; the proxy routes via the envelope's Service/Path fields, not a URL-level prefix — fold the prefix into base_url instead")
@@ -2841,8 +2884,8 @@ func validateTierRouting(s *APISpec) error {
 			return err
 		}
 	}
-	if anyTierBaseURL && s.HasResourceBaseURLOverride() {
-		return fmt.Errorf("resource or endpoint base_url overrides are incompatible with tier_routing tier base_url overrides; choose one routing source")
+	if anyTierBaseURL && s.HasAbsoluteRequestPath() {
+		return fmt.Errorf("resource or endpoint base_url overrides and absolute endpoint paths are incompatible with tier_routing tier base_url overrides; choose one routing source")
 	}
 	for name, resource := range s.Resources {
 		if err := validateTierRoutingResource(s, name, resource, "", ""); err != nil {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4013,7 +4013,7 @@ func TestInferEndpointTemplateVarsFromBaseURLsFastPathSources(t *testing.T) {
 			name: "absolute endpoint path",
 			mutate: func(s *APISpec) {
 				resource := s.Resources["items"]
-				resource.Endpoints["list"] = Endpoint{Method: "GET", Path: "https://{endpoint_path}.api.example.com/items"}
+				resource.Endpoints["list"] = Endpoint{Method: "GET", Path: "https://{endpoint_path}.api.example.com/items/{id}"}
 				s.Resources["items"] = resource
 			},
 			want: "endpoint_path",
@@ -4052,6 +4052,31 @@ func TestInferEndpointTemplateVarsFromBaseURLsFastPathSources(t *testing.T) {
 			assert.Equal(t, []string{tc.want}, s.EndpointTemplateVars)
 		})
 	}
+}
+
+func TestInferEndpointTemplateVarsIgnoresAbsoluteEndpointPathParams(t *testing.T) {
+	t.Parallel()
+
+	s := &APISpec{
+		Name:    "templated",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]Resource{
+			"items": {
+				Endpoints: map[string]Endpoint{
+					"get": {
+						Method: "GET",
+						Path:   "https://api.example.com/items/{id}",
+						Params: []Param{{Name: "id", Type: "string", Positional: true}},
+					},
+				},
+			},
+		},
+	}
+
+	s.InferEndpointTemplateVarsFromBaseURLs()
+
+	assert.Empty(t, s.EndpointTemplateVars,
+		"path-segment params in absolute endpoint paths should stay command inputs, not env-backed template vars")
 }
 
 func TestValidateTierRouting(t *testing.T) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3782,6 +3782,72 @@ func TestValidateRejectsAbsoluteEndpointPathWithProxyEnvelope(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsEndpointBaseURLWithAbsoluteEndpointPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*APISpec)
+	}{
+		{
+			name: "top-level endpoint",
+			mutate: func(s *APISpec) {
+				items := s.Resources["items"]
+				items.Endpoints["list"] = Endpoint{
+					Method:      "GET",
+					Path:        "https://absolute.example.com/items",
+					BaseURL:     "https://override.example.com/v1",
+					Description: "List",
+				}
+				s.Resources["items"] = items
+			},
+		},
+		{
+			name: "subresource endpoint",
+			mutate: func(s *APISpec) {
+				items := s.Resources["items"]
+				items.SubResources = map[string]Resource{
+					"children": {
+						Endpoints: map[string]Endpoint{
+							"list": {
+								Method:      "GET",
+								Path:        "https://children.example.com/items",
+								BaseURL:     "https://override.example.com/v1",
+								Description: "List children",
+							},
+						},
+					},
+				}
+				s.Resources["items"] = items
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &APISpec{
+				Name:    "absolute-conflict",
+				Version: "0.1.0",
+				BaseURL: "https://api.example.com",
+				Resources: map[string]Resource{
+					"items": {
+						Endpoints: map[string]Endpoint{
+							"list": {Method: "GET", Path: "/items", Description: "List"},
+						},
+					},
+				},
+			}
+			tc.mutate(s)
+
+			err := s.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "base_url")
+			assert.Contains(t, err.Error(), "absolute endpoint path")
+		})
+	}
+}
+
 // TestValidateRejectsBasePathWithProxyEnvelope — proxy-envelope routes via
 // the envelope's Service/Path fields, not a URL-level prefix; a BasePath
 // would be silently ignored by the proxy. Validate must fail-fast.

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3717,6 +3717,71 @@ func TestValidateRejectsResourceBaseURLWithProxyEnvelope(t *testing.T) {
 	assert.Contains(t, err.Error(), "base_url")
 }
 
+func TestValidateRejectsAbsoluteEndpointPathWithProxyEnvelope(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*APISpec)
+	}{
+		{
+			name: "top-level endpoint",
+			mutate: func(s *APISpec) {
+				items := s.Resources["items"]
+				items.Endpoints["list"] = Endpoint{
+					Method:      "GET",
+					Path:        "https://other.example.com/items",
+					Description: "List",
+				}
+				s.Resources["items"] = items
+			},
+		},
+		{
+			name: "subresource endpoint",
+			mutate: func(s *APISpec) {
+				items := s.Resources["items"]
+				items.SubResources = map[string]Resource{
+					"children": {
+						Endpoints: map[string]Endpoint{
+							"list": {
+								Method:      "GET",
+								Path:        "https://children.example.com/items",
+								Description: "List children",
+							},
+						},
+					},
+				}
+				s.Resources["items"] = items
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &APISpec{
+				Name:          "proxytest",
+				Version:       "0.1.0",
+				BaseURL:       "https://proxy.example.com",
+				ClientPattern: "proxy-envelope",
+				Resources: map[string]Resource{
+					"items": {
+						Endpoints: map[string]Endpoint{
+							"list": {Method: "GET", Path: "/items", Description: "List"},
+						},
+					},
+				},
+			}
+			tc.mutate(s)
+
+			err := s.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "proxy-envelope")
+			assert.Contains(t, err.Error(), "absolute endpoint paths")
+		})
+	}
+}
+
 // TestValidateRejectsBasePathWithProxyEnvelope — proxy-envelope routes via
 // the envelope's Service/Path fields, not a URL-level prefix; a BasePath
 // would be silently ignored by the proxy. Validate must fail-fast.
@@ -3945,6 +4010,15 @@ func TestInferEndpointTemplateVarsFromBaseURLsFastPathSources(t *testing.T) {
 			want: "endpoint",
 		},
 		{
+			name: "absolute endpoint path",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				resource.Endpoints["list"] = Endpoint{Method: "GET", Path: "https://{endpoint_path}.api.example.com/items"}
+				s.Resources["items"] = resource
+			},
+			want: "endpoint_path",
+		},
+		{
 			name: "subresource base url",
 			mutate: func(s *APISpec) {
 				resource := s.Resources["items"]
@@ -4088,6 +4162,32 @@ func TestValidateTierRouting(t *testing.T) {
 				s.Resources["items"] = resource
 			},
 			wantErr: "base_url",
+		},
+		{
+			name: "absolute endpoint path conflict",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				endpoint := resource.Endpoints["list"]
+				endpoint.Path = "https://other.example.com/items"
+				resource.Endpoints["list"] = endpoint
+				s.Resources["items"] = resource
+			},
+			wantErr: "absolute endpoint paths",
+		},
+		{
+			name: "subresource absolute endpoint path conflict",
+			mutate: func(s *APISpec) {
+				resource := s.Resources["items"]
+				resource.SubResources = map[string]Resource{
+					"children": {
+						Endpoints: map[string]Endpoint{
+							"list": {Method: "GET", Path: "https://children.example.com/items", Description: "List children"},
+						},
+					},
+				}
+				s.Resources["items"] = resource
+			},
+			wantErr: "absolute endpoint paths",
 		},
 		{
 			name: "auth-bearing tier through resource base url must pass host review",


### PR DESCRIPTION
## Intent

Generated clients now honor endpoint paths that are already absolute URLs, so mixed-host internal YAML specs can call non-default hosts without producing malformed URLs like `https://default.example.comhttps://other.example.com/path`.

Closes #1975

## Approach

The generator now treats resource BaseURL overrides, endpoint BaseURL overrides, and direct absolute endpoint paths as the same request-path class. Command handlers pass the precomputed effective path to the client, and the client skips `BaseURL` concatenation when that path already starts with `http://` or `https://`.

Spec validation now rejects absolute endpoint paths in proxy-envelope and tier-base-URL routing combinations where those per-request hosts would be silently ignored or bypass routing. Template-var inference also scans absolute endpoint paths so `{tenant}`-style hosts still get env-backed runtime substitution.

## Scope

Primary area: generator client and command templates plus spec validation.

Why this belongs in this repo: the bug is in the Printing Press generator. Fixing a printed CLI would leave every future mixed-host CLI vulnerable to the same malformed URL behavior.

## Catalog Justification

N/A

## Risk

This changes generated client and command output only for specs that declare absolute endpoint paths or per-request host overrides. The main risk is altering existing multi-host routing behavior, covered by focused generated-CLI runtime tests and existing resource override regression tests.

## Output Contract

Generated command handlers now emit `path := "<effective path>"`, where the effective path may be a relative endpoint path or an absolute URL. Generated clients with any absolute request path emit an `isAbsoluteURL` branch and skip default `BaseURL` concatenation for those calls.

## Verification

- `go fmt ./...`
- `go test ./internal/spec -run 'TestValidateRejectsAbsoluteEndpointPathWithProxyEnvelope|TestValidateRejectsResourceBaseURLWithProxyEnvelope|TestInferEndpointTemplateVarsFromBaseURLsFastPathSources|TestValidateTierRouting'`
- `go test ./internal/generator -run 'TestEndpointPathWithBaseLeavesAbsolutePathAlone|TestClientAbsoluteEndpointPathLiveRequest|TestGenerateResourceBaseURLOverrideRoutesToOverrideHost|TestGenerateResourceBaseURLWithEndpointTemplateVars|TestGenerateNoResourceBaseURLOverrideByteCompat'`
- `go test ./internal/spec ./internal/generator`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
