### PR TITLE
fix(skills): detect truncated Go stdlib in preflight

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -231,7 +231,7 @@ func TestPrintingPressSkillPreflightSmokeTestsGoStdlib(t *testing.T) {
 
 	assert.Contains(t, smokeBlock, `$HOME/.printing-press-smoke`)
 	assert.Contains(t, smokeBlock, `mktemp -d "$_go_smoke_root/stdlib.XXXXXX"`)
-	assert.Contains(t, smokeBlock, `go run .`)
+	assert.Contains(t, smokeBlock, `GOFLAGS= go run .`)
 	assert.Contains(t, smokeBlock, `"fmt"`)
 	assert.Contains(t, smokeBlock, `"io"`)
 	assert.Contains(t, smokeBlock, `"net/http"`)

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -231,7 +231,7 @@ func TestPrintingPressSkillPreflightSmokeTestsGoStdlib(t *testing.T) {
 
 	assert.Contains(t, smokeBlock, `$HOME/.printing-press-smoke`)
 	assert.Contains(t, smokeBlock, `mktemp -d "$_go_smoke_root/stdlib.XXXXXX"`)
-	assert.Contains(t, smokeBlock, `GOFLAGS= go run .`)
+	assert.Contains(t, smokeBlock, `GOFLAGS= GOWORK=off go run .`)
 	assert.Contains(t, smokeBlock, `"fmt"`)
 	assert.Contains(t, smokeBlock, `"io"`)
 	assert.Contains(t, smokeBlock, `"net/http"`)

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -222,6 +222,29 @@ func TestPrintingPressSkillPreflightChecksGoToolchain(t *testing.T) {
 	assert.Contains(t, block, `https://go.dev/dl/`)
 }
 
+func TestPrintingPressSkillPreflightSmokeTestsGoStdlib(t *testing.T) {
+	skillPath := filepath.Join("..", "..", "skills", "printing-press", "SKILL.md")
+	full := readContractFile(t, skillPath)
+	block := extractContractBlock(t, full)
+
+	smokeBlock := substringBetween(t, block, `_go_smoke_root=`, `# Resolve and emit the absolute path`)
+
+	assert.Contains(t, smokeBlock, `$HOME/.printing-press-smoke`)
+	assert.Contains(t, smokeBlock, `mktemp -d "$_go_smoke_root/stdlib.XXXXXX"`)
+	assert.Contains(t, smokeBlock, `go run .`)
+	assert.Contains(t, smokeBlock, `"fmt"`)
+	assert.Contains(t, smokeBlock, `"io"`)
+	assert.Contains(t, smokeBlock, `"net/http"`)
+	assert.Contains(t, smokeBlock, `"encoding/json"`)
+	assert.Contains(t, smokeBlock, `"regexp"`)
+	assert.Contains(t, smokeBlock, `"context"`)
+	assert.Contains(t, smokeBlock, `[setup-error] Go std library is incomplete (truncated or corrupted install).`)
+	assert.Contains(t, smokeBlock, `Reinstall Go from https://go.dev/dl/`)
+	assert.Contains(t, smokeBlock, `rm -rf "$_go_smoke_dir"`)
+	assert.NotContains(t, smokeBlock, `${TMPDIR`)
+	assert.NotContains(t, smokeBlock, `/tmp`)
+}
+
 func TestPrintingPressSkillDistinguishesBearerFromRawAPIKey(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 	block := substringBetween(t, skill, "### Pre-Generation Auth Enrichment", "**Why enrich before generation")

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -191,6 +191,75 @@ if ! command -v go >/dev/null 2>&1; then
   return 1 2>/dev/null || exit 1
 fi
 
+# Verify the installed Go tree can compile and run common standard library
+# imports. A truncated Go extraction can leave the binary working enough for
+# `go version` while missing packages under $GOROOT/src, which otherwise fails
+# deep into generation during later Go quality gates.
+_go_smoke_root="${PRINTING_PRESS_GO_SMOKE_DIR:-$HOME/.printing-press-smoke}"
+if ! mkdir -p "$_go_smoke_root"; then
+  echo ""
+  echo "[setup-error] Unable to create Go smoke-test workspace at $_go_smoke_root."
+  echo "Set PRINTING_PRESS_GO_SMOKE_DIR to a writable non-temp directory and retry."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+_go_smoke_dir="$(mktemp -d "$_go_smoke_root/stdlib.XXXXXX" 2>/dev/null || true)"
+if [ -z "$_go_smoke_dir" ]; then
+  echo ""
+  echo "[setup-error] Unable to create Go smoke-test workspace under $_go_smoke_root."
+  echo "Set PRINTING_PRESS_GO_SMOKE_DIR to a writable non-temp directory and retry."
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+cat > "$_go_smoke_dir/go.mod" <<'__PP_GO_SMOKE_MOD__'
+module pp-go-stdlib-smoke
+
+go 1.20
+__PP_GO_SMOKE_MOD__
+cat > "$_go_smoke_dir/main.go" <<'__PP_GO_SMOKE_MAIN__'
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+func main() {
+	ctx := context.Background()
+	payload, err := json.Marshal(map[string]string{"status": "ok"})
+	if err != nil {
+		panic(err)
+	}
+	if !regexp.MustCompile(`ok`).Match(payload) {
+		panic("regexp mismatch")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = fmt.Fprint(io.Discard, req.Method)
+}
+__PP_GO_SMOKE_MAIN__
+if ! (cd "$_go_smoke_dir" && go run . >/dev/null 2>"$_go_smoke_dir/error.log"); then
+  _go_smoke_output="$(sed -n '1,12p' "$_go_smoke_dir/error.log" 2>/dev/null || true)"
+  rm -rf "$_go_smoke_dir"
+  echo ""
+  echo "[setup-error] Go std library is incomplete (truncated or corrupted install)."
+  echo "Reinstall Go from https://go.dev/dl/ and verify with the smoke test before retrying."
+  if [ -n "$_go_smoke_output" ]; then
+    echo ""
+    echo "Go smoke test output:"
+    printf '%s\n' "$_go_smoke_output"
+  fi
+  echo ""
+  return 1 2>/dev/null || exit 1
+fi
+rm -rf "$_go_smoke_dir"
+
 # Resolve and emit the absolute path the agent must use for every later
 # `cli-printing-press` invocation. `export PATH` above only affects this one
 # Bash tool call; subsequent calls open a fresh shell and resolve bare

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -244,7 +244,7 @@ func main() {
 	_, _ = fmt.Fprint(io.Discard, req.Method)
 }
 __PP_GO_SMOKE_MAIN__
-if ! (cd "$_go_smoke_dir" && go run . >/dev/null 2>"$_go_smoke_dir/error.log"); then
+if ! (cd "$_go_smoke_dir" && GOFLAGS= go run . >/dev/null 2>"$_go_smoke_dir/error.log"); then
   _go_smoke_output="$(sed -n '1,12p' "$_go_smoke_dir/error.log" 2>/dev/null || true)"
   rm -rf "$_go_smoke_dir"
   echo ""

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -244,7 +244,7 @@ func main() {
 	_, _ = fmt.Fprint(io.Discard, req.Method)
 }
 __PP_GO_SMOKE_MAIN__
-if ! (cd "$_go_smoke_dir" && GOFLAGS= go run . >/dev/null 2>"$_go_smoke_dir/error.log"); then
+if ! (cd "$_go_smoke_dir" && GOFLAGS= GOWORK=off go run . >/dev/null 2>"$_go_smoke_dir/error.log"); then
   _go_smoke_output="$(sed -n '1,12p' "$_go_smoke_dir/error.log" 2>/dev/null || true)"
   rm -rf "$_go_smoke_dir"
   echo ""


### PR DESCRIPTION
## Summary

The Printing Press setup contract now catches corrupted Go installs before generation starts. After confirming `go` exists, preflight compiles and runs a stdlib-only smoke program from `$HOME/.printing-press-smoke`; healthy installs stay silent, while missing stdlib packages fail fast with the requested `[setup-error]` and reinstall pointer.

Closes #1337.

## Verification

- `go test ./internal/pipeline -run 'TestSkillSetupBlocksMatchWorkspaceContract|TestPrintingPressSkillPreflight(ChecksGoToolchain|SmokeTestsGoStdlib)'`
- `go test ./internal/pipeline`
- `go test ./internal/cli -run 'TestPrintingPressSkill|TestInternalSkillMinimumBinaryVersionsTrackMajor'`
- `git diff --check`
- pre-push hook: `golangci-lint` reported `0 issues`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
