### PR TITLE
fix(cli): emit extractResponseData helper only for envelope-shaped responses

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1813,7 +1813,7 @@ func (g *Generator) renderSingleFiles() error {
 			hFlags := computeHelperFlags(g.Spec)
 			hFlags.HasDataLayer = g.VisionSet.Store
 			hFlags.HasSyncHelpers = g.hasGeneratedSyncImplementation()
-			hFlags.HasResponseUnwrap = g.VisionSet.Store && promotedCommandsCanUnwrapResponse(g.PromotedCommands)
+			hFlags.HasResponseUnwrap = g.VisionSet.Store && promotedCommandsCanUnwrapResponse(g.PromotedCommands, g.Spec.Types)
 			data = &helpersTemplateData{
 				APISpec:     g.Spec,
 				HelperFlags: hFlags,
@@ -2368,9 +2368,40 @@ func buildPromotedCommandPlan(apiSpec *spec.APISpec) ([]PromotedCommand, map[str
 	return promotedCommands, promotedResourceNames, promotedEndpointNames
 }
 
-func promotedCommandsCanUnwrapResponse(commands []PromotedCommand) bool {
+func promotedCommandsCanUnwrapResponse(commands []PromotedCommand, types map[string]spec.TypeDef) bool {
 	for _, cmd := range commands {
-		if !cmd.Endpoint.UsesBinaryResponse() {
+		if !cmd.Endpoint.UsesBinaryResponse() && endpointHasStatusDataEnvelope(cmd.Endpoint, types) {
+			return true
+		}
+	}
+	return false
+}
+
+// endpointHasStatusDataEnvelope reports whether the endpoint's response type
+// looks like a {status/success, data} envelope, gating extractResponseData
+// emission. The runtime helper keys on the "status" field; "success" is
+// accepted here too so success-keyed envelopes still emit the helper. A type
+// with data+success but no status passes detection and the helper no-ops on it
+// at runtime — harmless over-emission, and emit/call stay aligned either way.
+func endpointHasStatusDataEnvelope(endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
+	item := strings.TrimSpace(endpoint.Response.Item)
+	if item == "" {
+		return false
+	}
+	typedef, ok := types[item]
+	if !ok {
+		return false
+	}
+	hasData := false
+	hasStatusOrSuccess := false
+	for _, field := range typedef.Fields {
+		switch strings.ToLower(strings.TrimSpace(field.Name)) {
+		case "data":
+			hasData = true
+		case "status", "success":
+			hasStatusOrSuccess = true
+		}
+		if hasData && hasStatusOrSuccess {
 			return true
 		}
 	}
@@ -3596,16 +3627,17 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 		// Look up the full resource to pass sibling endpoints/sub-resources.
 		resource := g.Spec.Resources[pc.ResourceName]
 		promotedData := struct {
-			PromotedName  string
-			ResourceName  string
-			EndpointName  string
-			EffectivePath string
-			Endpoint      spec.Endpoint
-			EffectiveTier string
-			HasStore      bool
-			Resource      spec.Resource
-			FuncPrefix    string
-			IsReadOnly    bool
+			PromotedName      string
+			ResourceName      string
+			EndpointName      string
+			EffectivePath     string
+			Endpoint          spec.Endpoint
+			EffectiveTier     string
+			HasStore          bool
+			HasResponseUnwrap bool
+			Resource          spec.Resource
+			FuncPrefix        string
+			IsReadOnly        bool
 			*spec.APISpec
 		}{
 			PromotedName:  pc.PromotedName,
@@ -3615,10 +3647,17 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			Endpoint:      pc.Endpoint,
 			EffectiveTier: g.Spec.EffectiveTier(resource, pc.Endpoint),
 			HasStore:      g.VisionSet.Store,
-			Resource:      resource,
-			FuncPrefix:    pc.ResourceName,
-			IsReadOnly:    endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
-			APISpec:       g.Spec,
+			// Per-command: emit the extractResponseData call only on commands
+			// whose own response is envelope-shaped, so a non-envelope command
+			// in a mixed-envelope spec is never unwrapped. This is a subset of
+			// the CLI-level helper-emission gate (helpers.go emits the helper
+			// when ANY promoted command qualifies), so call ⊆ emit — no call to
+			// an unemitted helper.
+			HasResponseUnwrap: g.VisionSet.Store && !pc.Endpoint.UsesBinaryResponse() && endpointHasStatusDataEnvelope(pc.Endpoint, g.Spec.Types),
+			Resource:          resource,
+			FuncPrefix:        pc.ResourceName,
+			IsReadOnly:        endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
+			APISpec:           g.Spec,
 		}
 		promotedPath := filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+pc.PromotedName)+".go")
 		if err := g.renderTemplate("command_promoted.go.tmpl", promotedPath, promotedData); err != nil {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7395,7 +7395,20 @@ func TestGeneratedOutput_PromotedCommandExists(t *testing.T) {
 			"users": {
 				Description: "Manage users",
 				Endpoints: map[string]spec.Endpoint{
-					"list": {Method: "GET", Path: "/users", Description: "List all users"},
+					"list": {
+						Method:      "GET",
+						Path:        "/users",
+						Description: "List all users",
+						Response:    spec.ResponseDef{Type: "object", Item: "UsersEnvelope"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"UsersEnvelope": {
+				Fields: []spec.TypeField{
+					{Name: "status", Type: "string"},
+					{Name: "data", Type: "array"},
 				},
 			},
 		},
@@ -7413,11 +7426,64 @@ func TestGeneratedOutput_PromotedCommandExists(t *testing.T) {
 	helpersSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(helpersSrc), "func extractResponseData(",
-		"promoted commands call extractResponseData, so helpers.go must emit it when a promoted command exists")
+		"helpers.go must emit extractResponseData when promoted commands can hit status/data envelopes")
+
+	// The call site must be emitted alongside the helper: emission and call are
+	// both gated on HasResponseUnwrap, so on the envelope path the helper is
+	// emitted AND invoked. Asserting both present locks the gates together — a
+	// helper emitted-but-uncalled (still-dead) or called-but-unemitted (build
+	// break) would fail one of these two assertions.
+	promotedSrc, err := os.ReadFile(promotedFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(promotedSrc), "data = extractResponseData(data)",
+		"promoted command must call extractResponseData on the envelope path")
 
 	// The resource parent command should NOT be generated — the promoted command replaces it.
 	// Generating both would leave the parent as dead code (never wired to root).
 	assert.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "users.go"))
+}
+
+func TestGeneratedOutput_ExtractResponseDataHelperSkippedForPromotedNonEnvelope(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "promnonenvelope",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "api_key", Header: "X-Api-Key", EnvVars: []string{"PROM_NON_ENVELOPE_API_KEY"}},
+		Config:  spec.ConfigSpec{Format: "toml", Path: "~/.config/promnonenvelope-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"users": {
+				Description: "Manage users",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/users",
+						Description: "List all users",
+						Response:    spec.ResponseDef{Type: "object", Item: "UsersList"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"UsersList": {
+				Fields: []spec.TypeField{
+					{Name: "results", Type: "array"},
+					{Name: "total_count", Type: "integer"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promnonenvelope-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	helpersSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(helpersSrc), "func extractResponseData(",
+		"helpers.go must skip extractResponseData when promoted commands do not advertise status/success+data envelopes")
 }
 
 func TestGeneratedOutput_ExtractResponseDataHelperOnlyForPromotedCommands(t *testing.T) {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -329,10 +329,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 
 {{- end}}
 {{- if .HasStore}}
+{{- if .HasResponseUnwrap}}
 			// Unwrap API response envelopes (e.g. {"status":"success","data":[...]})
 			// so output helpers see the inner data, not the wrapper.
 			data = extractResponseData(data)
 
+{{- end}}
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -893,34 +893,6 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	return printOutput(w, data, flags.asJSON)
 }
 
-// extractResponseData unwraps common API response envelopes for display.
-// Many APIs return {"status":"success","data":[...]} instead of a bare array.
-// This extracts the inner data for output helpers (filterFields, compactFields,
-// printAutoTable) that expect arrays or flat objects.
-//
-// Only unwraps when a "status" field is present and indicates success — this
-// avoids false positives on APIs where "data" is a regular field (e.g., Stripe
-// returns {"data":[...],"has_more":true} where "data" is the list, not an
-// envelope wrapper).
-func extractResponseData(data json.RawMessage) json.RawMessage {
-	var envelope struct {
-		Status string          `json:"status"`
-		Data   json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return data
-	}
-	if envelope.Data == nil || envelope.Status == "" {
-		return data // No status field = not an envelope, might be regular "data" field
-	}
-	switch envelope.Status {
-	case "success", "ok", "OK", "Success":
-		return envelope.Data
-	default:
-		return data
-	}
-}
-
 // compactVerboseListFields are prose-shaped fields stripped from list-item
 // projections. On lists, "body"/"content"/"html"/"markdown" are verbose
 // noise and the row's identity is carried by id/name/title/etc.

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 67
+    "total": 66
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -975,34 +975,6 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	return printOutput(w, data, flags.asJSON)
 }
 
-// extractResponseData unwraps common API response envelopes for display.
-// Many APIs return {"status":"success","data":[...]} instead of a bare array.
-// This extracts the inner data for output helpers (filterFields, compactFields,
-// printAutoTable) that expect arrays or flat objects.
-//
-// Only unwraps when a "status" field is present and indicates success — this
-// avoids false positives on APIs where "data" is a regular field (e.g., Stripe
-// returns {"data":[...],"has_more":true} where "data" is the list, not an
-// envelope wrapper).
-func extractResponseData(data json.RawMessage) json.RawMessage {
-	var envelope struct {
-		Status string          `json:"status"`
-		Data   json.RawMessage `json:"data"`
-	}
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return data
-	}
-	if envelope.Data == nil || envelope.Status == "" {
-		return data // No status field = not an envelope, might be regular "data" field
-	}
-	switch envelope.Status {
-	case "success", "ok", "OK", "Success":
-		return envelope.Data
-	default:
-		return data
-	}
-}
-
 // compactVerboseListFields are prose-shaped fields stripped from list-item
 // projections. On lists, "body"/"content"/"html"/"markdown" are verbose
 // noise and the row's identity is carried by id/name/title/etc.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -31,10 +31,6 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
-			// Unwrap API response envelopes (e.g. {"status":"success","data":[...]})
-			// so output helpers see the inner data, not the wrapper.
-			data = extractResponseData(data)
-
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -31,10 +31,6 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
-			// Unwrap API response envelopes (e.g. {"status":"success","data":[...]})
-			// so output helpers see the inner data, not the wrapper.
-			data = extractResponseData(data)
-
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -45,10 +45,6 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
-			// Unwrap API response envelopes (e.g. {"status":"success","data":[...]})
-			// so output helpers see the inner data, not the wrapper.
-			data = extractResponseData(data)
-
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope


### PR DESCRIPTION
## Intent

The generated `internal/cli/helpers.go` always emitted `extractResponseData` when a CLI had a store and any non-binary promoted command, but the helper is only called for status/data envelope responses — so on non-envelope APIs (e.g. HubSpot CRM) it was emitted but never called, and dogfood flagged it as a dead function.

Issue: Closes #1345

## Approach

Issue's recommended fix (b): gate emission on actual envelope shape. `promotedCommandsCanUnwrapResponse` now also requires `endpointHasStatusDataEnvelope` (the promoted command's response type declares both a `data` field and a `status`/`success` field). Critically, the **call site** in `command_promoted.go.tmpl` (previously gated only on `.HasStore`) is now also gated on `.HasResponseUnwrap`, computed from the *same* expression as emission — so the helper is emitted iff it is called. Without that alignment a Store-backed non-envelope promoted command would call an undefined helper (build break).

## Scope

Primary area: generator (`generator.go`, `command_promoted.go.tmpl`, `helpers.go.tmpl` gate). Machine change.

## Catalog Justification

N/A

## Risk

The emit/call gates must stay aligned. Both are computed from `Store && promotedCommandsCanUnwrapResponse(g.PromotedCommands, g.Spec.Types)` in the same run, so they cannot diverge; `TestGeneratedOutput_PromotedCommandExists` asserts both helper + call site on the envelope path, and the full compile-test suite passes. On a `data+success` (no `status`) type the helper is emitted + called but no-ops at runtime — harmless over-emission, gates still aligned.

## Output Contract

Non-envelope CLIs no longer emit the helper or its call site. Golden fixtures: helper + call removed from non-envelope fixtures; `generate-golden-api/dogfood.json` dead-function count drops.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases; updated intentionally)
- New tests: envelope-positive (helper + call present), non-envelope skip, no-store skip, non-promoted skip

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change