### PR TITLE
fix(cli): skip promotion when body exceeds the flag-depth cap

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6043,6 +6043,13 @@ func buildPromotedCommands(s *spec.APISpec) []PromotedCommand {
 		if !found {
 			continue
 		}
+		// A body that recurses past maxBodyFlagDepth must NOT be promoted: the
+		// promoted template emits no --stdin fallback, so the truncated subtree
+		// would silently drop fields. Skipping promotion keeps the canonical
+		// command (which has --stdin) as the reachable surface.
+		if bodyExceedsFlagDepth(bestEndpoint) {
+			continue
+		}
 
 		promotedName := toKebab(name)
 		if builtinCommands[promotedName] {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7342,6 +7342,53 @@ func TestBuildPromotedCommands(t *testing.T) {
 		assert.True(t, names["password-forgot"], "POST-only password-forgot resource should promote")
 	})
 
+	t.Run("single-endpoint POST with body beyond max flag depth is not promoted", func(t *testing.T) {
+		t.Parallel()
+		s := &spec.APISpec{
+			Name:    "test",
+			Version: "0.1.0",
+			BaseURL: "https://api.example.com",
+			Resources: map[string]spec.Resource{
+				"orders": {
+					Endpoints: map[string]spec.Endpoint{
+						"create": {
+							Method:      "POST",
+							Path:        "/orders",
+							Description: "Create order",
+							Body: []spec.Param{
+								{
+									Name: "level0",
+									Type: "object",
+									Fields: []spec.Param{
+										{
+											Name: "level1",
+											Type: "object",
+											Fields: []spec.Param{
+												{
+													Name: "level2",
+													Type: "object",
+													Fields: []spec.Param{
+														{
+															Name: "tooDeep",
+															Type: "string",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		promoted := buildPromotedCommands(s)
+		assert.Empty(t, promoted, "deep-body single-endpoint POST must remain non-promoted so canonical endpoint command with --stdin stays reachable")
+	})
+
 	t.Run("multi-endpoint resource still requires GET for promotion (write-only resources stay nested)", func(t *testing.T) {
 		t.Parallel()
 		s := &spec.APISpec{


### PR DESCRIPTION
## Intent

After #1240 capped per-field body flags at `maxBodyFlagDepth`, a promoted POST/PUT/PATCH command whose body recurses past the cap silently dropped the deeper subtree — including required fields — with no flag-level signal, and the promoted template (unlike the endpoint template) emits no `--stdin` fallback.

Issue: Closes #1520

## Approach

Issue's option 1 (smaller scope): refuse to promote an endpoint when `bodyExceedsFlagDepth(endpoint)` is true. The canonical (non-promoted) command — which keeps `--stdin` — stays the reachable surface. A 3-line guard in `buildPromotedCommands`, placed after endpoint selection and before the promotion is recorded. Reuses the same depth helper `command_endpoint`'s `--stdin` gate uses, so detection and emission cannot drift.

## Scope

Primary area: generator (`buildPromotedCommands`). Machine change.

## Catalog Justification

N/A

## Risk

Guard fires only when `bodyExceedsFlagDepth` is true (false for GET/no-body and shallow bodies), so shallow promoted commands and reads are unaffected. Skipping promotion falls back to the full raw command tree (keyed off the promotion maps), so no endpoint is left without a command. No catalog spec has a deep-body promotion candidate, so golden output is unchanged (verify clean).

## Output Contract

Deep-body single-endpoint POST/PUT/PATCH resources are no longer promoted; their canonical commands (with `--stdin`) generate instead. No existing golden fixture changes.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases, no drift)
- New test asserts a depth-4-body single-endpoint POST resource is NOT promoted; existing shallow-promotion tests still pass

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change