### PR TITLE
fix(cli): wire GraphQL list arguments into the query operation

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -269,9 +269,24 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"mcpParamDesc":                       g.mcpParamDescription,
 		"flagName":                           flagName,
 		"paramIdent":                         paramIdent,
-		"paramWireName":                      paramWireName,
-		"typeFieldIdent":                     typeFieldIdent,
-		"safeTypeName":                       safeTypeName,
+		// isWirableListArg reports whether a GraphQL list-field param should be
+		// wired as an operation variable: a non-pagination, non-positional,
+		// non-path arg that carries a (scalar) GraphQL type. Keeps the
+		// "wirable arg" definition in one place across the command and query
+		// templates so they can't drift.
+		"isWirableListArg": func(p spec.Param) bool {
+			if p.Positional || p.PathParam || p.GraphQLType == "" {
+				return false
+			}
+			switch p.Name {
+			case "first", "after", "last", "before":
+				return false
+			}
+			return true
+		},
+		"paramWireName":  paramWireName,
+		"typeFieldIdent": typeFieldIdent,
+		"safeTypeName":   safeTypeName,
 		"hasNonScalarType": func(types map[string]spec.TypeDef) bool {
 			for _, td := range types {
 				for _, f := range td.Fields {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11543,6 +11543,75 @@ func TestGenerateGraphQLCompiles(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGenerateGraphQLListWiresNonPaginationArgsIntoVariables(t *testing.T) {
+	t.Parallel()
+
+	const sdl = `enum IssueOrder {
+  CREATED_AT
+  UPDATED_AT
+}
+
+type Query {
+  issues(first: Int, after: String, query: String, minComments: Int, orderBy: IssueOrder, requiredFilter: String!, labels: [String!]): IssueConnection
+  issue(id: String!): Issue
+}
+
+type IssueConnection {
+  nodes: [Issue]
+  pageInfo: PageInfo
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+
+type Issue {
+  id: ID!
+  title: String!
+}`
+
+	sdlPath := filepath.Join(t.TempDir(), "graphql_query_arg.graphql")
+	require.NoError(t, os.WriteFile(sdlPath, []byte(sdl), 0o600))
+
+	gqlSpec, err := graphql.ParseSDL(sdlPath)
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	require.NoError(t, New(gqlSpec, outputDir).Generate())
+
+	issuesGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "issues_list.go"))
+	require.NoError(t, err)
+	content := string(issuesGo)
+
+	assert.Contains(t, content, `StringVar(&flagQuery, "query"`, "list arg flag should be registered")
+	assert.Contains(t, content, `variables["query"] = flagQuery`, "non-pagination list args should be wired into GraphQL variables")
+	assert.Contains(t, content, `variables["minComments"] = flagMinComments`, "integer list args should be wired into GraphQL variables")
+	assert.Contains(t, content, `variables["orderBy"] = flagOrderBy`, "enum list args should be wired into GraphQL variables")
+	assert.Contains(t, content, `variables["requiredFilter"] = flagRequiredFilter`, "required list args must be wired into GraphQL variables")
+	assert.NotContains(t, content, `if flagRequiredFilter != `,
+		"a required list arg must be assigned unconditionally (not gated on the zero-value) — otherwise it's dropped at default and the required operation variable breaks the request")
+
+	queriesGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "queries.go"))
+	require.NoError(t, err)
+	queriesContent := string(queriesGo)
+	assert.Contains(t, queriesContent, `query($first: Int!, $after: String, $query: String, $minComments: Int, $orderBy: IssueOrder, $requiredFilter: String!) {`,
+		"list query should declare non-pagination operation vars with raw GraphQL types (incl. required ! types)")
+	assert.Contains(t, queriesContent, `issues(first: $first, after: $after, query: $query, minComments: $minComments, orderBy: $orderBy, requiredFilter: $requiredFilter) {`,
+		"list query should pass non-pagination args into the field call")
+
+	// List/array args (labels: [String!]) are intentionally left unwired: the
+	// generated flag is a scalar StringVar that can't satisfy a list variable,
+	// so wiring it would emit a type-mismatched request. They stay inert
+	// (absent from both the operation and the variables map) rather than break.
+	assert.NotContains(t, queriesContent, "$labels",
+		"list-typed args must be skipped in the operation (scalar flag can't satisfy a list variable)")
+	assert.NotContains(t, content, `variables["labels"]`,
+		"list-typed args must not be wired into GraphQL variables")
+
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
 func TestGraphQLFieldSelectionSupportsNestedSelections(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -179,6 +179,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if flagAfter != "" {
 				variables["after"] = flagAfter
 			}
+{{- range .Endpoint.Params}}
+{{- if isWirableListArg .}}
+{{- if .Required}}
+			variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
+{{- else}}
+			if flag{{camel (paramIdent .)}} != {{zeroValForParam .Name .Type}} {
+				variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
+			}
+{{- end}}
+{{- end}}
+{{- end}}
 {{- if $supportsAllPagination}}
 			var data json.RawMessage
 			if flagAll && !flags.dryRun {

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -9,8 +9,8 @@ package client
 {{- if eq $eName "list"}}
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}
 
-const {{pascal $rName}}ListQuery = {{backtick}}query($first: Int!, $after: String) {
-  {{$queryField}}(first: $first, after: $after) {
+const {{pascal $rName}}ListQuery = {{backtick}}query($first: Int!, $after: String{{- range $endpoint.Params}}{{- if isWirableListArg .}}, ${{.Name}}: {{.GraphQLType}}{{- end}}{{- end}}) {
+  {{$queryField}}(first: $first, after: $after{{- range $endpoint.Params}}{{- if isWirableListArg .}}, {{.Name}}: ${{.Name}}{{- end}}{{- end}}) {
     nodes {
 {{- range graphqlFieldSelection $endpoint.Response.Item $.Types}}
       {{.}}

--- a/internal/graphql/parser.go
+++ b/internal/graphql/parser.go
@@ -463,6 +463,15 @@ func mapArg(arg gqlArg, enumMap map[string][]string) spec.Param {
 		Required: required,
 		Format:   format,
 	}
+	// Preserve the raw GraphQL type only for scalar args. List/array args
+	// (e.g. [String!]) are left unset so the list-query template and the
+	// variables wiring skip them: the generated flag is a scalar StringVar
+	// that can't satisfy a list-typed operation variable, so wiring it would
+	// emit a type-mismatched request. Leaving them unwired keeps the prior
+	// (inert) behavior until list-typed flags are supported.
+	if !strings.Contains(arg.Type, "[") {
+		param.GraphQLType = strings.TrimSpace(arg.Type)
+	}
 	if enumValues := enumMap[unwrapType(arg.Type)]; len(enumValues) > 0 {
 		param.Enum = append([]string(nil), enumValues...)
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1769,7 +1769,11 @@ type Param struct {
 	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
 	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
 	Format      string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
-	Purpose     string   `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	// GraphQLType is the raw GraphQL type ref (for example String, ID!,
+	// OrderSortKeys, [ID!]). It is set only for GraphQL-sourced params and
+	// used to emit operation variable declarations.
+	GraphQLType string `yaml:"graphql_type,omitempty" json:"graphql_type,omitempty"`
+	Purpose     string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
 	// FieldSelectorDefault is a sync-time default for field-selector params
 	// such as opt_fields, fields, expand, include, or select. It stays separate
 	// from Default so generated endpoint commands do not silently change their


### PR DESCRIPTION
## Intent

Issue: Closes #2058

GraphQL `<resource> list` commands declared and registered flags for the underlying field's arguments (e.g. `--query` for a `$query: String` arg) and advertised them in `--help`, but the argument was silently ignored — the command ran unfiltered. Caught on shopify-pp-cli for `orders`, `customers`, `products`, `inventory-items`, `abandoned-checkouts`.

## Approach

The arg was dropped at **two** layers; both are fixed so it actually reaches the server:
1. **Command** (`command_endpoint.go.tmpl`): the list block only put pagination args (`first`/`after`) into the `variables` map. Now it assigns every declared non-pagination, non-positional, non-path scalar list arg into `variables` when set.
2. **Operation** (`graphql_queries.go.tmpl`): the generated query only *declared* `query($first, $after)` and passed only those to the field — so even a transport variable would be ignored by the server. Now it declares each non-pagination arg as an operation variable with its real GraphQL type and passes it into the field: `query($first: Int!, $after: String, $query: String, $orderBy: IssueOrder) { issues(first: $first, after: $after, query: $query, orderBy: $orderBy) {…} }`.
3. **Type preservation** (`spec.Param.GraphQLType`, populated in `internal/graphql/parser.go`): emitting a valid operation-variable declaration needs the raw GraphQL type, but `mapGraphQLType` collapses `String`/`ID`/enums/custom-scalars to a single Go kind. So the raw arg type ref is preserved on the param (GraphQL-only; `omitempty`; never set for OpenAPI). A lossy reverse-map would emit invalid operations for enum/custom-scalar args.

Generalizes beyond `--query` to any scalar GraphQL list field argument (the test covers `query: String`, `minComments: Int`, and an enum `orderBy: IssueOrder`, asserting the real types appear in the operation).

**Scoping — list/array args stay inert (no regression):** a list-typed arg like `labels: [String!]` is intentionally left unwired. Its generated flag is a scalar `StringVar`, which can't satisfy a list-typed operation variable — wiring it would emit a *type-mismatched* request, which is worse than the prior silent-drop. So array args are skipped in both the operation and the variables map (kept inert, exactly as before) until list-typed flags are supported. The test asserts `labels` appears in neither. This was surfaced by code review and addressed so the change introduces no new failure mode.

## Scope

Primary area: generator templates (GraphQL list command + query operation) + GraphQL parser/spec (`GraphQLType`).

Why this belongs in this repo: machine change; every printed GraphQL CLI inherits working list-field filtering on next generate.

## Catalog Justification

N/A

## Risk

Low. Scalar list args now reach the server (the fix); array args remain inert (no regression). `GraphQLType` is GraphQL-only + `omitempty`, so OpenAPI generation is untouched (golden 24/24, no drift). The generated CLI is compiled in-test.

## Output Contract

Generated GraphQL `<Resource>ListQuery` now declares + passes scalar non-pagination args with their real types; the list command wires them into `variables`. `spec.Param` gains a `graphql_type` field (omitempty). No golden fixture changed (the GraphQL golden's list field has only pagination args).

## Verification

- `go test ./...` — pass. Test asserts the operation string declares + passes `query`/`minComments`/`orderBy` with real types (incl. the enum), the command wires them into `variables`, the array arg `labels` is wired in neither, and the generated CLI compiles. Confirmed the operation-string assertions fail against the pre-fix template.
- `scripts/golden.sh verify` — 24/24 pass
- `gofmt` / `golangci-lint run ./internal/graphql/... ./internal/generator/... ./internal/spec/...` — clean

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
