### PR TITLE
fix(cli): make scoreVision 10/10 reachable

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1211,6 +1211,9 @@ func scoreVision(dir string) int {
 	}
 
 	// Tier 2: Feature Intelligence (0-5 points)
+	// - schema+wiring combined cap: 3.5
+	// - FTS5: 1.0
+	// - search uses store: 0.5
 	tier2 := 0.0
 
 	// Schema depth (0-1.5): check if store.go has domain-specific tables
@@ -1245,8 +1248,8 @@ func scoreVision(dir string) int {
 		}
 		tier2 += float64(wired) * 0.25
 		tier2 += float64(registeredVisionCapabilityFiles(commandContent)) * 0.75
-		if tier2 > 3.0 { // cap wiring contribution
-			tier2 = 3.0
+		if tier2 > 3.5 { // cap schema+wiring contribution so tier2 can reach its documented 5.0 max
+			tier2 = 3.5
 		}
 	}
 

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -4009,3 +4009,83 @@ func newImportCmd(flags any) {}
 	assert.Equal(t, 3, scoreVision(build(false)))
 	assert.Equal(t, 4, scoreVision(build(true)))
 }
+
+func TestScoreVision_MaxReachableAndPartialStaysSub10(t *testing.T) {
+	build := func(includeLearn, includeFTS5 bool) string {
+		dir := t.TempDir()
+
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(
+		newSyncCmd(nil),
+		newSearchCmd(nil),
+		newExportCmd(nil),
+		newTailCmd(nil),
+		newImportCmd(nil),
+		newAnalyticsCmd(nil),
+	)
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/sync.go", `package cli
+func newSyncCmd(flags any) {}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/search.go", `package cli
+import "example.com/project/internal/store"
+func newSearchCmd(flags any) {
+	_ = store.Open()
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/export.go", `package cli
+import (
+	"encoding/json"
+	"example.com/project/internal/store"
+)
+func newExportCmd(flags any) {
+	_ = json.NewEncoder(nil)
+	_ = store.Open()
+}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/tail.go", `package cli
+func newTailCmd(flags any) {}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/import.go", `package cli
+func newImportCmd(flags any) {}
+`)
+		writeScorecardFixture(t, dir, "internal/cli/analytics.go", `package cli
+func newAnalyticsCmd(flags any) {
+	first := c.Get("/one")
+	second := c.Get("/two")
+	_, _ = first, second
+}
+`)
+
+		storeBody := `package store
+func Open() DB { return DB{} }
+type DB struct{}
+const schema = `
+		if includeFTS5 {
+			storeBody += "`CREATE TABLE projects(id INTEGER PRIMARY KEY);\n" +
+				"CREATE TABLE datasets(id INTEGER PRIMARY KEY);\n" +
+				"CREATE TABLE models(id INTEGER PRIMARY KEY);\n" +
+				"CREATE VIRTUAL TABLE docs_fts USING fts5(content);`"
+		} else {
+			storeBody += "`CREATE TABLE projects(id INTEGER PRIMARY KEY);\n" +
+				"CREATE TABLE datasets(id INTEGER PRIMARY KEY);\n" +
+				"CREATE TABLE models(id INTEGER PRIMARY KEY);`"
+		}
+		writeScorecardFixture(t, dir, "internal/store/store.go", storeBody)
+
+		if includeLearn {
+			writeScorecardFixture(t, dir, "internal/learn/doc.go", `// Package learn owns the generated recall/teach loop.
+package learn
+`)
+		}
+		return dir
+	}
+
+	// Before the tier2 schema+wiring cap fix, build(true,true) scored 9 and
+	// build(false,false) scored 8. Both sat in the affected (3.0,3.5] band;
+	// the full fixture now reaches 10, the partial reaches 9.
+	assert.Equal(t, 10, scoreVision(build(true, true)))
+	assert.Equal(t, 9, scoreVision(build(false, false)))
+}


### PR DESCRIPTION
## Intent

Issue: Closes #1721

`scoreVision` documents a `vision 0-10` range but can never return 10. tier1 caps at 5.0; tier2's components sum to a hard max of 4.5 (schema+wiring capped at 3.0, + FTS5 1.0 + search-uses-store 0.5), so the total maxes at 9.5 and `min(int(9.5),10)=9`. The published CLIs confirm it: shopify (feature-complete) scores 9, never 10.

## Approach

Raise the tier2 schema+wiring sub-cap from 3.0 to 3.5. A fully-featured CLI then reaches tier2 = 3.5 + 1.0 + 0.5 = 5.0 and total = 10.0 → 10. tier1, the FTS5/search-store additions, and the final `min(int(...),10)` are unchanged; the new tier2 max is exactly 5.0, so no path can exceed 10.

**Blast radius (intentional, disclosed):** this is not only the perfect-10 case. The prior 3.0 cap under-counted any CLI whose raw schema+wiring sum fell in (3.0, 3.5]; those gain up to +0.5, which — because the final score floors `tier1+tier2` — can lift such a CLI by one integer point. That is the intended correction (the sub-cap was tighter than the documented 5.0 tier2 max, so those CLIs were under-scored), but reviewers should know it re-scores a band of existing CLIs upward, not just unlocks 10. If maintainers prefer to move *only* the perfect-10 case, that would need a different mechanism (rebalancing the component weights); flagging the choice explicitly.

## Scope

Primary area: scorer (`internal/pipeline/scorecard.go`, `scoreVision`).

Why this belongs in this repo: machine change; the scorer is generator-owned.

## Catalog Justification

N/A

## Risk

Low-to-moderate: vision scores in the (3.0, 3.5] schema+wiring band shift up by one point. Vision is a quality heuristic (not a downstream contract), and the golden suite passes unchanged (the `generate-golden-api` fixture's vision=9 CLI is not in the affected band).

## Output Contract

`scoreVision` can now return 10. The `min(int(...),10)` ceiling is unchanged. Golden fixtures: `scripts/golden.sh verify` passes 24/24 (no scorecard fixture is in the affected band).

## Verification

- `go test ./...` — pass (incl. `TestScoreVision_MaxReachableAndPartialStaysSub10`: fully-featured fixture asserts 10 — fails pre-change at 9 — and a partial fixture asserts sub-10)
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/pipeline/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
