### PR TITLE
fix(skills): rerun live dogfood during publish

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -396,6 +396,27 @@ func TestPolishSkillHardGatesPublishValidate(t *testing.T) {
 	assert.Contains(t, skill, "ship cannot fire while publish validate fails")
 }
 
+func TestPublishSkillRerunsLiveGateBeforeManagedClone(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+	validateStart := strings.Index(skill, "## Step 4: Validate")
+	liveGateStart := strings.Index(skill, "## Step 4.5: Live End-to-End Gate")
+	cloneStart := strings.Index(skill, "## Step 5: Managed Clone")
+	require.NotEqual(t, -1, validateStart)
+	require.NotEqual(t, -1, liveGateStart)
+	require.NotEqual(t, -1, cloneStart)
+	require.Less(t, validateStart, liveGateStart)
+	require.Less(t, liveGateStart, cloneStart)
+
+	liveGateBlock := skill[liveGateStart:cloneStart]
+	assert.Contains(t, liveGateBlock, `dogfood`)
+	assert.Contains(t, liveGateBlock, `--live`)
+	assert.Contains(t, liveGateBlock, `--level full`)
+	assert.Contains(t, liveGateBlock, `--write-acceptance "$PROOFS_DIR/phase5-acceptance.json"`)
+	assert.Contains(t, liveGateBlock, `"$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json`)
+	assert.Contains(t, skill, `--skip-live-test=<reason>`)
+	assert.Contains(t, skill, "### Publish Live Gate")
+}
+
 func TestPolishPublishOfferRequiresFreshUserTurn(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
 	reference := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "references", "publish-turn-boundary.md"))

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -411,9 +411,13 @@ func TestPublishSkillRerunsLiveGateBeforeManagedClone(t *testing.T) {
 	assert.Contains(t, liveGateBlock, `dogfood`)
 	assert.Contains(t, liveGateBlock, `--live`)
 	assert.Contains(t, liveGateBlock, `--level full`)
+	assert.Contains(t, liveGateBlock, `--timeout 120s`)
 	assert.Contains(t, liveGateBlock, `--write-acceptance "$PROOFS_DIR/phase5-acceptance.json"`)
 	assert.Contains(t, liveGateBlock, `"$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json`)
-	assert.Contains(t, skill, `--skip-live-test=<reason>`)
+	assert.Contains(t, liveGateBlock, `--skip-live-test=<reason>`)
+	assert.Contains(t, liveGateBlock, `auth_type=none during a known upstream outage`)
+	assert.Contains(t, liveGateBlock, `API_KEY_AVAILABLE=true`)
+	assert.Contains(t, liveGateBlock, `api_key_available: $api_key_available`)
 	assert.Contains(t, skill, "### Publish Live Gate")
 }
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -21,6 +21,7 @@ Publish a generated CLI from your local library to the [printing-press-library](
 /printing-press publish notion-pp-cli
 /printing-press publish notion
 /printing-press publish notion --from-polish
+/printing-press publish notion --skip-live-test=auth-unavailable
 /printing-press publish
 ```
 
@@ -40,6 +41,13 @@ If the fresh user-authored request includes `--from-polish`, record
 resolving the CLI name. The marker is not a second confirmation and is not
 passed to `cli-printing-press`; it only preserves standalone polish's old
 post-publish retro offer after the fresh-turn publish completes.
+
+If the fresh user-authored request includes `--skip-live-test=<reason>`, record
+the exact non-empty reason as `SKIP_LIVE_TEST_REASON` and remove the flag before
+resolving the CLI name. This is the only supported escape valve for the
+publish-time live test gate. Use it only for auth-unavailable, known upstream
+outage, or similarly concrete operator-approved cases; never infer a skip from
+ordinary latency or from the presence of an older Phase 5 marker.
 
 The public library treats `library/<category>/<api-slug>/.printing-press.json`
 and `manifest.json` as the source of truth for registry-display fields. Do not
@@ -257,6 +265,115 @@ fails, tell the user to re-print or re-package with current Printing Press
 metadata before opening the library PR.
 
 Save the `help_output` field from the result — it's used in the PR description.
+
+## Step 4.5: Live End-to-End Gate
+
+Before touching the managed publish clone, rerun the live behavioral gate
+against the CLI that is about to be published. Step 4 proves the source builds
+and validates structurally; this step proves the current post-edit tree still
+works against the real upstream API. Do not rely on an older
+`phase5-acceptance.json` from generation or polish because the CLI may have
+been hand-edited since that marker was written.
+
+Resolve the Phase 5 proofs directory from the CLI manifest:
+
+```bash
+MANIFEST="$CLI_DIR/.printing-press.json"
+API_SLUG=$(jq -r '.api_name // empty' "$MANIFEST")
+CLI_NAME=$(jq -r '.cli_name // empty' "$MANIFEST")
+RUN_ID=$(jq -r '.run_id // empty' "$MANIFEST")
+AUTH_TYPE=$(jq -r '.auth_type // "none"' "$MANIFEST")
+AUTH_ENV=$(jq -r '.auth_env_vars[0] // empty' "$MANIFEST")
+
+if [ -z "$API_SLUG" ] || [ -z "$RUN_ID" ]; then
+  echo "ERROR: manifest is missing api_name or run_id; cannot run publish live gate."
+  exit 1
+fi
+
+PROOFS_DIR="$CLI_DIR/.manuscripts/$RUN_ID/proofs"
+if [ ! -d "$PROOFS_DIR" ] && [ -n "$API_SLUG" ] && [ -d "$PRESS_MANUSCRIPTS/$API_SLUG/$RUN_ID/proofs" ]; then
+  PROOFS_DIR="$PRESS_MANUSCRIPTS/$API_SLUG/$RUN_ID/proofs"
+elif [ ! -d "$PROOFS_DIR" ] && [ -n "$CLI_NAME" ] && [ -d "$PRESS_MANUSCRIPTS/$CLI_NAME/$RUN_ID/proofs" ]; then
+  PROOFS_DIR="$PRESS_MANUSCRIPTS/$CLI_NAME/$RUN_ID/proofs"
+fi
+mkdir -p "$PROOFS_DIR"
+```
+
+If `SKIP_LIVE_TEST_REASON` is unset, run full live dogfood and write a fresh
+acceptance marker into that proofs directory:
+
+```bash
+LIVE_GATE_JSON="$PROOFS_DIR/publish-live-gate.json"
+LIVE_GATE_ARGS=(
+  dogfood
+  --dir "$CLI_DIR"
+  --live
+  --level full
+  --timeout 30s
+  --write-acceptance "$PROOFS_DIR/phase5-acceptance.json"
+  --json
+)
+if [ -n "$AUTH_ENV" ]; then
+  LIVE_GATE_ARGS+=(--auth-env "$AUTH_ENV")
+fi
+
+rm -f "$PROOFS_DIR/phase5-skip.json"
+if ! "$PRINTING_PRESS_BIN" "${LIVE_GATE_ARGS[@]}" >"$LIVE_GATE_JSON"; then
+  echo "Publish live gate failed. See $LIVE_GATE_JSON and $PROOFS_DIR/phase5-acceptance.json."
+  jq -r '.tests[]? | select(.status == "fail") | "- \(.command) [\(.kind)]: \(.reason // "failed")"' "$LIVE_GATE_JSON" 2>/dev/null || true
+  exit 1
+fi
+```
+
+On failure, stop exactly like Step 4's `passed: false`: no managed clone, no
+branch, no package, no PR. Report the failed command, exit code when present,
+stderr or reason snippet, and the path to the fresh proof files so the operator
+can re-run dogfood and fix the CLI.
+
+If `SKIP_LIVE_TEST_REASON` is set, write a fresh skip marker instead of running
+dogfood:
+
+```bash
+case "$AUTH_TYPE" in
+  api_key|bearer_token|oauth2)
+    ;;
+  *)
+    echo "ERROR: --skip-live-test is not valid for auth_type=$AUTH_TYPE. Run the live gate instead."
+    exit 1
+    ;;
+esac
+
+rm -f "$PROOFS_DIR/phase5-acceptance.json"
+jq -n \
+  --arg api "$API_SLUG" \
+  --arg run "$RUN_ID" \
+  --arg reason "$SKIP_LIVE_TEST_REASON" \
+  --arg auth "$AUTH_TYPE" \
+  '{
+    schema_version: 1,
+    api_name: $api,
+    run_id: $run,
+    status: "skip",
+    level: "none",
+    skip_reason: $reason,
+    auth_context: {
+      type: $auth,
+      api_key_available: false,
+      browser_session_available: false
+    }
+  }' > "$PROOFS_DIR/phase5-skip.json"
+LIVE_GATE_JSON=""
+```
+
+Then rerun Step 4's validation:
+
+```bash
+"$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json
+```
+
+This second validation proves the fresh acceptance or skip marker satisfies the
+same Phase 5 contract that package and publish rely on. If it fails, stop
+before Step 5.
 
 ## Step 5: Managed Clone
 
@@ -869,6 +986,8 @@ Build the PR description from:
 - The CLI's README (first 2-3 paragraphs, or note that README is missing)
 - Links to every file under `.manuscripts/<run-id>/research/` and `.manuscripts/<run-id>/proofs/`. Each link must be a full `https://github.com/mvanhorn/printing-press-library/blob/<HEAD_SHA>/library/<category>/<api-slug>/.manuscripts/<run-id>/<subdir>/<filename>` URL — never a relative path (GitHub resolves those against `…/pull/`, producing broken `…/pull/library/…` URLs) and never a directory (the blob view requires a file). Enumerate the actual files; do not invent or skip them.
 - The validation results from Step 4
+- The publish live gate result from Step 4.5, including any explicit
+  `--skip-live-test` reason
 - A Gaps section listing any missing manifest fields
 
 Read `novel_features` from
@@ -963,6 +1082,11 @@ $ <cli-name> --help
 | --help | PASS/FAIL |
 | --version | PASS/FAIL |
 | Manuscripts | PRESENT/MISSING |
+
+### Publish Live Gate
+
+<If Step 4.5 ran dogfood: "Full live dogfood reran at publish time and passed. Proof: `<proof path or manuscript link>`">
+<If Step 4.5 was skipped: "Skipped with explicit reason: `<SKIP_LIVE_TEST_REASON>`">
 
 ### Gaps
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -309,7 +309,7 @@ LIVE_GATE_ARGS=(
   --dir "$CLI_DIR"
   --live
   --level full
-  --timeout 30s
+  --timeout 120s
   --write-acceptance "$PROOFS_DIR/phase5-acceptance.json"
   --json
 )
@@ -330,12 +330,23 @@ branch, no package, no PR. Report the failed command, exit code when present,
 stderr or reason snippet, and the path to the fresh proof files so the operator
 can re-run dogfood and fix the CLI.
 
-If `SKIP_LIVE_TEST_REASON` is set, write a fresh skip marker instead of running
-dogfood:
+If `SKIP_LIVE_TEST_REASON` is set from `--skip-live-test=<reason>`, write a
+fresh skip marker instead of running dogfood:
 
 ```bash
+SKIP_REASON_LOWER=$(printf '%s' "$SKIP_LIVE_TEST_REASON" | tr '[:upper:]' '[:lower:]')
 case "$AUTH_TYPE" in
   api_key|bearer_token|oauth2)
+    ;;
+  none)
+    case "$SKIP_REASON_LOWER" in
+      *upstream*outage*)
+        ;;
+      *)
+        echo "ERROR: --skip-live-test is only valid for auth_type=none during a known upstream outage."
+        exit 1
+        ;;
+    esac
     ;;
   *)
     echo "ERROR: --skip-live-test is not valid for auth_type=$AUTH_TYPE. Run the live gate instead."
@@ -343,12 +354,19 @@ case "$AUTH_TYPE" in
     ;;
 esac
 
+API_KEY_AVAILABLE=false
+if [ -n "$AUTH_ENV" ] && [ -n "${!AUTH_ENV:-}" ]; then
+  API_KEY_AVAILABLE=true
+fi
+
 rm -f "$PROOFS_DIR/phase5-acceptance.json"
 jq -n \
   --arg api "$API_SLUG" \
   --arg run "$RUN_ID" \
   --arg reason "$SKIP_LIVE_TEST_REASON" \
   --arg auth "$AUTH_TYPE" \
+  --argjson api_key_available "$API_KEY_AVAILABLE" \
+  --argjson browser_session_available false \
   '{
     schema_version: 1,
     api_name: $api,
@@ -358,8 +376,8 @@ jq -n \
     skip_reason: $reason,
     auth_context: {
       type: $auth,
-      api_key_available: false,
-      browser_session_available: false
+      api_key_available: $api_key_available,
+      browser_session_available: $browser_session_available
     }
   }' > "$PROOFS_DIR/phase5-skip.json"
 LIVE_GATE_JSON=""


### PR DESCRIPTION
## Summary

Publishing now reruns full live dogfood against the CLI that is about to be submitted, so a stale Phase 5 marker from generation or polish can no longer let post-edit breakage reach the public library PR.

The publish flow records a fresh acceptance marker before touching the managed clone, supports an explicit `--skip-live-test=<reason>` escape valve for credential or upstream-outage cases, and carries the live-gate outcome into the generated PR body.

Closes #1601

## Test plan

- `go test ./internal/pipeline -run 'TestPublishSkillRerunsLiveGateBeforeManagedClone|TestPolishSkillHardGatesPublishValidate'`
- `go test ./...`
- `git diff --check`
