### PR TITLE
fix(cli): add editable store migration extras hook

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2739,6 +2739,9 @@ func (g *Generator) renderStoreFiles(schema []TableDef) error {
 		if err := g.renderTemplate("store.go.tmpl", filepath.Join("internal", "store", "store.go"), storeData); err != nil {
 			return fmt.Errorf("rendering store: %w", err)
 		}
+		if err := g.renderTemplate("store_extras.go.tmpl", filepath.Join("internal", "store", "extras.go"), storeData); err != nil {
+			return fmt.Errorf("rendering store extras: %w", err)
+		}
 		if err := g.renderTemplate("store_schema_version_test.go.tmpl", filepath.Join("internal", "store", "schema_version_test.go"), storeData); err != nil {
 			return fmt.Errorf("rendering store schema version test: %w", err)
 		}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -77,6 +77,7 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		"internal/client/client_test.go",
 		"internal/client/client_verify_short_circuit_test.go",
 		"internal/config/config.go",
+		"internal/store/extras.go",
 		"internal/mcp/cobratree/walker.go",
 		"internal/mcp/cobratree/classify.go",
 		"internal/mcp/cobratree/typemap.go",
@@ -95,9 +96,9 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		// Bump it AND add to mustInclude above when adding always-emitted
 		// templates. Per-spec dynamic files (per-resource command files,
 		// generated tests) account for the difference between fixtures.
-		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 69},
-		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 74},
-		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 71},
+		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 70},
+		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 75},
+		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 72},
 	}
 
 	for _, tt := range tests {
@@ -127,6 +128,33 @@ func TestGenerateProjectsCompile(t *testing.T) {
 			runGoCommand(t, outputDir, "build", "./...")
 		})
 	}
+}
+
+func TestGenerateStoreExtrasHook(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("storeextras")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	extrasSrc := readGeneratedFile(t, outputDir, "internal", "store", "extras.go")
+	assert.NotContains(t, extrasSrc, "DO NOT EDIT")
+	assert.Contains(t, extrasSrc, "func (s *Store) migrateExtras(ctx context.Context, conn *sql.Conn) error")
+	assert.Contains(t, extrasSrc, "Add CREATE TABLE IF NOT EXISTS statements here")
+
+	storeSrc := readGeneratedFile(t, outputDir, "internal", "store", "store.go")
+	migrationIndex := strings.Index(storeSrc, "for _, m := range migrations")
+	extrasIndex := strings.Index(storeSrc, "s.migrateExtras(ctx, conn)")
+	stampIndex := strings.Index(storeSrc, "PRAGMA user_version = %d")
+	require.NotEqual(t, -1, migrationIndex, "store.go must still run generated migrations")
+	require.NotEqual(t, -1, extrasIndex, "store.go must call migrateExtras")
+	require.NotEqual(t, -1, stampIndex, "store.go must still stamp user_version")
+	assert.Less(t, migrationIndex, extrasIndex, "extras must run after generated migrations")
+	assert.Less(t, extrasIndex, stampIndex, "extras must run before the schema version stamp")
+
+	runGoCommand(t, outputDir, "test", "./internal/store")
 }
 
 // TestGenerateCliutilPackage verifies that every generated CLI ships with

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -399,6 +399,9 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migration failed: %w", err)
 			}
 		}
+		if err := s.migrateExtras(ctx, conn); err != nil {
+			return fmt.Errorf("running extra migrations: %w", err)
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.

--- a/internal/generator/templates/store_extras.go.tmpl
+++ b/internal/generator/templates/store_extras.go.tmpl
@@ -1,0 +1,29 @@
+// Copyright {{currentYear}} {{.Owner}}. Licensed under Apache-2.0. See LICENSE.
+
+// Package store provides local SQLite persistence for {{.Name}}-pp-cli.
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// migrateExtras runs after the generated store migrations and before the
+// schema-version stamp. It is the canonical place for novel-feature auxiliary
+// tables that need to live in the local store.
+//
+// Edit this file when adding tables for novel commands. Keep migrations
+// idempotent with CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS so
+// every store open can safely re-run them.
+func (s *Store) migrateExtras(ctx context.Context, conn *sql.Conn) error {
+	migrations := []string{
+		// Add CREATE TABLE IF NOT EXISTS statements here.
+	}
+	for _, m := range migrations {
+		if _, err := conn.ExecContext(ctx, m); err != nil {
+			return fmt.Errorf("extra migration failed: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -52,10 +52,11 @@ var regenmergeGeneratorOwnedDirs = map[string]struct{}{
 //
 // When opts.NovelOnly is true, only NOVEL and NOVEL-COLLISION verdicts are
 // preserved; TEMPLATED-WITH-ADDITIONS, TEMPLATED-BODY-DRIFT, and
-// TEMPLATED-VALUE-DRIFT files are left as fresh emitted them, and lost
-// AddCommand re-injection is skipped. The non-classified file sweep and
-// go.mod merge still run because both are spec-orthogonal — non-Go files
-// and go.mod require additions are valid preservation targets even when
+// TEMPLATED-VALUE-DRIFT files are left as fresh emitted them unless the file
+// is a generated editable hook whose whole purpose is to carry agent-authored
+// additions. Lost AddCommand re-injection is skipped. The non-classified file
+// sweep and go.mod merge still run because both are spec-orthogonal — non-Go
+// files and go.mod require additions are valid preservation targets even when
 // the fresh spec differs from the snapshot's.
 func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts Options) error {
 	if report == nil {
@@ -79,7 +80,7 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 			}
 			fc.Applied = true
 		case VerdictTemplatedWithAdditions, VerdictTemplatedBodyDrift, VerdictTemplatedValueDrift:
-			if opts.NovelOnly {
+			if opts.NovelOnly && !preserveTemplatedDriftInNovelOnly(fc.Path) {
 				continue
 			}
 			if err := copyPreserveFile(snapshotDir, freshDir, fc.Path); err != nil {
@@ -126,6 +127,10 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 
 	report.Applied = true
 	return nil
+}
+
+func preserveTemplatedDriftInNovelOnly(rel string) bool {
+	return filepath.ToSlash(rel) == "internal/store/extras.go"
 }
 
 // copyPreserveFile copies snapshot/rel → fresh/rel, refusing symlinks and

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -130,7 +130,15 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 }
 
 func preserveTemplatedDriftInNovelOnly(rel string) bool {
-	return filepath.ToSlash(rel) == "internal/store/extras.go"
+	_, ok := novelOnlyEditableHookPaths[filepath.ToSlash(rel)]
+	return ok
+}
+
+// novelOnlyEditableHookPaths lists generator-emitted files whose intended
+// purpose is to carry agent-authored edits. Add future editable hooks here
+// when they need NovelOnly regen to preserve templated drift.
+var novelOnlyEditableHookPaths = map[string]struct{}{
+	"internal/store/extras.go": {},
 }
 
 // copyPreserveFile copies snapshot/rel → fresh/rel, refusing symlinks and

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -84,6 +84,28 @@ const placeholderQuery = ""
 func TestMergeIntoFreshTreePreservesStoreExtrasEdits(t *testing.T) {
 	t.Parallel()
 
+	snap, fresh, rel := writeStoreExtrasFixture(t)
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true}))
+
+	assertStoreExtrasMigrationPreserved(t, fresh, rel)
+}
+
+func TestMergeIntoFreshTreeNovelOnlyPreservesStoreExtrasEdits(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh, rel := writeStoreExtrasFixture(t)
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true, NovelOnly: true}))
+
+	assertStoreExtrasMigrationPreserved(t, fresh, rel)
+}
+
+func writeStoreExtrasFixture(t *testing.T) (string, string, string) {
+	t.Helper()
+
 	snap, fresh := makeMergeFixture(t)
 	rel := "internal/store/extras.go"
 	require.NoError(t, os.MkdirAll(filepath.Join(snap, "internal", "store"), 0o755))
@@ -132,10 +154,11 @@ func (s *Store) migrateExtras(ctx context.Context, conn *sql.Conn) error {
 	require.NoError(t, os.WriteFile(filepath.Join(snap, rel), snapBody, 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), freshBody, 0o644))
 
-	report, err := Classify(snap, fresh, Options{Force: true})
-	require.NoError(t, err)
-	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true}))
+	return snap, fresh, rel
+}
 
+func assertStoreExtrasMigrationPreserved(t *testing.T, fresh, rel string) {
+	t.Helper()
 	got, err := os.ReadFile(filepath.Join(fresh, rel))
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "novel_events",

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -81,6 +81,67 @@ const placeholderQuery = ""
 	assert.Contains(t, string(got), "GetCategories", "added function survives")
 }
 
+func TestMergeIntoFreshTreePreservesStoreExtrasEdits(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	rel := "internal/store/extras.go"
+	require.NoError(t, os.MkdirAll(filepath.Join(snap, "internal", "store"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, "internal", "store"), 0o755))
+
+	freshBody := []byte(`package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func (s *Store) migrateExtras(ctx context.Context, conn *sql.Conn) error {
+	migrations := []string{
+		// Add CREATE TABLE IF NOT EXISTS statements here.
+	}
+	for _, m := range migrations {
+		if _, err := conn.ExecContext(ctx, m); err != nil {
+			return fmt.Errorf("extra migration failed: %w", err)
+		}
+	}
+	return nil
+}
+`)
+	snapBody := []byte(`package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func (s *Store) migrateExtras(ctx context.Context, conn *sql.Conn) error {
+	migrations := []string{
+		` + "`" + `CREATE TABLE IF NOT EXISTS novel_events (id TEXT PRIMARY KEY)` + "`" + `,
+	}
+	for _, m := range migrations {
+		if _, err := conn.ExecContext(ctx, m); err != nil {
+			return fmt.Errorf("extra migration failed: %w", err)
+		}
+	}
+	return nil
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(snap, rel), snapBody, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), freshBody, 0o644))
+
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true}))
+
+	got, err := os.ReadFile(filepath.Join(fresh, rel))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "novel_events",
+		"agent-authored store extras migrations must survive regen merge")
+}
+
 // TestMergeIntoFreshTreeReinjectsLostAddCommand covers a hand-added
 // cmd.AddCommand line in a parent-command file — LostRegistrations must
 // re-inject the call into the freshly emitted host.

--- a/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
+++ b/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
@@ -32,6 +32,7 @@ learn-loop-example/internal/cli/root.go
 # search_patterns, entity_lookups, teach_log_metadata. The additive
 # v2 -> v3 migration is the contract every learn-enabled CLI inherits.
 learn-loop-example/internal/store/store.go
+learn-loop-example/internal/store/extras.go
 
 # Learn package shape — one representative file per subpackage so a
 # template rename / signature change in any subpackage trips the gate:

--- a/testdata/golden/cases/generate-sync-walker-api/artifacts.txt
+++ b/testdata/golden/cases/generate-sync-walker-api/artifacts.txt
@@ -4,3 +4,4 @@ sync-walker-golden/internal/cli/sync.go
 sync-walker-golden/internal/cli/promoted_games.go
 sync-walker-golden/internal/cli/promoted_leagues.go
 sync-walker-golden/internal/store/store.go
+sync-walker-golden/internal/store/extras.go

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/extras.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/extras.go
@@ -1,4 +1,4 @@
-// Copyright {{currentYear}} {{.Owner}}. Licensed under Apache-2.0. See LICENSE.
+// Copyright 2026 printing-press-golden. Licensed under Apache-2.0. See LICENSE.
 
 package store
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -351,6 +351,9 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migration failed: %w", err)
 			}
 		}
+		if err := s.migrateExtras(ctx, conn); err != nil {
+			return fmt.Errorf("running extra migrations: %w", err)
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/extras.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/extras.go
@@ -1,4 +1,4 @@
-// Copyright {{currentYear}} {{.Owner}}. Licensed under Apache-2.0. See LICENSE.
+// Copyright 2026 printing-press-golden. Licensed under Apache-2.0. See LICENSE.
 
 package store
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -314,6 +314,9 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migration failed: %w", err)
 			}
 		}
+		if err := s.migrateExtras(ctx, conn); err != nil {
+			return fmt.Errorf("running extra migrations: %w", err)
+		}
 		// Stamp the schema version. On a fresh DB this writes the current
 		// StoreSchemaVersion; on an already-stamped DB this is a no-op
 		// write of the same value.


### PR DESCRIPTION
## Summary

Generated CLIs with a local store now get an editable `internal/store/extras.go` hook for novel-feature auxiliary tables. Agent-authored table migrations can live beside the generated store and run inside the normal migration lock, after generated migrations and before the schema version stamp.

This also pins the regen path so edits to `extras.go` survive fresh-tree merge, matching the intended preservation contract for novel feature code.

## Verification

- `go test ./internal/generator -run 'TestGenerate(StoreExtrasHook|ProjectsCompile)$' -count=1`
- `go test ./internal/pipeline/regenmerge -run TestMergeIntoFreshTreePreservesStoreExtrasEdits -count=1`
- `go test ./...`
- `go fmt ./...`
- `scripts/golden.sh verify`

Closes #1051

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
