### PR TITLE
fix(cli): reword UpsertBatch cache-index warning to not imply data loss

### DIFF
--- a/internal/generator/store_warning_wording_test.go
+++ b/internal/generator/store_warning_wording_test.go
@@ -1,0 +1,22 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateStoreUpsertBatchWarningUsesNotCachedLocallyWording(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("store-warning-wording")
+	outputDir := filepath.Join(t.TempDir(), "store-warning-wording-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc := readGeneratedFile(t, outputDir, "internal", "store", "store.go")
+	require.Contains(t, storeSrc, "not cached locally")
+	require.NotContains(t, storeSrc, "items skipped")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1087,7 +1087,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	// Warn when most items in a batch lack an extractable ID — this likely
 	// means the API uses a primary key field we don't recognize yet.
 	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
-		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items skipped (no extractable ID field found)\n", skippedCount, len(items), resourceType)
+		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 {{- if $hasDomainTable}}
 	// Surface typed-table failures without aborting the batch. Generic rows

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -999,7 +999,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	// Warn when most items in a batch lack an extractable ID — this likely
 	// means the API uses a primary key field we don't recognize yet.
 	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
-		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items skipped (no extractable ID field found)\n", skippedCount, len(items), resourceType)
+		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 	// Surface typed-table failures without aborting the batch. Generic rows
 	// already committed; only the typed projection failed.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -920,7 +920,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	// Warn when most items in a batch lack an extractable ID — this likely
 	// means the API uses a primary key field we don't recognize yet.
 	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
-		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items skipped (no extractable ID field found)\n", skippedCount, len(items), resourceType)
+		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 	// Surface typed-table failures without aborting the batch. Generic rows
 	// already committed; only the typed projection failed.


### PR DESCRIPTION
## Intent
Issue: Closes #1224

Generated `UpsertBatch()` warned `warning: N/M <resource> items skipped (no extractable ID field found)` when >50% of a batch couldn't be indexed by the local SQLite cache's PK extractor. "items skipped" reads as **data loss**, but no data is dropped — the user's stdout payload (JSON/CSV/plain) is complete; only the local cache index is incomplete.

## Approach
Reword the warning in `store.go.tmpl` to be accurate and non-alarming: "items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)". Wording-only — no change to the cache layer, extractor heuristics, or stderr progress events. (The issue's optional `--data-source` guard is intentionally out of scope.)

## Scope
Primary area: generator template (`store.go.tmpl`). Machine change; every printed CLI inherits the clearer wording.

## Catalog Justification
N/A

## Risk
Negligible — a stderr string change.

## Output Contract
Generated `internal/store/store.go` warning text changes; 2 golden store.go fixtures regenerated (the wording line only).

## Verification
- `go test ./...` — pass (new generator test asserts the new wording; a `TestCaptureTimeoutCleansTempDir` flake under local CPU contention passes in isolation)
- `scripts/golden.sh update` then inspected: only the warning line in 2 store.go fixtures
- `gofmt` / `golangci-lint run ./internal/generator/...` — clean

## AI / Automation Disclosure
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
