### PR TITLE
docs(skills): add MCP intent YAML example

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2502,10 +2502,19 @@ mcp:
   orchestration: code         # thin <api>_search + <api>_execute pair
   endpoint_tools: hidden      # suppress raw per-endpoint mirrors
   intents:                    # optional; named multi-step intents
-    - name: <intent_name>
-      description: <agent-facing intent description>
-      params: [...]
-      steps: [...]
+    - name: fetch_and_summarize
+      description: Fetch an item then summarize it
+      params:
+        - name: item_id
+          type: string
+          required: true
+          description: item identifier
+      steps:
+        - endpoint: items.get
+          bind:
+            id: ${input.item_id}
+          capture: item
+      returns: item
 ```
 
 `mcp.transport: [stdio, http]` adds HTTP streamable transport so cloud-hosted

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2516,7 +2516,7 @@ mcp:
           capture: item
         - endpoint: items.summarize
           bind:
-            item: ${capture.item}
+            body: ${item.body}
           capture: summary
       returns: summary
 ```

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2514,7 +2514,11 @@ mcp:
           bind:
             id: ${input.item_id}
           capture: item
-      returns: item
+        - endpoint: items.summarize
+          bind:
+            item: ${capture.item}
+          capture: summary
+      returns: summary
 ```
 
 `mcp.transport: [stdio, http]` adds HTTP streamable transport so cloud-hosted


### PR DESCRIPTION
## Summary

The Printing Press skill now shows a complete MCP intent YAML block that agents can copy into a spec without tripping the intent-step parser. The example uses the same `endpoint`, `bind`, `capture`, and `returns` shape covered by the parser fixture.

Closes #1611

## Verification

- `go test ./internal/spec -run 'TestMCPIntents(Parse|Validation)'`
- `bash .github/scripts/validate-skill-docs.sh`
- `node .github/scripts/validate-printing-press-skill-list.mjs`
