### PR TITLE
fix(cli): short-circuit oauth2 auth login under verify env

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1365,6 +1365,58 @@ func TestGenerateOAuth2AuthorizationCodeRegression(t *testing.T) {
 		"authorization_code spec must NOT pick the client_credentials template")
 }
 
+func TestGenerateOAuth2LoginVerifyEnvShortCircuitBeforeBrowserLaunch(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "oauth2-verifyenv-login",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:             "oauth2",
+			Header:           "Authorization",
+			Format:           "Bearer {token}",
+			OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+			AuthorizationURL: "https://api.example.com/oauth/authorize",
+			TokenURL:         "https://api.example.com/oauth/token",
+		},
+		Config: spec.ConfigSpec{Format: "toml", Path: "~/.config/oauth2-verifyenv-login-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	authBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	body := string(authBytes)
+
+	verifyIdx := strings.Index(body, "if cliutil.IsVerifyEnv() {")
+	wouldLaunchIdx := strings.Index(body, `fmt.Fprintf(w, "would launch: %s\n",`)
+	openBrowserIdx := strings.Index(body, "openBrowser(fullURL)")
+	listenIdx := strings.Index(body, `net.Listen("tcp"`)
+	require.NotEqual(t, -1, verifyIdx, "oauth2 login must short-circuit in verify mode")
+	require.NotEqual(t, -1, wouldLaunchIdx, "oauth2 login verify short-circuit must print launch URL")
+	require.NotEqual(t, -1, openBrowserIdx, "oauth2 login should still launch browser outside verify mode")
+	require.NotEqual(t, -1, listenIdx, "oauth2 login binds a callback listener outside verify mode")
+	assert.Less(t, verifyIdx, openBrowserIdx, "verify short-circuit must run before browser launch")
+	assert.Less(t, wouldLaunchIdx, openBrowserIdx, "verify short-circuit output must run before browser launch")
+	assert.Less(t, verifyIdx, listenIdx, "verify short-circuit must run before binding the callback port (no port bind in verify mode)")
+
+	// Text assertions alone pass even when the generated auth.go has a compile
+	// error (e.g. redirectURI referenced but never declared). Compile the
+	// generated module so such regressions fail this suite directly.
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 func TestGenerateOAuth2DeviceCodeAuth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -20,9 +20,7 @@ import (
 	"strings"
 	"time"
 
-{{- if or .Auth.KeyURL .WebsiteURL}}
 	"{{modulePath}}/internal/cliutil"
-{{- end}}
 	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -139,6 +137,7 @@ func newAuthLoginCmd(flags *rootFlags) *cobra.Command {
 }
 
 func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret string, port int) error {
+	w := cmd.OutOrStdout()
 	cfg, err := config.Load(flags.configPath)
 	if err != nil {
 		return err
@@ -154,14 +153,6 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 	}
 	state := hex.EncodeToString(stateBytes)
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		return fmt.Errorf("starting callback server: %w", err)
-	}
-	defer listener.Close()
-
-	redirectURI := fmt.Sprintf("http://localhost:%d/callback", listener.Addr().(*net.TCPAddr).Port)
-
 	authURL := ""
 {{- if .Auth.AuthorizationURL}}
 	authURL = cfg.AuthorizationURL
@@ -172,7 +163,6 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 {{- $refreshMech := .Auth.ParseRefreshTokenMechanism}}
 	params := url.Values{
 		"client_id":     {clientID},
-		"redirect_uri":  {redirectURI},
 		"response_type": {"code"},
 		"state":         {state},
 	}
@@ -187,7 +177,31 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 		params.Set("scope", strings.Join(scopes, " "))
 	}
 
+	// Short-circuit BEFORE binding the callback port or opening a browser, so
+	// verify / validate-narrative neither binds 127.0.0.1:<port> (which would
+	// EADDRINUSE on a parallel run or occupied port) nor launches a browser
+	// (which would time out). The redirect_uri shown here is informational and
+	// derived from the configured --port; the live flow below uses the actual
+	// bound port, which the OS assigns when --port 0 is passed.
+	if cliutil.IsVerifyEnv() {
+		params.Set("redirect_uri", fmt.Sprintf("http://localhost:%d/callback", port))
+		fmt.Fprintf(w, "would launch: %s\n", authURL+"?"+params.Encode())
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("starting callback server: %w", err)
+	}
+	defer listener.Close()
+
+	// Derive the redirect URI from the live listener address so an OS-assigned
+	// ephemeral port (--port 0) is reflected in both the auth request and the
+	// token exchange below.
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", listener.Addr().(*net.TCPAddr).Port)
+	params.Set("redirect_uri", redirectURI)
 	fullURL := authURL + "?" + params.Encode()
+
 	fmt.Fprintf(os.Stderr, "Opening browser for authentication...\n")
 	fmt.Fprintf(os.Stderr, "If the browser doesn't open, visit:\n%s\n\n", fullURL)
 	openBrowser(fullURL)


### PR DESCRIPTION
## Intent
Issue: Closes #1059

The generator-emitted oauth2 `auth login` (`runOAuthLogin` in `auth.go.tmpl`) had no `cliutil.IsVerifyEnv()` short-circuit, so under `PRINTING_PRESS_VERIFY=1` (verify / `validate-narrative --full-examples`) it opened a real browser, bound the callback server (port 8085), and timed out after 2 minutes — failing the quickstart example. The sibling `newAuthSetupCmd` in the same template already guards correctly.

## Approach
Add the same `if cliutil.IsVerifyEnv() { fmt.Fprintf(w, "would launch: %s\n", fullURL); return nil }` short-circuit to `runOAuthLogin` — placed after flag validation but before any side effect (callback bind / openBrowser / wait). Make the `cliutil` import unconditional in this template since `runOAuthLogin` now always references it (it was previously gated on `KeyURL`/`WebsiteURL`, which an oauth2 spec may not set — that omission caused an `undefined: cliutil` compile error until the import was unconditioned).

## Scope
Primary area: generator template (`auth.go.tmpl`, the oauth2 authorization-code auth surface). Machine change.

## Catalog Justification
N/A

## Risk
Low. Verify-mode now prints "would launch" instead of opening a browser; real `auth login` behavior is unchanged. No golden fixture exercises this template (oauth2-cc uses a different auth template), so no golden diff; coverage is a generator test that compiles the generated oauth2 CLI.

## Output Contract
Generated oauth2 `auth.go` `runOAuthLogin` gains the verify short-circuit; `cliutil` is now always imported in that template.

## Verification
- `go test ./...` — pass (new `TestGenerateOAuth2LoginVerifyEnvShortCircuitBeforeBrowserLaunch` asserts the guard precedes `openBrowser`; the generator compile-tests that build an oauth2 CLI confirm the import fix)
- `scripts/golden.sh update` — no diff (template not in any golden fixture)
- `gofmt` / `golangci-lint run ./internal/generator/...` — clean

## AI / Automation Disclosure
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
