### PR TITLE
fix(cli): derive BaseURL from spec source URL for relative-only servers

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -796,7 +796,11 @@ func readSpec(specFile string, refresh bool, skipCache bool) ([]byte, error) {
 }
 
 func parseOpenAPISpec(specFile string, data []byte, opts openapi.ParseOptions) (*spec.APISpec, error) {
-	if !openapi.IsRemoteSpecSource(specFile) {
+	if openapi.IsRemoteSpecSource(specFile) {
+		// Remote source: record the URL so the parser can derive an absolute
+		// BaseURL when the spec's servers: block is relative-only.
+		opts.SourceURL = specFile
+	} else {
 		opts.Path = specFile
 	}
 	return openapi.ParseWithOptions(data, opts)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -358,20 +358,31 @@ type ParseOptions struct {
 	// caller knows which one fits the printed CLI's intended auth model.
 	// Unknown names are ignored (default selection runs).
 	AuthPreference string
+	// SourceURL is the http(s) URL the spec was fetched from, when the spec
+	// is remote. Used to derive an absolute BaseURL for specs whose servers:
+	// block is relative-only (e.g. {url: /api/v3}). It does NOT affect $ref
+	// resolution (that uses Path/location).
+	SourceURL string
 }
 
 // ParseWithOptions is the canonical parser entry point; the older Parse* and
 // ParseFile* helpers delegate to it with default ParseOptions plus their own
 // path/lenient settings.
 func ParseWithOptions(data []byte, opts ParseOptions) (*spec.APISpec, error) {
+	var sourceURL *url.URL
+	if opts.SourceURL != "" {
+		if u, err := url.Parse(opts.SourceURL); err == nil {
+			sourceURL = u
+		}
+	}
 	if opts.Path == "" {
-		return parseWithLocation(data, opts.Lenient, opts.StrictRefs, nil, opts.AuthPreference)
+		return parseWithLocation(data, opts.Lenient, opts.StrictRefs, nil, sourceURL, opts.AuthPreference)
 	}
 	location, err := fileLocation(opts.Path)
 	if err != nil {
 		return nil, err
 	}
-	return parseWithLocation(data, opts.Lenient, opts.StrictRefs, location, opts.AuthPreference)
+	return parseWithLocation(data, opts.Lenient, opts.StrictRefs, location, sourceURL, opts.AuthPreference)
 }
 
 func parseFileWithOptions(path string, opts ParseOptions) (*spec.APISpec, error) {
@@ -383,7 +394,7 @@ func parseFileWithOptions(path string, opts ParseOptions) (*spec.APISpec, error)
 	return ParseWithOptions(data, opts)
 }
 
-func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url.URL, authPreference string) (*spec.APISpec, error) {
+func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url.URL, sourceURL *url.URL, authPreference string) (*spec.APISpec, error) {
 	var metadata specDataMetadata
 	if normalized, meta, err := normalizeSpecDataWithMetadata(data); err == nil {
 		data = normalized
@@ -555,6 +566,15 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 			baseURL = perOpURL
 			basePath = perOpPath
 		}
+	}
+	// Relative-only servers URL (e.g. `servers: [{url: /api/v3}]`) yields an
+	// empty BaseURL but a non-empty BasePath. If the spec was fetched from an
+	// http(s) URL, derive the absolute origin from that source so the generated
+	// client doesn't construct scheme-less request URLs. Uses the spec's source
+	// URL, not the ref-resolution location (which is file:// for local specs).
+	if baseURL == "" && basePath != "" && sourceURL != nil &&
+		(sourceURL.Scheme == "http" || sourceURL.Scheme == "https") && sourceURL.Host != "" {
+		baseURL = sourceURL.Scheme + "://" + sourceURL.Host
 	}
 	baseURLIsPlaceholder := false
 	if baseURL == "" && basePath == "" {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7746,6 +7746,45 @@ paths:
 	})
 }
 
+func TestParseDerivesBaseURLFromRemoteSourceForRelativeServer(t *testing.T) {
+	t.Parallel()
+
+	specYAML := []byte(`openapi: "3.0.3"
+info:
+  title: Relative Server Test
+  version: "1.0"
+servers:
+  - url: /api/v3
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200': {description: OK}
+`)
+
+	t.Run("remote http source seeds base URL", func(t *testing.T) {
+		// ParseWithOptions{SourceURL} is the real entry point the cli layer
+		// uses for a remote spec (parseOpenAPISpec sets SourceURL when the
+		// source is an http(s) URL).
+		parsed, err := ParseWithOptions(specYAML, ParseOptions{SourceURL: "https://petstore3.swagger.io/api/v3/openapi.yaml"})
+		require.NoError(t, err)
+		assert.Equal(t, "https://petstore3.swagger.io", parsed.BaseURL)
+		assert.Equal(t, "/api/v3", parsed.BasePath)
+		assert.False(t, parsed.BaseURLIsPlaceholder)
+	})
+
+	t.Run("local file source keeps existing empty base URL behavior", func(t *testing.T) {
+		// No SourceURL (local-file path source) — host is not derivable, so
+		// BaseURL stays empty and the user must set base_url.
+		parsed, err := Parse(specYAML)
+		require.NoError(t, err)
+		assert.Equal(t, "", parsed.BaseURL)
+		assert.Equal(t, "/api/v3", parsed.BasePath)
+		assert.False(t, parsed.BaseURLIsPlaceholder)
+	})
+}
+
 // TestAuthCompanionFromOpenAPI exercises the x-auth-companion extension at
 // both scheme level and info level, including the scheme-wins precedence
 // when both are set.


### PR DESCRIPTION
## Intent

Issue: Closes #1383

When an OpenAPI spec declares `servers:` with a relative-only URL (e.g. `{url: /api/v3}` — a path with no scheme/host), the parser set `BaseURL = ""` and `BasePath = "/api/v3"`. The generated client then built `Get "/api/v3/<path>"` and Go's net/http rejected it with `unsupported protocol scheme ""` — every live call failed until the user manually exported `<API>_BASE_URL`. The Petstore spec (`https://petstore3.swagger.io/api/v3/openapi.yaml`, `servers: [{url: /api/v3}]`) reproduces it.

## Approach

The origin is recoverable from the URL the spec was fetched from, but that URL wasn't reaching the parser: for a remote spec the parser was called with no location (local files got a `file://` location for `$ref` resolution; remote specs got `nil`). So derive the origin from the source URL — and plumb that URL in:

- Add `ParseOptions.SourceURL` (the http(s) URL the spec was fetched from).
- Thread it through `ParseWithOptions` to `parseWithLocation` as a **dedicated** parameter, kept separate from the `file://` ref-resolution `location` so `$ref` resolution behavior is unchanged.
- In `parseWithLocation`, when `BaseURL` is empty, `BasePath` is non-empty, and `SourceURL` is an http(s) URL with a host, set `BaseURL = scheme://host`.
- `parseOpenAPISpec` (the generate entry point) sets `SourceURL` for remote specs.

Local-file sources (no derivable host) and the placeholder fallback are unchanged.

> Note: an earlier draft of this fix keyed off the existing `location`, but that is always `file://` (local) or `nil` (remote) in production — so it would have been inert for the real `generate <url>` flow. This version plumbs the actual remote URL and the test drives the real `ParseWithOptions{SourceURL}` entry point rather than a synthesized internal call.

## Scope

Primary area: openapi-parser + the generate entry point (`internal/cli/root.go` `parseOpenAPISpec`).

Why this belongs in this repo: machine change; every `generate <url>` of a relative-server spec now produces a working BaseURL.

## Catalog Justification

N/A

## Risk

Low. The new derivation only fires when BaseURL is empty, BasePath is set, and the source is an http(s) URL — exactly the broken case. `SourceURL` is separate from the ref-resolution `location`, so `$ref` resolution is untouched. Local/in-memory parsing is unchanged.

## Output Contract

`ParseOptions` gains a `SourceURL` field. For a remote relative-server spec, `BaseURL` is now `scheme://host` instead of empty. `golden verify` passes 24/24 (golden specs are local files → no `SourceURL` → unchanged).

## Verification

- `go test ./...` — pass. New test drives the real `ParseWithOptions{SourceURL: "https://petstore3.swagger.io/..."}` entry point (asserts derived BaseURL; fails pre-change) plus a local-source negative case (BaseURL stays empty).
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/openapi/... ./internal/cli/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
