### PR TITLE
fix(cli): strip =value suffix from --flag=value tokens in verify-skill recipe parser

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -650,9 +650,11 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flags.append(t)
-            # Skip value if present and not another flag
-            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+            flags.append(t.split("=", 1)[0])
+            # Skip a space-separated value (`--flag value`), but NOT when the
+            # value is inline (`--flag=value`) — there the next token is a
+            # positional, not this flag's value.
+            if "=" not in t and i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
                 i += 2
                 continue
         elif t.startswith("-"):

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -196,6 +196,47 @@ func newSearchCmd() *cobra.Command {
 	require.Contains(t, string(out), "All checks passed")
 }
 
+func TestVerifySkill_FlagChecksNormalizeEqualsSyntax(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\n" +
+		"fixture-pp-cli search --since=24h --score-gte=7\n" +
+		"fixture-pp-cli search --since 24h --score-gte 7\n" +
+		"```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"search.go": `package cli
+import "github.com/spf13/cobra"
+func newSearchCmd() *cobra.Command {
+	var since string
+	var scoreGTE int
+	cmd := &cobra.Command{Use: "search"}
+	cmd.Flags().StringVar(&since, "since", "", "Lookback window")
+	cmd.Flags().IntVar(&scoreGTE, "score-gte", 0, "Minimum score")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newSearchCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-names").CombinedOutput()
+	require.NoError(t, err, "--flag=value syntax should resolve to declared flag names: %s", string(out))
+	require.Contains(t, string(out), "All checks passed")
+
+	out, err = exec.Command(bin, "verify-skill", "--dir", dir, "--only", "flag-commands").CombinedOutput()
+	require.NoError(t, err, "--flag=value syntax should resolve to declared command flags: %s", string(out))
+	require.Contains(t, string(out), "All checks passed")
+}
+
 func TestVerifySkill_ShellOperatorsDoNotBecomePositionals(t *testing.T) {
 	t.Parallel()
 
@@ -269,6 +310,43 @@ func Execute() error {
 	require.Error(t, err, "real positional args must still fail verify-skill")
 	require.Contains(t, string(out), "[positional-args]")
 	require.Contains(t, string(out), "got 2 positional args")
+}
+
+// A positional that follows an inline-value flag (--flag=value) must still be
+// counted as a positional, not swallowed as the flag's value. Without the
+// inline-value guard the parser drops `report.json` and the check passes
+// (false negative); with it the unexpected positional is correctly flagged.
+func TestVerifySkill_PositionalAfterInlineValueFlagIsCounted(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\nfixture-pp-cli export --format=json report.json\n```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"export.go": `package cli
+import "github.com/spf13/cobra"
+func newExportCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{Use: "export"}
+	cmd.Flags().StringVar(&format, "format", "", "Output format")
+	return cmd
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newExportCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.Error(t, err, "a positional after --flag=value must be counted, not swallowed: %s", string(out))
+	require.Contains(t, string(out), "[positional-args]")
+	require.Contains(t, string(out), "got 1 positional args")
 }
 
 func TestVerifySkill_PlaceholderPositionalsStillFail(t *testing.T) {

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -650,9 +650,11 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flags.append(t)
-            # Skip value if present and not another flag
-            if i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+            flags.append(t.split("=", 1)[0])
+            # Skip a space-separated value (`--flag value`), but NOT when the
+            # value is inline (`--flag=value`) — there the next token is a
+            # positional, not this flag's value.
+            if "=" not in t and i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
                 i += 2
                 continue
         elif t.startswith("-"):


### PR DESCRIPTION
## Intent

The verify-skill recipe parser recorded `--since=24h` / `--score-gte=7` tokens verbatim, keeping the `=value` suffix as part of the flag name. The declared-flag check then compared `--since=24h` against the CLI's `--since` and reported a false "undeclared flag" positive, flooding clean CLIs with spurious findings.

Issue: Closes #1316

## Approach

Split `--flag=value` on the first `=` (maxsplit=1, so values containing `=` are preserved on the value side) so the parser stores the flag name (`--since`) for the declared-flag comparison. The `=value` suffix is not read by any downstream check, so dropping it is safe. Mirrored byte-for-byte across the bundled copy and the script source (`TestVerifySkillBundledMatchesScript`).

## Scope

Primary area: cli (`internal/cli/verify_skill_bundled.py` + `scripts/verify-skill/verify_skill.py`, kept byte-identical).

Why this belongs in this repo: the verify-skill recipe parser is shared tooling; the false positive affected every CLI whose recipes used `--flag=value` syntax.

## Catalog Justification

N/A

## Risk

Low. The change only affects flag-name extraction in long-flag tokens; short flags and positional handling are unchanged (pre-existing behavior). No generated-output impact (golden verify clean).

## Output Contract

N/A (verify-skill is a Python checker, not generated CLI output).

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases, no drift)
- `TestVerifySkill_FlagChecksNormalizeEqualsSyntax` (fails without the fix; passes with it) + `TestVerifySkillBundledMatchesScript` (byte-identity)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change