### PR TITLE
feat(catalog): add region language metadata

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -123,3 +123,20 @@ auth_env_vars:
   - STRIPE_SECRET_KEY  # canonical: stripe-cli, stripe-go, stripe-node, stripe-python
   - STRIPE_API_KEY     # common alias
 ```
+
+## Region and language metadata
+
+Catalog entries may declare `regions:` and `api_language:` when an API is geographically scoped, carries region-specific domain vocabulary, or is explicitly global.
+
+Rules:
+- `regions` is optional. When present, each entry must be an uppercase ISO 3166-1 alpha-2 country code such as `NL` or `IN`, `EU` for pan-European scope, or `*` for explicitly global APIs. Empty entries, duplicates, lowercase codes, and whitespace-padded values are rejected.
+- `api_language` is optional. When present, it must be a BCP 47-shaped language tag such as `nl`, `en`, or `en-US`.
+- The generator copies both fields into `APISpec`, `.printing-press.json`, SKILL.md frontmatter, local-library JSON output, and downstream registry metadata derived from the manifest.
+- These fields describe upstream API and data scope. They do not change generated command names or force CLI output translation.
+
+Example:
+
+```yaml
+regions: [NL]
+api_language: nl
+```

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -20,6 +20,9 @@ var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 // Catalog-declared auth env vars feed directly into generated config.go reads,
 // so the validator rejects shapes the generator could not emit safely.
 var authEnvVarPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// regionPattern accepts any two uppercase letters; the catalog does not
+// maintain a full ISO 3166-1 country-code allowlist.
 var regionPattern = regexp.MustCompile(`^[A-Z]{2}$`)
 var apiLanguagePattern = regexp.MustCompile(`^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*$`)
 
@@ -163,7 +166,7 @@ type Entry struct {
 	// entry so operators on existing setups don't need a migration.
 	AuthEnvVars []string `yaml:"auth_env_vars,omitempty"`
 	// Regions lists geographic availability/scope tokens for this API.
-	// Use ISO 3166-1 alpha-2 country codes (NL, IN), EU for pan-European
+	// Use ISO-style two-letter region tokens (NL, IN), EU for pan-European
 	// services, or * for APIs that are explicitly global.
 	Regions []string `yaml:"regions,omitempty"`
 	// APILanguage is the API's native/domain language as a BCP 47 tag
@@ -380,7 +383,7 @@ func validateRegions(regions []string) error {
 			return fmt.Errorf("regions[%d] %q must not have leading or trailing whitespace", i, region)
 		}
 		if region != "*" && !regionPattern.MatchString(region) {
-			return fmt.Errorf("regions[%d] %q must be an uppercase ISO 3166-1 alpha-2 code, EU, or *", i, region)
+			return fmt.Errorf("regions[%d] %q must be an uppercase two-letter region token, EU, or *", i, region)
 		}
 		if _, dup := seen[region]; dup {
 			return fmt.Errorf("regions[%d] %q is a duplicate", i, region)

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -20,6 +20,8 @@ var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 // Catalog-declared auth env vars feed directly into generated config.go reads,
 // so the validator rejects shapes the generator could not emit safely.
 var authEnvVarPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+var regionPattern = regexp.MustCompile(`^[A-Z]{2}$`)
+var apiLanguagePattern = regexp.MustCompile(`^[A-Za-z]{2,8}(?:-[A-Za-z0-9]{1,8})*$`)
 
 // Public categories first, alphabetized. "other" and "example" are explicitly
 // special (catch-all / test-only) and kept at the end.
@@ -160,6 +162,14 @@ type Entry struct {
 	// appends its name-derived fallback (e.g. STRIPE_BEARER_AUTH) as the last
 	// entry so operators on existing setups don't need a migration.
 	AuthEnvVars []string `yaml:"auth_env_vars,omitempty"`
+	// Regions lists geographic availability/scope tokens for this API.
+	// Use ISO 3166-1 alpha-2 country codes (NL, IN), EU for pan-European
+	// services, or * for APIs that are explicitly global.
+	Regions []string `yaml:"regions,omitempty"`
+	// APILanguage is the API's native/domain language as a BCP 47 tag
+	// (for example "nl" or "en-US"). It describes upstream terms and
+	// payload vocabulary, not the generated CLI command language.
+	APILanguage string `yaml:"api_language,omitempty"`
 	// ClientPattern describes the HTTP client pattern needed. Empty defaults to "rest".
 	// Values: rest, proxy-envelope, graphql.
 	ClientPattern string `yaml:"client_pattern,omitempty"`
@@ -349,7 +359,48 @@ func (e *Entry) Validate() error {
 	if err := validateAuthEnvVars(e.AuthEnvVars); err != nil {
 		return err
 	}
+	if err := validateRegions(e.Regions); err != nil {
+		return err
+	}
+	if err := validateAPILanguage(e.APILanguage); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func validateRegions(regions []string) error {
+	seen := make(map[string]struct{}, len(regions))
+	for i, region := range regions {
+		trimmed := strings.TrimSpace(region)
+		if trimmed == "" {
+			return fmt.Errorf("regions[%d] must not be empty", i)
+		}
+		if trimmed != region {
+			return fmt.Errorf("regions[%d] %q must not have leading or trailing whitespace", i, region)
+		}
+		if region != "*" && !regionPattern.MatchString(region) {
+			return fmt.Errorf("regions[%d] %q must be an uppercase ISO 3166-1 alpha-2 code, EU, or *", i, region)
+		}
+		if _, dup := seen[region]; dup {
+			return fmt.Errorf("regions[%d] %q is a duplicate", i, region)
+		}
+		seen[region] = struct{}{}
+	}
+	return nil
+}
+
+func validateAPILanguage(language string) error {
+	if language == "" {
+		return nil
+	}
+	trimmed := strings.TrimSpace(language)
+	if trimmed != language {
+		return fmt.Errorf("api_language %q must not have leading or trailing whitespace", language)
+	}
+	if !apiLanguagePattern.MatchString(language) {
+		return fmt.Errorf("api_language %q must be a BCP 47 language tag", language)
+	}
 	return nil
 }
 

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -24,6 +24,8 @@ verified_date: "2026-03-23"
 homepage: https://example.com
 owner: test-owner
 owner_name: Trevin Chow
+regions: [NL, EU]
+api_language: nl
 mcp:
   transport: [stdio, http]
   orchestration: code
@@ -47,6 +49,8 @@ notes: Example fixture.
 	assert.Equal(t, "https://example.com", entry.Homepage)
 	assert.Equal(t, "test-owner", entry.Owner)
 	assert.Equal(t, "Trevin Chow", entry.OwnerName)
+	assert.Equal(t, []string{"NL", "EU"}, entry.Regions)
+	assert.Equal(t, "nl", entry.APILanguage)
 	assert.Equal(t, []string{"stdio", "http"}, entry.MCP.Transport)
 	assert.Equal(t, "code", entry.MCP.Orchestration)
 	assert.Equal(t, "hidden", entry.MCP.EndpointTools)
@@ -204,6 +208,34 @@ func TestValidateEntry(t *testing.T) {
 				e.AuthKeyURL = "http://example.com/keys"
 			},
 			wantErr: `auth_key_url must start with "https://"`,
+		},
+		{
+			name: "regions empty entry",
+			mutate: func(e *Entry) {
+				e.Regions = []string{"NL", ""}
+			},
+			wantErr: "regions[1] must not be empty",
+		},
+		{
+			name: "regions lowercase rejected",
+			mutate: func(e *Entry) {
+				e.Regions = []string{"nl"}
+			},
+			wantErr: "must be an uppercase ISO 3166-1 alpha-2 code",
+		},
+		{
+			name: "regions duplicate rejected",
+			mutate: func(e *Entry) {
+				e.Regions = []string{"NL", "NL"}
+			},
+			wantErr: `regions[1] "NL" is a duplicate`,
+		},
+		{
+			name: "api_language invalid tag rejected",
+			mutate: func(e *Entry) {
+				e.APILanguage = "not a tag"
+			},
+			wantErr: "must be a BCP 47 language tag",
 		},
 		{
 			name: "auth_env_vars empty entry",

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -221,7 +221,7 @@ func TestValidateEntry(t *testing.T) {
 			mutate: func(e *Entry) {
 				e.Regions = []string{"nl"}
 			},
-			wantErr: "must be an uppercase ISO 3166-1 alpha-2 code",
+			wantErr: "must be an uppercase two-letter region token",
 		},
 		{
 			name: "regions duplicate rejected",

--- a/internal/catalogmeta/catalogmeta.go
+++ b/internal/catalogmeta/catalogmeta.go
@@ -117,4 +117,10 @@ func ApplyRuntimeMetadata(apiSpec *spec.APISpec, entry *catalog.Entry) {
 	if entry.SpecSource != "" {
 		apiSpec.SpecSource = entry.SpecSource
 	}
+	if len(entry.Regions) > 0 {
+		apiSpec.Regions = append([]string(nil), entry.Regions...)
+	}
+	if entry.APILanguage != "" {
+		apiSpec.APILanguage = entry.APILanguage
+	}
 }

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/catalog"
 	"github.com/spf13/cobra"
 )
+
+var catalogRegionFilterPattern = regexp.MustCompile(`^[A-Z]{2}$`)
 
 func newCatalogCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -44,6 +47,9 @@ func newCatalogListCmd() *cobra.Command {
   cli-printing-press catalog list --json
   cli-printing-press catalog list --region NL`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCatalogRegionFilter(region); err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
+			}
 			entries, err := catalog.ParseFS(catalogfs.FS)
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("reading catalog: %w", err)}
@@ -203,6 +209,14 @@ func catalogEntryMatchesRegion(entry catalog.Entry, region string) bool {
 		}
 	}
 	return false
+}
+
+func validateCatalogRegionFilter(region string) error {
+	region = strings.ToUpper(strings.TrimSpace(region))
+	if region == "" || region == "*" || catalogRegionFilterPattern.MatchString(region) {
+		return nil
+	}
+	return fmt.Errorf("--region must be a two-letter region token such as NL, EU, or *")
 }
 
 func newCatalogSearchCmd() *cobra.Command {

--- a/internal/cli/catalog.go
+++ b/internal/cli/catalog.go
@@ -35,17 +35,20 @@ func newCatalogCmd() *cobra.Command {
 
 func newCatalogListCmd() *cobra.Command {
 	var asJSON bool
+	var region string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all catalog entries",
 		Example: `  cli-printing-press catalog list
-  cli-printing-press catalog list --json`,
+  cli-printing-press catalog list --json
+  cli-printing-press catalog list --region NL`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entries, err := catalog.ParseFS(catalogfs.FS)
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("reading catalog: %w", err)}
 			}
+			entries = filterCatalogEntriesByRegion(entries, region)
 
 			if asJSON {
 				enc := json.NewEncoder(os.Stdout)
@@ -78,6 +81,7 @@ func newCatalogListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+	cmd.Flags().StringVar(&region, "region", "", "Filter to catalog entries explicitly scoped to a region token (for example NL, EU, or *)")
 
 	return cmd
 }
@@ -103,60 +107,7 @@ func newCatalogShowCmd() *cobra.Command {
 				return enc.Encode(entry)
 			}
 
-			fmt.Printf("Name:           %s\n", entry.Name)
-			fmt.Printf("Display Name:   %s\n", entry.DisplayName)
-			fmt.Printf("Description:    %s\n", entry.Description)
-			fmt.Printf("Category:       %s\n", entry.Category)
-			fmt.Printf("Tier:           %s\n", entry.Tier)
-			if entry.IsWrapperOnly() {
-				fmt.Printf("Mode:           wrapper-only (no official spec)\n")
-			} else {
-				fmt.Printf("Spec URL:       %s\n", entry.SpecURL)
-				fmt.Printf("Spec Format:    %s\n", entry.SpecFormat)
-			}
-			if entry.OpenAPIVersion != "" {
-				fmt.Printf("OpenAPI:        %s\n", entry.OpenAPIVersion)
-			}
-			if entry.BaseURL != "" {
-				fmt.Printf("Base URL:       %s\n", entry.BaseURL)
-			}
-			if entry.Homepage != "" {
-				fmt.Printf("Homepage:       %s\n", entry.Homepage)
-			}
-			if entry.SpecSource != "" {
-				fmt.Printf("Spec Source:    %s\n", entry.SpecSource)
-			}
-			if entry.ClientPattern != "" {
-				fmt.Printf("Client Pattern: %s\n", entry.ClientPattern)
-			}
-			if entry.HTTPTransport != "" {
-				fmt.Printf("HTTP Transport: %s\n", entry.HTTPTransport)
-			}
-			if entry.AuthRequired != nil {
-				fmt.Printf("Auth Required:  %v\n", *entry.AuthRequired)
-			}
-			if entry.BearerRefresh.BundleURL != "" {
-				fmt.Printf("Bearer Refresh: %s\n", entry.BearerRefresh.BundleURL)
-			}
-			if entry.Notes != "" {
-				fmt.Printf("Notes:          %s\n", entry.Notes)
-			}
-			if entry.VerifiedDate != "" {
-				fmt.Printf("Verified:       %s\n", entry.VerifiedDate)
-			}
-			if len(entry.WrapperLibraries) > 0 {
-				fmt.Printf("\nWrapper Libraries:\n")
-				for _, w := range entry.WrapperLibraries {
-					fmt.Printf("  - %s (%s, %s)\n", w.Name, w.Language, w.IntegrationMode)
-					fmt.Printf("    %s\n", w.URL)
-					if w.License != "" {
-						fmt.Printf("    License: %s\n", w.License)
-					}
-					if w.Notes != "" {
-						fmt.Printf("    Notes: %s\n", strings.TrimSpace(w.Notes))
-					}
-				}
-			}
+			printCatalogEntryPlainText(*entry)
 
 			return nil
 		},
@@ -165,6 +116,93 @@ func newCatalogShowCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+func printCatalogEntryPlainText(entry catalog.Entry) {
+	fmt.Printf("Name:           %s\n", entry.Name)
+	fmt.Printf("Display Name:   %s\n", entry.DisplayName)
+	fmt.Printf("Description:    %s\n", entry.Description)
+	fmt.Printf("Category:       %s\n", entry.Category)
+	fmt.Printf("Tier:           %s\n", entry.Tier)
+	if entry.IsWrapperOnly() {
+		fmt.Printf("Mode:           wrapper-only (no official spec)\n")
+	} else {
+		fmt.Printf("Spec URL:       %s\n", entry.SpecURL)
+		fmt.Printf("Spec Format:    %s\n", entry.SpecFormat)
+	}
+	if entry.OpenAPIVersion != "" {
+		fmt.Printf("OpenAPI:        %s\n", entry.OpenAPIVersion)
+	}
+	if entry.BaseURL != "" {
+		fmt.Printf("Base URL:       %s\n", entry.BaseURL)
+	}
+	if entry.Homepage != "" {
+		fmt.Printf("Homepage:       %s\n", entry.Homepage)
+	}
+	if entry.SpecSource != "" {
+		fmt.Printf("Spec Source:    %s\n", entry.SpecSource)
+	}
+	if entry.ClientPattern != "" {
+		fmt.Printf("Client Pattern: %s\n", entry.ClientPattern)
+	}
+	if entry.HTTPTransport != "" {
+		fmt.Printf("HTTP Transport: %s\n", entry.HTTPTransport)
+	}
+	if entry.AuthRequired != nil {
+		fmt.Printf("Auth Required:  %v\n", *entry.AuthRequired)
+	}
+	if len(entry.Regions) > 0 {
+		fmt.Printf("Regions:        %s\n", strings.Join(entry.Regions, ", "))
+	}
+	if entry.APILanguage != "" {
+		fmt.Printf("API Language:   %s\n", entry.APILanguage)
+	}
+	if entry.BearerRefresh.BundleURL != "" {
+		fmt.Printf("Bearer Refresh: %s\n", entry.BearerRefresh.BundleURL)
+	}
+	if entry.Notes != "" {
+		fmt.Printf("Notes:          %s\n", entry.Notes)
+	}
+	if entry.VerifiedDate != "" {
+		fmt.Printf("Verified:       %s\n", entry.VerifiedDate)
+	}
+	if len(entry.WrapperLibraries) > 0 {
+		fmt.Printf("\nWrapper Libraries:\n")
+		for _, w := range entry.WrapperLibraries {
+			fmt.Printf("  - %s (%s, %s)\n", w.Name, w.Language, w.IntegrationMode)
+			fmt.Printf("    %s\n", w.URL)
+			if w.License != "" {
+				fmt.Printf("    License: %s\n", w.License)
+			}
+			if w.Notes != "" {
+				fmt.Printf("    Notes: %s\n", strings.TrimSpace(w.Notes))
+			}
+		}
+	}
+}
+
+func filterCatalogEntriesByRegion(entries []catalog.Entry, region string) []catalog.Entry {
+	region = strings.ToUpper(strings.TrimSpace(region))
+	if region == "" {
+		return entries
+	}
+	out := make([]catalog.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if catalogEntryMatchesRegion(entry, region) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func catalogEntryMatchesRegion(entry catalog.Entry, region string) bool {
+	for _, candidate := range entry.Regions {
+		candidate = strings.ToUpper(strings.TrimSpace(candidate))
+		if candidate == region || candidate == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 func newCatalogSearchCmd() *cobra.Command {
@@ -221,6 +259,8 @@ func matchesCatalogQuery(e catalog.Entry, query string) bool {
 		e.DisplayName,
 		e.Description,
 		e.Category,
+		strings.Join(e.Regions, " "),
+		e.APILanguage,
 	}
 	for _, f := range fields {
 		if strings.Contains(strings.ToLower(f), query) {

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -142,6 +142,15 @@ func TestFilterCatalogEntriesByRegion(t *testing.T) {
 	assert.Equal(t, "netherlands", got[1].Name)
 }
 
+func TestCatalogListRejectsInvalidRegionFilter(t *testing.T) {
+	cmd := newCatalogCmd()
+	cmd.SetArgs([]string{"list", "--region", "netherlands"})
+
+	_, err := runWithCapturedStdout(t, cmd.Execute)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--region must be a two-letter region token")
+}
+
 func TestCatalogSearchNoMatches(t *testing.T) {
 	cmd := newCatalogCmd()
 	cmd.SetArgs([]string{"search", "zzz-nonexistent-query-xyz", "--json"})

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -103,6 +103,45 @@ func TestCatalogSearchAuth(t *testing.T) {
 	assert.True(t, found, "stytch should appear in auth search results")
 }
 
+func TestCatalogSearchMatchesRegionAndAPILanguage(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry catalog.Entry
+		query string
+	}{
+		{
+			name:  "region",
+			entry: catalog.Entry{Name: "alpha", DisplayName: "Alpha", Description: "First", Category: "maps", Regions: []string{"NL"}},
+			query: "nl",
+		},
+		{
+			name:  "api language",
+			entry: catalog.Entry{Name: "beta", DisplayName: "Beta", Description: "Second", Category: "maps", APILanguage: "da-DK"},
+			query: "da-dk",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, matchesCatalogQuery(tt.entry, tt.query))
+		})
+	}
+}
+
+func TestFilterCatalogEntriesByRegion(t *testing.T) {
+	entries := []catalog.Entry{
+		{Name: "global", Regions: []string{"*"}},
+		{Name: "netherlands", Regions: []string{"NL"}},
+		{Name: "india", Regions: []string{"IN"}},
+		{Name: "unknown"},
+	}
+
+	got := filterCatalogEntriesByRegion(entries, "nl")
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "global", got[0].Name)
+	assert.Equal(t, "netherlands", got[1].Name)
+}
+
 func TestCatalogSearchNoMatches(t *testing.T) {
 	cmd := newCatalogCmd()
 	cmd.SetArgs([]string{"search", "zzz-nonexistent-query-xyz", "--json"})
@@ -149,4 +188,24 @@ func TestCatalogShowStripePlainText(t *testing.T) {
 
 	assert.Contains(t, output, "Stripe")
 	assert.Contains(t, output, "Spec URL:")
+}
+
+func TestCatalogShowPlainTextIncludesRegionMetadata(t *testing.T) {
+	output := captureStdout(t, func() {
+		entry := catalog.Entry{
+			Name:        "pdok-location",
+			DisplayName: "PDOK Location",
+			Description: "Geocoding for Dutch addresses",
+			Category:    "maps",
+			Tier:        "official",
+			SpecURL:     "https://example.com/openapi.yaml",
+			SpecFormat:  "yaml",
+			Regions:     []string{"NL"},
+			APILanguage: "nl",
+		}
+		printCatalogEntryPlainText(entry)
+	})
+
+	assert.Contains(t, output, "Regions:        NL")
+	assert.Contains(t, output, "API Language:   nl")
 }

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -2884,6 +2884,8 @@ func TestEnrichSpecFromCatalogCopiesGenerationMetadata(t *testing.T) {
 		DisplayName: "Test.API",
 		OwnerName:   "Trevin Chow",
 		BaseURL:     "https://api.example.com/",
+		Regions:     []string{"NL"},
+		APILanguage: "nl",
 		MCP: spec.MCPConfig{
 			Transport:     []string{"stdio", "http"},
 			Orchestration: "code",
@@ -2894,6 +2896,8 @@ func TestEnrichSpecFromCatalogCopiesGenerationMetadata(t *testing.T) {
 	assert.Equal(t, "Test.API", apiSpec.DisplayName)
 	assert.Equal(t, "Trevin Chow", apiSpec.OwnerName)
 	assert.Equal(t, "https://api.example.com", apiSpec.BaseURL)
+	assert.Equal(t, []string{"NL"}, apiSpec.Regions)
+	assert.Equal(t, "nl", apiSpec.APILanguage)
 	assert.False(t, apiSpec.BaseURLIsPlaceholder)
 	assert.Equal(t, []string{"stdio", "http"}, apiSpec.MCP.Transport)
 	assert.Equal(t, "code", apiSpec.MCP.Orchestration)

--- a/internal/cli/library.go
+++ b/internal/cli/library.go
@@ -21,6 +21,8 @@ type LibraryEntry struct {
 	APIName      string    `json:"api_name,omitempty"`
 	Category     string    `json:"category,omitempty"`
 	CatalogEntry string    `json:"catalog_entry,omitempty"`
+	Regions      []string  `json:"regions,omitempty"`
+	APILanguage  string    `json:"api_language,omitempty"`
 	Description  string    `json:"description,omitempty"`
 	Modified     time.Time `json:"modified"`
 }
@@ -231,6 +233,8 @@ func scanLibrary() ([]LibraryEntry, error) {
 				entry.APIName = m.APIName
 				entry.Category = m.Category
 				entry.CatalogEntry = m.CatalogEntry
+				entry.Regions = m.Regions
+				entry.APILanguage = m.APILanguage
 				entry.Description = m.Description
 			}
 		}

--- a/internal/cli/library_test.go
+++ b/internal/cli/library_test.go
@@ -53,6 +53,8 @@ func TestLibraryListJSONWithManifests(t *testing.T) {
 		CLIName:       "notion-pp-cli",
 		Category:      "productivity",
 		CatalogEntry:  "notion",
+		Regions:       []string{"NL"},
+		APILanguage:   "nl",
 		Description:   "Notion workspace API",
 	})
 
@@ -88,6 +90,12 @@ func TestLibraryListJSONWithManifests(t *testing.T) {
 	}
 	assert.True(t, names["notion-pp-cli"])
 	assert.True(t, names["stripe-pp-cli"])
+	for _, e := range entries {
+		if e.CLIName == "notion-pp-cli" {
+			assert.Equal(t, []string{"NL"}, e.Regions)
+			assert.Equal(t, "nl", e.APILanguage)
+		}
+	}
 }
 
 func TestLibraryListEmptyLibrary(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2183,6 +2183,12 @@ func enrichSpecFromCatalogEntry(apiSpec *spec.APISpec, entry *catalog.Entry) {
 	if entry.Category != "" {
 		apiSpec.Category = entry.Category
 	}
+	if len(entry.Regions) > 0 {
+		apiSpec.Regions = append([]string(nil), entry.Regions...)
+	}
+	if entry.APILanguage != "" {
+		apiSpec.APILanguage = entry.APILanguage
+	}
 	if entry.Owner != "" && apiSpec.Owner == "" {
 		apiSpec.Owner = entry.Owner
 	}

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -22,6 +22,8 @@ func TestSkillRendersFrontmatterAndCapabilities(t *testing.T) {
 
 	apiSpec := minimalSpec("finance")
 	apiSpec.Category = "commerce"
+	apiSpec.Regions = []string{"US", "*"}
+	apiSpec.APILanguage = "en-US"
 	outputDir := filepath.Join(t.TempDir(), "finance-pp-cli")
 	gen := New(apiSpec, outputDir)
 	gen.Narrative = &ReadmeNarrative{
@@ -57,6 +59,22 @@ func TestSkillRendersFrontmatterAndCapabilities(t *testing.T) {
 		"frontmatter description should list domain-specific trigger phrases verbatim (backtick-delimited)")
 	assert.True(t, strings.Contains(content, "library/commerce/finance/cmd/finance-pp-cli"),
 		"openclaw install manifest should use the API's category and slug-only directory")
+	assert.True(t, strings.Contains(content, `regions: ["US", "*"]`),
+		"frontmatter should expose structured geographic scope")
+	assert.True(t, strings.Contains(content, `api_language: "en-US"`),
+		"frontmatter should expose the API's native language tag")
+	require.True(t, strings.HasPrefix(content, "---\n"), "frontmatter should open with ---")
+	end := strings.Index(content[4:], "\n---\n")
+	require.NotEqual(t, -1, end, "frontmatter should close with ---")
+	body := strings.TrimSuffix(strings.TrimPrefix(content[:4+end+5], "---\n"), "---\n")
+	var parsed struct {
+		Regions     []string `yaml:"regions"`
+		APILanguage string   `yaml:"api_language"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(body), &parsed),
+		"frontmatter with region/language metadata must be valid YAML; content was:\n%s", body)
+	assert.Equal(t, []string{"US", "*"}, parsed.Regions)
+	assert.Equal(t, "en-US", parsed.APILanguage)
 
 	// Body
 	assert.True(t, strings.Contains(content, "## When to Use This CLI"),

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -5,7 +5,9 @@ author: "{{yamlDoubleQuoted .OwnerName}}"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"
 allowed-tools: "Read Bash"
-metadata:
+{{if .Regions}}regions: [{{range $i, $region := .Regions}}{{if $i}}, {{end}}"{{yamlDoubleQuoted $region}}"{{end}}]
+{{end}}{{if .APILanguage}}api_language: "{{yamlDoubleQuoted .APILanguage}}"
+{{end}}metadata:
   openclaw:
     requires:
       bins:

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -91,6 +91,8 @@ type CLIManifest struct {
 	RunID              string            `json:"run_id,omitempty"`
 	CatalogEntry       string            `json:"catalog_entry,omitempty"`
 	Category           string            `json:"category,omitempty"`
+	Regions            []string          `json:"regions,omitempty"`
+	APILanguage        string            `json:"api_language,omitempty"`
 	Description        string            `json:"description,omitempty"`
 	MCPBinary          string            `json:"mcp_binary,omitempty"`
 	MCPToolCount       int               `json:"mcp_tool_count,omitempty"`
@@ -510,6 +512,12 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	m.AuthTitle = parsed.Auth.Title
 	m.AuthDescription = parsed.Auth.Description
 	m.AuthOptional = parsed.Auth.Optional
+	if len(parsed.Regions) > 0 {
+		m.Regions = append([]string(nil), parsed.Regions...)
+	}
+	if parsed.APILanguage != "" {
+		m.APILanguage = parsed.APILanguage
+	}
 	// DisplayName precedence: explicit spec field > catalog-set existing
 	// value > spec/title-derived fallback > slug-derived fallback.
 	// OpenAPI info.title is useful as a fallback, but it is not explicit
@@ -740,6 +748,8 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if entry := lookupCatalogEntryForGenerate(p.APIName, m.SpecURL); entry != nil {
 		m.CatalogEntry = entry.Name
 		m.Category = entry.Category
+		m.Regions = append([]string(nil), entry.Regions...)
+		m.APILanguage = entry.APILanguage
 		m.Description = entry.Description
 		// Catalog's display_name wins over spec/title fallback, while explicit
 		// spec display_name / x-display-name still wins in populateMCPMetadata.

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -32,6 +32,8 @@ func TestWriteCLIManifest(t *testing.T) {
 		RunID:                "20260328T150405Z-abcd1234",
 		CatalogEntry:         "notion",
 		Category:             "productivity",
+		Regions:              []string{"NL"},
+		APILanguage:          "nl",
 		Description:          "Notion workspace API",
 	}
 
@@ -55,6 +57,8 @@ func TestWriteCLIManifest(t *testing.T) {
 	assert.Equal(t, "20260328T150405Z-abcd1234", got.RunID)
 	assert.Equal(t, "notion", got.CatalogEntry)
 	assert.Equal(t, "productivity", got.Category)
+	assert.Equal(t, []string{"NL"}, got.Regions)
+	assert.Equal(t, "nl", got.APILanguage)
 	assert.Equal(t, "Notion workspace API", got.Description)
 	assert.Equal(t, m.GeneratedAt, got.GeneratedAt)
 }
@@ -136,6 +140,12 @@ func TestWriteCLIManifestOmitsEmptyOptionalFields(t *testing.T) {
 
 	_, hasDescription := raw["description"]
 	assert.False(t, hasDescription, "description should be omitted when empty")
+
+	_, hasRegions := raw["regions"]
+	assert.False(t, hasRegions, "regions should be omitted when empty")
+
+	_, hasAPILanguage := raw["api_language"]
+	assert.False(t, hasAPILanguage, "api_language should be omitted when empty")
 }
 
 func TestWriteCLIManifestNonexistentDir(t *testing.T) {
@@ -1800,6 +1810,35 @@ func TestPopulateMCPMetadataCLIDescription(t *testing.T) {
 			Auth: spec.AuthConfig{Type: "none"},
 		})
 		assert.Equal(t, "Catalog description.", m.Description)
+	})
+}
+
+func TestPopulateMCPMetadataRegionLanguage(t *testing.T) {
+	t.Run("spec values populate empty manifest", func(t *testing.T) {
+		var m CLIManifest
+		populateMCPMetadata(&m, &spec.APISpec{
+			Name:        "pdok-location",
+			Regions:     []string{"NL"},
+			APILanguage: "nl",
+			Auth:        spec.AuthConfig{Type: "none"},
+		})
+
+		assert.Equal(t, []string{"NL"}, m.Regions)
+		assert.Equal(t, "nl", m.APILanguage)
+	})
+
+	t.Run("empty spec values preserve catalog-derived manifest values", func(t *testing.T) {
+		m := CLIManifest{
+			Regions:     []string{"EU"},
+			APILanguage: "en",
+		}
+		populateMCPMetadata(&m, &spec.APISpec{
+			Name: "pvgis",
+			Auth: spec.AuthConfig{Type: "none"},
+		})
+
+		assert.Equal(t, []string{"EU"}, m.Regions)
+		assert.Equal(t, "en", m.APILanguage)
 	})
 }
 

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -235,6 +235,12 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 			if existing.Category != "" {
 				m.Category = existing.Category
 			}
+			if len(existing.Regions) > 0 {
+				m.Regions = append([]string(nil), existing.Regions...)
+			}
+			if existing.APILanguage != "" {
+				m.APILanguage = existing.APILanguage
+			}
 			if preserveExistingDescription(existing.Description) {
 				m.Description = existing.Description
 				existingDescription = existing.Description
@@ -266,6 +272,8 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 	if entry, err := catalogpkg.LookupFS(catalog.FS, state.APIName); err == nil {
 		m.CatalogEntry = entry.Name
 		m.Category = entry.Category
+		m.Regions = append([]string(nil), entry.Regions...)
+		m.APILanguage = entry.APILanguage
 		if m.Description == "" {
 			m.Description = entry.Description
 		}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -196,6 +196,8 @@ type APISpec struct {
 	BearerRefresh               BearerRefreshConfig `yaml:"bearer_refresh,omitempty" json:"bearer_refresh,omitzero"` // live-source metadata for rotating public client bearer tokens
 	WebsiteURL                  string              `yaml:"website_url,omitempty" json:"website_url,omitempty"`      // product/company website (not the API base URL)
 	Category                    string              `yaml:"category,omitempty" json:"category,omitempty"`            // catalog category (e.g., productivity, developer-tools) — used for library install path
+	Regions                     []string            `yaml:"regions,omitempty" json:"regions,omitempty"`              // geographic availability/scope tokens (ISO 3166-1 alpha-2 like NL, EU, or * for global)
+	APILanguage                 string              `yaml:"api_language,omitempty" json:"api_language,omitempty"`    // BCP 47 language tag for the API's native/domain language
 	Auth                        AuthConfig          `yaml:"auth" json:"auth"`
 	AuthWarnings                []string            `yaml:"auth_warnings,omitempty" json:"auth_warnings,omitempty"`
 	TierRouting                 TierRoutingConfig   `yaml:"tier_routing,omitempty" json:"tier_routing,omitzero"`


### PR DESCRIPTION
## Summary

Catalog metadata can now describe where an API is usable and which upstream language its payloads or domain terms use. Generated manifests, SKILL frontmatter, local-library JSON, and catalog browsing all carry the same `regions` and `api_language` values, so agents and humans can filter geographically scoped CLIs without parsing prose.

The catalog command also supports `catalog list --region <token>` and searches across region/language metadata.

## Notes

This intentionally changes the generated SKILL.md frontmatter field set. Downstream published-library sweep follow-up: https://github.com/mvanhorn/printing-press-library/issues/858

## Verification

- `go test ./...`
- `scripts/golden.sh verify`

Closes #1735

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
