### PR TITLE
docs(cli): clarify html link prefix semantics

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1816,7 +1816,7 @@ func (e Endpoint) UsesBinaryResponse() bool {
 
 type HTMLExtract struct {
 	Mode         string   `yaml:"mode,omitempty" json:"mode,omitempty"`                   // page (default), links, or embedded-json
-	LinkPrefixes []string `yaml:"link_prefixes,omitempty" json:"link_prefixes,omitempty"` // URL path prefixes to keep when extracting links (mode: links)
+	LinkPrefixes []string `yaml:"link_prefixes,omitempty" json:"link_prefixes,omitempty"` // path-segment prefixes to keep when extracting links (mode: links)
 	Limit        int      `yaml:"limit,omitempty" json:"limit,omitempty"`                 // max links to return; defaults at runtime (mode: links)
 	// ScriptSelector identifies the <script> tag containing serialized
 	// page state when mode is embedded-json. Defaults to

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1749,6 +1749,12 @@ Do not treat a persistent browser sidecar as a shippable CLI runtime. Browsers a
 
 Useful same-site HTML document pages count as a replayable surface when they return real content, not challenge/login pages. Browser-sniff can promote these into `response_format: html` endpoints so generated commands extract page metadata and filtered links through Surf/direct HTTP instead of keeping a browser sidecar alive.
 
+When hand-authoring a `response_format: html` spec with `html_extract.mode: links`,
+document and choose `link_prefixes` as path-segment prefixes. A prefix `/items`
+matches `/items` and `/items/...`, but not `/items123.html`; use the parent
+directory prefix when the leaf segment has embedded IDs or suffixes. See
+`skills/printing-press/references/spec-format.md` for the exact contract.
+
 If the browser capture contained only challenge/login/error pages, this exception does not apply.
 
 ### The Check

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -98,6 +98,7 @@ resources:                        # map[string]Resource (REQUIRED: at least one 
         response_format: json     # string optional: json | html | binary; defaults to json
         html_extract:             # object optional, only with response_format: html
           mode: page              # string optional: page | links | embedded-json
+          link_prefixes: []       # []string optional for links; path-segment-anchored prefixes
           script_selector: ""     # string optional for embedded-json; defaults to script#__NEXT_DATA__
           json_path: ""           # string optional for embedded-json; empty returns the full JSON
         response_path: data       # string optional path to extract list payload from wrapper response
@@ -115,6 +116,17 @@ GET/HEAD HTML documents, including HTML pages with embedded JSON such as
 Next.js `__NEXT_DATA__` or schema.org JSON-LD; prefer `html_extract` modes
 `page`, `links`, or `embedded-json` before writing custom extraction code. Use
 `binary` for opaque byte payloads.
+
+**`html_extract.link_prefixes` are path-segment anchored.** In `mode: links`, a
+prefix such as `/items` keeps links whose path is exactly `/items` or starts
+with `/items/`. It does not keep `/items123.html`, `/items-archive`, or other
+same-string-prefix leaf paths where the next character is not `/`.
+
+To keep all links under a subtree regardless of the leaf segment shape, choose
+the parent directory as the prefix. For paths like `/items/123.html` and
+`/items/456.html`, use `link_prefixes: ["/items"]`. Do not use a partial leaf
+prefix such as `/items/1` unless the target path is exactly `/items/1` or has a
+slash boundary after it.
 
 **`types.X.fields` is a list, not a map.** Each field is an item with
 `- name: <field-name>` followed by `type:`, `description:`, and other field

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -122,6 +122,9 @@ prefix such as `/items` keeps links whose path is exactly `/items` or starts
 with `/items/`. It does not keep `/items123.html`, `/items-archive`, or other
 same-string-prefix leaf paths where the next character is not `/`.
 
+The one exception is `/@`, which uses simple string-prefix matching so
+social-media-style handle paths such as `/@alice` and `/@bob` are kept.
+
 To keep all links under a subtree regardless of the leaf segment shape, choose
 the parent directory as the prefix. For paths like `/items/123.html` and
 `/items/456.html`, use `link_prefixes: ["/items"]`. Do not use a partial leaf


### PR DESCRIPTION
## Summary

Spec authors can now see that `html_extract.link_prefixes` use path-segment matching: `/items` matches `/items` and `/items/...`, but not `/items123.html` or other same-string-prefix leaf paths. The Printing Press skill also points hand-authored HTML link specs to the exact internal YAML contract.

Closes #1498

## Verification

- `git diff --check`
- `go test ./internal/spec`
- `go test ./...`
- pre-push hook: `fmt`, `lint`
