### PR TITLE
docs(cli): add local plugin dev recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ catalog/specs/*.graphql
 .gotmp/
 .omx/
 .claude/worktrees/
+.claude/local/
 /refactor/artifacts/
 /tests/artifacts/perf/
 /printing-press

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thanks for helping improve the Printing Press. This repository contains the gene
 
 - Check for an existing issue or PR that already covers the same work.
 - Read [AGENTS.md](AGENTS.md) for the repository conventions, especially the machine vs printed CLI boundary, golden-output rules, commit style, and verification expectations.
+- If you are editing the plugin from a clone, see [docs/PLUGIN-DEV.md](docs/PLUGIN-DEV.md) for the persistent local Claude Code setup.
 - For larger behavior changes, open or comment on an issue first so the scope is clear before implementation.
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ claude --plugin-dir .          # load this repo's skills directly
 claude --plugin-dir . -w       # ...in a new git worktree (parallel runs)
 ```
 
+For a persistent local setup that survives restarts and also loads in background sessions, see [Local Plugin Development](docs/PLUGIN-DEV.md).
+
 </details>
 
 ### 2. Start a printing session
@@ -496,7 +498,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 
 ## Troubleshooting
 
-**`/printing-press` slash command doesn't appear in Claude Code.** Restart your Claude Code session after installing the skills. Run `npx -y skills@latest list -g -a claude-code` to verify the install. If you're developing from a clone, confirm `claude --plugin-dir .` was run from the cloned repo root.
+**`/printing-press` slash command doesn't appear in Claude Code.** Restart your Claude Code session after installing the skills. Run `npx -y skills@latest list -g -a claude-code` to verify the install. If you're developing from a clone, confirm `claude --plugin-dir .` was run from the cloned repo root or use the persistent local setup in [Local Plugin Development](docs/PLUGIN-DEV.md).
 
 **`cli-printing-press: command not found` after a successful `go install`.** `$GOPATH/bin` (default `~/go/bin`) isn't on your `PATH`. Add it to your shell profile.
 
@@ -556,7 +558,7 @@ lefthook install --reset-hooks-path
 
 Use `--reset-hooks-path` so stale local `core.hooksPath` settings do not block hook sync. Avoid `lefthook install --force` unless intentionally overriding a custom hooks path.
 
-If you use the clone-based developer path above, `claude --plugin-dir .` loads `/printing-press` from your working copy, so local skill edits take effect on the next session start. See [AGENTS.md](AGENTS.md) for full conventions, glossary, and release flow.
+If you use the clone-based developer path above, `claude --plugin-dir .` loads `/printing-press` from your working copy, so local skill edits take effect on the next session start. For a restart-safe local plugin setup, see [Local Plugin Development](docs/PLUGIN-DEV.md). See [AGENTS.md](AGENTS.md) for full conventions, glossary, and release flow.
 
 </details>
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -26,3 +26,4 @@ The extracted developer docs are:
 - `docs/ARTIFACTS.md` — local library, manuscripts, and public-library flow
 - `docs/CURSOR.md` — using printed CLIs and skills in Cursor
 - `docs/DOCS.md` — this doc-authoring guidance
+- `docs/PLUGIN-DEV.md` — persistent local plugin development setup

--- a/docs/PLUGIN-DEV.md
+++ b/docs/PLUGIN-DEV.md
@@ -1,0 +1,58 @@
+# Local Plugin Development
+
+Use this when you are developing the Printing Press plugin from a clone and want Claude Code to load the working tree across restarts and background sessions.
+
+The quick path in the README uses `claude --plugin-dir .`. That is useful for one-off local testing, but it is a process flag. It does not persist to the next `claude` invocation, and background sessions do not inherit it from the parent session.
+
+For persistent local development, register a gitignored local marketplace in `.claude/settings.local.json`.
+
+## Persistent Working-Tree Plugin
+
+Create the local marketplace directory:
+
+```bash
+mkdir -p .claude/local/dev-marketplace/.claude-plugin
+```
+
+Create `.claude/local/dev-marketplace/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "cli-printing-press-local",
+  "owner": { "name": "local-dev" },
+  "plugins": [
+    {
+      "name": "cli-printing-press",
+      "source": "./../../.."
+    }
+  ]
+}
+```
+
+The `./../../..` source points from `.claude/local/dev-marketplace/.claude-plugin/` back to the repository root.
+
+Then create or update `.claude/settings.local.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "cli-printing-press-local": {
+      "source": {
+        "source": "directory",
+        "path": ".claude/local/dev-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "cli-printing-press@cli-printing-press-local": true
+  }
+}
+```
+
+Restart Claude Code. The plugin's skills, including `/printing-press` and `/printing-press-polish`, load from this working tree without passing `--plugin-dir` each time.
+
+## Why This Is Local-Only
+
+Both `.claude/settings.local.json` and `.claude/local/` are gitignored. Keep this setup out of tracked files because it points Claude Code at your personal checkout and can conflict with another contributor's installed plugin.
+
+Do not change `.claude-plugin/marketplace.json` for local development. That file describes the published plugin source.

--- a/docs/PLUGIN-DEV.md
+++ b/docs/PLUGIN-DEV.md
@@ -29,7 +29,7 @@ Create `.claude/local/dev-marketplace/.claude-plugin/marketplace.json`:
 }
 ```
 
-The `./../../..` source points from `.claude/local/dev-marketplace/.claude-plugin/` back to the repository root.
+The `./../../..` source points from `.claude/local/dev-marketplace/` back to the repository root.
 
 Then create or update `.claude/settings.local.json`:
 


### PR DESCRIPTION
## Summary

Contributors developing the Printing Press plugin from a clone now have a persistent local Claude Code setup that survives restarts and background sessions without relying on `claude --plugin-dir .` each time.

This adds a gitignored `.claude/local/` workspace for local marketplace files, documents the `.claude/settings.local.json` recipe, and links the guide from the clone-development and contributing paths.

## Verification

- `git diff --check`
- `jq -e .` against both JSON snippets in `docs/PLUGIN-DEV.md`

Closes #1636
