### PR TITLE
fix(cli): skip auth-flow inputs as bearer tokens

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -620,10 +620,10 @@ func TestBearerAuthFlowPerCallFallbackStillAuthenticates(t *testing.T) {
 	if got := cfg.AuthHeader(); got != "Bearer fallback-token" {
 		t.Fatalf("AuthHeader() = %q, want Bearer fallback-token", got)
 	}
-}
+	}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "bearer_flow_input_test.go"), []byte(runtimeTest), 0o644))
-	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestBearerAuthFlowInputs")
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestBearerAuthFlow")
 }
 
 // TestAuthHeader_BearerHarvestedInputsPreferAccessToken pins the harvested

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -536,6 +536,96 @@ func TestAuthHeader_OAuth2DoesNotUseSetupEnvVars(t *testing.T) {
 	}
 }
 
+// TestAuthHeader_BearerAuthFlowInputsPreferAccessToken pins the OpenAPI
+// session-handshake shape where the declared Bearer scheme lists setup inputs
+// via x-auth-vars kind=auth_flow_input. Those values are only used by auth
+// login; the stored AccessToken is the request credential.
+func TestAuthHeader_BearerAuthFlowInputsPreferAccessToken(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-flow-input")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "bearer_token",
+		Header: "Authorization",
+		Format: "Bearer {token}",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "BEARER_FLOW_IDENTIFIER", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: false},
+			{Name: "BEARER_FLOW_APP_PASSWORD", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: true, Sensitive: true},
+			{Name: "BEARER_FLOW_FALLBACK_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-flow-input-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	body := authHeaderBody(t, string(cfgSrc))
+
+	identifierCheck := "if c." + resolveEnvVarField("BEARER_FLOW_IDENTIFIER") + ` != ""`
+	passwordCheck := "if c." + resolveEnvVarField("BEARER_FLOW_APP_PASSWORD") + ` != ""`
+	fallbackCheck := "if c." + resolveEnvVarField("BEARER_FLOW_FALLBACK_TOKEN") + ` != ""`
+	require.NotContains(t, body, identifierCheck, "auth_flow_input identifier must not be used as a bearer token")
+	require.NotContains(t, body, passwordCheck, "auth_flow_input secret must not be used as a bearer token")
+	require.Contains(t, body, fallbackCheck, "per_call fallback token must remain usable")
+	require.Contains(t, body, `if c.AccessToken != ""`, "stored AccessToken must remain the Bearer request credential")
+
+	const runtimeTest = `package config
+
+import "testing"
+
+func TestBearerAuthFlowInputsUseAccessToken(t *testing.T) {
+	t.Setenv("BEARER_FLOW_IDENTIFIER", "alice.example")
+	t.Setenv("BEARER_FLOW_APP_PASSWORD", "app-password")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	cfg.AccessToken = "access-jwt"
+
+	if got := cfg.AuthHeader(); got != "Bearer access-jwt" {
+		t.Fatalf("AuthHeader() = %q, want Bearer access-jwt", got)
+	}
+	if cfg.AuthSource != "oauth2" {
+		t.Fatalf("AuthSource after AuthHeader() = %q, want oauth2", cfg.AuthSource)
+	}
+}
+
+func TestBearerAuthFlowInputsAloneDoNotAuthenticate(t *testing.T) {
+	t.Setenv("BEARER_FLOW_IDENTIFIER", "alice.example")
+	t.Setenv("BEARER_FLOW_APP_PASSWORD", "app-password")
+	t.Setenv("BEARER_FLOW_FALLBACK_TOKEN", "")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got := cfg.AuthHeader(); got != "" {
+		t.Fatalf("AuthHeader() = %q, want empty", got)
+	}
+}
+
+func TestBearerAuthFlowPerCallFallbackStillAuthenticates(t *testing.T) {
+	t.Setenv("BEARER_FLOW_IDENTIFIER", "alice.example")
+	t.Setenv("BEARER_FLOW_APP_PASSWORD", "app-password")
+	t.Setenv("BEARER_FLOW_FALLBACK_TOKEN", "fallback-token")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got := cfg.AuthHeader(); got != "Bearer fallback-token" {
+		t.Fatalf("AuthHeader() = %q, want Bearer fallback-token", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "bearer_flow_input_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestBearerAuthFlowInputs")
+}
+
 func TestAuthLoginEnvVarsUseShellSafePrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -626,6 +626,68 @@ func TestBearerAuthFlowPerCallFallbackStillAuthenticates(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestBearerAuthFlowInputs")
 }
 
+// TestAuthHeader_BearerHarvestedInputsPreferAccessToken pins the harvested
+// env-var variant of the non-request Bearer flow. Harvested values are setup
+// artifacts, not values to replay directly as request credentials.
+func TestAuthHeader_BearerHarvestedInputsPreferAccessToken(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-harvested-input")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "bearer_token",
+		Header: "Authorization",
+		Format: "Bearer {token}",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "BEARER_HARVESTED_SESSION", Kind: spec.AuthEnvVarKindHarvested, Required: false, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-harvested-input-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	body := authHeaderBody(t, string(cfgSrc))
+
+	harvestedCheck := "if c." + resolveEnvVarField("BEARER_HARVESTED_SESSION") + ` != ""`
+	require.NotContains(t, body, harvestedCheck, "harvested session material must not be used as a bearer token")
+	require.Contains(t, body, `if c.AccessToken != ""`, "stored AccessToken must remain the Bearer request credential")
+
+	const runtimeTest = `package config
+
+import "testing"
+
+func TestBearerHarvestedInputsUseAccessToken(t *testing.T) {
+	t.Setenv("BEARER_HARVESTED_SESSION", "harvested-cookie")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	cfg.AccessToken = "access-jwt"
+
+	if got := cfg.AuthHeader(); got != "Bearer access-jwt" {
+		t.Fatalf("AuthHeader() = %q, want Bearer access-jwt", got)
+	}
+}
+
+func TestBearerHarvestedInputsAloneDoNotAuthenticate(t *testing.T) {
+	t.Setenv("BEARER_HARVESTED_SESSION", "harvested-cookie")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got := cfg.AuthHeader(); got != "" {
+		t.Fatalf("AuthHeader() = %q, want empty", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "bearer_harvested_input_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestBearerHarvestedInputs")
+}
+
 func TestAuthLoginEnvVarsUseShellSafePrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -310,6 +310,7 @@ func (c *Config) AuthHeader() string {
 {{- $canonicalEnvVar := .Auth.CanonicalEnvVar}}
 {{- $isAuthEnvVarORCase := .Auth.IsAuthEnvVarORCase}}
 {{- $basicAuthEnvVars := basicAuthEnvVars .Auth}}
+{{- $hasNonRequestEnvVars := or (hasAuthEnvVarKind .Auth.EnvVarSpecs "auth_flow_input") (hasAuthEnvVarKind .Auth.EnvVarSpecs "harvested")}}
 {{- if and .BearerRefresh.Enabled (eq .Auth.Type "bearer_token") (ne .Auth.EffectiveOAuth2Grant "client_credentials")}}
 	if c.AuthHeaderVal != "" && c.AccessToken == "" {
 		return c.AuthHeaderVal
@@ -440,7 +441,23 @@ func (c *Config) AuthHeader() string {
 		{{- end}}
 	}
 {{- else}}
+{{- if $hasNonRequestEnvVars}}
+	// Flow-input and harvested env vars are not request credentials. When a
+	// Bearer-shaped spec declares them, auth login stores the usable token in
+	// AccessToken, so it must win before considering any per-call fallbacks.
+	if c.AccessToken != "" {
+		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
+			c.AuthSource = "oauth2"
+		}
+		{{- if .Auth.Format}}
+		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		{{- else}}
+		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
+		{{- end}}
+	}
+{{- else}}
 	// Env-var token wins over file-stored AccessToken (env > config convention).
+{{- end}}
 {{- end}}
 {{- if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
@@ -462,7 +479,9 @@ func (c *Config) AuthHeader() string {
 	}
 {{- end}}
 {{- else}}
-	{{- with $canonicalEnvVar}}
+{{- if .Auth.EnvVarSpecs}}
+{{- range .Auth.EnvVarSpecs}}
+{{- if eq .Kind "per_call"}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
@@ -479,9 +498,30 @@ func (c *Config) AuthHeader() string {
 		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
 		{{- end}}
 	}
-	{{- end}}
 {{- end}}
-{{- if not .BearerRefresh.Enabled}}
+{{- end}}
+{{- else}}
+{{- with $canonicalEnvVar}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		if c.AuthSource == "" {
+			c.AuthSource = "env:{{.Name}}"
+		}
+		{{- if $.Auth.Format}}
+		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
+			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{- if ne (envVarPlaceholder .Name) "token"}}
+			"token": c.{{resolveEnvVarField .Name}},
+			{{- end}}
+		})
+		{{- else}}
+		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
+		{{- end}}
+	}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- if and (not .BearerRefresh.Enabled) (not $hasNonRequestEnvVars)}}
 	if c.AccessToken != "" {
 		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
 			c.AuthSource = "oauth2"

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -461,6 +461,7 @@ func (c *Config) AuthHeader() string {
 {{- end}}
 {{- if $isAuthEnvVarORCase}}
 {{- range .Auth.EnvVarSpecs}}
+{{- if eq .Kind "per_call"}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
@@ -477,6 +478,7 @@ func (c *Config) AuthHeader() string {
 		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
 		{{- end}}
 	}
+{{- end}}
 {{- end}}
 {{- else}}
 {{- if .Auth.EnvVarSpecs}}


### PR DESCRIPTION
## Summary

Bearer auth generated from session-login OpenAPI overlays now uses the stored access token for requests instead of treating `auth_flow_input` values such as identifiers or app passwords as the bearer credential.

This keeps `AuthHeaderVal` as the manual override, then uses `AccessToken` for auth-flow-backed Bearer specs, and only falls back to declared `per_call` env vars. Setup-only and harvested env vars are never emitted as runtime Bearer headers.

Closes #1242

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestAuthHeader_BearerAuthFlowInputsPreferAccessToken|TestAuthHeader_EnvVarWinsOverFileToken|TestAuthHeader_BearerTokenPrefixMissedSites|TestCatalogAuthEnvVars_GenerateReadsCatalogNamesFirst' -count=1`
- `go test ./internal/generator ./internal/spec`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `git diff --check`
- pre-push hook: `golangci-lint run ./...`
