### PR TITLE
fix(cli): backfill publish printer attribution

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -349,6 +350,10 @@ func newPublishPackageCmd() *cobra.Command {
 			if err := pipeline.CopyDir(dir, outCLIDir); err != nil {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("copying CLI: %w", err)}
+			}
+			if err := backfillPackagedManifestAttribution(outCLIDir); err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("backfilling printer attribution: %w", err)}
 			}
 
 			// Strip build/ from the staged tree. autoBundleForHost writes
@@ -786,6 +791,7 @@ func runValidation(dir string) ValidateResult {
 
 func validatePublishManifestContract(dir string, manifest pipeline.CLIManifest) []string {
 	var issues []string
+	manifest = manifestWithPublishAttributionFallbacks(manifest)
 	if manifest.SchemaVersion != pipeline.CurrentCLIManifestSchemaVersion {
 		issues = append(issues, fmt.Sprintf("schema_version must be %d (found %d)", pipeline.CurrentCLIManifestSchemaVersion, manifest.SchemaVersion))
 	}
@@ -813,6 +819,9 @@ func validatePublishManifestContract(dir string, manifest pipeline.CLIManifest) 
 	if isPublishPrinterSentinel(manifest.Printer) {
 		issues = append(issues, fmt.Sprintf("printer must not be the literal sentinel %q", manifest.Printer))
 	}
+	if issue := validateGitHubPrinterExists(manifest.Printer); issue != "" {
+		issues = append(issues, issue)
+	}
 
 	if manifestAdvertisesMCP(manifest) {
 		for _, filename := range []string{pipeline.MCPBManifestFilename, pipeline.ToolsManifestFilename} {
@@ -824,6 +833,113 @@ func validatePublishManifestContract(dir string, manifest pipeline.CLIManifest) 
 	}
 
 	return issues
+}
+
+func manifestWithPublishAttributionFallbacks(manifest pipeline.CLIManifest) pipeline.CLIManifest {
+	if strings.TrimSpace(manifest.Printer) != "" && strings.TrimSpace(manifest.PrinterName) != "" {
+		return manifest
+	}
+	fallback := resolvePublishAttributionFallback()
+	if strings.TrimSpace(manifest.Printer) == "" && fallback.Printer != "" {
+		manifest.Printer = fallback.Printer
+	}
+	if strings.TrimSpace(manifest.PrinterName) == "" && fallback.PrinterName != "" {
+		manifest.PrinterName = fallback.PrinterName
+	}
+	return manifest
+}
+
+type publishAttributionFallback struct {
+	Printer     string
+	PrinterName string
+}
+
+func resolvePublishAttributionFallback() publishAttributionFallback {
+	printer := firstNonNullCommandOutput(
+		[]string{"git", "config", "github.user"},
+		[]string{"gh", "api", "user", "--jq", ".login"},
+	)
+	printerName := firstNonNullCommandOutput(
+		[]string{"git", "config", "user.name"},
+		[]string{"gh", "api", "user", "--jq", ".name"},
+	)
+	return publishAttributionFallback{Printer: printer, PrinterName: printerName}
+}
+
+func firstNonNullCommandOutput(commands ...[]string) string {
+	for _, args := range commands {
+		if len(args) == 0 {
+			continue
+		}
+		out, err := exec.Command(args[0], args[1:]...).Output()
+		if err != nil {
+			continue
+		}
+		value := strings.TrimSpace(string(out))
+		if value != "" && value != "null" {
+			return value
+		}
+	}
+	return ""
+}
+
+func validateGitHubPrinterExists(printer string) string {
+	printer = strings.TrimSpace(printer)
+	if printer == "" || isPublishPrinterSentinel(printer) {
+		return ""
+	}
+	out, err := exec.Command("gh", "api", "users/"+url.PathEscape(printer), "--jq", ".login").CombinedOutput()
+	if err == nil {
+		return ""
+	}
+	output := string(out)
+	if strings.Contains(output, "404") || strings.Contains(strings.ToLower(output), "not found") {
+		return fmt.Sprintf("printer %q does not resolve to a GitHub user", printer)
+	}
+	return ""
+}
+
+func backfillPackagedManifestAttribution(dir string) error {
+	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var manifest pipeline.CLIManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return err
+	}
+	fallback := resolvePublishAttributionFallback()
+	changed := false
+	if strings.TrimSpace(manifest.Printer) == "" && fallback.Printer != "" {
+		encoded, err := json.Marshal(fallback.Printer)
+		if err != nil {
+			return err
+		}
+		raw["printer"] = encoded
+		changed = true
+	}
+	if strings.TrimSpace(manifest.PrinterName) == "" && fallback.PrinterName != "" {
+		encoded, err := json.Marshal(fallback.PrinterName)
+		if err != nil {
+			return err
+		}
+		raw["printer_name"] = encoded
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	updated, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return err
+	}
+	updated = append(updated, '\n')
+	return os.WriteFile(manifestPath, updated, 0o644)
 }
 
 func isPublishPrinterSentinel(printer string) bool {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -968,8 +968,16 @@ func backfillPackagedManifestAttribution(dir string) error {
 		return err
 	}
 	fallback := resolvePublishAttributionFallback(manifest)
+	needsPrinter := strings.TrimSpace(manifest.Printer) == ""
+	needsPrinterName := strings.TrimSpace(manifest.PrinterName) == ""
+	if needsPrinter && fallback.Printer == "" {
+		return fmt.Errorf("printer attribution is missing and no fallback could be resolved")
+	}
+	if needsPrinterName && fallback.PrinterName == "" {
+		return fmt.Errorf("printer_name attribution is missing and no fallback could be resolved")
+	}
 	changed := false
-	if strings.TrimSpace(manifest.Printer) == "" && fallback.Printer != "" {
+	if needsPrinter && fallback.Printer != "" {
 		encoded, err := json.Marshal(fallback.Printer)
 		if err != nil {
 			return err
@@ -977,7 +985,7 @@ func backfillPackagedManifestAttribution(dir string) error {
 		raw["printer"] = encoded
 		changed = true
 	}
-	if strings.TrimSpace(manifest.PrinterName) == "" && fallback.PrinterName != "" {
+	if needsPrinterName && fallback.PrinterName != "" {
 		encoded, err := json.Marshal(fallback.PrinterName)
 		if err != nil {
 			return err

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -839,7 +839,7 @@ func manifestWithPublishAttributionFallbacks(manifest pipeline.CLIManifest) pipe
 	if strings.TrimSpace(manifest.Printer) != "" && strings.TrimSpace(manifest.PrinterName) != "" {
 		return manifest
 	}
-	fallback := resolvePublishAttributionFallback()
+	fallback := resolvePublishAttributionFallback(manifest)
 	if strings.TrimSpace(manifest.Printer) == "" && fallback.Printer != "" {
 		manifest.Printer = fallback.Printer
 	}
@@ -854,16 +854,66 @@ type publishAttributionFallback struct {
 	PrinterName string
 }
 
-func resolvePublishAttributionFallback() publishAttributionFallback {
-	printer := firstNonNullCommandOutput(
-		[]string{"git", "config", "github.user"},
-		[]string{"gh", "api", "user", "--jq", ".login"},
-	)
-	printerName := firstNonNullCommandOutput(
-		[]string{"git", "config", "user.name"},
-		[]string{"gh", "api", "user", "--jq", ".name"},
-	)
-	return publishAttributionFallback{Printer: printer, PrinterName: printerName}
+func resolvePublishAttributionFallback(manifest pipeline.CLIManifest) publishAttributionFallback {
+	printer := strings.TrimSpace(manifest.Printer)
+	printerName := strings.TrimSpace(manifest.PrinterName)
+	if printer != "" && printerName == "" {
+		return publishAttributionFallback{PrinterName: resolveGitHubUserName(printer)}
+	}
+	if printer == "" && printerName == "" {
+		return resolveCurrentPublishAttributionFallback()
+	}
+	return publishAttributionFallback{}
+}
+
+func resolveCurrentPublishAttributionFallback() publishAttributionFallback {
+	if fallback := resolveGitPublishAttributionFallback(); fallback.complete() {
+		return fallback
+	}
+	if fallback := resolveGhPublishAttributionFallback(); fallback.complete() {
+		return fallback
+	}
+	return publishAttributionFallback{}
+}
+
+func (fallback publishAttributionFallback) complete() bool {
+	return strings.TrimSpace(fallback.Printer) != "" && strings.TrimSpace(fallback.PrinterName) != ""
+}
+
+func resolveGitPublishAttributionFallback() publishAttributionFallback {
+	return publishAttributionFallback{
+		Printer:     firstNonNullCommandOutput([]string{"git", "config", "github.user"}),
+		PrinterName: firstNonNullCommandOutput([]string{"git", "config", "user.name"}),
+	}
+}
+
+func resolveGhPublishAttributionFallback() publishAttributionFallback {
+	var user struct {
+		Login string `json:"login"`
+		Name  string `json:"name"`
+	}
+	if !readGhAPIJSON("user", &user) {
+		return publishAttributionFallback{}
+	}
+	return publishAttributionFallback{Printer: strings.TrimSpace(user.Login), PrinterName: strings.TrimSpace(user.Name)}
+}
+
+func resolveGitHubUserName(printer string) string {
+	var user struct {
+		Name string `json:"name"`
+	}
+	if !readGhAPIJSON("users/"+url.PathEscape(strings.TrimSpace(printer)), &user) {
+		return ""
+	}
+	return strings.TrimSpace(user.Name)
+}
+
+func readGhAPIJSON(path string, target any) bool {
+	out, err := exec.Command("gh", "api", path).Output()
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(out, target) == nil
 }
 
 func firstNonNullCommandOutput(commands ...[]string) string {
@@ -896,7 +946,11 @@ func validateGitHubPrinterExists(printer string) string {
 	if strings.Contains(output, "404") || strings.Contains(strings.ToLower(output), "not found") {
 		return fmt.Sprintf("printer %q does not resolve to a GitHub user", printer)
 	}
-	return ""
+	detail := strings.Join(strings.Fields(output), " ")
+	if detail == "" {
+		detail = err.Error()
+	}
+	return fmt.Sprintf("could not verify printer %q with gh: %s", printer, detail)
 }
 
 func backfillPackagedManifestAttribution(dir string) error {
@@ -913,7 +967,7 @@ func backfillPackagedManifestAttribution(dir string) error {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return err
 	}
-	fallback := resolvePublishAttributionFallback()
+	fallback := resolvePublishAttributionFallback(manifest)
 	changed := false
 	if strings.TrimSpace(manifest.Printer) == "" && fallback.Printer != "" {
 		encoded, err := json.Marshal(fallback.Printer)
@@ -939,7 +993,11 @@ func backfillPackagedManifestAttribution(dir string) error {
 		return err
 	}
 	updated = append(updated, '\n')
-	return os.WriteFile(manifestPath, updated, 0o644)
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(manifestPath, updated, info.Mode())
 }
 
 func isPublishPrinterSentinel(printer string) bool {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -302,6 +302,26 @@ exit 1
 	assert.Equal(t, fs.FileMode(0o600), info.Mode().Perm())
 }
 
+func TestBackfillPackagedManifestAttributionFailsWithoutFallback(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"#!/bin/sh\nexit 1\n",
+		"#!/bin/sh\nexit 1\n",
+	)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.CLIManifestFilename), []byte(`{
+  "schema_version": 1,
+  "printing_press_version": "4.2.1",
+  "api_name": "test",
+  "cli_name": "test-pp-cli",
+  "run_id": "20260509-000000"
+}`+"\n"), 0o644))
+
+	err := backfillPackagedManifestAttribution(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "attribution")
+	assert.Contains(t, err.Error(), "fallback")
+}
+
 func TestPublishManifestContractRejectsUnresolvablePrinterHandle(t *testing.T) {
 	stubPublishIdentityCommands(t,
 		"",

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -39,6 +39,21 @@ func publishCheckByName(t *testing.T, result ValidateResult, name string) CheckR
 	return CheckResult{}
 }
 
+func stubPublishIdentityCommands(t *testing.T, gitScript, ghScript string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell scripts are Unix-only")
+	}
+	dir := t.TempDir()
+	if gitScript != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(gitScript), 0o755))
+	}
+	if ghScript != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "gh"), []byte(ghScript), 0o755))
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestPublishValidateMissingManifest(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
@@ -125,7 +140,6 @@ func TestPublishValidateRejectsStaleAttributionManifest(t *testing.T) {
 	manifestCheck := publishCheckByName(t, result, "manifest")
 	assert.False(t, manifestCheck.Passed)
 	assert.Contains(t, manifestCheck.Error, "schema_version must be 1")
-	assert.Contains(t, manifestCheck.Error, "printer_name")
 }
 
 func TestPublishManifestContractRejectsPrinterSentinel(t *testing.T) {
@@ -141,6 +155,99 @@ func TestPublishManifestContractRejectsPrinterSentinel(t *testing.T) {
 
 	require.Len(t, issues, 1)
 	assert.Contains(t, issues[0], "literal sentinel")
+}
+
+func TestPublishManifestContractBackfillsAttributionFromGh(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"#!/bin/sh\nexit 0\n",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then
+  echo nlarkin1986
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".name" ]; then
+  echo "Nick Larkin"
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "users/nlarkin1986" ]; then
+  echo nlarkin1986
+  exit 0
+fi
+exit 1
+`,
+	)
+
+	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "4.2.1",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                "20260509-000000",
+	})
+
+	assert.Empty(t, issues)
+}
+
+func TestBackfillPackagedManifestAttributionPreservesUnknownFields(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"#!/bin/sh\nexit 0\n",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then
+  echo amitav13
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".name" ]; then
+  echo "Amitav Khandelwal"
+  exit 0
+fi
+exit 1
+`,
+	)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.CLIManifestFilename), []byte(`{
+  "schema_version": 1,
+  "printing_press_version": "4.2.1",
+  "api_name": "test",
+  "cli_name": "test-pp-cli",
+  "run_id": "20260509-000000",
+  "custom_field": {"keep": true}
+}`+"\n"), 0o644))
+
+	require.NoError(t, backfillPackagedManifestAttribution(dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, pipeline.CLIManifestFilename))
+	require.NoError(t, err)
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.JSONEq(t, `"amitav13"`, string(got["printer"]))
+	assert.JSONEq(t, `"Amitav Khandelwal"`, string(got["printer_name"]))
+	assert.JSONEq(t, `{"keep": true}`, string(got["custom_field"]))
+}
+
+func TestPublishManifestContractRejectsUnresolvablePrinterHandle(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "users/vinnypasceri" ]; then
+  echo "gh: Not Found (HTTP 404)" >&2
+  exit 1
+fi
+exit 1
+`,
+	)
+
+	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "4.2.1",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                "20260509-000000",
+		Printer:              "vinnypasceri",
+		PrinterName:          "Vinny Pasceri",
+	})
+
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0], `printer "vinnypasceri" does not resolve to a GitHub user`)
 }
 
 func TestPublishManifestContractRequiresMCPMetadataFiles(t *testing.T) {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -1372,6 +1372,21 @@ func TestPublishRenameJSONError(t *testing.T) {
 func writePublishableTestCLI(t *testing.T, dir string) {
 	t.Helper()
 
+	stubPublishIdentityCommands(t,
+		"",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "users/tmchow" ]; then
+  if [ "$3" = "--jq" ]; then
+    echo "tmchow"
+  else
+    echo '{"login":"tmchow","name":"Trevin Chow"}'
+  fi
+  exit 0
+fi
+exit 1
+`,
+	)
+
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cmd", "test-pp-cli"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(`module example.com/test-pp-cli
 

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -161,16 +162,12 @@ func TestPublishManifestContractBackfillsAttributionFromGh(t *testing.T) {
 	stubPublishIdentityCommands(t,
 		"#!/bin/sh\nexit 0\n",
 		`#!/bin/sh
-if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then
-  echo nlarkin1986
-  exit 0
-fi
-if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".name" ]; then
-  echo "Nick Larkin"
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo '{"login":"nlarkin1986","name":"Nick Larkin"}'
   exit 0
 fi
 if [ "$1" = "api" ] && [ "$2" = "users/nlarkin1986" ]; then
-  echo nlarkin1986
+  echo '{"login":"nlarkin1986","name":"Nick Larkin"}'
   exit 0
 fi
 exit 1
@@ -188,16 +185,69 @@ exit 1
 	assert.Empty(t, issues)
 }
 
+func TestPublishManifestContractDoesNotMixGitAndGhAttributionFallbacks(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		`#!/bin/sh
+if [ "$1" = "config" ] && [ "$2" = "github.user" ]; then
+  echo stalebot
+  exit 0
+fi
+exit 1
+`,
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo '{"login":"nlarkin1986","name":"Nick Larkin"}'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "users/nlarkin1986" ]; then
+  echo '{"login":"nlarkin1986","name":"Nick Larkin"}'
+  exit 0
+fi
+exit 1
+`,
+	)
+
+	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "4.2.1",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                "20260509-000000",
+	})
+
+	assert.Empty(t, issues)
+}
+
+func TestPublishManifestContractBackfillsPrinterNameFromExistingPrinter(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "users/amitav13" ]; then
+  echo '{"login":"amitav13","name":"Amitav Khandelwal"}'
+  exit 0
+fi
+exit 1
+`,
+	)
+
+	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "4.2.1",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                "20260509-000000",
+		Printer:              "amitav13",
+	})
+
+	assert.Empty(t, issues)
+}
+
 func TestBackfillPackagedManifestAttributionPreservesUnknownFields(t *testing.T) {
 	stubPublishIdentityCommands(t,
 		"#!/bin/sh\nexit 0\n",
 		`#!/bin/sh
-if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then
-  echo amitav13
-  exit 0
-fi
-if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".name" ]; then
-  echo "Amitav Khandelwal"
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo '{"login":"amitav13","name":"Amitav Khandelwal"}'
   exit 0
 fi
 exit 1
@@ -222,6 +272,34 @@ exit 1
 	assert.JSONEq(t, `"amitav13"`, string(got["printer"]))
 	assert.JSONEq(t, `"Amitav Khandelwal"`, string(got["printer_name"]))
 	assert.JSONEq(t, `{"keep": true}`, string(got["custom_field"]))
+}
+
+func TestBackfillPackagedManifestAttributionPreservesManifestMode(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"#!/bin/sh\nexit 0\n",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo '{"login":"amitav13","name":"Amitav Khandelwal"}'
+  exit 0
+fi
+exit 1
+`,
+	)
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{
+  "schema_version": 1,
+  "printing_press_version": "4.2.1",
+  "api_name": "test",
+  "cli_name": "test-pp-cli",
+  "run_id": "20260509-000000"
+}`+"\n"), 0o600))
+
+	require.NoError(t, backfillPackagedManifestAttribution(dir))
+
+	info, err := os.Stat(manifestPath)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0o600), info.Mode().Perm())
 }
 
 func TestPublishManifestContractRejectsUnresolvablePrinterHandle(t *testing.T) {
@@ -250,7 +328,45 @@ exit 1
 	assert.Contains(t, issues[0], `printer "vinnypasceri" does not resolve to a GitHub user`)
 }
 
+func TestPublishManifestContractRejectsUnverifiedPrinterHandle(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "users/vinnypasceri" ]; then
+  echo "gh: authentication required" >&2
+  exit 1
+fi
+exit 1
+`,
+	)
+
+	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
+		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
+		PrintingPressVersion: "4.2.1",
+		APIName:              "test",
+		CLIName:              "test-pp-cli",
+		RunID:                "20260509-000000",
+		Printer:              "vinnypasceri",
+		PrinterName:          "Vinny Pasceri",
+	})
+
+	require.Len(t, issues, 1)
+	assert.Contains(t, issues[0], `could not verify printer "vinnypasceri" with gh`)
+	assert.Contains(t, issues[0], "authentication required")
+}
+
 func TestPublishManifestContractRequiresMCPMetadataFiles(t *testing.T) {
+	stubPublishIdentityCommands(t,
+		"",
+		`#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "users/tmchow" ]; then
+  echo '{"login":"tmchow","name":"Trevin Chow"}'
+  exit 0
+fi
+exit 1
+`,
+	)
+
 	issues := validatePublishManifestContract(t.TempDir(), pipeline.CLIManifest{
 		SchemaVersion:        pipeline.CurrentCLIManifestSchemaVersion,
 		PrintingPressVersion: "4.2.1",


### PR DESCRIPTION
## Summary

Publishing old printed CLIs no longer dead-ends when their manifest was created before printer attribution was available. `publish validate` now accepts missing `printer` / `printer_name` when they can be resolved from the current git or GitHub CLI identity, and `publish package` writes those resolved fields into the staged manifest so the public-library copy has complete provenance.

The manifest check also rejects printer handles that an authenticated `gh api users/<handle>` reports as missing, catching name-derived slugs that would otherwise publish 404ing GitHub profile links.

## Testing

- `go test ./internal/cli -run 'TestPublishValidateRejectsStaleAttributionManifest|TestPublishManifestContract|TestBackfillPackagedManifestAttribution'`
- `go test ./internal/generator -run 'TestResolvePrinter'`
- `go test ./...`
- Push hook: `golangci-lint` (`0 issues`)

Closes #1124
