### PR TITLE
fix(cli): derive header sibling auth env vars

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -488,6 +488,9 @@ Rules:
   generated per-call env var for that sibling header. Use `x-auth-vars` for
   richer metadata or when more than one credential variable belongs to the
   same scheme.
+- If a sibling apiKey/header scheme omits `x-auth-env-vars` and `x-auth-vars`,
+  the parser derives a required per-call env var from the API slug and header
+  name, for example `DISPATCH_ST_APP_KEY` for `ST-App-Key`.
 
 Catalog-driven equivalent: when a catalog entry declares `auth_env_vars`, the
 generator layers the canonical names on top of the parser-derived default at

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1116,6 +1116,61 @@ func TestGenerateComposedApiKeyPlusBearerEmitsAdditionalHeader(t *testing.T) {
 		"MCP context must expose sibling apiKey credentials to agents")
 }
 
+func TestGenerateComposedHeaderApiKeyDerivesMissingSiblingEnvVar(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Dispatch
+  version: "1.0.0"
+servers:
+  - url: https://api.servicetitan.io
+security:
+  - oauth: []
+    appKey: []
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.servicetitan.io/connect/token
+          scopes: {}
+      x-auth-env-vars:
+        - ST_CLIENT_ID
+        - ST_CLIENT_SECRET
+    appKey:
+      type: apiKey
+      in: header
+      name: ST-App-Key
+paths:
+  /customers:
+    get:
+      operationId: listCustomers
+      responses:
+        "200":
+          description: OK
+`))
+	require.NoError(t, err)
+	apiSpec.Name = "dispatch"
+	apiSpec.Config = spec.ConfigSpec{Format: "toml", Path: "~/.config/dispatch-pp-cli/config.toml"}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	configBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	configSrc := string(configBytes)
+	assert.Regexp(t, `DispatchStAppKey\s+string`, configSrc)
+	assert.Contains(t, configSrc, `os.Getenv("DISPATCH_ST_APP_KEY")`)
+	assert.Contains(t, configSrc, `cfg.DispatchStAppKey = v`)
+
+	clientBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(clientBytes), `req.Header.Set("ST-App-Key", v)`)
+}
+
 // Trello-shaped OpenAPI specs require two apiKey query credentials in the
 // same security requirement. The first key follows the primary auth path; the
 // sibling token must be loaded into config, counted by doctor, and attached to

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -29,6 +29,14 @@ var (
 	endpointLimitExplicit   = false // true when user set --max-endpoints-per-resource
 )
 
+type additionalHeaderFallbackMode int
+
+const (
+	additionalHeaderFallbackNone additionalHeaderFallbackMode = iota
+	additionalHeaderFallbackScheme
+	additionalHeaderFallbackHeader
+)
+
 const (
 	extensionAuthEnvVars           = "x-auth-env-vars"
 	extensionAuthVars              = "x-auth-vars"
@@ -1006,12 +1014,13 @@ func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescript
 // header on every Bearer-authenticated request. Only schemes co-located with
 // the winner in a requirement object are promoted.
 //
-// Only apiKey-typed siblings with `in: header` or `in: query` are considered. Rich
-// x-auth-vars per_call declarations win; legacy x-auth-env-vars supplies the
-// same credential name for specs that do not use the rich shape. For all-apiKey
-// AND groups, missing extension metadata falls back to a deterministic
-// scheme-derived env var so every required credential reaches generated config
-// and client code.
+// Only apiKey-typed siblings with `in: header` or `in: query` are considered.
+// Rich x-auth-vars per_call declarations win; legacy x-auth-env-vars supplies
+// the same credential name for specs that do not use the rich shape. Missing
+// extension metadata falls back to a deterministic header-derived env var for
+// header siblings, and to a scheme-derived env var for all-apiKey AND groups,
+// so every required supported credential reaches generated config and client
+// code.
 func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []spec.AdditionalAuthHeader {
 	if doc == nil || doc.Components == nil || len(doc.Components.SecuritySchemes) <= 1 {
 		return nil
@@ -1067,7 +1076,13 @@ func collectAdditionalAuthHeaders(doc *openapi3.T, winner, envPrefix string) []s
 		if placement != "header" && placement != "query" {
 			continue
 		}
-		envVars := additionalHeaderEnvVars(scheme, name, envPrefix, fallbackEligible[name])
+		fallbackMode := additionalHeaderFallbackNone
+		if fallbackEligible[name] {
+			fallbackMode = additionalHeaderFallbackScheme
+		} else if placement == "header" {
+			fallbackMode = additionalHeaderFallbackHeader
+		}
+		envVars := additionalHeaderEnvVars(scheme, name, header, envPrefix, fallbackMode)
 		for _, ev := range envVars {
 			if ev.EffectiveKind() != spec.AuthEnvVarKindPerCall {
 				continue
@@ -1180,7 +1195,7 @@ func additionalHeaderSiblingSignature(req openapi3.SecurityRequirement, winner s
 	return strings.Join(siblings, "|")
 }
 
-func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, envPrefix string, allowFallback bool) []spec.AuthEnvVar {
+func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, headerName, envPrefix string, fallbackMode additionalHeaderFallbackMode) []spec.AuthEnvVar {
 	if scheme == nil {
 		return nil
 	}
@@ -1206,10 +1221,10 @@ func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, envPre
 			Inferred:  true,
 		}}
 	}
-	if !allowFallback {
+	if fallbackMode == additionalHeaderFallbackNone {
 		return nil
 	}
-	name := derivedAdditionalHeaderEnvVar(schemeName, envPrefix)
+	name := derivedAdditionalHeaderEnvVar(schemeName, headerName, envPrefix, fallbackMode)
 	if name == "" {
 		return nil
 	}
@@ -1222,7 +1237,14 @@ func additionalHeaderEnvVars(scheme *openapi3.SecurityScheme, schemeName, envPre
 	}}
 }
 
-func derivedAdditionalHeaderEnvVar(schemeName, envPrefix string) string {
+func derivedAdditionalHeaderEnvVar(schemeName, headerName, envPrefix string, fallbackMode additionalHeaderFallbackMode) string {
+	if fallbackMode == additionalHeaderFallbackHeader {
+		headerSuffix := toSnakeCase(headerName)
+		if headerSuffix == "" {
+			return ""
+		}
+		return envPrefix + "_" + strings.ToUpper(headerSuffix)
+	}
 	envVars := defaultAuthEnvVars("api_key", "", schemeName, envPrefix)
 	if len(envVars) == 0 {
 		return ""

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -4668,16 +4668,15 @@ paths:
 		"OR alternative schemes must not surface as required siblings")
 }
 
-// A sibling apiKey scheme that omits the x-auth-vars extension is silently
-// skipped: collectAdditionalAuthHeaders never invents env-var names. The
-// scheme's per-call credential simply isn't covered, and the primary auth
-// remains untouched.
-func TestSiblingApiKeyWithoutAuthVarsIsSkipped(t *testing.T) {
+// A sibling header apiKey scheme that omits the x-auth-vars extension still
+// needs a deterministic env var: in an AND security requirement, the API
+// requires both the primary auth and the sibling header credential.
+func TestSiblingHeaderApiKeyWithoutAuthVarsDerivesEnvVar(t *testing.T) {
 	t.Parallel()
 
 	yamlSpec := []byte(`openapi: "3.0.3"
 info:
-  title: no-auth-vars-sibling
+  title: Dispatch
   version: "1.0.0"
 servers:
   - url: https://api.example.com
@@ -4692,7 +4691,7 @@ components:
     apiKey:
       type: apiKey
       in: header
-      name: X-Sibling-Key
+      name: ST-App-Key
 paths:
   /items:
     get:
@@ -4702,7 +4701,15 @@ paths:
 `)
 	parsed, err := Parse(yamlSpec)
 	require.NoError(t, err)
-	assert.Empty(t, parsed.Auth.AdditionalHeaders)
+	require.Len(t, parsed.Auth.AdditionalHeaders, 1)
+	additional := parsed.Auth.AdditionalHeaders[0]
+	assert.Equal(t, "ST-App-Key", additional.Header)
+	assert.Equal(t, "header", additional.In)
+	assert.Equal(t, "apiKey", additional.Scheme)
+	assert.Equal(t, "DISPATCH_ST_APP_KEY", additional.EnvVar.Name)
+	assert.Equal(t, spec.AuthEnvVarKindPerCall, additional.EnvVar.Kind)
+	assert.True(t, additional.EnvVar.Required)
+	assert.True(t, additional.EnvVar.Sensitive)
 }
 
 // Sibling apiKey-in-query schemes are required credentials just like
@@ -4754,6 +4761,48 @@ paths:
 	assert.Equal(t, "query", additional.In)
 	assert.Equal(t, "APIToken", additional.Scheme)
 	assert.Equal(t, "TRELLO_TOKEN", additional.EnvVar.Name)
+	assert.Equal(t, spec.AuthEnvVarKindPerCall, additional.EnvVar.Kind)
+	assert.True(t, additional.EnvVar.Required)
+	assert.True(t, additional.EnvVar.Sensitive)
+}
+
+func TestAllApiKeyQuerySiblingWithoutAuthVarsKeepsSchemeDerivedFallback(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: trello-shaped
+  version: "1.0.0"
+servers:
+  - url: https://api.trello.com/1
+security:
+  - APIKey: []
+    APIToken: []
+components:
+  securitySchemes:
+    APIKey:
+      type: apiKey
+      in: query
+      name: key
+    APIToken:
+      type: apiKey
+      in: query
+      name: token
+paths:
+  /members/me:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+	require.Len(t, parsed.Auth.AdditionalHeaders, 1)
+	additional := parsed.Auth.AdditionalHeaders[0]
+	assert.Equal(t, "token", additional.Header)
+	assert.Equal(t, "query", additional.In)
+	assert.Equal(t, "APIToken", additional.Scheme)
+	assert.Equal(t, "TRELLO_SHAPED_APITOKEN", additional.EnvVar.Name)
 	assert.Equal(t, spec.AuthEnvVarKindPerCall, additional.EnvVar.Kind)
 	assert.True(t, additional.EnvVar.Required)
 	assert.True(t, additional.EnvVar.Sensitive)


### PR DESCRIPTION
## Summary

Generated CLIs now keep required sibling header credentials when an OpenAPI security requirement combines OAuth or bearer auth with an undecorated `apiKey` header scheme. Instead of silently dropping the header, the parser derives a per-call env var from the API slug and header name, such as `DISPATCH_ST_APP_KEY` for `ST-App-Key`, and the existing config/client templates emit the field, env read, and request header.

This preserves the existing explicit override path for `x-auth-vars` and `x-auth-env-vars`, keeps OR-alternative schemes skipped, and leaves existing all-apiKey query fallback behavior scheme-derived.

Closes #1333

## Verification

- `go test ./internal/openapi -run 'TestSibling(HeaderApiKeyWithoutAuthVarsDerivesEnvVar|ApiKeyInDifferentRequirementGroupIsSkipped|ApiKeyInQueryIsCollected)|TestAllApiKeyQuerySiblingWithoutAuthVarsKeepsSchemeDerivedFallback'`
- `go test ./internal/generator -run 'TestGenerateComposed(HeaderApiKeyDerivesMissingSiblingEnvVar|ApiKeyPlusBearerEmitsAdditionalHeader|QueryApiKeysEmitAdditionalQueryParam|OAuth2WithoutAdditionalHeadersIsClean)'`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
