### PR TITLE
fix(cli): preserve docs-derived request paths

### DIFF
--- a/docs/solutions/logic-errors/docs-derived-path-preservation-after-llm-normalization.md
+++ b/docs/solutions/logic-errors/docs-derived-path-preservation-after-llm-normalization.md
@@ -1,0 +1,68 @@
+---
+title: "Docs-derived paths must preserve documented request paths after LLM normalization"
+date: 2026-05-25
+category: logic-errors
+module: internal/docspec
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Generated docs-source commands hit request paths that differed from the vendor documentation"
+  - "Plural path segments could be singularized, such as get_pending_orders becoming get_pending_order"
+  - "Slash-separated documented segments could be collapsed into underscores, such as funding_rate/batch becoming funding_rate_batch"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - docspec
+  - docs-derived-specs
+  - path-preservation
+  - llm-normalization
+  - generator
+---
+
+# Docs-derived paths must preserve documented request paths after LLM normalization
+
+## Problem
+
+`generate --docs` can route documentation through an LLM doc-to-spec pass before the generator emits a printed CLI. Issue #1987 showed that this pass could normalize path segments while deriving YAML: Bitunix Futures docs listed `/api/v1/futures/tpsl/get_pending_orders` and `/api/v1/futures/market/funding_rate/batch`, but generated commands used `/get_pending_order` and `/funding_rate_batch`.
+
+That is a request-path contract bug. The endpoint name, resource name, and command path can be derived for ergonomics, but the HTTP request path must come from the documentation verbatim when the docs contain an explicit method/path pair.
+
+## Symptoms
+
+- Generated commands received real API error envelopes because they called non-documented routes.
+- The failures looked like path-segment normalization rather than random hallucination: plural-to-singular and slash-to-underscore drift.
+- Local manual correction of the request paths made the live endpoints succeed.
+
+## What Didn't Work
+
+- Relying on prompt wording alone is not enough. It reduces the odds of normalization, but it does not make the LLM output authoritative.
+- Repairing `Endpoint.Path` after parsing without re-syncing path params is incomplete. `spec.ParseBytes` has already enriched `{placeholder}` params, so a later path rewrite can leave stale positional/path params behind.
+
+## Solution
+
+Treat the regex-extracted docs method/path pairs as the authority for request paths, then use the LLM spec as the authority for the richer surrounding metadata. After `GenerateFromDocsLLM` parses the YAML, compare each parsed endpoint path against the documented path set:
+
+- Leave exact method/path matches unchanged.
+- Build a conservative canonical key that tolerates the observed LLM drift: separator differences, simple trailing plural `s`, and placeholder-name normalization.
+- Rewrite only when the current method plus canonical path maps to exactly one documented path.
+- Prune stale positional/path params on rewritten endpoints, then rerun `EnrichPathParams` and `Validate`.
+
+The regression test should exercise the full `GenerateFromDocsLLM` path with a fake LLM binary on `PATH`, not just the helper, so the wiring is protected.
+
+## Why This Works
+
+The documented request path is the source of truth for the wire contract. Names derived for CLI ergonomics may safely normalize, but the path sent to the API must not. Matching through a uniqueness gate avoids guessing when two documented paths collapse to the same canonical form, while re-enrichment keeps the repaired path and generated command schema aligned.
+
+## Prevention
+
+- When a generator step combines an authoritative source with an LLM or heuristic derivation, name which field remains authoritative before emitting the generated artifact.
+- Add negative tests for lookalike paths and HTTP-method partitioning so fuzzy repair cannot rewrite a different endpoint.
+- If a fix mutates endpoint paths after parsing, re-run path-param enrichment or prove the placeholder set is unchanged.
+
+## Related Issues
+
+- Issue #1987
+- `docs/solutions/logic-errors/mcp-handler-conflates-path-and-query-positional-params-2026-05-05.md`
+- `docs/solutions/logic-errors/store-columns-sourced-from-request-params-instead-of-response-2026-05-08.md`
+- `docs/solutions/logic-errors/non-catalog-category-must-enter-generate-before-emission-2026-05-22.md`

--- a/internal/docspec/docspec.go
+++ b/internal/docspec/docspec.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -13,14 +14,15 @@ import (
 )
 
 var (
-	endpointRe = regexp.MustCompile(`(GET|POST|PUT|PATCH|DELETE)\s+(/[a-zA-Z0-9/{}_.\-]+)`)
-	baseURLRe  = regexp.MustCompile(`https://api\.[a-zA-Z0-9.\-]+`)
-	bearerRe   = regexp.MustCompile(`(?i)(Bearer|Authorization:\s*Bearer)`)
-	apiKeyRe   = regexp.MustCompile(`(?i)(API[_ ]key|api_key|X-API-Key)`)
-	oauthRe    = regexp.MustCompile(`(?i)OAuth`)
-	paramRowRe = regexp.MustCompile(`(?i)<t[dr][^>]*>\s*(\w+)\s*</t[dr]>\s*<t[dr][^>]*>\s*(string|integer|int|boolean|bool|number|float|array|object)\s*</t[dr]>`)
-	jsonKeyRe  = regexp.MustCompile(`"(\w+)"\s*:`)
-	preBlockRe = regexp.MustCompile(`(?s)<(?:pre|code)[^>]*>(.*?)</(?:pre|code)>`)
+	endpointRe     = regexp.MustCompile(`(GET|POST|PUT|PATCH|DELETE)\s+(/[a-zA-Z0-9/{}_.\-]+)`)
+	baseURLRe      = regexp.MustCompile(`https://api\.[a-zA-Z0-9.\-]+`)
+	bearerRe       = regexp.MustCompile(`(?i)(Bearer|Authorization:\s*Bearer)`)
+	apiKeyRe       = regexp.MustCompile(`(?i)(API[_ ]key|api_key|X-API-Key)`)
+	oauthRe        = regexp.MustCompile(`(?i)OAuth`)
+	paramRowRe     = regexp.MustCompile(`(?i)<t[dr][^>]*>\s*(\w+)\s*</t[dr]>\s*<t[dr][^>]*>\s*(string|integer|int|boolean|bool|number|float|array|object)\s*</t[dr]>`)
+	jsonKeyRe      = regexp.MustCompile(`"(\w+)"\s*:`)
+	preBlockRe     = regexp.MustCompile(`(?s)<(?:pre|code)[^>]*>(.*?)</(?:pre|code)>`)
+	pathParamKeyRe = regexp.MustCompile(`\{[A-Za-z_][A-Za-z0-9_]*\}`)
 )
 
 // GenerateFromDocs fetches an API documentation page and extracts a best-effort
@@ -359,6 +361,12 @@ func GenerateFromDocsLLM(docsURL, apiName string) (*spec.APISpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	if preserveDocumentedEndpointPaths(parsed, extractEndpoints(html)) {
+		parsed.EnrichPathParams()
+		if err := parsed.Validate(); err != nil {
+			return nil, fmt.Errorf("validation after preserving documented paths: %w", err)
+		}
+	}
 	// The prompt template (BuildDocSpecLLMPrompt) seeds base_url with the
 	// PlaceholderBaseURL; an LLM that can't find a real host often echoes
 	// it back. Set the flag here so callers refuse to ship — yaml:"-" on
@@ -367,6 +375,129 @@ func GenerateFromDocsLLM(docsURL, apiName string) (*spec.APISpec, error) {
 		parsed.BaseURLIsPlaceholder = true
 	}
 	return parsed, nil
+}
+
+func preserveDocumentedEndpointPaths(apiSpec *spec.APISpec, documented []rawEndpoint) bool {
+	if apiSpec == nil || len(documented) == 0 {
+		return false
+	}
+
+	exact := map[string]map[string]bool{}
+	canonical := map[string]map[string][]string{}
+	for _, ep := range documented {
+		method := strings.ToUpper(strings.TrimSpace(ep.Method))
+		path := strings.TrimSpace(ep.Path)
+		if method == "" || path == "" {
+			continue
+		}
+		if exact[method] == nil {
+			exact[method] = map[string]bool{}
+		}
+		exact[method][path] = true
+
+		key := canonicalDocumentedPathKey(path)
+		if key == "" {
+			continue
+		}
+		if canonical[method] == nil {
+			canonical[method] = map[string][]string{}
+		}
+		if !slices.Contains(canonical[method][key], path) {
+			canonical[method][key] = append(canonical[method][key], path)
+		}
+	}
+
+	var changed bool
+	for resourceName, resource := range apiSpec.Resources {
+		if preserveResourceEndpointPaths(&resource, exact, canonical) {
+			changed = true
+		}
+		apiSpec.Resources[resourceName] = resource
+	}
+	return changed
+}
+
+func preserveResourceEndpointPaths(resource *spec.Resource, exact map[string]map[string]bool, canonical map[string]map[string][]string) bool {
+	var changed bool
+	for endpointName, endpoint := range resource.Endpoints {
+		method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
+		path := strings.TrimSpace(endpoint.Path)
+		if exact[method][path] {
+			continue
+		}
+
+		key := canonicalDocumentedPathKey(path)
+		candidates := canonical[method][key]
+		if len(candidates) != 1 {
+			continue
+		}
+
+		endpoint.Path = candidates[0]
+		pruneStalePathParams(&endpoint)
+		resource.Endpoints[endpointName] = endpoint
+		changed = true
+	}
+	for subResourceName, subResource := range resource.SubResources {
+		if preserveResourceEndpointPaths(&subResource, exact, canonical) {
+			changed = true
+		}
+		resource.SubResources[subResourceName] = subResource
+	}
+	return changed
+}
+
+func pruneStalePathParams(endpoint *spec.Endpoint) {
+	names := map[string]bool{}
+	for _, param := range extractPathParams(endpoint.Path) {
+		names[param.Name] = true
+	}
+	if len(endpoint.Params) == 0 {
+		return
+	}
+
+	params := endpoint.Params[:0]
+	for _, param := range endpoint.Params {
+		if (param.Positional || param.PathParam) && !names[param.Name] {
+			continue
+		}
+		params = append(params, param)
+	}
+	endpoint.Params = params
+}
+
+func canonicalDocumentedPathKey(path string) string {
+	path = pathParamKeyRe.ReplaceAllString(strings.ToLower(path), "{param}")
+	tokens := strings.FieldsFunc(path, func(r rune) bool {
+		switch r {
+		case '/', '_', '-':
+			return true
+		default:
+			return false
+		}
+	})
+	if len(tokens) == 0 {
+		return ""
+	}
+	for i, token := range tokens {
+		if token != "{param}" {
+			tokens[i] = singularizePathToken(token)
+		}
+	}
+	return strings.Join(tokens, "")
+}
+
+func singularizePathToken(token string) string {
+	if len(token) <= 3 || !strings.HasSuffix(token, "s") {
+		return token
+	}
+	switch {
+	case strings.HasSuffix(token, "ss"),
+		strings.HasSuffix(token, "us"),
+		strings.HasSuffix(token, "is"):
+		return token
+	default:
+		return strings.TrimSuffix(token, "s")
+	}
 }
 
 // BuildDocSpecLLMPrompt constructs a prompt that asks the LLM to read API docs
@@ -427,6 +558,7 @@ Rules:
 - Extract ALL endpoints you can find in the docs
 - Detect the correct auth type from the documentation
 - Extract the real base URL from the docs
+- Preserve documented request paths verbatim. Do not singularize path segments or convert underscores into slashes, or slashes into underscores.
 - Group endpoints by resource (the first path segment after version prefix)
 - Every resource must have at least one endpoint
 - Every endpoint must have method and path

--- a/internal/docspec/docspec.go
+++ b/internal/docspec/docspec.go
@@ -361,11 +361,12 @@ func GenerateFromDocsLLM(docsURL, apiName string) (*spec.APISpec, error) {
 	if err != nil {
 		return nil, err
 	}
-	if preserveDocumentedEndpointPaths(parsed, extractEndpoints(html)) {
+	documentedEndpoints := extractEndpoints(html)
+	if preserveDocumentedEndpointPaths(parsed, documentedEndpoints) {
 		parsed.EnrichPathParams()
-		if err := parsed.Validate(); err != nil {
-			return nil, fmt.Errorf("validation after preserving documented paths: %w", err)
-		}
+	}
+	if err := parsed.Validate(); err != nil {
+		return nil, fmt.Errorf("validation after preserving documented paths: %w", err)
 	}
 	// The prompt template (BuildDocSpecLLMPrompt) seeds base_url with the
 	// PlaceholderBaseURL; an LLM that can't find a real host often echoes
@@ -490,6 +491,8 @@ func singularizePathToken(token string) string {
 	if len(token) <= 3 || !strings.HasSuffix(token, "s") {
 		return token
 	}
+	// Keep this conservative: -es/-ies plurals stay unmatched instead of
+	// guessing a singular form that could rewrite to the wrong documented path.
 	switch {
 	case strings.HasSuffix(token, "ss"),
 		strings.HasSuffix(token, "us"),

--- a/internal/docspec/docspec_test.go
+++ b/internal/docspec/docspec_test.go
@@ -3,6 +3,8 @@ package docspec
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -110,6 +112,148 @@ func TestEndpointName(t *testing.T) {
 	assert.Equal(t, "create_users", endpointName("POST", "/v1/users"))
 	assert.Equal(t, "get_users", endpointName("GET", "/v1/users/{id}"))
 	assert.Equal(t, "delete_items", endpointName("DELETE", "/items/{id}"))
+}
+
+func TestPreserveDocumentedEndpointPathsRestoresLLMNormalizedSegments(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"tp-sl": {
+				Endpoints: map[string]spec.Endpoint{
+					"get_pending_tp_sl_order": {
+						Method: "GET",
+						Path:   "/api/v1/futures/tpsl/get_pending_order",
+					},
+				},
+			},
+			"market": {
+				Endpoints: map[string]spec.Endpoint{
+					"get_funding_rate_batch": {
+						Method: "GET",
+						Path:   "/api/v1/futures/market/funding_rate_batch",
+					},
+				},
+			},
+		},
+	}
+
+	preserveDocumentedEndpointPaths(apiSpec, []rawEndpoint{
+		{Method: "GET", Path: "/api/v1/futures/tpsl/get_pending_orders"},
+		{Method: "GET", Path: "/api/v1/futures/market/funding_rate/batch"},
+	})
+
+	assert.Equal(t, "/api/v1/futures/tpsl/get_pending_orders", apiSpec.Resources["tp-sl"].Endpoints["get_pending_tp_sl_order"].Path)
+	assert.Equal(t, "/api/v1/futures/market/funding_rate/batch", apiSpec.Resources["market"].Endpoints["get_funding_rate_batch"].Path)
+}
+
+func TestGenerateFromDocsLLMPreservesDocumentedEndpointPaths(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body>
+<p>Base URL: https://api.bitunix.com</p>
+<pre>GET /api/v1/futures/tpsl/get_pending_orders</pre>
+<pre>GET /api/v1/futures/market/funding_rate/batch</pre>
+<pre>GET /api/v1/users/{id}</pre>
+</body></html>`))
+	}))
+	defer srv.Close()
+
+	fakeBinDir := t.TempDir()
+	fakeClaude := filepath.Join(fakeBinDir, "claude")
+	require.NoError(t, os.WriteFile(fakeClaude, []byte(`#!/bin/sh
+cat <<'YAML'
+name: bitunix
+description: "CLI for bitunix"
+version: "1.0.0"
+base_url: "https://api.bitunix.com"
+auth:
+  type: "none"
+config:
+  format: "toml"
+  path: "~/.config/bitunix-pp-cli/config.toml"
+resources:
+  tp_sl:
+    description: "Operations on tp_sl"
+    endpoints:
+      get_pending_tp_sl_order:
+        method: GET
+        path: "/api/v1/futures/tpsl/get_pending_order"
+        description: "Get pending TP SL order"
+        params: []
+        response:
+          type: object
+  market:
+    description: "Operations on market"
+    endpoints:
+      get_funding_rate_batch:
+        method: GET
+        path: "/api/v1/futures/market/funding_rate_batch"
+        description: "Get funding rate batch"
+        params: []
+        response:
+          type: object
+  users:
+    description: "Operations on users"
+    endpoints:
+      get_user:
+        method: GET
+        path: "/api/v1/users/{user}"
+        description: "Get user"
+        params:
+          - name: user
+            type: string
+            required: true
+            positional: true
+            description: "stale placeholder"
+        response:
+          type: object
+YAML
+`), 0o755))
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	apiSpec, err := GenerateFromDocsLLM(srv.URL, "bitunix")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v1/futures/tpsl/get_pending_orders", apiSpec.Resources["tp_sl"].Endpoints["get_pending_tp_sl_order"].Path)
+	assert.Equal(t, "/api/v1/futures/market/funding_rate/batch", apiSpec.Resources["market"].Endpoints["get_funding_rate_batch"].Path)
+	users := apiSpec.Resources["users"].Endpoints["get_user"]
+	assert.Equal(t, "/api/v1/users/{id}", users.Path)
+	require.Len(t, users.Params, 1)
+	assert.Equal(t, "id", users.Params[0].Name)
+	assert.True(t, users.Params[0].Positional)
+}
+
+func TestPreserveDocumentedEndpointPathsLeavesExactAndAmbiguousPaths(t *testing.T) {
+	apiSpec := &spec.APISpec{
+		Resources: map[string]spec.Resource{
+			"users": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/api/v1/users",
+					},
+					"ambiguous": {
+						Method: "GET",
+						Path:   "/api/v1/orderitems",
+					},
+					"wrong_method": {
+						Method: "POST",
+						Path:   "/api/v1/funding_rate_batch",
+					},
+				},
+			},
+		},
+	}
+
+	preserveDocumentedEndpointPaths(apiSpec, []rawEndpoint{
+		{Method: "GET", Path: "/api/v1/users"},
+		{Method: "GET", Path: "/api/v1/order/item"},
+		{Method: "GET", Path: "/api/v1/order_item"},
+		{Method: "GET", Path: "/api/v1/funding_rate/batch"},
+	})
+
+	assert.Equal(t, "/api/v1/users", apiSpec.Resources["users"].Endpoints["list"].Path)
+	assert.Equal(t, "/api/v1/orderitems", apiSpec.Resources["users"].Endpoints["ambiguous"].Path)
+	assert.Equal(t, "/api/v1/funding_rate_batch", apiSpec.Resources["users"].Endpoints["wrong_method"].Path)
 }
 
 func TestExtractParams(t *testing.T) {


### PR DESCRIPTION
## Summary

Docs-generated CLIs now keep the request path from the documentation when the LLM doc-to-spec pass normalizes path segments. This fixes docs-source endpoints like Bitunix Futures where plural segments and slash-separated path components were being rewritten into non-documented routes.

## Approach

The docs extractor now keeps the regex-extracted method/path pairs as the authority for request paths after LLM parsing. It only repairs a parsed endpoint when the HTTP method plus a conservative canonical path maps to exactly one documented path, then re-syncs path params and validates the spec so CLI and MCP schemas stay aligned.

## Scope

Primary area: `internal/docspec` docs-derived spec generation.

This belongs in the Printing Press generator because the symptom appeared in a printed CLI, but the defect is systemic for any `generate --docs` run whose LLM output normalizes documented request paths.

## Catalog Justification

N/A

## Risk

The main risk is over-repairing lookalike paths. The fix avoids that by leaving exact matches alone, partitioning by HTTP method, and skipping ambiguous canonical matches.

## Output Contract

Docs-derived generated specs can now differ from raw LLM YAML when the docs page contains an unambiguous verbatim method/path pair for the same endpoint. Existing exact matches are unchanged.

## Compounded learnings

- File: `docs/solutions/logic-errors/docs-derived-path-preservation-after-llm-normalization.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate with prior wrong-source/path-param generator learnings
- Instruction-file edit: none needed
- Refresh recommendation: none

## Verification

- `go test ./internal/docspec -count=1`
- `go test ./... -timeout 20m`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `ruby -e 'text=File.read(ARGV[0]); abort("missing frontmatter") unless text.start_with?("---\n"); fm=text.split("---\n",3)[1]; require "yaml"; y=YAML.safe_load(fm, permitted_classes: [Date], aliases: false); %w[title date category module problem_type component symptoms root_cause resolution_type severity tags].each{|k| abort("missing #{k}") unless y.key?(k)}; puts "frontmatter ok"' docs/solutions/logic-errors/docs-derived-path-preservation-after-llm-normalization.md`

Closes #1987

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
