### PR TITLE
fix(cli): wire GraphQL query list variable

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -353,6 +353,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"publicFlagName":           publicFlagName,
 		"publicFlagAliases":        publicFlagAliases,
 		"flagChangedExpr":          flagChangedExpr,
+		"graphqlListParams":        graphqlListParams,
+		"graphqlVariableType":      graphqlVariableType,
 		"mcpInputName":             mcpInputName,
 		"mcpParamBindings":         mcpParamBindings,
 		// endpointNeedsClientLimit reports whether a list endpoint needs
@@ -5767,6 +5769,44 @@ func graphqlFieldSelection(typeName string, types map[string]spec.TypeDef) []str
 		return []string{"id"}
 	}
 	return fields
+}
+
+// graphqlListParams returns the GraphQL list arguments this generator knows how
+// to render into the query document and command variables map.
+func graphqlListParams(endpoint spec.Endpoint) []spec.Param {
+	params := make([]spec.Param, 0, len(endpoint.Params))
+	for _, p := range endpoint.Params {
+		if p.Positional || p.PathParam {
+			continue
+		}
+		switch p.Name {
+		case "first", "after", "before", "query":
+		default:
+			continue
+		}
+		params = append(params, p)
+	}
+	return params
+}
+
+func graphqlVariableType(p spec.Param) string {
+	var typ string
+	switch primitiveKind(p.Type) {
+	case "int":
+		typ = "Int"
+	case "float":
+		typ = "Float"
+	case "bool":
+		typ = "Boolean"
+	case "array":
+		typ = "[String!]"
+	default:
+		typ = "String"
+	}
+	if p.Required || strings.EqualFold(p.Name, "first") {
+		typ += "!"
+	}
+	return typ
 }
 
 type templateEndpoint struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5780,7 +5780,7 @@ func graphqlListParams(endpoint spec.Endpoint) []spec.Param {
 			continue
 		}
 		switch p.Name {
-		case "first", "after", "before", "query":
+		case "first", "after", "query":
 		default:
 			continue
 		}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11609,6 +11609,7 @@ func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 						Params: []spec.Param{
 							{Name: "first", Type: "integer", Default: 100},
 							{Name: "after", Type: "string"},
+							{Name: "before", Type: "string"},
 						},
 						Pagination: &spec.Pagination{
 							Type:           "cursor",
@@ -11621,10 +11622,26 @@ func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 					},
 				},
 			},
+			"customers": {
+				Description: "Customers",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "List customers",
+						ResponsePath: "data.customers.nodes",
+						Params: []spec.Param{
+							{Name: "status", Type: "string"},
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "Customer"},
+					},
+				},
+			},
 		},
 		Types: map[string]spec.TypeDef{
 			"Order":            {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
 			"FulfillmentOrder": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "status", Type: "string"}}},
+			"Customer":         {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "email", Type: "string"}}},
 		},
 	}
 
@@ -11642,7 +11659,11 @@ func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 	assert.Contains(t, queriesContent, "query($first: Int!, $after: String, $query: String)")
 	assert.Contains(t, queriesContent, "orders(first: $first, after: $after, query: $query)")
 	assert.Contains(t, queriesContent, "query($first: Int!, $after: String) {\n  fulfillmentOrders(first: $first, after: $after)")
+	assert.NotContains(t, queriesContent, "before: $before")
 	assert.NotContains(t, queriesContent, "fulfillmentOrders(first: $first, after: $after, query: $query)")
+	assert.Contains(t, queriesContent, "query {\n  customers {\n")
+	assert.NotContains(t, queriesContent, "query()")
+	assert.NotContains(t, queriesContent, "customers()")
 }
 
 func TestGraphQLFieldSelectionSupportsNestedSelections(t *testing.T) {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11543,6 +11543,108 @@ func TestGenerateGraphQLCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:                "shopify-query",
+		Description:         "Shopify Admin GraphQL query fixture",
+		Version:             "2026-04",
+		BaseURL:             "https://example.myshopify.com",
+		GraphQLEndpointPath: "/admin/api/2026-04/graphql.json",
+		Auth:                spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/shopify-query-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"orders": {
+				Description: "Orders",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "Get an order",
+						ResponsePath: "data.order",
+						Params:       []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+						Response:     spec.ResponseDef{Type: "object", Item: "Order"},
+					},
+					"list": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "List orders",
+						ResponsePath: "data.orders.nodes",
+						Params: []spec.Param{
+							{Name: "first", Type: "integer", Default: 100},
+							{Name: "after", Type: "string"},
+							{Name: "query", Type: "string", Description: "Shopify search filter"},
+						},
+						Pagination: &spec.Pagination{
+							Type:           "cursor",
+							LimitParam:     "first",
+							CursorParam:    "after",
+							NextCursorPath: "data.orders.pageInfo.endCursor",
+							HasMoreField:   "data.orders.pageInfo.hasNextPage",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "Order"},
+					},
+				},
+			},
+			"fulfillment-orders": {
+				Description: "Fulfillment orders",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "Get a fulfillment order",
+						ResponsePath: "data.fulfillmentOrder",
+						Params:       []spec.Param{{Name: "id", Type: "string", Required: true, Positional: true}},
+						Response:     spec.ResponseDef{Type: "object", Item: "FulfillmentOrder"},
+					},
+					"list": {
+						Method:       "GET",
+						Path:         "/graphql",
+						Description:  "List fulfillment orders",
+						ResponsePath: "data.fulfillmentOrders.nodes",
+						Params: []spec.Param{
+							{Name: "first", Type: "integer", Default: 100},
+							{Name: "after", Type: "string"},
+						},
+						Pagination: &spec.Pagination{
+							Type:           "cursor",
+							LimitParam:     "first",
+							CursorParam:    "after",
+							NextCursorPath: "data.fulfillmentOrders.pageInfo.endCursor",
+							HasMoreField:   "data.fulfillmentOrders.pageInfo.hasNextPage",
+						},
+						Response: spec.ResponseDef{Type: "array", Item: "FulfillmentOrder"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Order":            {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}}},
+			"FulfillmentOrder": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "status", Type: "string"}}},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	ordersContent := generatedCLISourceContaining(t, outputDir, `variables["query"] = flagQuery`)
+	assert.Contains(t, ordersContent, `cmd.Flags().StringVar(&flagQuery, "query", "", "Shopify search filter")`)
+	assert.Contains(t, ordersContent, `if cmd.Flags().Changed("query") {`)
+	assert.Contains(t, ordersContent, `variables["query"] = flagQuery`)
+
+	queriesGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "queries.go"))
+	require.NoError(t, err)
+	queriesContent := string(queriesGo)
+	assert.Contains(t, queriesContent, "query($first: Int!, $after: String, $query: String)")
+	assert.Contains(t, queriesContent, "orders(first: $first, after: $after, query: $query)")
+	assert.Contains(t, queriesContent, "query($first: Int!, $after: String) {\n  fulfillmentOrders(first: $first, after: $after)")
+	assert.NotContains(t, queriesContent, "fulfillmentOrders(first: $first, after: $after, query: $query)")
+}
+
 func TestGraphQLFieldSelectionSupportsNestedSelections(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -173,12 +173,16 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 
 {{- if or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")}}
 {{- if and $isGraphQLEndpoint (eq .EndpointName "list")}}
-			variables := map[string]any{
-				"first": flagFirst,
+			variables := map[string]any{}
+{{- range graphqlListParams .Endpoint}}
+{{- if or .Required .Default (eq .Name "first")}}
+			variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
+{{- else}}
+			if {{flagChangedExpr .}} {
+				variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
 			}
-			if flagAfter != "" {
-				variables["after"] = flagAfter
-			}
+{{- end}}
+{{- end}}
 {{- if $supportsAllPagination}}
 			var data json.RawMessage
 			if flagAll && !flags.dryRun {

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -10,8 +10,8 @@ package client
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}
 {{- $params := graphqlListParams $endpoint}}
 
-const {{pascal $rName}}ListQuery = {{backtick}}query({{- range $i, $p := $params}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}) {
-  {{$queryField}}({{- range $i, $p := $params}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}) {
+const {{pascal $rName}}ListQuery = {{backtick}}query{{if $params}}({{- range $i, $p := $params}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}){{end}} {
+  {{$queryField}}{{if $params}}({{- range $i, $p := $params}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}){{end}} {
     nodes {
 {{- range graphqlFieldSelection $endpoint.Response.Item $.Types}}
       {{.}}

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -8,9 +8,10 @@ package client
 {{- range $eName, $endpoint := $resource.Endpoints}}
 {{- if eq $eName "list"}}
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}
+{{- $params := graphqlListParams $endpoint}}
 
-const {{pascal $rName}}ListQuery = {{backtick}}query($first: Int!, $after: String) {
-  {{$queryField}}(first: $first, after: $after) {
+const {{pascal $rName}}ListQuery = {{backtick}}query({{- range $i, $p := $params}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}) {
+  {{$queryField}}({{- range $i, $p := $params}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}) {
     nodes {
 {{- range graphqlFieldSelection $endpoint.Response.Item $.Types}}
       {{.}}


### PR DESCRIPTION
## Summary
GraphQL list commands now carry supported list variables through end to end. When a GraphQL field supports `query`, the generated query document declares it, calls the field with it, and the Cobra command only adds `variables["query"]` when `--query` is set, so filtering is no longer silently ignored.

The generator keeps non-query list fields unchanged, so resources without `query` do not grow a stale variable or field argument.

Closes #2058

## Tests
- `go test ./internal/generator -run 'TestGenerateGraphQL(ListWiresOptionalQueryVariable|Compiles)' -count=1`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
