### PR TITLE
fix(cli): allowlist reserved synthetic values and GitHub IDs in PII scanner

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -371,14 +371,31 @@ func normalizePIIJSONKey(key string) string {
 func redactPIIPatterns(text string) string {
 	redacted := text
 	for _, det := range piiDetectors {
-		redacted = det.pattern.ReplaceAllStringFunc(redacted, func(match string) string {
-			if isSyntheticPIIPlaceholder(det.kind, match) {
-				return match
-			}
-			return PIIRedactedSentinel
-		})
+		redacted = redactDetectorMatches(det, redacted)
 	}
 	return redacted
+}
+
+func redactDetectorMatches(det piiDetector, text string) string {
+	locs := det.pattern.FindAllStringIndex(text, -1)
+	if len(locs) == 0 {
+		return text
+	}
+	var b strings.Builder
+	last := 0
+	for _, loc := range locs {
+		match := text[loc[0]:loc[1]]
+		b.WriteString(text[last:loc[0]])
+		if isSyntheticPIIPlaceholder(det.kind, match) ||
+			(det.kind == PIIKindPhoneUS && isGitHubContextBarePhoneID(text, loc[0], match)) {
+			b.WriteString(match)
+		} else {
+			b.WriteString(PIIRedactedSentinel)
+		}
+		last = loc[1]
+	}
+	b.WriteString(text[last:])
+	return b.String()
 }
 
 // Scoped to the capture-to-publish leak path: manuscripts, test
@@ -545,6 +562,35 @@ func isNANPFictionalPhone(matched string) bool {
 	default:
 		return false
 	}
+}
+
+func isGitHubContextBarePhoneID(line string, matchStart int, matchedSpan string) bool {
+	if !isBareDigits(matchedSpan) {
+		return false
+	}
+	start := max(0, matchStart-30)
+	context := strings.ToLower(line[start:matchStart])
+	for _, token := range []string{
+		"comment id", "comment_id", "comment-id", "issuecomment", "discussion_r",
+		"/comments/", "/commit/", "/commits/", "/pull/", "/issues/",
+	} {
+		if strings.Contains(context, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBareDigits(span string) bool {
+	if span == "" {
+		return false
+	}
+	for _, r := range span {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // FindPII walks root, applies the file-scoping rules, and returns all
@@ -767,6 +813,9 @@ func scanPIIFileWithRel(path, relSlash string) ([]PIIFinding, error) {
 			for _, match := range det.pattern.FindAllStringIndex(line, -1) {
 				matchedSpan := line[match[0]:match[1]]
 				if isSyntheticPIIPlaceholder(det.kind, matchedSpan) {
+					continue
+				}
+				if det.kind == PIIKindPhoneUS && isGitHubContextBarePhoneID(line, match[0], matchedSpan) {
 					continue
 				}
 				findings = append(findings, PIIFinding{

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -72,6 +72,17 @@ func TestRedactPIIText_RedactsPlainTextPatterns(t *testing.T) {
 	require.Contains(t, got, PIIRedactedSentinel)
 }
 
+func TestRedactPIIText_KeepsGitHubContextIDAndReservedValues(t *testing.T) {
+	got := RedactPIIText("see #issuecomment-3249672648 and email user@example.com or call 212-555-0142")
+	require.Contains(t, got, "3249672648", "GitHub comment ID must not be redacted")
+	require.Contains(t, got, "user@example.com", "reserved example.com email must not be redacted")
+	require.Contains(t, got, "212-555-0142", "NANP fictional phone must not be redacted")
+
+	real := RedactPIIText("reach me at 415-234-5678")
+	require.NotContains(t, real, "415-234-5678", "a real phone must still be redacted")
+	require.Contains(t, real, PIIRedactedSentinel)
+}
+
 func TestFindPII_CardLast4(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -196,6 +207,26 @@ func TestFindPII_PhoneUS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := scanLine(t, tt.line, "test.json")
+			assertKinds(t, got, tt.expectKinds, PIIKindPhoneUS)
+		})
+	}
+}
+
+func TestFindPII_PhoneUS_GitHubContextIDSkips(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		expectKinds []string
+	}{
+		{name: "comment-id", line: `see comment id 3249672558`, expectKinds: nil},
+		{name: "issuecomment-anchor", line: `https://github.com/o/r/pull/12#issuecomment-3249672648`, expectKinds: nil},
+		{name: "comments-url-path", line: `https://github.com/o/r/issues/5/comments/3249672700`, expectKinds: nil},
+		{name: "bare-real-phone-no-github-token", line: `contact 4152345678`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "bare-commit-word-near-real-phone-still-flags", line: `we will commit then call 4152345678`, expectKinds: []string{PIIKindPhoneUS}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanLine(t, tt.line, "README.md")
 			assertKinds(t, got, tt.expectKinds, PIIKindPhoneUS)
 		})
 	}


### PR DESCRIPTION
## Intent

Issue: Closes #1589, Closes #1343, Closes #1477

Three issues, one root cause: the PII scanner (`internal/artifacts/pii.go`, shared by `pii-audit`, `publish package`, and the polish gates) had no allowlist for values that are reserved-by-standard or context-disambiguated. So it false-positived on:
- RFC 2606/6761 reserved synthetic emails (`user@example.com`) and phones (NANP `555-01XX`) that APIs echo back in dogfood output (#1589, #1343) — blocking publish or forcing polish churn that the "never scaffold to satisfy the gate" rule forbids resolving cleanly.
- 10-digit GitHub comment/commit/PR IDs that match the NANP phone shape and appear in archived retro/manuscript proofs (#1477) — every publish after the first retro aborted.

## Approach

Add narrow allowlists at the single shared chokepoint, `isSyntheticPIIPlaceholder` (called by both detection in `scanPIIFileWithRel` and redaction in `redactPIIPatterns`, so they can't drift):
- **Email:** skip `example.com`/`.org`/`.net` (and their subdomains — RFC 2606 reserves the whole tree) and the RFC 6761 suffixes `.test`/`.example`/`.invalid`/`.localhost`.
- **Phone:** skip the NANP fictional reserved range `555-0100..555-0199`, robust to `+1`/parens/separators.

For the GitHub-ID case (which needs surrounding context), a skip in the scan loop: a **bare-digit** 10-digit run that matches the phone shape is skipped only when a **GitHub-structured token** (`comment id`, `issuecomment`, `discussion_r`, `/comments/`, `/commit/`, `/pull/`, `/issues/`) sits within 30 chars before it. Bare English words like "commit"/"comment" are intentionally NOT matched, so a real phone near those words in prose is still flagged.

**Not weakened:** real emails on real domains, real phones (including bare-digit phones with no GitHub token), and the boundary cases (`555-0099`, `555-0200`, `notexample.com`) all stay flagged. The reserved values added are standards-mandated unregisterable/fictional, so they can never alias real PII.

## Scope

Primary area: scorer / artifacts PII scanner.

Why this belongs in this repo: machine change; every printed CLI's pii-audit/publish/polish flow inherits the allowlist.

## Catalog Justification

N/A

## Risk

Low and safe-directional: every allowlist errs toward over-flagging (the boundary/lookalike cases stay flagged); the only values skipped are standards-reserved or GitHub-token-adjacent bare IDs. The narrowest residual is the GitHub-ID skip, which is gated tightly (bare digits + structured token) and scoped to markdown/proof prose.

## Output Contract

N/A for generated output (the change is to the scanner, not generate output — no golden impact; `golden verify` passes 24/24). Behavior contract: reserved synthetic emails/phones and GitHub-structured reference IDs are no longer reported/redacted as PII.

## Verification

- `go test ./...` — pass. Includes new table-driven positive/negative/boundary cases in `pii_test.go` (verified failing pre-change), and migration of pre-existing detection/redaction/gate fixtures off `@example.com` (which is now correctly allowlisted) onto a non-reserved domain so they still exercise real-PII handling.
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/artifacts/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
