### PR TITLE
fix(ci): clarify review feedback gates

### DIFF
--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -1,7 +1,9 @@
-name: Conversation resolution check
+name: Review threads resolved check
 
 # Surfaces unresolved review threads as a commit status on the PR head
-# SHA so authors get a specific cue when threads are the holdup. The
+# SHA so authors get a specific cue when threads are the holdup. This
+# status intentionally checks thread-resolution state only; Mergify also
+# gates on requested-changes review state via .mergify.yml. The
 # canonical signal lives in a commit status (latest-by-context), not the
 # workflow job's auto check_run; commit statuses with the same context
 # override on each push, so the rollup never holds a stale FAILURE next
@@ -21,6 +23,9 @@ name: Conversation resolution check
 # Review, and no specific cue that unresolved threads are the holdup.
 # This workflow puts that cue in the same place authors look — the
 # status checks list — and keeps it there regardless of label state.
+# GitHub Actions still does not fire on thread-resolution clicks, so a
+# resolved-thread-only change may require manual workflow_dispatch until a
+# webhook-backed app replaces this workflow.
 
 on:
   pull_request_target:
@@ -29,15 +34,17 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - labeled
+      - unlabeled
   pull_request_review:
-    types: [submitted]
+    types: [submitted, edited, dismissed]
   pull_request_review_comment:
-    types: [created, deleted]
+    types: [created, edited, deleted]
   # Note: GitHub Actions does NOT support a `pull_request_review_thread`
   # event trigger (despite that event existing in the webhook payload set).
   # So clicking "Resolve conversation" in the UI does not auto-fire this
-  # workflow. The status will refresh on the next push, review, or
-  # comment event. workflow_dispatch is the manual escape hatch.
+  # workflow. The status will refresh on the next push, label, review,
+  # or comment event. workflow_dispatch is the manual escape hatch.
   workflow_dispatch:
     inputs:
       pr:
@@ -48,7 +55,7 @@ permissions:
   contents: read
   pull-requests: read
   # statuses: write lets the job POST a commit status with context
-  # "All conversations resolved" via the statuses API. Commit statuses
+  # "Review threads resolved" via the statuses API. Commit statuses
   # dedupe by (sha, context) — the latest post wins for that context —
   # so a successful re-run cleanly overrides any prior failure-state
   # status from an earlier run of this workflow. Auto check_runs from
@@ -60,13 +67,13 @@ permissions:
 jobs:
   evaluate:
     # The job's auto check_run is intentionally separated from the
-    # canonical "All conversations resolved" signal. The job exits 0 in
+    # canonical "Review threads resolved" signal. The job exits 0 in
     # both pass and fail cases; the actual pass/fail lives in the commit
     # status posted below. Without this split, the auto check_runs from
     # prior runs of the workflow on the same SHA accumulate as separate
     # rollup entries (failure → cancelled → success), and consumers that
     # don't dedupe by completed_at can pick the stale failure (#1878).
-    name: Evaluate conversation threads
+    name: Evaluate review threads
     # Skip drafts across every event source. The original guard only
     # covered pull_request_target, but pull_request_review and
     # pull_request_review_comment events also carry a pull_request
@@ -139,6 +146,7 @@ jobs:
           fi
 
           threads_json="$(mktemp)"
+          # shellcheck disable=SC2016 # GraphQL variables are expanded by GitHub, not the shell.
           gh api graphql --paginate \
             -F owner="${owner}" -F repo="${repo}" -F number="${PR_NUMBER}" \
             -f query='
@@ -170,19 +178,20 @@ jobs:
           echo "total=${total} unresolved=${unresolved} (active=${unresolved_active} outdated=${unresolved_outdated})"
 
           if [ "${unresolved}" -eq 0 ]; then
-            printf '## All %s conversation(s) resolved\n\nNo unresolved review threads on this PR.\n' \
+            printf '## All %s review thread(s) resolved\n\nNo unresolved review threads on this PR.\n\nIf this status was stale before, the latest commit status has now been refreshed.\n' \
               "${total}" >> "${GITHUB_STEP_SUMMARY}"
             echo "PASS: 0 unresolved threads on ${HEAD_SHA}"
             echo "state=success" >> "${GITHUB_OUTPUT}"
             # Status descriptions are capped at 140 chars by GitHub. The
             # pass-state copy is short by construction.
-            echo "description=All ${total} conversation(s) resolved" >> "${GITHUB_OUTPUT}"
+            echo "description=All ${total} review thread(s) resolved" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           # Build the detailed thread listing once, reused for the step
           # summary (rendered on the workflow run page) and the
           # ::error:: annotation (rendered in the workflow-run UI).
+          # shellcheck disable=SC2016 # jq variables are expanded by jq, not the shell.
           listing="$(jq -r '
             [.[] | select(.isResolved == false)] as $u |
             ($u | length) as $count |
@@ -205,6 +214,7 @@ jobs:
           {
             printf '## %s\n\n%s\n\n---\n\n' "${heading}" "${listing}"
             printf '**To unblock the merge**, click "Resolve conversation" on each unresolved thread in the GitHub UI. Per repo convention every Greptile finding should be resolved (in code, or with a concrete reply explaining the deferral) before merge.\n'
+            printf '\nIf all threads already look resolved, manually refresh this status with: gh workflow run conversation-resolution-check.yml -f pr=%s\n' "${PR_NUMBER}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
           # ::error:: annotation surfaces in the workflow-run UI as a
@@ -244,11 +254,11 @@ jobs:
         run: |
           set -euo pipefail
           # Use the canonical name as the status context so a single
-          # rollup entry "All conversations resolved" carries the
+          # rollup entry "Review threads resolved" carries the
           # current truth. Reposting with the same (sha, context)
           # overrides — that's what fixes #1878.
           gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="${STATE}" \
-            -f context="All conversations resolved" \
+            -f context="Review threads resolved" \
             -f description="${DESCRIPTION}" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/conversation-resolution-check.yml
+++ b/.github/workflows/conversation-resolution-check.yml
@@ -1,14 +1,18 @@
-name: Review threads resolved check
+name: Conversation resolution check
 
 # Surfaces unresolved review threads as a commit status on the PR head
 # SHA so authors get a specific cue when threads are the holdup. This
 # status intentionally checks thread-resolution state only; Mergify also
 # gates on requested-changes review state via .mergify.yml. The
 # canonical signal lives in a commit status (latest-by-context), not the
-# workflow job's auto check_run; commit statuses with the same context
-# override on each push, so the rollup never holds a stale FAILURE next
-# to a later SUCCESS the way it did when the job conclusion was the
-# canonical signal (issue #1878).
+# workflow job's auto check_run. The status context intentionally keeps
+# the legacy name "All conversations resolved" to avoid breaking any
+# GitHub required-check settings that may reference it, but the emitted
+# description and summary clarify that this workflow checks review-thread
+# resolution only. Commit statuses with the same context override on each
+# push, so the rollup never holds a stale FAILURE next to a later SUCCESS
+# the way it did when the job conclusion was the canonical signal (issue
+# #1878).
 #
 # Not an enforcement gate — Mergify's `#review-threads-unresolved = 0`
 # condition in .mergify.yml is what actually blocks the merge queue. This
@@ -55,7 +59,7 @@ permissions:
   contents: read
   pull-requests: read
   # statuses: write lets the job POST a commit status with context
-  # "Review threads resolved" via the statuses API. Commit statuses
+  # "All conversations resolved" via the statuses API. Commit statuses
   # dedupe by (sha, context) — the latest post wins for that context —
   # so a successful re-run cleanly overrides any prior failure-state
   # status from an earlier run of this workflow. Auto check_runs from
@@ -67,13 +71,13 @@ permissions:
 jobs:
   evaluate:
     # The job's auto check_run is intentionally separated from the
-    # canonical "Review threads resolved" signal. The job exits 0 in
+    # canonical "All conversations resolved" signal. The job exits 0 in
     # both pass and fail cases; the actual pass/fail lives in the commit
     # status posted below. Without this split, the auto check_runs from
     # prior runs of the workflow on the same SHA accumulate as separate
     # rollup entries (failure → cancelled → success), and consumers that
     # don't dedupe by completed_at can pick the stale failure (#1878).
-    name: Evaluate review threads
+    name: Evaluate conversation threads
     # Skip drafts across every event source. The original guard only
     # covered pull_request_target, but pull_request_review and
     # pull_request_review_comment events also carry a pull_request
@@ -254,11 +258,12 @@ jobs:
         run: |
           set -euo pipefail
           # Use the canonical name as the status context so a single
-          # rollup entry "Review threads resolved" carries the
-          # current truth. Reposting with the same (sha, context)
-          # overrides — that's what fixes #1878.
+          # rollup entry "All conversations resolved" carries the current
+          # truth without requiring branch-protection/ruleset updates.
+          # Reposting with the same (sha, context) overrides — that's what
+          # fixes #1878.
           gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="${STATE}" \
-            -f context="Review threads resolved" \
+            -f context="All conversations resolved" \
             -f description="${DESCRIPTION}" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,12 +20,14 @@ queue_rules:
     # skips the bot-owned speculative check branches.
     queue_conditions:
       - base = main
-      # All Greptile/human inline review threads must be resolved before
-      # the PR enters the queue. Greptile Review's check_run going green
-      # only reflects the confidence score, not whether inline findings
-      # are addressed; without this condition a PR with unresolved P0/P1
-      # findings would auto-merge as soon as `ready-to-merge` is applied.
+      # All Greptile/human inline review threads must be resolved and no
+      # requested-changes review may remain before the PR enters the queue.
+      # Greptile Review's check_run going green only reflects the confidence
+      # score, not whether inline findings are addressed; without these
+      # conditions a PR with unresolved P0/P1 findings or stale requested
+      # changes would auto-merge as soon as `ready-to-merge` is applied.
       - "#review-threads-unresolved = 0"
+      - "#changes-requested-reviews-by = 0"
       - check-success = build-and-test
       - check-success = generated-test
       - check-success = go-lint
@@ -108,10 +110,12 @@ merge_protections:
         - and:
           - head = release-please--branches--main
           - "title ~= ^chore\\(main\\): release"
-      # Mirrors the queue_conditions rule. Belt-and-suspenders so a queued
-      # PR that picks up new Greptile findings during the queue's CI re-run
-      # is held until those threads are resolved.
+      # Mirrors the queue_conditions review-feedback rules. Belt-and-suspenders
+      # so a queued PR that picks up new Greptile findings or requested-changes
+      # state during the queue's CI re-run is held until the feedback is
+      # addressed.
       - "#review-threads-unresolved = 0"
+      - "#changes-requested-reviews-by = 0"
       - check-success = build-and-test
       - check-success = generated-test
       - check-success = go-lint


### PR DESCRIPTION
## Summary
- rename the review-thread visibility status to `Review threads resolved` so it no longer implies all PR feedback is cleared
- refresh the status on more nearby PR/review/comment events while documenting the remaining GitHub Actions thread-resolution blind spot
- require `#changes-requested-reviews-by = 0` alongside unresolved-thread checks in Mergify queue entry and merge protections

## Validation
- `actionlint .github/workflows/conversation-resolution-check.yml`
- `mergify config validate -f .mergify.yml`
- `git diff --check -- .mergify.yml .github/workflows/conversation-resolution-check.yml`