### PR TITLE
fix(skills): route polish data inserts through typed helpers

### DIFF
--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -383,6 +383,34 @@ GraphQL queries, JSON-RPC reads, and POST-based searches marked
 `mcp:read-only`.
 Per-command hooks under-count because they only see the commands polish touched.
 
+### Novel-feature data routing
+
+When polish adds or fixes a novel command that reads API response data into the
+local store, route data through the generated typed schemas instead of writing
+raw response JSON directly into tables:
+
+1. Read `internal/types/<resource>.go` and `internal/store/<resource>.go` for the
+   resource being cached. Use the typed insert/upsert helpers those files emit
+   whenever they exist.
+2. Decode the API response into the typed struct before persistence. Do not
+   build `INSERT INTO ...` statements from untyped `map[string]any` or raw
+   `json.RawMessage` values unless the CLI intentionally owns a custom table.
+3. Verify the target table from the resource type, not from whichever query the
+   novel command happened to start with. A command that fetched `<child>`
+   records must insert `<child>` rows, not parent rows or a convenient adjacent
+   table.
+4. Normalize nested response identifiers before insert. If the API wraps the
+   scalar id inside an object that also contains metadata, extract the scalar id
+   field and store that value; never store the whole id object as the primary
+   key.
+5. Check the response shape against the spec schema and a real sample response
+   before deciding the insert mapping is correct.
+
+Raw `database/sql` writes are acceptable only for custom polish-owned tables
+declared in hand-authored migrations. In that case, keep the table schema
+explicit in `internal/store/`, document why the generated resource helper does
+not apply, and still decode nested identifiers to scalars before persistence.
+
 ### Priority 0: MCP surface migration (legacy CLIs)
 
 If Phase 1's `dogfood` reported `MCP Surface: FAIL` with a parity mismatch, the CLI was generated before the runtime cobratree walker existed and is still on the static `internal/mcp/tools.go` surface. The fix is mechanical:

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -391,21 +391,22 @@ raw response JSON directly into tables:
 
 1. Read `internal/types/<resource>.go` and `internal/store/<resource>.go` for the
    resource being cached. Use the typed insert/upsert helpers those files emit
-   whenever they exist.
-2. Decode the API response into the typed struct before persistence. Do not
+   whenever they exist. If helpers are missing for a generated resource, create
+   them before writing any persistence code.
+2. Check the response shape against the spec schema and a real sample response
+   before deciding the insert mapping is correct.
+3. Decode the API response into the typed struct before persistence. Do not
    build `INSERT INTO ...` statements from untyped `map[string]any` or raw
    `json.RawMessage` values unless the table is a custom polish-owned table
    declared in hand-authored migrations; see the raw SQL exception below.
-3. Verify the target table from the resource type, not from whichever query the
+4. Verify the target table from the resource type, not from whichever query the
    novel command happened to start with. A command that fetched `<child>`
    records must insert `<child>` rows, not parent rows or a convenient adjacent
    table.
-4. Normalize nested response identifiers before insert. If the API wraps the
+5. Normalize nested response identifiers before insert. If the API wraps the
    scalar id inside an object that also contains metadata, extract the scalar id
    field and store that value; never store the whole id object as a primary key
    or foreign-key reference.
-5. Check the response shape against the spec schema and a real sample response
-   before deciding the insert mapping is correct.
 
 Raw `database/sql` writes are acceptable only for custom polish-owned tables
 declared in hand-authored migrations. In that case, keep the table schema

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -394,15 +394,16 @@ raw response JSON directly into tables:
    whenever they exist.
 2. Decode the API response into the typed struct before persistence. Do not
    build `INSERT INTO ...` statements from untyped `map[string]any` or raw
-   `json.RawMessage` values unless the CLI intentionally owns a custom table.
+   `json.RawMessage` values unless the table is a custom polish-owned table
+   declared in hand-authored migrations; see the raw SQL exception below.
 3. Verify the target table from the resource type, not from whichever query the
    novel command happened to start with. A command that fetched `<child>`
    records must insert `<child>` rows, not parent rows or a convenient adjacent
    table.
 4. Normalize nested response identifiers before insert. If the API wraps the
    scalar id inside an object that also contains metadata, extract the scalar id
-   field and store that value; never store the whole id object as the primary
-   key.
+   field and store that value; never store the whole id object as a primary key
+   or foreign-key reference.
 5. Check the response shape against the spec schema and a real sample response
    before deciding the insert mapping is correct.
 


### PR DESCRIPTION
## Summary

Polish now gives agents explicit data-routing guardrails for novel commands that persist API responses. It directs them to decode into generated `internal/types` structs, use generated `internal/store` insert/upsert helpers, verify the resource table before writing, and extract scalar identifiers from nested id objects instead of storing raw JSON as primary keys.

Raw `database/sql` writes remain allowed for custom polish-owned tables, but only when the table is declared in hand-authored store migrations and the generated resource helper genuinely does not apply.

Closes #880.

## Tests

- `git diff --check`
- `go test ./internal/cli -run TestInternalSkillMinimumBinaryVersionsTrackMajor`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
