### PR TITLE
fix(skills): add LAN reachability carve-out

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -56,3 +56,21 @@ func TestPrintingPressSkillTranscendenceCollectorSliceInit(t *testing.T) {
 	require.NotContains(t, content, "var failures []fetchFailure")
 	require.NotContains(t, content, "var successfulItems []yourEntryType")
 }
+
+func TestPrintingPressSkillReachabilityGateAllowsLANOnlyCarveout(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "Exception for LAN-only / mDNS-discovered APIs")
+	require.Contains(t, content, "http://localhost:<port>")
+	require.Contains(t, content, "http://127.0.0.1:<port>")
+	require.Contains(t, content, "http://[::1]:<port>")
+	require.Contains(t, content, "SSDP / mDNS-discovered")
+	require.Contains(t, content, "Reason: lan-only-no-global-url")
+	require.Contains(t, content, "Then proceed to Phase 2")
+	require.Contains(t, content, "do not use this carve-out for normal public/cloud origins such as `https://api.example.com`")
+	require.Contains(t, content, "those still run the reachability probe and decision matrix below")
+}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1764,6 +1764,19 @@ directory prefix when the leaf segment has embedded IDs or suffixes. See
 
 If the browser capture contained only challenge/login/error pages, this exception does not apply.
 
+**Exception for LAN-only / mDNS-discovered APIs:** If the resolved spec's `base_url` is a localhost or loopback placeholder (`http://localhost:<port>`, `http://127.0.0.1:<port>`, or `http://[::1]:<port>`), or Phase 1 research explicitly identifies the API as LAN-only / SSDP / mDNS-discovered with no stable global origin, do not run the generic curl/WebFetch reachability probe. A probe from the generation host would test the agent's loopback or current network, not the user's appliance, speaker, bridge, or local service.
+
+For this case, record a Phase 1.9 PASS carve-out in the research brief:
+
+```markdown
+## Reachability Gate
+- Decision: PASS (carve-out)
+- Reason: lan-only-no-global-url
+- Evidence: <base_url or research line showing localhost, loopback, SSDP, mDNS, or LAN-only discovery>
+```
+
+Then proceed to Phase 2. Do not write a freeform manual proof for this case, do not call it a missing-API-key skip, and do not use this carve-out for normal public/cloud origins such as `https://api.example.com`; those still run the reachability probe and decision matrix below.
+
 ### The Check
 
 Prefer the spec's `auth.verify_path` when it is set; otherwise pick the simplest GET endpoint from the resolved spec (no required params, no auth if possible). If no such endpoint exists, use the spec's base URL. Run one HTTP request and preserve the response body when the server returns a 4xx:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3127,6 +3127,17 @@ The generator handles Priority 0 (data layer) and most of Priority 1 (absorbed A
 
 **Starter templates for novel commands.** Cobra wiring is mechanical and consistent across novel features; the actual feature work lives in the RunE body. Copy the wrapper below and one of the RunE skeletons that follows, fill in the placeholders from the absorb manifest's transcendence row (`Name`, `Command`, `Description`, `Example`, `WhyItMatters`), and replace the body comments with your implementation. Dogfood, verify, and scorecard still apply to the result — the templates raise the floor without changing what shipcheck checks.
 
+**Helpers already emitted by the generator.** Do not reinvent these helpers in novel command files. They live in `internal/cli/helpers.go` after generation and are available to every hand-written command in package `cli`:
+
+- `printJSONFiltered(w io.Writer, v any, flags *rootFlags) error` - apply `--select`, `--compact`, `--csv`, and `--quiet` while writing JSON from a Go value.
+- `printAutoTable(w io.Writer, items []map[string]any) error` - render JSON-like rows as the generated human table format.
+- `defaultDBPath(name string) string` - resolve the local SQLite database path for `<name>`.
+- `dryRunOK(flags *rootFlags) bool` - detect verify-friendly `--dry-run` short-circuits before network, store, or filesystem work.
+- `filterFields(data json.RawMessage, fields string) json.RawMessage` - apply `--select` to a JSON blob.
+- `compactFields(data json.RawMessage) json.RawMessage` - apply `--compact` to a JSON blob.
+- `isTerminal(w io.Writer) bool` - detect terminal output versus pipes.
+- `wantsHumanTable(w io.Writer, flags *rootFlags) bool` - detect when output should use the generated human table instead of machine JSON.
+
 ```go
 // internal/cli/<command>.go — replace <command> with the kebab leaf
 // of NovelFeature.Command (e.g., "issues stale" → "issues_stale.go").


### PR DESCRIPTION
## Summary

- Adds a canonical Phase 1.9 reachability-gate carve-out for LAN-only and mDNS-discovered APIs whose spec uses a localhost or loopback placeholder instead of a globally reachable origin.
- Records the skip as `lan-only-no-global-url`, proceeds to Phase 2, and keeps normal public cloud API origins on the existing probe path.
- Adds a static regression test so future skill edits preserve the carve-out and negative branch.

Closes #925

## Tests

- `bash .github/scripts/validate-skill-docs.sh`
- `go test ./internal/cli -run 'TestPrintingPressSkill'`
- `go test ./internal/cli -count=1`
- `go test ./...` attempted; first run failed in `internal/cli`, then `go test ./internal/cli -count=1` passed on rerun.
