### PR TITLE
fix(cli): catch zero-row mock syncs

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -222,6 +222,7 @@ type openAPISpec struct {
 	Kind                   string // see apispec.KindREST / apispec.KindSynthetic
 	HTTPTransport          string
 	OAuthScopeRequirements []oauthScopeRequirement
+	NestedDataEnvelopes    map[string]nestedDataEnvelopeFixture
 	// ParamDefaults maps a positional placeholder name (lowercase) to its
 	// spec-declared default value, when one is set. Verify mock-mode uses
 	// this as the first step in its lookup chain so spec authors can name
@@ -238,6 +239,10 @@ type openAPISpec struct {
 	// records the dimension as unscored). Surfaced by hackernews retro
 	// #350 finding F8.
 	IsInternalYAML bool
+}
+
+type nestedDataEnvelopeFixture struct {
+	ArrayKey string
 }
 
 func (s *openAPISpec) IsSynthetic() bool {
@@ -1111,6 +1116,7 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 	}
 
 	summary, summaryErr := loadOpenAPISpecData(data, specPath)
+	nestedDataEnvelopes := detectNestedDataEnvelopeFixtures(data)
 	parsed, parseErr := openapiparser.ParseWithPathLenient(data, specPath)
 	if parseErr == nil {
 		var scopeRequirements []oauthScopeRequirement
@@ -1121,6 +1127,7 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 			Paths:                  collectDogfoodSpecPaths(parsed.Resources),
 			Auth:                   parsed.Auth,
 			OAuthScopeRequirements: scopeRequirements,
+			NestedDataEnvelopes:    nestedDataEnvelopes,
 		}, nil
 	}
 
@@ -1132,6 +1139,7 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 		Paths:                  summary.Paths,
 		Auth:                   deriveDogfoodAuth(summary),
 		OAuthScopeRequirements: summary.OAuthScopeRequirements,
+		NestedDataEnvelopes:    nestedDataEnvelopes,
 	}, nil
 }
 

--- a/internal/pipeline/dogfood_mock.go
+++ b/internal/pipeline/dogfood_mock.go
@@ -54,8 +54,17 @@ func detectNestedDataEnvelopeFixturesFromRaw(raw map[string]any) map[string]nest
 		if !ok {
 			continue
 		}
-		for method, operationValue := range pathItem {
+		methods := make([]string, 0, len(pathItem))
+		for method := range pathItem {
 			if !isDogfoodHTTPMethod(method) {
+				continue
+			}
+			methods = append(methods, method)
+		}
+		slices.Sort(methods)
+		for _, method := range methods {
+			operationValue, ok := pathItem[method]
+			if !ok {
 				continue
 			}
 			operation, ok := operationValue.(map[string]any)

--- a/internal/pipeline/dogfood_mock.go
+++ b/internal/pipeline/dogfood_mock.go
@@ -1,0 +1,267 @@
+package pipeline
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func detectNestedDataEnvelopeFixtures(data []byte) map[string]nestedDataEnvelopeFixture {
+	raw, err := decodeOpenAPIRaw(data)
+	if err != nil {
+		return nil
+	}
+	return detectNestedDataEnvelopeFixturesFromRaw(raw)
+}
+
+func decodeOpenAPIRaw(data []byte) (map[string]any, error) {
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty spec")
+	}
+	var raw map[string]any
+	if trimmed[0] == '{' {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func detectNestedDataEnvelopeFixturesFromRaw(raw map[string]any) map[string]nestedDataEnvelopeFixture {
+	paths, ok := raw["paths"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	fixtures := map[string]nestedDataEnvelopeFixture{}
+	pathNames := make([]string, 0, len(paths))
+	for path := range paths {
+		pathNames = append(pathNames, path)
+	}
+	slices.Sort(pathNames)
+	for _, path := range pathNames {
+		pathItem, ok := paths[path].(map[string]any)
+		if !ok {
+			continue
+		}
+		for method, operationValue := range pathItem {
+			if !isDogfoodHTTPMethod(method) {
+				continue
+			}
+			operation, ok := operationValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			schema := selectedResponseSchemaFromRaw(operation, raw)
+			if key := nestedDataArrayKey(schema, raw); key != "" {
+				fixtures[path] = nestedDataEnvelopeFixture{ArrayKey: key}
+				break
+			}
+		}
+	}
+	if len(fixtures) == 0 {
+		return nil
+	}
+	return fixtures
+}
+
+func isDogfoodHTTPMethod(method string) bool {
+	switch strings.ToLower(method) {
+	case "get", "post", "put", "patch", "delete", "head", "options", "trace":
+		return true
+	default:
+		return false
+	}
+}
+
+func selectedResponseSchemaFromRaw(operation map[string]any, root map[string]any) map[string]any {
+	responses, ok := operation["responses"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	for _, status := range sortedSuccessStatuses(responses) {
+		response, ok := responses[status].(map[string]any)
+		if !ok {
+			continue
+		}
+		response = resolveRawSchemaRef(response, root)
+		content, ok := response["content"].(map[string]any)
+		if !ok {
+			continue
+		}
+		contentTypes := make([]string, 0, len(content))
+		for contentType := range content {
+			if isJSONMediaType(contentType) {
+				contentTypes = append(contentTypes, contentType)
+			}
+		}
+		slices.Sort(contentTypes)
+		for _, contentType := range contentTypes {
+			media, ok := content[contentType].(map[string]any)
+			if !ok {
+				continue
+			}
+			schema, _ := media["schema"].(map[string]any)
+			if len(schema) > 0 {
+				return schema
+			}
+		}
+	}
+	return nil
+}
+
+func isJSONMediaType(mediaType string) bool {
+	mediaType = strings.ToLower(strings.TrimSpace(strings.Split(mediaType, ";")[0]))
+	return mediaType == "application/json" ||
+		mediaType == "application/problem+json" ||
+		strings.HasSuffix(mediaType, "+json")
+}
+
+func sortedSuccessStatuses(responses map[string]any) []string {
+	statuses := make([]string, 0, len(responses))
+	for status := range responses {
+		if status == "default" || strings.HasPrefix(status, "2") {
+			statuses = append(statuses, status)
+		}
+	}
+	slices.Sort(statuses)
+	return statuses
+}
+
+func nestedDataArrayKey(schema map[string]any, root map[string]any) string {
+	schema = resolveRawSchemaRef(schema, root)
+	if schemaType(schema) != "object" {
+		return ""
+	}
+	dataSchema := schemaProperty(schema, "data")
+	if len(dataSchema) == 0 {
+		return ""
+	}
+	dataSchema = resolveRawSchemaRef(dataSchema, root)
+	if schemaType(dataSchema) != "object" {
+		return ""
+	}
+	properties, ok := dataSchema["properties"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"items", "results", "records", "nodes", "entries", "values"} {
+		if prop := schemaProperty(dataSchema, key); isRawArraySchema(prop, root) {
+			return key
+		}
+	}
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		if isRawArraySchema(schemaProperty(dataSchema, key), root) {
+			return key
+		}
+	}
+	return ""
+}
+
+func schemaProperty(schema map[string]any, key string) map[string]any {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	prop, _ := properties[key].(map[string]any)
+	return prop
+}
+
+func isRawArraySchema(schema map[string]any, root map[string]any) bool {
+	schema = resolveRawSchemaRef(schema, root)
+	return schemaType(schema) == "array"
+}
+
+func schemaType(schema map[string]any) string {
+	if schema == nil {
+		return ""
+	}
+	switch value := schema["type"].(type) {
+	case string:
+		return value
+	case []any:
+		for _, item := range value {
+			if str, ok := item.(string); ok && str != "null" {
+				return str
+			}
+		}
+	}
+	if _, ok := schema["properties"].(map[string]any); ok {
+		return "object"
+	}
+	if _, ok := schema["items"].(map[string]any); ok {
+		return "array"
+	}
+	return ""
+}
+
+func resolveRawSchemaRef(schema map[string]any, root map[string]any) map[string]any {
+	for range 8 {
+		ref, _ := schema["$ref"].(string)
+		if ref != "" {
+			resolved := resolveRawPointer(ref, root)
+			if resolved == nil {
+				return schema
+			}
+			schema = resolved
+			continue
+		}
+		if nested := singleCompositionSchema(schema); nested != nil {
+			schema = nested
+			continue
+		}
+		return schema
+	}
+	return schema
+}
+
+func resolveRawPointer(ref string, root map[string]any) map[string]any {
+	if !strings.HasPrefix(ref, "#/") {
+		return nil
+	}
+	cur := any(root)
+	for part := range strings.SplitSeq(strings.TrimPrefix(ref, "#/"), "/") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		part = strings.ReplaceAll(strings.ReplaceAll(part, "~1", "/"), "~0", "~")
+		next, ok := obj[part]
+		if !ok {
+			return nil
+		}
+		cur = next
+	}
+	resolved, ok := cur.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return resolved
+}
+
+func singleCompositionSchema(schema map[string]any) map[string]any {
+	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+		items, ok := schema[key].([]any)
+		if !ok || len(items) != 1 {
+			continue
+		}
+		nested, _ := items[0].(map[string]any)
+		return nested
+	}
+	return nil
+}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -652,10 +652,10 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 			continue
 		}
 		count := parseCountOutput(countOut)
-		if expectedRows > 0 && count < expectedRows {
-			return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", table, count, expectedRows, mode)
-		}
 		if count > 0 {
+			if expectedRows > 0 && count < expectedRows {
+				return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", table, count, expectedRows, mode)
+			}
 			return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
 		}
 	}

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -647,6 +647,9 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 
 	var bestShortTable string
 	var bestShortCount int
+	var bestPassTable string
+	var bestPassCount int
+	var zeroDataTable string
 	for _, table := range tables {
 		countQuery := fmt.Sprintf("SELECT count(*) FROM \"%s\"", table)
 		countOut, countErr := runCLIWithOutput(binary, []string{"sql", countQuery}, env, 10*time.Second)
@@ -657,7 +660,11 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 		if count > 0 {
 			if expectedRows > 0 {
 				if count >= expectedRows {
-					return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
+					if !isAuxiliaryPipelineTable(table, len(tables)) && count > bestPassCount {
+						bestPassTable = table
+						bestPassCount = count
+					}
+					continue
 				}
 				if count > bestShortCount {
 					bestShortTable = table
@@ -667,11 +674,32 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 			}
 			return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
 		}
+		if expectedRows > 0 && zeroDataTable == "" && !isAuxiliaryPipelineTable(table, len(tables)) {
+			zeroDataTable = table
+		}
+	}
+	if bestPassTable != "" {
+		return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), bestPassTable, bestPassCount)
 	}
 	if bestShortTable != "" {
 		return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", bestShortTable, bestShortCount, expectedRows, mode)
 	}
+	if zeroDataTable != "" && len(tables) > 1 {
+		return false, fmt.Sprintf("FAIL: %s has 0 rows after sync, expected at least %d (%s mode)", zeroDataTable, expectedRows, mode)
+	}
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
+}
+
+func isAuxiliaryPipelineTable(table string, totalTables int) bool {
+	if totalTables <= 1 {
+		return false
+	}
+	switch strings.ToLower(table) {
+	case "config", "configs", "metadata", "settings":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseSQLOutput extracts non-empty, non-header lines from sql command output.

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -645,6 +645,8 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 		return true, "WARN: sync completed but no domain tables found in sqlite_master"
 	}
 
+	var bestShortTable string
+	var bestShortCount int
 	for _, table := range tables {
 		countQuery := fmt.Sprintf("SELECT count(*) FROM \"%s\"", table)
 		countOut, countErr := runCLIWithOutput(binary, []string{"sql", countQuery}, env, 10*time.Second)
@@ -653,11 +655,21 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 		}
 		count := parseCountOutput(countOut)
 		if count > 0 {
-			if expectedRows > 0 && count < expectedRows {
-				return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", table, count, expectedRows, mode)
+			if expectedRows > 0 {
+				if count >= expectedRows {
+					return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
+				}
+				if count > bestShortCount {
+					bestShortTable = table
+					bestShortCount = count
+				}
+				continue
 			}
 			return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
 		}
+	}
+	if bestShortTable != "" {
+		return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", bestShortTable, bestShortCount, expectedRows, mode)
 	}
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
 }

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -308,7 +308,11 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 		report.Results = append(report.Results, result)
 	}
 
-	report.DataPipeline, report.DataPipelineDetail = runDataPipelineTest(binaryPath, report.Mode, buildEnv)
+	expectedMockRows := 0
+	if report.Mode == "mock" && spec != nil && len(spec.NestedDataEnvelopes) > 0 {
+		expectedMockRows = 2
+	}
+	report.DataPipeline, report.DataPipelineDetail = runDataPipelineTest(binaryPath, report.Mode, buildEnv, expectedMockRows)
 	report.Freshness = runFreshnessContractTest(cfg.Dir)
 	report.PathParamProbes = runPathParamProbes(binaryPath, buildEnv(), paramDefaults)
 
@@ -598,7 +602,7 @@ func runBrowserSessionProofTest(binary string, auth apispec.AuthConfig) CommandR
 
 // runDataPipelineTest tests the sync -> sql -> search -> health chain.
 // Returns (pass bool, detail string) where detail gives PASS/WARN/SKIP/FAIL context.
-func runDataPipelineTest(binary, mode string, envFn func() []string) (bool, string) {
+func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRows int) (bool, string) {
 	env := envFn()
 
 	// Create a temp dir for the test database
@@ -614,7 +618,10 @@ func runDataPipelineTest(binary, mode string, envFn func() []string) (bool, stri
 	// Test sync (if it exists)
 	syncErr := runCLI(binary, []string{"sync", "--db", dbPath, "--resources", "repos", "--full"}, env, 30*time.Second)
 	if syncErr != nil {
-		// Sync might not accept --db flag - try without
+		syncErr = runCLI(binary, []string{"sync", "--db", dbPath, "--full"}, env, 30*time.Second)
+	}
+	if syncErr != nil {
+		// Sync might not accept --db flag - try without.
 		syncErr = runCLI(binary, []string{"sync", "--full"}, env, 30*time.Second)
 	}
 	if syncErr != nil {
@@ -624,12 +631,10 @@ func runDataPipelineTest(binary, mode string, envFn func() []string) (bool, stri
 	// Test health (if available)
 	_ = runCLI(binary, []string{"health", "--db", dbPath}, env, 10*time.Second)
 
-	// Discover domain tables via sql command
 	tableQuery := `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite%' AND name NOT LIKE '%_fts%' AND name != 'sync_state'`
 	tablesOut, sqlErr := runCLIWithOutput(binary, []string{"sql", tableQuery}, env, 10*time.Second)
 	if sqlErr != nil {
-		// sql command may not exist or may not accept positional args — fall back to basic check
-		return true, "PASS: sync completed (table validation skipped — sql command unavailable)"
+		return true, "PASS: sync completed (sql unavailable, table validation skipped)"
 	}
 
 	// Parse table names from output (one per line, skip empty lines and header noise)
@@ -640,24 +645,21 @@ func runDataPipelineTest(binary, mode string, envFn func() []string) (bool, stri
 		return true, "WARN: sync completed but no domain tables found in sqlite_master"
 	}
 
-	// In live mode, check that at least one table has rows
-	if mode == "live" {
-		for _, table := range tables {
-			countQuery := fmt.Sprintf("SELECT count(*) FROM \"%s\"", table)
-			countOut, countErr := runCLIWithOutput(binary, []string{"sql", countQuery}, env, 10*time.Second)
-			if countErr != nil {
-				continue
-			}
-			count := parseCountOutput(countOut)
-			if count > 0 {
-				return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
-			}
+	for _, table := range tables {
+		countQuery := fmt.Sprintf("SELECT count(*) FROM \"%s\"", table)
+		countOut, countErr := runCLIWithOutput(binary, []string{"sql", countQuery}, env, 10*time.Second)
+		if countErr != nil {
+			continue
 		}
-		return false, fmt.Sprintf("WARN: %d domain tables created but 0 rows after sync (live mode)", len(tables))
+		count := parseCountOutput(countOut)
+		if expectedRows > 0 && count < expectedRows {
+			return false, fmt.Sprintf("FAIL: %s has %d rows after sync, expected at least %d (%s mode)", table, count, expectedRows, mode)
+		}
+		if count > 0 {
+			return true, fmt.Sprintf("PASS: %d domain tables, %s has %d rows", len(tables), table, count)
+		}
 	}
-
-	// Mock mode: tables created is sufficient (mock data is minimal)
-	return true, fmt.Sprintf("PASS: %d domain tables created", len(tables))
+	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
 }
 
 // parseSQLOutput extracts non-empty, non-header lines from sql command output.
@@ -778,7 +780,9 @@ func startMockServer(spec *openAPISpec) (*httptest.Server, string) {
 
 		// Check if the path looks like a list endpoint
 		path := r.URL.Path
-		if strings.HasSuffix(path, "s") || strings.Contains(path, "/search") {
+		if fixture, ok := nestedDataEnvelopeForPath(spec, path); ok {
+			fmt.Fprint(w, renderNestedDataEnvelopeFixture(fixture))
+		} else if strings.HasSuffix(path, "s") || strings.Contains(path, "/search") {
 			// Return array
 			fmt.Fprint(w, `[{"id": 1, "name": "mock-item-1", "state": "open", "title": "Mock Item", "created_at": "2026-03-27T00:00:00Z", "updated_at": "2026-03-27T00:00:00Z"}]`)
 		} else if strings.Contains(path, "/rate_limit") {
@@ -795,6 +799,43 @@ func startMockServer(spec *openAPISpec) (*httptest.Server, string) {
 
 	server := httptest.NewServer(mux)
 	return server, server.URL
+}
+
+func nestedDataEnvelopeForPath(spec *openAPISpec, path string) (nestedDataEnvelopeFixture, bool) {
+	if spec == nil || len(spec.NestedDataEnvelopes) == 0 {
+		return nestedDataEnvelopeFixture{}, false
+	}
+	if fixture, ok := spec.NestedDataEnvelopes[path]; ok {
+		return fixture, true
+	}
+	for specPath, fixture := range spec.NestedDataEnvelopes {
+		if pathMatchesSpec(path, compileSpecPathPatterns([]string{specPath})) {
+			return fixture, true
+		}
+	}
+	return nestedDataEnvelopeFixture{}, false
+}
+
+func renderNestedDataEnvelopeFixture(fixture nestedDataEnvelopeFixture) string {
+	arrayKey := fixture.ArrayKey
+	if arrayKey == "" {
+		arrayKey = "items"
+	}
+	body := map[string]any{
+		"success": true,
+		"data": map[string]any{
+			arrayKey: []map[string]any{
+				{"id": 1, "name": "mock-item-1", "state": "open", "title": "Mock Item", "created_at": "2026-03-27T00:00:00Z", "updated_at": "2026-03-27T00:00:00Z"},
+				{"id": 2, "name": "mock-item-2", "state": "open", "title": "Mock Item 2", "created_at": "2026-03-27T00:00:00Z", "updated_at": "2026-03-27T00:00:00Z"},
+			},
+			"pagination": map[string]any{"total": 2},
+		},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return `{"success":true,"data":{"items":[{"id":1,"name":"mock-item-1"},{"id":2,"name":"mock-item-2"}],"pagination":{"total":2}}}`
+	}
+	return string(data)
 }
 
 // templateVarReadRe matches the shape config.go.tmpl emits for each

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -694,8 +694,8 @@ func isAuxiliaryPipelineTable(table string, totalTables int) bool {
 	if totalTables <= 1 {
 		return false
 	}
-	switch strings.ToLower(table) {
-	case "config", "configs", "metadata", "settings":
+	switch strings.ToLower(strings.TrimSpace(table)) {
+	case "config", "configs", "metadata", "schema_migrations", "settings":
 		return true
 	default:
 		return false

--- a/internal/pipeline/runtime_report.go
+++ b/internal/pipeline/runtime_report.go
@@ -37,6 +37,8 @@ func finalizeVerifyReport(report *VerifyReport, threshold int, requireDataPipeli
 		passGate = passGate && report.DataPipeline
 	}
 	switch {
+	case requireDataPipeline && !report.DataPipeline:
+		report.Verdict = "FAIL"
 	case passGate:
 		report.Verdict = "PASS"
 	case report.PassRate >= 60 && report.Critical <= 3:

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -210,7 +210,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
 
 		assert.False(t, pass)
-		assert.Contains(t, detail, "items has 0 rows after sync, expected at least 2")
+		assert.Contains(t, detail, "1 domain tables created but 0 rows after sync")
 	})
 
 	t.Run("fails when nested mock sync stores fewer rows than served", func(t *testing.T) {
@@ -224,6 +224,15 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 
 	t.Run("passes when sync stores rows", func(t *testing.T) {
 		binary := buildDataPipelineProbeBinary(t, 2)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Contains(t, detail, "items has 2 rows")
+	})
+
+	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t)
 
 		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
 
@@ -570,6 +579,59 @@ func main() {
 	os.Exit(1)
 }
 `, rowCount))
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "sync":
+		return
+	case "sql":
+		if len(args) < 2 {
+			os.Exit(1)
+		}
+		query := args[1]
+		if strings.Contains(query, "sqlite_master") {
+			fmt.Println("settings")
+			fmt.Println("items")
+			return
+		}
+		if strings.Contains(query, "count(*)") {
+			if strings.Contains(query, "\"settings\"") {
+				fmt.Println(0)
+				return
+			}
+			if strings.Contains(query, "\"items\"") {
+				fmt.Println(2)
+				return
+			}
+			os.Exit(1)
+		}
+	}
+	os.Exit(1)
+}
+`)
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -232,7 +232,16 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	})
 
 	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
-		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t)
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Contains(t, detail, "items has 2 rows")
+	})
+
+	t.Run("passes when an auxiliary table has fewer rows before populated data table", func(t *testing.T) {
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 1)
 
 		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
 
@@ -586,12 +595,12 @@ func main() {
 	return binaryPath
 }
 
-func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T) string {
+func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T, settingsRows int) string {
 	t.Helper()
 
 	dir := t.TempDir()
 	mainFile := filepath.Join(dir, "main.go")
-	writeTestFile(t, mainFile, `package main
+	writeTestFile(t, mainFile, fmt.Sprintf(`package main
 
 import (
 	"fmt"
@@ -619,7 +628,7 @@ func main() {
 		}
 		if strings.Contains(query, "count(*)") {
 			if strings.Contains(query, "\"settings\"") {
-				fmt.Println(0)
+				fmt.Println(%d)
 				return
 			}
 			if strings.Contains(query, "\"items\"") {
@@ -631,7 +640,7 @@ func main() {
 	}
 	os.Exit(1)
 }
-`)
+`, settingsRows))
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -1,7 +1,9 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -201,6 +203,160 @@ func TestRunCommandTestsUsesHappyArgsAnnotation(t *testing.T) {
 	assert.Equal(t, 3, result.Score)
 }
 
+func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
+	t.Run("fails when sync creates tables but stores no rows", func(t *testing.T) {
+		binary := buildDataPipelineProbeBinary(t, 0)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Contains(t, detail, "items has 0 rows after sync, expected at least 2")
+	})
+
+	t.Run("fails when nested mock sync stores fewer rows than served", func(t *testing.T) {
+		binary := buildDataPipelineProbeBinary(t, 1)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Contains(t, detail, "items has 1 rows after sync, expected at least 2")
+	})
+
+	t.Run("passes when sync stores rows", func(t *testing.T) {
+		binary := buildDataPipelineProbeBinary(t, 2)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Contains(t, detail, "items has 2 rows")
+	})
+}
+
+func TestFinalizeVerifyReportFailsRequiredDataPipeline(t *testing.T) {
+	report := &VerifyReport{
+		DataPipeline:       false,
+		DataPipelineDetail: "FAIL: 1 domain tables created but 0 rows after sync (mock mode)",
+		Results: []CommandResult{{
+			Command: "items",
+			Score:   3,
+		}},
+	}
+
+	finalizeVerifyReport(report, 80, true)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+}
+
+func TestStartMockServerServesNestedDataEnvelopeFixtureFromSpec(t *testing.T) {
+	specPath := filepath.Join(t.TempDir(), "spec.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: Nested Data API
+  version: "1.0"
+paths:
+  /users/{user_id}/items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          $ref: "#/components/responses/ListItems"
+components:
+  responses:
+    ListItems:
+      description: ok
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ListEnvelope"
+  schemas:
+    ListEnvelope:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+            pagination:
+              type: object
+`)
+	spec, err := loadDogfoodOpenAPISpec(specPath)
+	require.NoError(t, err)
+
+	server, baseURL := startMockServer(spec)
+	defer server.Close()
+
+	resp, err := http.Get(baseURL + "/users/mock-user/items")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Items      []map[string]any `json:"items"`
+			Pagination map[string]any   `json:"pagination"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.True(t, body.Success)
+	assert.Len(t, body.Data.Items, 2)
+	assert.Equal(t, float64(2), body.Data.Pagination["total"])
+}
+
+func TestStartMockServerIgnoresNestedDataEnvelopeForNonJSONResponses(t *testing.T) {
+	specPath := filepath.Join(t.TempDir(), "spec.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: XML Data API
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+`)
+	spec, err := loadDogfoodOpenAPISpec(specPath)
+	require.NoError(t, err)
+	assert.Empty(t, spec.NestedDataEnvelopes)
+
+	server, baseURL := startMockServer(spec)
+	defer server.Close()
+
+	resp, err := http.Get(baseURL + "/items")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Len(t, body, 1)
+}
+
 func TestRunCommandTestsWithoutHappyArgsKeepsGenericFailure(t *testing.T) {
 	binary := buildHappyArgsProbeBinary(t)
 	cmd := discoveredCommand{
@@ -369,6 +525,51 @@ func main() {
 	}
 }
 `)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildDataPipelineProbeBinary(t *testing.T, rowCount int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, fmt.Sprintf(`package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "sync":
+		return
+	case "sql":
+		if len(args) < 2 {
+			os.Exit(1)
+		}
+		query := args[1]
+		if strings.Contains(query, "sqlite_master") {
+			fmt.Println("items")
+			return
+		}
+		if strings.Contains(query, "count(*)") {
+			fmt.Println(%d)
+			return
+		}
+	}
+	os.Exit(1)
+}
+`, rowCount))
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -232,7 +232,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	})
 
 	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
-		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0)
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0, 2)
 
 		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
 
@@ -241,12 +241,21 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	})
 
 	t.Run("passes when an auxiliary table has fewer rows before populated data table", func(t *testing.T) {
-		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 1)
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 1, 2)
 
 		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Contains(t, detail, "items has 2 rows")
+	})
+
+	t.Run("fails when only an auxiliary table satisfies expected rows", func(t *testing.T) {
+		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 3, 0)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Contains(t, detail, "items has 0 rows")
 	})
 }
 
@@ -373,6 +382,53 @@ paths:
 	var body []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	assert.Len(t, body, 1)
+}
+
+func TestDetectNestedDataEnvelopeFixturesSortsHTTPMethods(t *testing.T) {
+	spec := []byte(`openapi: 3.0.0
+info:
+  title: Method Order API
+  version: "1.0"
+paths:
+  /items:
+    patch:
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      results:
+                        type: array
+                        items:
+                          type: object
+    get:
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+`)
+
+	fixtures := detectNestedDataEnvelopeFixtures(spec)
+
+	require.Contains(t, fixtures, "/items")
+	assert.Equal(t, "items", fixtures["/items"].ArrayKey)
 }
 
 func TestRunCommandTestsWithoutHappyArgsKeepsGenericFailure(t *testing.T) {
@@ -595,7 +651,7 @@ func main() {
 	return binaryPath
 }
 
-func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T, settingsRows int) string {
+func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T, settingsRows, itemRows int) string {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -632,7 +688,7 @@ func main() {
 				return
 			}
 			if strings.Contains(query, "\"items\"") {
-				fmt.Println(2)
+				fmt.Println(%d)
 				return
 			}
 			os.Exit(1)
@@ -640,7 +696,7 @@ func main() {
 	}
 	os.Exit(1)
 }
-`, settingsRows))
+`, settingsRows, itemRows))
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()

--- a/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
+++ b/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
@@ -3,7 +3,7 @@
     "binary": "<ARTIFACT_DIR>/verify-runtime-matrix/fixtures/mock-pass-pp-cli/mock-pass-pp-cli",
     "critical": 0,
     "data_pipeline": true,
-    "data_pipeline_detail": "PASS: 1 domain tables created",
+    "data_pipeline_detail": "PASS: 1 domain tables, items has 1 rows",
     "failed": 0,
     "freshness": {
       "detail": "cache freshness helper not emitted",


### PR DESCRIPTION
## Summary
Mock verify now exercises JSend-style list responses instead of flattening every list endpoint to a root JSON array. When a spec returns `{success:true,data:{items:[...]}}`, the mock server serves two nested items and the data-pipeline gate requires the generated sync to persist both rows, so silent-drop syncs fail instead of passing.

The verifier also reports a hard FAIL when the required data-pipeline gate fails, and the runtime matrix golden now records the row-count detail for the existing passing mock fixture.

Closes #2015

## Tests
- `go test ./...`
- `go test ./internal/pipeline`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push hook: `fmt`, `golangci-lint`
