### PR TITLE
fix(cli): narrow pii-audit fixture scope

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -398,20 +398,18 @@ func redactDetectorMatches(det piiDetector, text string) string {
 	return b.String()
 }
 
-// Scoped to the capture-to-publish leak path: manuscripts, test
-// fixtures, README, and *_test.go files. Non-test Go source and
-// module metadata are excluded by default.
+// Scoped to the capture-to-publish leak path: manuscripts, operator-authored
+// JSON/YAML/Markdown, and README files. Generated test fixtures are excluded
+// because synthetic placeholder values there are not customer PII.
 var highRiskFileGlobs = []string{
 	"*.json",
 	"*.yaml",
 	"*.yml",
 	"*.md",
-	"*_test.go",
 }
 
 var highRiskDirGlobs = []string{
 	".manuscripts",
-	"testdata",
 }
 
 // ToolsPolishLedgerFilename is the tools-audit polish ledger basename.
@@ -432,9 +430,10 @@ var excludedFiles = map[string]bool{
 // `--spec`. Vendor-published `example:` values (emails, phones,
 // addresses) are documentation, not customer PII, so a Stripe/Zendesk/
 // GitHub spec doesn't false-fail every promote. Exemption is depth-1
-// only; a spec.yaml nested under .manuscripts/ or testdata/ is captured
-// content and stays in scope unless content-detection identifies it as
-// an archived vendor spec (see manuscriptsDir + looksLikeVendorAPISpec).
+// only; a spec.yaml nested under .manuscripts/ is captured content and
+// stays in scope unless content-detection identifies it as an archived vendor
+// spec (see manuscriptsDir + looksLikeVendorAPISpec). Generated test fixtures
+// under testdata/ are outside the audit scope.
 // Mirrors findArchivedSpec()'s candidate set in
 // internal/pipeline/climanifest.go.
 var rootVendorSpecFiles = map[string]bool{
@@ -501,10 +500,13 @@ func isUnderManuscripts(relSlash string) bool {
 // skippedDirs are subtree names the walker never descends into at the
 // top level. Scoping to depth-1 is deliberate — `.git` and friends as
 // direct children of the cli-dir are infrastructure; the same names
-// nested inside `.manuscripts/` or `testdata/` are captured content
-// and must be scanned.
+// nested inside `.manuscripts/` is captured content and must be scanned.
+// Generated fixture and top-level tooling workspaces are skipped at the root.
 var skippedDirs = map[string]bool{
+	".claude":      true,
 	".git":         true,
+	".omc":         true,
+	"testdata":     true,
 	"node_modules": true,
 	"vendor":       true,
 	"build":        true,

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -292,7 +292,7 @@ func TestFindPII_FileScoping(t *testing.T) {
 	write(t, filepath.Join(root, "in-scope.json"), pii)
 	write(t, filepath.Join(root, "in-scope.yaml"), pii)
 	write(t, filepath.Join(root, "in-scope.md"), pii)
-	write(t, filepath.Join(root, "in_scope_test.go"), pii)
+	write(t, filepath.Join(root, "out_of_scope_test.go"), pii)
 	write(t, filepath.Join(root, "out-of-scope.go"), pii)
 	write(t, filepath.Join(root, "out-of-scope.txt"), pii)
 	write(t, filepath.Join(root, "out-of-scope.lock"), pii)
@@ -302,14 +302,16 @@ func TestFindPII_FileScoping(t *testing.T) {
 
 	files := uniqueFiles(findings)
 	assert.ElementsMatch(t, []string{
-		"in-scope.json", "in-scope.yaml", "in-scope.md", "in_scope_test.go",
+		"in-scope.json", "in-scope.yaml", "in-scope.md",
 	}, files)
 }
 
 func TestFindPII_DirScoping(t *testing.T) {
 	root := t.TempDir()
 	pii := `"phone": "(415) 234-5678"`
-	// .manuscripts and testdata are in scope regardless of extension
+	// .manuscripts is in scope regardless of extension. testdata is
+	// intentionally excluded because generated fixtures commonly carry
+	// synthetic placeholder values.
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".manuscripts", "run1"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata", "fixtures"), 0755))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal"), 0755))
@@ -322,8 +324,30 @@ func TestFindPII_DirScoping(t *testing.T) {
 
 	files := uniqueFiles(findings)
 	assert.Contains(t, files, ".manuscripts/run1/raw.har")
-	assert.Contains(t, files, "testdata/fixtures/sample.txt")
+	assert.NotContains(t, files, "testdata/fixtures/sample.txt")
 	assert.NotContains(t, files, "internal/client.go")
+}
+
+func TestFindPII_SkipsFixtureAndToolingWorkspaces(t *testing.T) {
+	root := t.TempDir()
+	pii := `"email": "leak@gmail.com"`
+	write(t, filepath.Join(root, "helpers_test.go"), pii)
+	write(t, filepath.Join(root, "testdata", "fixtures", "sample.json"), pii)
+	write(t, filepath.Join(root, ".omc", "state.json"), pii)
+	write(t, filepath.Join(root, ".claude", "scratch.md"), pii)
+	write(t, filepath.Join(root, "config.yaml"), pii)
+	write(t, filepath.Join(root, "README.md"), pii)
+
+	findings, err := FindPII(root)
+	require.NoError(t, err)
+
+	files := uniqueFiles(findings)
+	assert.NotContains(t, files, "helpers_test.go")
+	assert.NotContains(t, files, "testdata/fixtures/sample.json")
+	assert.NotContains(t, files, ".omc/state.json")
+	assert.NotContains(t, files, ".claude/scratch.md")
+	assert.Contains(t, files, "config.yaml")
+	assert.Contains(t, files, "README.md")
 }
 
 func TestFindPII_ExcludedFiles(t *testing.T) {
@@ -364,10 +388,11 @@ func TestFindPII_RootVendorSpecExempt(t *testing.T) {
 	assert.Contains(t, files, "config.yaml")
 }
 
-// Negative: nested spec.yaml files are captured content, not vendor
-// source. They stay in scope so browser-sniff captures keep flagging.
+// Negative: nested spec.yaml files outside fixture directories are captured
+// content, not vendor source. They stay in scope so browser-sniff captures keep
+// flagging.
 // Two scope re-entry paths are exercised:
-//   - high-risk dirs (.manuscripts/, testdata/) match via highRiskDirGlobs
+//   - high-risk dirs (.manuscripts/) match via highRiskDirGlobs
 //   - arbitrary subdirs (output/) match via the *.yaml entry in
 //     highRiskFileGlobs; pinned here as a regression guard against a
 //     future tweak that broadens the exemption from depth-1 to all paths
@@ -390,7 +415,7 @@ func TestFindPII_NestedSpecYamlStillScans(t *testing.T) {
 
 	files := uniqueFiles(findings)
 	assert.Contains(t, files, ".manuscripts/run1/research/spec.yaml")
-	assert.Contains(t, files, "testdata/spec.yaml")
+	assert.NotContains(t, files, "testdata/spec.yaml")
 	assert.Contains(t, files, "output/spec.yaml")
 }
 
@@ -482,9 +507,8 @@ func TestFindPIIWithOptions_ManuscriptsVendorSpecExemptUsesStagedPath(t *testing
 }
 
 // Negative regression: vendor-spec content detection only applies inside
-// .manuscripts/. A file at docs/api.yaml or testdata/openapi.json with
-// OpenAPI markers still scans — those are committed, hand-curated
-// artifacts that could legitimately accumulate real PII.
+// .manuscripts/. A file at docs/api.yaml with OpenAPI markers still scans —
+// committed, hand-curated artifacts could legitimately accumulate real PII.
 func TestFindPII_VendorSpecOutsideManuscriptsStillScans(t *testing.T) {
 	root := t.TempDir()
 	openapiYAML := `openapi: 3.0.0
@@ -500,9 +524,7 @@ paths:
               email: leaked@victim.com
 `
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "testdata"), 0755))
 	write(t, filepath.Join(root, "docs", "api.yaml"), openapiYAML)
-	write(t, filepath.Join(root, "testdata", "openapi.json"), `{"openapi":"3.0.0","info":{"title":"x"},"paths":{"/u":{"post":{"requestBody":{"content":{"application/json":{"example":{"email":"leaked@victim.com"}}}}}}}}`)
 
 	findings, err := FindPII(root)
 	require.NoError(t, err)
@@ -510,8 +532,6 @@ paths:
 	files := uniqueFiles(findings)
 	assert.Contains(t, files, "docs/api.yaml",
 		"vendor-spec exemption must not bypass docs/ committed artifacts")
-	assert.Contains(t, files, "testdata/openapi.json",
-		"vendor-spec exemption must not bypass testdata fixtures")
 }
 
 // Negative regression: HARs and session-state captures under

--- a/internal/cli/pii_audit.go
+++ b/internal/cli/pii_audit.go
@@ -30,7 +30,7 @@ func newPIIAuditCmd() *cobra.Command {
 		Use:   "pii-audit <cli-dir>",
 		Short: "Mechanically audit a printed CLI's high-risk files for customer-PII shapes",
 		Long: `Walks <cli-dir>'s high-risk file scope (JSON, YAML, Markdown,
-*_test.go, .manuscripts/**, testdata/**) and reports per-line findings
+.manuscripts/**) and reports per-line findings
 that signal PII-shape leaks. Detection is purely mechanical: card
 last-4 with context tokens, email addresses, US-shaped phone numbers,
 ZIP+4, and street-address-line shapes. The agent layer

--- a/internal/cli/pii_audit_test.go
+++ b/internal/cli/pii_audit_test.go
@@ -52,6 +52,28 @@ func TestPIIAuditCmd_JSON(t *testing.T) {
 	assert.Equal(t, artifacts.PIIKindEmail, findings[0].Kind)
 }
 
+func TestPIIAuditCmd_ExcludesGeneratedFixturesAndOMCWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "root_test.go"), `"email": "leak@gmail.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "testdata", "fixtures", "sample.json"), `"email": "leak@gmail.com"`+"\n")
+	writeFile(t, filepath.Join(dir, ".omc", "state.json"), `"email": "leak@gmail.com"`+"\n")
+	writeFile(t, filepath.Join(dir, "config.yaml"), `"email": "leak@gmail.com"`+"\n")
+
+	cmd := newPIIAuditCmd()
+	stdout := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{dir, "--json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var findings []artifacts.PIIFinding
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	assert.Equal(t, "config.yaml", findings[0].File)
+	assert.Equal(t, artifacts.PIIKindEmail, findings[0].Kind)
+}
+
 func TestPIIAuditCmd_ManuscriptsRunDirUsesStagedPackagePaths(t *testing.T) {
 	dir := t.TempDir()
 	runDir := filepath.Join(t.TempDir(), "manuscripts", "tenderned", "20260517-211252")

--- a/skills/printing-press-polish/references/pii-polish.md
+++ b/skills/printing-press-polish/references/pii-polish.md
@@ -72,7 +72,11 @@ When a downstream consumer (parser, schema validator) needs a valid-shape value,
 
 **Manuscripts (`.manuscripts/<runID>/`).** Highest-risk source — captured browser-sniff content is by construction where customer values entered. Acceptance for manuscript findings requires the explicit `evidence_context`-cited justification; "captured data" alone is not sufficient. When in doubt, replace the value in the manuscript file directly (it's local working state) and use a hand-authored fixture with synthetic values for any downstream tests.
 
-**Vendor spec files at the CLI root (`spec.yaml`, `spec.yml`, `spec.json`).** Exempt from the audit by design — these are the OpenAPI/internal source the operator passed to `--spec`, and vendor `example:` blocks (Stripe `jenny@example.com`, GitHub user-schema example phones) are documentation, not customer PII. The exemption is depth-1 only; the same basename nested under `testdata/` is captured content and stays in scope.
+**Generated test fixtures (`*_test.go`, `testdata/`).** Exempt from the audit by design — generated tests commonly carry standards-reserved or synthetic placeholder values, and rewriting them during polish creates churn without reducing customer-PII risk. Real PII in production code, config, README, and manuscript files remains in scope.
+
+**Tooling workspaces (`.omc/`, `.claude/`).** Exempt from the audit at the CLI root — these are agent orchestration or scratch directories, not shippable printed-CLI content.
+
+**Vendor spec files at the CLI root (`spec.yaml`, `spec.yml`, `spec.json`).** Exempt from the audit by design — these are the OpenAPI/internal source the operator passed to `--spec`, and vendor `example:` blocks (Stripe `jenny@example.com`, GitHub user-schema example phones) are documentation, not customer PII.
 
 **Vendor spec source archived under `.manuscripts/`.** Files anywhere inside a `.manuscripts/` subtree whose head bytes match an OpenAPI 2.x/3.x or Swagger 2.0 root-document marker are exempt — the operator archived the vendor's published spec source alongside research, and its `example:` blocks are documentation. The exemption is content-based, not glob-based, so per-resource subdir basenames like `apps/calendars.json` or vendor-named files like `pushpress-v3.yaml` are covered without an allowlist. HARs, `session-state.json`, hand-edited proofs, and any other non-spec content under `.manuscripts/` stays in scope because the marker check fails on them.
 


### PR DESCRIPTION
## Summary

`pii-audit` no longer reports generated fixture placeholders or OMC workspace notes as pending customer-PII findings. The scanner now skips generated test scope (`*_test.go`, top-level `testdata/`) and root-level agent tooling workspaces (`.omc/`, `.claude/`) while continuing to flag real PII shapes in production JSON, YAML, Markdown, README, and manuscript capture files.

The polish reference now documents the narrowed scope so future runs do not churn on synthetic fixture values.

Closes #1480

## Validation

- `go test ./internal/artifacts ./internal/cli -run 'PII|PIIAudit'`
- `go test ./internal/pipeline -run 'PII|PromoteWorkingCLI_PII'`
- `go test ./internal/artifacts ./internal/cli ./internal/pipeline -run 'PII|PIIAudit|PromoteWorkingCLI_PII'`
- `go test ./...`
- `scripts/golden.sh verify`
