### PR TITLE
fix(cli): keep sole query input param from global-param filter

### DIFF
--- a/internal/generator/global_param_flag_test.go
+++ b/internal/generator/global_param_flag_test.go
@@ -1,0 +1,74 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/openapi"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end guard for #982: a tRPC-style spec whose GET endpoints route per-
+// call input through a single optional `input` query param (present on every
+// endpoint) must still expose a `--input` flag. filterGlobalParams previously
+// stripped it as global noise, so the generated command emitted
+// `params := map[string]string{}` with no flag and calls 400'd. The parser-
+// layer test guards param retention; this guards the emitted flag + wiring.
+func TestGenerateKeepsSoleGlobalQueryParamAsFlag(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Trpc Input API
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      tags: [users]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+  /projects:
+    get:
+      operationId: listProjects
+      tags: [projects]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+  /tasks:
+    get:
+      operationId: listTasks
+      tags: [tasks]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+`))
+	require.NoError(t, err)
+	apiSpec.Name = "trpcinput"
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/trpcinput-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), "trpcinput-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	// Each single-endpoint resource is promoted to a top-level command; all
+	// three must expose the flag, not just the first.
+	for _, file := range []string{"promoted_users.go", "promoted_projects.go", "promoted_tasks.go"} {
+		cmdBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", file))
+		require.NoError(t, err, "%s should be generated", file)
+		cmdSrc := string(cmdBytes)
+
+		assert.Contains(t, cmdSrc, `cmd.Flags().StringVar(&flagInput, "input", "", "Input")`,
+			"%s: the sole global query param must be registered as a --input flag", file)
+		assert.Contains(t, cmdSrc, `params["input"] = fmt.Sprintf("%v", flagInput)`,
+			"%s: the --input flag value must propagate into the request params map", file)
+	}
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3725,7 +3725,38 @@ func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
 		return
 	}
 
+	// droppedCounts records how many endpoints each global param was actually
+	// removed from, so the warning reflects reality: a param retained on every
+	// endpoint (because dropping it would empty the surface) must not be
+	// reported as filtered.
+	droppedCounts := map[string]int{}
 	walkResourceEndpoints(resources, func(endpoint *spec.Endpoint) {
+		// Keep tRPC-style global `input` params when dropping them would leave
+		// the endpoint with no non-path request params at all. Other global
+		// query params like `limit` should still be filtered even when that
+		// leaves an endpoint with no request surface.
+		hasNonFilteredSurface := false
+		nonPathCount := 0
+		for _, param := range endpoint.Params {
+			if isPathSubstitutionParam(param) {
+				continue
+			}
+			nonPathCount++
+			if isGlobalFilterCandidate(param) {
+				key := strings.ToLower(param.Name)
+				if _, ok := filteredParams[key]; ok {
+					if isRetainableSoleGlobalInputParam(param) {
+						continue
+					}
+				}
+			}
+			hasNonFilteredSurface = true
+			break
+		}
+		if nonPathCount > 0 && !hasNonFilteredSurface {
+			return
+		}
+
 		filtered := endpoint.Params[:0]
 		for _, param := range endpoint.Params {
 			key := strings.ToLower(param.Name)
@@ -3735,6 +3766,7 @@ func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
 					param.GlobalScope = true
 					param.EnvVar = globalScopeParamEnvVar(apiName, scopeParam.name)
 				} else if _, ok := filteredParams[key]; ok {
+					droppedCounts[key]++
 					continue
 				}
 			}
@@ -3754,15 +3786,14 @@ func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
 		warnf("promoted global scope query param %q to required env-backed flag: present on %d/%d endpoints", name, scopeParams[key].count, totalEndpoints)
 	}
 
-	filteredNames := make([]string, 0, len(filteredParams))
-	for _, param := range filteredParams {
-		filteredNames = append(filteredNames, param.name)
+	filteredNames := make([]string, 0, len(droppedCounts))
+	for key := range droppedCounts {
+		filteredNames = append(filteredNames, key)
 	}
 	sort.Strings(filteredNames)
 
-	for _, name := range filteredNames {
-		key := strings.ToLower(name)
-		warnf("filtered global query param %q from generated commands: present on %d/%d endpoints", name, filteredParams[key].count, totalEndpoints)
+	for _, key := range filteredNames {
+		warnf("filtered global query param %q from generated commands: dropped from %d/%d endpoints where present (%d total)", filteredParams[key].name, droppedCounts[key], filteredParams[key].count, totalEndpoints)
 	}
 }
 
@@ -3778,6 +3809,10 @@ func isPathSubstitutionParam(param spec.Param) bool {
 
 func isGlobalFilterCandidate(param spec.Param) bool {
 	return !isPathSubstitutionParam(param) && !param.Required
+}
+
+func isRetainableSoleGlobalInputParam(param spec.Param) bool {
+	return strings.EqualFold(param.Name, "input")
 }
 
 func isGlobalScopeParamName(name string) bool {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7917,6 +7917,126 @@ paths:
 	}
 }
 
+// TestFilterGlobalParamsKeepsOnlyQueryInputParam guards against specs that
+// carry per-call input through a single optional query parameter (e.g.
+// `input`). Even when that parameter appears on most/all endpoints, dropping
+// it would leave the commands with no query-input surface.
+func TestFilterGlobalParamsKeepsOnlyQueryInputParam(t *testing.T) {
+	t.Parallel()
+
+	specYAML := `openapi: 3.0.0
+info:
+  title: Trpc Input API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      tags: [users]
+      parameters:
+        - name: input
+          in: query
+          schema: {type: string}
+      responses:
+        "200":
+          description: ok
+  /projects:
+    get:
+      operationId: listProjects
+      tags: [projects]
+      parameters:
+        - name: input
+          in: query
+          schema: {type: string}
+      responses:
+        "200":
+          description: ok
+  /tasks:
+    get:
+      operationId: listTasks
+      tags: [tasks]
+      parameters:
+        - name: input
+          in: query
+          schema: {type: string}
+      responses:
+        "200":
+          description: ok
+`
+	parsed, err := Parse([]byte(specYAML))
+	require.NoError(t, err)
+
+	for _, path := range []string{"/users", "/projects", "/tasks"} {
+		endpoint := findEndpoint(t, parsed, path)
+		require.Len(t, endpoint.Params, 1, "%s must retain the only query input param", path)
+		assert.Equal(t, "input", endpoint.Params[0].Name)
+		assert.False(t, endpoint.Params[0].Required)
+	}
+}
+
+// TestFilterGlobalParamsMixedEndpoints covers the asymmetric case: endpoints
+// whose only non-path param is the global `input` retain it, while an endpoint
+// that also carries a non-global param still loses `input` through the normal
+// filter. This guards against the retain-sole-input path over-firing and
+// leaving `input` on endpoints that should drop it.
+func TestFilterGlobalParamsMixedEndpoints(t *testing.T) {
+	t.Parallel()
+
+	specYAML := `openapi: 3.0.0
+info:
+  title: Trpc Mixed API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      tags: [users]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+  /projects:
+    get:
+      operationId: listProjects
+      tags: [projects]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+  /tasks:
+    get:
+      operationId: listTasks
+      tags: [tasks]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+  /reports:
+    get:
+      operationId: listReports
+      tags: [reports]
+      parameters:
+        - {name: input, in: query, schema: {type: string}}
+        - {name: expand, in: query, schema: {type: string}}
+      responses: {"200": {description: ok}}
+`
+	parsed, err := Parse([]byte(specYAML))
+	require.NoError(t, err)
+
+	for _, path := range []string{"/users", "/projects", "/tasks"} {
+		endpoint := findEndpoint(t, parsed, path)
+		require.Len(t, endpoint.Params, 1, "%s must retain its sole input param", path)
+		assert.Equal(t, "input", endpoint.Params[0].Name)
+	}
+
+	reports := findEndpoint(t, parsed, "/reports")
+	var names []string
+	for _, p := range reports.Params {
+		names = append(names, p.Name)
+	}
+	assert.NotContains(t, names, "input",
+		"/reports has another non-path param, so the global input is still filtered")
+	assert.Contains(t, names, "expand",
+		"/reports keeps its non-global param")
+}
+
 // TestParsePerOperationServersFallback covers the case where a spec has no
 // top-level `servers:` block but each operation declares its own. The parser
 // must walk per-operation servers and pick the most common one as base URL.


### PR DESCRIPTION
## Intent

GET endpoints that route per-call input through a single optional query param (e.g. a tRPC-style `input`) lost that param to `filterGlobalParams`: when the param appeared on most/all endpoints it was classified as global noise and dropped, so the generated command emitted `params := map[string]string{}` with no flag and calls 400'd because the server required `?input=`.

Issue: Closes #982

## Approach

In `filterGlobalParams`, skip the global-param drop for an endpoint when removing the candidates would leave it with **zero** non-path request params. Prevalence alone does not make a param noise when it is the endpoint's only input surface. The generator already emits a flag and populates the params map for retained non-path params, so keeping the param restores the `--input` flag end to end.

Also fixed the post-filter warning, which previously claimed it "filtered" a param even when the new logic retained it on every endpoint; it now reports the actual per-endpoint drop count.

## Scope

Primary area: OpenAPI parser (`internal/openapi/parser.go`)

Why this belongs in this repo: machine change — the over-filtering happened in the shared parser and affected every spec with a prevalent optional query param.

## Catalog Justification

N/A

## Risk

Per-endpoint and narrowly scoped: the keep-logic only short-circuits when filtering would empty an endpoint's non-path surface. Endpoints with other non-path params still get their global params filtered. `golden.sh verify` passes with zero drift across existing fixtures.

## Output Contract

No change to existing golden fixtures (verified). New behavior covered by an end-to-end generator test asserting the `--input` flag is registered and wired into the params map.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases)
- `internal/openapi/parser_test.go` (param retention) + new `internal/generator/global_param_flag_test.go` (emitted `--input` flag + params population + compile)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change