### PR TITLE
fix(cli): send in:cookie security credential as cookie not header

### DIFF
--- a/internal/generator/client_cookie_apikey_test.go
+++ b/internal/generator/client_cookie_apikey_test.go
@@ -1,0 +1,118 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAPIKeyCookieInjectionUsesAddCookie(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Cookie Key API
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+security:
+  - cookieAuth: []
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: __Secure-next-auth.session-token
+paths:
+  /me:
+    get:
+      operationId: getMe
+      responses:
+        "200":
+          description: OK
+`))
+	require.NoError(t, err)
+	apiSpec.Name = "cookiekey"
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/cookiekey-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), "cookiekey-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientSrc := string(clientBytes)
+
+	assert.Contains(t, clientSrc, `req.AddCookie(&http.Cookie{Name: "__Secure-next-auth.session-token", Value: authHeader})`,
+		"apiKey in:cookie must emit AddCookie on request construction")
+	// The auth cookie is added by name exactly once, on the initial request.
+	// The redirect handler must NOT re-add it on same-host hops (Go carries the
+	// Cookie header verbatim, so a second AddCookie would duplicate it). The
+	// cross-host branch may re-add OTHER cookies via a variable, so count only
+	// the named-literal AddCookie.
+	assert.Equal(t, 1, strings.Count(clientSrc, `AddCookie(&http.Cookie{Name: "__Secure-next-auth.session-token"`),
+		"apiKey in:cookie must add the named auth cookie exactly once")
+	assert.Contains(t, clientSrc, `req.Header.Del("Cookie")`,
+		"cross-host redirect must strip the auth cookie so it cannot leak to a redirect target")
+	assert.Contains(t, clientSrc, `if ck.Name != "__Secure-next-auth.session-token"`,
+		"cross-host strip must remove only the auth cookie by name, preserving others")
+	assert.NotContains(t, clientSrc, `req.Header.Set("__Secure-next-auth.session-token", authHeader)`,
+		"apiKey in:cookie must not be emitted as a custom request header")
+
+	// --dry-run must preview the credential in cookie wire format, not as a
+	// bare request header.
+	assert.Contains(t, clientSrc, `"  Cookie: %s=%s\n", "__Secure-next-auth.session-token"`,
+		"dry-run must preview in:cookie auth as a Cookie header")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestGenerateAPIKeyHeaderInjectionDoesNotUseAddCookie(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Header Key API
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+security:
+  - apiKeyAuth: []
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+paths:
+  /me:
+    get:
+      operationId: getMe
+      responses:
+        "200":
+          description: OK
+`))
+	require.NoError(t, err)
+	apiSpec.Name = "headerkey"
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/headerkey-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), "headerkey-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientSrc := string(clientBytes)
+
+	assert.Contains(t, clientSrc, `req.Header.Set("X-API-Key", authHeader)`,
+		"apiKey in:header must keep header injection")
+	assert.Contains(t, clientSrc, `req.Header.Set("X-API-Key", h)`,
+		"apiKey in:header redirect path must keep header injection")
+	assert.NotContains(t, clientSrc, `req.AddCookie(&http.Cookie{Name: "X-API-Key", Value: authHeader})`,
+		"apiKey in:header must not emit AddCookie")
+}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -473,6 +473,23 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
 		// Auth lives on URL query; Go preserves the query on relative
 		// redirects, so nothing to re-derive.
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+		// The auth cookie set on the initial request is carried verbatim by Go
+		// on same-host redirects, so re-adding it here would double the Cookie
+		// header (the same hazard the cookie-jar branch below avoids). Only the
+		// cross-host hop needs handling: Go does not strip a manually-set Cookie
+		// for custom names, so drop the auth cookie by name to keep the
+		// credential from leaking to a redirect target, while preserving any
+		// other cookies on the request.
+		if req.URL.Host != via[0].URL.Host {
+			preserved := req.Cookies()
+			req.Header.Del("Cookie")
+			for _, ck := range preserved {
+				if ck.Name != "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}" {
+					req.AddCookie(ck)
+				}
+			}
+		}
 {{- else if eq .Auth.Type "cookie"}}
 		// Cookie-auth redirects: Go's http.Client + http.CookieJar handle
 		// cookie carriage on 3xx hops natively. Setting the Cookie header
@@ -1316,6 +1333,8 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			q := req.URL.Query()
 			q.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", authHeader)
 			req.URL.RawQuery = q.Encode()
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+			req.AddCookie(&http.Cookie{Name: "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", Value: authHeader})
 {{- else if eq .Auth.Type "cookie"}}
 			// Cookie-auth: LoadCookieJar is the sole source of outbound
 			// cookies. net/http's Client.send calls jar.Cookies + AddCookie
@@ -1621,6 +1640,12 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{.Auth.TokenParamName}}", maskToken(authHeader))
 	}
 {{- end}}
+{{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
+	if authHeader != "" {
+		// in:cookie auth ships on the Cookie header; preview it as such so the
+		// dry run matches the live wire format.
+		fmt.Fprintf(os.Stderr, "  Cookie: %s=%s\n", "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", maskToken(authHeader))
+	}
 {{- else if not (and .Auth .Auth.In (eq .Auth.In "query"))}}
 	if authHeader != "" {
 		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", maskToken(authHeader))


### PR DESCRIPTION
## Intent

An OpenAPI `cookieAuth`-style securityScheme (`type: apiKey`, `in: cookie`) was wired into the generated HTTP client as a request **header** instead of an HTTP **cookie**, so the credential never reached servers that read it from `Cookie`. This is distinct from `auth.type == cookie` (full cookie-jar auth).

Issue: Closes #981

## Approach

Emit `req.AddCookie(...)` for the `.Auth.In == "cookie"` case on the request-construction path (cookie name = the scheme's `name`, falling back to `api_key`).

For redirects: Go carries the `Cookie` header verbatim on same-host hops, so the handler does **not** re-add the cookie (re-adding would duplicate the `Cookie` header — the same double-send hazard the cookie-jar branch guards against). It only strips the cookie on a cross-host hop so a custom-named auth cookie cannot leak to a redirect target. `--dry-run` previews the credential in `Cookie:` wire format to match the live path.

## Scope

Primary area: generator (`internal/generator/templates/client.go.tmpl`)

Why this belongs in this repo: this is a machine/template change — every future printed CLI generated from an `in: cookie` securityScheme inherits the correct cookie wiring.

## Catalog Justification

N/A

## Risk

Template change affecting any CLI with `in: cookie` auth. No existing golden fixture uses this auth shape, so golden output is unchanged (`golden.sh verify` passes). The redirect handler now relies on Go's native same-host carriage rather than re-adding; cross-host stripping is preserved as defense-in-depth.

## Output Contract

Generated `internal/client/client.go` for `in: cookie` specs now emits `req.AddCookie(...)` on the request path, a cross-host `req.Header.Del("Cookie")` in `CheckRedirect`, and a `Cookie:`-format dry-run preview. No golden fixture exercises `in: cookie`, so no fixture drift.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases)
- New/updated regression tests in `internal/generator/client_cookie_apikey_test.go` (cookie added exactly once, cross-host strip present, dry-run cookie format, generated module compiles)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change