### PR TITLE
fix(cli): apply research canonical auth env vars

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3175,6 +3175,21 @@ func TestApplyResearchAuthMetadataRejectsUnsafeCanonicalEnvVars(t *testing.T) {
 			wantEnvVars:  []string{"TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"},
 			wantSpecName: "TWILIO_ACCOUNT_SID",
 		},
+		{
+			name:      "multi credential auth ignored",
+			canonical: "STRIPE_SECRET_KEY",
+			auth: spec.AuthConfig{
+				Type:    "oauth2",
+				Format:  "Bearer {access_token}",
+				EnvVars: []string{"CLIENT_ID", "CLIENT_SECRET"},
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "CLIENT_ID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false, Inferred: true},
+					{Name: "CLIENT_SECRET", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+				},
+			},
+			wantEnvVars:  []string{"CLIENT_ID", "CLIENT_SECRET"},
+			wantSpecName: "CLIENT_ID",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3010,6 +3010,201 @@ func TestRunGenerateProjectReturnsResearchNarrativeCatalogMetadata(t *testing.T)
 	assert.Equal(t, "Search Alaska Airlines flights and check Atmos Rewards balance from the terminal, with offline-cached airports and agent-native JSON output.", got.CatalogDescription)
 }
 
+func TestRunGenerateProjectAppliesResearchCanonicalAuthEnvVar(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	researchData, err := json.Marshal(&pipeline.ResearchResult{
+		APIName: "apify",
+		Auth: &pipeline.ResearchAuth{
+			CanonicalEnvVar: "APIFY_TOKEN",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), researchData, 0o644))
+
+	apiSpec := &spec.APISpec{
+		Name:    "apify",
+		Version: "1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "bearer_token",
+			Header:  "Authorization",
+			EnvVars: []string{"APIFY_HTTP_BEARER"},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "APIFY_HTTP_BEARER", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "apify")
+
+	_, err = runGenerateProject(apiSpec, outputDir, generateProjectOptions{researchDir: researchDir})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"APIFY_TOKEN", "APIFY_HTTP_BEARER"}, apiSpec.Auth.EnvVars)
+	require.Len(t, apiSpec.Auth.EnvVarSpecs, 2)
+	assert.True(t, apiSpec.Auth.IsAuthEnvVarORCase(), "canonical and fallback names should behave as alternatives")
+
+	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	content := string(cfgSrc)
+	canonicalIdx := strings.Index(content, `os.Getenv("APIFY_TOKEN")`)
+	fallbackIdx := strings.Index(content, `os.Getenv("APIFY_HTTP_BEARER")`)
+	require.NotEqual(t, -1, canonicalIdx, "config must read the research-discovered canonical env var")
+	require.NotEqual(t, -1, fallbackIdx, "config must retain the parser-derived fallback env var")
+	assert.Less(t, canonicalIdx, fallbackIdx, "canonical env var should be checked before fallback")
+}
+
+func TestRunGenerateProjectCanonicalAuthEnvVarPreservesFormattedAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	researchDir := t.TempDir()
+	researchData, err := json.Marshal(&pipeline.ResearchResult{
+		APIName: "format-test",
+		Auth: &pipeline.ResearchAuth{
+			CanonicalEnvVar: "DISCORD_TOKEN",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), researchData, 0o644))
+
+	apiSpec := &spec.APISpec{
+		Name:    "format-test",
+		Version: "1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			In:      "header",
+			Format:  "Bot {bot_token}",
+			EnvVars: []string{"DISCORD_BOT_TOKEN"},
+			EnvVarSpecs: []spec.AuthEnvVar{
+				{Name: "DISCORD_BOT_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"users": {
+				Description: "Users",
+				Endpoints: map[string]spec.Endpoint{
+					"me": {Method: "GET", Path: "/users/@me", Description: "Current user"},
+				},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "format-test")
+
+	_, err = runGenerateProject(apiSpec, outputDir, generateProjectOptions{researchDir: researchDir})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"DISCORD_TOKEN", "DISCORD_BOT_TOKEN"}, apiSpec.Auth.EnvVars)
+	assert.Equal(t, "Bot {token}", apiSpec.Auth.Format)
+
+	cfgSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	content := string(cfgSrc)
+	assert.Contains(t, content, `return applyAuthFormat("Bot {token}", map[string]string{`)
+	assert.Contains(t, content, `"token":`)
+	assert.Contains(t, content, `c.DiscordToken,`)
+	assert.NotContains(t, content, `applyAuthFormat("Bot {bot_token}"`)
+}
+
+func TestApplyResearchAuthMetadataRejectsUnsafeCanonicalEnvVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		canonical    string
+		auth         spec.AuthConfig
+		wantEnvVars  []string
+		wantSpecName string
+	}{
+		{
+			name:      "placeholder value ignored",
+			canonical: "<CANONICAL_ENV_VAR, omit when unknown>",
+			auth: spec.AuthConfig{
+				Type:    "bearer_token",
+				EnvVars: []string{"APIFY_HTTP_BEARER"},
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "APIFY_HTTP_BEARER", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+				},
+			},
+			wantEnvVars:  []string{"APIFY_HTTP_BEARER"},
+			wantSpecName: "APIFY_HTTP_BEARER",
+		},
+		{
+			name:      "lowercase value ignored",
+			canonical: "apify_token",
+			auth: spec.AuthConfig{
+				Type:    "bearer_token",
+				EnvVars: []string{"APIFY_HTTP_BEARER"},
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "APIFY_HTTP_BEARER", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+				},
+			},
+			wantEnvVars:  []string{"APIFY_HTTP_BEARER"},
+			wantSpecName: "APIFY_HTTP_BEARER",
+		},
+		{
+			name:      "no auth ignored",
+			canonical: "APIFY_TOKEN",
+			auth: spec.AuthConfig{
+				Type: "none",
+			},
+			wantEnvVars: nil,
+		},
+		{
+			name:      "basic auth ignored",
+			canonical: "TWILIO_TOKEN",
+			auth: spec.AuthConfig{
+				Type:    "api_key",
+				Format:  "Basic {credentials}",
+				EnvVars: []string{"TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"},
+				EnvVarSpecs: []spec.AuthEnvVar{
+					{Name: "TWILIO_ACCOUNT_SID", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: false, Inferred: true},
+					{Name: "TWILIO_AUTH_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true, Inferred: true},
+				},
+			},
+			wantEnvVars:  []string{"TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"},
+			wantSpecName: "TWILIO_ACCOUNT_SID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			researchDir := t.TempDir()
+			researchData, err := json.Marshal(&pipeline.ResearchResult{
+				APIName: "test",
+				Auth: &pipeline.ResearchAuth{
+					CanonicalEnvVar: tt.canonical,
+				},
+			})
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(researchDir, "research.json"), researchData, 0o644))
+
+			apiSpec := &spec.APISpec{Name: "test", Auth: tt.auth}
+			applyResearchAuthMetadata(apiSpec, researchDir)
+
+			assert.Equal(t, tt.wantEnvVars, apiSpec.Auth.EnvVars)
+			if tt.wantSpecName == "" {
+				assert.Empty(t, apiSpec.Auth.EnvVarSpecs)
+			} else {
+				require.NotEmpty(t, apiSpec.Auth.EnvVarSpecs)
+				assert.Equal(t, tt.wantSpecName, apiSpec.Auth.EnvVarSpecs[0].Name)
+			}
+		})
+	}
+}
+
 func TestEnrichSpecFromCatalogReplacesTitleDerivedDisplayName(t *testing.T) {
 	apiSpec := &spec.APISpec{
 		Name:                        "trigger-dev",

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -550,6 +550,7 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	if apiSpec != nil {
 		catalogEntry = lookupCatalogEntryForGenerateSpec(apiSpec.Name, catalogSpecLookupRefs(opts.specFiles, opts.specURL))
 		enrichSpecFromCatalogEntry(apiSpec, catalogEntry)
+		applyResearchAuthMetadata(apiSpec, opts.researchDir)
 	}
 	gen := generator.New(apiSpec, absOut)
 	if catalogEntry != nil {
@@ -2114,6 +2115,105 @@ func translateNarrative(n *pipeline.ReadmeNarrative) *generator.ReadmeNarrative 
 		})
 	}
 	return out
+}
+
+func applyResearchAuthMetadata(apiSpec *spec.APISpec, researchDir string) {
+	if apiSpec == nil || strings.TrimSpace(researchDir) == "" {
+		return
+	}
+	research, err := pipeline.LoadResearch(researchDir)
+	if err != nil {
+		return
+	}
+	envVar := research.CanonicalAuthEnvVar()
+	if !isResearchCanonicalEnvVar(envVar) {
+		return
+	}
+	applyCanonicalAuthEnvVar(&apiSpec.Auth, envVar)
+}
+
+func isResearchCanonicalEnvVar(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if i == 0 {
+			if c < 'A' || c > 'Z' {
+				return false
+			}
+			continue
+		}
+		if (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func applyCanonicalAuthEnvVar(auth *spec.AuthConfig, canonical string) {
+	if auth == nil || canonical == "" || auth.Type == "" || auth.Type == "none" {
+		return
+	}
+	if strings.Contains(strings.ToLower(auth.Format), "basic ") {
+		return
+	}
+	if len(auth.EnvVars) > 0 && strings.TrimSpace(auth.EnvVars[0]) == canonical {
+		return
+	}
+	oldEnvVars := append([]string(nil), auth.EnvVars...)
+	merged := mergeAuthEnvVarNames([]string{canonical}, auth.EnvVars)
+	if len(merged) == 0 {
+		return
+	}
+	normalizeSingleTokenAuthFormatForAliases(auth, oldEnvVars)
+	auth.EnvVars = merged
+	if len(merged) == 1 {
+		auth.EnvVarSpecs = []spec.AuthEnvVar{{
+			Name:      merged[0],
+			Kind:      spec.AuthEnvVarKindPerCall,
+			Required:  true,
+			Sensitive: true,
+			Inferred:  true,
+		}}
+		return
+	}
+	auth.EnvVarSpecs = spec.NewORCaseEnvVarSpecs(merged)
+}
+
+func normalizeSingleTokenAuthFormatForAliases(auth *spec.AuthConfig, oldEnvVars []string) {
+	if auth == nil || auth.Format == "" || len(oldEnvVars) != 1 {
+		return
+	}
+	oldName := strings.TrimSpace(oldEnvVars[0])
+	if oldName == "" {
+		return
+	}
+	oldPlaceholder := naming.EnvVarPlaceholder(oldName)
+	if oldPlaceholder != "" {
+		auth.Format = strings.ReplaceAll(auth.Format, "{"+oldPlaceholder+"}", "{token}")
+	}
+	auth.Format = strings.ReplaceAll(auth.Format, "{"+oldName+"}", "{token}")
+}
+
+func mergeAuthEnvVarNames(canonical, existing []string) []string {
+	seen := make(map[string]struct{}, len(canonical)+len(existing))
+	merged := make([]string, 0, len(canonical)+len(existing))
+	for _, source := range [][]string{canonical, existing} {
+		for _, name := range source {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			merged = append(merged, name)
+		}
+	}
+	return merged
 }
 
 // enrichSpecFromCatalog looks up the API in the embedded catalog and copies

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2159,6 +2159,9 @@ func applyCanonicalAuthEnvVar(auth *spec.AuthConfig, canonical string) {
 	if strings.Contains(strings.ToLower(auth.Format), "basic ") {
 		return
 	}
+	if len(auth.EnvVars) > 1 {
+		return
+	}
 	if len(auth.EnvVars) > 0 && strings.TrimSpace(auth.EnvVars[0]) == canonical {
 		return
 	}

--- a/internal/pipeline/research.go
+++ b/internal/pipeline/research.go
@@ -35,6 +35,10 @@ type ResearchResult struct {
 	// NOT omitempty: an empty [] means "dogfood ran, nothing survived" while a
 	// missing field means "dogfood hasn't validated yet."
 	NovelFeaturesBuilt *[]NovelFeature `json:"novel_features_built,omitempty"`
+	// Auth holds auth-specific research signals discovered by the skill flow.
+	// These signals complement, but do not replace, the parsed OpenAPI/internal
+	// YAML auth model.
+	Auth *ResearchAuth `json:"auth,omitempty"`
 	// Narrative holds LLM-authored prose for README and SKILL.md rendering.
 	// Optional: templates fall back to generic content when absent. Populated
 	// during the absorb phase alongside NovelFeatures.
@@ -92,6 +96,19 @@ func (f *flexibleResearchStrings) UnmarshalJSON(data []byte) error {
 
 	*f = out
 	return nil
+}
+
+// ResearchAuth holds auth-specific research signals that are not part of the
+// source spec but should influence fresh generation.
+type ResearchAuth struct {
+	CanonicalEnvVar string `json:"canonical_env_var,omitempty"`
+}
+
+func (r *ResearchResult) CanonicalAuthEnvVar() string {
+	if r == nil || r.Auth == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.Auth.CanonicalEnvVar)
 }
 
 func renderResearchString(name, reason string) string {

--- a/internal/pipeline/research_test.go
+++ b/internal/pipeline/research_test.go
@@ -83,6 +83,9 @@ func TestWriteAndLoadResearch(t *testing.T) {
 		APIName:        "test-api",
 		NoveltyScore:   8,
 		Recommendation: "proceed",
+		Auth: &ResearchAuth{
+			CanonicalEnvVar: "TEST_API_TOKEN",
+		},
 		Alternatives: []Alternative{
 			{Name: "alt-1", URL: "https://example.com/alt-1"},
 		},
@@ -98,6 +101,8 @@ func TestWriteAndLoadResearch(t *testing.T) {
 	assert.Equal(t, "test-api", loaded.APIName)
 	assert.Equal(t, 8, loaded.NoveltyScore)
 	assert.Equal(t, "proceed", loaded.Recommendation)
+	require.NotNil(t, loaded.Auth)
+	assert.Equal(t, "TEST_API_TOKEN", loaded.CanonicalAuthEnvVar())
 	assert.Len(t, loaded.Alternatives, 1)
 	assert.Equal(t, "alt-1", loaded.Alternatives[0].Name)
 }

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1585,6 +1585,9 @@ cat > "$API_RUN_DIR/research.json" <<REOF
     {"name": "<tool1>", "url": "<github-url>", "language": "<Go|JavaScript|Python|etc>", "stars": <N>, "command_count": <N>},
     ...
   ],
+  "auth": {
+    "canonical_env_var": "<CANONICAL_ENV_VAR, omit when unknown>"
+  },
   "novel_features": [
     {
       "name": "<Feature Name>",
@@ -1637,6 +1640,9 @@ For each tool, fill in what you know from the research. Stars and command_count 
 7. `group` clusters related features under a theme name. Pick 2–5 themes total (e.g. "Local state that compounds", "Agent-native plumbing", "Reachability mitigation"). Use the same `group` string verbatim across features that belong together — exact matches drive README grouping. Leave `group` empty if the CLI has too few novel features to warrant clustering.
 8. If no transcendence features scored >= 5/10, omit the `novel_features` field entirely.
 9. Do not add a feature to `novel_features` merely to expose it through MCP. Any user-facing Cobra command becomes an MCP tool automatically unless it sets `cmd.Annotations["mcp:hidden"] = "true"`.
+
+**Auth research rule**:
+1. `auth.canonical_env_var` is the single-token credential env var discovered from vendor docs, MCP/source analysis, or dominant SDK/CLI convention (for example `APIFY_TOKEN`, `GITHUB_TOKEN`, `STRIPE_SECRET_KEY`). Omit it when no canonical name is known, when auth is HTTP Basic or another credential pair, or when the auth flow needs richer metadata. Fresh generation reads this env var first and keeps the parser-derived name as a fallback automatically.
 
 **Narrative rules** (the `narrative` object drives README headline, Quick Start, Auth, Troubleshooting, and the entire SKILL.md):
 1. `display_name` is the canonical prose name, discovered during research, with exact brand casing and spacing. This is agentic/research-owned, not slug-inferred by Go code. Good: "Product Hunt", "GitHub", "YouTube", "Cal.com". Bad: "Producthunt", "Github", "Youtube", "Cal Com". Use the slug only for binary names, directories, module paths, config paths, and env-var prefixes.
@@ -2047,8 +2053,11 @@ auth:
     - <API_NAME>_TOKEN  # bearer_token → _TOKEN, api_key → _API_KEY
 ```
 
-When research or source metadata names a real env var, use only that canonical
-name in `env_vars`; do not add guessed slug-based aliases.
+When research or source metadata names a real single-token env var, record it
+in `research.json` as `auth.canonical_env_var`; fresh generation reads that
+name first and keeps the parser-derived env var as a trailing fallback. When
+you are editing an internal YAML spec directly, use only the canonical name in
+`env_vars`; do not add guessed slug-based aliases.
 
 For OpenAPI specs, choose the security scheme by wire format, not by whether
 the token feels like an API key. Use `type: http` with `scheme: bearer` when
@@ -2089,11 +2098,15 @@ Walk through:
 2. Check Phase 1 research, Phase 1.5a MCP source code analysis, and community
    wrapper READMEs for a canonical env var name documented by the vendor or
    in widespread use.
-3. If they differ, add `x-auth-env-vars` on the selected security scheme
-   (OpenAPI) or set `auth.env_vars` to the canonical name (internal YAML).
-   Use only the canonical name; do not retain the slug-derived form as an
-   alias. For HTTP Basic, supply the full two-entry canonical pair
-   (username position first, password position second). For OAuth2
+3. If they differ and the canonical name is a single-token credential, record
+   it in `research.json` as `auth.canonical_env_var`. The generator will read
+   the canonical name first and retain the slug-derived form as a fallback.
+   If you are editing the source spec directly instead, add `x-auth-env-vars`
+   on the selected security scheme (OpenAPI) or set `auth.env_vars` to the
+   canonical name (internal YAML). Use only the canonical name in the spec
+   edit; do not retain guessed aliases there. For HTTP Basic, supply the full
+   two-entry canonical pair (username position first, password position
+   second) via `x-auth-env-vars`. For OAuth2
    `client_credentials`, the parser silently re-applies the
    `CLIENT_ID`/`CLIENT_SECRET` default when `x-auth-env-vars` has fewer
    than two entries (see `applyAuthEnvVarDefaults` in


### PR DESCRIPTION
## Summary

Research-discovered canonical auth env vars can now become the first credential source for fresh generated CLIs, while the parser-derived env var remains as a fallback for existing setups. A researched Apify CLI can read `APIFY_TOKEN` first without breaking users who already exported `APIFY_HTTP_BEARER`.

The new `research.json` field is limited to single-token credentials, skips invalid placeholder values and Basic auth pairs, and normalizes formatted auth placeholders so canonical aliases still render valid headers such as `Bot <token>`.

Closes #1435

## Tests

- `go test ./internal/cli -run 'Test(RunGenerateProject(CanonicalAuthEnvVarPreservesFormattedAuthHeader|AppliesResearchCanonicalAuthEnvVar)|ApplyResearchAuthMetadataRejectsUnsafeCanonicalEnvVars)'`
- `go test ./internal/cli ./internal/pipeline`
- `go test ./...`
- `scripts/golden.sh verify`
