### PR TITLE
fix(cli): allow reserved PII placeholders

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -495,12 +495,55 @@ var skippedDirs = map[string]bool{
 
 func isSyntheticPIIPlaceholder(kind, matched string) bool {
 	switch kind {
+	case PIIKindEmail:
+		return isRFCReservedEmail(matched)
+	case PIIKindPhoneUS:
+		return isNANPFictionalPhone(matched)
 	case PIIKindOrderID:
 		return piiplaceholders.IsSyntheticOrderID(matched)
 	case PIIKindASIN:
 		return piiplaceholders.IsSyntheticASIN(matched)
 	case PIIKindPostalAddress:
 		return piiplaceholders.IsSyntheticPostalAddress(matched)
+	default:
+		return false
+	}
+}
+
+func isRFCReservedEmail(matched string) bool {
+	at := strings.LastIndexByte(matched, '@')
+	if at == -1 || at == len(matched)-1 {
+		return false
+	}
+	domain := strings.ToLower(strings.Trim(matched[at+1:], "."))
+	if domain == "example.com" || domain == "example.org" || domain == "example.net" {
+		return true
+	}
+	return strings.HasSuffix(domain, ".example.com") ||
+		strings.HasSuffix(domain, ".example.org") ||
+		strings.HasSuffix(domain, ".example.net") ||
+		strings.HasSuffix(domain, ".example") ||
+		strings.HasSuffix(domain, ".test") ||
+		strings.HasSuffix(domain, ".invalid") ||
+		strings.HasSuffix(domain, ".localhost")
+}
+
+func isNANPFictionalPhone(matched string) bool {
+	var digits strings.Builder
+	for _, r := range matched {
+		if r >= '0' && r <= '9' {
+			digits.WriteRune(r)
+		}
+	}
+	normalized := digits.String()
+	if len(normalized) == 11 && normalized[0] == '1' {
+		normalized = normalized[1:]
+	}
+	switch len(normalized) {
+	case 7:
+		return normalized[0:3] == "555" && strings.HasPrefix(normalized[3:], "01")
+	case 10:
+		return normalized[3:6] == "555" && strings.HasPrefix(normalized[6:], "01")
 	default:
 		return false
 	}

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -540,8 +540,6 @@ func isNANPFictionalPhone(matched string) bool {
 		normalized = normalized[1:]
 	}
 	switch len(normalized) {
-	case 7:
-		return normalized[0:3] == "555" && strings.HasPrefix(normalized[3:], "01")
 	case 10:
 		return normalized[3:6] == "555" && strings.HasPrefix(normalized[6:], "01")
 	default:

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -65,9 +65,9 @@ func TestRedactPIIJSONKeys_FragmentRedactsValueWhenKeyEqualsValue(t *testing.T) 
 }
 
 func TestRedactPIIText_RedactsPlainTextPatterns(t *testing.T) {
-	got := RedactPIIText("billing email jane@example.com lives at 123 Main Street")
+	got := RedactPIIText("billing email jane@gmail.com lives at 123 Main Street")
 
-	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "jane@gmail.com")
 	require.NotContains(t, got, "123 Main Street")
 	require.Contains(t, got, PIIRedactedSentinel)
 }
@@ -144,8 +144,14 @@ func TestFindPII_Email(t *testing.T) {
 		line        string
 		expectKinds []string
 	}{
-		{name: "standard", line: `"email": "alice@example.com"`, expectKinds: []string{PIIKindEmail}},
-		{name: "plus-tag", line: `"email": "alice+tag@example.com"`, expectKinds: []string{PIIKindEmail}},
+		{name: "standard", line: `"email": "customer@gmail.com"`, expectKinds: []string{PIIKindEmail}},
+		{name: "plus-tag", line: `"email": "customer+tag@gmail.com"`, expectKinds: []string{PIIKindEmail}},
+		{name: "reserved-example-com", line: `"email": "alice@example.com"`, expectKinds: nil},
+		{name: "reserved-example-org", line: `"email": "anything@example.org"`, expectKinds: nil},
+		{name: "reserved-example-net-subdomain", line: `"email": "user@docs.example.net"`, expectKinds: nil},
+		{name: "reserved-test-tld", line: `"email": "printer@app.test"`, expectKinds: nil},
+		{name: "reserved-localhost-tld", line: `"email": "printer@app.localhost"`, expectKinds: nil},
+		{name: "reserved-invalid-tld", line: `"email": "printer@app.invalid"`, expectKinds: nil},
 		{name: "no-tld", line: `"handle": "alice@example"`, expectKinds: nil},
 		{name: "missing-at", line: `"site": "example.com"`, expectKinds: nil},
 	}
@@ -163,9 +169,14 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		line        string
 		expectKinds []string
 	}{
-		{name: "parens-space-dash", line: `"phone": "(415) 555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
-		{name: "all-dashes", line: `"phone": "415-555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
-		{name: "country-code", line: `"phone": "+1 415 555 0123"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "parens-space-dash", line: `"phone": "(415) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "all-dashes", line: `"phone": "415-234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "country-code", line: `"phone": "+1 415 234 5678"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "fictional-exchange-dashes", line: `"phone": "415-555-0123"`, expectKinds: nil},
+		{name: "fictional-exchange-parens", line: `"phone": "(212) 555-0100"`, expectKinds: nil},
+		{name: "fictional-exchange-country-code", line: `"phone": "+1 415 555 0199"`, expectKinds: nil},
+		{name: "fictional-555-area-compact", line: `"phone": "5555550100"`, expectKinds: nil},
+		{name: "fictional-seven-digit-local", line: `"phone": "555-0123"`, expectKinds: nil},
 		{name: "version-string", line: `"version": "1.2.3"`, expectKinds: nil},
 		{name: "ip-address", line: `"addr": "192.168.1.1"`, expectKinds: nil},
 		// NANP-shape filters — area code and exchange code must each
@@ -180,7 +191,7 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "no-area-code-leading-one", line: `"phone": "115-555-0123"`, expectKinds: nil},
 		{name: "no-exchange-leading-zero", line: `"phone": "415-055-0123"`, expectKinds: nil},
 		{name: "no-exchange-leading-one", line: `"phone": "415-155-0123"`, expectKinds: nil},
-		{name: "area-code-212-valid", line: `"phone": "(212) 555-0123"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "area-code-212-valid", line: `"phone": "(212) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "area-code-900-valid", line: `"phone": "(900) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 	}
 	for _, tt := range tests {
@@ -247,7 +258,7 @@ func TestFindPII_PostalAddress(t *testing.T) {
 func TestFindPII_FileScoping(t *testing.T) {
 	root := t.TempDir()
 	// Same PII shape planted in different file types
-	pii := `"email": "leak@example.com"`
+	pii := `"email": "leak@gmail.com"`
 	write(t, filepath.Join(root, "in-scope.json"), pii)
 	write(t, filepath.Join(root, "in-scope.yaml"), pii)
 	write(t, filepath.Join(root, "in-scope.md"), pii)
@@ -267,7 +278,7 @@ func TestFindPII_FileScoping(t *testing.T) {
 
 func TestFindPII_DirScoping(t *testing.T) {
 	root := t.TempDir()
-	pii := `"phone": "(415) 555-0123"`
+	pii := `"phone": "(415) 234-5678"`
 	// .manuscripts and testdata are in scope regardless of extension
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run1"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata", "fixtures"), 0755))
@@ -287,7 +298,7 @@ func TestFindPII_DirScoping(t *testing.T) {
 
 func TestFindPII_ExcludedFiles(t *testing.T) {
 	root := t.TempDir()
-	pii := `"email": "leak@example.com"`
+	pii := `"email": "leak@gmail.com"`
 	write(t, filepath.Join(root, "tools-manifest.json"), pii)
 	write(t, filepath.Join(root, "data.json"), pii)
 
@@ -305,7 +316,7 @@ func TestFindPII_ExcludedFiles(t *testing.T) {
 // .manuscripts/ is captured content and stays in scope.
 func TestFindPII_RootVendorSpecExempt(t *testing.T) {
 	root := t.TempDir()
-	pii := `"email": "jenny@example.com"`
+	pii := `"email": "jenny@gmail.com"`
 	write(t, filepath.Join(root, "spec.yaml"), pii)
 	write(t, filepath.Join(root, "spec.yml"), pii)
 	write(t, filepath.Join(root, "spec.json"), pii)
@@ -430,7 +441,7 @@ func TestFindPIIWithOptions_ManuscriptsVendorSpecExemptUsesStagedPath(t *testing
   "paths": {"/users": {"post": {"requestBody": {"content": {"application/json": {"example": {"email": "user1@testemail.com"}}}}}}}
 }`
 	write(t, filepath.Join(runDir, "research.json"), openapiJSON)
-	write(t, filepath.Join(runDir, "research", "brief.md"), "Contact support@example.com for access.\n")
+	write(t, filepath.Join(runDir, "research", "brief.md"), "Contact support@gmail.com for access.\n")
 
 	findings, err := FindPIIWithOptions(root, PIIAuditOptions{ManuscriptsDir: runDir})
 	require.NoError(t, err)
@@ -600,7 +611,7 @@ openapi: 3.0.0
 func TestFindPII_BinaryFileSkip(t *testing.T) {
 	root := t.TempDir()
 	// Planted PII in a "json" file with embedded nulls (mimics binary)
-	bin := []byte("\"email\": \"leak@example.com\"\x00\x00\x00binary content")
+	bin := []byte("\"email\": \"leak@gmail.com\"\x00\x00\x00binary content")
 	require.NoError(t, os.WriteFile(filepath.Join(root, "blob.json"), bin, 0644))
 
 	findings, err := FindPII(root)
@@ -611,9 +622,9 @@ func TestFindPII_BinaryFileSkip(t *testing.T) {
 func TestFindPII_StableOrder(t *testing.T) {
 	root := t.TempDir()
 	content := strings.Join([]string{
-		`"email": "alice@example.com"`,  // line 1, kind email
+		`"email": "alice@gmail.com"`,    // line 1, kind email
 		`"address": "1234 MAIN STREET"`, // line 2, kind postal-address
-		`"phone": "(415) 555-0123"`,     // line 3, kind phone-us
+		`"phone": "(415) 234-5678"`,     // line 3, kind phone-us
 	}, "\n")
 	write(t, filepath.Join(root, "data.json"), content)
 

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -176,7 +176,6 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "fictional-exchange-parens", line: `"phone": "(212) 555-0100"`, expectKinds: nil},
 		{name: "fictional-exchange-country-code", line: `"phone": "+1 415 555 0199"`, expectKinds: nil},
 		{name: "fictional-555-area-compact", line: `"phone": "5555550100"`, expectKinds: nil},
-		{name: "fictional-seven-digit-local", line: `"phone": "555-0123"`, expectKinds: nil},
 		{name: "version-string", line: `"version": "1.2.3"`, expectKinds: nil},
 		{name: "ip-address", line: `"addr": "192.168.1.1"`, expectKinds: nil},
 		// NANP-shape filters — area code and exchange code must each

--- a/internal/cli/pii_audit_test.go
+++ b/internal/cli/pii_audit_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestPIIAuditCmd_RunsAndPersistsLedger(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	cmd := newPIIAuditCmd()
 	stdout := &bytes.Buffer{}
@@ -36,7 +36,7 @@ func TestPIIAuditCmd_RunsAndPersistsLedger(t *testing.T) {
 
 func TestPIIAuditCmd_JSON(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	cmd := newPIIAuditCmd()
 	stdout := &bytes.Buffer{}
@@ -82,7 +82,7 @@ func TestPIIAuditCmd_ManuscriptsRunDirUsesStagedPackagePaths(t *testing.T) {
 
 func TestPIIAuditCmd_StrictExitsNonZeroOnPending(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	cmd := newPIIAuditCmd()
 	cmd.SetOut(&bytes.Buffer{})
@@ -98,7 +98,7 @@ func TestPIIAuditCmd_StrictExitsNonZeroOnPending(t *testing.T) {
 
 func TestPIIAuditCmd_StrictPassesWithValidAccepts(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	// Run once to populate ledger
 	cmd := newPIIAuditCmd()
@@ -126,7 +126,7 @@ func TestPIIAuditCmd_StrictPassesWithValidAccepts(t *testing.T) {
 
 func TestPIIAuditCmd_StrictFailsOnAcceptMissingCategory(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	cmd := newPIIAuditCmd()
 	cmd.SetOut(&bytes.Buffer{})
@@ -154,7 +154,7 @@ func TestPIIAuditCmd_StrictFailsOnAcceptMissingCategory(t *testing.T) {
 
 func TestPIIAuditCmd_AgentFieldsSurviveReRun(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@example.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "data.json"), `"email": "leak@gmail.com"`+"\n")
 
 	// Run once
 	cmd := newPIIAuditCmd()

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -738,7 +738,7 @@ func TestPublishPackageRejectsPIIInStagedCLI(t *testing.T) {
 	// Plant real-shaped PII in a high-risk file
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cliDir, "data.json"),
-		[]byte(`{"customer_email": "alice@example.com"}`+"\n"),
+		[]byte(`{"customer_email": "alice@gmail.com"}`+"\n"),
 		0o644,
 	))
 
@@ -755,6 +755,37 @@ func TestPublishPackageRejectsPIIInStagedCLI(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "failed packaging should clean up the staging target")
 }
 
+func TestPublishPackageAllowsReservedSyntheticPII(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cliDir, "data.json"),
+		[]byte(`{"customer_email": "alice@example.com", "docs_email": "team@app.test", "phone": "(415) 555-0123"}`+"\n"),
+		0o644,
+	))
+
+	runID := "20260329-100000"
+	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "captured.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
+	require.NoError(t, os.WriteFile(
+		researchFile,
+		[]byte(`{"recipient_email": "new@example.com", "phone": "5555550100"}`+"\n"),
+		0o644,
+	))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.DirExists(t, result.StagedDir)
+}
+
 func TestPublishPackageRejectsPIIInManuscripts(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
@@ -762,7 +793,7 @@ func TestPublishPackageRejectsPIIInManuscripts(t *testing.T) {
 	runID := "20260329-100000"
 	researchFile := filepath.Join(home, "manuscripts", "test", runID, "research", "captured.json")
 	require.NoError(t, os.MkdirAll(filepath.Dir(researchFile), 0o755))
-	require.NoError(t, os.WriteFile(researchFile, []byte(`{"recipient_email": "leak@example.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(researchFile, []byte(`{"recipient_email": "leak@gmail.com"}`+"\n"), 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
@@ -789,7 +820,7 @@ func TestPublishPackageCombinesSecretAndPIIReports(t *testing.T) {
 	))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(cliDir, "data.json"),
-		[]byte(`{"customer_email": "alice@example.com"}`+"\n"),
+		[]byte(`{"customer_email": "alice@gmail.com"}`+"\n"),
 		0o644,
 	))
 

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -512,10 +512,10 @@ func TestLiveCheck_OutputCap(t *testing.T) {
 }
 
 func TestLiveCheck_OutputSampleRedactsPII(t *testing.T) {
-	got := sampleOutput(`{"name":"Jane Doe","email":"jane@example.com","address":"123 Main Street","id":42,"status":"active"}`)
+	got := sampleOutput(`{"name":"Jane Doe","email":"jane@gmail.com","address":"123 Main Street","id":42,"status":"active"}`)
 
 	require.NotContains(t, got, "Jane Doe")
-	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "jane@gmail.com")
 	require.NotContains(t, got, "123 Main Street")
 	require.Contains(t, got, `"name":"<redacted>"`)
 	require.Contains(t, got, `"email":"<redacted>"`)
@@ -532,11 +532,11 @@ func TestLiveCheck_OutputSampleLeavesStructuralJSONUnchanged(t *testing.T) {
 
 func TestLiveCheck_OutputSampleRedactsPIIBeforeTruncatingJSON(t *testing.T) {
 	longNote := strings.Repeat("x", outputSampleMaxBytes)
-	got := sampleOutput(fmt.Sprintf(`{"name":"Jane Doe","email":"jane@example.com","note":%q}`, longNote))
+	got := sampleOutput(fmt.Sprintf(`{"name":"Jane Doe","email":"jane@gmail.com","note":%q}`, longNote))
 
 	require.Contains(t, got, "…[truncated]")
 	require.NotContains(t, got, "Jane Doe")
-	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "jane@gmail.com")
 	require.Contains(t, got, `"name":"<redacted>"`)
 	require.Contains(t, got, `"email":"<redacted>"`)
 }
@@ -551,10 +551,10 @@ func TestLiveCheck_OutputSampleRedactsNDJSONAndMixedParts(t *testing.T) {
 }
 
 func TestLiveCheck_OutputSampleRedactsPIIAcrossTruncationBoundary(t *testing.T) {
-	got := sampleOutput(strings.Repeat("x", outputSampleMaxBytes-8) + " jane@example.com")
+	got := sampleOutput(strings.Repeat("x", outputSampleMaxBytes-8) + " jane@gmail.com")
 
 	require.Contains(t, got, "…[truncated]")
-	require.NotContains(t, got, "jane@example.com")
+	require.NotContains(t, got, "jane@gmail.com")
 	require.NotContains(t, got, "jane@")
 	require.Contains(t, got, "<redacted>")
 }
@@ -1078,7 +1078,7 @@ printf 'Hello cookie world\n'
 
 func TestRunOneFeatureCheck_RedactsPIIFromFailureReason(t *testing.T) {
 	binary := buildFakeCLI(t, `#!/usr/bin/env bash
-printf '{"name":"Jane Doe","email":"jane@example.com"}' >&2
+printf '{"name":"Jane Doe","email":"jane@gmail.com"}' >&2
 exit 7
 `)
 	feature := NovelFeature{
@@ -1090,16 +1090,16 @@ exit 7
 
 	require.Equal(t, StatusFail, result.Status)
 	require.NotContains(t, result.Reason, "Jane Doe")
-	require.NotContains(t, result.Reason, "jane@example.com")
+	require.NotContains(t, result.Reason, "jane@gmail.com")
 	require.Contains(t, result.Reason, `"name":"<redacted>"`)
 	require.Contains(t, result.Reason, `"email":"<redacted>"`)
 }
 
 func TestTrimOutput_RedactsPIIBeforeTruncatingFailureReason(t *testing.T) {
-	got := trimOutput(strings.Repeat("x", 290) + " jane@example.com")
+	got := trimOutput(strings.Repeat("x", 290) + " jane@gmail.com")
 
 	require.NotContains(t, got, "jane@")
-	require.NotContains(t, got, "example.com")
+	require.NotContains(t, got, "gmail.com")
 	require.Contains(t, got, "<redacted")
 }
 

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -862,7 +862,7 @@ func TestPromoteWorkingCLI_PIIGateHaltsOnPendingFindings(t *testing.T) {
 	// Plant real-shaped PII in a high-risk file
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workDir, "data.json"),
-		[]byte(`{"customer_email": "alice@example.com"}`+"\n"),
+		[]byte(`{"customer_email": "alice@gmail.com"}`+"\n"),
 		0o644,
 	))
 
@@ -895,7 +895,7 @@ func TestPromoteWorkingCLI_PIIGatePassesWithValidAccepts(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module test-pp-cli\n\ngo 1.21\n"), 0o644))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workDir, "data.json"),
-		[]byte(`{"customer_email": "alice@example.com"}`+"\n"),
+		[]byte(`{"customer_email": "alice@gmail.com"}`+"\n"),
 		0o644,
 	))
 
@@ -997,7 +997,7 @@ func TestPromoteWorkingCLI_PIIGateHaltsOnGateFailure(t *testing.T) {
 	// duplicate-rationale gate (threshold 5)
 	var lines []string
 	for i := range 6 {
-		lines = append(lines, `"email": "user`+string(rune('A'+i))+`@example.com"`)
+		lines = append(lines, `"email": "user`+string(rune('A'+i))+`@gmail.com"`)
 	}
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workDir, "data.json"),


### PR DESCRIPTION
## Summary

Publish-package PII scanning now lets reserved documentation placeholders pass: RFC 2606 email domains such as `example.com`, `example.org`, `example.net`, reserved test-style TLDs, and NANP fictional `555-01XX` phone values. Real-shaped email and phone values still block packaging, promote, live-check redaction, and `pii-audit` as before.

The scanner applies the allowlist before recording tier-2 findings, so manuscript proofs and staged CLI files can keep concrete safe examples without manual ledger accepts.

Closes #1589

## Tests

- `go fmt ./...`
- `git diff --check`
- `go test ./internal/artifacts`
- `go test ./internal/cli -run 'TestPIIAuditCmd|TestPublishPackage(RejectsPIIInStagedCLI|AllowsReservedSyntheticPII|RejectsPIIInManuscripts|CombinesSecretAndPIIReports)$'`
- `go test ./internal/pipeline -run 'TestLiveCheck_OutputSampleRedactsPIIAcrossTruncationBoundary|TestTrimOutput_RedactsPIIBeforeTruncatingFailureReason|TestPromoteWorkingCLI_PIIGate'`
- `go test ./...`
