### PR TITLE
fix(skills): gate large MCP endpoint surfaces

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -30,6 +30,7 @@ func TestPrintingPressSkillMCPEnrichmentGate(t *testing.T) {
 	content := string(data)
 	require.Contains(t, content, "Mandatory >50 endpoint-tools gate")
 	require.Contains(t, content, "spec exposes <N> MCP endpoint tools (>50 threshold)")
+	require.Contains(t, content, "actual numeric count printed by the generator")
 	require.Contains(t, content, "AskUserQuestion")
 	require.Contains(t, content, "Apply Cloudflare MCP pattern + regenerate (recommended)")
 	require.Contains(t, content, "OpenAPI input: write or update a root `x-mcp:` block")

--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -20,3 +20,19 @@ func TestPrintingPressSkillSideEffectNarrativeGuidance(t *testing.T) {
 	require.Contains(t, content, "These warnings do not fail strict aggregation")
 	require.Contains(t, content, "Non-side-effect unsupported examples still fail strict mode")
 }
+
+func TestPrintingPressSkillMCPEnrichmentGate(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "Mandatory >50 endpoint-tools gate")
+	require.Contains(t, content, "spec exposes <N> MCP endpoint tools (>50 threshold)")
+	require.Contains(t, content, "AskUserQuestion")
+	require.Contains(t, content, "Apply Cloudflare MCP pattern + regenerate (recommended)")
+	require.Contains(t, content, "OpenAPI input: write or update a root `x-mcp:` block")
+	require.Contains(t, content, "Internal YAML input: write or update the root `mcp:` block")
+	require.Contains(t, content, "If the runtime cannot ask a blocking question, stop")
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2415,8 +2415,9 @@ The total is what an agent loads at MCP server start.
 
 **Mandatory >50 endpoint-tools gate.** If the pre-generation count predicts
 more than 50 endpoint tools, or if any `generate` run prints the warning
-`spec exposes <N> MCP endpoint tools (>50 threshold)`, stop before continuing
-to verification, polish, dogfood, or publish. Present the warning context via
+`spec exposes <N> MCP endpoint tools (>50 threshold)`, where `<N>` is the
+actual numeric count printed by the generator, stop before continuing to
+verification, polish, dogfood, or publish. Present the warning context via
 `AskUserQuestion`; do not treat the generator warning as informational.
 
 Question: `The spec has <N> MCP endpoint tools. Apply the recommended Cloudflare MCP pattern before continuing?`

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2413,6 +2413,34 @@ The total is what an agent loads at MCP server start.
 | 30–50 | Ask the user. Suggest `mcp.transport: [stdio, http]` for remote reach; suggest `mcp.intents` if there are clear multi-step workflows. |
 | >50 | Default to recommending the Cloudflare pattern (transport + code orchestration + hidden endpoint tools). The generator will also print a warning at this size. |
 
+**Mandatory >50 endpoint-tools gate.** If the pre-generation count predicts
+more than 50 endpoint tools, or if any `generate` run prints the warning
+`spec exposes <N> MCP endpoint tools (>50 threshold)`, stop before continuing
+to verification, polish, dogfood, or publish. Present the warning context via
+`AskUserQuestion`; do not treat the generator warning as informational.
+
+Question: `The spec has <N> MCP endpoint tools. Apply the recommended Cloudflare MCP pattern before continuing?`
+
+Options:
+
+1. **Apply Cloudflare MCP pattern + regenerate (recommended)** — edit the input
+   spec, then re-run `generate` so templates emit the smaller MCP surface.
+2. **Keep endpoint-mirror surface** — continue with the raw endpoint tools and
+   verify with the known agent-context cost.
+3. **Review `docs/SPEC-EXTENSIONS.md` first** — stop this skill so the user can
+   read the schema and decide before generation continues.
+
+If the user picks option 1, edit the source spec before regenerating:
+
+- OpenAPI input: write or update a root `x-mcp:` block.
+- Internal YAML input: write or update the root `mcp:` block.
+- Use `transport: [stdio, http]`, `orchestration: code`, and
+  `endpoint_tools: hidden`. Preserve any existing `intents`, `addr`, or other
+  explicit MCP fields unless the user directs otherwise.
+
+If the runtime cannot ask a blocking question, stop after printing the warning
+and do not continue with a >50 raw endpoint-mirror surface by accident.
+
 **The Cloudflare pattern** (recommended for large surfaces) — edit the spec's
 `mcp:` block (internal YAML) or `x-mcp:` block (OpenAPI) before running
 `generate`:


### PR DESCRIPTION
## Summary

The Printing Press now treats the >50 MCP endpoint-tools warning as a mandatory decision gate instead of informational guidance. Agents must ask before continuing and either apply the Cloudflare MCP pattern plus regenerate, keep the raw endpoint-mirror surface knowingly, or pause for `docs/SPEC-EXTENSIONS.md` review.

The gate also spells out the source-spec edit: OpenAPI inputs use root `x-mcp:`, internal YAML inputs use root `mcp:`, and existing explicit MCP fields are preserved unless the user directs otherwise.

Closes #1130

## Verification

- `go test ./internal/cli -run TestPrintingPressSkillMCPEnrichmentGate -count=1`
- `git diff --check`
- Push hook: `fmt`, `lint`
- Not run: `go test ./...` because two pre-existing `go test ./...` processes were already running in other shells; this docs/test-only change is covered by the focused regression test.
