### PR TITLE
fix(cli): align GraphQL sync --max-pages default to 100 and warn on cap-hit

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10274,6 +10274,35 @@ func TestGeneratedGraphQLSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
 	assertSyncDefaultConcurrency(t, string(syncGo), 1, "GraphQL sync.go")
 }
 
+func TestGeneratedGraphQLSyncMaxPagesDefault100(t *testing.T) {
+	t.Parallel()
+
+	gqlSpec, err := graphql.ParseSDL(filepath.Join("..", "..", "testdata", "graphql", "test.graphql"))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	gen := New(gqlSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	syncContent := string(syncGo)
+	assert.Contains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 100,`,
+		"GraphQL sync.go must declare --max-pages with default 100")
+	assert.NotContains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
+		"GraphQL sync.go must not retain the old 10-page default")
+	// The Long help advertises a {"event":"sync_warning",...} line in --json
+	// mode; the cap-hit path must actually emit one (not silently truncate
+	// for agent consumers).
+	assert.Contains(t, syncContent, `"reason":"max_pages_cap_hit"`,
+		"GraphQL sync.go must emit a sync_warning JSON event on --max-pages cap-hit")
+
+	// Compile the generated GraphQL CLI so the cap-hit warning plumbing
+	// (capWarn declared + threaded into syncResult.Warn) is verified to build.
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
 func TestGeneratedSyncAdvancesOffsetWhenHasMoreWithoutCursor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -238,7 +238,7 @@ Exit codes & warnings:
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "Database path (default: ~/.local/share/{{.Name}}-pp-cli/data.db)")
-	cmd.Flags().IntVar(&maxPages, "max-pages", 10, "Maximum pages to fetch per resource (0 = unlimited)")
+	cmd.Flags().IntVar(&maxPages, "max-pages", 100, "Maximum pages to fetch per resource (0 = unlimited)")
 	cmd.Flags().BoolVar(&latestOnly, "latest-only", false, "Refresh head of each resource only; clears resume cursor and caps pages at 1. Mutually exclusive with --since (--since wins).")
 
 	return cmd
@@ -267,6 +267,7 @@ func graphqlSyncDefs() map[string]graphqlSyncDef {
 // syncResource handles the full paginated sync of a single resource via GraphQL.
 func syncResource(ctx context.Context, c *client.Client, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
 	started := time.Now()
+	var capWarn error
 
 	if !humanFriendly {
 		fmt.Fprintf(os.Stderr, `{"event":"sync_start","resource":"%s"}`+"\n", resource)
@@ -403,8 +404,13 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 
 		// Enforce page ceiling
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if humanFriendly {
-				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			// Record the cap-hit as a warning so the closing sync_summary's
+			// warned count reflects it. JSON consumers get the detailed
+			// sync_warning event here; human output is printed once by the
+			// result collector via this Warn (avoids a double print).
+			capWarn = fmt.Errorf("reached --max-pages cap of %d (%d items); data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify", maxPages, totalCount)
+			if !humanFriendly {
+				fmt.Fprintf(os.Stderr, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
 			}
 			break
 		}
@@ -437,7 +443,7 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 		fmt.Fprintf(os.Stderr, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
 	}
 
-	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+	return syncResult{Resource: resource, Count: totalCount, Warn: capWarn, Duration: time.Since(started)}
 }
 
 func defaultSyncResources() []string {


### PR DESCRIPTION
## Intent

Issue: Closes #2057

Generated CLIs' GraphQL `sync` defaulted `--max-pages` to 10, capping every sync at ~500 rows (10 pages × 50) and silently truncating analytics windows. The REST sync template was already fixed (default 100 + cap-hit warning); the GraphQL path lagged.

## Approach

Two parts:
1. Raise the GraphQL `--max-pages` default from 10 to 100, matching the REST template (`0 = unlimited` semantics preserved). Aligning to REST's already-chosen 100 (rather than the issue's originally-suggested 0) keeps a runaway-sync ceiling and makes the two sync paths consistent.
2. Close the silent-truncation gap for agents (a code-review finding): the GraphQL sync's `Long` help advertises a `{"event":"sync_warning",...}` line in `--json` mode, but the cap-hit path only printed to stderr in human mode and emitted nothing in JSON mode. Add the `sync_warning` JSON event on cap-hit (matching REST's `reason`/`message`), and give the human-mode line REST's actionable "Re-run with --max-pages 0 (unlimited) or higher" wording. So the advertised behavior now actually happens, and agent consumers are warned rather than silently truncated.

## Scope

Primary area: generator template (`graphql_sync.go.tmpl`).

Why this belongs in this repo: machine change; every printed GraphQL CLI inherits the saner default and the cap-hit warning parity on next generate.

## Catalog Justification

N/A

## Risk

Low. The default only widens the page ceiling; `--max-pages 0` still means unlimited. The added JSON event is emitted only on cap-hit and matches the REST event shape and the GraphQL `Long` help's documented contract.

## Output Contract

Generated GraphQL `sync.go` now declares `--max-pages` default 100 and emits a `{"event":"sync_warning","reason":"max_pages_cap_hit",...}` line on cap-hit in `--json` mode. No golden fixture captures a GraphQL `sync.go`, so `golden verify` stays green (24/24); the generator test is the mechanical guard.

## Verification

- `go test ./...` — pass (new `TestGeneratedGraphQLSyncMaxPagesDefault100` asserts default 100, not 10, and presence of the `max_pages_cap_hit` JSON event; fails pre-change)
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/generator/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
