### PR TITLE
fix(skills): document multi-positional RunE shape so partial args fail with exit 2

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -233,6 +233,14 @@ func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	assert.Contains(t, template, "_ = cmd.Usage()")
 	assert.Contains(t, template, `return usageErr(fmt.Errorf("<flag-or-arg> is required"))`)
 	assert.Contains(t, template, "Do not collapse the first and third branches")
+	assert.Contains(t, template, "Multi-positional commands (N >= 2 required args) must use a two-check shape")
+	assert.Contains(t, template, "if len(args) < N {")
+	assert.Contains(t, template, `return usageErr(fmt.Errorf("missing required positional argument"))`)
+	// The multi-positional block specifically must print usage before the
+	// error (the bare Contains for "_ = cmd.Usage()" above is satisfied by the
+	// single-positional block, so scope this assertion to the new branch).
+	assert.Regexp(t, regexp.MustCompile(`if len\(args\) < N \{\s+_ = cmd\.Usage\(\)\s+return usageErr\(fmt\.Errorf\("missing required positional argument"\)\)`), template,
+		"multi-positional block must call cmd.Usage() before returning the usage error")
 
 	assert.Equal(t, 3, strings.Count(starters, "if len(args) == 0 && cmd.Flags().NFlag() == 0 {"))
 	assert.Equal(t, 3, strings.Count(starters, "return cmd.Help()"))

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2845,6 +2845,20 @@ RunE: func(cmd *cobra.Command, args []string) error {
 
 Why each branch exists: the `len(args) == 0 && cmd.Flags().NFlag() == 0` branch handles an interactive `<cli> mycommand` help-only invocation without treating help as an error. The `dryRunOK` branch handles verify's `<cli> mycommand <fixture> --dry-run` probes before network or filesystem IO. The required-input branch handles non-help invocations where a mode or output flag is present (`--no-input`, `--agent`, `--json`) but the required ID, query, path, or other command input is still missing. Missing required input must print usage and return `usageErr(...)` so callers get exit code 2 instead of a silent rc=0 skip.
 
+Multi-positional commands (N >= 2 required args) must use a two-check shape so only the bare help probe returns exit 0:
+
+```go
+if len(args) == 0 && cmd.Flags().NFlag() == 0 {
+	return cmd.Help() // bare invocation help probe
+}
+if len(args) < N {
+	_ = cmd.Usage()
+	return usageErr(fmt.Errorf("missing required positional argument"))
+}
+```
+
+This preserves verify-friendly help behavior for 0 args while making partial positional input (`1..N-1`) fail with exit 2 in dogfood `error_path`. Single-positional commands can keep the single required-input check. If a multi-positional command supports `--dry-run`, place its `dryRunOK(flags)` branch after the `len(args) < N` gate (once all N positionals are present), so the dry-run probe still short-circuits.
+
 Do not collapse the first and third branches into `if len(args) == 0 || <flag empty> { return cmd.Help() }`. `cmd.Help()` returns `nil`, so agents and scripts cannot distinguish "help was requested" from "the command skipped required work."
 
 For commands with no required inputs, omit the `usageErr(...)` branch entirely and keep the help-only plus dry-run branches.


### PR DESCRIPTION
## Intent

The "Verify-friendly RunE template" section in `skills/printing-press/SKILL.md` showed only the single-check `if len(args) == 0 { return cmd.Help() }` pattern. Agents generalizing it to multi-positional commands wrote `if len(args) < N { return cmd.Help() }`, which returns exit 0 on a bare help probe (correct) but ALSO on 1..N-1 args (wrong — should be a usage error), so dogfood's `error_path` test flagged it.

Issue: Closes #965

## Approach

Add explicit multi-positional guidance: a two-check shape that returns help only on a bare invocation (0 args, no flags), then `usageErr(...)` (exit 2) for partial positional input. Note that single-positional commands keep the single check, and that a dry-run-capable multi-positional command places its `dryRunOK` branch after the `len(args) < N` gate.

## Scope

Primary area: skills (`skills/printing-press/SKILL.md`). Authoring-guidance fix at the machine layer (affects what agents emit for multi-positional commands).

## Catalog Justification

N/A

## Risk

Docs-only guidance change, domain-neutral. Verified against the actual dogfood probe paths (`live_dogfood.go`): the two-check shape yields exit 0 only on the bare probe and exit 2 on partial positionals; happy/dry-run probes resolve all N positionals first, so they sail past the gate.

## Output Contract

N/A (SKILL.md is not a golden fixture).

## Verification

- `go test ./...` — pass
- `TestPrintingPressSkillRunERequiredInputContract` (internal/pipeline/contracts_test.go) asserts the two-check shape + `usageErr` guidance is present

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change