### PR TITLE
fix(cli): reject placeholder URLs when inferring auth key URL

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -1319,7 +1319,12 @@ func firstHTTPSURL(s string) string {
 		return ""
 	}
 	m := httpsURLPattern.FindString(s)
-	return strings.TrimRight(m, ".,;:!?)")
+	m = strings.TrimRight(m, ".,;:!?)")
+	if m == "" || strings.ContainsAny(m, "<>{}[]") {
+		// Reject templated placeholders (e.g. https://<your-dashboard>/...).
+		return ""
+	}
+	return m
 }
 
 // firstAuthRelatedURL returns the first HTTPS URL in s, but only when s also

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3998,6 +3998,29 @@ paths:
 `,
 			expected: "",
 		},
+		{
+			name: "placeholder URL in scheme description is rejected",
+			yaml: `openapi: "3.0.3"
+info:
+  title: Example
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-apikey
+      description: "Get your key at https://<your-dashboard>/api-keys"
+paths:
+  /ping:
+    get:
+      responses:
+        "200": { description: OK }
+`,
+			expected: "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -4005,6 +4028,39 @@ paths:
 			parsed, err := Parse([]byte(tc.yaml))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, parsed.Auth.KeyURL)
+		})
+	}
+}
+
+func TestFirstHTTPSURLRejectsPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "angle bracket placeholder",
+			in:   "Get your key at https://<your-dashboard>/api-keys",
+			want: "",
+		},
+		{
+			name: "real URL",
+			in:   "Register at https://dash.example.com/keys to get a token",
+			want: "https://dash.example.com/keys",
+		},
+		{
+			name: "brace placeholder",
+			in:   "https://api.example.com/v1/{tenant}/keys",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, firstHTTPSURL(tc.in))
 		})
 	}
 }


### PR DESCRIPTION
## Intent

Issue: Closes #2011

Doctor's auth hint (and the `auth`, `helpers`, and MCP tool-description surfaces) shipped the literal `Get a key at: https://<your-dashboard` — a truncated placeholder, no closing `>` — for self-hosted-only APIs whose spec has no real public docs/key URL.

## Approach

The leak's real source is the parser, not the templates (which already gate the "Get a key at" line on `{{if .Auth.KeyURL}}`). `inferAuthKeyURL` → `firstHTTPSURL` (`internal/openapi/parser.go`) extracts the first `https://…` substring from a security-scheme/info description. Its regex `https://[^\s)>\]"',]+` stops at `>` but does **not** exclude `<`, so a description containing `https://<your-dashboard>/api-keys` yields the match `https://<your-dashboard`, which becomes `Auth.KeyURL` and ships verbatim.

Fix at the source: `firstHTTPSURL` now returns `""` when the matched URL contains any templated-placeholder marker (`<`, `>`, `{`, `}`, `[`, `]`). `Auth.KeyURL` stays empty for placeholder-only descriptions, and the four templates' existing guards correctly omit the line — no `<`/`>` ships, and no template change is needed. Real key URLs are unaffected.

## Scope

Primary area: openapi-parser (`firstHTTPSURL`).

Why this belongs in this repo: machine change; fixing the single inference point corrects all four generated surfaces at once for every printed CLI.

## Catalog Justification

N/A

## Risk

Low and safe-directional: rejecting a placeholder yields an empty `KeyURL` (no "Get a key at" line), which is strictly better than shipping a broken one. A legitimate key URL never contains these markers (the pre-existing regex already excluded `>`/`]`, so an IPv6-literal host was never produced anyway).

## Output Contract

For specs whose only auth URL is a placeholder, `Auth.KeyURL` is now empty and the "Get a key at" line is omitted across doctor / auth / helpers / MCP. `golden verify` passes 24/24 (no fixture spec carried a placeholder URL).

## Verification

- `go test ./...` — pass (new `TestFirstHTTPSURLRejectsPlaceholders` + a parser-level case asserting empty `Auth.KeyURL`; both fail pre-change reproducing the issue's `https://<your-dashboard` value)
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/openapi/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
