### PR TITLE
fix(cli): preserve colliding body params in MCP

### DIFF
--- a/docs/solutions/logic-errors/mcp-body-param-public-name-collisions-2026-05-25.md
+++ b/docs/solutions/logic-errors/mcp-body-param-public-name-collisions-2026-05-25.md
@@ -1,0 +1,69 @@
+---
+title: MCP Body Param Public Name Collisions
+date: 2026-05-25
+category: docs/solutions/logic-errors
+module: internal/generator
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "A JSON request-body field disappeared from the generated MCP tool schema when its name collided with a path parameter"
+  - "The generated CLI could still send a raw stdin body, but agents could not supply both public inputs through the typed MCP surface"
+  - "Direct tools-manifest generation could emit duplicate public parameter names that the generated MCP surface later tried to disambiguate"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [mcp, tools-manifest, openapi, request-body, identifier-collision, wire-name]
+---
+
+# MCP Body Param Public Name Collisions
+
+## Problem
+
+OpenAPI permits the same JSON object key to appear in the request body that also appears as a path or query parameter. For example, `POST /tags/{id}/notes` can use the path `id` for the tag and a body `id` field for the note.
+
+The Printing Press previously treated the path/query name as enough reason to drop or hide the body field from the typed MCP-facing shape. That avoided one duplicate public name, but it also removed a real API input from agents.
+
+## Symptoms
+
+- The generated MCP tool exposed `id` for the path parameter but had no separate public input for the body `id`.
+- The body wire key needed to remain `id`, so simply renaming the spec field would have produced the wrong JSON payload.
+- `tools-manifest.json` could drift from generated MCP output because manifest generation did not reserve the same public names before adding body params.
+
+## What Didn't Work
+
+Dropping body params in the OpenAPI parser is too early. The parser only sees API wire names, while the generator and manifest writer decide which public names become CLI flags, MCP inputs, and manifest parameters.
+
+Mutating `Param.Name` is also wrong. `Name` is the wire key used for JSON payloads, URL query keys, and path replacement. Collision handling must use `IdentName` or manifest `wire_name` so the public input can change without changing the API request.
+
+## Solution
+
+Keep colliding body fields from the OpenAPI parser and disambiguate them later at each public surface:
+
+- In generator flag/body dedupe, reserve endpoint params, including positional path params, before naming top-level object body fields.
+- When a top-level body field collides, set `IdentName` to a deterministic suffix such as `id_2`; templates expose `id-2` publicly and still bind `WireName: "id"` for the JSON body.
+- In `tools-manifest.json`, reserve endpoint params and mutating-command reserved names before adding body params, then suffix the manifest public name while preserving `wire_name`.
+
+Regression coverage should assert both surfaces:
+
+- Generated `internal/mcp/tools.go` contains both the path input (`id`) and the body input (`id-2`).
+- The body binding has `PublicName: "id-2"` and `WireName: "id"`.
+- Direct manifest generation, before any generator pre-pass has mutated `IdentName`, emits the same public/body-wire split.
+
+## Why This Works
+
+The collision is a public-interface problem, not a wire-contract problem. Agents need unique input names, but the HTTP request still needs the original API key. `IdentName` and manifest `wire_name` already encode that split, so the fix follows the existing generator collision pattern instead of inventing a special body-only rule.
+
+Doing the manifest dedupe inside the manifest writer also protects standalone manifest generation paths that do not run the full generator pre-pass first.
+
+## Prevention
+
+- Do not remove request-body fields in the parser just because their normalized public name collides with path or query params.
+- Treat path params as public MCP inputs even when they are positional Cobra args rather than flags; they still reserve names in agent-facing schemas.
+- For any new manifest or MCP surface, test the direct writer path and the generated-code path when collision handling depends on generator pre-passes.
+- Preserve `Name` for wire contracts and use `IdentName`, public-name suffixing, or manifest `wire_name` for public disambiguation.
+
+## Related Issues
+
+- GitHub issue: https://github.com/mvanhorn/cli-printing-press/issues/1986
+- Related pattern: `docs/solutions/design-patterns/identifier-collision-uniquification-pattern-2026-05-08.md`
+- Related MCP surface bug: `docs/solutions/logic-errors/mcp-handler-conflates-path-and-query-positional-params-2026-05-05.md`

--- a/internal/generator/body_collision_test.go
+++ b/internal/generator/body_collision_test.go
@@ -206,6 +206,46 @@ func TestGenerateRenamesBodyFieldCollidingWithStdin(t *testing.T) {
 		"the body field named 'stdin' must not collide with the template's --stdin flag")
 }
 
+func TestGenerateRenamesObjectBodyFieldCollidingWithPathParam(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("collide-object-body")
+	apiSpec.Resources["widgets"] = spec.Resource{
+		Description: "Widgets",
+		Endpoints: map[string]spec.Endpoint{
+			"attach": {
+				Method:      "POST",
+				Path:        "/widgets/{id}/links",
+				Description: "Attach a linked object",
+				Params: []spec.Param{
+					{Name: "id", Type: "string", Required: true, Positional: true, Description: "Widget ID"},
+				},
+				Body: []spec.Param{
+					{Name: "id", Type: "object", Required: true, Description: "Linked object", Fields: []spec.Param{
+						{Name: "name", Type: "string", Description: "Linked object name"},
+					}},
+				},
+			},
+			"get": {
+				Method:      "GET",
+				Path:        "/widgets/{id}",
+				Description: "Get one widget",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "collide-object-body-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	mcpTools, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	mcpSource := string(mcpTools)
+	assert.Contains(t, mcpSource, `mcplib.WithString("id", mcplib.Required(), mcplib.Description("Widget ID"))`)
+	assert.Contains(t, mcpSource, `mcplib.WithString("id-2", mcplib.Required(), mcplib.Description("Linked object"))`)
+	assert.Contains(t, mcpSource, `PublicName: "id", WireName: "id", Location: "path"`)
+	assert.Contains(t, mcpSource, `PublicName: "id-2", WireName: "id", Location: "body"`)
+}
+
 // TestGenerateDeduplicatesNestedTreesCollapsedToSameIdent guards the
 // case where two distinct nested-object paths whose joined camelized
 // segments collapse to the same Go identifier. Project.Customer.name

--- a/internal/generator/flag_collision.go
+++ b/internal/generator/flag_collision.go
@@ -116,6 +116,8 @@ func uniquifyBodyTree(body []spec.Param, identPrefix, flagPrefix string, usedIde
 				flag := publicFlagName(p)
 				if _, flagTaken := usedFlags[flag]; flagTaken {
 					for n := 2; ; n++ {
+						// Name is the stable wire-root for suffix variants; IdentName
+						// is only the public override selected by this dedupe pass.
 						candidate := fmt.Sprintf("%s_%d", p.Name, n)
 						candFlag := flagName(candidate)
 						if _, flagTaken := usedFlags[candFlag]; !flagTaken {

--- a/internal/generator/flag_collision.go
+++ b/internal/generator/flag_collision.go
@@ -70,16 +70,17 @@ func dedupeEndpointIdentifiers(resKey, epName string, ep spec.Endpoint, asyncJob
 	// Pass 1: query/path params populate the flag<Camel> namespace.
 	ep.Params = uniquifyIdentifiers(ep.Params, "flag", flagIdents, flagNames)
 
-	// Pass 2: body fields populate the body<Camel> namespace, but their cobra
-	// flag names share the namespace with everything we just registered.
+	// Pass 2: body fields populate the body<Camel> namespace, but their public
+	// input names share the namespace with every endpoint param. Positional path
+	// params do not register cobra flags, but they do register MCP inputs, so a
+	// body field named the same as a path param still needs a distinct public
+	// name while keeping its wire-side body key unchanged.
 	bodyFlagNames := make(map[string]struct{}, len(flagNames)+len(ep.Params))
 	for k := range flagNames {
 		bodyFlagNames[k] = struct{}{}
 	}
 	for _, p := range ep.Params {
-		if !p.Positional {
-			bodyFlagNames[publicFlagName(p)] = struct{}{}
-		}
+		bodyFlagNames[publicFlagName(p)] = struct{}{}
 	}
 	// renderBodyVarDecls and renderBodyFlagRegs recurse into nested object
 	// Fields on the JSON-body path, so the dedup pass must walk the same
@@ -111,6 +112,22 @@ func uniquifyBodyTree(body []spec.Param, identPrefix, flagPrefix string, usedIde
 	out := make([]spec.Param, len(body))
 	for i, p := range body {
 		if p.Type == "object" && len(p.Fields) > 0 {
+			if flagPrefix == "" {
+				flag := publicFlagName(p)
+				if _, flagTaken := usedFlags[flag]; flagTaken {
+					for n := 2; ; n++ {
+						candidate := fmt.Sprintf("%s_%d", p.Name, n)
+						candFlag := flagName(candidate)
+						if _, flagTaken := usedFlags[candFlag]; !flagTaken {
+							p.IdentName = candidate
+							usedFlags[candFlag] = struct{}{}
+							break
+						}
+					}
+				} else {
+					usedFlags[flag] = struct{}{}
+				}
+			}
 			childIdent := identPrefix + toCamel(paramIdent(p))
 			childFlag := joinFlag(flagPrefix, publicFlagName(p))
 			p.Fields = uniquifyBodyTree(p.Fields, childIdent, childFlag, usedIdents, usedFlags)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2725,21 +2725,6 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			params := mapParameters(pathItem, op)
 			body, requestContentType, bodyJSONFallback, bodyRequired, bodyIsArray := mapRequestBody(op.RequestBody, method, path)
 
-			// Deduplicate body params that collide with query/path params by flag name
-			if len(body) > 0 && len(params) > 0 {
-				paramFlags := map[string]bool{}
-				for _, p := range params {
-					paramFlags[toKebabCase(p.Name)] = true
-				}
-				filtered := make([]spec.Param, 0, len(body))
-				for _, b := range body {
-					if !paramFlags[toKebabCase(b.Name)] {
-						filtered = append(filtered, b)
-					}
-				}
-				body = filtered
-			}
-
 			endpoint := spec.Endpoint{
 				Method:             strings.ToUpper(method),
 				Path:               path,

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -366,6 +366,7 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 		NoAuth:      ep.NoAuth,
 		Params:      make([]ManifestParam, 0, len(ep.Params)+len(ep.Body)),
 	}
+	publicNames := reservedManifestParamNames(ep)
 
 	// Regular params. A param ends up at "path" when the runtime
 	// substitutes it into the URL — that's true for both positional
@@ -381,7 +382,7 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 		if p.Positional || p.PathParam {
 			loc = "path"
 		}
-		name := p.PublicInputName()
+		name := uniqueManifestParamName(p.PublicInputName(), publicNames)
 		wireName := p.WireName()
 		if loc == "path" {
 			wireName = p.Name
@@ -399,7 +400,7 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 
 	// Body params → body.
 	for _, p := range ep.Body {
-		name := p.PublicInputName()
+		name := uniqueManifestParamName(p.PublicInputName(), publicNames)
 		tool.Params = append(tool.Params, ManifestParam{
 			Name:        name,
 			WireName:    manifestWireName(name, p.BodyWireName()),
@@ -423,6 +424,32 @@ func buildManifestTool(name, description string, ep spec.Endpoint, describeParam
 	}
 
 	return tool
+}
+
+func uniqueManifestParamName(name string, used map[string]struct{}) string {
+	if name == "" {
+		name = "param"
+	}
+	if _, ok := used[name]; !ok {
+		used[name] = struct{}{}
+		return name
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s-%d", name, n)
+		if _, ok := used[candidate]; !ok {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+	}
+}
+
+func reservedManifestParamNames(ep spec.Endpoint) map[string]struct{} {
+	names := map[string]struct{}{}
+	switch strings.ToUpper(ep.Method) {
+	case "POST", "PUT", "PATCH":
+		names["stdin"] = struct{}{}
+	}
+	return names
 }
 
 func manifestWireName(publicName, wireName string) string {

--- a/internal/pipeline/toolsmanifest.go
+++ b/internal/pipeline/toolsmanifest.go
@@ -443,6 +443,8 @@ func uniqueManifestParamName(name string, used map[string]struct{}) string {
 	}
 }
 
+// reservedManifestParamNames seeds generator-reserved public names only.
+// buildManifestTool adds endpoint params to the same map before body params.
 func reservedManifestParamNames(ep spec.Endpoint) map[string]struct{} {
 	names := map[string]struct{}{}
 	switch strings.ToUpper(ep.Method) {

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -383,6 +385,126 @@ func TestWriteToolsManifest_IdentNamePublicParamName(t *testing.T) {
 	assert.Empty(t, got.Tools[0].Params[0].WireName)
 	assert.Equal(t, "id-2", got.Tools[0].Params[1].Name)
 	assert.Equal(t, "id", got.Tools[0].Params[1].WireName)
+}
+
+func TestWriteToolsManifest_ReservesStdinBodyParamName(t *testing.T) {
+	dir := t.TempDir()
+	parsed := &spec.APISpec{
+		Name:    "stdin-body",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"uploads": {
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method: "POST",
+						Path:   "/uploads",
+						Body: []spec.Param{
+							{Name: "stdin", Type: "string", Description: "Body field named stdin"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+
+	require.Len(t, got.Tools, 1)
+	require.Len(t, got.Tools[0].Params, 1)
+	assert.Equal(t, "stdin-2", got.Tools[0].Params[0].Name)
+	assert.Equal(t, "stdin", got.Tools[0].Params[0].WireName)
+}
+
+func TestOpenAPIBodyFieldCollidingWithPathParamSurfacesInMCP(t *testing.T) {
+	t.Parallel()
+
+	const openAPIBodyPathCollision = `openapi: 3.0.0
+info:
+  title: Collision API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /tags/{id}/notes:
+    post:
+      summary: Add a tag to a note
+      operationId: tagNote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Tag ID
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+                  description: Note ID to tag
+      responses:
+        '200':
+          description: ok
+`
+
+	manifestParsed, err := openapi.Parse([]byte(openAPIBodyPathCollision))
+	require.NoError(t, err)
+
+	manifestDir := filepath.Join(t.TempDir(), "direct-manifest")
+	require.NoError(t, os.MkdirAll(manifestDir, 0o755))
+	require.NoError(t, WriteToolsManifest(manifestDir, manifestParsed))
+	got, err := ReadToolsManifest(manifestDir)
+	require.NoError(t, err)
+	assertCollisionManifestParams(t, got)
+
+	parsed, err := openapi.Parse([]byte(openAPIBodyPathCollision))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "collision-api-pp-cli")
+	require.NoError(t, generator.New(parsed, outputDir).Generate())
+
+	mcpTools, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	mcpSource := string(mcpTools)
+	assert.Contains(t, mcpSource, `mcplib.WithString("id", mcplib.Required(), mcplib.Description("Tag ID"))`)
+	assert.Contains(t, mcpSource, `mcplib.WithString("id-2", mcplib.Required(), mcplib.Description("Note ID to tag"))`)
+	assert.Contains(t, mcpSource, `PublicName: "id", WireName: "id", Location: "path"`)
+	assert.Contains(t, mcpSource, `PublicName: "id-2", WireName: "id", Location: "body"`)
+
+	require.NoError(t, WriteToolsManifest(outputDir, parsed))
+	got, err = ReadToolsManifest(outputDir)
+	require.NoError(t, err)
+	assertCollisionManifestParams(t, got)
+}
+
+func assertCollisionManifestParams(t *testing.T, got *ToolsManifest) {
+	t.Helper()
+
+	require.Len(t, got.Tools, 1)
+	require.Len(t, got.Tools[0].Params, 2)
+	assert.Equal(t, ManifestParam{
+		Name:        "id",
+		Type:        "string",
+		Location:    "path",
+		Description: "Tag ID",
+		Required:    true,
+	}, got.Tools[0].Params[0])
+	assert.Equal(t, ManifestParam{
+		Name:        "id-2",
+		WireName:    "id",
+		Type:        "string",
+		Location:    "body",
+		Description: "Note ID to tag",
+		Required:    true,
+	}, got.Tools[0].Params[1])
 }
 
 // TestWriteToolsManifest_ReclassifiedPathParamKeepsPathLocation pins


### PR DESCRIPTION
## Summary
Generated MCP tools now expose request-body fields even when their public name collides with a path or query parameter. The body input is renamed at the public surface (`id-2`) while the original body wire key (`id`) is preserved, so agent calls can supply both the path ID and the body ID instead of silently losing one.

This also keeps direct `tools-manifest.json` generation aligned with the generated MCP surface, including reserved mutating names such as `stdin`.

Closes #1986

## Verification
- `go test -p 1 ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

## Compounded learnings
- File: `docs/solutions/logic-errors/mcp-body-param-public-name-collisions-2026-05-25.md`
- Track: bug
- Category: logic-errors
- Overlap: moderate - related identifier-collision docs, new parser/manifest bypass angle
- Instruction-file edit: none needed
- Refresh recommendation: none

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)