### PR TITLE
refactor(cli): collapse Recall *entities.Config into Opts.EntityConfig

### DIFF
--- a/internal/generator/templates/learn/recall.go.tmpl
+++ b/internal/generator/templates/learn/recall.go.tmpl
@@ -67,9 +67,15 @@ type Result struct {
 //	MinConfidence -> 1 (any row)
 //	Limit         -> 10
 //	JaccardMin    -> 0.6
+//	EntityConfig  -> entities.NewConfig() (default English stopwords, no ticker patterns)
 //
 // DebugMismatches surfaces the mismatches array in the envelope.
 // NoLearn short-circuits to an empty envelope.
+//
+// EntityConfig is the per-CLI entity extractor config built once at
+// startup. Carried on Opts rather than positionally so callers that
+// don't need per-CLI configuration (legacy prediction-goat lineage,
+// future opt-out CLIs) can pass Opts{} and inherit defaults.
 //
 // ResourceTypeFields maps each resource_type to the ordered list of
 // JSON fields ResourceEntitiesFromJSON should read to pull entity
@@ -85,18 +91,24 @@ type Opts struct {
 	JaccardMin         float64
 	DebugMismatches    bool
 	NoLearn            bool
+	EntityConfig       *entities.Config
 	ResourceTypeFields map[string][]string
 	PatternKinds       []string
 }
 
-// Recall is the entity-aware read path. cfg is the per-CLI entity
-// extractor config built once at startup; db is the open *sql.DB
-// pointing at the local SQLite store with the v3 learn schema.
+// Recall is the entity-aware read path. db is the open *sql.DB
+// pointing at the local SQLite store with the v3 learn schema; the
+// per-CLI entity extractor config is carried on opts.EntityConfig
+// (nil falls back to entities.NewConfig() defaults).
 //
 // Returns a non-nil Result on every call: cold queries get the
 // envelope shape populated with the normalized form and the query
 // entities. Errors are reserved for DB-level failures.
-func Recall(ctx context.Context, db *sql.DB, cfg *entities.Config, query string, opts Opts) (Result, error) {
+func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, error) {
+	cfg := opts.EntityConfig
+	if cfg == nil {
+		cfg = entities.NewConfig()
+	}
 	normalized := Normalize(query, cfg)
 	result := Result{
 		Query:         query,

--- a/internal/generator/templates/learn/recall_test.go.tmpl
+++ b/internal/generator/templates/learn/recall_test.go.tmpl
@@ -93,7 +93,8 @@ func TestRecall_HappyPath(t *testing.T) {
 	// matcher expects.
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 3)
 
-	got, err := Recall(context.Background(), db, testConfig(), "Alpha widget", Opts{
+	got, err := Recall(context.Background(), db, "Alpha widget", Opts{
+		EntityConfig:       testConfig(),
 		ResourceTypeFields: map[string][]string{"widgets": {"title"}},
 	})
 	if err != nil {
@@ -113,7 +114,7 @@ func TestRecall_HappyPath(t *testing.T) {
 func TestRecall_Miss(t *testing.T) {
 	t.Parallel()
 	db := openRecallTestDB(t)
-	got, err := Recall(context.Background(), db, testConfig(), "totally unrelated query", Opts{})
+	got, err := Recall(context.Background(), db, "totally unrelated query", Opts{EntityConfig: testConfig()})
 	if err != nil {
 		t.Fatalf("recall: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestRecall_NoLearnReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	db := openRecallTestDB(t)
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 3)
-	got, err := Recall(context.Background(), db, testConfig(), "Alpha widget", Opts{NoLearn: true})
+	got, err := Recall(context.Background(), db, "Alpha widget", Opts{EntityConfig: testConfig(), NoLearn: true})
 	if err != nil {
 		t.Fatalf("recall: %v", err)
 	}
@@ -151,7 +152,7 @@ func TestRecall_ConfidenceFloor(t *testing.T) {
 	db := openRecallTestDB(t)
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 1)
 	// MinConfidence=3 should drop the row.
-	got, err := Recall(context.Background(), db, testConfig(), "Alpha widget", Opts{MinConfidence: 3})
+	got, err := Recall(context.Background(), db, "Alpha widget", Opts{EntityConfig: testConfig(), MinConfidence: 3})
 	if err != nil {
 		t.Fatalf("recall: %v", err)
 	}
@@ -166,7 +167,8 @@ func TestRecall_EntityMismatchFiltersToMismatches(t *testing.T) {
 	seedRecallResource(t, db, "widgets", "PREFIX-AL", `{"title":"Alpha widget"}`)
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 3)
 	// Query a different entity entirely.
-	got, err := Recall(context.Background(), db, testConfig(), "Bravo widget", Opts{
+	got, err := Recall(context.Background(), db, "Bravo widget", Opts{
+		EntityConfig:       testConfig(),
 		DebugMismatches:    true,
 		ResourceTypeFields: map[string][]string{"widgets": {"title"}},
 	})
@@ -186,7 +188,8 @@ func TestRecall_DebugMismatchesGate(t *testing.T) {
 	db := openRecallTestDB(t)
 	seedRecallResource(t, db, "widgets", "PREFIX-AL", `{"title":"Alpha widget"}`)
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 3)
-	got, err := Recall(context.Background(), db, testConfig(), "Bravo widget", Opts{
+	got, err := Recall(context.Background(), db, "Bravo widget", Opts{
+		EntityConfig:       testConfig(),
 		ResourceTypeFields: map[string][]string{"widgets": {"title"}},
 	})
 	if err != nil {
@@ -202,7 +205,8 @@ func TestRecall_LowConfidenceWarning(t *testing.T) {
 	db := openRecallTestDB(t)
 	seedRecallResource(t, db, "widgets", "PREFIX-AL", `{"title":"Alpha widget"}`)
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 1)
-	got, err := Recall(context.Background(), db, testConfig(), "Alpha widget", Opts{
+	got, err := Recall(context.Background(), db, "Alpha widget", Opts{
+		EntityConfig:       testConfig(),
 		ResourceTypeFields: map[string][]string{"widgets": {"title"}},
 	})
 	if err != nil {
@@ -228,7 +232,7 @@ func TestRecall_ResourceNotInStoreWarning(t *testing.T) {
 	db := openRecallTestDB(t)
 	// No seeded resource; the recall still finds the learning row.
 	seedLearning(t, db, "widget", `["Alpha"]`, `["PREFIX-AL"]`, "widgets", "boost", 3)
-	got, err := Recall(context.Background(), db, testConfig(), "Alpha widget", Opts{})
+	got, err := Recall(context.Background(), db, "Alpha widget", Opts{EntityConfig: testConfig()})
 	if err != nil {
 		t.Fatalf("recall: %v", err)
 	}

--- a/internal/generator/templates/teach.go.tmpl
+++ b/internal/generator/templates/teach.go.tmpl
@@ -344,7 +344,8 @@ when learnings exist.`,
 			}
 			defer s.Close()
 
-			result, err := learn.Recall(cmd.Context(), s.DB(), learnCfg, query, learn.Opts{
+			result, err := learn.Recall(cmd.Context(), s.DB(), query, learn.Opts{
+				EntityConfig:    learnCfg,
 				MinConfidence:   minConf,
 				Limit:           limit,
 				DebugMismatches: debugMismatches,

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -1162,7 +1162,7 @@ func newRecallCmd(flags *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			db, err := store.Open("x.db")
 			if err != nil { return err }
-			hit, err := learn.Recall(cmd.Context(), db, nil, args[0])
+			hit, err := learn.Recall(cmd.Context(), db, args[0], learn.Opts{})
 			if err != nil { return err }
 			_ = hit
 			return nil

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/teach.go
@@ -344,7 +344,8 @@ when learnings exist.`,
 			}
 			defer s.Close()
 
-			result, err := learn.Recall(cmd.Context(), s.DB(), learnCfg, query, learn.Opts{
+			result, err := learn.Recall(cmd.Context(), s.DB(), query, learn.Opts{
+				EntityConfig:    learnCfg,
 				MinConfidence:   minConf,
 				Limit:           limit,
 				DebugMismatches: debugMismatches,

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/learn/recall.go
@@ -67,9 +67,15 @@ type Result struct {
 //	MinConfidence -> 1 (any row)
 //	Limit         -> 10
 //	JaccardMin    -> 0.6
+//	EntityConfig  -> entities.NewConfig() (default English stopwords, no ticker patterns)
 //
 // DebugMismatches surfaces the mismatches array in the envelope.
 // NoLearn short-circuits to an empty envelope.
+//
+// EntityConfig is the per-CLI entity extractor config built once at
+// startup. Carried on Opts rather than positionally so callers that
+// don't need per-CLI configuration (legacy prediction-goat lineage,
+// future opt-out CLIs) can pass Opts{} and inherit defaults.
 //
 // ResourceTypeFields maps each resource_type to the ordered list of
 // JSON fields ResourceEntitiesFromJSON should read to pull entity
@@ -85,18 +91,24 @@ type Opts struct {
 	JaccardMin         float64
 	DebugMismatches    bool
 	NoLearn            bool
+	EntityConfig       *entities.Config
 	ResourceTypeFields map[string][]string
 	PatternKinds       []string
 }
 
-// Recall is the entity-aware read path. cfg is the per-CLI entity
-// extractor config built once at startup; db is the open *sql.DB
-// pointing at the local SQLite store with the v3 learn schema.
+// Recall is the entity-aware read path. db is the open *sql.DB
+// pointing at the local SQLite store with the v3 learn schema; the
+// per-CLI entity extractor config is carried on opts.EntityConfig
+// (nil falls back to entities.NewConfig() defaults).
 //
 // Returns a non-nil Result on every call: cold queries get the
 // envelope shape populated with the normalized form and the query
 // entities. Errors are reserved for DB-level failures.
-func Recall(ctx context.Context, db *sql.DB, cfg *entities.Config, query string, opts Opts) (Result, error) {
+func Recall(ctx context.Context, db *sql.DB, query string, opts Opts) (Result, error) {
+	cfg := opts.EntityConfig
+	if cfg == nil {
+		cfg = entities.NewConfig()
+	}
 	normalized := Normalize(query, cfg)
 	result := Result{
 		Query:         query,


### PR DESCRIPTION
## Summary

Generated CLIs call \`learn.Recall(ctx, db, cfg, query, opts)\` with the entity config as a positional argument; prediction-goat's original shape takes \`(ctx, db, query, opts)\` with no \`cfg\` slot. This PR moves \`EntityConfig\` onto \`Opts\` so both lineages are call-compatible and future CLIs that don't need per-CLI configuration can pass \`Opts{}\` and inherit defaults.

Caller in \`teach.go.tmpl\` updated to pass via the \`EntityConfig\` field; nil falls back to \`entities.NewConfig()\` inside Recall. Golden fixture for \`generate-learn-loop-api\` updated.

## Context

This is the small prerequisite (U1) from \`docs/plans/2026-05-25-001-feat-generic-recall-rerank-middleware-plan.md\`, which is being restructured to address a larger finding: PR #2085's learn-loop templates diverged from prediction-goat in schema (composite PK vs id-based, \`resource_ids\` JSON array vs single \`resource_id\`) and dropped the \`internal/store/learnings.go\` Apply engine entirely. The Recall signature collapse here is the one piece of that restructure that's small enough to land independently and is aligned with restoring the prediction-goat call shape regardless of how the larger restructure plays out.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/generator/...\` — 1192 tests pass
- [x] \`go test ./internal/pipeline/...\` — 1706 tests pass
- [x] \`scripts/golden.sh verify\` — passes after \`golden.sh update\` regenerated the \`generate-learn-loop-api\` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)