### PR TITLE
fix(skills): initialize transcendence collector slices with make([]T, 0)

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -37,3 +37,22 @@ func TestPrintingPressSkillMCPEnrichmentGate(t *testing.T) {
 	require.Contains(t, content, "Internal YAML input: write or update the root `mcp:` block")
 	require.Contains(t, content, "If the runtime cannot ask a blocking question, stop")
 }
+
+func TestPrintingPressSkillTranscendenceCollectorSliceInit(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "results := make([]yourRowType, 0)")
+	require.Contains(t, content, "empty marshals")
+	require.NotContains(t, content, "var results []yourRowType")
+
+	// The aggregation skeleton's other collector slices must use make() too, so
+	// empty results marshal as [] not null across every emitted slice.
+	require.Contains(t, content, "failures := make([]fetchFailure, 0)")
+	require.Contains(t, content, "successfulItems := make([]yourEntryType, 0)")
+	require.NotContains(t, content, "var failures []fetchFailure")
+	require.NotContains(t, content, "var successfulItems []yourEntryType")
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3063,8 +3063,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 			fetchErrors[r.idx] = r.err
 		}
 	}
-	var failures []fetchFailure
-	var successfulItems []yourEntryType
+	failures := make([]fetchFailure, 0)        // empty marshals as [] not null
+	successfulItems := make([]yourEntryType, 0) // empty marshals as [] not null
 	var total float64
 	var denominator int
 	for idx, entry := range ordered {
@@ -3151,7 +3151,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	// pulled from a typed FTS/upsert table can be NULL — use sql.Null*
 	// scan targets (or COALESCE in the SQL) for those, see the NULL-safe
 	// scans paragraph below.
-	var results []yourRowType // scan rows into the slice
+	results := make([]yourRowType, 0) // scan rows into this slice; make([]T, 0) keeps empty JSON as [] not null
+	// (loop over rows here: results = append(results, scannedRow))
 	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")


### PR DESCRIPTION
## Intent

The Phase 3 RunE aggregation skeleton in `skills/printing-press/SKILL.md` declared collector slices as `var x []T`. Codex pattern-matches the skeleton and emits Go that marshals empty results to JSON `null`, not `[]` — agent consumers iterating or calling `.length` crash on `null`.

Issue: Closes #1344

## Approach

Initialize the skeleton's marshaled collector slices (`results`, `failures`, `successfulItems`) with `make([]T, 0)` so empty results marshal as `[]`. The `references/codex-delegation.md` doc already documents this rule; this aligns the skeleton it points at. Found and fixed a second collector site (`failures`/`successfulItems` in the aggregation shape) beyond the store-query `results` slice.

## Scope

Primary area: skills (`skills/printing-press/SKILL.md`). Skeleton-guidance fix at the machine layer (affects every Codex-delegated transcendence build).

## Catalog Justification

N/A

## Risk

Skeleton-only change using domain-neutral placeholders (`yourRowType`, `yourEntryType`, `fetchFailure`). Non-slice and non-marshaled `var` declarations (scalars, structs, sized buffers) are intentionally left unchanged. No generated Go is compiled from the skeleton; the only code change is an additive test.

## Output Contract

N/A (SKILL.md is not a golden fixture).

## Verification

- `go test ./...` — pass
- `TestPrintingPressSkillTranscendenceCollectorSliceInit` asserts all three `make([]T, 0)` forms present and all three `var x []T` forms gone

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change