### PR TITLE
fix(cli): unify digit-leading command identifiers

### DIFF
--- a/internal/generator/digit_leading_identifier_test.go
+++ b/internal/generator/digit_leading_identifier_test.go
@@ -1,0 +1,101 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandIdentPrefixesDigitLeadingSegments(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "User2fa", commandIdent("user-2fa"))
+	assert.Equal(t, "User2fa", commandIdent("user", "2fa"))
+	assert.Equal(t, "UserV2fa", commandIdent("user", "v2fa"))
+	assert.Equal(t, "V3dSecure", commandIdent("3d_secure"))
+	assert.Equal(t, "Oauth2Token", commandIdent("oauth2-token"))
+}
+
+func TestGenerateDigitLeadingPathSegmentsUseConsistentCommandIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("digit-leading")
+	apiSpec.Resources = map[string]spec.Resource{
+		"user": {
+			Description: "Manage users",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/user/{userId}",
+					Description: "Get user",
+					Params: []spec.Param{
+						{Name: "userId", Type: "string", Required: true, Positional: true},
+					},
+				},
+			},
+			SubResources: map[string]spec.Resource{
+				"2fa": {
+					Description: "Manage two-factor authentication",
+					Endpoints: map[string]spec.Endpoint{
+						"get-user2fa": {
+							Method:      "GET",
+							Path:        "/user/{userId}/2fa",
+							Description: "Get user two-factor authentication status",
+							Params: []spec.Param{
+								{Name: "userId", Type: "string", Required: true, Positional: true},
+							},
+						},
+					},
+				},
+				"v2fa": {
+					Description: "Manage versioned two-factor authentication",
+					Endpoints: map[string]spec.Endpoint{
+						"get": {
+							Method:      "GET",
+							Path:        "/user/{userId}/v2fa",
+							Description: "Get versioned two-factor authentication status",
+							Params: []spec.Param{
+								{Name: "userId", Type: "string", Required: true, Positional: true},
+							},
+						},
+					},
+				},
+			},
+		},
+		"3d-secure": {
+			Description: "Manage 3D Secure records",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/v1/3d_secure",
+					Description: "List 3D Secure records",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Export: true}
+	require.NoError(t, gen.Generate())
+
+	promotedUser := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_user.go")
+	user2FAParent := readGeneratedFile(t, outputDir, "internal", "cli", "user_2fa.go")
+	userV2FAParent := readGeneratedFile(t, outputDir, "internal", "cli", "user_v2fa.go")
+	require.Contains(t, promotedUser, "sub := newUser2faCmd(flags)")
+	require.Contains(t, promotedUser, "sub := newUserV2faCmd(flags)")
+	require.Contains(t, user2FAParent, "func newUser2faCmd(flags *rootFlags) *cobra.Command")
+	require.Contains(t, userV2FAParent, "func newUserV2faCmd(flags *rootFlags) *cobra.Command")
+
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	promoted3DSecure := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_3d-secure.go")
+	require.Contains(t, root, "rootCmd.AddCommand(newV3dSecurePromotedCmd(flags))")
+	require.Contains(t, promoted3DSecure, "func newV3dSecurePromotedCmd(flags *rootFlags) *cobra.Command")
+	assert.NotContains(t, root, "new3dSecure", "digit-leading resource must not produce an invalid constructor")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -209,6 +209,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"upper":                 strings.ToUpper,
 		"join":                  strings.Join,
 		"camel":                 toCamel,
+		"cmdIdent":              commandIdent,
 		"snake":                 naming.Snake,
 		"pascal":                toPascal,
 		"goType":                goType,
@@ -3701,6 +3702,17 @@ func toCamel(s string) string {
 		result = "V" + result
 	}
 	return result
+}
+
+func commandIdent(parts ...string) string {
+	joined := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimLeft(part, "$")
+		if part != "" {
+			joined = append(joined, part)
+		}
+	}
+	return toCamel(strings.Join(joined, "-"))
 }
 
 func toPascal(s string) string {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func new{{camel .FuncPrefix}}{{camel .EndpointName}}Cmd(flags *rootFlags) *cobra.Command {
+func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Command {
 {{- range .Endpoint.Params}}
 {{- if not .Positional}}
 	var flag{{camel (paramIdent .)}} {{goTypeForParam .Name .Type}}

--- a/internal/generator/templates/command_parent.go.tmpl
+++ b/internal/generator/templates/command_parent.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func new{{camel .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
+func new{{cmdIdent .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "{{kebab .ResourceName}}",
 		Short: "{{.Short}}",
@@ -17,10 +17,10 @@ func new{{camel .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
 		RunE: parentNoSubcommandRunE(flags),
 	}
 {{range $eName, $endpoint := .Resource.Endpoints}}
-	cmd.AddCommand(new{{camel $.FuncPrefix}}{{camel $eName}}Cmd(flags))
+	cmd.AddCommand(new{{cmdIdent $.FuncPrefix $eName}}Cmd(flags))
 {{- end}}
 {{- range $subName, $sub := .Resource.SubResources}}
-	cmd.AddCommand(new{{camel $.FuncPrefix}}{{camel $subName}}Cmd(flags))
+	cmd.AddCommand(new{{cmdIdent $.FuncPrefix $subName}}Cmd(flags))
 {{- end}}
 	return cmd
 }

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
+func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- range .Endpoint.Params}}
 {{- if not .Positional}}
 	var flag{{camel (paramIdent .)}} {{goTypeForParam .Name .Type}}
@@ -382,12 +382,12 @@ func new{{camel .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 	// Wire sibling endpoints and sub-resources as subcommands
 {{- range $eName, $endpoint := .Resource.Endpoints}}
 {{- if ne $eName $.EndpointName}}
-	cmd.AddCommand(new{{camel $.FuncPrefix}}{{camel $eName}}Cmd(flags))
+	cmd.AddCommand(new{{cmdIdent $.FuncPrefix $eName}}Cmd(flags))
 {{- end}}
 {{- end}}
 {{- range $subName, $sub := .Resource.SubResources}}
 	{
-		sub := new{{camel $.FuncPrefix}}{{camel $subName}}Cmd(flags)
+		sub := new{{cmdIdent $.FuncPrefix $subName}}Cmd(flags)
 		sub.Hidden = false // unhide: the raw parent is hidden but these are useful under the promoted command
 		cmd.AddCommand(sub)
 	}

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -325,7 +325,7 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 
 {{- range $name, $resource := .Resources}}
 {{- if and (not (index $.PromotedResourceNames $name)) (not (and (eq $name "auth") $.HasAuthCommand)) (not (index $.VisionCmdNames $name))}}
-	rootCmd.AddCommand(new{{camel $name}}Cmd(flags))
+	rootCmd.AddCommand(new{{cmdIdent $name}}Cmd(flags))
 {{- end}}
 {{- end}}
 	rootCmd.AddCommand(newDoctorCmd(flags))
@@ -376,7 +376,7 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	rootCmd.AddCommand(newAPICmd(flags))
 {{- end}}
 {{- range .PromotedCommands}}
-	rootCmd.AddCommand(new{{camel .PromotedName}}PromotedCmd(flags))
+	rootCmd.AddCommand(new{{cmdIdent .PromotedName}}PromotedCmd(flags))
 {{- end}}
 	rootCmd.AddCommand(newVersionCliCmd())
 


### PR DESCRIPTION
## Summary

Fixes generated command constructor naming for digit-leading path and resource segments by routing parent, promoted, endpoint, and root constructor references through one `cmdIdent` helper.

This prevents generated CLIs from disagreeing between names such as `newUser2faCmd` and `newUserV2faCmd` for paths like `/user/{userId}/2fa`, while preserving distinct alpha-prefixed names like `v2fa`.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go build -o ./cli-printing-press ./cmd/printing-press`
- `go test ./internal/generator -run 'TestCommandIdentPrefixesDigitLeadingSegments|TestGenerateDigitLeadingPathSegmentsUseConsistentCommandIdentifiers' -count=1`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

Closes #2014
