### PR TITLE
fix(cli): accept accounted phase5 skips in gate

### DIFF
--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -220,8 +220,12 @@ func phase5AcceptancePassed(marker Phase5GateMarker) (bool, string) {
 		if marker.TestsFailed != 0 {
 			return false, fmt.Sprintf("phase5 full acceptance has %d failed tests", marker.TestsFailed)
 		}
-		if marker.TestsPassed != marker.MatrixSize {
-			return false, fmt.Sprintf("phase5 full acceptance requires all %d tests passed, got %d", marker.MatrixSize, marker.TestsPassed)
+		if marker.TestsPassed == marker.MatrixSize {
+			return true, ""
+		}
+		accountedTests := marker.TestsPassed + marker.TestsSkipped
+		if accountedTests != marker.MatrixSize {
+			return false, fmt.Sprintf("phase5 full acceptance requires all %d tests accounted for (passed+skipped), got %d passed + %d skipped = %d", marker.MatrixSize, marker.TestsPassed, marker.TestsSkipped, accountedTests)
 		}
 		return true, ""
 	default:

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -240,6 +240,48 @@ func TestValidatePhase5Gate_FullPassRejectsFailures(t *testing.T) {
 	assert.Contains(t, result.Detail, "full")
 }
 
+func TestValidatePhase5Gate_FullPassAcceptsAccountedSkips(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none"}
+	writePhase5GateMarker(t, proofsDir, Phase5AcceptanceFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         "run-1",
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    110,
+		TestsPassed:   66,
+		TestsSkipped:  44,
+		TestsFailed:   0,
+		AuthContext:   Phase5AuthContext{Type: "none"},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.True(t, result.Passed, result.Detail)
+	assert.Equal(t, "pass", result.Status)
+}
+
+func TestValidatePhase5Gate_FullPassRejectsSilentGaps(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none"}
+	writePhase5GateMarker(t, proofsDir, Phase5AcceptanceFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         "run-1",
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    110,
+		TestsPassed:   66,
+		TestsSkipped:  43,
+		TestsFailed:   0,
+		AuthContext:   Phase5AuthContext{Type: "none"},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.False(t, result.Passed)
+	assert.Contains(t, result.Detail, "accounted")
+}
+
 func TestValidatePhase5Gate_ManualLevelDocumentsAcceptedValues(t *testing.T) {
 	proofsDir := t.TempDir()
 	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none"}


### PR DESCRIPTION
## Summary

Phase 5 full acceptance now treats explicitly skipped dogfood slots as accounted instead of failed. A marker with no failures and `tests_passed + tests_skipped == matrix_size` can promote, while existing counted-matrix markers where `tests_passed == matrix_size` still pass.

Closes #964

## Verification

- `go test ./internal/pipeline -run 'TestValidatePhase5Gate_FullPass(AcceptsAccountedSkips|RejectsSilentGaps|RejectsFailures|Marker)$'`
- `go test ./internal/cli -run 'TestPromote|TestPublish|TestLibrary'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
