### PR TITLE
fix(cli): preserve force-regen provenance

### DIFF
--- a/docs/solutions/logic-errors/force-regen-provenance-preservation-needs-lineage-guard.md
+++ b/docs/solutions/logic-errors/force-regen-provenance-preservation-needs-lineage-guard.md
@@ -1,0 +1,90 @@
+---
+title: "Force regen provenance preservation needs a same-lineage guard"
+date: 2026-05-25
+category: logic-errors
+module: cli-printing-press-generator
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "`generate --force` preserved hand-edits but dropped `.manuscripts/` provenance records from promoted CLI directories"
+  - "Fresh `.printing-press.json` writes removed promoted manifest metadata such as `category`, `novel_features`, run IDs, and printer attribution"
+  - "Naive preservation could resurrect metadata from a different API when force-regenerating into the same output path"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - force-regen
+  - manifest-preservation
+  - same-lineage
+  - manuscripts
+  - provenance
+related_components:
+  - regenmerge
+  - manifest
+  - publish
+---
+
+# Force regen provenance preservation needs a same-lineage guard
+
+## Problem
+
+`generate --force` used a snapshot plus fresh-generation merge to preserve hand-authored CLI code, but it did not treat provenance as first-class state. Promoted CLIs could lose `.manuscripts/<run-id>/` records and manifest metadata needed by publish validation, creating a loop where the recommended canonical-drift fix made the next publish step fail.
+
+## Symptoms
+
+- `.manuscripts/<run-id>/research.json`, phase 5 acceptance, proofs, and briefing context disappeared after force regen.
+- `.printing-press.json` was rewritten from fresh generation data and dropped promoted metadata such as `category` and `novel_features`.
+- Preserving those fields without a lineage guard introduced the opposite failure: stale run IDs, attribution, category, or feature metadata from a previous API could be copied into a different fresh generation.
+
+## What Didn't Work
+
+- Preserving only source-like non-classified files was insufficient because `.manuscripts/` is hidden and the regen sweep skipped hidden directories.
+- Rewriting the manifest from a fresh `CLIManifest` struct fixed generated fields but erased operator-added or publish-synced metadata.
+- Blindly merging every old manifest key into the fresh manifest was unsafe because `--force` can be used against a different API or spec. Provenance preservation is only valid when the old and fresh manifests describe the same lineage.
+
+## Solution
+
+Treat provenance preservation as a same-lineage merge:
+
+- Let `regenmerge.MergeIntoFreshTree` walk `.manuscripts/` despite the hidden-directory skip, and copy files with a streaming atomic helper so large research artifacts do not get loaded entirely into memory.
+- In `WriteManifestForGenerate`, read the existing manifest after the force snapshot has been merged back.
+- Preserve known durable fields only when the existing manifest and fresh manifest have the same `api_name` and, when available, matching `spec_checksum`, `spec_url`, or `spec_path`.
+- Overlay fresh manifest fields onto the existing raw manifest instead of deleting every known JSON key. This keeps same-lineage known fields that fresh generation omits because of `omitempty`.
+- Use explicit-clear signals for fields where empty has meaning, such as `novel_features` when dogfood produced an explicit empty built list.
+
+The practical boundary is:
+
+```go
+preserveExisting := hasExisting && sameGenerateManifestLineage(existing, fresh)
+
+if preserveExisting && p.RunID == "" && existing.RunID != "" {
+    fresh.RunID = existing.RunID
+}
+if preserveExisting && p.NovelFeatures == nil {
+    fresh.NovelFeatures = existing.NovelFeatures
+}
+if preserveExisting && p.NovelFeatures != nil && len(p.NovelFeatures) == 0 {
+    clearFields["novel_features"] = struct{}{}
+}
+```
+
+For cross-lineage force regen, discard the old raw manifest extras and write a clean fresh manifest. That avoids stale metadata resurrection while still allowing same-CLI regens to keep publish-critical provenance.
+
+## Why This Works
+
+The force-regen snapshot is a recovery source, not an authority by itself. `.manuscripts/` is safe to copy back because it is provenance under the same output tree, but manifest values need a stricter rule: preserve when they describe the same generated CLI lineage, replace or clear when fresh generation has an explicit answer, and drop when the old manifest belongs to a different API/spec.
+
+This also keeps side artifacts coherent. The manifest writer updates the in-memory `CLIManifest` for preserved run ID, owner, printer, category, description, and novel features before writing sibling artifacts such as MCPB metadata, so the JSON on disk and generated sidecars do not disagree.
+
+## Prevention
+
+- Regression tests for force-regen preservation should include both files and metadata: `.manuscripts/` content/mode/mtime, `.printing-press.json` category, novel features, run ID, owner, printer, and unknown top-level keys.
+- Add reciprocal tests for replacement and clearing, not just preservation. Fresh category or non-empty novel features must replace stale manifest values; explicit empty built features must clear stale features.
+- Include a cross-API or cross-spec test proving stale manifest extras are not carried forward.
+- For any future preserved manifest field, decide whether empty means "unavailable, preserve existing" or "fresh result is explicitly empty, clear existing" and encode that distinction in tests.
+
+## Related Issues
+
+- Issue #1976: force regen wiped `.manuscripts/` and manifest extras in promoted CLIs.
+- [Snapshot merge with AST classifier for force regen](../design-patterns/snapshot-merge-with-ast-classifier-for-force-regen-2026-05-10.md)
+- [Existing manifest wins over re-derivation for identity fields in regen paths](../conventions/manifest-wins-over-re-derivation-for-identity-fields-in-regen-paths-2026-05-12.md)

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	catalogfs "github.com/mvanhorn/cli-printing-press/v4/catalog"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/catalogmeta"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -99,6 +101,116 @@ func staleGeneratedCommand() {}
 
 	runGoCommandForCLITest(t, outputDir, "mod", "tidy")
 	runGoCommandForCLITest(t, outputDir, "build", "./cmd/regenapp-pp-cli")
+}
+
+func TestGenerateCmdForcePreservesManuscriptsAndManifestExtras(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "regenextras")
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: regenextras
+description: Regen extras API
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/regenextras-pp-cli/config.toml
+resources:
+  markets:
+    description: Manage markets
+    endpoints:
+      list:
+        method: GET
+        path: /markets
+        description: List markets
+`), 0o644))
+
+	runGenerate := func() {
+		cmd := newGenerateCmd()
+		cmd.SetArgs([]string{
+			"--spec", specPath,
+			"--output", outputDir,
+			"--validate=false",
+			"--force",
+		})
+		require.NoError(t, cmd.Execute())
+	}
+
+	runGenerate()
+
+	manuscriptPath := filepath.Join(outputDir, ".manuscripts", "20260523-171100", "research.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(manuscriptPath), 0o755))
+	require.NoError(t, os.WriteFile(manuscriptPath, []byte(`{"accepted":true}`), 0o640))
+	wantModTime := time.Date(2026, 5, 23, 17, 11, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(manuscriptPath, wantModTime, wantModTime))
+
+	manifestPath := filepath.Join(outputDir, pipeline.CLIManifestFilename)
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{
+  "schema_version": 1,
+  "api_name": "regenextras",
+  "cli_name": "regenextras-pp-cli",
+  "category": "other",
+  "novel_features": [
+    {
+      "name": "Market scanner",
+      "command": "markets scan",
+      "description": "Finds active markets"
+    }
+  ],
+  "operator_note": "published-library override"
+}`), 0o644))
+
+	runGenerate()
+
+	gotManuscript, err := os.ReadFile(manuscriptPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"accepted":true}`, string(gotManuscript))
+	info, err := os.Stat(manuscriptPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	assert.True(t, info.ModTime().Equal(wantModTime), "manuscript mtime should survive force regen")
+
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	var manifest pipeline.CLIManifest
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	assert.Equal(t, "other", manifest.Category)
+	require.Len(t, manifest.NovelFeatures, 1)
+	assert.Equal(t, "Market scanner", manifest.NovelFeatures[0].Name)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `"published-library override"`, string(raw["operator_note"]))
+}
+
+func TestLoadResearchSourcesReturnsExplicitEmptyManifestNovelFeatures(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), []byte(`{
+  "api_name": "regenextras",
+  "novel_features": [
+    {
+      "name": "Planned scanner",
+      "command": "planned scan",
+      "description": "Planned feature"
+    }
+  ],
+  "novel_features_built": []
+}`), 0o644))
+
+	gen := generator.New(&spec.APISpec{
+		Name: "regenextras",
+		Auth: spec.AuthConfig{Type: "none"},
+	}, t.TempDir())
+
+	got := loadResearchSources(gen, researchDir)
+	require.NotNil(t, got, "empty built list is an explicit fresh result, not unavailable metadata")
+	assert.Empty(t, got)
+	assert.Empty(t, gen.NovelFeatures)
 }
 
 func TestGenerateCmdHelpDescribesForceAsGeneratedOverwrite(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1908,6 +1908,7 @@ func loadResearchSources(gen *generator.Generator, researchDir string) []pipelin
 			})
 		}
 		if research.NovelFeaturesBuilt != nil {
+			manifestNovel = []pipeline.NovelFeatureManifest{}
 			for _, nf := range *research.NovelFeaturesBuilt {
 				manifestNovel = append(manifestNovel, pipeline.NovelFeatureManifest{
 					Name:        nf.Name,

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -665,10 +665,7 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if runID == "" {
 		runID = now.Format(runIDTimeFormat)
 	}
-	var existingDescription string
-	if existing, err := ReadCLIManifest(p.OutputDir); err == nil {
-		existingDescription = existing.Description
-	}
+	existing, existingRaw, hasExisting := readExistingManifestForGenerate(p.OutputDir)
 	m := CLIManifest{
 		SchemaVersion:        CurrentCLIManifestSchemaVersion,
 		GeneratedAt:          now,
@@ -758,17 +755,48 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if description := strings.TrimSpace(p.Description); description != "" {
 		m.Description = description
 	}
+	preserveExisting := hasExisting && sameGenerateManifestLineage(existing, m)
 	// A durable manifest description may be hand-edited after generation.
 	// Operators can delete or replace the field when they want changed spec
 	// prose to become canonical on a later generate run.
-	if preserveExistingDescription(existingDescription) {
-		m.Description = existingDescription
+	if preserveExisting && preserveExistingDescription(existing.Description) {
+		m.Description = existing.Description
 	}
 	if len(p.NovelFeatures) > 0 {
 		m.NovelFeatures = p.NovelFeatures
+	} else if p.NovelFeatures != nil {
+		m.NovelFeatures = []NovelFeatureManifest{}
+	} else if preserveExisting && len(existing.NovelFeatures) > 0 {
+		m.NovelFeatures = existing.NovelFeatures
 	}
 
-	if err := WriteCLIManifest(p.OutputDir, m); err != nil {
+	if preserveExisting && m.Category == "" && strings.TrimSpace(existing.Category) != "" {
+		m.Category = existing.Category
+	}
+	if preserveExisting && p.RunID == "" && strings.TrimSpace(existing.RunID) != "" {
+		m.RunID = existing.RunID
+		runID = existing.RunID
+	}
+	if preserveExisting {
+		if strings.TrimSpace(existing.Owner) != "" {
+			m.Owner = existing.Owner
+		}
+		if strings.TrimSpace(existing.Printer) != "" {
+			m.Printer = existing.Printer
+		}
+		if strings.TrimSpace(existing.PrinterName) != "" {
+			m.PrinterName = existing.PrinterName
+		}
+	} else {
+		existingRaw = nil
+	}
+
+	clearFields := map[string]struct{}{}
+	if preserveExisting && p.NovelFeatures != nil && len(p.NovelFeatures) == 0 {
+		clearFields["novel_features"] = struct{}{}
+	}
+
+	if err := writeCLIManifestForGenerate(p.OutputDir, m, existingRaw, clearFields); err != nil {
 		return err
 	}
 	// Emit the customizations index alongside .printing-press.json. The
@@ -781,6 +809,61 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	// Emit MCPB manifest.json next to .printing-press.json. Pass the
 	// in-memory struct so we don't re-read the file we just wrote.
 	return WriteMCPBManifestFromStruct(p.OutputDir, m)
+}
+
+func readExistingManifestForGenerate(dir string) (CLIManifest, map[string]json.RawMessage, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	if err != nil {
+		return CLIManifest{}, nil, false
+	}
+	var m CLIManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return CLIManifest{}, nil, false
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		raw = nil
+	}
+	return m, raw, true
+}
+
+func writeCLIManifestForGenerate(dir string, m CLIManifest, existingRaw map[string]json.RawMessage, clearFields map[string]struct{}) error {
+	if len(existingRaw) == 0 {
+		return WriteCLIManifest(dir, m)
+	}
+	generatedFields, err := marshalCLIManifestFields(m)
+	if err != nil {
+		return err
+	}
+	merged := maps.Clone(existingRaw)
+	for key := range clearFields {
+		delete(merged, key)
+	}
+	maps.Copy(merged, generatedFields)
+	data, err := marshalCLIManifestObject(merged)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, CLIManifestFilename), data, 0o644); err != nil {
+		return fmt.Errorf("writing CLI manifest: %w", err)
+	}
+	return nil
+}
+
+func sameGenerateManifestLineage(existing, generated CLIManifest) bool {
+	if existing.APIName == "" || generated.APIName == "" || existing.APIName != generated.APIName {
+		return false
+	}
+	if existing.SpecChecksum != "" && generated.SpecChecksum != "" {
+		return existing.SpecChecksum == generated.SpecChecksum
+	}
+	if existing.SpecURL != "" && generated.SpecURL != "" {
+		return existing.SpecURL == generated.SpecURL
+	}
+	if existing.SpecPath != "" && generated.SpecPath != "" {
+		return existing.SpecPath == generated.SpecPath
+	}
+	return true
 }
 
 func preserveExistingDescription(description string) bool {

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -778,13 +778,13 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		runID = existing.RunID
 	}
 	if preserveExisting {
-		if strings.TrimSpace(existing.Owner) != "" {
+		if p.Owner == "" && strings.TrimSpace(existing.Owner) != "" {
 			m.Owner = existing.Owner
 		}
-		if strings.TrimSpace(existing.Printer) != "" {
+		if p.Printer == "" && strings.TrimSpace(existing.Printer) != "" {
 			m.Printer = existing.Printer
 		}
-		if strings.TrimSpace(existing.PrinterName) != "" {
+		if p.PrinterName == "" && strings.TrimSpace(existing.PrinterName) != "" {
 			m.PrinterName = existing.PrinterName
 		}
 	} else {
@@ -794,6 +794,14 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	clearFields := map[string]struct{}{}
 	if preserveExisting && p.NovelFeatures != nil && len(p.NovelFeatures) == 0 {
 		clearFields["novel_features"] = struct{}{}
+	}
+	if preserveExisting {
+		if m.SpecURL != "" && m.SpecPath == "" {
+			clearFields["spec_path"] = struct{}{}
+		}
+		if m.SpecPath != "" && m.SpecURL == "" {
+			clearFields["spec_url"] = struct{}{}
+		}
 	}
 
 	if err := writeCLIManifestForGenerate(p.OutputDir, m, existingRaw, clearFields); err != nil {
@@ -857,10 +865,10 @@ func sameGenerateManifestLineage(existing, generated CLIManifest) bool {
 	if existing.SpecChecksum != "" && generated.SpecChecksum != "" {
 		return existing.SpecChecksum == generated.SpecChecksum
 	}
-	if existing.SpecURL != "" && generated.SpecURL != "" {
-		return existing.SpecURL == generated.SpecURL
-	}
-	if existing.SpecPath != "" && generated.SpecPath != "" {
+	if (existing.SpecURL != "" || existing.SpecPath != "") && (generated.SpecURL != "" || generated.SpecPath != "") {
+		if existing.SpecURL != "" || generated.SpecURL != "" {
+			return existing.SpecURL == generated.SpecURL
+		}
 		return existing.SpecPath == generated.SpecPath
 	}
 	return true

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1955,6 +1955,42 @@ func TestWriteManifestForGenerateDoesNotPreserveCrossAPIManifestExtras(t *testin
 	assert.Empty(t, got.NovelFeatures)
 }
 
+func TestWriteManifestForGenerateDoesNotPreserveStaleSpecURLWhenFreshSourceIsPath(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi.json")
+	require.NoError(t, os.WriteFile(specPath, []byte(`{"openapi":"3.0.0","info":{"title":"Synthetic Polymarket","version":"1.0.0"},"paths":{}}`), 0o644))
+	existingRaw := `{
+  "schema_version": 1,
+  "api_name": "synthetic-polymarket",
+  "cli_name": "synthetic-polymarket-pp-cli",
+  "spec_url": "https://example.com/old-openapi.json",
+  "operator_note": "published-library override"
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(existingRaw), 0o644))
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "synthetic-polymarket",
+		SpecSrcs:  []string{specPath},
+		OutputDir: dir,
+		Spec: &spec.APISpec{
+			Name: "synthetic-polymarket",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "operator_note")
+	assert.NotContains(t, raw, "spec_url")
+
+	got := readPublishedManifest(t, dir)
+	assert.Empty(t, got.SpecURL)
+	assert.Equal(t, specPath, got.SpecPath)
+}
+
 func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *testing.T) {
 	dir := t.TempDir()
 	existingRaw := `{
@@ -1963,6 +1999,9 @@ func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *tes
   "cli_name": "synthetic-polymarket-pp-cli",
   "category": "other",
   "display_name": "Stale Display",
+  "owner": "stale-owner",
+  "printer": "stale-printer",
+  "printer_name": "Stale Printer",
   "novel_features": [
     {
       "name": "Stale scanner",
@@ -1978,6 +2017,9 @@ func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *tes
 		APIName:     "synthetic-polymarket",
 		OutputDir:   dir,
 		DisplayName: "Fresh Display",
+		Owner:       "fresh-owner",
+		Printer:     "fresh-printer",
+		PrinterName: "Fresh Printer",
 		NovelFeatures: []NovelFeatureManifest{
 			{
 				Name:        "Fresh scanner",
@@ -2002,6 +2044,9 @@ func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *tes
 	got := readPublishedManifest(t, dir)
 	assert.Equal(t, "travel", got.Category)
 	assert.Equal(t, "Fresh Display", got.DisplayName)
+	assert.Equal(t, "fresh-owner", got.Owner)
+	assert.Equal(t, "fresh-printer", got.Printer)
+	assert.Equal(t, "Fresh Printer", got.PrinterName)
 	require.Len(t, got.NovelFeatures, 1)
 	assert.Equal(t, "Fresh scanner", got.NovelFeatures[0].Name)
 }

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1857,6 +1857,185 @@ func TestWriteManifestForGeneratePreservesExistingDurableDescription(t *testing.
 	assert.Equal(t, existing, got.Description)
 }
 
+func TestWriteManifestForGeneratePreservesExistingManifestExtras(t *testing.T) {
+	dir := t.TempDir()
+	existingRaw := `{
+  "schema_version": 1,
+  "api_name": "synthetic-polymarket",
+  "cli_name": "synthetic-polymarket-pp-cli",
+  "run_id": "20260523-171100",
+  "owner": "original-owner",
+  "printer": "original-printer",
+  "printer_name": "Original Printer",
+  "spec_url": "https://example.com/openapi.json",
+  "api_version": "2026-05-23",
+  "category": "other",
+  "novel_features": [
+    {
+      "name": "Market scanner",
+      "command": "markets scan",
+      "description": "Finds active markets"
+    }
+  ],
+  "operator_note": "published-library override"
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(existingRaw), 0o644))
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "synthetic-polymarket",
+		OutputDir: dir,
+		Spec: &spec.APISpec{
+			Name: "synthetic-polymarket",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `"published-library override"`, string(raw["operator_note"]))
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "20260523-171100", got.RunID)
+	assert.Equal(t, "original-owner", got.Owner)
+	assert.Equal(t, "original-printer", got.Printer)
+	assert.Equal(t, "Original Printer", got.PrinterName)
+	assert.Equal(t, "https://example.com/openapi.json", got.SpecURL)
+	assert.Equal(t, "2026-05-23", got.APIVersion)
+	assert.Equal(t, "other", got.Category)
+	require.Len(t, got.NovelFeatures, 1)
+	assert.Equal(t, "Market scanner", got.NovelFeatures[0].Name)
+}
+
+func TestWriteManifestForGenerateDoesNotPreserveCrossAPIManifestExtras(t *testing.T) {
+	dir := t.TempDir()
+	existingRaw := `{
+  "schema_version": 1,
+  "api_name": "old-api",
+  "cli_name": "old-api-pp-cli",
+  "run_id": "20260523-171100",
+  "owner": "old-owner",
+  "printer": "old-printer",
+  "category": "other",
+  "novel_features": [
+    {
+      "name": "Old scanner",
+      "command": "old scan",
+      "description": "Old feature"
+    }
+  ],
+  "operator_note": "published-library override"
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(existingRaw), 0o644))
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "new-api",
+		OutputDir: dir,
+		Spec: &spec.APISpec{
+			Name: "new-api",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "operator_note")
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "new-api", got.APIName)
+	assert.NotEqual(t, "20260523-171100", got.RunID)
+	assert.Empty(t, got.Owner)
+	assert.Empty(t, got.Printer)
+	assert.Empty(t, got.Category)
+	assert.Empty(t, got.NovelFeatures)
+}
+
+func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *testing.T) {
+	dir := t.TempDir()
+	existingRaw := `{
+  "schema_version": 1,
+  "api_name": "synthetic-polymarket",
+  "cli_name": "synthetic-polymarket-pp-cli",
+  "category": "other",
+  "display_name": "Stale Display",
+  "novel_features": [
+    {
+      "name": "Stale scanner",
+      "command": "stale scan",
+      "description": "Old feature"
+    }
+  ],
+  "operator_note": "published-library override"
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, CLIManifestFilename), []byte(existingRaw), 0o644))
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:     "synthetic-polymarket",
+		OutputDir:   dir,
+		DisplayName: "Fresh Display",
+		NovelFeatures: []NovelFeatureManifest{
+			{
+				Name:        "Fresh scanner",
+				Command:     "fresh scan",
+				Description: "Fresh feature",
+			},
+		},
+		Spec: &spec.APISpec{
+			Name:     "synthetic-polymarket",
+			Category: "travel",
+			Auth:     spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.JSONEq(t, `"published-library override"`, string(raw["operator_note"]))
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "travel", got.Category)
+	assert.Equal(t, "Fresh Display", got.DisplayName)
+	require.Len(t, got.NovelFeatures, 1)
+	assert.Equal(t, "Fresh scanner", got.NovelFeatures[0].Name)
+}
+
+func TestWriteManifestForGenerateEmptyFreshNovelFeaturesClearExisting(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, CLIManifest{
+		APIName:  "synthetic-polymarket",
+		CLIName:  "synthetic-polymarket-pp-cli",
+		Category: "other",
+		NovelFeatures: []NovelFeatureManifest{
+			{
+				Name:        "Stale scanner",
+				Command:     "stale scan",
+				Description: "Old feature",
+			},
+		},
+	})
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:       "synthetic-polymarket",
+		OutputDir:     dir,
+		NovelFeatures: []NovelFeatureManifest{},
+		Spec: &spec.APISpec{
+			Name: "synthetic-polymarket",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Empty(t, got.NovelFeatures)
+}
+
 func TestWriteManifestForGenerateReplacesLiteralEllipsisDescription(t *testing.T) {
 	dir := t.TempDir()
 	fresh := "Curated catalog description without a truncation marker."

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -3,6 +3,7 @@ package regenmerge
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -140,16 +141,50 @@ func copyPreserveFile(snapshotDir, freshDir, rel string) error {
 	if info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to preserve symlinked snapshot file: %s", rel)
 	}
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return fmt.Errorf("reading snapshot file %s: %w", rel, err)
-	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("creating parent for %s: %w", rel, err)
 	}
-	if err := writeFileAtomic(dst, data); err != nil {
+	if err := copyFileAtomic(src, dst, info.Mode().Perm()); err != nil {
 		return fmt.Errorf("writing preserved %s: %w", rel, err)
 	}
+	if err := os.Chmod(dst, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("preserving mode for %s: %w", rel, err)
+	}
+	if err := os.Chtimes(dst, info.ModTime(), info.ModTime()); err != nil {
+		return fmt.Errorf("preserving mtime for %s: %w", rel, err)
+	}
+	return nil
+}
+
+func copyFileAtomic(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("creating temporary destination: %w", err)
+	}
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copying bytes: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing temporary destination: %w", err)
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		return fmt.Errorf("replacing destination: %w", err)
+	}
+	removeTmp = false
 	return nil
 }
 
@@ -171,6 +206,9 @@ func sweepNonClassifiedFiles(snapshotDir, freshDir string) error {
 		}
 		relSlash := filepath.ToSlash(rel)
 		if d.IsDir() {
+			if isManuscriptsPath(relSlash) {
+				return nil
+			}
 			if !shouldWalkDir(d.Name()) {
 				return filepath.SkipDir
 			}
@@ -179,14 +217,11 @@ func sweepNonClassifiedFiles(snapshotDir, freshDir string) error {
 			}
 			return nil
 		}
-		if !shouldWalkDir(filepath.Base(filepath.Dir(path))) {
+		if !isManuscriptsPath(relSlash) && !shouldWalkDir(filepath.Base(filepath.Dir(path))) {
 			return nil
 		}
 		if shouldClassifyFile(relSlash) {
 			return nil
-		}
-		if d.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to sweep symlinked snapshot file: %s", relSlash)
 		}
 		dst := filepath.Join(freshDir, rel)
 		if _, err := os.Stat(dst); err == nil {
@@ -195,18 +230,15 @@ func sweepNonClassifiedFiles(snapshotDir, freshDir string) error {
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("statting fresh path %s: %w", relSlash, err)
 		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("reading snapshot file %s: %w", relSlash, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return fmt.Errorf("creating parent for swept %s: %w", relSlash, err)
-		}
-		if err := writeFileAtomic(dst, data); err != nil {
-			return fmt.Errorf("writing swept %s: %w", relSlash, err)
+		if err := copyPreserveFile(snapshotDir, freshDir, rel); err != nil {
+			return fmt.Errorf("sweeping snapshot file %s: %w", relSlash, err)
 		}
 		return nil
 	})
+}
+
+func isManuscriptsPath(relSlash string) bool {
+	return relSlash == ".manuscripts" || strings.HasPrefix(relSlash, ".manuscripts/")
 }
 
 // isGeneratorOwnedInternalDir reports whether relSlash names a directory

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,6 +197,32 @@ func TestMergeIntoFreshTreeSweepsNonClassifiedFiles(t *testing.T) {
 	got, err = os.ReadFile(filepath.Join(fresh, "Makefile"))
 	require.NoError(t, err)
 	assert.Equal(t, "# custom\n", string(got))
+}
+
+func TestMergeIntoFreshTreePreservesManuscripts(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	rel := filepath.Join(".manuscripts", "20260523-171100", "research.json")
+	path := filepath.Join(snap, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"status":"accepted"}`), 0o640))
+	wantModTime := time.Date(2026, 5, 23, 17, 11, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(path, wantModTime, wantModTime))
+
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true}))
+
+	gotPath := filepath.Join(fresh, rel)
+	got, err := os.ReadFile(gotPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"status":"accepted"}`, string(got))
+
+	info, err := os.Stat(gotPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	assert.True(t, info.ModTime().Equal(wantModTime), "mtime should survive force-regen sweep")
 }
 
 // TestMergeIntoFreshTreeNovelOnlySkipsValueDrift verifies that the


### PR DESCRIPTION
## Summary

Force regeneration now keeps promoted CLI provenance intact instead of creating a wipe-restore loop. Re-running `generate --force` on an already-promoted CLI preserves `.manuscripts/<run-id>/` records and same-lineage manifest metadata such as run ID, original owner/printer attribution, category, novel features, and unknown top-level manifest extensions.

The preservation boundary is lineage-aware: fresh generation still replaces stale fields when it has a real answer, explicit empty verified novel features clear stale entries, and cross-API/spec force regens write a clean fresh manifest instead of resurrecting old metadata.

## Verification

- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `git diff --check`
- `python3` frontmatter parser-safety check for the new solution doc; the repository does not contain `scripts/validate-frontmatter.py`

## Compounded learnings

- File: `docs/solutions/logic-errors/force-regen-provenance-preservation-needs-lineage-guard.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with existing force-regen snapshot and manifest-authority docs; created a narrower doc for provenance lineage guards
- Instruction-file edit: none needed; `AGENTS.md` already surfaces `docs/solutions/`
- Refresh recommendation: none

Closes #1976

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
