### PR TITLE
fix(cli): default generated sync max-pages to unlimited

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10263,6 +10263,8 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 		"GraphQL sync.go must declare --max-pages with default 0")
 	assert.Contains(t, string(syncGo), `if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages")`,
 		"GraphQL sync.go must bound dogfood syncs only when --max-pages was not explicitly set")
+	assert.Contains(t, string(syncGo), `maxPages = 10`,
+		"GraphQL sync.go dogfood cap must still bound generated syncs to 10 pages")
 	assert.NotContains(t, string(syncGo), `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
 		"GraphQL sync.go must not retain the old 10-page default")
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9989,8 +9989,9 @@ func TestIsSyncAccessWarningClassification(t *testing.T) {
 }
 
 // TestGeneratedSyncMaxPagesAndStickyCursor verifies that the generated
-// sync command (a) defaults --max-pages to 100 (covers <=10k items/resource
-// at default page size; bigger resources opt in explicitly), (b) emits a
+// sync command (a) defaults --max-pages to 0 so normal runs are unlimited,
+// with a bounded dogfood default only when the operator did not pass the flag,
+// (b) emits a
 // structured sync_warning with reason "max_pages_cap_hit" on BOTH the flat
 // and dependent-resource code paths when the cap is reached, and (c) breaks
 // the pagination loop with a "stuck_pagination" sync_warning when the API
@@ -10056,11 +10057,16 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 	require.NoError(t, err)
 	syncContent := string(syncGo)
 
-	// (a) Default --max-pages is 100 (covers <=10k items per resource at
-	// the default page size of 100; the old 10-page default silently
-	// truncated reference resources at 1000 items).
-	assert.Contains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 100,`,
-		"sync.go must declare --max-pages with default 100")
+	// (a) Default --max-pages is 0 (unlimited) for normal users. Dogfood
+	// keeps a bounded default unless the operator explicitly passed the flag.
+	assert.Contains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 0,`,
+		"sync.go must declare --max-pages with default 0")
+	assert.Contains(t, syncContent, `if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages")`,
+		"sync.go must bound dogfood syncs only when --max-pages was not explicitly set")
+	assert.Contains(t, syncContent, `maxPages = 10`,
+		"sync.go must keep a dogfood-only page cap")
+	assert.NotContains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 100,`,
+		"sync.go must not retain the old finite 100-page default")
 	assert.NotContains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
 		"sync.go must not retain the old 10-page default")
 
@@ -10100,8 +10106,9 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 	// (b4) The cap-hit guard must consume an effective value derived from
 	// both --latest-only AND --since. When --since is set, --latest-only is
 	// already a no-op for the maxPages pin (block at sync.go.tmpl ~154),
-	// and any cap hit reflects the default 100-page limit — a real anomaly
-	// worth surfacing. Passing the raw --latest-only flag value would
+	// and any cap hit reflects an explicit operator limit or the dogfood
+	// safety limit, a real anomaly worth surfacing. Passing the raw
+	// --latest-only flag value would
 	// silently suppress legitimate warnings on the --latest-only --since
 	// combined path. Pin the derivation and the callsites that consume it.
 	assert.Contains(t, syncContent,
@@ -10252,6 +10259,12 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 	assertVerifyEnvConcurrencyPin(t, string(syncGo), naming.CLI(gqlSpec.Name)+"/internal/cliutil", "GraphQL sync.go")
 	assert.Contains(t, string(syncGo), "sinceTS = ts.UTC().Format(time.RFC3339)",
 		"GraphQL sync --since must normalize duration-derived timestamps to UTC before query filters consume them")
+	assert.Contains(t, string(syncGo), `cmd.Flags().IntVar(&maxPages, "max-pages", 0,`,
+		"GraphQL sync.go must declare --max-pages with default 0")
+	assert.Contains(t, string(syncGo), `if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages")`,
+		"GraphQL sync.go must bound dogfood syncs only when --max-pages was not explicitly set")
+	assert.NotContains(t, string(syncGo), `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
+		"GraphQL sync.go must not retain the old 10-page default")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -100,6 +100,10 @@ Exit codes & warnings:
 				}
 			}
 
+			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
+				maxPages = 10
+			}
+
 			// --latest-only: cap at page 1 and clear the resume cursor so
 			// we fetch from the head. --since takes precedence when both
 			// are set (historical context trumps latest-head).
@@ -238,7 +242,7 @@ Exit codes & warnings:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/{{.Name}}-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 
 	return cmd

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -245,6 +245,10 @@ Resource scoping:
 				}
 			}
 
+			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
+				maxPages = 10
+			}
+
 			// --latest-only narrows to the first page of each resource
 			// ignoring the historical resume cursor. We cap maxPages at 1
 			// here rather than re-interpreting it downstream so the rest
@@ -269,10 +273,10 @@ Resource scoping:
 			}
 			// effectiveLatestOnly drives the max_pages_cap_hit suppression
 			// below. It must reflect whether --latest-only is actually the
-			// cap source — i.e., only when --since is empty. If --since wins
+			// cap source, i.e. only when --since is empty. If --since wins
 			// (block above), --latest-only is a no-op for maxPages and any
-			// cap hit reflects the default --max-pages 100 limit, which is
-			// a real anomaly worth surfacing.
+			// cap hit reflects an explicit operator limit or the dogfood
+			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
 			// Resolve --since into an RFC3339 timestamp
@@ -466,7 +470,7 @@ Resource scoping:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/{{.Name}}-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero on any per-resource failure (default: only critical failures or all-resource failure exit non-zero).")
 	cmd.Flags().StringArrayVar(&paramFlags, "param", nil, "Extra query param to inject into flat-list sync requests (repeatable, key=value). Skipped on path-scoped dependent requests so a top-level scope like workspace=<id> does not double up on /parents/<id>/children calls. Use --global-param to inject everywhere. Avoid pagination keys (limit/since/cursor) — overriding them corrupts resume state.")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -149,6 +149,10 @@ Resource scoping:
 				}
 			}
 
+			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
+				maxPages = 10
+			}
+
 			// --latest-only narrows to the first page of each resource
 			// ignoring the historical resume cursor. We cap maxPages at 1
 			// here rather than re-interpreting it downstream so the rest
@@ -173,10 +177,10 @@ Resource scoping:
 			}
 			// effectiveLatestOnly drives the max_pages_cap_hit suppression
 			// below. It must reflect whether --latest-only is actually the
-			// cap source — i.e., only when --since is empty. If --since wins
+			// cap source, i.e. only when --since is empty. If --since wins
 			// (block above), --latest-only is a no-op for maxPages and any
-			// cap hit reflects the default --max-pages 100 limit, which is
-			// a real anomaly worth surfacing.
+			// cap hit reflects an explicit operator limit or the dogfood
+			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
 			// Resolve --since into an RFC3339 timestamp
@@ -354,7 +358,7 @@ Resource scoping:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/printing-press-golden-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero on any per-resource failure (default: only critical failures or all-resource failure exit non-zero).")
 	cmd.Flags().StringArrayVar(&paramFlags, "param", nil, "Extra query param to inject into flat-list sync requests (repeatable, key=value). Skipped on path-scoped dependent requests so a top-level scope like workspace=<id> does not double up on /parents/<id>/children calls. Use --global-param to inject everywhere. Avoid pagination keys (limit/since/cursor) — overriding them corrupts resume state.")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -149,6 +149,10 @@ Resource scoping:
 				}
 			}
 
+			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
+				maxPages = 10
+			}
+
 			// --latest-only narrows to the first page of each resource
 			// ignoring the historical resume cursor. We cap maxPages at 1
 			// here rather than re-interpreting it downstream so the rest
@@ -173,10 +177,10 @@ Resource scoping:
 			}
 			// effectiveLatestOnly drives the max_pages_cap_hit suppression
 			// below. It must reflect whether --latest-only is actually the
-			// cap source — i.e., only when --since is empty. If --since wins
+			// cap source, i.e. only when --since is empty. If --since wins
 			// (block above), --latest-only is a no-op for maxPages and any
-			// cap hit reflects the default --max-pages 100 limit, which is
-			// a real anomaly worth surfacing.
+			// cap hit reflects an explicit operator limit or the dogfood
+			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
 			// Resolve --since into an RFC3339 timestamp
@@ -354,7 +358,7 @@ Resource scoping:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/sync-walker-golden-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero on any per-resource failure (default: only critical failures or all-resource failure exit non-zero).")
 	cmd.Flags().StringArrayVar(&paramFlags, "param", nil, "Extra query param to inject into flat-list sync requests (repeatable, key=value). Skipped on path-scoped dependent requests so a top-level scope like workspace=<id> does not double up on /parents/<id>/children calls. Use --global-param to inject everywhere. Avoid pagination keys (limit/since/cursor) — overriding them corrupts resume state.")

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -146,6 +146,10 @@ Resource scoping:
 				}
 			}
 
+			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
+				maxPages = 10
+			}
+
 			// --latest-only narrows to the first page of each resource
 			// ignoring the historical resume cursor. We cap maxPages at 1
 			// here rather than re-interpreting it downstream so the rest
@@ -170,10 +174,10 @@ Resource scoping:
 			}
 			// effectiveLatestOnly drives the max_pages_cap_hit suppression
 			// below. It must reflect whether --latest-only is actually the
-			// cap source — i.e., only when --since is empty. If --since wins
+			// cap source, i.e. only when --since is empty. If --since wins
 			// (block above), --latest-only is a no-op for maxPages and any
-			// cap hit reflects the default --max-pages 100 limit, which is
-			// a real anomaly worth surfacing.
+			// cap hit reflects an explicit operator limit or the dogfood
+			// safety limit, which is a real anomaly worth surfacing.
 			effectiveLatestOnly := latestOnly && since == ""
 
 			// Resolve --since into an RFC3339 timestamp
@@ -321,7 +325,7 @@ Resource scoping:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/tier-routing-golden-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 0, "Maximum pages to fetch per resource (0 = unlimited; cap-hit emits a sync_warning event)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero on any per-resource failure (default: only critical failures or all-resource failure exit non-zero).")
 	cmd.Flags().StringArrayVar(&paramFlags, "param", nil, "Extra query param to inject into flat-list sync requests (repeatable, key=value). Skipped on path-scoped dependent requests so a top-level scope like workspace=<id> does not double up on /parents/<id>/children calls. Use --global-param to inject everywhere. Avoid pagination keys (limit/since/cursor) — overriding them corrupts resume state.")


### PR DESCRIPTION
## Summary
Generated sync commands now run without a page cap by default, so production-sized data windows are not silently truncated. Live dogfood runs still get a bounded default when the operator did not pass `--max-pages`, and explicit caps, including `--max-pages 0`, continue to behave as requested.

This updates both REST and GraphQL sync templates and refreshes the generated golden fixtures that expose the REST sync contract.

Closes #2057

## Verification
- `go test ./internal/generator -run 'TestGeneratedSyncMaxPagesAndStickyCursor|TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv'`
- `go test ./...`
- `scripts/golden.sh verify`
- `git diff --check`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
