### PR TITLE
fix(cli): normalize GraphQL sync since timestamps

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10250,6 +10250,8 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	assertVerifyEnvConcurrencyPin(t, string(syncGo), naming.CLI(gqlSpec.Name)+"/internal/cliutil", "GraphQL sync.go")
+	assert.Contains(t, string(syncGo), "sinceTS = ts.UTC().Format(time.RFC3339)",
+		"GraphQL sync --since must normalize duration-derived timestamps to UTC before query filters consume them")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -124,7 +124,7 @@ Exit codes & warnings:
 				if err != nil {
 					return fmt.Errorf("invalid --since value %q: %w", since, err)
 				}
-				sinceTS = ts.Format(time.RFC3339)
+				sinceTS = ts.UTC().Format(time.RFC3339)
 			}
 
 			// Worker pool: produce resources, N workers consume


### PR DESCRIPTION
## Summary
GraphQL sync generated with `--since` now emits UTC RFC3339 timestamps before those values feed search-style query filters, so APIs like Shopify do not silently return empty pages on machines outside UTC.

This keeps the generator-level behavior aligned with the Shopify reprint fix and pins the behavior in generator coverage.

## Verification
- `go test ./internal/generator -run TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv -count=1`
- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

Closes #2056
