### PR TITLE
fix(cli): accept Windows staged live-check binaries

### DIFF
--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -402,9 +402,6 @@ func liveCheckExistingStageBinaryPath(cliDir, name string) (string, string) {
 			if filepath.Dir(cleanPath) != filepath.Clean(stagedDir) {
 				continue
 			}
-			if runtime.GOOS == "windows" && !strings.EqualFold(filepath.Ext(cleanPath), ".exe") {
-				continue
-			}
 			if _, err := os.Stat(cleanPath); err == nil {
 				return cleanPath, candidate
 			}
@@ -451,17 +448,21 @@ func newestLiveCheckSourceModTime(cliDir, cmdDir string) (time.Time, bool, error
 // is non-empty it's used verbatim; otherwise RunLiveCheck tries the common
 // `<base>-pp-cli` naming convention and falls back to `<base>`.
 func resolveBinaryPath(cliDir, name string) (string, error) {
-	candidates := liveCheckBinaryCandidates(cliDir, name)
+	return resolveBinaryPathForGOOS(cliDir, name, runtime.GOOS)
+}
+
+func resolveBinaryPathForGOOS(cliDir, name, goos string) (string, error) {
+	candidates := liveCheckBinaryCandidatesForGOOS(cliDir, name, goos)
 	var nonExecutablePath string
 	for _, candidate := range liveCheckBinaryNames(cliDir, name) {
 		var bestPath string
 		var bestModTime time.Time
-		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, runtime.GOOS) {
+		for _, path := range liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos) {
 			info, err := os.Stat(path)
 			if err != nil {
 				continue
 			}
-			if !isLiveCheckExecutable(path, info.Mode()) {
+			if !isLiveCheckExecutableForGOOS(path, info.Mode(), goos) {
 				if nonExecutablePath == "" {
 					nonExecutablePath = path
 				}
@@ -486,19 +487,14 @@ func resolveBinaryPath(cliDir, name string) (string, error) {
 	return "", fmt.Errorf("no runnable binary found in %q (tried %v)", cliDir, candidates)
 }
 
-func isLiveCheckExecutable(path string, mode os.FileMode) bool {
-	return isLiveCheckExecutableForGOOS(path, mode, runtime.GOOS)
-}
-
 func isLiveCheckExecutableForGOOS(path string, mode os.FileMode, goos string) bool {
+	if mode.IsDir() {
+		return false
+	}
 	if goos == "windows" {
-		return strings.EqualFold(filepath.Ext(path), ".exe")
+		return true
 	}
 	return mode&0o111 != 0
-}
-
-func liveCheckBinaryCandidates(cliDir, name string) []string {
-	return liveCheckBinaryCandidatesForGOOS(cliDir, name, runtime.GOOS)
 }
 
 func liveCheckBinaryCandidatesForGOOS(cliDir, name, goos string) []string {

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -700,15 +700,33 @@ func TestLiveCheckResolveBinaryPathSkipsNonExecutableCandidate(t *testing.T) {
 	require.Equal(t, filepath.Clean(rootPath), got)
 }
 
-func TestLiveCheckExecutableHonorsWindowsExeExtension(t *testing.T) {
+func TestLiveCheckResolveBinaryPathAcceptsWindowsExtensionlessCandidate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	stagedDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+
+	stagedPath := filepath.Join(stagedDir, "stub")
+	require.NoError(t, os.WriteFile(stagedPath, []byte("windows binary"), 0o644))
+
+	got, err := resolveBinaryPathForGOOS(dir, "stub", "windows")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(stagedPath), got)
+}
+
+func TestLiveCheckExecutableUsesHostExecutableRules(t *testing.T) {
 	t.Parallel()
 
 	assert.True(t,
 		isLiveCheckExecutableForGOOS(`C:\tmp\petstore-pp-cli.exe`, 0o644, "windows"),
-		"Windows executability is extension-based, not POSIX mode-bit-based")
-	assert.False(t,
+		"Windows executability is path-based, not POSIX mode-bit-based")
+	assert.True(t,
 		isLiveCheckExecutableForGOOS(`C:\tmp\petstore-pp-cli`, 0o755, "windows"),
-		"Windows live-check should only accept .exe binaries")
+		"Windows live-check should skip POSIX executable-bit checks")
+	assert.False(t,
+		isLiveCheckExecutableForGOOS(`C:\tmp\petstore-pp-cli`, os.ModeDir|0o755, "windows"),
+		"Windows live-check should still reject directories")
 	assert.True(t,
 		isLiveCheckExecutableForGOOS("/tmp/petstore-pp-cli", 0o755, "linux"),
 		"Unix live-check should keep honoring executable bits")


### PR DESCRIPTION
## Summary
Windows scorecard live checks can now resolve extensionless staged binaries instead of treating missing Unix exec bits as "not executable". The resolver still skips non-executable Unix candidates and reports a real error when no runnable candidate exists.

## Validation
- `go test ./internal/pipeline -run 'TestLiveCheckResolveBinaryPath|TestLiveCheckExecutableUsesHostExecutableRules'`
- `golangci-lint run ./internal/pipeline`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`

Closes #1726
