### PR TITLE
fix(cli): synthesize Google Discovery API key auth

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -594,6 +594,7 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 		baseURLIsPlaceholder = true
 	}
 
+	injectGoogleDiscoveryAPIKeyAuth(doc, name)
 	auth := mapAuthWithDescriptionInference(doc, name, !metadata.explicitEmptySecuritySchemes, authPreference)
 	if auth.Type != "none" && allOperationsAllowAnonymous(doc) {
 		auth = spec.AuthConfig{Type: "none"}
@@ -879,6 +880,159 @@ func parseStringExtensionValue(extensions map[string]any, key string) (string, e
 
 func mapAuth(doc *openapi3.T, name string) spec.AuthConfig {
 	return mapAuthWithDescriptionInference(doc, name, true, "")
+}
+
+func injectGoogleDiscoveryAPIKeyAuth(doc *openapi3.T, name string) {
+	if doc == nil || !shouldInjectGoogleAPIKeyAuth(doc) {
+		return
+	}
+	if doc.Components == nil {
+		doc.Components = &openapi3.Components{}
+	}
+	if doc.Components.SecuritySchemes == nil {
+		doc.Components.SecuritySchemes = openapi3.SecuritySchemes{}
+	}
+
+	schemeName := googleAPIKeySecuritySchemeName(doc)
+	if schemeName == "" {
+		schemeName = uniqueSecuritySchemeName(doc.Components.SecuritySchemes, "ApiKey")
+		doc.Components.SecuritySchemes[schemeName] = &openapi3.SecuritySchemeRef{
+			Value: &openapi3.SecurityScheme{
+				Type: "apiKey",
+				In:   "query",
+				Name: "key",
+				Extensions: map[string]any{
+					extensionAuthVars: []any{
+						map[string]any{
+							"name":      naming.EnvPrefix(name) + "_API_KEY",
+							"kind":      string(spec.AuthEnvVarKindPerCall),
+							"required":  true,
+							"sensitive": true,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	requirement := openapi3.SecurityRequirement{schemeName: []string{}}
+	if doc.Security == nil {
+		if !hasNonAPIKeySecurityScheme(doc) {
+			doc.Security = openapi3.SecurityRequirements{requirement}
+		}
+	} else if !securityRequirementsReferenceScheme(doc.Security, schemeName) && !securityRequirementsAllowAnonymous(doc.Security) {
+		doc.Security = append(doc.Security, requirement)
+	}
+
+	if doc.Paths == nil {
+		return
+	}
+	for _, pathItem := range doc.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			if op == nil || op.Security == nil {
+				continue
+			}
+			if securityRequirementsAllowAnonymous(*op.Security) || securityRequirementsReferenceScheme(*op.Security, schemeName) {
+				continue
+			}
+			*op.Security = append(*op.Security, requirement)
+		}
+	}
+}
+
+func shouldInjectGoogleAPIKeyAuth(doc *openapi3.T) bool {
+	if isGoogleDiscoverySpec(doc) {
+		return true
+	}
+	return hasGoogleAPIsServer(doc) && hasNonAnonymousSecurityRequirements(doc)
+}
+
+func googleAPIKeySecuritySchemeName(doc *openapi3.T) string {
+	if doc == nil || doc.Components == nil {
+		return ""
+	}
+	for _, name := range allSecuritySchemeNames(doc) {
+		scheme := securitySchemeValue(doc.Components.SecuritySchemes[name])
+		if scheme != nil &&
+			strings.EqualFold(scheme.Type, "apiKey") &&
+			strings.EqualFold(strings.TrimSpace(scheme.In), "query") &&
+			strings.EqualFold(strings.TrimSpace(scheme.Name), "key") {
+			return name
+		}
+	}
+	return ""
+}
+
+func uniqueSecuritySchemeName(schemes openapi3.SecuritySchemes, base string) string {
+	if _, ok := schemes[base]; !ok {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s%d", base, i)
+		if _, ok := schemes[candidate]; !ok {
+			return candidate
+		}
+	}
+}
+
+func securityRequirementsReferenceScheme(requirements openapi3.SecurityRequirements, schemeName string) bool {
+	for _, requirement := range requirements {
+		if _, ok := requirement[schemeName]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonAPIKeySecurityScheme(doc *openapi3.T) bool {
+	if doc == nil || doc.Components == nil {
+		return false
+	}
+	for _, name := range allSecuritySchemeNames(doc) {
+		scheme := securitySchemeValue(doc.Components.SecuritySchemes[name])
+		if scheme != nil && !strings.EqualFold(scheme.Type, "apiKey") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonAnonymousSecurityRequirements(doc *openapi3.T) bool {
+	if doc == nil {
+		return false
+	}
+	if nonAnonymousSecurityRequirements(doc.Security) {
+		return true
+	}
+	if doc.Paths == nil {
+		return false
+	}
+	for _, pathItem := range doc.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			if op != nil && op.Security != nil && nonAnonymousSecurityRequirements(*op.Security) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nonAnonymousSecurityRequirements(requirements openapi3.SecurityRequirements) bool {
+	if len(requirements) == 0 {
+		return false
+	}
+	for _, requirement := range requirements {
+		if len(requirement) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func mapAuthWithDescriptionInference(doc *openapi3.T, name string, allowDescriptionInference bool, authPreference string) spec.AuthConfig {
@@ -6057,9 +6211,86 @@ func isGoogleDiscoverySpec(doc *openapi3.T) bool {
 		if format, ok := entry["format"].(string); ok && strings.EqualFold(strings.TrimSpace(format), "google") {
 			return true
 		}
-		if originURL, ok := entry["url"].(string); ok && strings.Contains(originURL, "googleapis.com/$discovery") {
+		if originURL, ok := entry["url"].(string); ok && isGoogleDiscoveryOriginURL(originURL) {
 			return true
 		}
+	}
+	return false
+}
+
+func isGoogleDiscoveryOriginURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	if host != "googleapis.com" && !strings.HasSuffix(host, ".googleapis.com") {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimLeft(parsed.EscapedPath(), "/"), "$discovery/")
+}
+
+func hasGoogleAPIsServer(doc *openapi3.T) bool {
+	if doc == nil {
+		return false
+	}
+	for _, server := range doc.Servers {
+		if server != nil && isGoogleAPIsServerURL(server.URL) {
+			return true
+		}
+	}
+	if doc.Paths == nil {
+		return false
+	}
+	for _, pathItem := range doc.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		for _, server := range pathItem.Servers {
+			if server != nil && isGoogleAPIsServerURL(server.URL) {
+				return true
+			}
+		}
+		for _, op := range pathItem.Operations() {
+			if op == nil || op.Servers == nil {
+				continue
+			}
+			for _, server := range *op.Servers {
+				if server != nil && isGoogleAPIsServerURL(server.URL) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isGoogleAPIsServerURL(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	parsed, err := url.Parse(raw)
+	if err == nil {
+		if host := strings.ToLower(strings.TrimSpace(parsed.Hostname())); host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com") {
+			return true
+		}
+		if parsed.Host != "" {
+			host := strings.ToLower(strings.Trim(parsed.Host, "[]"))
+			if host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com") {
+				return true
+			}
+		}
+	}
+	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
+		host := raw
+		if afterScheme, ok := strings.CutPrefix(host, "https://"); ok {
+			host = afterScheme
+		} else if afterScheme, ok := strings.CutPrefix(host, "http://"); ok {
+			host = afterScheme
+		}
+		host = strings.ToLower(strings.TrimSpace(strings.SplitN(host, "/", 2)[0]))
+		return host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com")
 	}
 	return false
 }

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -944,10 +944,10 @@ func injectGoogleDiscoveryAPIKeyAuth(doc *openapi3.T, name string) {
 }
 
 func shouldInjectGoogleAPIKeyAuth(doc *openapi3.T) bool {
-	if isGoogleDiscoverySpec(doc) {
-		return true
+	if !hasNonAnonymousSecurityRequirements(doc) {
+		return false
 	}
-	return hasGoogleAPIsServer(doc) && hasNonAnonymousSecurityRequirements(doc)
+	return isGoogleDiscoverySpec(doc) || hasGoogleAPIsServer(doc)
 }
 
 func googleAPIKeySecuritySchemeName(doc *openapi3.T) string {
@@ -6275,22 +6275,6 @@ func isGoogleAPIsServerURL(raw string) bool {
 		if host := strings.ToLower(strings.TrimSpace(parsed.Hostname())); host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com") {
 			return true
 		}
-		if parsed.Host != "" {
-			host := strings.ToLower(strings.Trim(parsed.Host, "[]"))
-			if host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com") {
-				return true
-			}
-		}
-	}
-	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
-		host := raw
-		if afterScheme, ok := strings.CutPrefix(host, "https://"); ok {
-			host = afterScheme
-		} else if afterScheme, ok := strings.CutPrefix(host, "http://"); ok {
-			host = afterScheme
-		}
-		host = strings.ToLower(strings.TrimSpace(strings.SplitN(host, "/", 2)[0]))
-		return host == "googleapis.com" || strings.HasSuffix(host, ".googleapis.com")
 	}
 	return false
 }

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3825,6 +3825,333 @@ paths:
 	}
 }
 
+func TestParseGoogleDiscoveryOriginInjectsAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: YouTube Data API
+  version: "v3"
+  x-origin:
+    - format: google
+      url: https://youtube.googleapis.com/$discovery/rest?version=v3
+servers:
+  - url: https://youtube.googleapis.com
+components:
+  securitySchemes: {}
+paths:
+  /youtube/v3/search:
+    get:
+      operationId: youtube.search.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/youtube.readonly
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "ApiKey", parsed.Auth.Scheme)
+	assert.Equal(t, "query", parsed.Auth.In)
+	assert.Equal(t, "key", parsed.Auth.Header)
+	assert.Equal(t, []string{"YOUTUBE_DATA_API_KEY"}, parsed.Auth.EnvVars)
+	require.Len(t, parsed.Auth.EnvVarSpecs, 1)
+	assert.Equal(t, spec.AuthEnvVarKindPerCall, parsed.Auth.EnvVarSpecs[0].Kind)
+	assert.True(t, parsed.Auth.EnvVarSpecs[0].Required)
+	assert.True(t, parsed.Auth.EnvVarSpecs[0].Sensitive)
+}
+
+func TestParseGoogleAPIsServerInjectsAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Cloud Run Admin API
+  version: "v2"
+servers:
+  - url: https://run.googleapis.com
+components:
+  securitySchemes: {}
+paths:
+  /v2/projects/{project}/locations:
+    get:
+      operationId: run.projects.locations.list
+      security:
+        - Oauth2:
+            - https://www.googleapis.com/auth/cloud-platform
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "ApiKey", parsed.Auth.Scheme)
+	assert.Equal(t, []string{"CLOUD_RUN_ADMIN_API_KEY"}, parsed.Auth.EnvVars)
+}
+
+func TestParseGoogleDiscoveryDoesNotOverrideExistingAPIKeyScheme(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Google Example API
+  version: "v1"
+  x-origin:
+    - format: google
+servers:
+  - url: https://example.googleapis.com
+components:
+  securitySchemes:
+    ExistingKey:
+      type: apiKey
+      in: query
+      name: key
+paths:
+  /items:
+    get:
+      security:
+        - OAuth2:
+            - https://www.googleapis.com/auth/example
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "ExistingKey", parsed.Auth.Scheme)
+	assert.Equal(t, "key", parsed.Auth.Header)
+}
+
+func TestParseGoogleDiscoveryIgnoresIncompatibleExistingAPIKeyScheme(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Google Example API
+  version: "v1"
+  x-origin:
+    - format: google
+servers:
+  - url: https://example.googleapis.com
+components:
+  securitySchemes:
+    HeaderKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+paths:
+  /items:
+    get:
+      security:
+        - OAuth2:
+            - https://www.googleapis.com/auth/example
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "ApiKey", parsed.Auth.Scheme)
+	assert.Equal(t, "query", parsed.Auth.In)
+	assert.Equal(t, "key", parsed.Auth.Header)
+}
+
+func TestParseGoogleDiscoveryKeepsOAuthPrimaryWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Gmail API
+  version: "v1"
+  x-origin:
+    - format: google
+servers:
+  - url: https://gmail.googleapis.com
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/gmail.readonly: Read mail
+paths:
+  /gmail/v1/users/{userId}/messages:
+    get:
+      security:
+        - OAuth2:
+            - https://www.googleapis.com/auth/gmail.readonly
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, "OAuth2", parsed.Auth.Scheme)
+}
+
+func TestParseGoogleDiscoveryDoesNotMakeSyntheticAPIKeyGlobalDefaultWhenOAuthExists(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Gmail API
+  version: "v1"
+  x-origin:
+    - format: google
+servers:
+  - url: https://gmail.googleapis.com
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://accounts.google.com/o/oauth2/v2/auth
+          tokenUrl: https://oauth2.googleapis.com/token
+          scopes:
+            https://www.googleapis.com/auth/gmail.readonly: Read mail
+paths:
+  /gmail/v1/users/{userId}/profile:
+    get:
+      responses:
+        "200":
+          description: OK
+  /gmail/v1/users/{userId}/messages:
+    get:
+      security:
+        - OAuth2:
+            - https://www.googleapis.com/auth/gmail.readonly
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, "OAuth2", parsed.Auth.Scheme)
+}
+
+func TestParseGoogleAPIsServerWithoutSecurityDoesNotInjectAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Public Google API
+  version: "v1"
+servers:
+  - url: https://public.googleapis.com
+components:
+  securitySchemes: {}
+paths:
+  /public:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", parsed.Auth.Type)
+	assert.Empty(t, parsed.Auth.Scheme)
+}
+
+func TestParseGoogleAPIsOperationServerInjectsAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Books API
+  version: "v1"
+components:
+  securitySchemes: {}
+paths:
+  /books/v1/volumes:
+    get:
+      servers:
+        - url: https://books.googleapis.com
+      security:
+        - OAuth2:
+            - https://www.googleapis.com/auth/books
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "ApiKey", parsed.Auth.Scheme)
+	assert.Equal(t, []string{"BOOKS_API_KEY"}, parsed.Auth.EnvVars)
+}
+
+func TestParseNonGoogleOriginURLContainingGoogleDiscoveryPathDoesNotInjectAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Proxy API
+  version: "1.0.0"
+  x-origin:
+    - url: https://example.com/proxy/googleapis.com/$discovery/rest?version=v1
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes: {}
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", parsed.Auth.Type)
+	assert.Empty(t, parsed.Auth.Scheme)
+}
+
+func TestParseNonGoogleSpecDoesNotInjectAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Linear API
+  version: "1.0.0"
+servers:
+  - url: https://api.linear.app
+components:
+  securitySchemes: {}
+paths:
+  /viewer:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", parsed.Auth.Type)
+	assert.Empty(t, parsed.Auth.Scheme)
+}
+
 func TestSpeakeasyAuthExampleOverridesDerivedEnvVar(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -4071,6 +4071,34 @@ paths:
 	assert.Empty(t, parsed.Auth.Scheme)
 }
 
+func TestParseGoogleDiscoveryWithoutSecurityDoesNotInjectAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Public Google Discovery API
+  version: "v1"
+  x-origin:
+    - format: google
+      url: https://public.googleapis.com/$discovery/rest?version=v1
+servers:
+  - url: https://public.googleapis.com
+components:
+  securitySchemes: {}
+paths:
+  /public:
+    get:
+      responses:
+        "200":
+          description: OK
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", parsed.Auth.Type)
+	assert.Empty(t, parsed.Auth.Scheme)
+}
+
 func TestParseGoogleAPIsOperationServerInjectsAPIKeyAuth(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Google Discovery-derived specs that lose their OAuth schemes now still generate CLIs with a usable `?key=` API-key path. The parser synthesizes a query `ApiKey` scheme for Google Discovery metadata and Google API server specs that still carry security requirements, while leaving non-Google specs and public Google-hosted specs alone.

The synthesis reuses an existing compatible `in: query, name: key` scheme, avoids treating unrelated header/cookie API keys as Google query keys, and keeps OAuth primary when valid OAuth schemes are still present.

Closes #1454

## Verification
- `go test ./internal/openapi -run 'TestParse(Google|NonGoogle)'`
- `go test ./internal/openapi`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
