### PR TITLE
fix(cli): reject invalid enum flag values with the valid set

### DIFF
--- a/internal/generator/enum_validation_test.go
+++ b/internal/generator/enum_validation_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // TestEnumParamEmitsValidation ensures that params declared with enum constraints
-// cause the generated command to (a) emit runtime validation that warns on
-// unknown values and (b) include a "(one of: ...)" hint in the flag description.
-// Regression guard for #205.
+// cause the generated command to (a) emit runtime validation that rejects
+// unknown values with the valid set and (b) include a "(one of: ...)" hint in
+// the flag description. Regression guard for #205 and #1139.
 func TestEnumParamEmitsValidation(t *testing.T) {
 	t.Parallel()
 
@@ -59,8 +59,46 @@ func TestEnumParamEmitsValidation(t *testing.T) {
 	// Runtime validation block emitted.
 	require.Contains(t, code, `allowedStatus := []string{"active", "archived", "pending"}`,
 		"runtime validation must declare the allowed set")
-	require.Contains(t, code, `warning: --%s %q not in allowed set %v`,
-		"runtime validation must warn on unknown value")
+	require.Contains(t, code, `return fmt.Errorf("invalid value %q for --%s: must be one of %v"`,
+		"runtime validation must REJECT (return error) on unknown value, not warn")
+	require.NotContains(t, code, `"warning: --%s %q not in allowed set`,
+		"the old warn-and-continue enum behavior must be gone")
+}
+
+// TestEnumParamPromotedCommandRejects covers the promoted-command template's
+// enum path (command_promoted.go.tmpl), which carries the same warn→reject
+// change as the endpoint template but is otherwise only validated by reading
+// template source. A single-endpoint resource is promoted; its enum param must
+// reject invalid values with the same error.
+func TestEnumParamPromotedCommandRejects(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("enum-promoted")
+	apiSpec.Resources["themes"] = spec.Resource{
+		Description: "Themes",
+		Endpoints: map[string]spec.Endpoint{
+			"search": {
+				Method:      "GET",
+				Path:        "/themes/search",
+				Description: "Search themes by mode",
+				Params: []spec.Param{
+					{Name: "mode", Type: "string", Required: false, Enum: []string{"light", "dark"}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "enum-promoted-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "promoted_themes.go"))
+	require.NoError(t, err)
+	code := string(src)
+
+	require.Contains(t, code, `allowedMode := []string{"light", "dark"}`,
+		"promoted command must declare the allowed enum set")
+	require.Contains(t, code, `return fmt.Errorf("invalid value %q for --%s: must be one of %v"`,
+		"promoted command must reject unknown enum values, not warn")
 }
 
 // TestNonEnumParamDoesNotEmitValidation ensures the enum block is gated

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -90,7 +90,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 					}
 				}
 				if !valid{{camel (paramIdent .)}} {
-					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "{{publicFlagName .}}", flag{{camel (paramIdent .)}}, allowed{{camel (paramIdent .)}})
+					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", allowed{{camel (paramIdent .)}})
 				}
 			}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -72,7 +72,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 				if !valid{{camel (paramIdent .)}} {
-					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "{{publicFlagName .}}", flag{{camel (paramIdent .)}}, allowed{{camel (paramIdent .)}})
+					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", allowed{{camel (paramIdent .)}})
 				}
 			}
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -33,7 +33,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 				if !validStatus {
-					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "status", flagStatus, allowedStatus)
+					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flagStatus, "status", allowedStatus)
 				}
 			}
 			c, err := flags.newClient()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -37,7 +37,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 				if !validPriority {
-					fmt.Fprintf(os.Stderr, "warning: --%s %q not in allowed set %v\n", "priority", flagPriority, allowedPriority)
+					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flagPriority, "priority", allowedPriority)
 				}
 			}
 			c, err := flags.newClient()


### PR DESCRIPTION
## Intent

Raw mirror commands generated from an OpenAPI enum only WARNED on an out-of-set value and then sent it to the API, which returned an opaque HTTP 400. A user/agent who learned a human-friendly alias from a curated command (e.g. `--by program`) and applied it to a raw mirror command got no hint about the accepted wire values.

Issue: Closes #1139

## Approach

Issue's recommended fix (b): change the generated enum check (endpoint + promoted templates) from a stderr warning to a hard error naming the valid set — `invalid value "program" for --by: must be one of [ByProgram, ByNetwork, ...]`. This is the generator-appropriate fix; per-API alias-translation tables (option a) don't generalize. The check stays gated on `cmd.Flags().Changed(...)`, so an unset/default enum flag never errors.

## Scope

Primary area: generator (`command_endpoint.go.tmpl`, `command_promoted.go.tmpl`). Machine change — every printed CLI gains a hard enum gate on next regen.

## Catalog Justification

N/A

## Risk

Behavior change for invalid enum input across all printed CLIs: a hard local non-zero exit instead of a warning. The rejected input would have failed at the API anyway (opaque 400); this surfaces a helpful local error instead. Not a release-breaking change (no removed/renamed surface). Golden fixtures updated (two enum-bearing commands).

## Output Contract

Generated enum-validation block now returns an error instead of printing a warning. `generate-golden-api` fixtures (`projects_list.go` status, `projects_tasks_list-project.go` priority) updated.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases; 2 updated intentionally)
- `enum_validation_test.go` asserts the reject behavior; sibling tests pin scope (non-enum, int-enum-skip, positional-skip)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change