### PR TITLE
fix(skills): route polish instrumentation through client

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -370,6 +370,15 @@ If a polish fix adds or changes a runtime mode, data-source option, auth tier, t
 
 Keep the checklist in the polish notes or result block. Skip it for ordinary bug fixes that do not change runtime variants or defaults.
 
+### Cross-cutting API-call instrumentation
+
+When polish builds a feature class that must observe every outbound API call,
+such as a quota ledger, request log, or audit trail, instrument the generated
+client middleware in `internal/client/client.go`'s `do()` method instead of
+individual command handlers. That method is the shared path for typed endpoint
+mirrors, sync iterations, and novel features that use the generated client.
+Per-command hooks under-count because they only see the commands polish touched.
+
 ### Priority 0: MCP surface migration (legacy CLIs)
 
 If Phase 1's `dogfood` reported `MCP Surface: FAIL` with a parity mismatch, the CLI was generated before the runtime cobratree walker existed and is still on the static `internal/mcp/tools.go` surface. The fix is mechanical:

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -374,9 +374,13 @@ Keep the checklist in the polish notes or result block. Skip it for ordinary bug
 
 When polish builds a feature class that must observe every outbound API call,
 such as a quota ledger, request log, or audit trail, instrument the generated
-client middleware in `internal/client/client.go`'s `do()` method instead of
-individual command handlers. That method is the shared path for typed endpoint
-mirrors, sync iterations, and novel features that use the generated client.
+client middleware in `internal/client/client.go` instead of individual command
+handlers. Prefer a shared pre-dispatch hook when one exists; otherwise cover
+both `do()` and `doRead()`. The `do()` path handles standard endpoint mirrors,
+sync iterations, and novel features that use the generated client, while
+`doRead()` handles read-only operations that ride POST-like transports, such as
+GraphQL queries, JSON-RPC reads, and POST-based searches marked
+`mcp:read-only`.
 Per-command hooks under-count because they only see the commands polish touched.
 
 ### Priority 0: MCP surface migration (legacy CLIs)


### PR DESCRIPTION
## Summary

Polish now tells agents to put API-call-wide features like quota ledgers, request logs, and audit trails in the generated client middleware so typed endpoints, sync, and novel features are all covered.

This closes the silent under-counting guidance gap from the quota-ledger retro by warning against per-command hooks for cross-cutting call instrumentation.

Closes #882

## Test plan

- `./cli-printing-press verify-internal-skill --dir skills/printing-press-polish`
- `go test ./internal/cli -run 'TestMarketplaceJSONHasNoPluginVersion|TestSkill|TestVerifyInternalSkill'`
- `go test ./internal/pipeline -run 'Polish|Contract'`
- `git diff --check`
