### PR TITLE
fix(cli): infer path-param resource id fields

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11184,6 +11184,162 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/store/...", "-run", "TestUpsertBatch_TemplatedIDFieldOverrideWins|TestUpsertBatch_GenericFallbackList|TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses")
 }
 
+func TestGeneratedSyncIDFieldOverridesFromMemberPathParam(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Path Param IDs
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /identity-providers:
+    get:
+      operationId: listIdentityProviders
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    idpId: {type: string}
+                    name: {type: string}
+  /identity-providers/{idpId}:
+    get:
+      operationId: getIdentityProvider
+      parameters:
+        - name: idpId
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  idpId: {type: string}
+                  name: {type: string}
+`))
+	require.NoError(t, err)
+	profile := profiler.Profile(apiSpec)
+	require.Len(t, profile.SyncableResources, 1)
+	assert.Equal(t, "identity-providers", profile.SyncableResources[0].Name)
+	assert.Equal(t, "idpId", profile.SyncableResources[0].IDField)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(syncGo), `"identity-providers": "idpId",`)
+	assert.Contains(t, string(storeGo), `"identity-providers": "idpId",`)
+}
+
+func TestGeneratedDependentSyncIDFieldOverridesFromMemberPathParam(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Dependent Path Param IDs
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /sites:
+    get:
+      operationId: listSites
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+                    name: {type: string}
+  /sites/{siteId}/identity-providers:
+    get:
+      operationId: listSiteIdentityProviders
+      parameters:
+        - name: siteId
+          in: path
+          required: true
+          schema: {type: string}
+        - name: limit
+          in: query
+          schema: {type: integer}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    idpId: {type: string}
+                    name: {type: string}
+  /sites/{siteId}/identity-providers/{idpId}:
+    get:
+      operationId: getSiteIdentityProvider
+      parameters:
+        - name: siteId
+          in: path
+          required: true
+          schema: {type: string}
+        - name: idpId
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  idpId: {type: string}
+                  name: {type: string}
+`))
+	require.NoError(t, err)
+	profile := profiler.Profile(apiSpec)
+	require.Len(t, profile.DependentSyncResources, 1)
+	assert.Equal(t, "identity_providers", profile.DependentSyncResources[0].Name)
+	assert.Equal(t, "idpId", profile.DependentSyncResources[0].IDField)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+	require.Len(t, gen.profile.DependentSyncResources, 1)
+	assert.Equal(t, "identity_providers", gen.profile.DependentSyncResources[0].Name)
+	assert.Equal(t, "idpId", gen.profile.DependentSyncResources[0].IDField)
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(syncGo), `"identity_providers": "idpId",`)
+	assert.Contains(t, string(storeGo), `"identity_providers": "idpId",`)
+}
+
 func TestGenerateOperationRoutingPathParamDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2761,6 +2761,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			endpoint.NoAuth = operationAllowsAnonymous(op, doc)
 
 			// IDField fallback chain: explicit x-resource-id wins over
+			// path-param/resource-shape inference, which wins over the generic
 			// response-schema inference. Resolution happens at parse time so
 			// the profiler sees a single resolved value per endpoint and
 			// templates do not re-walk schemas at generation time.
@@ -2769,6 +2770,9 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			}
 			if pathResourceIDOverride != "" {
 				endpoint.IDField = pathResourceIDOverride
+			} else if idField := resolveIDFieldFromPathParam(op, path, targetResourceName); idField != "" {
+				endpoint.IDField = idField
+				endpoint.IDFieldFromPathParam = true
 			} else {
 				endpoint.IDField = resolveIDFieldFromResponseSchema(op, targetResourceName)
 			}
@@ -4539,6 +4543,92 @@ func readWalkerExtension(extensions map[string]any, context string) *spec.Walker
 	return &cfg
 }
 
+// Member paths can provide a stronger primary-key signal than generic response
+// fallbacks: /sites/{siteId} points at siteId even when the schema also has a
+// display name. Prefer placeholders after the endpoint's target resource
+// segment, with a trailing member placeholder fallback for nested resources
+// whose generated name includes more context than one path segment.
+func resolveIDFieldFromPathParam(op *openapi3.Operation, path string, resourceName string) string {
+	itemSchema := responseItemSchema(op)
+	if itemSchema == nil || resourceName == "" {
+		return ""
+	}
+
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	for i := 0; i < len(segments)-1; i++ {
+		if !pathSegmentMatchesResource(segments[i], resourceName) {
+			continue
+		}
+		placeholder, ok := pathPlaceholderName(segments[i+1])
+		if !ok {
+			continue
+		}
+		if field := responsePropertyForPathParam(itemSchema, placeholder); field != "" {
+			return field
+		}
+	}
+	if placeholder, ok := pathPlaceholderName(segments[len(segments)-1]); ok {
+		if field := responsePropertyForPathParam(itemSchema, placeholder); field != "" {
+			return field
+		}
+	}
+	return ""
+}
+
+func pathSegmentMatchesResource(segment string, resourceName string) bool {
+	segmentSnake := singularizeIdentifier(toSnakeCase(strings.Trim(segment, "/")))
+	resourceSnake := singularizeIdentifier(toSnakeCase(resourceName))
+	return segmentSnake != "" && segmentSnake == resourceSnake
+}
+
+func pathPlaceholderName(segment string) (string, bool) {
+	segment = strings.TrimSpace(segment)
+	if !strings.HasPrefix(segment, "{") || !strings.HasSuffix(segment, "}") {
+		return "", false
+	}
+	name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(segment, "{"), "}"))
+	return name, name != ""
+}
+
+func responsePropertyForPathParam(schema *openapi3.Schema, paramName string) string {
+	if schema == nil || paramName == "" {
+		return ""
+	}
+	if propRef, ok := schema.Properties[paramName]; ok && propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+		return paramName
+	}
+	paramSnake := toSnakeCase(paramName)
+	propNames := make([]string, 0, len(schema.Properties))
+	for propName := range schema.Properties {
+		propNames = append(propNames, propName)
+	}
+	sort.Strings(propNames)
+	for _, propName := range propNames {
+		if toSnakeCase(propName) != paramSnake {
+			continue
+		}
+		if propRef := schema.Properties[propName]; propRef != nil && isPlausibleIDFieldSchema(schemaRefValue(propRef)) {
+			return propName
+		}
+	}
+	return ""
+}
+
+func responseItemSchema(op *openapi3.Operation) *openapi3.Schema {
+	if op == nil || op.Responses == nil {
+		return nil
+	}
+	success := selectSuccessResponse(op.Responses)
+	if success == nil || success.Value == nil {
+		return nil
+	}
+	schemaRef := selectResponseSchema(success.Value)
+	if schemaRef == nil || schemaRef.Value == nil {
+		return nil
+	}
+	return unwrapItemSchema(schemaRef.Value)
+}
+
 // resolveIDFieldFromResponseSchema implements tiers 2-5 of the IDField fallback
 // chain: prefer "id", then a resource-prefixed key (`<singular>_id` /
 // `_uuid` / `_guid`), then a vendor identifier (`gid` / `sid` / `uid` /
@@ -4552,20 +4642,7 @@ func readWalkerExtension(extensions map[string]any, context string) *spec.Walker
 // the resource-prefixed heuristic and may be empty for synthetic endpoints,
 // in which case that tier is skipped.
 func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName string) string {
-	if op == nil || op.Responses == nil {
-		return ""
-	}
-	success := selectSuccessResponse(op.Responses)
-	if success == nil || success.Value == nil {
-		return ""
-	}
-	schemaRef := selectResponseSchema(success.Value)
-	if schemaRef == nil || schemaRef.Value == nil {
-		return ""
-	}
-
-	// Walk to the item schema: arrays, {data: [...]} wrappers, or the object itself.
-	itemSchema := unwrapItemSchema(schemaRef.Value)
+	itemSchema := responseItemSchema(op)
 	if itemSchema == nil {
 		return ""
 	}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -6195,6 +6195,136 @@ paths:
 	}
 }
 
+// Member-endpoint placeholders catch acronym or vendor-shaped keys, such as
+// idpId, that cannot be derived from the resource name alone.
+func TestParseIDFieldPathParamHeuristic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		schemaYAML string
+		wantID     string
+		wantPathID bool
+	}{
+		{
+			name: "camelCase member placeholder wins over display name",
+			path: "/idps/{idpId}",
+			schemaYAML: `                  type: object
+                  properties:
+                    idpId: {type: string}
+                    name: {type: string}
+`,
+			wantID:     "idpId",
+			wantPathID: true,
+		},
+		{
+			name: "snake_case placeholder matches camelCase response property",
+			path: "/resources/{resource_id}",
+			schemaYAML: `                  type: object
+                  properties:
+                    resourceId: {type: string}
+                    name: {type: string}
+`,
+			wantID:     "resourceId",
+			wantPathID: true,
+		},
+		{
+			name: "nested member uses child placeholder, not parent placeholder",
+			path: "/sites/{siteId}/targets/{targetId}",
+			schemaYAML: `                  type: object
+                  properties:
+                    siteId: {type: string}
+                    targetId: {type: string}
+                    name: {type: string}
+`,
+			wantID:     "targetId",
+			wantPathID: true,
+		},
+		{
+			name: "child collection does not use parent placeholder as child primary key",
+			path: "/sites/{siteId}/targets",
+			schemaYAML: `                  type: object
+                  properties:
+                    siteId: {type: string}
+                    name: {type: string}
+`,
+			wantID: "name",
+		},
+		{
+			name: "path param without matching response property falls through",
+			path: "/idps/{idpId}",
+			schemaYAML: `                  type: object
+                  properties:
+                    name: {type: string}
+`,
+			wantID: "name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  ` + tt.path + `:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+` + tt.schemaYAML)
+			parsed, err := Parse(yamlSpec)
+			require.NoError(t, err)
+
+			ep := findEndpoint(t, parsed, tt.path)
+			assert.Equal(t, tt.wantID, ep.IDField)
+			assert.Equal(t, tt.wantPathID, ep.IDFieldFromPathParam)
+		})
+	}
+}
+
+func TestParseIDFieldExplicitResourceIDWinsOverPathParamHeuristic(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets/{widgetId}:
+    x-resource-id: canonical_id
+    get:
+      operationId: getWidget
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  widgetId: {type: string}
+                  canonical_id: {type: string}
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	ep := findEndpoint(t, parsed, "/widgets/{widgetId}")
+	assert.Equal(t, "canonical_id", ep.IDField)
+	assert.False(t, ep.IDFieldFromPathParam)
+}
+
 // TestParseXResourceIDAppliesToEveryOperationOnPath exercises the "extensions
 // live on the path item" rule — both GET and POST operations under /widgets
 // inherit the x-resource-id and x-critical values, even though x-critical is

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -274,6 +274,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 	resourceNames, resourceNameIndex := collectResourceNameMetadata(s.Resources)
 	syncable := make(map[string]syncableMeta) // resource name -> chosen list endpoint metadata
 	syncCandidates := make(map[string][]syncableCandidate)
+	pathDerivedIDFields := make(map[string]string)
 	addSyncCandidate := func(resourceName string, meta syncableMeta) {
 		for _, candidate := range syncCandidates[resourceName] {
 			if candidate.meta.Path == meta.Path {
@@ -337,6 +338,12 @@ func Profile(s *spec.APISpec) *APIProfile {
 
 			endpointNameLower := strings.ToLower(endpointName)
 			pathLower := strings.ToLower(endpoint.Path)
+			if endpoint.IDFieldFromPathParam && endpoint.IDField != "" {
+				key := normalizeName(resourceName)
+				if existing := pathDerivedIDFields[key]; existing == "" || endpoint.IDField < existing {
+					pathDerivedIDFields[key] = endpoint.IDField
+				}
+			}
 
 			if containsAny(endpointNameLower, []string{"search"}) || containsAny(pathLower, []string{"search"}) {
 				hasSearchEndpoint = true
@@ -565,6 +572,8 @@ func Profile(s *spec.APISpec) *APIProfile {
 		walk(name, resource, "", "")
 	}
 	applySyncCandidates(syncable, syncCandidates)
+	applyPathDerivedIDFields(syncable, pathDerivedIDFields, s.Types)
+	applyPathDerivedIDFieldsToParameterized(parameterized, pathDerivedIDFields, s.Types)
 
 	if p.TotalEndpoints > 0 {
 		p.ReadRatio = float64(getEndpoints) / float64(p.TotalEndpoints)
@@ -1768,6 +1777,7 @@ type syncableMeta struct {
 	IDWalkPageSize     int
 	FieldSelector      FieldSelector
 	Discriminator      DiscriminatorDispatch
+	ResponseItem       string
 }
 
 type syncableCandidate struct {
@@ -1807,6 +1817,7 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		IDWalkPageSize:     idWalkPageSize,
 		FieldSelector:      detectEndpointFieldSelector(e),
 		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
+		ResponseItem:       e.Response.Item,
 	}
 }
 
@@ -1986,6 +1997,61 @@ func applySyncCandidates(syncable map[string]syncableMeta, candidates map[string
 			addSyncableIfUnique(syncable, name, entry.meta)
 		}
 	}
+}
+
+func applyPathDerivedIDFields(syncable map[string]syncableMeta, pathDerivedIDFields map[string]string, types map[string]spec.TypeDef) {
+	for _, resourceName := range sortedKeys(syncable) {
+		idField := pathDerivedIDFieldForResource(resourceName, pathDerivedIDFields)
+		if idField == "" {
+			continue
+		}
+		meta, ok := syncable[resourceName]
+		if !ok || !shouldUsePathDerivedIDField(meta.IDField) || !responseTypeHasField(meta.ResponseItem, types, idField) {
+			continue
+		}
+		meta.IDField = idField
+		syncable[resourceName] = meta
+	}
+}
+
+func applyPathDerivedIDFieldsToParameterized(parameterized map[string]parameterizedEntry, pathDerivedIDFields map[string]string, types map[string]spec.TypeDef) {
+	for _, key := range sortedKeys(parameterized) {
+		entry := parameterized[key]
+		idField := pathDerivedIDFieldForResource(entry.name, pathDerivedIDFields)
+		if idField == "" || !shouldUsePathDerivedIDField(entry.meta.IDField) || !responseTypeHasField(entry.meta.ResponseItem, types, idField) {
+			continue
+		}
+		entry.meta.IDField = idField
+		parameterized[key] = entry
+	}
+}
+
+func shouldUsePathDerivedIDField(existing string) bool {
+	existing = strings.TrimSpace(existing)
+	return existing == "" || strings.EqualFold(existing, "name")
+}
+
+func pathDerivedIDFieldForResource(resourceName string, pathDerivedIDFields map[string]string) string {
+	for _, variant := range nameVariants(resourceName) {
+		if idField := pathDerivedIDFields[variant]; idField != "" {
+			return idField
+		}
+	}
+	return ""
+}
+
+func responseTypeHasField(typeName string, types map[string]spec.TypeDef, fieldName string) bool {
+	typeDef, ok := lookupTypeDef(typeName, types)
+	if !ok {
+		return false
+	}
+	fieldSnake := spec.ToSnakeCase(fieldName)
+	for _, field := range typeDef.Fields {
+		if field.Name == fieldName || spec.ToSnakeCase(field.Name) == fieldSnake {
+			return true
+		}
+	}
+	return false
 }
 
 func siblingSyncResourceName(resourceName string, candidate syncableCandidate) string {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -340,6 +340,8 @@ func Profile(s *spec.APISpec) *APIProfile {
 			pathLower := strings.ToLower(endpoint.Path)
 			if endpoint.IDFieldFromPathParam && endpoint.IDField != "" {
 				key := normalizeName(resourceName)
+				// Prefer the lexicographically first path-derived field so the
+				// result stays stable regardless of map iteration order.
 				if existing := pathDerivedIDFields[key]; existing == "" || endpoint.IDField < existing {
 					pathDerivedIDFields[key] = endpoint.IDField
 				}
@@ -2005,8 +2007,8 @@ func applyPathDerivedIDFields(syncable map[string]syncableMeta, pathDerivedIDFie
 		if idField == "" {
 			continue
 		}
-		meta, ok := syncable[resourceName]
-		if !ok || !shouldUsePathDerivedIDField(meta.IDField) || !responseTypeHasField(meta.ResponseItem, types, idField) {
+		meta := syncable[resourceName]
+		if !shouldUsePathDerivedIDField(meta.IDField) || !responseTypeHasField(meta.ResponseItem, types, idField) {
 			continue
 		}
 		meta.IDField = idField

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1737,6 +1737,110 @@ func TestProfileSyncableResourcePropagatesIDFieldAndCritical(t *testing.T) {
 	assert.False(t, byName["events"].Critical)
 }
 
+func TestProfileSyncableResourceUsesMemberPathIDFieldHint(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "idps",
+		Types: map[string]spec.TypeDef{
+			"IDP": {
+				Fields: []spec.TypeField{{Name: "idpId", Type: "string"}, {Name: "name", Type: "string"}},
+			},
+			"StableIDP": {
+				Fields: []spec.TypeField{{Name: "uuid", Type: "string"}, {Name: "stableIdpId", Type: "string"}},
+			},
+			"Target": {
+				Fields: []spec.TypeField{{Name: "siteId", Type: "string"}, {Name: "name", Type: "string"}},
+			},
+			"DetailOnlyIDP": {
+				Fields: []spec.TypeField{{Name: "name", Type: "string"}},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"idps": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/idps",
+						Response: spec.ResponseDef{Type: "array", Item: "IDP"},
+						IDField:  "name",
+					},
+					"get": {
+						Method:               "GET",
+						Path:                 "/idps/{idpId}",
+						Response:             spec.ResponseDef{Type: "object", Item: "IDP"},
+						IDField:              "idpId",
+						IDFieldFromPathParam: true,
+					},
+				},
+			},
+			"stable-idps": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/stable-idps",
+						Response: spec.ResponseDef{Type: "array", Item: "StableIDP"},
+						IDField:  "uuid",
+					},
+					"get": {
+						Method:               "GET",
+						Path:                 "/stable-idps/{stableIdpId}",
+						Response:             spec.ResponseDef{Type: "object", Item: "StableIDP"},
+						IDField:              "stableIdpId",
+						IDFieldFromPathParam: true,
+					},
+				},
+			},
+			"targets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/targets",
+						Response: spec.ResponseDef{Type: "array", Item: "Target"},
+						IDField:  "name",
+					},
+					"scoped-list": {
+						Method:   "GET",
+						Path:     "/sites/{siteId}/targets",
+						Response: spec.ResponseDef{Type: "array", Item: "Target"},
+						IDField:  "siteId",
+					},
+				},
+			},
+			"detail-only-idps": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/detail-only-idps",
+						Response: spec.ResponseDef{Type: "array", Item: "DetailOnlyIDP"},
+						IDField:  "name",
+					},
+					"get": {
+						Method:               "GET",
+						Path:                 "/detail-only-idps/{detailOnlyIdpId}",
+						Response:             spec.ResponseDef{Type: "object"},
+						IDField:              "detailOnlyIdpId",
+						IDFieldFromPathParam: true,
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := make(map[string]SyncableResource, len(profile.SyncableResources))
+	for _, r := range profile.SyncableResources {
+		byName[r.Name] = r
+	}
+
+	require.Contains(t, byName, "idps")
+	assert.Equal(t, "idpId", byName["idps"].IDField)
+	require.Contains(t, byName, "stable-idps")
+	assert.Equal(t, "uuid", byName["stable-idps"].IDField, "path-derived ID must not replace a stronger list endpoint ID")
+	require.Contains(t, byName, "targets")
+	assert.Equal(t, "name", byName["targets"].IDField, "parent siteId must not become the child target ID")
+	require.Contains(t, byName, "detail-only-idps")
+	assert.Equal(t, "name", byName["detail-only-idps"].IDField, "detail-only path ID must not replace a list response that lacks the field")
+}
+
 // TestProfileSyncableResourceUnsetMetadata pins the negative case — a spec with
 // no IDField/Critical on its endpoints emits a SyncableResource with both
 // fields zero-valued. Lets templates fall through to the runtime fallback list.

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1623,11 +1623,17 @@ type Endpoint struct {
 	ObservedAuth []string `yaml:"observed_auth,omitempty" json:"observed_auth,omitempty"`
 	Tier         string   `yaml:"tier,omitempty" json:"tier,omitempty"`
 	// IDField is the resolved primary-key field name for items returned by this
-	// endpoint, populated either by a path-item-level `x-resource-id` extension
-	// or, for OpenAPI specs, by walking the response schema (id → name → first
-	// required scalar). Empty when no key could be resolved; templates fall back
-	// to runtime list scanning. Internal YAML specs may set this directly.
+	// endpoint, populated either by a path-item-level `x-resource-id` extension,
+	// a resource member path parameter that also appears in the response item,
+	// or, for OpenAPI specs, by walking the response schema. Empty when no key
+	// could be resolved; templates fall back to runtime list scanning. Internal
+	// YAML specs may set this directly.
 	IDField string `yaml:"id_field,omitempty" json:"id_field,omitempty"`
+	// IDFieldFromPathParam is parser-only provenance used by the profiler to
+	// promote member-path primary-key hints onto same-resource list endpoints
+	// without re-inferring how IDField was resolved. It is intentionally not
+	// serialized as part of the internal spec contract.
+	IDFieldFromPathParam bool `yaml:"-" json:"-"`
 	// Critical flags this endpoint's resource as essential to a sync run. When
 	// true, a per-resource failure is treated as a hard failure even under the
 	// new (non-strict) exit-code policy. Populated from the path-item-level


### PR DESCRIPTION
## Summary
Sync and store generation now use member path parameters such as `{idpId}` as the resource primary key when that field also appears in the response item. That keeps generated CLIs from falling back to display fields like `name`, including parent-keyed dependent sync resources, while preserving explicit `x-resource-id` and stronger list endpoint IDs.

Closes #2016

## Tests
- `go test ./internal/openapi -run 'TestParseIDFieldPathParamHeuristic|TestParseIDFieldExplicitResourceIDWinsOverPathParamHeuristic' -count=1`
- `go test ./internal/profiler -run 'TestProfileSyncableResourceUsesMemberPathIDFieldHint|TestProfileDependentResourcePropagatesIDFieldAndCritical' -count=1`
- `go test ./internal/generator -run 'TestGeneratedSyncIDFieldOverridesFromMemberPathParam|TestGeneratedDependentSyncIDFieldOverridesFromMemberPathParam|TestGeneratedSyncIDFieldOverridesAndProbes' -count=1`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
