### PR TITLE
fix(cli): infer sniffed response type stubs

### DIFF
--- a/internal/browsersniff/schema.go
+++ b/internal/browsersniff/schema.go
@@ -158,17 +158,28 @@ func mergeObject(fields map[string]*inferredField, object map[string]any, depth 
 		field.count++
 		field.param = inferParam(name, value, depth)
 
-		if field.param.Type == "object" && len(field.param.Fields) > 0 {
+		if (field.param.Type == "object" || field.param.Type == "array") && len(field.param.Fields) > 0 {
 			if field.nested == nil {
 				field.nested = make(map[string]*inferredField)
 			}
 
-			child, ok := value.(map[string]any)
-			if ok {
+			if child, ok := nestedObjectSample(value); ok {
 				mergeObject(field.nested, child, depth+1)
 			}
 		}
 	}
+}
+
+func nestedObjectSample(value any) (map[string]any, bool) {
+	if child, ok := value.(map[string]any); ok {
+		return child, true
+	}
+	items, ok := value.([]any)
+	if !ok || len(items) == 0 {
+		return nil, false
+	}
+	child, ok := items[0].(map[string]any)
+	return child, ok
 }
 
 func inferParam(name string, value any, depth int) spec.Param {
@@ -236,7 +247,7 @@ func buildParams(fields map[string]*inferredField, sampleCount int) []spec.Param
 		param := field.param
 		param.Name = name
 		param.Required = field.count == sampleCount
-		if field.param.Type == "object" && field.nested != nil {
+		if (field.param.Type == "object" || field.param.Type == "array") && field.nested != nil {
 			param.Fields = buildParams(field.nested, field.count)
 		}
 		params = append(params, param)

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -86,8 +86,8 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 	groups := deduplicateSpecEndpoints(regularEntries, options)
 	inferredTypes := newResponseTypeBuilder()
 	for _, group := range groups {
-		endpoint := buildEndpoint(group, auth)
-		inferredTypes.addEndpointTypes(group.NormalizedPath, &endpoint, inferResponseFields(group.Entries))
+		endpoint, responseFields := buildEndpoint(group, auth)
+		inferredTypes.addEndpointTypes(group.NormalizedPath, &endpoint, responseFields)
 		if options.PreserveHosts {
 			groupBaseURL := mostCommonBaseURL(group.Entries)
 			if groupBaseURL != "" && groupBaseURL != baseURL {
@@ -598,7 +598,7 @@ func DefaultCachePath(name string) string {
 	return filepath.Join(home, ".cache", "printing-press", "sniff", name+"-spec.yaml")
 }
 
-func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) spec.Endpoint {
+func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) (spec.Endpoint, []spec.Param) {
 	responseBodies := make([]string, 0, len(group.Entries))
 	for _, entry := range group.Entries {
 		if strings.TrimSpace(entry.ResponseBody) != "" {
@@ -639,7 +639,7 @@ func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) spec.Endpoint {
 		endpoint.HTMLExtract = inferHTMLExtract(group)
 		endpoint.Description = htmlEndpointDescription(group)
 	}
-	return endpoint
+	return endpoint, responseFields
 }
 
 type responseTypeBuilder struct {
@@ -652,16 +652,6 @@ func newResponseTypeBuilder() *responseTypeBuilder {
 		types: map[string]spec.TypeDef{},
 		used:  map[string]int{},
 	}
-}
-
-func inferResponseFields(entries []EnrichedEntry) []spec.Param {
-	responseBodies := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if strings.TrimSpace(entry.ResponseBody) != "" {
-			responseBodies = append(responseBodies, entry.ResponseBody)
-		}
-	}
-	return InferResponseSchema(responseBodies)
 }
 
 func (b *responseTypeBuilder) addEndpointTypes(path string, endpoint *spec.Endpoint, fields []spec.Param) {
@@ -683,12 +673,26 @@ func (b *responseTypeBuilder) addEndpointTypes(path string, endpoint *spec.Endpo
 }
 
 func firstCollectionField(fields []spec.Param) *spec.Param {
+	candidates := make([]*spec.Param, 0, len(fields))
 	for i := range fields {
 		if fields[i].Type == "array" && len(fields[i].Fields) > 0 {
-			return &fields[i]
+			candidates = append(candidates, &fields[i])
 		}
 	}
-	return nil
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	for _, preferred := range []string{"items", "data", "results", "records", "values"} {
+		for _, candidate := range candidates {
+			if strings.EqualFold(candidate.Name, preferred) {
+				return candidate
+			}
+		}
+	}
+	return candidates[0]
 }
 
 func (b *responseTypeBuilder) addType(preferredName string, params []spec.Param) string {
@@ -799,8 +803,6 @@ func singularize(name string) string {
 	switch {
 	case strings.HasSuffix(lower, "ies") && len(name) > 3:
 		return name[:len(name)-3] + "y"
-	case strings.HasSuffix(lower, "ses") && len(name) > 2:
-		return name[:len(name)-2]
 	case strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") && !strings.HasSuffix(lower, "us") && len(name) > 1:
 		return name[:len(name)-1]
 	default:

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/discovery"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"gopkg.in/yaml.v3"
 )
@@ -83,8 +84,10 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 	auth, authWarnings := detectAuthWithWarnings(capture, apiEntries, name)
 
 	groups := deduplicateSpecEndpoints(regularEntries, options)
+	inferredTypes := newResponseTypeBuilder()
 	for _, group := range groups {
 		endpoint := buildEndpoint(group, auth)
+		inferredTypes.addEndpointTypes(group.NormalizedPath, &endpoint, inferResponseFields(group.Entries))
 		if options.PreserveHosts {
 			groupBaseURL := mostCommonBaseURL(group.Entries)
 			if groupBaseURL != "" && groupBaseURL != baseURL {
@@ -126,7 +129,7 @@ func AnalyzeCaptureWithOptions(capture *EnrichedCapture, options AnalyzeOptions)
 			Path:   fmt.Sprintf("~/.config/%s-pp-cli/config.toml", name),
 		},
 		Resources: resources,
-		Types:     map[string]spec.TypeDef{},
+		Types:     inferredTypes.types,
 	}
 
 	if err := apiSpec.Validate(); err != nil {
@@ -637,6 +640,172 @@ func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) spec.Endpoint {
 		endpoint.Description = htmlEndpointDescription(group)
 	}
 	return endpoint
+}
+
+type responseTypeBuilder struct {
+	types map[string]spec.TypeDef
+	used  map[string]int
+}
+
+func newResponseTypeBuilder() *responseTypeBuilder {
+	return &responseTypeBuilder{
+		types: map[string]spec.TypeDef{},
+		used:  map[string]int{},
+	}
+}
+
+func inferResponseFields(entries []EnrichedEntry) []spec.Param {
+	responseBodies := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.ResponseBody) != "" {
+			responseBodies = append(responseBodies, entry.ResponseBody)
+		}
+	}
+	return InferResponseSchema(responseBodies)
+}
+
+func (b *responseTypeBuilder) addEndpointTypes(path string, endpoint *spec.Endpoint, fields []spec.Param) {
+	if b == nil || endpoint == nil || endpoint.ResponseFormat == spec.ResponseFormatHTML {
+		return
+	}
+	if len(fields) == 0 {
+		return
+	}
+	baseName := typeNameFromPath(path, "response")
+	if collection := firstCollectionField(fields); collection != nil && len(collection.Fields) > 0 {
+		typeName := b.addType(typeNameFromPath(path, singularize(collection.Name)), collection.Fields)
+		endpoint.Response = spec.ResponseDef{Type: "array", Item: typeName}
+		endpoint.ResponsePath = collection.Name
+		return
+	}
+	typeName := b.addType(baseName, fields)
+	endpoint.Response = spec.ResponseDef{Type: endpoint.Response.Type, Item: typeName}
+}
+
+func firstCollectionField(fields []spec.Param) *spec.Param {
+	for i := range fields {
+		if fields[i].Type == "array" && len(fields[i].Fields) > 0 {
+			return &fields[i]
+		}
+	}
+	return nil
+}
+
+func (b *responseTypeBuilder) addType(preferredName string, params []spec.Param) string {
+	if len(params) == 0 {
+		return ""
+	}
+	typeName := b.reserveTypeName(preferredName)
+	fields := make([]spec.TypeField, 0, len(params))
+	for _, param := range params {
+		field := spec.TypeField{
+			Name:      param.Name,
+			Type:      responseFieldType(param.Type),
+			Enum:      param.Enum,
+			OmitEmpty: !param.Required,
+			Format:    param.Format,
+		}
+		switch {
+		case param.Type == "object" && len(param.Fields) > 0:
+			childName := b.addType(typeNameFromField(param.Name), param.Fields)
+			if childName != "" {
+				field.Type = "ref:" + childName
+			}
+		case param.Type == "array" && len(param.Fields) > 0:
+			childName := b.addType(typeNameFromField(singularize(param.Name)), param.Fields)
+			if childName != "" {
+				field.Type = "[]ref:" + childName
+			}
+		}
+		fields = append(fields, field)
+	}
+	b.types[typeName] = spec.TypeDef{Fields: fields}
+	return typeName
+}
+
+func (b *responseTypeBuilder) reserveTypeName(preferredName string) string {
+	base := safeSampleTypeName(preferredName)
+	if base == "" {
+		base = "Response"
+	}
+	count := b.used[base]
+	b.used[base] = count + 1
+	if count == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s%d", base, count+1)
+}
+
+func responseFieldType(t string) string {
+	switch t {
+	case "boolean":
+		return "bool"
+	case "integer":
+		return "integer"
+	case "number":
+		return "number"
+	case "array":
+		return "array"
+	case "object":
+		return "object"
+	default:
+		return "string"
+	}
+}
+
+func typeNameFromPath(path string, fallback string) string {
+	segments := discovery.SignificantSegments(path)
+	if len(segments) == 0 {
+		return typeNameFromField(fallback)
+	}
+	base := singularize(segments[len(segments)-1])
+	suffix := singularize(fallback)
+	if suffix != "" && suffix != "response" && !strings.EqualFold(base, suffix) {
+		return typeNameFromField(base + "_" + suffix)
+	}
+	return typeNameFromField(base)
+}
+
+func typeNameFromField(name string) string {
+	ascii := naming.ASCIIFold(name)
+	parts := strings.FieldsFunc(ascii, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	if len(parts) == 0 {
+		return ""
+	}
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func safeSampleTypeName(name string) string {
+	name = typeNameFromField(name)
+	if name == "" {
+		return ""
+	}
+	if !unicode.IsLetter(rune(name[0])) {
+		return "T" + name
+	}
+	return name
+}
+
+func singularize(name string) string {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.HasSuffix(lower, "ies") && len(name) > 3:
+		return name[:len(name)-3] + "y"
+	case strings.HasSuffix(lower, "ses") && len(name) > 2:
+		return name[:len(name)-2]
+	case strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") && !strings.HasSuffix(lower, "us") && len(name) > 1:
+		return name[:len(name)-1]
+	default:
+		return name
+	}
 }
 
 func discoverHTMLSurfaceEntries(entries []EnrichedEntry, targetURL string) []EnrichedEntry {

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -67,6 +67,12 @@ func TestWriteSpec(t *testing.T) {
 		},
 		Types: map[string]spec.TypeDef{},
 	}
+	apiSpec.Types["Widget"] = spec.TypeDef{
+		Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "label", Type: "string", OmitEmpty: true},
+		},
+	}
 	apiSpec.AuthWarnings = []string{`rejected auth candidate "keywords" from body: search input`}
 
 	outputPath := filepath.Join(t.TempDir(), "nested", "spec.yaml")
@@ -76,12 +82,64 @@ func TestWriteSpec(t *testing.T) {
 	data, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "auth_warnings:")
+	assert.Contains(t, string(data), "omit_empty: true")
+	assert.NotContains(t, string(data), "omitempty: true")
 
 	parsed, err := spec.ParseBytes(data)
 	require.NoError(t, err)
 	assert.Equal(t, apiSpec.Name, parsed.Name)
 	assert.Equal(t, apiSpec.BaseURL, parsed.BaseURL)
 	assert.Equal(t, apiSpec.AuthWarnings, parsed.AuthWarnings)
+	require.True(t, parsed.Types["Widget"].Fields[1].OmitEmpty)
+}
+
+func TestAnalyzeCapture_PrefersCanonicalCollectionEnvelope(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://api.example.com",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/api/search",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"categories":[{"id":"cat"}],"items":[{"id":"item","title":"Item"}]}`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var endpoint spec.Endpoint
+	found := false
+	for _, resource := range apiSpec.Resources {
+		for _, candidate := range resource.Endpoints {
+			if candidate.Path == "/api/search" {
+				endpoint = candidate
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "expected /api/search endpoint")
+	assert.Equal(t, "items", endpoint.ResponsePath)
+	assert.Equal(t, spec.ResponseDef{Type: "array", Item: "SearchItem"}, endpoint.Response)
+	require.Contains(t, apiSpec.Types, "SearchItem")
+	require.Len(t, apiSpec.Types["SearchItem"].Fields, 2)
+	assert.Equal(t, "id", apiSpec.Types["SearchItem"].Fields[0].Name)
+	assert.Equal(t, "title", apiSpec.Types["SearchItem"].Fields[1].Name)
+}
+
+func TestSingularizeSESWords(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"cases":     "case",
+		"responses": "response",
+		"licenses":  "license",
+	}
+	for input, want := range tests {
+		assert.Equal(t, want, singularize(input))
+	}
 }
 
 func TestDeriveNameFromURL(t *testing.T) {

--- a/internal/generator/captured_fixture_test.go
+++ b/internal/generator/captured_fixture_test.go
@@ -48,3 +48,86 @@ func TestGenerateCapturedFixtureUsesSyntheticSamples(t *testing.T) {
 	require.Contains(t, src, `"purchased_date"`)
 	require.Contains(t, src, `"2026-01-15"`)
 }
+
+func TestGenerateSniffedResponseTypeStubs(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := browsersniff.AnalyzeCapture(&browsersniff.EnrichedCapture{
+		TargetURL: "https://api.example.com",
+		Entries: []browsersniff.EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/api/search?q=cafe",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[{"id":"1","title":"Cafe","ratingData":{"reviewCount":12},"has_рассрочка":"yes"}]}`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/api/search?q=tea",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[{"id":"2","title":"Tea","ratingData":{}}]}`,
+			},
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/api/search?q=bakery",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[{"id":"3","title":"Bakery"}]}`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "sniffed-types-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "internal", "types", "types.go"))
+	require.NoError(t, err)
+	src := string(data)
+
+	require.Contains(t, src, "type SearchItem struct {")
+	require.Contains(t, src, "Id            string     `json:\"id\"`")
+	require.Contains(t, src, "Title         string     `json:\"title\"`")
+	require.Contains(t, src, "RatingData    RatingData `json:\"ratingData,omitempty\"`")
+	require.Contains(t, src, "HasRassrochka string     `json:\"has_рассрочка,omitempty\"`")
+	require.Contains(t, src, "// JSON tag: has_рассрочка")
+	require.Contains(t, src, "type RatingData struct {")
+	require.Contains(t, src, "ReviewCount int `json:\"reviewCount,omitempty\"`")
+}
+
+func TestGenerateSniffedTypesPreservesExistingHandAuthoredTypes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := browsersniff.AnalyzeCapture(&browsersniff.EnrichedCapture{
+		TargetURL: "https://api.example.com",
+		Entries: []browsersniff.EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://api.example.com/api/search",
+				ResponseStatus:      200,
+				ResponseContentType: "application/json",
+				ResponseBody:        `{"items":[{"id":"1","title":"Cafe"}]}`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), "sniffed-types-preserve-pp-cli")
+	typesPath := filepath.Join(outputDir, "internal", "types", "types.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(typesPath), 0o755))
+	handAuthored := `package types
+
+type HandAuthored struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+`
+	require.NoError(t, os.WriteFile(typesPath, []byte(handAuthored), 0o644))
+
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	data, err := os.ReadFile(typesPath)
+	require.NoError(t, err)
+	require.Equal(t, handAuthored, string(data))
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -271,6 +271,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"paramIdent":                         paramIdent,
 		"paramWireName":                      paramWireName,
 		"typeFieldIdent":                     typeFieldIdent,
+		"typeFieldJSONTagComment":            typeFieldJSONTagComment,
 		"safeTypeName":                       safeTypeName,
 		"hasNonScalarType": func(types map[string]spec.TypeDef) bool {
 			for _, td := range types {
@@ -1707,6 +1708,9 @@ func (g *Generator) renderSingleFiles() error {
 	}
 
 	for tmplName, outPath := range singleFiles {
+		if tmplName == "types.go.tmpl" && g.shouldPreserveExistingTypesFile(outPath) {
+			continue
+		}
 		var data any
 		switch tmplName {
 		case "readme.md.tmpl", "agents.md.tmpl", "skill.md.tmpl", "which.go.tmpl", "which_test.go.tmpl":
@@ -1749,6 +1753,26 @@ func (g *Generator) renderSingleFiles() error {
 	}
 
 	return nil
+}
+
+func (g *Generator) shouldPreserveExistingTypesFile(outPath string) bool {
+	if g == nil || g.Spec == nil || g.Spec.SpecSource != "sniffed" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(g.OutputDir, outPath))
+	if err != nil {
+		return false
+	}
+	return generatedTypesFileHasDeclarations(string(data))
+}
+
+func generatedTypesFileHasDeclarations(content string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "type ") {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *Generator) renderOptionalSupportFiles() error {
@@ -3918,12 +3942,27 @@ func goType(t string) string {
 // Unlike goType (used for CLI flags which are always primitives),
 // this maps object/array types to json.RawMessage for type fidelity.
 func goStructType(t string) string {
+	if ref, ok := strings.CutPrefix(t, "ref:"); ok {
+		return safeTypeName(ref)
+	}
+	if ref, ok := strings.CutPrefix(t, "[]ref:"); ok {
+		return "[]" + safeTypeName(ref)
+	}
 	switch primitiveKind(t) {
 	case "object", "array":
 		return "json.RawMessage"
 	default:
 		return goType(t)
 	}
+}
+
+func typeFieldJSONTagComment(f spec.TypeField) string {
+	for _, r := range f.Name {
+		if r > unicode.MaxASCII {
+			return f.Name
+		}
+	}
+	return ""
 }
 
 func goStoreType(sqlType string) string {

--- a/internal/generator/templates/types.go.tmpl
+++ b/internal/generator/templates/types.go.tmpl
@@ -8,7 +8,10 @@ import "encoding/json"
 {{range $name, $typeDef := .Types}}
 type {{safeTypeName $name}} struct {
 {{- range $typeDef.Fields}}
-	{{camel (typeFieldIdent .)}} {{goStructType .Type}} `json:"{{.Name}}"`
+{{- with typeFieldJSONTagComment .}}
+	// JSON tag: {{.}}
+{{- end}}
+	{{camel (typeFieldIdent .)}} {{goStructType .Type}} `json:"{{.Name}}{{if .OmitEmpty}},omitempty{{end}}"`
 {{- end}}
 }
 {{end}}

--- a/internal/generator/type_collision.go
+++ b/internal/generator/type_collision.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"fmt"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
@@ -31,15 +32,25 @@ func uniquifyTypeFieldIdentifiers(fields []spec.TypeField) []spec.TypeField {
 	used := make(map[string]struct{}, len(fields))
 	out := make([]spec.TypeField, len(fields))
 	for i, f := range fields {
-		f.IdentName = "" // ensure idempotence when callers reuse the same APISpec
-		ident := toCamel(f.Name)
+		baseName := f.IdentName
+		if baseName == "" {
+			baseName = naming.ASCIIFold(f.Name)
+		}
+		if baseName == "" {
+			baseName = f.Name
+		}
+		f.IdentName = ""
+		if baseName != f.Name {
+			f.IdentName = baseName
+		}
+		ident := toCamel(baseName)
 		if _, taken := used[ident]; !taken {
 			used[ident] = struct{}{}
 			out[i] = f
 			continue
 		}
 		for n := 2; ; n++ {
-			candidate := fmt.Sprintf("%s_%d", f.Name, n)
+			candidate := fmt.Sprintf("%s_%d", baseName, n)
 			candidateIdent := toCamel(candidate)
 			if _, taken := used[candidateIdent]; !taken {
 				f.IdentName = candidate

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1937,7 +1937,7 @@ type TypeField struct {
 	Enum []string `yaml:"enum,omitempty" json:"enum,omitempty"`
 	// OmitEmpty marks fields inferred from optional or nullable JSON samples.
 	// It only affects Go struct-tag emission; wire names still come from Name.
-	OmitEmpty bool `yaml:"omitempty,omitempty" json:"omitempty,omitempty"`
+	OmitEmpty bool `yaml:"omit_empty,omitempty" json:"omit_empty,omitempty"`
 	// Format mirrors the OpenAPI `format` hint for the field (date-time,
 	// date, email, uri, …). Carried through so SQLite column derivation
 	// can map date/date-time response fields to DATETIME instead of TEXT.

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1935,6 +1935,9 @@ type TypeField struct {
 	Name string   `yaml:"name" json:"name"`
 	Type string   `yaml:"type" json:"type"`
 	Enum []string `yaml:"enum,omitempty" json:"enum,omitempty"`
+	// OmitEmpty marks fields inferred from optional or nullable JSON samples.
+	// It only affects Go struct-tag emission; wire names still come from Name.
+	OmitEmpty bool `yaml:"omitempty,omitempty" json:"omitempty,omitempty"`
 	// Format mirrors the OpenAPI `format` hint for the field (date-time,
 	// date, email, uri, …). Carried through so SQLite column derivation
 	// can map date/date-time response fields to DATETIME instead of TEXT.


### PR DESCRIPTION
## Summary

Sniffed CLIs now get useful `internal/types/types.go` stubs from captured JSON responses, including nested structs, `omitempty` tags for fields missing across samples, and ASCII-safe Go identifiers for non-ASCII JSON keys.

Closes #954

## Approach

Browser-sniff response inference now merges object fields inside array samples instead of keeping only the last sample's shape, then threads the inferred response shape into `APISpec.Types`. Collection envelopes such as `{"items":[...]}` are promoted to array responses with `response_path` set to the collection field, so generated store/type consumers see the item shape directly.

For sniffed regenerations, an existing `internal/types/types.go` with type declarations is preserved so Phase 3 hand-authored types are not overwritten by rough stubs.

## Output Contract

Generated sniffed specs may now include `types:` entries derived from response samples, and generated `types.go` may contain referenced nested structs instead of an empty `package types` file. Existing non-empty sniffed `internal/types/types.go` files are left untouched on regeneration.

## Verification

- `go test ./internal/generator -run 'TestGenerateSniffedResponseTypeStubs|TestGenerateSniffedTypesPreservesExistingHandAuthoredTypes' -count=1`
- `go test ./internal/browsersniff -run 'TestInferResponseSchema|TestWriteSpec' -count=1`
- `go test ./internal/browsersniff ./internal/generator -count=1`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
