### PR TITLE
fix(cli): streamline oauth login setup

### DIFF
--- a/internal/generator/auth_oauth_login_test.go
+++ b/internal/generator/auth_oauth_login_test.go
@@ -46,6 +46,9 @@ func TestOAuthLoginTopLevelCommandAndCredentialFallback(t *testing.T) {
 	require.Contains(t, auth, "promptOAuthCredential(cmd, reader, \"OAuth2 Client Secret (press Enter if not required)\")")
 	require.Contains(t, auth, `"mcp:hidden": "true"`)
 	require.Contains(t, auth, "flags.noInput")
+	require.Contains(t, auth, `fmt.Fprintln(w, "  oauth-login-prompts-pp-cli login")`)
+	require.Contains(t, auth, `Run 'oauth-login-prompts-pp-cli login' to authenticate.`)
+	require.Contains(t, auth, `Run 'oauth-login-prompts-pp-cli login' to re-authenticate.`)
 	require.NotContains(t, auth, "return fmt.Errorf(\"--client-id is required\")")
 
 	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
@@ -66,7 +69,9 @@ func TestOAuthLoginTopLevelCommandAndCredentialFallback(t *testing.T) {
 	const runtimeTest = `package cli
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -134,9 +139,31 @@ func TestResolveOAuthCredentialsNoInputRequiresClientID(t *testing.T) {
 		t.Fatalf("error = %q, want env-var hint", err)
 	}
 }
-`
+
+type partialReadErrorReader struct{}
+
+func (partialReadErrorReader) Read(p []byte) (int, error) {
+	copy(p, "partial")
+	return len("partial"), errors.New("short read")
+}
+
+func TestPromptOAuthCredentialRejectsPartialReadError(t *testing.T) {
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&stderr)
+	reader := bufio.NewReader(partialReadErrorReader{})
+
+	_, err := promptOAuthCredential(cmd, reader, "OAuth2 Client ID")
+	if err == nil {
+		t.Fatalf("promptOAuthCredential() error = nil, want partial-read error")
+	}
+	if !strings.Contains(err.Error(), "reading oauth2 client id: short read") {
+		t.Fatalf("error = %q, want partial-read context", err)
+	}
+}
+	`
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "oauth_credentials_test.go"), []byte(runtimeTest), 0o644))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveOAuthCredentials")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "Test(ResolveOAuthCredentials|PromptOAuthCredential)")
 
 	const mcpRuntimeTest = `package cobratree
 
@@ -174,6 +201,36 @@ func TestTopLevelOAuthLoginIsHiddenFromMCP(t *testing.T) {
 	if strings.Contains(auth, "auth login --client-id <id> --client-secret <secret>") {
 		t.Fatalf("setup hint still points users at the flag-heavy nested login form")
 	}
+}
+
+func TestOAuthClientCredentialsUsesNestedAuthLoginHints(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth-client-credentials-login")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:        "oauth2",
+		Header:      "Authorization",
+		Format:      "Bearer {token}",
+		OAuth2Grant: spec.OAuth2GrantClientCredentials,
+		TokenURL:    "https://accounts.example.com/oauth/token",
+		KeyURL:      "https://console.example.com/oauth",
+		EnvVars:     []string{"OAUTH_CC_CLIENT_ID", "OAUTH_CC_CLIENT_SECRET"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth-client-credentials-login-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(rootSrc), "rootCmd.AddCommand(newAuthLoginCmd(flags))")
+	require.NotContains(t, sortedKeys(New(apiSpec, outputDir).activeFrameworkCobraUseNames()), "login")
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	auth := string(authSrc)
+	require.Contains(t, auth, "Mint an OAuth2 bearer token via the client_credentials grant")
+	require.Contains(t, auth, `oauth-client-credentials-login-pp-cli auth login`)
+	require.NotContains(t, auth, `oauth-client-credentials-login-pp-cli login`)
 }
 
 func TestOAuthLoginTopLevelCommandForBearerTokenAuthCodeSpec(t *testing.T) {

--- a/internal/generator/auth_oauth_login_test.go
+++ b/internal/generator/auth_oauth_login_test.go
@@ -1,0 +1,202 @@
+package generator
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthLoginTopLevelCommandAndCredentialFallback(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth-login-prompts")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		Format:           "Bearer {token}",
+		OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		AuthorizationURL: "https://accounts.example.com/oauth/authorize",
+		TokenURL:         "https://accounts.example.com/oauth/token",
+		KeyURL:           "https://console.example.com/oauth",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth-login-prompts-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	root := string(rootSrc)
+	require.Contains(t, root, "rootCmd.AddCommand(newAuthCmd(flags))")
+	require.Contains(t, root, "rootCmd.AddCommand(newAuthLoginCmd(flags))")
+	require.Contains(t, sortedKeys(New(apiSpec, outputDir).activeFrameworkCobraUseNames()), "login")
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	auth := string(authSrc)
+	require.Contains(t, auth, "func runOAuthLogin(")
+	require.Contains(t, auth, "return runOAuthLogin(cmd, flags, clientID, clientSecret, port)")
+	require.Contains(t, auth, "clientID = cfg.ClientID")
+	require.Contains(t, auth, "clientSecret = cfg.ClientSecret")
+	require.Contains(t, auth, "promptOAuthCredential(cmd, reader, \"OAuth2 Client ID\")")
+	require.Contains(t, auth, "promptOAuthCredential(cmd, reader, \"OAuth2 Client Secret (press Enter if not required)\")")
+	require.Contains(t, auth, `"mcp:hidden": "true"`)
+	require.Contains(t, auth, "flags.noInput")
+	require.NotContains(t, auth, "return fmt.Errorf(\"--client-id is required\")")
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(doctorSrc), `report["auth_hint"] = "oauth-login-prompts-pp-cli login"`)
+
+	binPath := filepath.Join(outputDir, "oauth-login-prompts-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binPath, "./cmd/oauth-login-prompts-pp-cli")
+	helpOut, err := exec.Command(binPath, "login", "--help").CombinedOutput()
+	require.NoError(t, err, "top-level login --help failed: %s", string(helpOut))
+	require.Contains(t, string(helpOut), "Authenticate via OAuth2")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	noInputOut, err := exec.Command(binPath, "--config", configPath, "--no-input", "login").CombinedOutput()
+	require.Error(t, err, "top-level login --no-input should fail when no credentials are available")
+	require.Contains(t, string(noInputOut), "OAUTH_LOGIN_PROMPTS_CLIENT_ID")
+
+	const runtimeTest = `package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"oauth-login-prompts-pp-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestResolveOAuthCredentialsUsesSavedConfig(t *testing.T) {
+	cfg := &config.Config{ClientID: "saved-id", ClientSecret: "saved-secret"}
+	clientID, clientSecret, err := resolveOAuthCredentials(&cobra.Command{}, &rootFlags{noInput: true}, cfg, "", "")
+	if err != nil {
+		t.Fatalf("resolveOAuthCredentials() error = %v", err)
+	}
+	if clientID != "saved-id" || clientSecret != "saved-secret" {
+		t.Fatalf("credentials = %q/%q, want saved-id/saved-secret", clientID, clientSecret)
+	}
+}
+
+func TestResolveOAuthCredentialsExplicitValuesWinOverSavedConfig(t *testing.T) {
+	cfg := &config.Config{ClientID: "saved-id", ClientSecret: "saved-secret"}
+	clientID, clientSecret, err := resolveOAuthCredentials(&cobra.Command{}, &rootFlags{noInput: true}, cfg, "flag-id", "flag-secret")
+	if err != nil {
+		t.Fatalf("resolveOAuthCredentials() error = %v", err)
+	}
+	if clientID != "flag-id" || clientSecret != "flag-secret" {
+		t.Fatalf("credentials = %q/%q, want flag-id/flag-secret", clientID, clientSecret)
+	}
+
+	clientID, clientSecret, err = resolveOAuthCredentials(&cobra.Command{}, &rootFlags{noInput: true}, cfg, "new-id", "")
+	if err != nil {
+		t.Fatalf("resolveOAuthCredentials() new ID error = %v", err)
+	}
+	if clientID != "new-id" || clientSecret != "" {
+		t.Fatalf("new-ID credentials = %q/%q, want new-id/empty secret", clientID, clientSecret)
+	}
+}
+
+func TestResolveOAuthCredentialsPromptsForMissingClientID(t *testing.T) {
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&stderr)
+	cmd.SetIn(strings.NewReader("typed-id\ntyped-secret\n"))
+
+	clientID, clientSecret, err := resolveOAuthCredentials(cmd, &rootFlags{}, &config.Config{}, "", "")
+	if err != nil {
+		t.Fatalf("resolveOAuthCredentials() error = %v", err)
+	}
+	if clientID != "typed-id" {
+		t.Fatalf("clientID = %q, want typed-id", clientID)
+	}
+	if clientSecret != "typed-secret" {
+		t.Fatalf("clientSecret = %q, want typed-secret", clientSecret)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Create OAuth credentials at: https://console.example.com/oauth") || !strings.Contains(got, "OAuth2 Client ID:") || !strings.Contains(got, "OAuth2 Client Secret (press Enter if not required):") {
+		t.Fatalf("stderr = %q, want setup URL and credential prompts", got)
+	}
+}
+
+func TestResolveOAuthCredentialsNoInputRequiresClientID(t *testing.T) {
+	_, _, err := resolveOAuthCredentials(&cobra.Command{}, &rootFlags{noInput: true}, &config.Config{}, "", "")
+	if err == nil {
+		t.Fatalf("resolveOAuthCredentials() error = nil, want missing client ID error")
+	}
+	if !strings.Contains(err.Error(), "OAUTH_LOGIN_PROMPTS_CLIENT_ID") {
+		t.Fatalf("error = %q, want env-var hint", err)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "oauth_credentials_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestResolveOAuthCredentials")
+
+	const mcpRuntimeTest = `package cobratree
+
+import (
+	"testing"
+
+	"oauth-login-prompts-pp-cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+func TestTopLevelOAuthLoginIsHiddenFromMCP(t *testing.T) {
+	root := cli.RootCmd()
+	login, _, err := root.Find([]string{"login"})
+	if err != nil {
+		t.Fatalf("RootCmd().Find(login) error = %v", err)
+	}
+	if login == nil || login.Name() != "login" {
+		t.Fatalf("top-level login command not found: %#v", login)
+	}
+	if got := classify(login); got != commandHidden {
+		t.Fatalf("classify(top-level oauth login) = %v, want commandHidden", got)
+	}
+	plainLogin := &cobra.Command{
+		Use: "login",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	if got := classify(plainLogin); got != commandNovel {
+		t.Fatalf("classify(unannotated login) = %v, want commandNovel", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "cobratree", "oauth_login_hidden_test.go"), []byte(mcpRuntimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "TestTopLevelOAuthLoginIsHiddenFromMCP")
+
+	if strings.Contains(auth, "auth login --client-id <id> --client-secret <secret>") {
+		t.Fatalf("setup hint still points users at the flag-heavy nested login form")
+	}
+}
+
+func TestOAuthLoginTopLevelCommandForBearerTokenAuthCodeSpec(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-auth-code-login")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "bearer_token",
+		Header:           "Authorization",
+		Format:           "Bearer {token}",
+		AuthorizationURL: "https://accounts.example.com/oauth/authorize",
+		TokenURL:         "https://accounts.example.com/oauth/token",
+		KeyURL:           "https://console.example.com/oauth",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-auth-code-login-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(rootSrc), "rootCmd.AddCommand(newAuthLoginCmd(flags))")
+
+	doctorSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "doctor.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(doctorSrc), `report["auth_hint"] = "bearer-auth-code-login-pp-cli login"`)
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2091,6 +2091,9 @@ func (g *Generator) activeFrameworkCobraUseNames() map[string]struct{} {
 	}
 	if g.shouldEmitAuth() {
 		names["auth"] = struct{}{}
+		if g.emitsTopLevelOAuthLogin() {
+			names["login"] = struct{}{}
+		}
 	}
 	if g.Spec.BearerRefresh.Enabled() {
 		names["refresh-bearer"] = struct{}{}
@@ -2605,6 +2608,11 @@ func (g *Generator) shouldEmitAuth() bool {
 	return g.Spec.Auth.Type != "none" ||
 		g.Spec.Auth.AuthorizationURL != "" ||
 		g.hasTrafficAnalysisHint("graphql_persisted_query")
+}
+
+func (g *Generator) emitsTopLevelOAuthLogin() bool {
+	return g.Spec.Auth.AuthorizationURL != "" &&
+		(g.Spec.Auth.EffectiveOAuth2Grant() != spec.OAuth2GrantClientCredentials || g.Spec.Auth.TokenURL == "")
 }
 
 func (g *Generator) renderMCPEntrypoint() error {

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -65,7 +65,11 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 {{- end}}
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "Then run:")
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
 			fmt.Fprintln(w, "  {{.Name}}-pp-cli login")
+{{- else}}
+			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth login")
+{{- end}}
 			if !launch {
 				return nil
 			}
@@ -303,7 +307,11 @@ func resolveOAuthCredentials(cmd *cobra.Command, flags *rootFlags, cfg *config.C
 		return clientID, clientSecret, nil
 	}
 	if flags.noInput {
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
 		return "", "", fmt.Errorf("OAuth2 client ID is required; pass --client-id, set {{envName .Name}}_CLIENT_ID, or run '{{.Name}}-pp-cli login' without --no-input")
+{{- else}}
+		return "", "", fmt.Errorf("OAuth2 client ID is required; pass --client-id, set {{envName .Name}}_CLIENT_ID, or run '{{.Name}}-pp-cli auth login' without --no-input")
+{{- end}}
 	}
 	reader := bufio.NewReader(cmd.InOrStdin())
 	printOAuthCredentialHint(cmd.ErrOrStderr())
@@ -336,7 +344,7 @@ func printOAuthCredentialHint(w io.Writer) {
 func promptOAuthCredential(cmd *cobra.Command, reader *bufio.Reader, label string) (string, error) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s: ", label)
 	line, err := reader.ReadString('\n')
-	if err != nil && line == "" && err != io.EOF {
+	if err != nil && err != io.EOF {
 		return "", fmt.Errorf("reading %s: %w", strings.ToLower(label), err)
 	}
 	return strings.TrimSpace(line), nil
@@ -366,7 +374,11 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if !authed {
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
 				fmt.Fprintf(w, "  %s Not authenticated. Run '{{.Name}}-pp-cli login' to authenticate.\n", red("FAIL"))
+{{- else}}
+				fmt.Fprintf(w, "  %s Not authenticated. Run '{{.Name}}-pp-cli auth login' to authenticate.\n", red("FAIL"))
+{{- end}}
 				return nil
 			}
 
@@ -378,7 +390,11 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				if cfg.RefreshToken != "" {
 					fmt.Fprintf(w, "  %s Token expired (will auto-refresh on next request)\n", yellow("WARN"))
 				} else {
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
 					fmt.Fprintf(w, "  %s Token expired. Run '{{.Name}}-pp-cli login' to re-authenticate.\n", red("FAIL"))
+{{- else}}
+					fmt.Fprintf(w, "  %s Token expired. Run '{{.Name}}-pp-cli auth login' to re-authenticate.\n", red("FAIL"))
+{{- end}}
 				}
 			}
 

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -4,11 +4,13 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -63,7 +65,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 {{- end}}
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "Then run:")
-			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth login --client-id <id> --client-secret <secret>")
+			fmt.Fprintln(w, "  {{.Name}}-pp-cli login")
 			if !launch {
 				return nil
 			}
@@ -117,161 +119,11 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate via OAuth2",
+		Annotations: map[string]string{
+			"mcp:hidden": "true",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if clientID == "" {
-				return fmt.Errorf("--client-id is required")
-			}
-
-			cfg, err := config.Load(flags.configPath)
-			if err != nil {
-				return err
-			}
-
-			stateBytes := make([]byte, 16)
-			if _, err := rand.Read(stateBytes); err != nil {
-				return fmt.Errorf("generating state: %w", err)
-			}
-			state := hex.EncodeToString(stateBytes)
-
-			listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-			if err != nil {
-				return fmt.Errorf("starting callback server: %w", err)
-			}
-			defer listener.Close()
-
-			redirectURI := fmt.Sprintf("http://localhost:%d/callback", listener.Addr().(*net.TCPAddr).Port)
-
-			authURL := ""
-{{- if .Auth.AuthorizationURL}}
-			authURL = cfg.AuthorizationURL
-			if authURL == "" {
-				authURL = "{{.Auth.AuthorizationURL}}"
-			}
-{{- end}}
-{{- $refreshMech := .Auth.ParseRefreshTokenMechanism}}
-			params := url.Values{
-				"client_id":     {clientID},
-				"redirect_uri":  {redirectURI},
-				"response_type": {"code"},
-				"state":         {state},
-			}
-{{- if eq $refreshMech.Kind "query"}}
-			params.Set({{printf "%q" $refreshMech.Key}}, {{printf "%q" $refreshMech.Value}})
-{{- end}}
-			scopes := []string{ {{- range .Auth.Scopes}}"{{.}}", {{end}} }
-{{- if eq $refreshMech.Kind "scope"}}
-			scopes = append(scopes, {{printf "%q" $refreshMech.Scope}})
-{{- end}}
-			if len(scopes) > 0 {
-				params.Set("scope", strings.Join(scopes, " "))
-			}
-
-			fullURL := authURL + "?" + params.Encode()
-			fmt.Fprintf(os.Stderr, "Opening browser for authentication...\n")
-			fmt.Fprintf(os.Stderr, "If the browser doesn't open, visit:\n%s\n\n", fullURL)
-			openBrowser(fullURL)
-
-			codeCh := make(chan string, 1)
-			errCh := make(chan error, 1)
-
-			mux := http.NewServeMux()
-			mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Query().Get("state") != state {
-					errCh <- fmt.Errorf("state mismatch")
-					http.Error(w, "State mismatch", http.StatusBadRequest)
-					return
-				}
-				if errMsg := r.URL.Query().Get("error"); errMsg != "" {
-					errCh <- fmt.Errorf("auth error: %s", errMsg)
-					http.Error(w, errMsg, http.StatusBadRequest)
-					return
-				}
-				code := r.URL.Query().Get("code")
-				if code == "" {
-					errCh <- fmt.Errorf("no code in callback")
-					http.Error(w, "No code", http.StatusBadRequest)
-					return
-				}
-				w.Header().Set("Content-Type", "text/html")
-				fmt.Fprint(w, "<html><body><h2>Authentication successful!</h2><p>You can close this tab.</p></body></html>")
-				codeCh <- code
-			})
-
-			server := &http.Server{Handler: mux}
-			go server.Serve(listener)
-
-			var code string
-			select {
-			case code = <-codeCh:
-			case err := <-errCh:
-				return err
-			case <-time.After(2 * time.Minute):
-				return fmt.Errorf("authentication timed out after 2 minutes")
-			}
-
-			server.Shutdown(context.Background())
-
-			tokenURL := ""
-{{- if .Auth.TokenURL}}
-			tokenURL = cfg.TokenURL
-			if tokenURL == "" {
-				tokenURL = "{{.Auth.TokenURL}}"
-			}
-{{- end}}
-			tokenParams := url.Values{
-				"grant_type":   {"authorization_code"},
-				"code":         {code},
-				"redirect_uri": {redirectURI},
-				"client_id":    {clientID},
-			}
-			if clientSecret != "" {
-				tokenParams.Set("client_secret", clientSecret)
-			}
-
-			resp, err := http.PostForm(tokenURL, tokenParams)
-			if err != nil {
-				return fmt.Errorf("exchanging code for token: %w", err)
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode >= 400 {
-				var body map[string]any
-				if err := json.NewDecoder(resp.Body).Decode(&body); err == nil {
-					return fmt.Errorf("exchanging code for token: HTTP %d: %v", resp.StatusCode, body)
-				}
-				return fmt.Errorf("exchanging code for token: HTTP %d", resp.StatusCode)
-			}
-
-			var tokenResp struct {
-				AccessToken  string `json:"access_token"`
-				RefreshToken string `json:"refresh_token"`
-				ExpiresIn    int    `json:"expires_in"`
-				TokenType    string `json:"token_type"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-				return fmt.Errorf("parsing token response: %w", err)
-			}
-			if tokenResp.AccessToken == "" {
-				return fmt.Errorf("no access token in response")
-			}
-
-			// Guard against non-conformant servers that return expires_in: 0.
-			// A zero-duration expiry resolves to time.Now(), which authHeader()
-			// then treats as expired and triggers a refresh on every call.
-			expiry := time.Time{}
-			if tokenResp.ExpiresIn > 0 {
-				expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
-			}
-			if err := cfg.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, tokenResp.RefreshToken, expiry); err != nil {
-				return fmt.Errorf("saving tokens: %w", err)
-			}
-
-			if expiry.IsZero() {
-				fmt.Fprintf(os.Stderr, "%s Authentication successful! Token expiry not provided.\n", green("OK"))
-			} else {
-				fmt.Fprintf(os.Stderr, "%s Authentication successful! Token expires at %s\n", green("OK"), expiry.Format(time.RFC3339))
-			}
-			return nil
+			return runOAuthLogin(cmd, flags, clientID, clientSecret, port)
 		},
 	}
 
@@ -280,6 +132,214 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 8085, "Local callback server port")
 
 	return cmd
+}
+
+func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
+	cfg, err := config.Load(flags.configPath)
+	if err != nil {
+		return err
+	}
+	clientID, clientSecret, err = resolveOAuthCredentials(cmd, flags, cfg, clientID, clientSecret)
+	if err != nil {
+		return err
+	}
+
+	stateBytes := make([]byte, 16)
+	if _, err := rand.Read(stateBytes); err != nil {
+		return fmt.Errorf("generating state: %w", err)
+	}
+	state := hex.EncodeToString(stateBytes)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("starting callback server: %w", err)
+	}
+	defer listener.Close()
+
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", listener.Addr().(*net.TCPAddr).Port)
+
+	authURL := ""
+{{- if .Auth.AuthorizationURL}}
+	authURL = cfg.AuthorizationURL
+	if authURL == "" {
+		authURL = "{{.Auth.AuthorizationURL}}"
+	}
+{{- end}}
+{{- $refreshMech := .Auth.ParseRefreshTokenMechanism}}
+	params := url.Values{
+		"client_id":     {clientID},
+		"redirect_uri":  {redirectURI},
+		"response_type": {"code"},
+		"state":         {state},
+	}
+{{- if eq $refreshMech.Kind "query"}}
+	params.Set({{printf "%q" $refreshMech.Key}}, {{printf "%q" $refreshMech.Value}})
+{{- end}}
+	scopes := []string{ {{- range .Auth.Scopes}}"{{.}}", {{end}} }
+{{- if eq $refreshMech.Kind "scope"}}
+	scopes = append(scopes, {{printf "%q" $refreshMech.Scope}})
+{{- end}}
+	if len(scopes) > 0 {
+		params.Set("scope", strings.Join(scopes, " "))
+	}
+
+	fullURL := authURL + "?" + params.Encode()
+	fmt.Fprintf(os.Stderr, "Opening browser for authentication...\n")
+	fmt.Fprintf(os.Stderr, "If the browser doesn't open, visit:\n%s\n\n", fullURL)
+	openBrowser(fullURL)
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			errCh <- fmt.Errorf("state mismatch")
+			http.Error(w, "State mismatch", http.StatusBadRequest)
+			return
+		}
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			errCh <- fmt.Errorf("auth error: %s", errMsg)
+			http.Error(w, errMsg, http.StatusBadRequest)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- fmt.Errorf("no code in callback")
+			http.Error(w, "No code", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html><body><h2>Authentication successful!</h2><p>You can close this tab.</p></body></html>")
+		codeCh <- code
+	})
+
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return err
+	case <-time.After(2 * time.Minute):
+		return fmt.Errorf("authentication timed out after 2 minutes")
+	}
+
+	server.Shutdown(context.Background())
+
+	tokenURL := ""
+{{- if .Auth.TokenURL}}
+	tokenURL = cfg.TokenURL
+	if tokenURL == "" {
+		tokenURL = "{{.Auth.TokenURL}}"
+	}
+{{- end}}
+	tokenParams := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {redirectURI},
+		"client_id":    {clientID},
+	}
+	if clientSecret != "" {
+		tokenParams.Set("client_secret", clientSecret)
+	}
+
+	resp, err := http.PostForm(tokenURL, tokenParams)
+	if err != nil {
+		return fmt.Errorf("exchanging code for token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err == nil {
+			return fmt.Errorf("exchanging code for token: HTTP %d: %v", resp.StatusCode, body)
+		}
+		return fmt.Errorf("exchanging code for token: HTTP %d", resp.StatusCode)
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return fmt.Errorf("parsing token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return fmt.Errorf("no access token in response")
+	}
+
+	// Guard against non-conformant servers that return expires_in: 0.
+	// A zero-duration expiry resolves to time.Now(), which authHeader()
+	// then treats as expired and triggers a refresh on every call.
+	expiry := time.Time{}
+	if tokenResp.ExpiresIn > 0 {
+		expiry = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	}
+	if err := cfg.SaveTokens(clientID, clientSecret, tokenResp.AccessToken, tokenResp.RefreshToken, expiry); err != nil {
+		return fmt.Errorf("saving tokens: %w", err)
+	}
+
+	if expiry.IsZero() {
+		fmt.Fprintf(os.Stderr, "%s Authentication successful! Token expiry not provided.\n", green("OK"))
+	} else {
+		fmt.Fprintf(os.Stderr, "%s Authentication successful! Token expires at %s\n", green("OK"), expiry.Format(time.RFC3339))
+	}
+	return nil
+}
+
+func resolveOAuthCredentials(cmd *cobra.Command, flags *rootFlags, cfg *config.Config, clientID, clientSecret string) (string, string, error) {
+	explicitClientID := clientID
+	if clientID == "" && cfg != nil {
+		clientID = cfg.ClientID
+	}
+	if clientSecret == "" && cfg != nil && (explicitClientID == "" || explicitClientID == cfg.ClientID) {
+		clientSecret = cfg.ClientSecret
+	}
+	if clientID != "" {
+		return clientID, clientSecret, nil
+	}
+	if flags.noInput {
+		return "", "", fmt.Errorf("OAuth2 client ID is required; pass --client-id, set {{envName .Name}}_CLIENT_ID, or run '{{.Name}}-pp-cli login' without --no-input")
+	}
+	reader := bufio.NewReader(cmd.InOrStdin())
+	printOAuthCredentialHint(cmd.ErrOrStderr())
+	clientID, err := promptOAuthCredential(cmd, reader, "OAuth2 Client ID")
+	if err != nil {
+		return "", "", err
+	}
+	if clientID == "" {
+		return "", "", fmt.Errorf("OAuth2 client ID is required")
+	}
+	if clientSecret == "" {
+		clientSecret, err = promptOAuthCredential(cmd, reader, "OAuth2 Client Secret (press Enter if not required)")
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return clientID, clientSecret, nil
+}
+
+func printOAuthCredentialHint(w io.Writer) {
+{{- if .Auth.KeyURL}}
+	fmt.Fprintln(w, "Create OAuth credentials at: {{.Auth.KeyURL}}")
+{{- else if .WebsiteURL}}
+	fmt.Fprintln(w, "See API docs for OAuth app registration: {{.WebsiteURL}}")
+{{- else}}
+	fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
+{{- end}}
+}
+
+func promptOAuthCredential(cmd *cobra.Command, reader *bufio.Reader, label string) (string, error) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s: ", label)
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" && err != io.EOF {
+		return "", fmt.Errorf("reading %s: %w", strings.ToLower(label), err)
+	}
+	return strings.TrimSpace(line), nil
 }
 
 func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
@@ -306,7 +366,7 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if !authed {
-				fmt.Fprintf(w, "  %s Not authenticated. Run 'auth login' to authenticate.\n", red("FAIL"))
+				fmt.Fprintf(w, "  %s Not authenticated. Run '{{.Name}}-pp-cli login' to authenticate.\n", red("FAIL"))
 				return nil
 			}
 
@@ -318,7 +378,7 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				if cfg.RefreshToken != "" {
 					fmt.Fprintf(w, "  %s Token expired (will auto-refresh on next request)\n", yellow("WARN"))
 				} else {
-					fmt.Fprintf(w, "  %s Token expired. Run 'auth login' to re-authenticate.\n", red("FAIL"))
+					fmt.Fprintf(w, "  %s Token expired. Run '{{.Name}}-pp-cli login' to re-authenticate.\n", red("FAIL"))
 				}
 			}
 

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -279,8 +279,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- else}}
 					report["auth"] = "not configured"
 {{- end}}
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
+					report["auth_hint"] = "{{.Name}}-pp-cli login"
+{{- else}}
 {{- with $canonicalEnvVar}}
 					report["auth_hint"] = "export {{.Name}}=<your-key>"
+{{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
 					report["auth_key_url"] = "{{.Auth.KeyURL}}"

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -352,6 +352,9 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 {{- end}}
 {{- if .HasAuthCommand}}
 	rootCmd.AddCommand(newAuthCmd(flags))
+{{- if and .Auth.AuthorizationURL (not (and (eq .Auth.EffectiveOAuth2Grant "client_credentials") .Auth.TokenURL))}}
+	rootCmd.AddCommand(newAuthLoginCmd(flags))
+{{- end}}
 {{- end}}
 	rootCmd.AddCommand(newAgentContextCmd(rootCmd))
 	rootCmd.AddCommand(newProfileCmd(flags))

--- a/internal/spec/reserved_drift_test.go
+++ b/internal/spec/reserved_drift_test.go
@@ -143,15 +143,15 @@ func TestReservedCobraUseNames_CobratreeIsSubset(t *testing.T) {
 }
 
 // TestReservedCobraUseNames_NoSubcommandLeakage pins the negative: common
-// subcommand verbs (e.g., `auth login`, `jobs list`) must not appear in
+// subcommand-only verbs (e.g., `jobs list`) must not appear in
 // ReservedCobraUseNames. Including them would falsely block very common
 // API resource names. The constructor-resolution mechanism excludes them
 // by construction; this test fails loudly if that mechanism regresses.
 func TestReservedCobraUseNames_NoSubcommandLeakage(t *testing.T) {
-	subcommandVerbs := []string{"login", "logout", "list", "archive", "prune", "refresh", "save", "use"}
+	subcommandVerbs := []string{"logout", "list", "archive", "prune", "refresh", "save", "use"}
 	for _, verb := range subcommandVerbs {
 		if _, ok := spec.ReservedCobraUseNames[verb]; ok {
-			t.Errorf("ReservedCobraUseNames contains %q which is a subcommand verb (e.g., `auth login`, `jobs list`); blocking it would falsely reject very common API resource names.", verb)
+			t.Errorf("ReservedCobraUseNames contains %q which is a subcommand-only verb (e.g., `jobs list`); blocking it would falsely reject very common API resource names.", verb)
 		}
 	}
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2062,6 +2062,7 @@ var ReservedCobraUseNames = map[string]struct{}{
 	"import":         {},
 	"jobs":           {},
 	"learnings":      {},
+	"login":          {},
 	"load":           {},
 	"orphans":        {},
 	"profile":        {},
@@ -2091,6 +2092,9 @@ func (s *APISpec) ParseTimeReservedCobraUseName(name string) bool {
 	kebab := snakeToKebab(name)
 	if kebab == "auth" {
 		return s.emitsAuthCommand()
+	}
+	if kebab == "login" {
+		return s.emitsTopLevelOAuthLogin()
 	}
 	if kebab == "health" {
 		return false
@@ -2128,6 +2132,14 @@ func (s *APISpec) emitsAuthCommand() bool {
 	// Traffic-analysis-only auth is not known at parse time; the generator
 	// handles that conditional collision once traffic hints are attached.
 	return s.Auth.Type != "none" || s.Auth.AuthorizationURL != ""
+}
+
+func (s *APISpec) emitsTopLevelOAuthLogin() bool {
+	if s == nil {
+		return false
+	}
+	return s.Auth.AuthorizationURL != "" &&
+		(s.Auth.EffectiveOAuth2Grant() != OAuth2GrantClientCredentials || s.Auth.TokenURL == "")
 }
 
 // validateReservedNames rejects specs whose top-level resource names would

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3752,6 +3752,72 @@ resources:
 		require.NoError(t, err)
 	})
 
+	t.Run("login resource is rejected for oauth2 auth-code CLIs", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: oauth2
+  authorization_url: https://auth.example.com/oauth/authorize
+  token_url: https://auth.example.com/oauth/token
+resources:
+  login:
+    description: API login endpoint
+    endpoints:
+      create:
+        method: POST
+        path: /login
+        description: Log in
+`
+		_, err := ParseBytes([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"login"`)
+		assert.Contains(t, err.Error(), "shadow framework cobra command")
+	})
+
+	t.Run("login resource is rejected for bearer auth-code CLIs", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  authorization_url: https://auth.example.com/oauth/authorize
+  token_url: https://auth.example.com/oauth/token
+resources:
+  login:
+    description: API login endpoint
+    endpoints:
+      create:
+        method: POST
+        path: /login
+        description: Log in
+`
+		_, err := ParseBytes([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"login"`)
+		assert.Contains(t, err.Error(), "shadow framework cobra command")
+	})
+
+	t.Run("login resource passes for non-oauth CLIs", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+resources:
+  login:
+    description: API login endpoint
+    endpoints:
+      create:
+        method: POST
+        path: /login
+        description: Log in
+`
+		_, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+	})
+
 	t.Run("substring matches are NOT rejected", func(t *testing.T) {
 		t.Parallel()
 		// `versioning_history` contains `version` as a substring but is


### PR DESCRIPTION
## Summary
Fresh OAuth auth-code CLIs now give users the command they expect: `<binary> login` starts the same browser login flow as `auth login`, prompts once for missing OAuth app credentials, and then reuses the saved Client ID/Secret on later logins.

This keeps scripted callers working with `--client-id` / `--client-secret`, avoids pairing a new Client ID with a stale saved secret, and updates doctor/setup/status guidance away from the confusing bearer-token export hint. The top-level login command is also hidden from MCP shell-out mirroring so agents do not get an interactive browser credential tool.

Closes #1048

## Verification
- `go test ./internal/generator ./internal/spec -run 'TestOAuthLoginTopLevelCommand|TestValidateFrameworkCobraCollisions|TestReservedCobraUseNames' -count=1`\n- `scripts/golden.sh verify`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n- `golangci-lint run ./...`\n- `go test ./...`