### PR TITLE
fix(cli): print help on empty invocation of required-input commands

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -349,6 +349,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"endpointUsesCSVArray":     endpointUsesCSVArray,
 		"endpointHasQueryFlags":    endpointHasQueryFlags,
 		"endpointHasRequestParams": endpointHasRequestParams,
+		"endpointHasRequiredInput": endpointHasRequiredInput,
 		"endpointIsReadCommand":    endpointIsReadCommand,
 		"hasMultipartRequest":      hasMultipartRequest,
 		"formBodyMaps":             formBodyMaps,
@@ -4998,6 +4999,34 @@ func endpointHasQueryFlags(endpoint spec.Endpoint) bool {
 		if !p.Positional && !p.PathParam {
 			return true
 		}
+	}
+	return false
+}
+
+// endpointHasRequiredInput reports whether a bare invocation of the generated
+// command (no flags, no args) would fail a required-input check before
+// reaching the request: a required non-positional flag or a required body
+// field. It gates the empty-invocation help short-circuit so read commands
+// with only optional filters still execute on a bare call instead of printing
+// help. Both halves mirror exactly when the template emits a required check:
+// the flag half uses template.IsTrue to match the template's `(not .Default)`
+// gate (so a required flag carrying a non-empty default — which the template
+// lets satisfy itself — does not trigger the guard, just as it emits no
+// required-flag error), and the body half reuses bodyRequiredChecks, gated on
+// the body-bearing verbs the command template actually emits the body check
+// for (POST/PUT/PATCH/DELETE) so a GET that happens to declare a required body
+// param does not falsely trip the guard.
+func endpointHasRequiredInput(endpoint spec.Endpoint) bool {
+	for _, p := range endpoint.Params {
+		if p.Required && !p.Positional {
+			if truth, _ := template.IsTrue(p.Default); !truth {
+				return true
+			}
+		}
+	}
+	switch strings.ToUpper(endpoint.Method) {
+	case "POST", "PUT", "PATCH", "DELETE":
+		return strings.TrimSpace(bodyRequiredChecks(endpoint, "")) != ""
 	}
 	return false
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6392,6 +6392,131 @@ func TestPipedJsonGateRespectsExplicitFormatFlags(t *testing.T) {
 	}
 }
 
+// Required-body-flag commands should print help on truly empty invocations
+// (no args, no flags) and only then proceed to required-flag validation.
+// This keeps command UX consistent while preserving partial-invocation errors.
+func TestRequiredFlagCommands_HelpFallbackOnEmptyInvocation(t *testing.T) {
+	t.Parallel()
+
+	guard := "if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {"
+
+	for _, path := range []string{
+		filepath.Join("templates", "command_endpoint.go.tmpl"),
+		filepath.Join("templates", "command_promoted.go.tmpl"),
+	} {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err, "template must exist: %s", path)
+		body := string(data)
+
+		guardIdx := strings.Index(body, guard)
+		require.GreaterOrEqual(t, guardIdx, 0,
+			"%s must guard empty invocation by returning cmd.Help() before required-flag checks", path)
+
+		requireIdx := strings.Index(body, `return fmt.Errorf("required flag \"%s\" not set",`)
+		require.GreaterOrEqual(t, requireIdx, 0,
+			"%s must continue emitting required-flag validation", path)
+
+		assert.Less(t, guardIdx, requireIdx,
+			"%s must run the empty-invocation help fallback before required-flag errors", path)
+	}
+}
+
+// The empty-invocation help fallback must be gated to commands with required
+// input. A GET list whose only param is an optional filter must still execute
+// on a bare call (no guard), while a required-body create must short-circuit
+// to help. The template-string test above passes even for an ungated guard;
+// this generated-output test fails if the guard leaks onto optional-only reads.
+func TestRequiredFlagCommands_HelpFallbackGatedToRequiredInput(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "help-fallback-gating",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "api_key", Header: "X-Key", In: "header", EnvVars: []string{"HFG_API_KEY"}},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/help-fallback-gating-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method: "GET",
+						Path:   "/items",
+						Params: []spec.Param{{Name: "status", Type: "string"}},
+					},
+					"create": {
+						Method: "POST",
+						Path:   "/items",
+						Body:   []spec.Param{{Name: "title", Type: "string", Required: true}},
+					},
+				},
+			},
+			// Single-endpoint resource → promoted top-level command; exercises
+			// the promoted template's unconditional body-required path.
+			"subscribe": {
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method: "POST",
+						Path:   "/subscribe",
+						Body:   []spec.Param{{Name: "email", Type: "string", Required: true}},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	guard := "if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {"
+
+	listBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_list.go"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(listBytes), guard,
+		"optional-only GET list must execute on bare invocation, not short-circuit to help")
+
+	createBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_create.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(createBytes), guard,
+		"required-body create must short-circuit to help on bare invocation")
+
+	// Promoted command with a required body must also short-circuit to help.
+	promotedBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "promoted_subscribe.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(promotedBytes), guard,
+		"required-body promoted command must short-circuit to help on bare invocation")
+}
+
+// endpointHasRequiredInput must mirror the template's required-check gates
+// exactly, including the `(not .Default)` truthiness on required flags: a
+// required flag with no default OR a zero-value default counts as required
+// input (template emits the error), while a required flag carrying a non-empty
+// default does not (the default satisfies it). Positional params are handled
+// by the separate positional guard, not this predicate.
+func TestEndpointHasRequiredInputMirrorsTemplateGates(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ep   spec.Endpoint
+		want bool
+	}{
+		{"required flag, no default", spec.Endpoint{Method: "GET", Params: []spec.Param{{Name: "q", Required: true}}}, true},
+		{"required flag, empty-string default", spec.Endpoint{Method: "GET", Params: []spec.Param{{Name: "q", Required: true, Default: ""}}}, true},
+		{"required flag, non-empty default", spec.Endpoint{Method: "GET", Params: []spec.Param{{Name: "q", Required: true, Default: "active"}}}, false},
+		{"optional flag only", spec.Endpoint{Method: "GET", Params: []spec.Param{{Name: "status"}}}, false},
+		{"required positional only", spec.Endpoint{Method: "GET", Params: []spec.Param{{Name: "id", Required: true, Positional: true}}}, false},
+		{"required body field", spec.Endpoint{Method: "POST", Body: []spec.Param{{Name: "title", Required: true}}}, true},
+		{"optional body only", spec.Endpoint{Method: "POST", Body: []spec.Param{{Name: "note"}}}, false},
+		{"GET with required body ignored", spec.Endpoint{Method: "GET", Body: []spec.Param{{Name: "title", Required: true}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, endpointHasRequiredInput(tc.ep))
+		})
+	}
+}
+
 func TestGeneratedOutput_GetCommandsLackMutationEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -66,6 +66,14 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		Example: {{printf "%q" (exampleLine .CommandPath .EndpointName .Endpoint)}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
+{{- if endpointHasRequiredInput .Endpoint}}
+			// Bare invocation of a command with required input prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only read commands fall through so a bare call still executes.
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
+{{- end}}
 {{- if positionalArgs .Endpoint}}
 			if len(args) == 0 {
 				return cmd.Help()

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -52,6 +52,15 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Example: {{printf "%q" (promotedExampleLine .PromotedName .Endpoint)}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
+{{- if endpointHasRequiredInput .Endpoint}}
+			// Bare invocation of a command with a required flag/body prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only reads fall through so a bare call still executes; positional
+			// commands keep their existing usageErr (exit 2 + JSON envelope).
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
+{{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
 			if !{{flagChangedExpr .}} && !flags.dryRun {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -24,6 +24,12 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  printing-press-golden-pp-cli projects create --name example-resource",
 		Annotations: map[string]string{"pp:endpoint": "projects.create", "pp:method": "POST", "pp:path": "/projects"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Bare invocation of a command with required input prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only read commands fall through so a bare call still executes.
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
 			if !stdinBody {
 				if !cmd.Flags().Changed("name") && !flags.dryRun {
 					return fmt.Errorf("required flag \"%s\" not set", "name")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -21,6 +21,12 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  printing-press-golden-pp-cli reports export report-year --year 42",
 		Annotations: map[string]string{"pp:endpoint": "export.report-year", "pp:method": "GET", "pp:path": "/reports/{year}/export", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Bare invocation of a command with required input prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only read commands fall through so a bare call still executes.
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
 			if !cmd.Flags().Changed("year") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "year")
 			}

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -23,6 +23,12 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  public-param-golden-pp-cli stores create --store-code example-value",
 		Annotations: map[string]string{"pp:endpoint": "stores.create", "pp:method": "POST", "pp:path": "/stores"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Bare invocation of a command with required input prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only read commands fall through so a bare call still executes.
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
 			if !stdinBody {
 				if !(cmd.Flags().Changed("store-code") || cmd.Flags().Changed("code")) && !flags.dryRun {
 					return fmt.Errorf("required flag \"%s\" not set", "store-code")

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -22,6 +22,12 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "stores.find", "pp:method": "GET", "pp:path": "/power/store-locator", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Bare invocation of a command with required input prints help
+			// instead of pflag's terse "required flag not set" error. Optional-
+			// only read commands fall through so a bare call still executes.
+			if cmd.Flags().NFlag() == 0 && len(args) == 0 && !flags.dryRun {
+				return cmd.Help()
+			}
 			if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "address")
 			}


### PR DESCRIPTION
## Intent

Generated commands for endpoints with required body flags rejected a bare invocation with pflag's terse `required flag(s) "X" not set` instead of the full help shown by every other Cobra command.

Issue: Closes #1289

## Approach

Add a `RunE` pre-check that short-circuits to `cmd.Help()` when there are no flags and no args (and not `--dry-run`), placed before pflag's required-flag validation fires.

Crucially, the guard is **gated** on a new `endpointHasRequiredInput` helper so it only applies to commands that would otherwise error on empty (a required non-positional flag, or a required body field). Optional-only read commands (e.g. GET `list` with optional filters) keep executing on a bare call rather than printing help — preserving the default read path and the agent-native MCP surface. The flag half uses `template.IsTrue` to mirror the template's `(not .Default)` gate exactly; the body half reuses `bodyRequiredChecks`. Promoted positional-only commands keep their existing structured `usageErr` (exit 2 + JSON envelope).

## Scope

Primary area: generator (`internal/generator/generator.go`, `templates/command_endpoint.go.tmpl`, `templates/command_promoted.go.tmpl`)

Why this belongs in this repo: machine change — every printed CLI's required-input commands inherit the help-on-empty behavior.

## Catalog Justification

N/A

## Risk

The main risk is regressing the bare `<cli> <resource> list` read path (and its MCP tool) by printing help instead of returning data. The gate prevents this: the guard lands only on required-input commands. The golden diff confirms it appears on `*_create`, a required-flag `find`, a required-`--year` export — and **not** on any `*_list` command.

## Output Contract

Generated command files for required-input endpoints gain the empty-invocation help guard. Golden fixtures updated: the guard appears on required-flag/body commands; optional-only lists and positional-only promoted commands are unaffected.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases; updated intentionally)
- `internal/generator/generator_test.go`: behavioral test (guard on required-body create, not on optional-only list) + predicate unit test covering the `(not .Default)` truthiness, positional, and body cases

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change