### PR TITLE
fix(cli): detect unsafe chrome impersonation

### DIFF
--- a/internal/browsersniff/analysis.go
+++ b/internal/browsersniff/analysis.go
@@ -294,10 +294,11 @@ type AuthCandidate struct {
 }
 
 type ReachabilityAnalysis struct {
-	Mode       string        `json:"mode"`
-	Confidence float64       `json:"confidence"`
-	Reasons    []string      `json:"reasons,omitempty"`
-	Evidence   []EvidenceRef `json:"evidence,omitempty"`
+	Mode              string        `json:"mode"`
+	Confidence        float64       `json:"confidence"`
+	Reasons           []string      `json:"reasons,omitempty"`
+	Evidence          []EvidenceRef `json:"evidence,omitempty"`
+	ImpersonationSafe *bool         `json:"impersonation_safe,omitempty"`
 
 	// HTMLExtractSignature is set when Mode == "html_scrape" and carries
 	// which SSR state-blob signature triggered the promotion (one of
@@ -1630,6 +1631,9 @@ func deriveGenerationHints(analysis *TrafficAnalysis) []string {
 		}
 	}
 	if analysis.Reachability != nil {
+		if analysis.Reachability.ImpersonationSafe != nil && !*analysis.Reachability.ImpersonationSafe {
+			hints["impersonation_content_type_flip"] = true
+		}
 		switch analysis.Reachability.Mode {
 		case "browser_http":
 			hints["browser_http_transport"] = true

--- a/internal/browsersniff/analysis_test.go
+++ b/internal/browsersniff/analysis_test.go
@@ -521,6 +521,21 @@ func TestAnalyzeTraffic_ClassifiesBrowserClearanceReachability(t *testing.T) {
 	assert.Contains(t, analysis.GenerationHints, "requires_browser_auth")
 }
 
+func TestDeriveGenerationHintsIncludesImpersonationContentTypeFlip(t *testing.T) {
+	t.Parallel()
+
+	impersonationSafe := false
+	analysis := &TrafficAnalysis{
+		Reachability: &ReachabilityAnalysis{
+			Mode:              "standard_http",
+			Confidence:        0.95,
+			ImpersonationSafe: &impersonationSafe,
+		},
+	}
+
+	assert.Contains(t, deriveGenerationHints(analysis), "impersonation_content_type_flip")
+}
+
 func TestAnalyzeTraffic_IgnoresThirdPartyProtectionMarkersForReachability(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -38,7 +38,8 @@ const trafficAnalysisSchemaJSON = `{
         "mode": {"type": "string", "enum": ["standard_http", "browser_http", "browser_clearance_http", "browser_required", "blocked", "unknown"]},
         "confidence": {"type": "number", "minimum": 0, "maximum": 1},
         "reasons": {"type": "array", "items": {"type": "string"}},
-        "evidence": {"type": "array", "items": {"oneOf": [{"$ref": "#/$defs/evidence_ref"}, {"type": "string"}]}}
+        "evidence": {"type": "array", "items": {"oneOf": [{"$ref": "#/$defs/evidence_ref"}, {"type": "string"}]}},
+        "impersonation_safe": {"type": "boolean"}
       }
     },
     "protocols": {"type": "array", "items": {"$ref": "#/$defs/protocol_observation"}},

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -745,6 +745,7 @@ type clientTemplateData struct {
 	HasGraphQLPersistedQueries bool
 	HasMultipartRequest        bool
 	HasFormRequest             bool
+	UseChromeImpersonation     bool
 	// Populated by Generator.shouldEmitAuth() so this template gate stays in
 	// sync with auth.go emission, root.go registration, and scoreAuth.
 	HasAuthCommand bool
@@ -1546,6 +1547,13 @@ func (g *Generator) hasTrafficAnalysisHint(hint string) bool {
 	return slices.Contains(g.TrafficAnalysis.GenerationHints, hint)
 }
 
+func (g *Generator) shouldUseChromeImpersonation() bool {
+	if g == nil || g.TrafficAnalysis == nil || g.TrafficAnalysis.Reachability == nil || g.TrafficAnalysis.Reachability.ImpersonationSafe == nil {
+		return true
+	}
+	return *g.TrafficAnalysis.Reachability.ImpersonationSafe
+}
+
 func appendLimited(values []string, value string, limit int) []string {
 	value = strings.TrimSpace(value)
 	if value == "" || len(values) >= limit {
@@ -1829,6 +1837,7 @@ func (g *Generator) renderSingleFiles() error {
 				HasGraphQLPersistedQueries: g.hasTrafficAnalysisHint("graphql_persisted_query"),
 				HasMultipartRequest:        hasMultipartRequest(g.Spec),
 				HasFormRequest:             hasFormRequest(g.Spec),
+				UseChromeImpersonation:     g.shouldUseChromeImpersonation(),
 				HasAuthCommand:             g.shouldEmitAuth(),
 			}
 		case "config.go.tmpl":

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -329,8 +329,10 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 {{- else if .UsesBrowserHTTPTransport}}
 	builder := surf.NewClient().
 		Builder().
+{{- if .UseChromeImpersonation}}
 		Impersonate().
 		Chrome().
+{{- end}}
 		Timeout(timeout)
 {{- if .UsesBrowserHTTP3Transport}}
 	builder = builder.ForceHTTP3()

--- a/internal/generator/transport_timeout_test.go
+++ b/internal/generator/transport_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
@@ -64,6 +65,56 @@ func TestBrowserTransport_OverridesResponseHeaderTimeout(t *testing.T) {
 		"surfClient.GetTransport() must be type-asserted to *enetxhttp.Transport — surf returns the enetx HTTP fork's RoundTripper, not stdlib's, so a stdlib type-assertion is impossible")
 	require.Contains(t, src, "t.ResponseHeaderTimeout = timeout",
 		"ResponseHeaderTimeout must be set to the user-supplied timeout so --timeout reaches the transport layer")
+}
+
+func TestBrowserTransport_DropsChromeImpersonationWhenTrafficAnalysisMarksUnsafe(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:       "transport-content-negotiation-canary",
+		Version:    "0.1.0",
+		BaseURL:    "https://www.example.com",
+		SpecSource: "sniffed",
+		Owner:      "test-owner",
+		OwnerName:  "Test Author",
+		Auth:       spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/transport-content-negotiation-canary-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"stores": {
+				Description: "Browse stores",
+				Endpoints: map[string]spec.Endpoint{
+					"get": {Method: "GET", Path: "/api/Stores/{id}", Description: "Get store"},
+				},
+			},
+		},
+	}
+	impersonationSafe := false
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.TrafficAnalysis = &browsersniff.TrafficAnalysis{
+		Reachability: &browsersniff.ReachabilityAnalysis{
+			Mode:              "standard_http",
+			Confidence:        0.95,
+			ImpersonationSafe: &impersonationSafe,
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	src := string(clientSrc)
+
+	require.Contains(t, src, `"github.com/enetx/surf"`,
+		"sniffed CLIs still use surf transport when the spec defaults to browser transport")
+	require.NotContains(t, src, "Impersonate()",
+		"content-type flip evidence must suppress Chrome impersonation")
+	require.NotContains(t, src, "Chrome()",
+		"content-type flip evidence must suppress Chrome Accept-header impersonation")
+	require.Contains(t, src, "ForceHTTP2()",
+		"the existing sniffed browser transport default should still force HTTP/2")
 }
 
 // TestNonBrowserTransport_DoesNotEmitOverride asserts the override only

--- a/internal/reachability/probe.go
+++ b/internal/reachability/probe.go
@@ -119,7 +119,7 @@ func classifyStdlibSuccess(result *Result, partial bool) {
 		safe := false
 		result.ImpersonationSafe = &safe
 		result.Recommendation.Rationale = fmt.Sprintf(
-			"Plain stdlib HTTP returned %s, while Surf Chrome impersonation returned %s. Prefer non-impersonating HTTP so content negotiation stays on JSON.",
+			"Plain stdlib HTTP returned %s, while Surf Chrome impersonation returned %s. Prefer non-impersonating HTTP so content negotiation stays on the stdlib response type.",
 			displayContentType(stdlib.ContentType),
 			displayContentType(surf.ContentType),
 		)

--- a/internal/reachability/probe.go
+++ b/internal/reachability/probe.go
@@ -67,22 +67,12 @@ func Probe(ctx context.Context, url string, opts Options) (*Result, error) {
 	if runStdlib {
 		pr := runRung(ctx, url, TransportStdlib, opts)
 		result.Probes = append(result.Probes, pr)
-		if pr.Status > 0 && len(pr.Evidence) == 0 && statusIsClear(pr.Status) {
-			result.Mode = ModeStandardHTTP
-			result.Confidence = 0.95
-			result.Recommendation = Recommendation{
-				Runtime:   ModeStandardHTTP,
-				Rationale: "Plain stdlib HTTP returned a non-error response; no special transport needed.",
-			}
-			result.Partial = partial
-			return result, nil
-		}
 	}
 
 	if runSurf {
 		pr := runRung(ctx, url, TransportSurfChrome, opts)
 		result.Probes = append(result.Probes, pr)
-		if pr.Status > 0 && len(pr.Evidence) == 0 && statusIsClear(pr.Status) {
+		if pr.Status > 0 && len(pr.Evidence) == 0 && statusIsClear(pr.Status) && !stdlibCleared(result) {
 			result.Mode = ModeBrowserHTTP
 			result.Confidence = 0.85
 			result.Recommendation = Recommendation{
@@ -94,8 +84,96 @@ func Probe(ctx context.Context, url string, opts Options) (*Result, error) {
 		}
 	}
 
+	if stdlibCleared(result) {
+		classifyStdlibSuccess(result, partial)
+		return result, nil
+	}
+
 	classifyFailure(result, partial)
 	return result, nil
+}
+
+func stdlibCleared(result *Result) bool {
+	for _, pr := range result.Probes {
+		if pr.Transport == TransportStdlib && pr.Status > 0 && len(pr.Evidence) == 0 && statusIsClear(pr.Status) {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyStdlibSuccess(result *Result, partial bool) {
+	result.Mode = ModeStandardHTTP
+	result.Confidence = 0.95
+	result.Recommendation = Recommendation{
+		Runtime:   ModeStandardHTTP,
+		Rationale: "Plain stdlib HTTP returned a non-error response; no special transport needed.",
+	}
+	result.Partial = partial
+
+	stdlib, surf, ok := pairedClearProbes(result)
+	if !ok {
+		return
+	}
+	if contentTypesFlipJSONXML(stdlib.ContentType, surf.ContentType) {
+		safe := false
+		result.ImpersonationSafe = &safe
+		result.Recommendation.Rationale = fmt.Sprintf(
+			"Plain stdlib HTTP returned %s, while Surf Chrome impersonation returned %s. Prefer non-impersonating HTTP so content negotiation stays on JSON.",
+			displayContentType(stdlib.ContentType),
+			displayContentType(surf.ContentType),
+		)
+	}
+}
+
+func pairedClearProbes(result *Result) (ProbeResult, ProbeResult, bool) {
+	var stdlib ProbeResult
+	var surf ProbeResult
+	stdlibOK := false
+	surfOK := false
+	for _, pr := range result.Probes {
+		if pr.Status <= 0 || len(pr.Evidence) > 0 || !statusIsClear(pr.Status) {
+			continue
+		}
+		switch pr.Transport {
+		case TransportStdlib:
+			stdlib = pr
+			stdlibOK = true
+		case TransportSurfChrome:
+			surf = pr
+			surfOK = true
+		}
+	}
+	return stdlib, surf, stdlibOK && surfOK
+}
+
+func contentTypesFlipJSONXML(a, b string) bool {
+	ak := contentTypeKind(a)
+	bk := contentTypeKind(b)
+	return (ak == "json" && bk == "xml") || (ak == "xml" && bk == "json")
+}
+
+func contentTypeKind(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if i := strings.Index(value, ";"); i >= 0 {
+		value = strings.TrimSpace(value[:i])
+	}
+	switch {
+	case strings.Contains(value, "json"):
+		return "json"
+	case strings.Contains(value, "xml"):
+		return "xml"
+	default:
+		return ""
+	}
+}
+
+func displayContentType(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "an empty Content-Type"
+	}
+	return value
 }
 
 // statusIsClear is the status-only half of isClear. Used after evidence

--- a/internal/reachability/probe_test.go
+++ b/internal/reachability/probe_test.go
@@ -53,6 +53,22 @@ func ok200(_ *http.Request) (*http.Response, error) {
 	}, nil
 }
 
+func json200(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"application/json; charset=utf-8"}},
+		Body:       respBody(`{"ok":true}`),
+	}, nil
+}
+
+func xml200(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"application/xml; charset=utf-8"}},
+		Body:       respBody(`<StoreModel><ok>true</ok></StoreModel>`),
+	}, nil
+}
+
 func cloudflareChallenge(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 403,
@@ -83,10 +99,23 @@ func TestProbe_StdlibPasses(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, ModeStandardHTTP, result.Mode)
-	assert.Len(t, result.Probes, 1, "should stop at first clear pass")
+	assert.Len(t, result.Probes, 2, "full probes compare surf against stdlib for content negotiation drift")
 	assert.Equal(t, TransportStdlib, result.Probes[0].Transport)
 	assert.False(t, result.Partial)
 	assert.False(t, result.Recommendation.NeedsBrowserCapture)
+}
+
+func TestProbe_StdlibJSONSurfXMLMarksImpersonationUnsafe(t *testing.T) {
+	result, err := Probe(context.Background(), "https://example.com/api/stores/123", Options{
+		HTTPClientFactory: fakeFactory(json200, xml200),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ModeStandardHTTP, result.Mode)
+	require.NotNil(t, result.ImpersonationSafe)
+	assert.False(t, *result.ImpersonationSafe)
+	assert.Contains(t, result.Recommendation.Rationale, "Surf Chrome impersonation")
+	assert.Equal(t, "application/json; charset=utf-8", result.Probes[0].ContentType)
+	assert.Equal(t, "application/xml; charset=utf-8", result.Probes[1].ContentType)
 }
 
 func TestProbe_StdlibChallengedSurfClears_FoodS52Pattern(t *testing.T) {

--- a/internal/reachability/types.go
+++ b/internal/reachability/types.go
@@ -57,11 +57,12 @@ const (
 // printing-press skill (and any future scripts) can consume this without
 // depending on Go struct ordering.
 type Result struct {
-	URL            string         `json:"url"`
-	Mode           Mode           `json:"mode"`
-	Confidence     float64        `json:"confidence"`
-	Probes         []ProbeResult  `json:"probes"`
-	Recommendation Recommendation `json:"recommendation"`
+	URL               string         `json:"url"`
+	Mode              Mode           `json:"mode"`
+	Confidence        float64        `json:"confidence"`
+	Probes            []ProbeResult  `json:"probes"`
+	Recommendation    Recommendation `json:"recommendation"`
+	ImpersonationSafe *bool          `json:"impersonation_safe,omitempty"`
 	// Partial is true when --probe-only restricted the ladder to one rung.
 	// Skill consumers should ignore Mode when Partial is true.
 	Partial bool `json:"partial,omitempty"`

--- a/testdata/golden/expected/schema-traffic-analysis/stdout.txt
+++ b/testdata/golden/expected/schema-traffic-analysis/stdout.txt
@@ -30,7 +30,8 @@
         "mode": {"type": "string", "enum": ["standard_http", "browser_http", "browser_clearance_http", "browser_required", "blocked", "unknown"]},
         "confidence": {"type": "number", "minimum": 0, "maximum": 1},
         "reasons": {"type": "array", "items": {"type": "string"}},
-        "evidence": {"type": "array", "items": {"oneOf": [{"$ref": "#/$defs/evidence_ref"}, {"type": "string"}]}}
+        "evidence": {"type": "array", "items": {"oneOf": [{"$ref": "#/$defs/evidence_ref"}, {"type": "string"}]}},
+        "impersonation_safe": {"type": "boolean"}
       }
     },
     "protocols": {"type": "array", "items": {"$ref": "#/$defs/protocol_observation"}},


### PR DESCRIPTION
## Summary

Printed CLIs can now avoid Chrome impersonation when the reachability probe proves it changes API content negotiation from JSON to XML. `probe-reachability` compares stdlib and Surf Chrome responses on full runs, emits `impersonation_safe: false` for JSON/XML flips, and traffic-analysis can carry the same signal as `reachability.impersonation_safe`.

When that signal is false, generated browser-transport clients keep the existing Surf transport and HTTP version behavior but omit `Impersonate().Chrome()`, so ASP.NET WCF backends keep returning JSON instead of XML.

Closes #1950.

## Verification

- `go test ./internal/reachability`
- `go test ./internal/browsersniff`
- `go test ./internal/cli -run 'TestSchema|TestProbeReachability'`
- `go test ./internal/generator -run 'TestBrowserTransport_(OverridesResponseHeaderTimeout|DropsChromeImpersonationWhenTrafficAnalysisMarksUnsafe)$'`
- `scripts/golden.sh verify`
- `go test ./...`
- Post-rebase: `go test ./internal/reachability ./internal/browsersniff ./internal/generator`
- Post-rebase: `scripts/golden.sh verify`
- Live smoke: `./cli-printing-press probe-reachability 'https://bjacocksgreen.mybigjohns.com/api/Stores/96936521-4150-4910-91bd-6b8af0b8e5fe' --json --timeout 10s` returned stdlib `application/json`, Surf Chrome `application/xml`, and `impersonation_safe: false`
