### PR TITLE
fix(cli): store only basename for local spec_path in manifest

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -702,7 +702,7 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
 			m.SpecURL = src
 		} else {
-			m.SpecPath = src
+			m.SpecPath = sanitizeManifestSpecPath(src)
 			// Compute checksum and format from the actual input spec file.
 			if data, err := os.ReadFile(src); err == nil {
 				m.SpecFormat = detectSpecFormat(data)
@@ -892,6 +892,20 @@ func sameGenerateManifestLineage(existing, generated CLIManifest) bool {
 func preserveExistingDescription(description string) bool {
 	description = strings.TrimSpace(description)
 	return description != "" && !naming.HasLiteralEllipsisSuffix(description)
+}
+
+// sanitizeManifestSpecPath reduces a local spec file path to its basename so the
+// published manifest never leaks the printer's filesystem layout. Only http(s)
+// URLs pass through unchanged — a file:// URL embeds the same local path we are
+// trying to keep out of the published manifest, so it is basenamed too.
+func sanitizeManifestSpecPath(specPath string) string {
+	if specPath == "" {
+		return ""
+	}
+	if strings.HasPrefix(specPath, "http://") || strings.HasPrefix(specPath, "https://") {
+		return specPath
+	}
+	return filepath.Base(specPath)
 }
 
 func lookupCatalogEntryForGenerate(apiName, specURL string) *catalogpkg.Entry {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -74,6 +74,14 @@ func TestWriteCLIManifestSchemaVersionAlwaysOne(t *testing.T) {
 	assert.Equal(t, 1, got.SchemaVersion)
 }
 
+func TestSanitizeManifestSpecPath(t *testing.T) {
+	assert.Equal(t, "openapi.json", sanitizeManifestSpecPath("/Users/someone/Downloads/openapi.json"))
+	assert.Equal(t, "https://example.com/openapi.yaml", sanitizeManifestSpecPath("https://example.com/openapi.yaml"))
+	assert.Equal(t, "openapi.json", sanitizeManifestSpecPath("openapi.json"))
+	// file:// URLs embed the local path, so they are basenamed too.
+	assert.Equal(t, "openapi.json", sanitizeManifestSpecPath("file:///Users/someone/Downloads/openapi.json"))
+}
+
 func TestCLIManifestIsLocalDatastore(t *testing.T) {
 	tests := []struct {
 		name string
@@ -387,7 +395,7 @@ func TestPublishWorkingCLIWritesManifest(t *testing.T) {
 	assert.Equal(t, "test-api-pp-cli", got.CLIName)
 	assert.Equal(t, version.Version, got.PrintingPressVersion)
 	assert.Equal(t, "https://example.com/spec.json", got.SpecURL)
-	assert.Equal(t, "/tmp/test-spec.json", got.SpecPath)
+	assert.Equal(t, "test-spec.json", got.SpecPath)
 	assert.Equal(t, "openapi3", got.SpecFormat)
 	assert.NotEmpty(t, got.RunID)
 	assert.False(t, got.GeneratedAt.IsZero())
@@ -427,7 +435,7 @@ func TestPublishManifestNormalizesLocalPathInSpecURL(t *testing.T) {
 
 	// Local path should be in spec_path, NOT in spec_url
 	assert.Empty(t, got.SpecURL, "local file path should not appear in spec_url")
-	assert.Equal(t, "/tmp/my-spec.yaml", got.SpecPath)
+	assert.Equal(t, "my-spec.yaml", got.SpecPath)
 }
 
 func TestPublishManifestNormalizesURLDuplicatedInBothFields(t *testing.T) {
@@ -634,7 +642,7 @@ func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 
 	assert.Empty(t, got.SpecURL, "local path should not appear in spec_url")
-	assert.Equal(t, "/tmp/my-spec.yaml", got.SpecPath)
+	assert.Equal(t, "my-spec.yaml", got.SpecPath)
 }
 
 func TestWriteManifestForGenerateKeepsCatalogDisplayNameOverTitleFallback(t *testing.T) {
@@ -2008,7 +2016,7 @@ func TestWriteManifestForGenerateDoesNotPreserveStaleSpecURLWhenFreshSourceIsPat
 
 	got := readPublishedManifest(t, dir)
 	assert.Empty(t, got.SpecURL)
-	assert.Equal(t, specPath, got.SpecPath)
+	assert.Equal(t, filepath.Base(specPath), got.SpecPath)
 }
 
 func TestWriteManifestForGenerateFreshValuesReplaceExistingManifestExtras(t *testing.T) {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -201,7 +201,7 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		APIName:              state.APIName,
 		CLIName:              naming.CLI(state.APIName),
 		SpecURL:              specURL,
-		SpecPath:             specPath,
+		SpecPath:             sanitizeManifestSpecPath(specPath),
 		RunID:                state.RunID,
 	}
 	var existingDescription string

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/.printing-press.json
@@ -18,6 +18,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:6f0db63789d04842247de3b969d2d78ca99cd7ad85637f799f9f95e917f5568a",
   "spec_format": "openapi3",
-  "spec_path": "testdata/golden/fixtures/fastapi-operationids.yaml",
+  "spec_path": "fastapi-operationids.yaml",
   "spec_url": "file://testdata/golden/fixtures/fastapi-operationids.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -20,6 +20,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:8cfba131c384836e8dde461511c9fd63cf2cbab7793553067765d515f2007aa1",
   "spec_format": "openapi3",
-  "spec_path": "testdata/golden/fixtures/golden-api-unicode.yaml",
+  "spec_path": "golden-api-unicode.yaml",
   "spec_url": "file://testdata/golden/fixtures/golden-api-unicode.yaml"
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -21,6 +21,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:eee1bdd3ef6e6cd2fec50d851db4f213c9ca9d314fad88e3b544718383f3b4d8",
   "spec_format": "openapi3",
-  "spec_path": "testdata/golden/fixtures/golden-api.yaml",
+  "spec_path": "golden-api.yaml",
   "spec_url": "file://testdata/golden/fixtures/golden-api.yaml"
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/.printing-press.json
@@ -20,6 +20,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:517f6cb2bfb0da30a73fe697d08ba2eaef21aab2de8396ead501cf3ab643aae9",
   "spec_format": "internal",
-  "spec_path": "testdata/golden/fixtures/learn-loop-api.yaml",
+  "spec_path": "learn-loop-api.yaml",
   "spec_url": "file://testdata/golden/fixtures/learn-loop-api.yaml"
 }

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -20,6 +20,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:46c60ba489f2e138ffe6ab01531f2ed550369299820342a7f0093b94d0fc17b4",
   "spec_format": "openapi3",
-  "spec_path": "testdata/golden/fixtures/mcp-api.yaml",
+  "spec_path": "mcp-api.yaml",
   "spec_url": "file://testdata/golden/fixtures/mcp-api.yaml"
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/.printing-press.json
@@ -20,6 +20,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:2aa39c064cd068cb090102e22a446f9542fa06f75453d52e4fa9db5c21f27809",
   "spec_format": "internal",
-  "spec_path": "testdata/golden/fixtures/sync-walker-api.yaml",
+  "spec_path": "sync-walker-api.yaml",
   "spec_url": "file://testdata/golden/fixtures/sync-walker-api.yaml"
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/.printing-press.json
@@ -23,6 +23,6 @@
   "schema_version": 1,
   "spec_checksum": "sha256:a059b4da997e0e835f0cdcd911ef5894fc048b50506bdcd90260a7478efb2958",
   "spec_format": "internal",
-  "spec_path": "testdata/golden/fixtures/tier-routing-api.yaml",
+  "spec_path": "tier-routing-api.yaml",
   "spec_url": "file://testdata/golden/fixtures/tier-routing-api.yaml"
 }


### PR DESCRIPTION
## Intent

Issue: Closes #1587

The manifest writers recorded `spec_path` verbatim. When the printer passed a local `--spec /Users/<name>/Downloads/openapi.json`, that absolute path landed in the published `.printing-press.json`, leaking the printer's home directory (Greptile flagged it P2 on a prior publish PR).

## Approach

Added one shared helper, `sanitizeManifestSpecPath`, that reduces a local file path to its basename while leaving URLs (and already-bare basenames) unchanged, and applied it at both manifest writers — `WriteManifestForGenerate` (`internal/pipeline/climanifest.go`) and `writeCLIManifestForPublish` (`internal/pipeline/publish.go`). `spec_path` is provenance metadata only: spec loading uses the separate pipeline `State.SpecPath` / runtime `cfg.SpecPath` fields, not the manifest field, so basename-ing breaks no loader. `spec_url` and `spec_checksum` are written independently and preserve reproducibility.

The manifest-lineage match (`existing.SpecPath == generated.SpecPath`) stays consistent because both sides now flow through the same sanitizer. The only theoretical edge — an OLD manifest carrying an absolute `spec_path` compared against a NEW basenamed one during regen — is benign: that comparison is reached only when both `spec_checksum` and `spec_url` are empty, and the generator always computes `spec_checksum` for local specs, so checksum short-circuits the comparison first.

## Scope

Primary area: generator / pipeline (manifest writers).

Why this belongs in this repo: machine change in the manifest writers; every printed CLI inherits the sanitized `spec_path` on next generate/publish. Not a per-CLI fix.

## Catalog Justification

N/A

## Risk

Low. Only the local-file-path branch changes (basename instead of full path); URL inputs and checksum/URL provenance are untouched. No consumer re-opens the manifest's `spec_path`.

## Output Contract

`.printing-press.json` `spec_path` now records only the basename for local-spec inputs (e.g. `golden-api.yaml` instead of `testdata/golden/fixtures/golden-api.yaml`). 7 golden `.printing-press.json` fixtures regenerated to reflect this — the diff is exclusively the `spec_path` basename change.

## Verification

- `go test ./internal/pipeline/... ./internal/generator/...` — pass
- `scripts/golden.sh update` then inspected: diff is exactly the `spec_path` basename change in 7 fixtures, nothing else
- `gofmt` / `golangci-lint run ./internal/pipeline/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
