### PR TITLE
fix(cli): count parent-grouper scorecard commands

### DIFF
--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1495,7 +1495,7 @@ func registeredCommandFiles(cliDir string) map[string]bool {
 func addCommandConstructorCalls(content string) map[string]bool {
 	file, err := parser.ParseFile(token.NewFileSet(), "", content, 0)
 	if err != nil {
-		return nil
+		return map[string]bool{}
 	}
 
 	ctors := map[string]bool{}

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -1421,10 +1421,10 @@ func manifestNovelFeatureLeaves(dir string) map[string]bool {
 }
 
 // registeredCommandFiles returns the set of cli/*.go filenames whose command
-// constructor is referenced by root.go. Files without a registered constructor
-// should not inflate workflow/insight scores even if they match prefix or
-// behavioral heuristics — they're orphans, dead code, or half-built commands
-// that the user cannot actually invoke.
+// constructor is wired into the Cobra tree through AddCommand calls. Files
+// without a registered constructor should not inflate workflow/insight scores
+// even if they match prefix or behavioral heuristics — they're orphans, dead
+// code, or half-built commands that the user cannot actually invoke.
 //
 // Returns an empty map if root.go is missing or parsing yields no matches so
 // callers can fall open to the prior heuristic behavior (older or partial CLI
@@ -1435,21 +1435,9 @@ func registeredCommandFiles(cliDir string) map[string]bool {
 		return map[string]bool{}
 	}
 
-	// Match every `newXxxCmd(` invocation — but not definitions. root.go may
-	// contain helper function declarations (e.g. `func newRootCmd()`) that we
-	// must not count as registrations. Strip `func Name(` declaration heads
-	// before scanning so only call-sites contribute to the ctor set.
-	funcDeclRe := regexp.MustCompile(`(?m)^func\s+\w+\s*\(`)
-	scanContent := funcDeclRe.ReplaceAllString(rootContent, "")
-
-	ctorRe := regexp.MustCompile(`\bnew([A-Z][A-Za-z0-9_]*)Cmd\s*\(`)
-	rootMatches := ctorRe.FindAllStringSubmatch(scanContent, -1)
-	if len(rootMatches) == 0 {
+	reachableCtors := addCommandConstructorCalls(rootContent)
+	if len(reachableCtors) == 0 {
 		return map[string]bool{}
-	}
-	reachableCtors := make(map[string]bool, len(rootMatches))
-	for _, m := range rootMatches {
-		reachableCtors["new"+m[1]+"Cmd"] = true
 	}
 
 	// Walk cli/*.go and map each file to the reachable constructor it defines.
@@ -1493,9 +1481,8 @@ func registeredCommandFiles(cliDir string) map[string]bool {
 
 			result[name] = true
 			changed = true
-			callScanContent := funcDeclRe.ReplaceAllString(fileContent[name], "")
-			for _, m := range ctorRe.FindAllStringSubmatch(callScanContent, -1) {
-				reachableCtors["new"+m[1]+"Cmd"] = true
+			for ctor := range addCommandConstructorCalls(fileContent[name]) {
+				reachableCtors[ctor] = true
 			}
 		}
 		if !changed {
@@ -1503,6 +1490,52 @@ func registeredCommandFiles(cliDir string) map[string]bool {
 		}
 	}
 	return result
+}
+
+func addCommandConstructorCalls(content string) map[string]bool {
+	file, err := parser.ParseFile(token.NewFileSet(), "", content, 0)
+	if err != nil {
+		return nil
+	}
+
+	ctors := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "AddCommand" {
+			return true
+		}
+		for _, arg := range call.Args {
+			if ctor := commandConstructorName(arg); ctor != "" {
+				ctors[ctor] = true
+			}
+		}
+		return true
+	})
+	return ctors
+}
+
+func commandConstructorName(expr ast.Expr) string {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok || !isCommandConstructorName(ident.Name) {
+		return ""
+	}
+	return ident.Name
+}
+
+func isCommandConstructorName(name string) bool {
+	if !strings.HasPrefix(name, "new") || !strings.HasSuffix(name, "Cmd") {
+		return false
+	}
+	stem := strings.TrimSuffix(strings.TrimPrefix(name, "new"), "Cmd")
+	return stem != "" && stem[0] >= 'A' && stem[0] <= 'Z'
 }
 
 func scoreWorkflows(dir string) int {

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -175,7 +175,7 @@ func newAvailabilityGhostCmd(flags any) *cobra.Command {
 	return &cobra.Command{Use: "ghost"}
 }`)
 
-	writeFile(t, filepath.Join(dir, ".printing-press.json"), `{
+	writeFile(t, filepath.Join(dir, CLIManifestFilename), `{
   "cli_name": "demo-pp-cli",
   "novel_features": [
     {"name": "Sweep", "command": "availability sweep", "description": "x"},

--- a/internal/pipeline/scorecard_registered_test.go
+++ b/internal/pipeline/scorecard_registered_test.go
@@ -70,6 +70,125 @@ func newStaleCmd() {}`)
 	}
 }
 
+func TestRegisteredCommandFiles_FollowsParentGroupAddCommandCalls(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(newAvailabilityCmd(nil))
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityCmd(flags any) *cobra.Command {
+	cmd := &cobra.Command{Use: "availability"}
+	cmd.AddCommand(newAvailabilitySweepCmd(flags))
+	return cmd
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_sweep.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilitySweepCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "sweep"}
+}`)
+
+	registered := registeredCommandFiles(cliDir)
+	if !registered["availability.go"] {
+		t.Errorf("expected availability.go parent to be registered, got %v", registered)
+	}
+	if !registered["availability_sweep.go"] {
+		t.Errorf("expected child command registered through parent AddCommand to be registered, got %v", registered)
+	}
+}
+
+func TestRegisteredCommandFiles_IgnoresConstructorCallsOutsideAddCommand(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(newAvailabilityCmd(nil))
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityCmd(flags any) *cobra.Command {
+	_ = newAvailabilityGhostCmd(flags)
+	return &cobra.Command{Use: "availability"}
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_ghost.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityGhostCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "ghost"}
+}`)
+
+	registered := registeredCommandFiles(cliDir)
+	if registered["availability_ghost.go"] {
+		t.Errorf("expected non-AddCommand constructor call to stay unregistered, got %v", registered)
+	}
+}
+
+func TestScoreInsightCountsNovelCommandsRegisteredThroughParentGroupers(t *testing.T) {
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() {
+	rootCmd.AddCommand(newAvailabilityCmd(nil))
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityCmd(flags any) *cobra.Command {
+	cmd := &cobra.Command{Use: "availability"}
+	cmd.AddCommand(newAvailabilitySweepCmd(flags))
+	cmd.AddCommand(newAvailabilityDriftCmd(flags))
+	return cmd
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_sweep.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilitySweepCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "sweep"}
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_drift.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityDriftCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "drift"}
+}`)
+
+	writeFile(t, filepath.Join(cliDir, "availability_ghost.go"), `package cli
+import "github.com/spf13/cobra"
+func newAvailabilityGhostCmd(flags any) *cobra.Command {
+	return &cobra.Command{Use: "ghost"}
+}`)
+
+	writeFile(t, filepath.Join(dir, ".printing-press.json"), `{
+  "cli_name": "demo-pp-cli",
+  "novel_features": [
+    {"name": "Sweep", "command": "availability sweep", "description": "x"},
+    {"name": "Drift", "command": "availability drift", "description": "x"},
+    {"name": "Ghost", "command": "availability ghost", "description": "x"}
+  ]
+}`)
+
+	if score := scoreInsight(dir); score != 4 {
+		t.Fatalf("expected two registered parent-grouper insight commands to score 4, got %d", score)
+	}
+}
+
 // TestScoreWorkflows_IgnoresOrphanFile is the integration-level guard — the
 // workflows dimension must not count a dead-code file just because its name
 // matches a workflow prefix.


### PR DESCRIPTION
## Intent

Closes #922.

The scorecard now credits novel commands that are registered through parent-group `AddCommand` chains, so callable multi-word commands contribute to `Insight` instead of being filtered out because their constructors are not referenced directly from `root.go`.

## Approach

- Build the reachable command-file set from constructors passed to `AddCommand`, starting at `root.go` and recursively scanning newly reachable command files.
- Ignore constructor calls that are not passed to `AddCommand`, so helper or orphan command factories do not inflate scorer dimensions.
- Add focused scorer coverage for parent-grouper registration, the `Insight` manifest path, and the orphan negative case.

## Verification

- `go test ./internal/pipeline -run 'TestRegisteredCommandFiles|TestScoreWorkflows_FollowsRegisteredChildCommandFiles|TestScoreInsightCountsNovelCommandsRegisteredThroughParentGroupers|TestScoreInsight/credits|TestScoreInsight/ignores'`
- `go test ./...`
- `scripts/golden.sh verify`
- `git diff --check`
