### PR TITLE
feat(skills): add raw docs fetch helper

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -84,6 +84,7 @@ See the `printing-press-polish` skill for details. It runs diagnostics, fixes ve
 - **Bugs found during dogfood are fix-before-ship, not "file for v0.2".** If a 1-3 file edit resolves it, do it now. `ship-with-gaps` is deprecated as a default verdict (see Phase 4). Context is freshest in-session; a v0.2 backlog that may never be revisited ships known-broken CLIs.
 - **Features approved in Phase 1.5 are shipping scope.** Do not downgrade a shipping-scope feature to a stub mid-build. If implementation becomes infeasible, return to Phase 1.5 with a revised manifest and get explicit re-approval.
 - **Do not quote human-time estimates for sub-tasks** ("~15-30 min", "~1 hour", "quick fix") in `AskUserQuestion` options, phase descriptions, or reference docs. The agent does the work, not the user; agent-fabricated estimates are notoriously bad and train users to distrust the prompt. Describe scope instead (lines of code, files touched, relative size). The carve-outs are wall-clock estimates for genuinely time-bound things: the whole-CLI run (set the user's expectation up front — most CLIs take 30+ minutes), tool installs (`go install` takes ~10 seconds), and printing-press subcommands that do network-bound work (crowd-sniff scans npm + GitHub, ~5-10 minutes). Anything bounded by agent reasoning time is not time-bound — describe scope.
+- **Use raw captures for contract research.** When reading official docs, auth/error/rate-limit pages, endpoint references, OpenAPI/Postman links, or source pages whose exact identifiers affect the generated CLI, read [references/fetch-docs.md](references/fetch-docs.md) and use its `fetch-docs.sh` helper. Reserve `WebFetch` for quick TL;DR reads where losing field-level details is acceptable.
 - Optimize for time-to-ship, not time-to-document.
 - Reuse prior research whenever it is already good enough.
 - Do not split one idea across multiple mandatory artifacts.
@@ -623,9 +624,9 @@ Before new research:
 
    **URL Detection** — If the argument contains `://`, it's a URL. Determine whether it's a spec or a website before proceeding.
 
-   **Step 1: Content probe.** Fetch the URL (light GET via `WebFetch`) and inspect the response:
+   **Step 1: Content probe.** Fetch the URL with the raw docs helper from [references/fetch-docs.md](references/fetch-docs.md) and inspect the response status, `Content-Type`, and first few lines of the returned file:
    - Check the `Content-Type` header and the first few lines of the body.
-   - If the fetch fails (timeout, 404, DNS error), skip to Step 2 — treat it as a website.
+   - If the fetch fails (timeout, 404, DNS error), record the exact status/error, then skip to Step 2 — treat it as a website.
 
    If the content starts with `openapi:`, `swagger:`, or is valid JSON containing an `"openapi"` or `"swagger"` key → it's a spec. Treat as `--spec` and proceed directly. No disambiguation needed.
 
@@ -946,6 +947,8 @@ Resolve the API key gate (or skip it for public APIs) before moving to Phase 1.
 
 **When `BROWSER_SNIFF_TARGET_URL` is set:** Skip the catalog check, spec/docs search, and SDK wrapper search — none of these exist for an undocumented website feature. Focus research on understanding what the site/feature does, who uses it, what workflows it supports, and what competitors offer similar functionality. The spec will come from browser-sniffing in Phase 1.7.
 
+Before reading documentation, read [references/fetch-docs.md](references/fetch-docs.md). Use `fetch-docs.sh` for the API's primary docs, OpenAPI/Postman links, auth guides, error handling, rate limits, pagination, webhooks, and any per-endpoint reference page. Preserve exact status codes and inspect the returned local file directly so enum values, field constraints, casing, examples, and nav/link variants are not lost through summarization.
+
 Before starting research, check if the API has a built-in catalog entry:
 
 ```bash
@@ -986,7 +989,7 @@ The brief must answer:
 6. What is the product name and thesis?
 
 Research checklist:
-- Find the spec or docs source
+- Find the spec or docs source. For docs pages whose details affect generation, fetch the raw page with `fetch-docs.sh`, then read/grep the returned path directly.
 - Find the top 1-2 competitors
 - **Check GitHub issues on the top wrapper/SDK repo for "403", "blocked", "broken", "deprecated", "rate limit".** If multiple issues report the API is inaccessible or broken, flag this in the research brief as a reachability risk. This is critical for unofficial/reverse-engineered APIs.
 - Find official and popular SDK wrappers on npm (`site:npmjs.com`) and PyPI (`site:pypi.org`)
@@ -1433,7 +1436,7 @@ Run these searches in parallel:
 3. **WebSearch**: `"<API name>" Claude skill SKILL.md site:github.com`
 4. **WebSearch**: `"<API name>" CLI tool site:github.com` (competing CLIs)
 5. **WebSearch**: `"<API name>" CLI site:npmjs.com` (npm packages)
-6. **WebFetch**: Check `github.com/anthropics/claude-plugins-official/tree/main/external_plugins` for official plugin
+6. **Raw fetch**: Check `github.com/anthropics/claude-plugins-official/tree/main/external_plugins` for official plugins with the helper from [references/fetch-docs.md](references/fetch-docs.md), or with `gh api` when it can return the file/listing directly.
 7. **WebSearch**: `"<API name>" MCP site:lobehub.com OR site:mcpmarket.com OR site:fastmcp.me`
 8. **WebSearch**: `"<API name>" automation script workflow site:github.com`
 9. **WebSearch**: `"<API name>" SDK wrapper site:npmjs.com`
@@ -1447,7 +1450,7 @@ If step 1.5a discovered MCP server repos with public source code on GitHub, read
 
 **For the top 1-2 MCP repos found:**
 
-1. **Identify the main source file.** WebFetch the repo root to find the entry point — typically `src/index.ts`, `server.ts`, `server.py`, `main.go`, or a `tools/` directory. MCP servers are usually small (one main file + tool definitions).
+1. **Identify the main source file.** Use `gh api`, raw GitHub URLs, or the helper from [references/fetch-docs.md](references/fetch-docs.md) to inspect the repo tree and source files without a summarization layer. Find the entry point — typically `src/index.ts`, `server.ts`, `server.py`, `main.go`, or a `tools/` directory. MCP servers are usually small (one main file + tool definitions).
 
 2. **Extract three things:**
    - **API endpoint paths**: Look for HTTP client calls (`fetch(`, `axios.`, `requests.`, `http.Get`, `client.`) and extract the URL paths (e.g., `GET /v1/issues`, `POST /graphql`). These are the endpoints the MCP maintainer proved work.

--- a/skills/printing-press/references/fetch-docs.md
+++ b/skills/printing-press/references/fetch-docs.md
@@ -1,0 +1,44 @@
+# Raw Documentation Fetching
+
+> **When to read:** Before Phase 1 docs research, Phase 1.5 absorb reads, or any step that extracts contract details from documentation or source pages.
+
+Use `fetch-docs.sh` for fidelity-sensitive reads. The helper captures the raw response body with `curl`, preserves the final status code, caches successful reads for 24 hours, and returns the local file path for direct `Read`/`Grep` inspection.
+
+## When To Use It
+
+Use the helper for:
+
+- official API docs, auth guides, rate limits, error handling, pagination, webhooks, and per-endpoint reference pages
+- OpenAPI, Postman, AsyncAPI, JSON Schema, YAML, markdown, and raw source links
+- GitHub source files or plugin indexes where exact identifiers, enum values, header names, paths, and casing matter
+- re-checking any docs URL that `WebFetch` reported as missing, vague, or contradictory
+
+Reserve `WebFetch` for quick TL;DR reads of blog posts, community articles, or pages where exact field-level contract details are not being carried into the generated CLI.
+
+## Command
+
+```bash
+skills/printing-press/references/fetch-docs.sh [--ttl=<seconds>] [--force] [--md] <url>
+```
+
+Default behavior:
+
+- follows redirects and compressed responses
+- fails loudly on any final HTTP status other than `200`
+- writes captures under `${TMPDIR:-/tmp}/printing-press-fetch-docs/`
+- prints `path=`, `status=`, `content_type=`, and `effective_url=`
+- reuses a successful capture for 24 hours unless `--force` or `--ttl=0` is set
+
+Use `--force` or `--ttl=0` when validating route quirks such as trailing-slash `404` vs non-trailing-slash `200`.
+
+Use `--md` only when reader-mode markdown is helpful. If `readability-cli` and `turndown-cli` are installed, the helper converts HTML to markdown; otherwise it tries `npx --yes` for those tools. If conversion is unavailable or fails, it keeps the raw capture and prints a warning. For navigation discovery, raw HTML is usually better than reader-mode markdown because nav links are part of the contract surface.
+
+## Required Agent Handling
+
+After fetching:
+
+1. Read or grep the returned `path=` file directly.
+2. Record non-200 statuses as reachability evidence instead of summarizing them away.
+3. When two URL variants differ only by trailing slash, capitalization, `.html`, or a docs-build quirk, fetch both variants and preserve both status codes in the brief.
+4. Copy exact enum values, header names, field names, status codes, path casing, and examples from the raw capture when they affect spec authoring or CLI flags.
+5. Do not base generator-contract decisions on `WebFetch` summaries when the raw capture is available.

--- a/skills/printing-press/references/fetch-docs.sh
+++ b/skills/printing-press/references/fetch-docs.sh
@@ -189,7 +189,7 @@ OUT_FILE="$RAW_FILE"
 if [[ "$WANT_MD" == "true" && "$ext" != "md" && "$ext" != "mdx" ]]; then
   MD_FILE="$BASE.md"
   if command -v readability-cli >/dev/null 2>&1 && command -v turndown-cli >/dev/null 2>&1; then
-    if readability-cli "$RAW_FILE" | turndown-cli > "$MD_FILE"; then
+    if readability-cli "$effective_url" < "$RAW_FILE" | turndown-cli > "$MD_FILE"; then
       OUT_FILE="$MD_FILE"
       content_type="text/markdown; converted-from=$content_type"
     else
@@ -197,7 +197,7 @@ if [[ "$WANT_MD" == "true" && "$ext" != "md" && "$ext" != "mdx" ]]; then
       rm -f "$MD_FILE"
     fi
   elif command -v npx >/dev/null 2>&1; then
-    if npx --yes readability-cli "$RAW_FILE" | npx --yes turndown-cli > "$MD_FILE"; then
+    if npx --yes readability-cli "$effective_url" < "$RAW_FILE" | npx --yes turndown-cli > "$MD_FILE"; then
       OUT_FILE="$MD_FILE"
       content_type="text/markdown; converted-from=$content_type"
     else

--- a/skills/printing-press/references/fetch-docs.sh
+++ b/skills/printing-press/references/fetch-docs.sh
@@ -74,7 +74,7 @@ fi
 
 safe_slug() {
   printf '%s' "$1" |
-    sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#[/?#&=]+#-#g; s#[^A-Za-z0-9._-]+#-#g; s#^-+##; s#-+$##' |
+    sed -E 's%^[a-zA-Z][a-zA-Z0-9+.-]*://%%; s%[/?#&=]+%-%g; s%[^A-Za-z0-9._-]+%-%g; s%^-+%%; s%-+$%%' |
     cut -c1-80
 }
 
@@ -154,7 +154,7 @@ fi
 
 BODY_TMP="$(mktemp "$CACHE_ROOT/fetch-docs-body.XXXXXX")"
 HEADER_TMP="$(mktemp "$CACHE_ROOT/fetch-docs-headers.XXXXXX")"
-trap 'rm -f "$BODY_TMP" "$HEADER_TMP"' EXIT
+trap 'rm -f ${BODY_TMP:+"$BODY_TMP"} "$HEADER_TMP"' EXIT
 
 CURL_WRITE=$'status=%{http_code}\ncontent_type=%{content_type}\neffective_url=%{url_effective}\n'
 if ! CURL_META="$(curl -sS -L --compressed --connect-timeout 10 --max-time 30 \

--- a/skills/printing-press/references/fetch-docs.sh
+++ b/skills/printing-press/references/fetch-docs.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# fetch-docs.sh - fetch fidelity-sensitive docs without a summarization layer.
+#
+# Usage:
+#   fetch-docs.sh [--ttl=<seconds>] [--force] [--md] <url>
+#
+# Prints the cached/captured file path and response metadata. Exits non-zero on
+# network failure or any final HTTP status other than 200.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 [--ttl=<seconds>] [--force] [--md] <url>" >&2
+  exit 2
+}
+
+TTL_SECONDS=86400
+FORCE=false
+WANT_MD=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ttl=*)
+      TTL_SECONDS="${1#--ttl=}"
+      [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]] || usage
+      shift
+      ;;
+    --ttl)
+      TTL_SECONDS="${2:-}"
+      [[ "$TTL_SECONDS" =~ ^[0-9]+$ ]] || usage
+      shift 2
+      ;;
+    --force)
+      FORCE=true
+      TTL_SECONDS=0
+      shift
+      ;;
+    --md)
+      WANT_MD=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    --*)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[[ $# -eq 1 ]] || usage
+URL="$1"
+case "$URL" in
+  http://*|https://*) ;;
+  *) echo "fetch-docs: URL must start with http:// or https://" >&2; exit 2 ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "fetch-docs: curl is required" >&2
+  exit 127
+fi
+
+CACHE_ROOT="${TMPDIR:-/tmp}/printing-press-fetch-docs"
+mkdir -p "$CACHE_ROOT"
+
+if command -v shasum >/dev/null 2>&1; then
+  URL_HASH="$(printf '%s' "$URL" | shasum -a 256 | awk '{print $1}')"
+else
+  URL_HASH="$(printf '%s' "$URL" | cksum | awk '{print $1}')"
+fi
+
+safe_slug() {
+  printf '%s' "$1" |
+    sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#[/?#&=]+#-#g; s#[^A-Za-z0-9._-]+#-#g; s#^-+##; s#-+$##' |
+    cut -c1-80
+}
+
+extension_for() {
+  local url="$1"
+  local content_type="$2"
+  local path="${url%%\?*}"
+  path="${path%%#*}"
+  case "$path" in
+    *.md|*.markdown) echo "md"; return ;;
+    *.mdx) echo "mdx"; return ;;
+    *.json) echo "json"; return ;;
+    *.yaml|*.yml) echo "yaml"; return ;;
+    *.txt) echo "txt"; return ;;
+    *.xml) echo "xml"; return ;;
+    *.html|*.htm) echo "html"; return ;;
+  esac
+  case "$content_type" in
+    *markdown*) echo "md" ;;
+    *json*) echo "json" ;;
+    *yaml*|*yml*) echo "yaml" ;;
+    *xml*) echo "xml" ;;
+    *html*) echo "html" ;;
+    *text/plain*) echo "txt" ;;
+    *) echo "bin" ;;
+  esac
+}
+
+SLUG="$(safe_slug "$URL")"
+[[ -n "$SLUG" ]] || SLUG="docs"
+BASE="$CACHE_ROOT/${SLUG}-${URL_HASH:0:16}"
+META_FILE="$BASE.meta"
+
+cache_fresh() {
+  local file="$1"
+  [[ -f "$file" && -f "$META_FILE" ]] || return 1
+  [[ "$FORCE" == "false" ]] || return 1
+  [[ "$TTL_SECONDS" -gt 0 ]] || return 1
+
+  local now mtime age
+  now="$(date +%s)"
+  if mtime="$(stat -f %m "$file" 2>/dev/null)"; then
+    :
+  else
+    mtime="$(stat -c %Y "$file" 2>/dev/null)" || return 1
+  fi
+  age=$((now - mtime))
+  [[ "$age" -lt "$TTL_SECONDS" ]]
+}
+
+print_result() {
+  local file="$1"
+  local status="$2"
+  local content_type="$3"
+  local effective_url="$4"
+  printf 'path=%s\n' "$file"
+  printf 'status=%s\n' "$status"
+  printf 'content_type=%s\n' "$content_type"
+  printf 'effective_url=%s\n' "$effective_url"
+}
+
+cached_file=""
+if [[ -f "$META_FILE" ]]; then
+  cached_file="$(awk -F= '$1 == "path" {print substr($0, index($0, "=") + 1)}' "$META_FILE" 2>/dev/null || true)"
+  if [[ -n "$cached_file" ]] && cache_fresh "$cached_file"; then
+    status="$(awk -F= '$1 == "status" {print substr($0, index($0, "=") + 1)}' "$META_FILE")"
+    content_type="$(awk -F= '$1 == "content_type" {print substr($0, index($0, "=") + 1)}' "$META_FILE")"
+    effective_url="$(awk -F= '$1 == "effective_url" {print substr($0, index($0, "=") + 1)}' "$META_FILE")"
+    if [[ "$status" != "200" ]]; then
+      echo "fetch-docs: cached HTTP $status for $URL (body: $cached_file, final: $effective_url)" >&2
+      exit 22
+    fi
+    print_result "$cached_file" "$status" "$content_type" "$effective_url"
+    exit 0
+  fi
+fi
+
+BODY_TMP="$(mktemp "$CACHE_ROOT/fetch-docs-body.XXXXXX")"
+HEADER_TMP="$(mktemp "$CACHE_ROOT/fetch-docs-headers.XXXXXX")"
+trap 'rm -f "$BODY_TMP" "$HEADER_TMP"' EXIT
+
+CURL_WRITE=$'status=%{http_code}\ncontent_type=%{content_type}\neffective_url=%{url_effective}\n'
+if ! CURL_META="$(curl -sS -L --compressed --connect-timeout 10 --max-time 30 \
+    -D "$HEADER_TMP" -o "$BODY_TMP" -w "$CURL_WRITE" "$URL" 2>&1)"; then
+  echo "fetch-docs: curl failed for $URL" >&2
+  printf '%s\n' "$CURL_META" >&2
+  exit 1
+fi
+
+status="$(printf '%s\n' "$CURL_META" | awk -F= '$1 == "status" {print substr($0, index($0, "=") + 1)}')"
+content_type="$(printf '%s\n' "$CURL_META" | awk -F= '$1 == "content_type" {print substr($0, index($0, "=") + 1)}')"
+effective_url="$(printf '%s\n' "$CURL_META" | awk -F= '$1 == "effective_url" {print substr($0, index($0, "=") + 1)}')"
+[[ -n "$status" ]] || status="000"
+
+ext="$(extension_for "$effective_url" "$content_type")"
+RAW_FILE="$BASE.$ext"
+mv "$BODY_TMP" "$RAW_FILE"
+BODY_TMP=""
+
+if [[ "$status" != "200" ]]; then
+  {
+    printf 'path=%s\n' "$RAW_FILE"
+    printf 'status=%s\n' "$status"
+    printf 'content_type=%s\n' "$content_type"
+    printf 'effective_url=%s\n' "$effective_url"
+  } > "$META_FILE"
+  echo "fetch-docs: HTTP $status for $URL (body: $RAW_FILE, final: $effective_url)" >&2
+  exit 22
+fi
+
+OUT_FILE="$RAW_FILE"
+if [[ "$WANT_MD" == "true" && "$ext" != "md" && "$ext" != "mdx" ]]; then
+  MD_FILE="$BASE.md"
+  if command -v readability-cli >/dev/null 2>&1 && command -v turndown-cli >/dev/null 2>&1; then
+    if readability-cli "$RAW_FILE" | turndown-cli > "$MD_FILE"; then
+      OUT_FILE="$MD_FILE"
+      content_type="text/markdown; converted-from=$content_type"
+    else
+      echo "fetch-docs: markdown conversion failed; keeping raw capture $RAW_FILE" >&2
+      rm -f "$MD_FILE"
+    fi
+  elif command -v npx >/dev/null 2>&1; then
+    if npx --yes readability-cli "$RAW_FILE" | npx --yes turndown-cli > "$MD_FILE"; then
+      OUT_FILE="$MD_FILE"
+      content_type="text/markdown; converted-from=$content_type"
+    else
+      echo "fetch-docs: npx markdown conversion failed; keeping raw capture $RAW_FILE" >&2
+      rm -f "$MD_FILE"
+    fi
+  else
+    echo "fetch-docs: --md requested but readability-cli/turndown-cli or npx are unavailable; keeping raw capture $RAW_FILE" >&2
+  fi
+fi
+
+{
+  printf 'path=%s\n' "$OUT_FILE"
+  printf 'status=%s\n' "$status"
+  printf 'content_type=%s\n' "$content_type"
+  printf 'effective_url=%s\n' "$effective_url"
+} > "$META_FILE"
+
+print_result "$OUT_FILE" "$status" "$content_type" "$effective_url"


### PR DESCRIPTION
## Summary

Printing Press docs research now has a raw capture path for contract-sensitive pages, so agents can inspect exact statuses, headers, enum values, field casing, and source snippets instead of relying on WebFetch summaries.

The skill now routes URL probes, Phase 1 docs reads, absorb plugin checks, and MCP source inspection through the raw helper when exact details affect generation.

Closes #1478

## Verification

- `bash -n skills/printing-press/references/fetch-docs.sh`
- `shellcheck skills/printing-press/references/fetch-docs.sh`
- `skills/printing-press/references/fetch-docs.sh --force https://example.com`
- `skills/printing-press/references/fetch-docs.sh --force https://example.com/not-found` returned HTTP 404 and exit 22 as expected
- `skills/printing-press/references/fetch-docs.sh https://example.com/not-found` returned cached HTTP 404 and exit 22 as expected
- `git diff --check`
