### PR TITLE
feat(cli): add per-endpoint role gates

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -17,6 +17,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-proxy-routes` | `info` | `APISpec.ProxyRoutes` | No |
 | `x-origin` | `info` | Google Discovery resource fallback | No |
 | `x-providerName` | `info` | Google Discovery resource fallback | No |
+| `x-roles` | root or `info` | `APISpec.Roles` | No |
 | `x-tier-routing` | root or `info` | `APISpec.TierRouting` | No |
 | `x-rate-class` | root or `info` | `APISpec.RateClass` | No |
 | `x-mcp` | root or `info` | `APISpec.MCP` | No |
@@ -41,6 +42,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-critical` | path item | `Endpoint.Critical` | No |
 | `x-tier` | path item or operation | `Endpoint.Tier` | No |
 | `x-data-source-strategy` | path item or operation | `Endpoint.DataSourceStrategy` | No |
+| `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 
@@ -194,6 +196,26 @@ x-tier-routing:
         in: query
         header: api_key
         env_vars: [EXAMPLE_PAID_KEY]
+```
+
+### `x-roles`
+
+Declares the authenticated persona labels that operation-level RBAC gates may
+reference.
+
+Parsed field: `APISpec.Roles`
+
+Rules:
+- Optional.
+- May be declared at the OpenAPI root or under `info`.
+- Must be a string list.
+- Each role must match `^[A-Za-z][A-Za-z0-9_-]*$`.
+- Every operation-level `x-requires-role` value must name one declared role.
+
+Example:
+
+```yaml
+x-roles: [parent, student, teacher, admin]
 ```
 
 ### `x-rate-class`
@@ -1084,6 +1106,33 @@ paths:
   /reports/snapshot:
     get:
       x-data-source-strategy: local
+      responses:
+        "200": {description: ok}
+```
+
+### `x-requires-role`
+
+Requires the authenticated account to have one of the declared `x-roles` before
+the generated command calls the API.
+
+Parsed field: `Endpoint.RequiresRole`
+
+Rules:
+- Optional.
+- Must be on an operation, not the root, `info`, or path item.
+- Must be a string naming a role declared by `x-roles`.
+- The generator emits the guard framework and endpoint call site. How a printed
+  CLI discovers the authenticated account's role remains API-specific.
+
+Example:
+
+```yaml
+x-roles: [parent, student, teacher, admin]
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      x-requires-role: admin
       responses:
         "200": {description: ok}
 ```

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -656,6 +656,7 @@ type HelperFlags struct {
 	HasEmbeddedPaged     bool // at least one GET endpoint has detected embedded paged sub-resources → emit fetchEmbeddedPagedSubresource
 	HasResponseUnwrap    bool // at least one generated command can call extractResponseData
 	HasMutationEndpoints bool // spec has any non-GET/HEAD endpoint → emit partial-failure helpers + --allow-partial-failure flag
+	HasRequiredRoles     bool // spec has per-endpoint requires_role gates → emit persona helpers
 }
 
 // computeHelperFlags scans the spec's resources to determine which helpers are needed.
@@ -670,6 +671,9 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 				}
 				if isMutationMethod(e.Method) {
 					flags.HasMutationEndpoints = true
+				}
+				if strings.TrimSpace(e.RequiresRole) != "" {
+					flags.HasRequiredRoles = true
 				}
 				if endpointNeedsClientLimit(e) {
 					flags.HasClientLimit = true

--- a/internal/generator/role_gate_test.go
+++ b/internal/generator/role_gate_test.go
@@ -1,0 +1,132 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiresRoleEmitsEndpointGate(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("role-gate")
+	apiSpec.Roles = []string{"parent", "student", "teacher", "admin"}
+	items := apiSpec.Resources["items"]
+	items.Endpoints["get"] = endpointForRoleGate("GET", "/items/{id}", "Get item")
+	apiSpec.Resources["items"] = items
+	endpoint := apiSpec.Resources["items"].Endpoints["list"]
+	endpoint.RequiresRole = "admin"
+	apiSpec.Resources["items"].Endpoints["list"] = endpoint
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	require.Contains(t, helpersSrc, `PersonaAdmin`)
+	require.Contains(t, helpersSrc, `"admin"`)
+	require.Contains(t, helpersSrc, "func RequireRoleWith")
+	require.Contains(t, helpersSrc, "var resolveAuthRole = func")
+	require.Contains(t, helpersSrc, "authenticated account role is unknown")
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	require.Contains(t, configSrc, "AuthRole")
+	require.Contains(t, configSrc, "ROLE_GATE_AUTH_ROLE")
+	require.Contains(t, configSrc, `roleFromEnv := false`)
+	require.Contains(t, configSrc, `strings.HasPrefix(cfg.AuthSource, "env:")`)
+
+	commandSrc := readGeneratedFile(t, outputDir, "internal", "cli", "items_list.go")
+	require.Contains(t, commandSrc, "config.Load(flags.configPath)")
+	require.Contains(t, commandSrc, "RequireRoleWith(flags, cfg, cmd.CommandPath(), PersonaAdmin)")
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpSrc, "requiredRole cli.Persona")
+	require.Contains(t, mcpSrc, "cli.RequireRoleWith(nil, cfg, pathTemplate, requiredRole)")
+	require.Contains(t, mcpSrc, "cli.PersonaAdmin")
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "./internal/mcp", "./internal/config")
+}
+
+func TestRequiresRoleEmitsPromotedEndpointGate(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-role-gate")
+	apiSpec.Roles = []string{"admin"}
+	endpoint := apiSpec.Resources["items"].Endpoints["list"]
+	endpoint.RequiresRole = "admin"
+	apiSpec.Resources["items"].Endpoints["list"] = endpoint
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	promotedSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	require.Contains(t, promotedSrc, "config.Load(flags.configPath)")
+	require.Contains(t, promotedSrc, "RequireRoleWith(flags, cfg, cmd.CommandPath(), PersonaAdmin)")
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "./internal/mcp", "./internal/config")
+}
+
+func TestRequiresRoleEmitsMCPOrchestrationGates(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-role-gate")
+	apiSpec.Roles = []string{"admin"}
+	endpoint := apiSpec.Resources["items"].Endpoints["list"]
+	endpoint.RequiresRole = "admin"
+	apiSpec.Resources["items"].Endpoints["list"] = endpoint
+	apiSpec.MCP = spec.MCPConfig{
+		Orchestration: "code",
+		Intents: []spec.Intent{
+			{
+				Name:        "list_admin_items",
+				Description: "List admin items",
+				Steps: []spec.IntentStep{
+					{Endpoint: "items.list", Capture: "items"},
+				},
+				Returns: "items",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	codeOrchSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "code_orch.go")
+	require.Contains(t, codeOrchSrc, "RequiredRole cli.Persona")
+	require.Contains(t, codeOrchSrc, "cli.RequireRoleWith(nil, cfg, ep.ID, ep.RequiredRole)")
+	require.Contains(t, codeOrchSrc, "RequiredRole: cli.PersonaAdmin")
+
+	intentsSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "intents.go")
+	require.Contains(t, intentsSrc, "requiredRole cli.Persona")
+	require.Contains(t, intentsSrc, "cli.RequireRoleWith(nil, cfg, ref, ep.requiredRole)")
+	require.Contains(t, intentsSrc, "requiredRole: cli.PersonaAdmin")
+
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "./internal/cli", "./internal/config")
+}
+
+func endpointForRoleGate(method, path, description string) spec.Endpoint {
+	return spec.Endpoint{Method: method, Path: path, Description: description}
+}
+
+func TestRequiresRoleHelpersStayAbsentWithoutAnnotations(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("no-role-gate")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	require.NotContains(t, helpersSrc, "type Persona")
+	require.NotContains(t, helpersSrc, "RequireRoleWith")
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	require.NotContains(t, configSrc, "AuthRole")
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -32,6 +32,9 @@ import (
 	"{{modulePath}}/internal/client"
 
 {{- end}}
+{{ if .Endpoint.RequiresRole}}
+	"{{modulePath}}/internal/config"
+{{- end}}
 {{ if endpointUsesCSVArray .Endpoint}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
@@ -121,6 +124,15 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- bodyRequiredChecks .Endpoint "\t\t\t\t"}}
 			}
 {{- end}}
+{{- end}}
+{{- if .Endpoint.RequiresRole}}
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return err
+			}
+			if err := RequireRoleWith(flags, cfg, cmd.CommandPath(), Persona{{pascal .Endpoint.RequiresRole}}); err != nil {
+				return err
+			}
 {{- end}}
 			c, err := flags.newClient()
 			if err != nil {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -28,6 +28,9 @@ import (
 	"strconv"
 {{- end}}
 
+{{ if .Endpoint.RequiresRole}}
+	"{{modulePath}}/internal/config"
+{{- end}}
 {{ if endpointUsesCSVArray .Endpoint}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
@@ -94,6 +97,15 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				}
 			}
 {{- end}}
+{{- end}}
+{{- if .Endpoint.RequiresRole}}
+			cfg, err := config.Load(flags.configPath)
+			if err != nil {
+				return err
+			}
+			if err := RequireRoleWith(flags, cfg, cmd.CommandPath(), Persona{{pascal .Endpoint.RequiresRole}}); err != nil {
+				return err
+			}
 {{- end}}
 			c, err := flags.newClient()
 			if err != nil {

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -41,6 +41,9 @@ type Config struct {
 	AuthHeaderVal  string `{{configTag .Config.Format}}:"auth_header"`
 	Headers        map[string]string `{{configTag .Config.Format}}:"headers,omitempty"`
 	AuthSource     string `{{configTag .Config.Format}}:"-"`
+{{- if .HasRequiredRoles}}
+	AuthRole       string `{{configTag .Config.Format}}:"auth_role,omitempty"`
+{{- end}}
 {{- if .HasAuthCommand}}
 	AccessToken    string `{{configTag .Config.Format}}:"access_token"`
 	RefreshToken   string `{{configTag .Config.Format}}:"refresh_token"`
@@ -225,6 +228,16 @@ func Load(configPath string) (*Config, error) {
 	if v := os.Getenv("{{envName .Name}}_BASE_URL"); v != "" {
 		cfg.BaseURL = v
 	}
+{{- if .HasRequiredRoles}}
+	roleFromEnv := false
+	if v := strings.TrimSpace(os.Getenv("{{envName .Name}}_AUTH_ROLE")); v != "" {
+		cfg.AuthRole = v
+		roleFromEnv = true
+	}
+	if !roleFromEnv && (strings.HasPrefix(cfg.AuthSource, "env:") || strings.HasPrefix(cfg.AuthSource, "bus:")) {
+		cfg.AuthRole = ""
+	}
+{{- end}}
 {{- if .BasePath}}
 	if v := os.Getenv("{{envName .Name}}_BASE_PATH"); v != "" {
 		cfg.BasePath = v
@@ -640,6 +653,9 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+{{- if .HasRequiredRoles}}
+	c.AuthRole = ""
+{{- end}}
 	return c.save()
 }
 
@@ -656,6 +672,9 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
+{{- if .HasRequiredRoles}}
+	c.AuthRole = ""
+{{- end}}
 {{- with .Auth.CanonicalEnvVar}}
 	c.{{resolveEnvVarField .Name}} = token
 {{- end}}
@@ -669,6 +688,9 @@ func (c *Config) SaveBearerToken(accessToken string, refreshedAt time.Time) erro
 	c.AccessToken = accessToken
 	c.RefreshToken = ""
 	c.TokenExpiry = time.Time{}
+{{- if .HasRequiredRoles}}
+	c.AuthRole = ""
+{{- end}}
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 {{- if not (envVarIsBuiltinField .Name)}}
@@ -702,6 +724,9 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+{{- if .HasRequiredRoles}}
+	c.AuthRole = ""
+{{- end}}
 {{- if .BearerRefresh.Enabled}}
 	c.BearerTokenRefreshedAt = time.Time{}
 {{- end}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -145,8 +145,9 @@ func MarkPersona(cfg *config.Config, role Persona) {
 
 // resolveAuthRole is intentionally a variable so a printed CLI can install an
 // API-specific resolver from a hand-authored file without editing generated
-// command files. The default is "unknown", so role-gated commands fail closed
-// until role evidence is available from config, env, or the custom resolver.
+// command files. The default returns "" (treated as unknown), so role-gated
+// commands fail closed until role evidence is available from config, env, or
+// the custom resolver.
 var resolveAuthRole = func(_ *rootFlags, _ *config.Config) (Persona, error) {
 	return "", nil
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -35,6 +35,9 @@ import (
 {{- if and .Auth.Type (ne .Auth.Type "none")}}
 	"{{modulePath}}/internal/cliutil"
 {{- end}}
+{{- if .HasRequiredRoles}}
+	"{{modulePath}}/internal/config"
+{{- end}}
 {{- if or .HasSyncHelpers (and .Auth.Type (ne .Auth.Type "none"))}}
 	"{{modulePath}}/internal/client"
 {{- end}}
@@ -121,6 +124,58 @@ func authErr(err error) error     { return &cliError{code: 4, err: err} }
 func apiErr(err error) error      { return &cliError{code: 5, err: err} }
 func configErr(err error) error   { return &cliError{code: 10, err: err} }
 func rateLimitErr(err error) error { return &cliError{code: 7, err: err} }
+
+{{- if .HasRequiredRoles}}
+type Persona string
+
+const (
+{{- range .Roles}}
+	Persona{{pascal .}} Persona = "{{.}}"
+{{- end}}
+)
+
+// MarkPersona records an authenticated account role in config after an
+// API-specific auth flow or role probe has identified it.
+func MarkPersona(cfg *config.Config, role Persona) {
+	if cfg == nil {
+		return
+	}
+	cfg.AuthRole = string(role)
+}
+
+// resolveAuthRole is intentionally a variable so a printed CLI can install an
+// API-specific resolver from a hand-authored file without editing generated
+// command files. The default is "unknown", so role-gated commands fail closed
+// until role evidence is available from config, env, or the custom resolver.
+var resolveAuthRole = func(_ *rootFlags, _ *config.Config) (Persona, error) {
+	return "", nil
+}
+
+func RequireRoleWith(flags *rootFlags, cfg *config.Config, cmdName string, required Persona) error {
+	if required == "" {
+		return nil
+	}
+	actual := Persona("")
+	if cfg != nil {
+		actual = Persona(strings.TrimSpace(cfg.AuthRole))
+	}
+	if actual == "" {
+		resolved, err := resolveAuthRole(flags, cfg)
+		if err != nil {
+			return authErr(err)
+		}
+		actual = Persona(strings.TrimSpace(string(resolved)))
+	}
+	if actual == "" {
+		return usageErr(fmt.Errorf("%s is for [%s]. Your authenticated account role is unknown.", cmdName, required))
+	}
+	if actual == required {
+		return nil
+	}
+	return usageErr(fmt.Errorf("%s is for [%s]. Your authenticated account is role=%s.", cmdName, required, actual))
+}
+
+{{- end}}
 
 {{- if .HasMutationEndpoints}}
 // partialFailureErr signals that the upstream API returned a 2xx with a

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -24,6 +24,9 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+{{ if .HasRequiredRoles}}
+	"{{modulePath}}/internal/cli"
+{{- end}}
 )
 
 // RegisterCodeOrchestrationTools registers the two agent-facing tools that
@@ -58,6 +61,9 @@ type codeOrchEndpoint struct {
 	Method      string
 	Path        string
 	Tier        string
+{{- if .HasRequiredRoles}}
+	RequiredRole cli.Persona
+{{- end}}
 	Summary     string
 	Positional  []string
 	// QueryParams carries public-to-wire bindings for spec-declared in:query
@@ -95,6 +101,9 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		ID:      "{{$name}}.{{$eName}}",
 		Method:  "{{upper $endpoint.Method}}",
 		Path:    "{{$path}}",
+{{- if $.HasRequiredRoles}}
+		RequiredRole: {{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}},
+{{- end}}
 {{- if $.HasTierRouting}}
 		Tier:    {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}},
 {{- end}}
@@ -117,6 +126,9 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		ID:      "{{$name}}.{{$subName}}.{{$eName}}",
 		Method:  "{{upper $endpoint.Method}}",
 		Path:    "{{$path}}",
+{{- if $.HasRequiredRoles}}
+		RequiredRole: {{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}},
+{{- end}}
 {{- if $.HasTierRouting}}
 		Tier:    {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}},
 {{- end}}
@@ -252,10 +264,22 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 		params = map[string]any{}
 	}
 
+{{- if .HasRequiredRoles}}
+	cfg, err := newMCPConfig()
+	if err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
+	if err := cli.RequireRoleWith(nil, cfg, ep.ID, ep.RequiredRole); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
+	c := newMCPClientFromConfig(cfg)
+{{ else}}
+
 	c, err := newMCPClient()
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}
+{{ end}}
 {{- if .HasTierRouting}}
 	c = c.WithTier(ep.Tier)
 {{- end}}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -28,6 +28,10 @@ import (
 {{- if .MCP.Intents}}
 	"{{modulePath}}/internal/client"
 {{- end}}
+{{- if and .MCP.Intents .HasRequiredRoles}}
+	"{{modulePath}}/internal/cli"
+	"{{modulePath}}/internal/config"
+{{- end}}
 {{- if .RecipeIntents}}
 	"{{modulePath}}/internal/mcp/cobratree"
 {{- end}}
@@ -66,10 +70,18 @@ func RegisterIntents(s *server.MCPServer) {
 {{range .MCP.Intents}}
 // handle{{pascal .Name}} runs the {{.Name}} intent: {{.Description}}
 func handle{{pascal .Name}}(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+{{- if $.HasRequiredRoles}}
+	cfg, err := newMCPConfig()
+	if err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
+	c := newMCPClientFromConfig(cfg)
+{{- else}}
 	c, err := newMCPClient()
 	if err != nil {
 		return mcplib.NewToolResultError(err.Error()), nil
 	}
+{{- end}}
 
 	input := req.GetArguments()
 	scope := map[string]any{"input": input}
@@ -83,7 +95,7 @@ func handle{{pascal .Name}}(ctx context.Context, req mcplib.CallToolRequest) (*m
 			params[{{printf "%q" $paramName}}] = v
 		}
 {{- end}}
-		resp, err := callIntentEndpoint(ctx, c, {{printf "%q" $step.Endpoint}}, params)
+		resp, err := callIntentEndpoint(ctx, c, {{if $.HasRequiredRoles}}cfg, {{end}}{{printf "%q" $step.Endpoint}}, params)
 		if err != nil {
 			return mcplib.NewToolResultError(fmt.Sprintf("step %d ({{$step.Endpoint}}) failed: %v", {{add $i 1}}, err)), nil
 		}
@@ -198,11 +210,16 @@ func resolveIntentBinding(scope map[string]any, expr string) (any, bool) {
 // client. It uses the generator-emitted endpoint registry below to look up
 // the HTTP method, path template, and positional-param set so the intent
 // handler can stay generic across endpoints.
-func callIntentEndpoint(ctx context.Context, c *client.Client, ref string, params map[string]any) (any, error) {
+func callIntentEndpoint(ctx context.Context, c *client.Client, {{if .HasRequiredRoles}}cfg *config.Config, {{end}}ref string, params map[string]any) (any, error) {
 	ep, ok := intentEndpoints[ref]
 	if !ok {
 		return nil, fmt.Errorf("unknown endpoint %q", ref)
 	}
+{{- if .HasRequiredRoles}}
+	if err := cli.RequireRoleWith(nil, cfg, ref, ep.requiredRole); err != nil {
+		return nil, err
+	}
+{{- end}}
 {{- if .HasTierRouting}}
 	c = c.WithTier(ep.tier)
 {{- end}}
@@ -277,6 +294,9 @@ func callIntentEndpoint(ctx context.Context, c *client.Client, ref string, param
 type intentEndpointMeta struct {
 	method string
 	path   string
+{{- if .HasRequiredRoles}}
+	requiredRole cli.Persona
+{{- end}}
 {{- if .HasTierRouting}}
 	tier   string
 {{- end}}
@@ -295,7 +315,7 @@ var intentEndpoints = map[string]intentEndpointMeta{
 {{- range .MCP.Intents}}
 {{- range .Steps}}
 {{- $ep := lookupEndpoint $.APISpec .Endpoint}}
-	{{printf "%q" .Endpoint}}: {method: {{printf "%q" (upper $ep.Method)}}, path: {{printf "%q" $ep.EffectivePath}}{{if $.HasTierRouting}}, tier: {{printf "%q" $ep.EffectiveTier}}{{end}}{{if $ep.BodyIsArray}}, bodyIsArray: true{{end}}},
+	{{printf "%q" .Endpoint}}: {method: {{printf "%q" (upper $ep.Method)}}, path: {{printf "%q" $ep.EffectivePath}}{{if $.HasRequiredRoles}}, requiredRole: {{if $ep.RequiresRole}}cli.Persona{{pascal $ep.RequiresRole}}{{else}}cli.Persona(""){{end}}{{end}}{{if $.HasTierRouting}}, tier: {{printf "%q" $ep.EffectiveTier}}{{end}}{{if $ep.BodyIsArray}}, bodyIsArray: true{{end}}},
 {{- end}}
 {{- end}}
 }

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -70,9 +70,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -103,9 +103,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -221,15 +221,26 @@ func setNestedBodyArg(body map[string]any, path []string, value any) {
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 {{- if .HasTierRouting}}
-func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 {{- else}}
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 {{- end}}
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+{{- if .HasRequiredRoles}}
+		cfg, err := newMCPConfig()
+		if err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
+		if err := cli.RequireRoleWith(nil, cfg, pathTemplate, requiredRole); err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
+		c := newMCPClientFromConfig(cfg)
+{{- else}}
 		c, err := newMCPClient()
 		if err != nil {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
+{{- end}}
 	{{- if .HasTierRouting}}
 		c = c.WithTier(tier)
 	{{- end}}
@@ -618,12 +629,28 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 }
 
 func newMCPClient() (*client.Client, error) {
+{{- if .HasRequiredRoles}}
+	cfg, err := newMCPConfig()
+	if err != nil {
+		return nil, err
+	}
+	return newMCPClientFromConfig(cfg), nil
+}
+
+func newMCPConfig() (*config.Config, error) {
+{{- end}}
 	home, _ := os.UserHomeDir()
 	cfgPath := filepath.Join(home, ".config", "{{.Name}}-pp-cli", "config.toml")
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
+{{- if .HasRequiredRoles}}
+	return cfg, nil
+}
+
+func newMCPClientFromConfig(cfg *config.Config) *client.Client {
+{{- end}}
 {{- if eq .SpecSource "sniffed"}}
 	c := client.New(cfg, 60*time.Second, 2)
 {{- else}}
@@ -635,7 +662,11 @@ func newMCPClient() (*client.Client, error) {
 	// pre-mutation snapshot for up to the cache TTL. The interactive CLI
 	// constructs its own client and is unaffected.
 	c.NoCache = true
+{{- if .HasRequiredRoles}}
+	return c
+{{- else}}
 	return c, nil
+{{- end}}
 }
 
 func dbPath() string {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -52,6 +52,8 @@ const (
 	extensionSpeakeasyExample      = "x-speakeasy-example"
 	extensionTierRouting           = "x-tier-routing"
 	extensionTier                  = "x-tier"
+	extensionRoles                 = "x-roles"
+	extensionRequiresRole          = "x-requires-role"
 	extensionRateClass             = "x-rate-class"
 	extensionMCP                   = "x-mcp"
 	extensionLegacyMCP             = "mcp"
@@ -610,6 +612,10 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 	if err != nil {
 		return nil, err
 	}
+	roles, err := parseStringListOpenAPIExtension(doc, extensionRoles)
+	if err != nil {
+		return nil, err
+	}
 
 	mcpConfig, err := parseMCPExtension(doc)
 	if err != nil {
@@ -645,6 +651,7 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 		ProxyRoutes:                  proxyRoutes,
 		RateClass:                    rateClass,
 		Auth:                         auth,
+		Roles:                        roles,
 		TierRouting:                  tierRouting,
 		MCP:                          mcpConfig,
 		Cache:                        cacheConfig,
@@ -670,7 +677,9 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 	// has an exists-check, so Components-defined types win on name
 	// collisions; inline schemas only fill genuine gaps.
 	mapTypes(doc, result)
-	mapResources(doc, result, resourceBasePath)
+	if err := mapResources(doc, result, resourceBasePath); err != nil {
+		return nil, err
+	}
 
 	// Post-parse sweep: if the spec has no authentication at all (not inferred
 	// from description keywords), mark every endpoint as NoAuth. The per-operation
@@ -870,11 +879,33 @@ func parseStringOpenAPIExtension(doc *openapi3.T, key string) (string, error) {
 	return "", nil
 }
 
+func parseStringListOpenAPIExtension(doc *openapi3.T, key string) ([]string, error) {
+	if doc != nil && doc.Extensions != nil {
+		if _, ok := doc.Extensions[key]; ok {
+			return parseStringListExtensionValue(doc.Extensions, key)
+		}
+	}
+	if doc != nil && doc.Info != nil && doc.Info.Extensions != nil {
+		if _, ok := doc.Info.Extensions[key]; ok {
+			return parseStringListExtensionValue(doc.Info.Extensions, key)
+		}
+	}
+	return nil, nil
+}
+
 func parseStringExtensionValue(extensions map[string]any, key string) (string, error) {
 	if _, ok := extensions[key].(string); !ok {
 		return "", fmt.Errorf("%s must be a string", key)
 	}
 	return stringExtension(extensions, key), nil
+}
+
+func parseStringListExtensionValue(extensions map[string]any, key string) ([]string, error) {
+	values, ok := strictStringListValue(extensions[key])
+	if !ok {
+		return nil, fmt.Errorf("%s must be a string array", key)
+	}
+	return values, nil
 }
 
 func mapAuth(doc *openapi3.T, name string) spec.AuthConfig {
@@ -1908,6 +1939,33 @@ func stringListValue(value any) []string {
 	return nil
 }
 
+func strictStringListValue(value any) ([]string, bool) {
+	switch v := value.(type) {
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if item = strings.TrimSpace(item); item != "" {
+				out = append(out, item)
+			}
+		}
+		return out, true
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			if s = strings.TrimSpace(s); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
 func boolExtension(extensions map[string]any, name string) (bool, bool) {
 	value, ok := extensions[name]
 	if !ok {
@@ -2718,9 +2776,9 @@ func pathPriorityScore(path string) int {
 	return score
 }
 
-func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
+func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 	if doc == nil || out == nil || doc.Paths == nil {
-		return
+		return nil
 	}
 
 	tagDescriptions := mapTagDescriptions(doc.Tags)
@@ -2889,6 +2947,11 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 			if endpoint.Tier == "" {
 				endpoint.Tier = pathTier
 			}
+			requiresRole, err := readRequiresRoleExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
+			if err != nil {
+				return err
+			}
+			endpoint.RequiresRole = requiresRole
 			endpoint.DataSourceStrategy = readDataSourceStrategyExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
 			if endpoint.DataSourceStrategy == "" {
 				endpoint.DataSourceStrategy = pathDataSourceStrategy
@@ -2962,6 +3025,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) {
 
 	assignEndpointAliases(out.Resources)
 	filterGlobalParams(out.Resources)
+	return nil
 }
 
 func operationServerBaseURL(specBaseURL string, pathItem *openapi3.PathItem, op *openapi3.Operation) string {
@@ -4668,6 +4732,21 @@ func readTierExtension(extensions map[string]any, context string) string {
 		return ""
 	}
 	return strings.TrimSpace(tier)
+}
+
+func readRequiresRoleExtension(extensions map[string]any, context string) (string, error) {
+	if extensions == nil {
+		return "", nil
+	}
+	raw, ok := extensions[extensionRequiresRole]
+	if !ok {
+		return "", nil
+	}
+	role, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s: %s must be a string, got %T", context, extensionRequiresRole, raw)
+	}
+	return strings.TrimSpace(role), nil
 }
 
 func readDataSourceStrategyExtension(extensions map[string]any, context string) string {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -88,6 +88,82 @@ paths:
 	assert.Equal(t, "event_id", parsed.Streaming.Metadata.PrimaryKey)
 }
 
+func TestParseRequiresRoleExtension(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.3
+x-roles: [parent, student, teacher, admin]
+info:
+  title: Role API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      x-requires-role: admin
+      responses:
+        "200":
+          description: ok
+  /users/me:
+    get:
+      operationId: getCurrentUser
+      responses:
+        "200":
+          description: ok
+`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"parent", "student", "teacher", "admin"}, parsed.Roles)
+	assert.Equal(t, "admin", parsed.Resources["users"].Endpoints["list"].RequiresRole)
+	assert.Empty(t, parsed.Resources["users"].Endpoints["get-current-user"].RequiresRole)
+}
+
+func TestParseRequiresRoleExtensionRejectsInvalidShapes(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse([]byte(`
+openapi: 3.0.3
+x-roles: [admin]
+info:
+  title: Role API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      x-requires-role: [admin]
+      responses:
+        "200":
+          description: ok
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x-requires-role must be a string")
+
+	_, err = Parse([]byte(`
+openapi: 3.0.3
+x-roles: admin
+info:
+  title: Role API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      x-requires-role: admin
+      responses:
+        "200":
+          description: ok
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x-roles must be a string array")
+}
+
 func TestParseLenientStubsMissingLocalSchemaRefs(t *testing.T) {
 	specBytes := []byte(`
 openapi: 3.0.3

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"gopkg.in/yaml.v3"
@@ -198,6 +199,7 @@ type APISpec struct {
 	Category                    string              `yaml:"category,omitempty" json:"category,omitempty"`            // catalog category (e.g., productivity, developer-tools) — used for library install path
 	Auth                        AuthConfig          `yaml:"auth" json:"auth"`
 	AuthWarnings                []string            `yaml:"auth_warnings,omitempty" json:"auth_warnings,omitempty"`
+	Roles                       []string            `yaml:"roles,omitempty" json:"roles,omitempty"` // per-spec authenticated persona labels that endpoints may require (e.g. parent, teacher, admin)
 	TierRouting                 TierRoutingConfig   `yaml:"tier_routing,omitempty" json:"tier_routing,omitzero"`
 	RequiredHeaders             []RequiredHeader    `yaml:"required_headers,omitempty" json:"required_headers,omitempty"`
 	Config                      ConfigSpec          `yaml:"config" json:"config"`
@@ -638,6 +640,34 @@ func validateStreaming(c StreamingConfig) error {
 // Specs without this flag regenerate byte-identical to the pre-PR-3 output.
 func (s *APISpec) HasCostThrottling() bool {
 	return s != nil && s.Throttling.Enabled
+}
+
+// HasRequiredRoles reports whether any endpoint declares a role gate. Templates
+// use this to keep persona helpers out of CLIs that do not opt into RBAC.
+func (s *APISpec) HasRequiredRoles() bool {
+	if s == nil {
+		return false
+	}
+	for _, resource := range s.Resources {
+		if resourceHasRequiredRoles(resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceHasRequiredRoles(resource Resource) bool {
+	for _, endpoint := range resource.Endpoints {
+		if strings.TrimSpace(endpoint.RequiresRole) != "" {
+			return true
+		}
+	}
+	for _, sub := range resource.SubResources {
+		if resourceHasRequiredRoles(sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtraCommand declares a hand-written cobra command so the SKILL.md
@@ -1782,6 +1812,10 @@ type Endpoint struct {
 	// inferring from spec-level signals.
 	ObservedAuth []string `yaml:"observed_auth,omitempty" json:"observed_auth,omitempty"`
 	Tier         string   `yaml:"tier,omitempty" json:"tier,omitempty"`
+	// RequiresRole gates this endpoint behind a per-spec authenticated role.
+	// The generator emits the guard framework; API-specific role discovery
+	// remains a printed-CLI concern and plugs into the generated resolver hook.
+	RequiresRole string `yaml:"requires_role,omitempty" json:"requires_role,omitempty"`
 	// IDField is the resolved primary-key field name for items returned by this
 	// endpoint, populated either by a path-item-level `x-resource-id` extension,
 	// a resource member path parameter that also appears in the response item,
@@ -2948,6 +2982,9 @@ func (s *APISpec) Validate() error {
 	if err := validateAuthCompanion(s.Auth); err != nil {
 		return err
 	}
+	if err := validateRoles(s); err != nil {
+		return err
+	}
 	if err := validateAuthEnvVarSpecs("auth", s.Auth); err != nil {
 		return err
 	}
@@ -3630,6 +3667,103 @@ func validateEndpointResponseFormat(e Endpoint) error {
 		}
 	}
 	return nil
+}
+
+func validateRoles(s *APISpec) error {
+	if s == nil {
+		return nil
+	}
+	roles := make(map[string]struct{}, len(s.Roles))
+	personas := make(map[string]string, len(s.Roles))
+	normalized := make([]string, 0, len(s.Roles))
+	for _, role := range s.Roles {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			return fmt.Errorf("roles cannot contain empty values")
+		}
+		if !validRoleName(role) {
+			return fmt.Errorf("role %q must match ^[A-Za-z][A-Za-z0-9_-]*$", role)
+		}
+		if _, exists := roles[role]; exists {
+			return fmt.Errorf("role %q is declared more than once", role)
+		}
+		persona := rolePersonaSuffix(role)
+		if existing, exists := personas[persona]; exists {
+			return fmt.Errorf("roles %q and %q produce duplicate Persona%s constants", existing, role, persona)
+		}
+		roles[role] = struct{}{}
+		personas[persona] = role
+		normalized = append(normalized, role)
+	}
+	s.Roles = normalized
+
+	checkEndpoint := func(context string, endpoint Endpoint) error {
+		role := strings.TrimSpace(endpoint.RequiresRole)
+		if role == "" {
+			return nil
+		}
+		if !validRoleName(role) {
+			return fmt.Errorf("%s requires_role %q must match ^[A-Za-z][A-Za-z0-9_-]*$", context, role)
+		}
+		if len(roles) == 0 {
+			return fmt.Errorf("%s requires_role %q but roles is empty", context, role)
+		}
+		if _, ok := roles[role]; !ok {
+			return fmt.Errorf("%s requires_role %q is not declared in roles", context, role)
+		}
+		return nil
+	}
+	for rName, resource := range s.Resources {
+		if err := validateResourceRoles(fmt.Sprintf("resource %q", rName), resource, checkEndpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateResourceRoles(context string, resource Resource, checkEndpoint func(string, Endpoint) error) error {
+	for eName, endpoint := range resource.Endpoints {
+		if err := checkEndpoint(fmt.Sprintf("%s endpoint %q", context, eName), endpoint); err != nil {
+			return err
+		}
+	}
+	for subName, sub := range resource.SubResources {
+		if err := validateResourceRoles(fmt.Sprintf("%s sub-resource %q", context, subName), sub, checkEndpoint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validRoleName(role string) bool {
+	if role == "" {
+		return false
+	}
+	for i, r := range role {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		case i > 0 && (r == '_' || r == '-'):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func rolePersonaSuffix(role string) string {
+	parts := strings.FieldsFunc(role, func(r rune) bool {
+		return r == '_' || r == '-' || !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		lower := strings.ToLower(part)
+		parts[i] = strings.ToUpper(lower[:1]) + lower[1:]
+	}
+	return strings.Join(parts, "")
 }
 
 func validateDataSourceStrategy(context, strategy string) error {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -1902,6 +1902,119 @@ resources:
 	})
 }
 
+func TestEndpointRequiresRole(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: role-api
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: api_key
+  header: Authorization
+  env_vars: [ROLE_API_TOKEN]
+roles: [parent, student, teacher, admin]
+config:
+  format: toml
+resources:
+  users:
+    endpoints:
+      list:
+        method: GET
+        path: /users
+        requires_role: admin
+`)
+
+	s, err := ParseBytes(yamlSpec)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"parent", "student", "teacher", "admin"}, s.Roles)
+	assert.Equal(t, "admin", s.Resources["users"].Endpoints["list"].RequiresRole)
+}
+
+func TestEndpointRequiresRoleMustBeDeclared(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: role-api
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: api_key
+  header: Authorization
+  env_vars: [ROLE_API_TOKEN]
+roles: [parent]
+config:
+  format: toml
+resources:
+  users:
+    endpoints:
+      list:
+        method: GET
+        path: /users
+        requires_role: admin
+`)
+
+	_, err := ParseBytes(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `requires_role "admin" is not declared in roles`)
+}
+
+func TestEndpointRequiresRoleMustBeDeclaredInNestedSubResource(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: role-api
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+roles: [parent]
+config:
+  format: toml
+resources:
+  schools:
+    sub_resources:
+      classes:
+        sub_resources:
+          assignments:
+            endpoints:
+              list:
+                method: GET
+                path: /schools/{school_id}/classes/{class_id}/assignments
+                requires_role: admin
+`)
+
+	_, err := ParseBytes(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `sub-resource "classes" sub-resource "assignments" endpoint "list" requires_role "admin" is not declared in roles`)
+}
+
+func TestEndpointRolePersonaConstantsMustBeUnique(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: role-api
+version: "1.0"
+base_url: https://api.example.com
+auth:
+  type: none
+roles: [site-admin, site_admin]
+config:
+  format: toml
+resources:
+  users:
+    endpoints:
+      list:
+        method: GET
+        path: /users
+        requires_role: site-admin
+`)
+
+	_, err := ParseBytes(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate PersonaSiteAdmin constants`)
+}
+
 func TestEndpointIDFieldAndCritical(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Specs can now declare authenticated persona roles and mark individual endpoints with the role they require. Generated endpoint commands fail locally with exit 2 before client construction when the authenticated role is unknown or mismatched, so protected endpoints no longer fall through to upstream generic authorization failures.

The same gate is applied to agent-facing endpoint paths: typed MCP tools, code-orchestration execute, and MCP intent dispatch all run the generated role check before creating an API client. Role evidence can come from the generated config/env field or an API-specific resolver hook, and persisted role state is cleared or ignored when credentials change through auth commands, env credentials, or the secrets bus.

Closes #1408

## Verification

- `go fmt ./...`
- `go test ./internal/spec ./internal/openapi ./internal/generator`
- `go test ./internal/spec ./internal/openapi ./internal/generator -run 'TestEndpointRequiresRole|TestParseRequiresRoleExtension|TestRequiresRole'`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
