### PR TITLE
feat(cli): add MCP generate overrides

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"go/parser"
 	"go/token"
 	"os"
@@ -2318,7 +2319,7 @@ func TestApplyGenerateSpecFlagsSetsPublicCategory(t *testing.T) {
 
 	apiSpec := &spec.APISpec{Name: "docs-api"}
 
-	require.NoError(t, applyGenerateSpecFlags(apiSpec, "", "docs", "travel", "", "", ""))
+	require.NoError(t, applyGenerateSpecFlags(apiSpec, "", "docs", "travel", "", "", "", generateMCPFlagOverrides{}))
 
 	assert.Equal(t, "docs", apiSpec.SpecSource)
 	assert.Equal(t, "travel", apiSpec.Category)
@@ -2329,11 +2330,144 @@ func TestApplyGenerateSpecFlagsRejectsUnknownCategory(t *testing.T) {
 
 	apiSpec := &spec.APISpec{Name: "docs-api"}
 
-	err := applyGenerateSpecFlags(apiSpec, "", "docs", "banana", "", "", "")
+	err := applyGenerateSpecFlags(apiSpec, "", "docs", "banana", "", "", "", generateMCPFlagOverrides{})
 
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "--category must be one of:")
 	assert.Empty(t, apiSpec.Category)
+}
+
+func TestApplyGenerateSpecFlagsOverridesMCPConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	intentsPath := filepath.Join(dir, "mcp-intents.yaml")
+	require.NoError(t, os.WriteFile(intentsPath, []byte(`
+intents:
+  - name: lookup_item
+    description: Lookup an item by id
+    params:
+      - name: id
+        type: string
+        required: true
+        description: item id
+    steps:
+      - endpoint: items.get
+        bind:
+          id: ${input.id}
+        capture: item
+    returns: item
+`), 0o644))
+
+	apiSpec := &spec.APISpec{
+		Name:    "demo",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {
+				Endpoints: map[string]spec.Endpoint{
+					"get": {
+						Method: "GET",
+						Path:   "/items/{id}",
+						Params: []spec.Param{
+							{Name: "id", Type: "string", Required: true, PathParam: true},
+						},
+					},
+				},
+			},
+		},
+		MCP: spec.MCPConfig{
+			Orchestration: "endpoint-mirror",
+			EndpointTools: "visible",
+			Transport:     []string{"stdio"},
+		},
+	}
+
+	err := applyGenerateSpecFlags(apiSpec, "", "", "", "", "", "", generateMCPFlagOverrides{
+		Orchestration: "code",
+		Transport:     []string{"stdio", "HTTP"},
+		EndpointTools: "hidden",
+		IntentsPath:   intentsPath,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "code", apiSpec.MCP.Orchestration)
+	assert.Equal(t, []string{"stdio", "http"}, apiSpec.MCP.Transport)
+	assert.Equal(t, "hidden", apiSpec.MCP.EndpointTools)
+	require.Len(t, apiSpec.MCP.Intents, 1)
+	assert.Equal(t, "lookup_item", apiSpec.MCP.Intents[0].Name)
+}
+
+func TestApplyGenerateSpecFlagsRejectsInvalidMCPOverrides(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "demo",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+	}
+
+	err := applyGenerateSpecFlags(apiSpec, "", "", "", "", "", "", generateMCPFlagOverrides{
+		Transport: []string{"stdio", "stdio"},
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--mcp-transport contains duplicate value")
+}
+
+func TestGenerateCmdMCPFlagsOverrideOpenAPISurface(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi.yaml")
+	outputDir := filepath.Join(dir, "generated")
+	require.NoError(t, os.WriteFile(specPath, []byte(openAPISpecWithEndpointCount(60)), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--max-endpoints-per-resource", "60",
+		"--mcp-orchestration", "code",
+		"--mcp-endpoint-tools", "hidden",
+		"--mcp-transport", "stdio,http",
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	toolsSource, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(toolsSource), "RegisterCodeOrchestrationTools(s)")
+	assert.NotContains(t, string(toolsSource), `mcplib.NewTool("items_get_item_0"`)
+
+	codeOrchSource, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "code_orch.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(codeOrchSource), `mcplib.NewTool("mcp-flag_search"`)
+	assert.Contains(t, string(codeOrchSource), `mcplib.NewTool("mcp-flag_execute"`)
+}
+
+func openAPISpecWithEndpointCount(count int) string {
+	var b strings.Builder
+	b.WriteString(`openapi: 3.0.0
+info:
+  title: MCP Flag API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+`)
+	for i := range count {
+		fmt.Fprintf(&b, `  /items/%d:
+    get:
+      operationId: getItem%d
+      responses:
+        "200":
+          description: ok
+`, i, i)
+	}
+	return b.String()
 }
 
 // TestApplyHTTPTransportDefaultPreservesH2ForProtectionPath pins the

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -2397,6 +2397,25 @@ intents:
 	assert.Equal(t, "lookup_item", apiSpec.MCP.Intents[0].Name)
 }
 
+func TestReadMCPIntentsFileReportsFlatListDecodeError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	intentsPath := filepath.Join(dir, "mcp-intents.yaml")
+	require.NoError(t, os.WriteFile(intentsPath, []byte(`
+- name: lookup_item
+  description: Lookup an item by id
+  steps: not-a-list
+`), 0o644))
+
+	_, err := readMCPIntentsFile(intentsPath)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "parsing --mcp-intents file")
+	assert.ErrorContains(t, err, "cannot unmarshal")
+	assert.ErrorContains(t, err, "IntentStep")
+}
+
 func TestApplyGenerateSpecFlagsRejectsInvalidMCPOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -765,20 +765,36 @@ func readMCPIntentsFile(path string) ([]spec.Intent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading --mcp-intents file: %w", err)
 	}
-	var intents []spec.Intent
-	if err := yaml.Unmarshal(data, &intents); err == nil && intents != nil {
-		return intents, nil
-	}
-	var wrapped struct {
-		Intents []spec.Intent `yaml:"intents" json:"intents"`
-	}
-	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing --mcp-intents file: %w", err)
 	}
-	if wrapped.Intents == nil {
+	if len(doc.Content) == 0 {
 		return nil, fmt.Errorf("--mcp-intents file must contain either a list of intents or an intents: list")
 	}
-	return wrapped.Intents, nil
+
+	root := doc.Content[0]
+	switch root.Kind {
+	case yaml.SequenceNode:
+		var intents []spec.Intent
+		if err := root.Decode(&intents); err != nil {
+			return nil, fmt.Errorf("parsing --mcp-intents file: %w", err)
+		}
+		return intents, nil
+	case yaml.MappingNode:
+		var wrapped struct {
+			Intents []spec.Intent `yaml:"intents"`
+		}
+		if err := root.Decode(&wrapped); err != nil {
+			return nil, fmt.Errorf("parsing --mcp-intents file: %w", err)
+		}
+		if wrapped.Intents != nil {
+			return wrapped.Intents, nil
+		}
+		return nil, fmt.Errorf("--mcp-intents file must contain either a list of intents or an intents: list")
+	default:
+		return nil, fmt.Errorf("--mcp-intents file must contain either a list of intents or an intents: list")
+	}
 }
 
 func resolveGenerateOutputDir(outputDir, cliName string, force, claim bool) (resolvedAbsOut string, explicitOutput bool, snapshotDir string, err error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -123,6 +123,10 @@ func newGenerateCmd() *cobra.Command {
 	var planFile string
 	var trafficAnalysisPath string
 	var authPreference string
+	var mcpOrchestration string
+	var mcpTransport []string
+	var mcpEndpointTools string
+	var mcpIntentsPath string
 
 	cmd := &cobra.Command{
 		Use:   "generate",
@@ -176,7 +180,12 @@ func newGenerateCmd() *cobra.Command {
 				if err != nil {
 					return &ExitError{Code: ExitSpecError, Err: fmt.Errorf("parsing generated spec: %w", err)}
 				}
-				if err := applyGenerateSpecFlags(parsed, specSource, "docs", category, clientPattern, httpTransport, owner); err != nil {
+				if err := applyGenerateSpecFlags(parsed, specSource, "docs", category, clientPattern, httpTransport, owner, generateMCPFlagOverrides{
+					Orchestration: mcpOrchestration,
+					Transport:     mcpTransport,
+					EndpointTools: mcpEndpointTools,
+					IntentsPath:   mcpIntentsPath,
+				}); err != nil {
 					return err
 				}
 
@@ -233,6 +242,9 @@ func newGenerateCmd() *cobra.Command {
 			}
 
 			if planFile != "" {
+				if (generateMCPFlagOverrides{Orchestration: mcpOrchestration, Transport: mcpTransport, EndpointTools: mcpEndpointTools, IntentsPath: mcpIntentsPath}).hasAny() {
+					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--mcp-* flags cannot be used with --plan")}
+				}
 				if trafficAnalysisPath != "" {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--traffic-analysis cannot be used with --plan")}
 				}
@@ -357,7 +369,12 @@ func newGenerateCmd() *cobra.Command {
 				apiSpec = mergeSpecs(specs, cliName)
 			}
 
-			if err := applyGenerateSpecFlags(apiSpec, specSource, "", category, clientPattern, httpTransport, owner); err != nil {
+			if err := applyGenerateSpecFlags(apiSpec, specSource, "", category, clientPattern, httpTransport, owner, generateMCPFlagOverrides{
+				Orchestration: mcpOrchestration,
+				Transport:     mcpTransport,
+				EndpointTools: mcpEndpointTools,
+				IntentsPath:   mcpIntentsPath,
+			}); err != nil {
 				return err
 			}
 
@@ -472,6 +489,10 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "Public-library category for non-catalog generation")
 	cmd.Flags().StringVar(&clientPattern, "client-pattern", "", "HTTP client pattern: rest (default), proxy-envelope (wraps requests in POST envelope)")
 	cmd.Flags().StringVar(&httpTransport, "transport", "", "HTTP transport: standard, browser-http, browser-chrome, or browser-chrome-h3 (defaults based on spec provenance and reachability)")
+	cmd.Flags().StringVar(&mcpOrchestration, "mcp-orchestration", "", "MCP orchestration mode: endpoint-mirror or code")
+	cmd.Flags().StringSliceVar(&mcpTransport, "mcp-transport", nil, "MCP transports to compile: stdio, http, or a comma-separated list")
+	cmd.Flags().StringVar(&mcpEndpointTools, "mcp-endpoint-tools", "", "MCP endpoint mirror visibility: visible or hidden")
+	cmd.Flags().StringVar(&mcpIntentsPath, "mcp-intents", "", "Path to a YAML or JSON file containing MCP intents")
 	cmd.Flags().StringVar(&researchDir, "research-dir", "", "Pipeline directory containing research.json and discovery/ for README source credits")
 	cmd.Flags().IntVar(&maxResources, "max-resources", 0, "Maximum resource groups to generate (default 500, raise for enormous APIs)")
 	cmd.Flags().IntVar(&maxEndpointsPerResource, "max-endpoints-per-resource", 0, "Maximum endpoints per resource (default 50, raise for large APIs)")
@@ -580,7 +601,18 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	}, nil
 }
 
-func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource, category, clientPattern, httpTransport, owner string) error {
+type generateMCPFlagOverrides struct {
+	Orchestration string
+	Transport     []string
+	EndpointTools string
+	IntentsPath   string
+}
+
+func (o generateMCPFlagOverrides) hasAny() bool {
+	return o.Orchestration != "" || len(o.Transport) > 0 || o.EndpointTools != "" || o.IntentsPath != ""
+}
+
+func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource, category, clientPattern, httpTransport, owner string, mcpOverrides generateMCPFlagOverrides) error {
 	if specSource != "" {
 		normalized, err := normalizeSpecSource(specSource)
 		if err != nil {
@@ -616,6 +648,47 @@ func applyGenerateSpecFlags(apiSpec *spec.APISpec, specSource, defaultSpecSource
 	if owner != "" {
 		apiSpec.Owner = owner
 	}
+	if err := applyGenerateMCPOverrides(apiSpec, mcpOverrides); err != nil {
+		return &ExitError{Code: ExitInputError, Err: err}
+	}
+	return nil
+}
+
+func applyGenerateMCPOverrides(apiSpec *spec.APISpec, overrides generateMCPFlagOverrides) error {
+	if apiSpec == nil || !overrides.hasAny() {
+		return nil
+	}
+	if overrides.Orchestration != "" {
+		normalized, err := normalizeMCPOrchestration(overrides.Orchestration)
+		if err != nil {
+			return err
+		}
+		apiSpec.MCP.Orchestration = normalized
+	}
+	if len(overrides.Transport) > 0 {
+		normalized, err := normalizeMCPTransports(overrides.Transport)
+		if err != nil {
+			return err
+		}
+		apiSpec.MCP.Transport = normalized
+	}
+	if overrides.EndpointTools != "" {
+		normalized, err := normalizeMCPEndpointTools(overrides.EndpointTools)
+		if err != nil {
+			return err
+		}
+		apiSpec.MCP.EndpointTools = normalized
+	}
+	if overrides.IntentsPath != "" {
+		intents, err := readMCPIntentsFile(overrides.IntentsPath)
+		if err != nil {
+			return err
+		}
+		apiSpec.MCP.Intents = intents
+	}
+	if err := apiSpec.Validate(); err != nil {
+		return fmt.Errorf("applying MCP generation flags: %w", err)
+	}
 	return nil
 }
 
@@ -646,6 +719,66 @@ func normalizeHTTPTransport(value string) (string, error) {
 	default:
 		return "", fmt.Errorf("--transport must be one of: standard, browser-http, browser-chrome, browser-chrome-h2, browser-chrome-h3 (got %q)", value)
 	}
+}
+
+func normalizeMCPOrchestration(value string) (string, error) {
+	switch strings.TrimSpace(value) {
+	case "", "endpoint-mirror", "code":
+		return strings.TrimSpace(value), nil
+	default:
+		return "", fmt.Errorf("--mcp-orchestration must be one of: endpoint-mirror, code (got %q)", value)
+	}
+}
+
+func normalizeMCPEndpointTools(value string) (string, error) {
+	switch strings.TrimSpace(value) {
+	case "", "visible", "hidden":
+		return strings.TrimSpace(value), nil
+	default:
+		return "", fmt.Errorf("--mcp-endpoint-tools must be one of: visible, hidden (got %q)", value)
+	}
+}
+
+func normalizeMCPTransports(values []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		transport := strings.ToLower(strings.TrimSpace(value))
+		switch transport {
+		case "stdio", "http":
+		case "":
+			return nil, fmt.Errorf("--mcp-transport values must not be empty")
+		default:
+			return nil, fmt.Errorf("--mcp-transport must contain only stdio or http (got %q)", value)
+		}
+		if _, ok := seen[transport]; ok {
+			return nil, fmt.Errorf("--mcp-transport contains duplicate value %q", transport)
+		}
+		seen[transport] = struct{}{}
+		normalized = append(normalized, transport)
+	}
+	return normalized, nil
+}
+
+func readMCPIntentsFile(path string) ([]spec.Intent, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading --mcp-intents file: %w", err)
+	}
+	var intents []spec.Intent
+	if err := yaml.Unmarshal(data, &intents); err == nil && intents != nil {
+		return intents, nil
+	}
+	var wrapped struct {
+		Intents []spec.Intent `yaml:"intents" json:"intents"`
+	}
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("parsing --mcp-intents file: %w", err)
+	}
+	if wrapped.Intents == nil {
+		return nil, fmt.Errorf("--mcp-intents file must contain either a list of intents or an intents: list")
+	}
+	return wrapped.Intents, nil
 }
 
 func resolveGenerateOutputDir(outputDir, cliName string, force, claim bool) (resolvedAbsOut string, explicitOutput bool, snapshotDir string, err error) {


### PR DESCRIPTION
## Summary

OpenAPI generation can now opt into the Cloudflare-style MCP surface without editing the source spec. `generate` accepts MCP override flags for orchestration, transport, endpoint-tool visibility, and intent files, then applies the same spec validation path used by `mcp:` / `x-mcp` declarations.

This gives large OpenAPI CLIs a command-line path to emit the thin `<api>_search` and `<api>_execute` surface while leaving the default endpoint-mirror behavior unchanged when no overrides are provided.

Closes #1218

## Verification

- `go test ./internal/cli -run 'TestApplyGenerateSpecFlags|TestGenerateCmdMCPFlagsOverrideOpenAPISurface' -count=1`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`
