### PR TITLE
fix(cli): sync narrative value props during dogfood

### DIFF
--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 )
 
 type novelFeatureDocGroup struct {
@@ -16,8 +18,6 @@ type syncedArtifact struct {
 	Path   string
 	Detail string
 }
-
-const skillInstallSectionEndSubstr = "Do not proceed with skill commands until verification succeeds."
 
 // SyncCLINarrativeDocs rewrites generated README/SKILL narrative blocks from
 // the current research.json narrative. Empty narrative fields remove only the
@@ -170,11 +170,11 @@ func syncSkillValueProp(path, valueProp string) (bool, error) {
 		return false, nil
 	}
 	return syncMarkdownFile(path, func(content string) string {
-		markerIdx := strings.Index(content, skillInstallSectionEndSubstr)
+		markerIdx := strings.Index(content, generator.SkillInstallSectionEndSubstr)
 		if markerIdx < 0 {
 			return content
 		}
-		start := markerIdx + len(skillInstallSectionEndSubstr)
+		start := markerIdx + len(generator.SkillInstallSectionEndSubstr)
 		if next := strings.IndexByte(content[start:], '\n'); next >= 0 {
 			start += next + 1
 		}
@@ -240,7 +240,8 @@ func findReadmeIntroEnd(content string, start int) int {
 	}
 	if install := findMarkdownHeadingInRange(content, "## Install", start, len(content)); install >= 0 && install < end {
 		end = install
-	} else if heading := firstMarkdownHeading(content, start, len(content), 2, 2); heading.Start >= 0 && heading.Start < end {
+	}
+	if heading := firstMarkdownHeading(content, start, end, 2, 2); heading.Start >= 0 && heading.Start < end {
 		end = heading.Start
 	}
 	return end

--- a/internal/pipeline/docsync.go
+++ b/internal/pipeline/docsync.go
@@ -17,6 +17,8 @@ type syncedArtifact struct {
 	Detail string
 }
 
+const skillInstallSectionEndSubstr = "Do not proceed with skill commands until verification succeeds."
+
 // SyncCLINarrativeDocs rewrites generated README/SKILL narrative blocks from
 // the current research.json narrative. Empty narrative fields remove only the
 // narrative-owned subsections; generic fallback prose is left intact.
@@ -26,6 +28,26 @@ func SyncCLINarrativeDocs(dir, apiName string, narrative *ReadmeNarrative) ([]sy
 	}
 
 	var synced []syncedArtifact
+	if strings.TrimSpace(narrative.Headline) != "" || strings.TrimSpace(narrative.ValueProp) != "" {
+		changed, err := syncReadmeIntroNarrative(filepath.Join(dir, "README.md"), narrative)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			synced = append(synced, syncedArtifact{Path: "README.md", Detail: "Value Proposition"})
+		}
+	}
+
+	if strings.TrimSpace(narrative.ValueProp) != "" {
+		changed, err := syncSkillValueProp(filepath.Join(dir, "SKILL.md"), narrative.ValueProp)
+		if err != nil {
+			return nil, err
+		}
+		if changed {
+			synced = append(synced, syncedArtifact{Path: "SKILL.md", Detail: "Value Proposition"})
+		}
+	}
+
 	if len(narrative.QuickStart) > 0 {
 		changed, err := syncMarkdownFeatureSection(
 			filepath.Join(dir, "README.md"),
@@ -136,10 +158,117 @@ func syncReadmeAuthNarrative(path, authNarrative string) (bool, error) {
 	})
 }
 
+func syncReadmeIntroNarrative(path string, narrative *ReadmeNarrative) (bool, error) {
+	return syncMarkdownFile(path, func(content string) string {
+		return replaceReadmeIntroNarrative(content, narrative)
+	})
+}
+
+func syncSkillValueProp(path, valueProp string) (bool, error) {
+	valueProp = strings.TrimSpace(valueProp)
+	if valueProp == "" {
+		return false, nil
+	}
+	return syncMarkdownFile(path, func(content string) string {
+		markerIdx := strings.Index(content, skillInstallSectionEndSubstr)
+		if markerIdx < 0 {
+			return content
+		}
+		start := markerIdx + len(skillInstallSectionEndSubstr)
+		if next := strings.IndexByte(content[start:], '\n'); next >= 0 {
+			start += next + 1
+		}
+		sectionEnd := findNextLevelTwoHeading(content, start)
+		return joinMarkdownParts(content[:start], valueProp, content[sectionEnd:])
+	})
+}
+
 func syncReadmeTroubleshoots(path string, troubleshoots []TroubleshootTip) (bool, error) {
 	return syncMarkdownFile(path, func(content string) string {
 		return replaceMarkdownSubsection(content, "## Troubleshooting", "### API-specific", renderTroubleshootSubsection(troubleshoots))
 	})
+}
+
+func replaceReadmeIntroNarrative(content string, narrative *ReadmeNarrative) string {
+	title := firstMarkdownHeading(content, 0, len(content), 1, 1)
+	if title.Start < 0 {
+		return content
+	}
+	start := title.Start + len(strings.SplitN(content[title.Start:], "\n", 2)[0])
+	if start < len(content) && content[start] == '\n' {
+		start++
+	}
+	end := findReadmeIntroEnd(content, start)
+	replacement := renderReadmeIntroNarrative(narrative, existingReadmeIntroLead(content[start:end]))
+	if strings.TrimSpace(replacement) == "" {
+		return content
+	}
+	return joinMarkdownParts(content[:start], replacement, content[end:])
+}
+
+func renderReadmeIntroNarrative(narrative *ReadmeNarrative, fallbackLead string) string {
+	if narrative == nil {
+		return ""
+	}
+	var parts []string
+	if headline := strings.TrimSpace(narrative.Headline); headline != "" {
+		parts = append(parts, "**"+headline+"**")
+	} else if fallbackLead = strings.TrimSpace(fallbackLead); fallbackLead != "" {
+		parts = append(parts, fallbackLead)
+	}
+	if valueProp := strings.TrimSpace(narrative.ValueProp); valueProp != "" {
+		parts = append(parts, valueProp)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func existingReadmeIntroLead(intro string) string {
+	for paragraph := range strings.SplitSeq(strings.TrimSpace(intro), "\n\n") {
+		if paragraph = strings.TrimSpace(paragraph); paragraph != "" {
+			return paragraph
+		}
+	}
+	return ""
+}
+
+func findReadmeIntroEnd(content string, start int) int {
+	end := len(content)
+	for _, prefix := range []string{"Learn more at ", "Printed by "} {
+		if idx := findLineWithPrefix(content, start, prefix); idx >= 0 && idx < end {
+			end = idx
+		}
+	}
+	if install := findMarkdownHeadingInRange(content, "## Install", start, len(content)); install >= 0 && install < end {
+		end = install
+	} else if heading := firstMarkdownHeading(content, start, len(content), 2, 2); heading.Start >= 0 && heading.Start < end {
+		end = heading.Start
+	}
+	return end
+}
+
+func findLineWithPrefix(content string, start int, prefix string) int {
+	if start < 0 {
+		start = 0
+	}
+	if start > len(content) {
+		return -1
+	}
+	for lineStart := start; lineStart < len(content); {
+		lineEnd := strings.IndexByte(content[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(content)
+		} else {
+			lineEnd += lineStart
+		}
+		if strings.HasPrefix(content[lineStart:lineEnd], prefix) {
+			return lineStart
+		}
+		if lineEnd == len(content) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return -1
 }
 
 func renderQuickStartSection(steps []QuickStartStep) string {

--- a/internal/pipeline/docsync_test.go
+++ b/internal/pipeline/docsync_test.go
@@ -6,9 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSkillInstallSectionEndSubstrMatchesGenerator(t *testing.T) {
+	assert.Equal(t, generator.SkillInstallSectionEndSubstr, skillInstallSectionEndSubstr)
+}
 
 func TestSyncReadmeAuthNarrativeRemovesStaleAuthenticationWhenOptionalExists(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/pipeline/docsync_test.go
+++ b/internal/pipeline/docsync_test.go
@@ -6,14 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestSkillInstallSectionEndSubstrMatchesGenerator(t *testing.T) {
-	assert.Equal(t, generator.SkillInstallSectionEndSubstr, skillInstallSectionEndSubstr)
-}
 
 func TestSyncReadmeAuthNarrativeRemovesStaleAuthenticationWhenOptionalExists(t *testing.T) {
 	dir := t.TempDir()
@@ -47,6 +42,36 @@ func TestSyncReadmeAuthNarrativeRemovesStaleAuthenticationWhenOptionalExists(t *
 	assert.NotContains(t, readme, "## Authentication")
 	assert.NotContains(t, readme, "Old required setup.")
 	assert.Contains(t, readme, "## Quick Start")
+}
+
+func TestReplaceReadmeIntroNarrativeStopsAtHeadingBeforeInstall(t *testing.T) {
+	content := strings.Join([]string{
+		"# Example CLI",
+		"",
+		"Old headline.",
+		"",
+		"## Authentication",
+		"",
+		"Keep this auth section.",
+		"",
+		"## Install",
+		"",
+		"Install instructions.",
+		"",
+	}, "\n")
+
+	updated := replaceReadmeIntroNarrative(content, &ReadmeNarrative{
+		Headline:  "New headline",
+		ValueProp: "New value proposition.",
+	})
+
+	assert.Contains(t, updated, "**New headline**")
+	assert.Contains(t, updated, "New value proposition.")
+	assert.Contains(t, updated, "## Authentication\n\nKeep this auth section.")
+	assert.Contains(t, updated, "## Install\n\nInstall instructions.")
+	assert.NotContains(t, updated, "Old headline.")
+	requireBefore(t, updated, "New value proposition.", "## Authentication")
+	requireBefore(t, updated, "## Authentication", "## Install")
 }
 
 func TestRenderSkillAuthSetupSectionDoesNotDuplicateDoctorInstruction(t *testing.T) {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1800,6 +1800,14 @@ func newHealthCmd() *cobra.Command {
 		writeTestFile(t, filepath.Join(cliDir, "README.md"), strings.Join([]string{
 			"# Test CLI",
 			"",
+			"**Old headline**",
+			"",
+			"Old value proposition mentions old quickstart.",
+			"",
+			"Learn more at [Test CLI](https://example.com).",
+			"",
+			"Printed by [@tester](https://github.com/tester).",
+			"",
 			"## Authentication",
 			"",
 			"Use the old auth command.",
@@ -1835,6 +1843,14 @@ func newHealthCmd() *cobra.Command {
 		writeTestFile(t, filepath.Join(cliDir, "SKILL.md"), strings.Join([]string{
 			"# Test Skill",
 			"",
+			"## Prerequisites: Install the CLI",
+			"",
+			"This skill drives the `test-pp-cli` binary.",
+			"",
+			"If `--version` reports \"command not found\" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.",
+			"",
+			"Old skill value proposition.",
+			"",
 			"## Unique Capabilities",
 			"",
 			"These capabilities aren't available in any other tool for this API.",
@@ -1867,6 +1883,8 @@ func newHealthCmd() *cobra.Command {
 				{Name: "Health dashboard", Command: "health", Description: "See scheduling health metrics at a glance"},
 			},
 			Narrative: &ReadmeNarrative{
+				Headline:      "Every Test feature plus verified health triage",
+				ValueProp:     "Health checks, OAuth setup, and agent-ready recipes stay in sync with research.json.",
 				AuthNarrative: "Use `test-pp-cli oauth-token --grant-type client_credentials` before protected calls.",
 				QuickStart: []QuickStartStep{
 					{Comment: "Check credentials", Command: "test-pp-cli doctor"},
@@ -1891,6 +1909,12 @@ func newHealthCmd() *cobra.Command {
 		readmeData, err := os.ReadFile(filepath.Join(cliDir, "README.md"))
 		require.NoError(t, err)
 		readme := string(readmeData)
+		assert.Contains(t, readme, "**Every Test feature plus verified health triage**")
+		assert.Contains(t, readme, "Health checks, OAuth setup, and agent-ready recipes stay in sync with research.json.")
+		assert.Contains(t, readme, "Learn more at [Test CLI](https://example.com).")
+		assert.Contains(t, readme, "Printed by [@tester](https://github.com/tester).")
+		assert.NotContains(t, readme, "Old headline")
+		assert.NotContains(t, readme, "Old value proposition")
 		assert.Contains(t, readme, "## Authentication\n\nUse `test-pp-cli oauth-token --grant-type client_credentials` before protected calls.")
 		assert.Contains(t, readme, "# Check credentials\ntest-pp-cli doctor")
 		assert.Contains(t, readme, "# Inspect health\ntest-pp-cli health --agent")
@@ -1903,6 +1927,10 @@ func newHealthCmd() *cobra.Command {
 		skillData, err := os.ReadFile(filepath.Join(cliDir, "SKILL.md"))
 		require.NoError(t, err)
 		skill := string(skillData)
+		assert.Contains(t, skill, "## Prerequisites: Install the CLI")
+		assert.Contains(t, skill, "Do not proceed with skill commands until verification succeeds.")
+		assert.Contains(t, skill, "Health checks, OAuth setup, and agent-ready recipes stay in sync with research.json.")
+		assert.NotContains(t, skill, "Old skill value proposition")
 		assert.Contains(t, skill, "## Recipes")
 		assert.Contains(t, skill, "### Inspect health")
 		assert.Contains(t, skill, "test-pp-cli health --agent")
@@ -1912,6 +1940,8 @@ func newHealthCmd() *cobra.Command {
 		assert.NotContains(t, skill, "Old recipe")
 		requireBefore(t, skill, "## Recipes", "## Auth Setup")
 
+		assert.Contains(t, stderr, "dogfood: synced README.md (Value Proposition) from research.json narrative")
+		assert.Contains(t, stderr, "dogfood: synced SKILL.md (Value Proposition) from research.json narrative")
 		assert.Contains(t, stderr, "dogfood: synced README.md (Quick Start) from research.json narrative")
 		assert.Contains(t, stderr, "dogfood: synced README.md (Authentication) from research.json narrative")
 		assert.Contains(t, stderr, "dogfood: synced README.md (Troubleshooting) from research.json narrative")
@@ -1928,6 +1958,58 @@ func newHealthCmd() *cobra.Command {
 		require.NoError(t, err)
 		assert.Equal(t, beforeReadme, string(afterReadme), "unchanged narrative should not rewrite README content")
 		assert.Equal(t, beforeSkill, string(afterSkill), "unchanged narrative should not rewrite SKILL content")
+	})
+
+	t.Run("value prop only preserves README lead paragraph", func(t *testing.T) {
+		cliDir := t.TempDir()
+		cliCodeDir := filepath.Join(cliDir, "internal", "cli")
+		require.NoError(t, os.MkdirAll(cliCodeDir, 0o755))
+		writeTestFile(t, filepath.Join(cliCodeDir, "health.go"),
+			`package cli
+func newHealthCmd() *cobra.Command {
+	return &cobra.Command{Use: "health"}
+}`)
+		writeTestFile(t, filepath.Join(cliDir, "README.md"), strings.Join([]string{
+			"# Test CLI",
+			"",
+			"Generated fallback description from the spec.",
+			"",
+			"Old value proposition.",
+			"",
+			"## Quick Start",
+			"",
+			"Run it.",
+			"",
+			"## Usage",
+			"",
+			"Run help.",
+			"",
+		}, "\n"))
+		writeTestFile(t, filepath.Join(cliDir, "SKILL.md"), "# Test Skill\n")
+
+		researchDir := t.TempDir()
+		research := &ResearchResult{
+			APIName: "test",
+			NovelFeatures: []NovelFeature{
+				{Name: "Health dashboard", Command: "health", Description: "See scheduling health metrics at a glance"},
+			},
+			Narrative: &ReadmeNarrative{
+				ValueProp: "Updated value proposition from research.json.",
+			},
+		}
+		require.NoError(t, writeResearchJSON(research, researchDir))
+
+		result := checkNovelFeatures(cliDir, researchDir)
+		assert.Equal(t, 1, result.Found)
+
+		readmeData, err := os.ReadFile(filepath.Join(cliDir, "README.md"))
+		require.NoError(t, err)
+		readme := string(readmeData)
+		assert.Contains(t, readme, "Generated fallback description from the spec.")
+		assert.Contains(t, readme, "Updated value proposition from research.json.")
+		assert.NotContains(t, readme, "Old value proposition.")
+		requireBefore(t, readme, "Generated fallback description from the spec.", "Updated value proposition from research.json.")
+		requireBefore(t, readme, "Updated value proposition from research.json.", "## Quick Start")
 	})
 
 	t.Run("inserts README and SKILL sections when absent", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfood narrative sync now refreshes the value-proposition surfaces that were still drifting after `research.json` edits. README headline/value-prop text and the SKILL value-prop paragraph are rewritten from the current narrative data, while generated website/printer metadata, install instructions, and fallback README descriptions are preserved.

Closes #1385

## Tests

- `go test ./internal/pipeline -run 'TestCheckNovelFeatures|TestSkillInstallSectionEndSubstrMatchesGenerator|TestSyncReadmeAuthNarrativeRemovesStaleAuthenticationWhenOptionalExists|TestRenderSkillAuthSetupSectionDoesNotDuplicateDoctorInstruction|TestMarkdownHeadingsRequiresMatchingFenceLength' -count=1`
- `go test ./...` attempted, but generated validation tests failed when `govulncheck` timed out fetching `golang.org/x/vuln` from `proxy.golang.org`
