### PR TITLE
fix(cli): detect Mailchimp/Linear/Anthropic key shapes in secret scanner

### DIFF
--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -89,6 +89,9 @@ var vendorPrefixSecretPatterns = []vendorPrefixSecretPattern{
 	{kind: "slack-token", pattern: regexp.MustCompile(`xox[abprs]-[A-Za-z0-9-]{32,}`)},
 	{kind: "slack-app-token", pattern: regexp.MustCompile(`xapp-[A-Za-z0-9-]{32,}`)},
 	{kind: "google-api-key", pattern: regexp.MustCompile(`AIza[A-Za-z0-9_-]{20,}`)},
+	{kind: "mailchimp-api-key", pattern: regexp.MustCompile(`\b[a-f0-9]{32}-us\d{1,2}\b`)},
+	{kind: "linear-api-key", pattern: regexp.MustCompile(`\blin_api_[A-Za-z0-9]{40,}`)},
+	{kind: "anthropic-api-key", pattern: regexp.MustCompile(`\bsk-ant-api03-[A-Za-z0-9_-]{40,}`)},
 	{
 		kind:    "aws-access-key",
 		pattern: regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),

--- a/internal/artifacts/secrets_test.go
+++ b/internal/artifacts/secrets_test.go
@@ -82,6 +82,45 @@ func TestFindVendorPrefixSecretsIgnoresPlaceholdersAndBinaryFiles(t *testing.T) 
 	require.Empty(t, findings)
 }
 
+func TestFindVendorPrefixSecretsDetectsMailchimpLinearAndAnthropic(t *testing.T) {
+	root := t.TempDir()
+	// Build the secret-shaped fixtures from fragments via testSecret so the
+	// recognizable vendor prefix never appears contiguously in this source
+	// file — otherwise GitHub push protection rejects the push of the very
+	// test that exercises this scanner.
+	mailchimpKey := testSecret("0123456789abcdef0123456789abcdef", "-us6")
+	linearKey := testSecret("lin_", "api_", "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcd")
+	anthropicKey := testSecret("sk-ant-", "api03-", "abcdefghijklmnopqrstuvwxyz0123456789ABCD")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "mailchimp.txt"), []byte("key="+mailchimpKey+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "linear.txt"), []byte("token="+linearKey+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "anthropic.txt"), []byte("auth="+anthropicKey+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "not-a-key.txt"), []byte("candidate="+testSecret("0123456789abcdef0123456789abcdeg", "-us6")+"\n"), 0o644))
+	// Boundary negatives: payloads one char short of the {40,} minimum must
+	// NOT match, so a regression that loosened the quantifier is caught.
+	linearShort := testSecret("lin_", "api_", "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789012")         // 39-char body
+	anthropicShort := testSecret("sk-ant-", "api03-", "abcdefghijklmnopqrstuvwxyz0123456789ABC") // 39-char body
+	require.NoError(t, os.WriteFile(filepath.Join(root, "linear-short.txt"), []byte("token="+linearShort+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "anthropic-short.txt"), []byte("auth="+anthropicShort+"\n"), 0o644))
+
+	findings, err := FindVendorPrefixSecrets(root)
+	require.NoError(t, err)
+	require.Len(t, findings, 3)
+
+	byPath := map[string]VendorPrefixSecretFinding{}
+	for _, finding := range findings {
+		byPath[finding.Path] = finding
+	}
+	require.Equal(t, "mailchimp-api-key", byPath["mailchimp.txt"].Kind)
+	require.Equal(t, "linear-api-key", byPath["linear.txt"].Kind)
+	require.Equal(t, "anthropic-api-key", byPath["anthropic.txt"].Kind)
+	_, flagged := byPath["not-a-key.txt"]
+	require.False(t, flagged)
+	_, linearShortFlagged := byPath["linear-short.txt"]
+	require.False(t, linearShortFlagged, "linear payload one char short of 40 must not match")
+	_, anthropicShortFlagged := byPath["anthropic-short.txt"]
+	require.False(t, anthropicShortFlagged, "anthropic payload one char short of 40 must not match")
+}
+
 func TestFindSpecDeclaredCookieSecretsReportsCookieNameOnly(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("Cookie:session-id=actuallyrealcookievaluexyz; x-main=your-cookie-here; y-main=not-an-example-real-value\n"), 0o644))


### PR DESCRIPTION
## Intent

Issue: Closes #1593

The local Tier-1 vendor-prefix secret scanner (`internal/artifacts/secrets.go`, run by `publish validate` and the polish gates via `FindVendorPrefixSecrets`/`FindPackageSecrets`) covered openrouter, stripe, calcom, github, slack, google, and aws — but not Mailchimp, Linear, or Anthropic. A real Mailchimp key committed in a test fixture passed every local layer; only GitHub server-side push protection caught it.

## Approach

Add the three documented vendor-prefix shapes to `vendorPrefixSecretPatterns` (additive, detection-only):
- `mailchimp-api-key`: `\b[a-f0-9]{32}-us\d{1,2}\b`
- `linear-api-key`: `\blin_api_[A-Za-z0-9]{40,}`
- `anthropic-api-key`: `\bsk-ant-api03-[A-Za-z0-9_-]{40,}`

No `accept` exemption is added: there is no documented synthetic placeholder for these vendors in `internal/piiplaceholders` (unlike AWS's `...EXAMPLE` convention). Anchoring matches the surrounding entries — a leading `\b` for the prefix-anchored keys, and both boundaries for the bare-hex Mailchimp shape.

## Scope

Primary area: scorer / artifacts secret scanner.

Why this belongs in this repo: machine change; the local scanner gains coverage every printed CLI's publish/polish flow relies on.

## Catalog Justification

N/A

## Risk

Low and fail-closed: a false positive only blocks a publish until a human looks, and the patterns match documented vendor key shapes. The Mailchimp `[a-f0-9]{32}-us\d{1,2}` could in principle match a 32-hex string immediately followed by literal `-us<digit>` (that adjacency is itself the key shape), consistent with the precision already accepted by sibling patterns (`AIza...`, `xox[abprs]-...`).

## Output Contract

N/A (detection-only change to the secret scanner; no generated-output or golden impact — verified no `testdata/`/`catalog/` strings match the new patterns).

## Verification

- `go test ./...` — pass (incl. new detection + negative cases; confirmed they fail pre-change)
- `gofmt` / `golangci-lint run ./internal/artifacts/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
