### PR TITLE
fix(cli): derive MCPBinary from api_name slug not spec title

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -488,7 +488,11 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 		return
 	}
 	total, public := parsed.CountMCPTools()
-	m.MCPBinary = naming.MCP(parsed.Name)
+	mcpName := m.APIName
+	if mcpName == "" {
+		mcpName = parsed.Name
+	}
+	m.MCPBinary = naming.MCP(mcpName)
 	m.MCPToolCount = total
 	m.MCPPublicToolCount = public
 	m.MCPReady = computeMCPReady(parsed.Auth.Type)

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1636,6 +1636,28 @@ func TestPopulateMCPMetadata(t *testing.T) {
 	assert.Equal(t, "Use this test credential.", m.AuthDescription)
 }
 
+func TestPopulateMCPMetadataMCPBinaryUsesAPINameWhenPresent(t *testing.T) {
+	t.Run("uses canonical api_name slug over parsed title slug", func(t *testing.T) {
+		m := CLIManifest{APIName: "youtube"}
+		populateMCPMetadata(&m, &spec.APISpec{
+			Name: "youtube-data",
+			Auth: spec.AuthConfig{Type: "none"},
+		})
+
+		assert.Equal(t, "youtube-pp-mcp", m.MCPBinary)
+	})
+
+	t.Run("falls back to parsed name when api_name missing", func(t *testing.T) {
+		var m CLIManifest
+		populateMCPMetadata(&m, &spec.APISpec{
+			Name: "youtube-data",
+			Auth: spec.AuthConfig{Type: "none"},
+		})
+
+		assert.Equal(t, "youtube-data-pp-mcp", m.MCPBinary)
+	})
+}
+
 func TestPopulateMCPMetadataIncludesTierEnvVars(t *testing.T) {
 	var m CLIManifest
 	populateMCPMetadata(&m, &spec.APISpec{


### PR DESCRIPTION
## Intent

Issue: Closes #1473

`populateMCPMetadata` derived the MCP binary name (`manifest.json.name`) from the spec-title slug rather than the canonical `api_name`. For multi-word titles — e.g. `info.title: "YouTube Data API v3"` → `cleanSpecName` → `youtube-data` — the manifest declared a `youtube-data-pp-mcp` binary that the build artifacts never produce (the cmd dir and goreleaser binary both use the `api_name` slug, `youtube-pp-mcp`). The published-library "Validate MCPB manifest contract" check fails with *"cmd/youtube-data-pp-mcp directory is missing"*, and `npx … install` resolves a binary that doesn't exist.

## Approach

`MCPBinary` was the lone field in `populateMCPMetadata` sourcing from `parsed.Name` (the title slug) instead of the canonical `m.APIName` that every other naming derivation uses. Switch it to `naming.MCP(m.APIName)`, falling back to `parsed.Name` only when `m.APIName` is empty — which preserves behavior for callers that build a manifest without an `APIName` (some tests, mcp-sync's pre-override path, regen-merge). The sibling fields in the function legitimately read semantic spec values (`parsed.Auth.*`, display-name fallback) and were left unchanged.

## Scope

Primary area: generator / pipeline (`internal/pipeline/climanifest.go`).

Why this belongs in this repo: this is a machine change in the manifest writer that every printed CLI inherits on next generate/refresh — not a per-CLI fix. It corrects the slug derivation at the single source so future prints, mcp-sync refreshes, and publishes all agree.

## Catalog Justification

N/A

## Risk

Low. The change only affects CLIs whose spec title slug differs from their `api_name` (multi-word titles) — exactly the broken case. For single-word titles `parsed.Name == m.APIName`, so output is unchanged (confirmed: golden suite passes all 24 cases unchanged). The empty-`APIName` fallback keeps mcp-sync / regen-merge / test callers identical.

## Output Contract

`manifest.json.name` / `.printing-press.json` `mcp_binary` now equals `naming.MCP(api_name)` for multi-word-title specs. No golden fixture changed (their titles are single-word, so the derived value is identical). The contract is now: MCPBinary always agrees with `cmd/<binary>/` and the goreleaser binary name.

## Verification

- `go test ./internal/pipeline/...` — pass (includes new regression test; confirmed it fails pre-fix with `youtube-data-pp-mcp`)
- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (24/24 cases, no diff)
- `gofmt` / `golangci-lint run ./internal/pipeline/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
