### PR TITLE
fix(cli): recognize local-datastore scorer shape

### DIFF
--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -241,7 +241,8 @@ const phase5MarkerSchemaJSON = `{
       "properties": {
         "type": {"type": "string"},
         "api_key_available": {"type": "boolean"},
-        "browser_session_available": {"type": "boolean"}
+        "browser_session_available": {"type": "boolean"},
+        "local_sqlite": {"type": "boolean"}
       }
     },
     "failure_summary": {
@@ -283,7 +284,8 @@ const phase5SkipSchemaJSON = `{
       "properties": {
         "type": {"type": "string"},
         "api_key_available": {"type": "boolean"},
-        "browser_session_available": {"type": "boolean"}
+        "browser_session_available": {"type": "boolean"},
+        "local_sqlite": {"type": "boolean"}
       }
     }
   }

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -139,7 +139,7 @@ func (m CLIManifest) IsLocalDatastore() bool {
 	format := strings.ToLower(strings.TrimSpace(m.SpecFormat))
 	source := strings.ToLower(strings.TrimSpace(m.SpecSource))
 	switch format {
-	case "sqlite", "local", "local-sqlite":
+	case "sqlite", "local-sqlite":
 		return true
 	}
 	return strings.Contains(source, "local") && strings.Contains(source, "sqlite")

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -86,6 +86,7 @@ type CLIManifest struct {
 	SpecURL            string            `json:"spec_url,omitempty"`
 	SpecPath           string            `json:"spec_path,omitempty"`
 	SpecFormat         string            `json:"spec_format,omitempty"`
+	SpecSource         string            `json:"spec_source,omitempty"`
 	SpecChecksum       string            `json:"spec_checksum,omitempty"`
 	RunID              string            `json:"run_id,omitempty"`
 	CatalogEntry       string            `json:"catalog_entry,omitempty"`
@@ -128,6 +129,20 @@ type CLIManifest struct {
 	// keys don't surface as mandatory in install dialogs.
 	AuthOptional  bool                   `json:"auth_optional,omitempty"`
 	NovelFeatures []NovelFeatureManifest `json:"novel_features,omitempty"`
+}
+
+// IsLocalDatastore reports whether the manifest describes a local-datastore
+// CLI rather than an HTTP API wrapper. These CLIs read operator-local stores
+// such as SQLite databases and should not be scored or dogfooded through
+// HTTP-only assumptions.
+func (m CLIManifest) IsLocalDatastore() bool {
+	format := strings.ToLower(strings.TrimSpace(m.SpecFormat))
+	source := strings.ToLower(strings.TrimSpace(m.SpecSource))
+	switch format {
+	case "sqlite", "local", "local-sqlite":
+		return true
+	}
+	return strings.Contains(source, "local") && strings.Contains(source, "sqlite")
 }
 
 // NovelFeatureManifest is a compact representation of a transcendence feature

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -74,6 +74,26 @@ func TestWriteCLIManifestSchemaVersionAlwaysOne(t *testing.T) {
 	assert.Equal(t, 1, got.SchemaVersion)
 }
 
+func TestCLIManifestIsLocalDatastore(t *testing.T) {
+	tests := []struct {
+		name string
+		m    CLIManifest
+		want bool
+	}{
+		{name: "sqlite spec format", m: CLIManifest{SpecFormat: "sqlite"}, want: true},
+		{name: "local spec format", m: CLIManifest{SpecFormat: "local"}, want: true},
+		{name: "local sqlite spec source", m: CLIManifest{SpecSource: "local-sqlite"}, want: true},
+		{name: "openapi spec format", m: CLIManifest{SpecFormat: "openapi3"}, want: false},
+		{name: "remote sqlite wording is not local", m: CLIManifest{SpecSource: "remote-sqlite"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.m.IsLocalDatastore())
+		})
+	}
+}
+
 func TestWriteCLIManifestOmitsEmptyOptionalFields(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -81,7 +81,7 @@ func TestCLIManifestIsLocalDatastore(t *testing.T) {
 		want bool
 	}{
 		{name: "sqlite spec format", m: CLIManifest{SpecFormat: "sqlite"}, want: true},
-		{name: "local spec format", m: CLIManifest{SpecFormat: "local"}, want: true},
+		{name: "local spec format without sqlite is not enough", m: CLIManifest{SpecFormat: "local"}, want: false},
 		{name: "local sqlite spec source", m: CLIManifest{SpecSource: "local-sqlite"}, want: true},
 		{name: "openapi spec format", m: CLIManifest{SpecFormat: "openapi3"}, want: false},
 		{name: "remote sqlite wording is not local", m: CLIManifest{SpecSource: "remote-sqlite"}, want: false},

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -180,7 +180,7 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 
 func scopeLiveDogfoodSubprocessHome(cliDir string) (func(), error) {
 	manifest, err := ReadCLIManifest(cliDir)
-	if err == nil && manifest.IsLocalDatastore() {
+	if err == nil && manifest.IsLocalDatastore() && strings.EqualFold(strings.TrimSpace(manifest.AuthType), "none") {
 		return func() {}, nil
 	}
 	return scopeSubprocessHome()

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -105,15 +105,15 @@ type liveDogfoodRun struct {
 }
 
 func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
-	releaseHome, err := scopeSubprocessHome()
+	if strings.TrimSpace(opts.CLIDir) == "" {
+		return nil, fmt.Errorf("CLIDir is required")
+	}
+	releaseHome, err := scopeLiveDogfoodSubprocessHome(opts.CLIDir)
 	if err != nil {
 		return nil, err
 	}
 	defer releaseHome()
 
-	if strings.TrimSpace(opts.CLIDir) == "" {
-		return nil, fmt.Errorf("CLIDir is required")
-	}
 	level, err := normalizeLiveDogfoodLevel(opts.Level)
 	if err != nil {
 		return nil, err
@@ -176,6 +176,14 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		}
 	}
 	return report, nil
+}
+
+func scopeLiveDogfoodSubprocessHome(cliDir string) (func(), error) {
+	manifest, err := ReadCLIManifest(cliDir)
+	if err == nil && manifest.IsLocalDatastore() {
+		return func() {}, nil
+	}
+	return scopeSubprocessHome()
 }
 
 func liveDogfoodBinaryPath(dir, name string) (string, error) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -332,6 +332,43 @@ func TestRunLiveDogfoodAPICLIRetainsScopedHome(t *testing.T) {
 	assert.Equal(t, "PASS", report.Verdict, report.Tests)
 }
 
+func TestRunLiveDogfoodAuthenticatedLocalDatastoreRetainsScopedHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	home := t.TempDir()
+	cacheHome := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "source.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheHome, "snapshot.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(configHome, "source.conf"), []byte("fixture"), 0o600))
+
+	dir, binaryName := writeLiveDogfoodHomeProbeFixture(t, `if [ -f "$HOME/source.db" ]; then echo "operator home leaked" >&2; exit 3; fi
+  if [ -f "$XDG_CACHE_HOME/snapshot.db" ]; then echo "operator cache leaked" >&2; exit 3; fi
+  if [ -f "$XDG_CONFIG_HOME/source.conf" ]; then echo "operator config leaked" >&2; exit 3; fi`)
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      "api_key",
+		SpecFormat:    "sqlite",
+	}))
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+}
+
 func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -258,6 +258,80 @@ func TestRunLiveDogfoodProcessSetsDogfoodEnvVar(t *testing.T) {
 	assert.Equal(t, "1", run.stdout, "live-dogfood subprocess should see PRINTING_PRESS_DOGFOOD=1")
 }
 
+func TestRunLiveDogfoodLocalDatastoreManifestPreservesOperatorHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	home := t.TempDir()
+	cacheHome := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "source.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheHome, "snapshot.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(configHome, "source.conf"), []byte("fixture"), 0o600))
+
+	dir, binaryName := writeLiveDogfoodHomeProbeFixture(t, `if [ ! -f "$HOME/source.db" ]; then echo "missing local source" >&2; exit 3; fi
+  if [ ! -f "$XDG_CACHE_HOME/snapshot.db" ]; then echo "missing local cache" >&2; exit 3; fi
+  if [ ! -f "$XDG_CONFIG_HOME/source.conf" ]; then echo "missing local config" >&2; exit 3; fi`)
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      "none",
+		SpecFormat:    "sqlite",
+	}))
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+}
+
+func TestRunLiveDogfoodAPICLIRetainsScopedHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	home := t.TempDir()
+	cacheHome := t.TempDir()
+	configHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "source.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheHome, "snapshot.db"), []byte("fixture"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(configHome, "source.conf"), []byte("fixture"), 0o600))
+
+	dir, binaryName := writeLiveDogfoodHomeProbeFixture(t, `if [ -f "$HOME/source.db" ]; then echo "operator home leaked" >&2; exit 3; fi
+  if [ -f "$XDG_CACHE_HOME/snapshot.db" ]; then echo "operator cache leaked" >&2; exit 3; fi
+  if [ -f "$XDG_CONFIG_HOME/source.conf" ]; then echo "operator config leaked" >&2; exit 3; fi`)
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       binaryName,
+		RunID:         "run-live-dogfood",
+		AuthType:      "none",
+		SpecFormat:    "openapi3",
+	}))
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+}
+
 func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -1823,6 +1897,78 @@ if [ "$1" = "widgets" ] && [ "$2" = "broken" ]; then
     exit 0
   fi
   echo 'broken'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
+func writeLiveDogfoodHomeProbeFixture(t *testing.T, probe string) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ "${1:-}" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"widgets","subcommands":[
+      {"name":"list"},
+      {"name":"recent"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "${1:-}" = "widgets" ] && [ "${2:-}" = "list" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List widgets.
+
+Usage:
+  fixture-pp-cli widgets list [flags]
+
+Examples:
+  fixture-pp-cli widgets list --json
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "${1:-}" = "widgets" ] && [ "${2:-}" = "recent" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List recent widgets.
+
+Usage:
+  fixture-pp-cli widgets recent [flags]
+
+Examples:
+  fixture-pp-cli widgets recent --json
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "${1:-}" = "widgets" ] && { [ "${2:-}" = "list" ] || [ "${2:-}" = "recent" ]; }; then
+  ` + probe + `
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"results":[{"id":"123"}]}'
+    exit 0
+  fi
+  echo 'widget 1'
   exit 0
 fi
 

--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -25,6 +25,7 @@ type Phase5AuthContext struct {
 	Type                    string `json:"type,omitempty"`
 	APIKeyAvailable         bool   `json:"api_key_available,omitempty"`
 	BrowserSessionAvailable bool   `json:"browser_session_available,omitempty"`
+	LocalSQLite             bool   `json:"local_sqlite,omitempty"`
 }
 
 type Phase5GateMarker struct {
@@ -254,6 +255,9 @@ func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, str
 		return false, fmt.Sprintf("phase5 skip marker auth type %q does not match manifest auth type %q", marker.AuthContext.Type, manifest.AuthType)
 	}
 	if authType == "" || authType == "none" {
+		if manifest.IsLocalDatastore() {
+			return true, ""
+		}
 		return false, "no-auth APIs require a phase5 pass marker, not a skip marker"
 	}
 	if marker.AuthContext.APIKeyAvailable {

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -303,6 +303,24 @@ func TestValidatePhase5Gate_NoAuthRequiresPassMarker(t *testing.T) {
 	assert.Contains(t, result.Detail, "no-auth")
 }
 
+func TestValidatePhase5Gate_LocalDatastoreNoAuthAllowsSkipMarker(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none", SpecFormat: "sqlite"}
+	writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         "run-1",
+		Status:        "skip",
+		Level:         "none",
+		SkipReason:    "local_source_requires_operator_database",
+		AuthContext:   Phase5AuthContext{Type: "none", LocalSQLite: true},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.True(t, result.Passed, result.Detail)
+	assert.Equal(t, "skip", result.Status)
+}
+
 func TestValidatePhase5Gate_APIKeyMissingSkipAllowed(t *testing.T) {
 	proofsDir := t.TempDir()
 	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "api_key"}

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -107,6 +107,7 @@ const (
 	DimCacheFreshness        = "cache_freshness"
 	DimPathValidity          = "path_validity"
 	DimAuthProtocol          = "auth_protocol"
+	DimSyncCorrectness       = "sync_correctness"
 	DimLiveAPIVerification   = "live_api_verification"
 )
 
@@ -188,6 +189,10 @@ func recordOptionalScore(sc *Scorecard, target *int, dimension string, score int
 }
 
 func scoreSpecDimensions(sc *Scorecard, outputDir, specPath string) error {
+	if isLocalDatastoreCLIDir(outputDir) {
+		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimPathValidity, DimAuthProtocol)
+		return nil
+	}
 	if specPath == "" {
 		// No spec: mark spec-dependent dimensions as unscored.
 		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimPathValidity, DimAuthProtocol)
@@ -222,7 +227,11 @@ func scoreSpecDimensions(sc *Scorecard, outputDir, specPath string) error {
 
 func scoreDomainDimensions(sc *Scorecard, outputDir string, verifyReport *VerifyReport) {
 	sc.Steinberger.DataPipelineIntegrity = scoreDataPipelineIntegrity(outputDir)
-	sc.Steinberger.SyncCorrectness = scoreSyncCorrectness(outputDir)
+	if isLocalDatastoreCLIDir(outputDir) {
+		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimSyncCorrectness)
+	} else {
+		sc.Steinberger.SyncCorrectness = scoreSyncCorrectness(outputDir)
+	}
 	sc.Steinberger.TypeFidelity = scoreTypeFidelity(outputDir)
 	sc.Steinberger.DeadCode = scoreDeadCode(outputDir)
 
@@ -553,19 +562,20 @@ func scoreDoctor(dir string) int {
 	if content == "" {
 		return 0
 	}
+	localDatastore := isLocalDatastoreCLIDir(dir)
 	score := 0
 	// Presence: doctor command exists
 	score += 2
 	// Quality: checks auth/token validity
-	if strings.Contains(content, "auth") || strings.Contains(content, "token") || strings.Contains(content, "Token") {
+	if strings.Contains(content, "auth") || strings.Contains(content, "token") || strings.Contains(content, "Token") || localDatastore {
 		score += 2
 	}
 	// Quality: checks API connectivity (makes an HTTP request)
-	if hasDoctorHTTPReachability(content) {
+	if hasDoctorHTTPReachability(content) || (localDatastore && hasLocalDatastoreReachability(content)) {
 		score += 2
 	}
 	// Quality: checks config file
-	if strings.Contains(content, "config") || strings.Contains(content, "Config") {
+	if strings.Contains(content, "config") || strings.Contains(content, "Config") || localDatastore {
 		score += 2
 	}
 	// Excellence: checks version or API compatibility
@@ -588,6 +598,16 @@ func hasDoctorHTTPReachability(content string) bool {
 	clientCallRe := regexp.MustCompile(`\b[A-Za-z_]\w*(?:Client|HTTPClient)?\.(?:Get|Head|Post|Put|Patch|Delete|Do)\s*\(`)
 	inlineClientCallRe := regexp.MustCompile(`\(&http\.Client\s*\{[^}]*\}\)\.(?:Get|Head|Post|Put|Patch|Delete|Do)\s*\(`)
 	return clientCallRe.MatchString(content) || inlineClientCallRe.MatchString(content)
+}
+
+func hasLocalDatastoreReachability(content string) bool {
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "sqlite") ||
+		strings.Contains(lower, "database/sql") ||
+		strings.Contains(lower, ".db") ||
+		strings.Contains(lower, "usercachedir") ||
+		strings.Contains(lower, "userhomedir") ||
+		strings.Contains(lower, "os.stat")
 }
 
 func scoreAgentNative(dir string) int {
@@ -674,18 +694,24 @@ func scoreAgentNative(dir string) int {
 func scoreMCPQuality(dir string) int {
 	mcpContent := readFileContent(filepath.Join(dir, "internal", "mcp", "tools.go"))
 	if mcpContent == "" {
-		return 0 // No MCP server generated
+		if !isLocalDatastoreCLIDir(dir) {
+			return 0 // No MCP server generated
+		}
+		mcpContent = readAllGoFiles(filepath.Join(dir, "internal", "mcp"))
+		if mcpContent == "" {
+			return 0
+		}
 	}
 
 	score := 0
 
 	// Presence: MCP tools.go exists and has RegisterTools
-	if strings.Contains(mcpContent, "RegisterTools") {
+	if strings.Contains(mcpContent, "RegisterTools") || strings.Contains(mcpContent, "NewServer") {
 		score += 2
 	}
 
 	// Context tool: has rich context/about tool with domain knowledge
-	if strings.Contains(mcpContent, `"context"`) || strings.Contains(mcpContent, "handleContext") {
+	if strings.Contains(mcpContent, `"context"`) || strings.Contains(mcpContent, "handleContext") || strings.Contains(mcpContent, "agent_context") {
 		score += 2
 	}
 
@@ -695,7 +721,7 @@ func scoreMCPQuality(dir string) int {
 	if strings.Contains(mcpContent, `"sql"`) && strings.Contains(mcpContent, "handleSQL") {
 		highlevelCount++
 	}
-	if strings.Contains(mcpContent, `"search"`) && strings.Contains(mcpContent, "handleSearch") {
+	if strings.Contains(mcpContent, `"search"`) && (strings.Contains(mcpContent, "handleSearch") || isLocalDatastoreCLIDir(dir)) {
 		highlevelCount++
 	}
 	if (strings.Contains(mcpContent, `"sync"`) && strings.Contains(mcpContent, "handleSync")) ||
@@ -814,6 +840,9 @@ func scoreMCPDescriptionQuality(dir string) (score int, scored bool) {
 }
 
 func scoreLocalCache(dir string) int {
+	if isLocalDatastoreCLIDir(dir) && hasLocalDatastoreCodeSignal(dir) {
+		return 10
+	}
 	clientContent := readFileContent(filepath.Join(dir, "internal", "client", "client.go"))
 	score := 0
 	// Presence: GET response caching
@@ -1048,7 +1077,7 @@ func recomputeScorecardTotals(sc *Scorecard) {
 		sc.Steinberger.LiveAPIVerification,
 	)
 
-	tier2Max := scorecardTierMax(sc, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol)
+	tier2Max := scorecardTierMax(sc, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol, DimSyncCorrectness)
 	tier2Normalized := 0
 	if tier2Max > 0 {
 		tier2Normalized = (tier2Raw * 50) / tier2Max
@@ -2643,6 +2672,13 @@ func scoreDataPipelineIntegrity(dir string) int {
 	score := 0
 	cliDir := filepath.Join(dir, "internal", "cli")
 	allCLIContent := readAllGoFiles(cliDir)
+	localDatastore := isLocalDatastoreCLIDir(dir)
+	allLocalContent := allCLIContent
+	if localDatastore {
+		allLocalContent += readAllGoFiles(filepath.Join(dir, "internal", "source"))
+		allLocalContent += readAllGoFiles(filepath.Join(dir, "internal", "store"))
+		allLocalContent += readAllGoFiles(filepath.Join(dir, "internal", "mcp"))
+	}
 	storeContent := readFileContent(filepath.Join(dir, "internal", "store", "store.go"))
 	registeredFiles := registeredCommandFiles(cliDir)
 	commandContent := registeredCommandContent(cliDir, registeredFiles)
@@ -2668,6 +2704,15 @@ func scoreDataPipelineIntegrity(dir string) int {
 		score += 3
 	} else if genericSearchRe.MatchString(allCLIContent) {
 		score += 0
+	}
+
+	if localDatastore && hasLocalDatastoreCodeSignalFromContent(allLocalContent) {
+		if score < 8 {
+			score = 8
+		}
+		if hasGenericResourcesSQLSearchSignal(allLocalContent) || strings.Contains(strings.ToLower(allLocalContent), "select ") {
+			score += 2
+		}
 	}
 
 	score += scoreDomainTables(storeContent)
@@ -3116,6 +3161,32 @@ func readFileContent(path string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func isLocalDatastoreCLIDir(dir string) bool {
+	manifest, err := loadCLIManifestForScorecard(dir)
+	return err == nil && manifest.IsLocalDatastore()
+}
+
+func hasLocalDatastoreCodeSignal(dir string) bool {
+	var b strings.Builder
+	for _, rel := range []string{
+		filepath.Join("internal", "cli"),
+		filepath.Join("internal", "source"),
+		filepath.Join("internal", "store"),
+		filepath.Join("internal", "mcp"),
+	} {
+		b.WriteString(readAllGoFiles(filepath.Join(dir, rel)))
+		b.WriteByte('\n')
+	}
+	return hasLocalDatastoreCodeSignalFromContent(b.String())
+}
+
+func hasLocalDatastoreCodeSignalFromContent(content string) bool {
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "sqlite") ||
+		strings.Contains(lower, "database/sql") ||
+		strings.Contains(lower, "sql.open")
 }
 
 func computeGrade(percentage int) string {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -567,7 +567,7 @@ func scoreDoctor(dir string) int {
 	// Presence: doctor command exists
 	score += 2
 	// Quality: checks auth/token validity
-	if strings.Contains(content, "auth") || strings.Contains(content, "token") || strings.Contains(content, "Token") || localDatastore {
+	if strings.Contains(content, "auth") || strings.Contains(content, "token") || strings.Contains(content, "Token") {
 		score += 2
 	}
 	// Quality: checks API connectivity (makes an HTTP request)
@@ -575,7 +575,7 @@ func scoreDoctor(dir string) int {
 		score += 2
 	}
 	// Quality: checks config file
-	if strings.Contains(content, "config") || strings.Contains(content, "Config") || localDatastore {
+	if strings.Contains(content, "config") || strings.Contains(content, "Config") {
 		score += 2
 	}
 	// Excellence: checks version or API compatibility
@@ -602,12 +602,15 @@ func hasDoctorHTTPReachability(content string) bool {
 
 func hasLocalDatastoreReachability(content string) bool {
 	lower := strings.ToLower(content)
-	return strings.Contains(lower, "sqlite") ||
-		strings.Contains(lower, "database/sql") ||
-		strings.Contains(lower, ".db") ||
-		strings.Contains(lower, "usercachedir") ||
-		strings.Contains(lower, "userhomedir") ||
-		strings.Contains(lower, "os.stat")
+	hasSQLiteSignal := strings.Contains(lower, "sqlite") || strings.Contains(lower, "database/sql")
+	if !hasSQLiteSignal {
+		return false
+	}
+	return strings.Contains(lower, "sql.open") ||
+		strings.Contains(lower, ".ping(") ||
+		strings.Contains(lower, ".query(") ||
+		strings.Contains(lower, ".queryrow(") ||
+		strings.Contains(lower, ".exec(")
 }
 
 func scoreAgentNative(dir string) int {
@@ -721,7 +724,8 @@ func scoreMCPQuality(dir string) int {
 	if strings.Contains(mcpContent, `"sql"`) && strings.Contains(mcpContent, "handleSQL") {
 		highlevelCount++
 	}
-	if strings.Contains(mcpContent, `"search"`) && (strings.Contains(mcpContent, "handleSearch") || isLocalDatastoreCLIDir(dir)) {
+	hasRegisteredSearch := hasRuntimeMirror && hasRegisteredCommandFileWithPrefix(filepath.Join(dir, "internal", "cli"), "search")
+	if strings.Contains(mcpContent, `"search"`) && (strings.Contains(mcpContent, "handleSearch") || hasRegisteredSearch) {
 		highlevelCount++
 	}
 	if (strings.Contains(mcpContent, `"sync"`) && strings.Contains(mcpContent, "handleSync")) ||

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -717,6 +717,37 @@ func handleSQL() {}
 	}
 }
 
+func TestScoreMCPQuality_LocalDatastoreSearchRequiresHandlerOrRegisteredCommand(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		CLIName:       "fixture-pp-cli",
+		AuthType:      "none",
+		SpecFormat:    "sqlite",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "internal", "mcp", "tools.go"), `package mcp
+func RegisterTools() {
+	_ = "context"
+	handleContext()
+	_ = "search"
+	_ = "sync"
+	handleSync()
+}
+func handleContext() {}
+func handleSync() {}
+`)
+
+	if score := scoreMCPQuality(dir); score != 6 {
+		t.Fatalf("expected bare search string not to score as a high-level MCP tool, got %d", score)
+	}
+}
+
 func TestScoreWorkflows_RecognizesRawSQLiteDataLayer(t *testing.T) {
 	dir := t.TempDir()
 	cliDir := filepath.Join(dir, "internal", "cli")

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2482,6 +2482,30 @@ func doctorCheck() {
 	})
 }
 
+func TestScoreDoctorLocalDatastoreRequiresRealSQLiteReachability(t *testing.T) {
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, ".printing-press.json", `{
+  "schema_version": 1,
+  "api_name": "local",
+  "cli_name": "local-pp-cli",
+  "auth_type": "none",
+  "spec_format": "sqlite"
+}`)
+	writeScorecardFixture(t, dir, "internal/cli/doctor.go", `package cli
+
+import "os"
+
+func newDoctorCmd() {}
+
+func doctorCheckPath(path string) error {
+	_, err := os.Stat(path)
+	return err
+}
+`)
+
+	assert.Equal(t, 2, scoreDoctor(dir), "local-datastore doctors should not receive auth/config/reachability credit from os.Stat alone")
+}
+
 func TestScorecardLocalDatastoreManifestCreditsLocalShape(t *testing.T) {
 	dir := t.TempDir()
 	writeScorecardFixture(t, dir, ".printing-press.json", `{
@@ -2546,9 +2570,10 @@ func NewServer() {
 	RegisterTools("context", "search")
 	_ = "Returns browsing-history results from the local SQLite database"
 }
+func handleSearch() {}
 `)
 
-	assert.GreaterOrEqual(t, scoreDoctor(dir), 8, "local SQLite reachability should substitute for HTTP reachability")
+	assert.GreaterOrEqual(t, scoreDoctor(dir), 4, "local SQLite reachability should substitute for HTTP reachability without granting unrelated credit")
 	assert.Equal(t, 10, scoreLocalCache(dir), "manifest-gated local SQLite source should count as the local datastore")
 	assert.GreaterOrEqual(t, scoreMCPQuality(dir), 6, "hand-authored local MCP server should not require generated tools.go")
 	assert.GreaterOrEqual(t, scoreDataPipelineIntegrity(dir), 8, "SQL-backed local source should count as real data pipeline")

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -2482,6 +2482,84 @@ func doctorCheck() {
 	})
 }
 
+func TestScorecardLocalDatastoreManifestCreditsLocalShape(t *testing.T) {
+	dir := t.TempDir()
+	writeScorecardFixture(t, dir, ".printing-press.json", `{
+  "schema_version": 1,
+  "api_name": "chrome-history",
+  "cli_name": "chrome-history-pp-cli",
+  "auth_type": "none",
+  "spec_format": "sqlite",
+  "spec_source": "local-sqlite"
+}`)
+	writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+
+func register() {
+	rootCmd.AddCommand(newListCmd())
+	rootCmd.AddCommand(newSyncCmd())
+}
+`)
+	writeScorecardFixture(t, dir, "internal/cli/doctor.go", `package cli
+
+import (
+	"database/sql"
+	"os"
+)
+
+func newDoctorCmd() {}
+
+func checkLocalSource(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return err
+	}
+	return db.Ping()
+}
+`)
+	writeScorecardFixture(t, dir, "internal/cli/list.go", `package cli
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{Use: "list"}
+}
+`)
+	writeScorecardFixture(t, dir, "internal/cli/sync.go", `package cli
+
+func newSyncCmd() *cobra.Command {
+	return &cobra.Command{Use: "sync"}
+}
+`)
+	writeScorecardFixture(t, dir, "internal/source/sqlite.go", `package source
+
+import "database/sql"
+
+func Query(db *sql.DB) {
+	rows, _ := db.Query("SELECT url FROM visits")
+	_ = rows
+}
+`)
+	writeScorecardFixture(t, dir, "internal/mcp/server.go", `package mcp
+
+func NewServer() {
+	RegisterTools("context", "search")
+	_ = "Returns browsing-history results from the local SQLite database"
+}
+`)
+
+	assert.GreaterOrEqual(t, scoreDoctor(dir), 8, "local SQLite reachability should substitute for HTTP reachability")
+	assert.Equal(t, 10, scoreLocalCache(dir), "manifest-gated local SQLite source should count as the local datastore")
+	assert.GreaterOrEqual(t, scoreMCPQuality(dir), 6, "hand-authored local MCP server should not require generated tools.go")
+	assert.GreaterOrEqual(t, scoreDataPipelineIntegrity(dir), 8, "SQL-backed local source should count as real data pipeline")
+
+	sc, err := RunScorecard(dir, t.TempDir(), filepath.Join(dir, "not-openapi.sqlite"), nil)
+	assert.NoError(t, err, "local-datastore manifests should bypass OpenAPI-only spec parsing")
+	assert.Contains(t, sc.UnscoredDimensions, DimPathValidity)
+	assert.Contains(t, sc.UnscoredDimensions, DimAuthProtocol)
+	assert.Contains(t, sc.UnscoredDimensions, DimSyncCorrectness)
+}
+
 func TestScoreWorkflows(t *testing.T) {
 	t.Run("counts files matching expanded prefixes", func(t *testing.T) {
 		dir := t.TempDir()

--- a/testdata/golden/expected/schema-phase5-marker/stdout.txt
+++ b/testdata/golden/expected/schema-phase5-marker/stdout.txt
@@ -35,7 +35,8 @@
       "properties": {
         "type": {"type": "string"},
         "api_key_available": {"type": "boolean"},
-        "browser_session_available": {"type": "boolean"}
+        "browser_session_available": {"type": "boolean"},
+        "local_sqlite": {"type": "boolean"}
       }
     },
     "failure_summary": {

--- a/testdata/golden/expected/schema-phase5-skip/stdout.txt
+++ b/testdata/golden/expected/schema-phase5-skip/stdout.txt
@@ -21,7 +21,8 @@
       "properties": {
         "type": {"type": "string"},
         "api_key_available": {"type": "boolean"},
-        "browser_session_available": {"type": "boolean"}
+        "browser_session_available": {"type": "boolean"},
+        "local_sqlite": {"type": "boolean"}
       }
     }
   }


### PR DESCRIPTION
## Summary

Local-datastore CLIs now get scored and phase5-gated on the shape they actually ship instead of being judged as HTTP API wrappers. Live dogfood preserves the operator's real home/cache/config paths for manifest-declared local SQLite CLIs, while API CLIs keep the scoped-home isolation that protects real credentials and config.

The scorecard now treats local SQLite manifests as a datastore contract: OpenAPI path/auth dimensions are omitted, sync correctness is not scored through HTTP-generator heuristics, local cache/data pipeline credit recognizes SQLite-backed source/store code, and hand-authored local MCP servers can receive MCP quality credit.

Phase5 skip markers can now represent no-auth local SQLite CLIs whose live automation is blocked by operator-local data requirements, with the JSON schemas updated for `auth_context.local_sqlite`.

Closes #2050

## Testing

- `go test ./internal/pipeline ./internal/cli`
- `scripts/golden.sh verify`
- `go test ./...`
