### PR TITLE
fix(cli): store synced_at as RFC3339 UTC so SQLite strftime works

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4363,13 +4363,13 @@ func TestGenerateStoreSubResourceUpsertBindingOrder(t *testing.T) {
 
 	// The argument bindings must follow that same order.
 	assert.Regexp(t,
-		`(?s)id,\s+lookupFieldValue\(obj, "domains_id"\),\s+string\(data\),\s+time\.Now\(\),`,
+		`(?s)id,\s+lookupFieldValue\(obj, "domains_id"\),\s+string\(data\),\s+time\.Now\(\)\.UTC\(\)\.Format\(time\.RFC3339\),`,
 		src,
 		"upsertVerifyTx binding order must match (id, domains_id, data, synced_at) column order")
 
 	// And the swapped order must be absent.
 	assert.NotRegexp(t,
-		`(?s)id,\s+string\(data\),\s+time\.Now\(\),\s+lookupFieldValue\(obj, "domains_id"\),`,
+		`(?s)id,\s+string\(data\),\s+time\.Now\(\)\.UTC\(\)\.Format\(time\.RFC3339\),\s+lookupFieldValue\(obj, "domains_id"\),`,
 		src,
 		"swapped (id, data, synced_at, fk) binding order must not be emitted")
 }

--- a/internal/generator/store_synced_at_rfc3339_test.go
+++ b/internal/generator/store_synced_at_rfc3339_test.go
@@ -1,0 +1,94 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateStoreSyncedAtStoredAsRFC3339ForSQLite(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("synced-at-format")
+	outputDir := filepath.Join(t.TempDir(), "synced-at-format-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "store", "synced_at_sqlite_time_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+)
+
+func TestSyncedAtIsSQLiteStrftimeParseable(t *testing.T) {
+	s, err := Open(t.TempDir() + "/data.db")
+	if err != nil {
+		t.Fatalf("NewStore error: %v", err)
+	}
+	defer s.Close()
+
+	legacy := "2026-05-17 02:23:57.241892 -0700 PDT m=+0.49"
+	if _, err := s.DB().Exec(
+		"INSERT INTO resources (id, resource_type, data, synced_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+		"1", "items", `+"`"+`{"id":"1"}`+"`"+`, legacy, legacy,
+	); err != nil {
+		t.Fatalf("seed legacy format row error: %v", err)
+	}
+
+	var legacyNormalized sql.NullString
+	if err := s.DB().QueryRow(
+		"SELECT strftime('%Y-%m-%dT%H:%M:%SZ', synced_at) FROM resources WHERE resource_type = ? AND id = ?",
+		"items", "1",
+	).Scan(&legacyNormalized); err != nil {
+		t.Fatalf("legacy strftime scan error: %v", err)
+	}
+	if legacyNormalized.Valid {
+		t.Fatalf("legacy Go verbose timestamp unexpectedly parseable: %q", legacyNormalized.String)
+	}
+
+	if err := s.Upsert("items", "1", json.RawMessage(`+"`"+`{"id":"1"}`+"`"+`)); err != nil {
+		t.Fatalf("Upsert error: %v", err)
+	}
+
+	var normalized sql.NullString
+	if err := s.DB().QueryRow(
+		"SELECT strftime('%Y-%m-%dT%H:%M:%SZ', synced_at) FROM resources WHERE resource_type = ? AND id = ?",
+		"items", "1",
+	).Scan(&normalized); err != nil {
+		t.Fatalf("strftime scan error: %v", err)
+	}
+	if !normalized.Valid {
+		t.Fatalf("strftime returned NULL for synced_at")
+	}
+	if normalized.String == "" {
+		t.Fatalf("strftime returned empty timestamp")
+	}
+
+	// Round-trip sync_state.last_synced_at: SaveSyncState now writes an
+	// RFC3339 string, and GetSyncState scans it back into a time.Time. Verify
+	// the driver parses the Z-suffixed string into a non-zero time (the code
+	// path this change introduces).
+	if err := s.SaveSyncState("items", "cursor-xyz", 5); err != nil {
+		t.Fatalf("SaveSyncState error: %v", err)
+	}
+	_, lastSynced, count, err := s.GetSyncState("items")
+	if err != nil {
+		t.Fatalf("GetSyncState error: %v", err)
+	}
+	if lastSynced.IsZero() {
+		t.Fatalf("GetSyncState returned zero time — RFC3339 last_synced_at did not scan back into time.Time")
+	}
+	if count != 5 {
+		t.Fatalf("GetSyncState count = %d, want 5", count)
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestSyncedAtIsSQLiteStrftimeParseable", "-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -646,7 +646,7 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(resource_type, id) DO UPDATE SET data = excluded.data, synced_at = excluded.synced_at, updated_at = excluded.updated_at`,
-		id, resourceType, string(data), time.Now(), time.Now(),
+		id, resourceType, string(data), time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return err
@@ -842,7 +842,7 @@ func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]a
 {{- else if eq .Name "data"}}
 		string(data),
 {{- else if eq .Name "synced_at"}}
-		time.Now(),
+		time.Now().UTC().Format(time.RFC3339),
 {{- else}}
 		lookupFieldValue(obj, "{{.Name}}"),
 {{- end}}
@@ -1100,7 +1100,7 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now(), count,
+		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -598,7 +598,7 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(resource_type, id) DO UPDATE SET data = excluded.data, synced_at = excluded.synced_at, updated_at = excluded.updated_at`,
-		id, resourceType, string(data), time.Now(), time.Now(),
+		id, resourceType, string(data), time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return err
@@ -787,7 +787,7 @@ func (s *Store) upsertLeaguesTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 ON CONFLICT("id") DO UPDATE SET "data" = excluded."data", "synced_at" = excluded."synced_at", "parent_id" = excluded."parent_id"`,
 		id,
 		string(data),
-		time.Now(),
+		time.Now().UTC().Format(time.RFC3339),
 		lookupFieldValue(obj, "parent_id"),
 	); err != nil {
 		return fmt.Errorf("insert into leagues: %w", err)
@@ -977,7 +977,7 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now(), count,
+		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
 	)
 	return err
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -561,7 +561,7 @@ func (s *Store) upsertGenericResourceTx(tx *sql.Tx, resourceType, id string, dat
 		`INSERT INTO resources (id, resource_type, data, synced_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(resource_type, id) DO UPDATE SET data = excluded.data, synced_at = excluded.synced_at, updated_at = excluded.updated_at`,
-		id, resourceType, string(data), time.Now(), time.Now(),
+		id, resourceType, string(data), time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return err
@@ -750,7 +750,7 @@ func (s *Store) upsertLeaguesTx(tx *sql.Tx, id string, obj map[string]any, data 
 		 ON CONFLICT("id") DO UPDATE SET "data" = excluded."data", "synced_at" = excluded."synced_at", "parent_id" = excluded."parent_id"`,
 		id,
 		string(data),
-		time.Now(),
+		time.Now().UTC().Format(time.RFC3339),
 		lookupFieldValue(obj, "parent_id"),
 	); err != nil {
 		return fmt.Errorf("insert into leagues: %w", err)
@@ -940,7 +940,7 @@ func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {
 		 VALUES (?, ?, ?, ?)
 		 ON CONFLICT(resource_type) DO UPDATE SET last_cursor = excluded.last_cursor,
 		 last_synced_at = excluded.last_synced_at, total_count = excluded.total_count`,
-		resourceType, cursor, time.Now(), count,
+		resourceType, cursor, time.Now().UTC().Format(time.RFC3339), count,
 	)
 	return err
 }


### PR DESCRIPTION
## Intent

Issue: Closes #1588

The store upserts bound `synced_at`/`updated_at` (and `sync_state.last_synced_at`) to a bare `time.Now()`. Through the SQLite driver that serialized to Go's verbose time form (`"2026-05-17 02:23:57.241892 -0700 PDT m=+0.49..."`), which SQLite's `strftime` cannot parse — so `strftime('%Y-%m-%dT%H:%M:%SZ', synced_at)` returns NULL and any command doing time-window logic on `synced_at` silently breaks (observed on emailoctopus's `lists diff --since`).

## Approach

Bind `time.Now().UTC().Format(time.RFC3339)` at all three store-template timestamp bind sites in `store.go.tmpl`: the generic `resources` upsert (`synced_at` + `updated_at`), the typed-resource upsert `synced_at`, and `SaveSyncState.last_synced_at`. RFC3339-with-`Z` is parsed by both `modernc.org/sqlite`'s scan path and SQLite's `strftime`, and it sorts lexicographically the same as the leading chars of any RFC3339 cutoff used in `WHERE synced_at >= ?` — preserving ordering.

## Scope

Primary area: generator template (`store.go.tmpl`).

Why this belongs in this repo: machine change; every printed store-backed CLI inherits parseable timestamps on next generate.

## Catalog Justification

N/A

## Risk

Low. Only the timestamp bind representation changes (TEXT column, no schema change); reads scan into `sql.NullTime`/`strftime` which both accept RFC3339. `time.Now()` uses for Go duration math are untouched.

## Output Contract

Generated store.go binds `synced_at`/`updated_at`/`last_synced_at` as RFC3339 UTC strings. 2 golden store.go fixtures regenerated (diff is exactly the three bind sites). `golden verify` passes 24/24.

## Verification

- `go test ./...` — pass. New emitted regression test generates a store CLI, proves `strftime(...)` is NULL on the legacy verbose value, then non-NULL after a real `Upsert`. Updated a binding-order test's regex (asserts the same column/bind order with the new format).
- `scripts/golden.sh update` then inspected: only the three timestamp binds changed.
- `gofmt` / `golangci-lint run ./internal/generator/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
