### PR TITLE
feat(skills): capture reachability 4xx body hints

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -39,6 +39,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-resource-id` | path item | `Endpoint.IDField` | No |
 | `x-critical` | path item | `Endpoint.Critical` | No |
 | `x-tier` | path item or operation | `Endpoint.Tier` | No |
+| `x-pp-safe-probe` | operation | Phase 1.9 reachability guidance | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 
 ## `info` Extensions
@@ -1006,6 +1007,35 @@ paths:
   /premium/search:
     get:
       x-tier: paid
+      responses:
+        "200": {description: ok}
+```
+
+### `x-pp-safe-probe`
+
+Marks a mutation endpoint as explicitly safe for the Phase 1.9 reachability gate
+to call once as an optional second probe after the low-risk GET/body capture.
+This extension is consumed by Printing Press skill guidance rather than the Go
+OpenAPI parser; it documents author intent for agents reviewing a resolved spec.
+
+Parsed field: Phase 1.9 reachability guidance
+
+Rules:
+- Optional.
+- Must be on an operation, not the root, `info`, or path item.
+- Accepts native boolean `true` only.
+- Use only for idempotent or otherwise harmless operations for the real account
+  being used.
+- Absence means mutation probing is not allowed; agents must stop after the
+  GET/body reachability capture.
+
+Example:
+
+```yaml
+paths:
+  /webhooks/test:
+    post:
+      x-pp-safe-probe: true
       responses:
         "200": {description: ok}
 ```

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -1018,7 +1018,7 @@ to call once as an optional second probe after the low-risk GET/body capture.
 This extension is consumed by Printing Press skill guidance rather than the Go
 OpenAPI parser; it documents author intent for agents reviewing a resolved spec.
 
-Parsed field: Phase 1.9 reachability guidance
+Parsed field: none; consumed by skill guidance only
 
 Rules:
 - Optional.
@@ -1026,8 +1026,8 @@ Rules:
 - Accepts native boolean `true` only.
 - Use only for idempotent or otherwise harmless operations for the real account
   being used.
-- Absence means mutation probing is not allowed; agents must stop after the
-  GET/body reachability capture.
+- Absence or any value other than native boolean `true` means mutation probing
+  is not allowed; agents must stop after the GET/body reachability capture.
 
 Example:
 

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -39,7 +39,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-resource-id` | path item | `Endpoint.IDField` | No |
 | `x-critical` | path item | `Endpoint.Critical` | No |
 | `x-tier` | path item or operation | `Endpoint.Tier` | No |
-| `x-pp-safe-probe` | operation | Phase 1.9 reachability guidance | No |
+| `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 
 ## `info` Extensions

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1715,7 +1715,11 @@ Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest
 ```bash
 body_file="$(mktemp "${TMPDIR:-/tmp}/pp-reachability-body.XXXXXX")"
 trap 'rm -f "$body_file"' EXIT
-status="$(curl -s --max-filesize 65536 -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
+status="$(curl -s --max-filesize 65536 -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || true)"
+case "$status" in
+  [0-9][0-9][0-9]) ;;
+  *) status="000" ;;
+esac
 printf '%s\n' "$status"
 ```
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1714,11 +1714,12 @@ Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest
 
 ```bash
 body_file="$(mktemp "${TMPDIR:-/tmp}/pp-reachability-body.XXXXXX")"
-status="$(curl -sS -L -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
+trap 'rm -f "$body_file"' EXIT
+status="$(curl -s -L -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
 printf '%s\n' "$status"
 ```
 
-Or use `WebFetch` if curl is unavailable, but keep the 4xx body in your notes. The goal is one real response code plus any 4xx body evidence the API chose to return.
+Or use `WebFetch` if curl is unavailable. Record the response status and, for any 4xx response body, run the same tier/permission keyword scan against the captured WebFetch body text before deciding. The goal is one real response code plus any 4xx body evidence the API chose to return.
 
 If `status` is any 4xx, inspect the body before deciding. Search it case-insensitively for tier or permission terms:
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1715,7 +1715,7 @@ Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest
 ```bash
 body_file="$(mktemp "${TMPDIR:-/tmp}/pp-reachability-body.XXXXXX")"
 trap 'rm -f "$body_file"' EXIT
-status="$(curl -s -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
+status="$(curl -s --max-filesize 65536 -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
 printf '%s\n' "$status"
 ```
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -969,6 +969,7 @@ Suggested shape:
 
 ## Reachability Risk
 - [None / Low / High] [evidence: e.g., "6 open issues on reteps/redfin about 403 errors since 2025"]
+- Tier/permission hints from 4xx body: [omit when absent; otherwise quote the matched bounded line(s) from Phase 1.9]
 
 ## Top Workflows
 1. ...
@@ -1709,13 +1710,34 @@ If the browser capture contained only challenge/login/error pages, this exceptio
 
 ### The Check
 
-Pick the simplest GET endpoint from the resolved spec (no required params, no auth if possible). If no such endpoint exists, use the spec's base URL. Run one HTTP request:
+Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest GET endpoint from the resolved spec (no required params, no auth if possible). If no such endpoint exists, use the spec's base URL. Run one HTTP request and preserve the response body when the server returns a 4xx:
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null
+body_file="$(mktemp "${TMPDIR:-/tmp}/pp-reachability-body.XXXXXX")"
+status="$(curl -sS -L -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
+printf '%s\n' "$status"
 ```
 
-Or use `WebFetch` if curl is unavailable. The goal is one real response code.
+Or use `WebFetch` if curl is unavailable, but keep the 4xx body in your notes. The goal is one real response code plus any 4xx body evidence the API chose to return.
+
+If `status` is any 4xx, inspect the body before deciding. Search it case-insensitively for tier or permission terms:
+
+```bash
+grep -Ei 'tier|allowed|permitted|subscription|quota|plan|scope|limit|permission|forbidden|unauthorized|upgrade|trial' "$body_file" | head -20
+```
+
+When matched lines are present, add them to the Phase 1 research brief under:
+
+```markdown
+## Reachability Risk
+- Tier/permission hints from 4xx body: "<matched line, truncated if needed>"
+```
+
+Keep the evidence bounded: include only the lines that explain the access model, trim each line to a readable length, and do not paste bearer tokens, API keys, cookies, or unrelated full response dumps. If the GET returns 2xx/3xx, omit this tier-hint subsection.
+
+Do not probe arbitrary mutation endpoints to discover tier limits. A generic "try a PUT/POST/PATCH/DELETE" rule can create accounts, send messages, capture payments, or mutate user data. Mutation probing is allowed only when the resolved spec or OpenAPI operation explicitly marks that endpoint as probe-safe with `x-pp-safe-probe: true`; the endpoint must be idempotent or otherwise harmless for the real account being used. If no endpoint has that explicit marker, stop after the GET body capture above.
+
+If one or more probe-safe endpoints are declared and the user provided credentials, run exactly one declared probe-safe endpoint as a second reachability probe and apply the same 4xx body capture and tier-keyword extraction. Prefer the lowest-risk declared endpoint when more than one exists. Record which endpoint was probe-safe in the brief so later phases know the evidence came from an opt-in safe probe.
 
 **If the check returns 403/429 with bot-protection evidence and `probe-reachability` has not already run for this URL during Phase 1.7's Direct HTTP challenge rule, run it now before consulting the decision matrix:**
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1715,7 +1715,7 @@ Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest
 ```bash
 body_file="$(mktemp "${TMPDIR:-/tmp}/pp-reachability-body.XXXXXX")"
 trap 'rm -f "$body_file"' EXIT
-status="$(curl -s -L -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
+status="$(curl -s -o "$body_file" -w "%{http_code}" -m 10 "<base_url>/<simplest_get_path>" 2>/dev/null || printf '000')"
 printf '%s\n' "$status"
 ```
 
@@ -1738,7 +1738,7 @@ Keep the evidence bounded: include only the lines that explain the access model,
 
 Do not probe arbitrary mutation endpoints to discover tier limits. A generic "try a PUT/POST/PATCH/DELETE" rule can create accounts, send messages, capture payments, or mutate user data. Mutation probing is allowed only when the resolved spec or OpenAPI operation explicitly marks that endpoint as probe-safe with `x-pp-safe-probe: true`; the endpoint must be idempotent or otherwise harmless for the real account being used. If no endpoint has that explicit marker, stop after the GET body capture above.
 
-If one or more probe-safe endpoints are declared and the user provided credentials, run exactly one declared probe-safe endpoint as a second reachability probe and apply the same 4xx body capture and tier-keyword extraction. Prefer the lowest-risk declared endpoint when more than one exists. Record which endpoint was probe-safe in the brief so later phases know the evidence came from an opt-in safe probe.
+If one or more probe-safe endpoints are declared and the user provided credentials, run exactly one declared probe-safe endpoint as a second reachability probe and apply the same 4xx body capture and tier-keyword extraction. When more than one exists, choose the lowest-risk declared endpoint by preferring methods in this order: HEAD/OPTIONS/GET, then PUT/PATCH, then POST, then DELETE only if it is the only declared safe option. Break ties by choosing the endpoint with the fewest required parameters and avoiding paths with account, billing, payment, deletion, or notification terms when any safer declared option exists. Record which endpoint was probe-safe in the brief so later phases know the evidence came from an opt-in safe probe.
 
 **If the check returns 403/429 with bot-protection evidence and `probe-reachability` has not already run for this URL during Phase 1.7's Direct HTTP challenge rule, run it now before consulting the decision matrix:**
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -970,6 +970,7 @@ Suggested shape:
 ## Reachability Risk
 - [None / Low / High] [evidence: e.g., "6 open issues on reteps/redfin about 403 errors since 2025"]
 - Tier/permission hints from 4xx body: [omit when absent; otherwise quote the matched bounded line(s) from Phase 1.9]
+- Probe-safe endpoint used: [omit when absent; otherwise "<METHOD> <path>" from `x-pp-safe-probe`]
 
 ## Top Workflows
 1. ...


### PR DESCRIPTION
## Summary

Phase 1.9 now preserves 4xx response bodies during the reachability probe, extracts bounded tier or permission hints into the research brief, and keeps mutation probes disabled unless a spec explicitly marks one endpoint as `x-pp-safe-probe: true`.

Closes #987

## Verification

- `bash .github/scripts/validate-skill-docs.sh`
- `git diff --check`
