### PR TITLE
fix(cli): run publish govulncheck with module toolchain

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -907,7 +907,7 @@ func runGoCommandCheckWithEnv(dir, name string, timeout time.Duration, env []str
 	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
 	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+		cmd.Env = envWithOverrides(os.Environ(), env)
 	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -920,6 +920,28 @@ func runGoCommandCheckWithEnv(dir, name string, timeout time.Duration, env []str
 		return CheckResult{Name: name, Passed: false, Error: errMsg}
 	}
 	return CheckResult{Name: name, Passed: true}
+}
+
+func envWithOverrides(base, overrides []string) []string {
+	overrideKeys := make(map[string]struct{}, len(overrides))
+	for _, entry := range overrides {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			overrideKeys[key] = struct{}{}
+		}
+	}
+
+	env := make([]string, 0, len(base)+len(overrides))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, exists := overrideKeys[key]; exists {
+				continue
+			}
+		}
+		env = append(env, entry)
+	}
+	return append(env, overrides...)
 }
 
 func runGoVulnCheck(dir string) CheckResult {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -897,10 +898,17 @@ func runGoCheck(dir string, args ...string) CheckResult {
 }
 
 func runGoCommandCheck(dir, name string, timeout time.Duration, args ...string) CheckResult {
+	return runGoCommandCheckWithEnv(dir, name, timeout, nil, args...)
+}
+
+func runGoCommandCheckWithEnv(dir, name string, timeout time.Duration, env []string, args ...string) CheckResult {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		errMsg := strings.TrimSpace(string(output))
@@ -918,7 +926,26 @@ func runGoVulnCheck(dir string) CheckResult {
 	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err != nil {
 		return CheckResult{Name: govulncheck.Name, Passed: false, Error: "go.mod not found"}
 	}
-	return runGoCommandCheck(dir, govulncheck.Name, vulnCheckTimeout, govulncheck.GoRunArgs("./...")...)
+	env := govulncheckToolchainEnv(dir)
+	return runGoCommandCheckWithEnv(dir, govulncheck.Name, vulnCheckTimeout, env, govulncheck.GoRunArgs("./...")...)
+}
+
+func govulncheckToolchainEnv(dir string) []string {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return nil
+	}
+	mod, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return nil
+	}
+	if mod.Toolchain != nil && mod.Toolchain.Name != "" {
+		return []string{"GOTOOLCHAIN=" + mod.Toolchain.Name}
+	}
+	if mod.Go != nil && strings.Count(mod.Go.Version, ".") >= 2 {
+		return []string{"GOTOOLCHAIN=go" + mod.Go.Version}
+	}
+	return nil
 }
 
 func checkGoModTidy(dir string) CheckResult {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -355,6 +355,7 @@ exit 42
 `), 0o755))
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("FAKE_GO_CALLS", callsPath)
+	t.Setenv("GOTOOLCHAIN", "auto")
 
 	result := runGoVulnCheck(dir)
 	assert.False(t, result.Passed)

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -337,7 +337,7 @@ func TestRunGoVulnCheckRequiresGoMod(t *testing.T) {
 	assert.Equal(t, "go.mod not found", result.Error)
 }
 
-func TestRunGoVulnCheckUsesPinnedDefaultCommand(t *testing.T) {
+func TestRunGoVulnCheckUsesPinnedDefaultCommandWithModuleToolchain(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake shell go binary is Unix-only")
 	}
@@ -348,7 +348,8 @@ func TestRunGoVulnCheckUsesPinnedDefaultCommand(t *testing.T) {
 	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
 	fakeGo := filepath.Join(fakeBin, "go")
 	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
-printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+printf 'args=%s\n' "$*" >> "$FAKE_GO_CALLS"
+printf 'toolchain=%s\n' "$GOTOOLCHAIN" >> "$FAKE_GO_CALLS"
 echo "fake govulncheck failure" >&2
 exit 42
 `), 0o755))
@@ -362,9 +363,23 @@ exit 42
 
 	calls, err := os.ReadFile(callsPath)
 	require.NoError(t, err)
-	assert.Equal(t, "run "+govulncheck.ToolModule+" ./...\n", string(calls))
+	assert.Equal(t, "args=run "+govulncheck.ToolModule+" ./...\ntoolchain=go1.26.3\n", string(calls))
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
+}
+
+func TestGovulncheckToolchainEnvPrefersToolchainDirective(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.3\n"), 0o644))
+
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.3"}, govulncheckToolchainEnv(dir))
+}
+
+func TestGovulncheckToolchainEnvIgnoresLanguageOnlyGoDirective(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
+
+	assert.Nil(t, govulncheckToolchainEnv(dir))
 }
 
 func TestPublishPackageMissingDirFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

`publish validate` now runs its govulncheck leg with the generated module's declared toolchain when `go.mod` names a concrete toolchain version. That keeps the pinned analyzer from switching down to an older Go runtime and falsely failing clean generated CLIs that declare `go 1.26.3`.

Real govulncheck findings still fail the check. Language-only directives such as `go 1.24` continue to use the default Go command behavior instead of forcing an invalid toolchain name.

Closes #1294

## Tests

- `go test ./internal/cli -run 'TestRunGoVulnCheck|TestGovulncheckToolchainEnv' -count=1`
- `go test ./internal/cli -run 'Test(Publish|RunGoVuln|Govuln)' -count=1 -timeout=2m`
- push hook: `fmt`, `lint`
