### PR TITLE
fix(ci): add generated output compile gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,12 +52,17 @@ N/A
 ## Output Contract
 
 <!-- Required only if this PR changes templates, generated files, manifests, command output, MCP schemas, scorecard output, catalog rendering, or pipeline artifacts. Otherwise write "N/A". -->
+<!-- For generator/template changes, name the generated-output evidence: emitted-code assertion, compiled generated CLI case, golden fixture, or why the existing cases are sufficient. -->
 
 N/A
 
 ## Verification
 
 <!-- List commands actually run. Say "Not run" with a reason if not run. -->
+
+- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
+- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
+- [ ] Generator/template change: checked emitted definitions and call sites for matching gates
 
 ## AI / Automation Disclosure
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -92,7 +92,7 @@ jobs:
               esac
 
               case "$file" in
-                .github/workflows/main-ci.yml|scripts/verify-generator-output.sh|internal/generator/*|internal/openapi/*|testdata/golden/cases/generate-*|testdata/golden/fixtures/*|go.mod|go.sum)
+                .github/workflows/main-ci.yml|scripts/verify-generator-output.sh|cmd/*|internal/generator/*|internal/openapi/*|testdata/golden/cases/generate-*|testdata/golden/fixtures/*|go.mod|go.sum)
                   needs_generated_output=true
                   ;;
               esac

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -34,6 +34,7 @@ jobs:
       needs_build: ${{ steps.changes.outputs.needs_build }}
       needs_tests: ${{ steps.changes.outputs.needs_tests }}
       needs_golden: ${{ steps.changes.outputs.needs_golden }}
+      needs_generated_output: ${{ steps.changes.outputs.needs_generated_output }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -48,6 +49,7 @@ jobs:
           needs_build=false
           needs_tests=false
           needs_golden=false
+          needs_generated_output=false
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
             # Keep the post-merge alarm full-strength on main. PRs get the
@@ -55,6 +57,7 @@ jobs:
             needs_build=true
             needs_tests=true
             needs_golden=true
+            needs_generated_output=true
           else
             git fetch --no-tags --prune origin "${{ github.base_ref }}"
             mapfile -t changed < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
@@ -68,6 +71,7 @@ jobs:
                   needs_build=true
                   needs_tests=true
                   needs_golden=true
+                  needs_generated_output=true
                   ;;
                 *.go|go.mod|go.sum|cmd/*|catalog/*|internal/*)
                   needs_build=true
@@ -86,6 +90,12 @@ jobs:
                   needs_golden=true
                   ;;
               esac
+
+              case "$file" in
+                .github/workflows/main-ci.yml|scripts/verify-generator-output.sh|internal/generator/*|internal/openapi/*|testdata/golden/cases/generate-*|testdata/golden/fixtures/*|go.mod|go.sum)
+                  needs_generated_output=true
+                  ;;
+              esac
             done
           fi
 
@@ -93,6 +103,7 @@ jobs:
             echo "needs_build=$needs_build"
             echo "needs_tests=$needs_tests"
             echo "needs_golden=$needs_golden"
+            echo "needs_generated_output=$needs_generated_output"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -101,6 +112,7 @@ jobs:
             echo "- build: \`$needs_build\`"
             echo "- tests: \`$needs_tests\`"
             echo "- golden: \`$needs_golden\`"
+            echo "- generated-output: \`$needs_generated_output\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   full-build:
@@ -163,6 +175,26 @@ jobs:
       - name: Verify golden fixtures
         run: bash scripts/golden.sh verify
 
+  generated_output_compile:
+    name: generated-output-compile
+    runs-on: ubuntu-latest
+    needs: classify
+    if: needs.classify.outputs.needs_generated_output == 'true'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Compile generated CLI outputs
+        run: bash scripts/verify-generator-output.sh
+
   build-and-test:
     runs-on: ubuntu-latest
     needs:
@@ -170,6 +202,7 @@ jobs:
       - full-build
       - full-test
       - full-golden
+      - generated_output_compile
     if: ${{ always() }}
     timeout-minutes: 5
     steps:
@@ -192,8 +225,13 @@ jobs:
             echo "full-golden failed or was cancelled."
             exit 1
           fi
+          if [[ "${{ needs.classify.outputs.needs_generated_output }}" == "true" && "${{ needs.generated_output_compile.result }}" != "success" ]]; then
+            echo "generated-output-compile failed or was cancelled."
+            exit 1
+          fi
 
           echo "Full-suite scope:"
           echo "  build=${{ needs.classify.outputs.needs_build }} result=${{ needs.full-build.result }}"
           echo "  tests=${{ needs.classify.outputs.needs_tests }} result=${{ needs.full-test.result }}"
           echo "  golden=${{ needs.classify.outputs.needs_golden }} result=${{ needs.full-golden.result }}"
+          echo "  generated-output=${{ needs.classify.outputs.needs_generated_output }} result=${{ needs.generated_output_compile.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,20 @@ Run `scripts/golden.sh verify` whenever a change may affect CLI command output, 
 Never update goldens just to make a failing check pass. Run `scripts/golden.sh update` only when the behavior change is intentional, then inspect the diff and explain it in your final response. See [`docs/GOLDEN.md`](docs/GOLDEN.md) for the decision rubric, fixture conventions, and failure handling.
 When adding a new deterministic CLI behavior or generated artifact contract, explicitly decide whether the golden suite needs a new or expanded fixture. A passing `scripts/golden.sh verify` on existing cases does not prove coverage for new auth, pagination, MCP, manifest, naming, or similar deterministic generation behavior.
 
+### Generator fixes require generated-output proof
+When touching `internal/generator/**`, `internal/openapi/**`, generator templates, parser-derived fields, MCP descriptions, naming, auth emission, or SKILL.md skeletons, verify the generated CLI behavior, not only the Printing Press source or template text.
+
+Required before handoff:
+- Run `go test ./...`, not only scoped `-run` tests. Scoped tests plus `scripts/golden.sh verify` are not enough for conditional or fallback branches.
+- Run `scripts/golden.sh verify` when output shape may change.
+- Run `scripts/verify-generator-output.sh` for generator/template changes that can alter emitted Go. Pass extra golden case names when the default cases do not exercise the affected variant.
+- Add or update a generated-output test when the fix changes an emitted contract. Prefer assertions on emitted code or compile-level behavior over assertions on template source.
+- Cover the fallback shape affected by the fix: missing defaults, missing summaries, envelope responses, promoted templates, endpoint templates, or every generated file involved.
+- When changing an emitted definition, grep for call sites and gate them with the same condition. When changing data flow, check dependent reporting and consumers.
+- Prefer established generator idioms: `oneline` / `OneLineNormalize` / `printf "%q"` for emitted literals, and `text/template.IsTrue` or a shared helper when Go code mirrors template truthiness.
+
+If the "obvious" fix violates a parser, verifier, scorer, or printed-CLI invariant, stop and resolve the invariant conflict rather than shipping a narrow band-aid.
+
 ## Cross-repo dependency: published-library sweep tool
 
 When a change to `internal/generator/templates/readme.md.tmpl` or `skill.md.tmpl` shifts canonical published-library shape — install-block structure, top-of-README section ordering, presence or removal of `## ` sections, frontmatter top-level field set, install command syntax — also update `tools/sweep-canonical/main.go` in [`mvanhorn/printing-press-library`](https://github.com/mvanhorn/printing-press-library) so the already-published CLIs can be retrofitted to match. Fresh prints from this generator will produce the new shape automatically, but every existing entry in the public library silently drifts from canonical shape until the sweep retrofit runs.

--- a/docs/GOLDEN.md
+++ b/docs/GOLDEN.md
@@ -10,6 +10,8 @@ Golden cases must be deterministic, offline, and auth-free. Do not add cases tha
 
 Passing `scripts/golden.sh verify` only proves existing fixtures did not drift. It does not prove golden coverage is complete. When adding a new deterministic CLI behavior or artifact contract, explicitly decide whether the golden suite needs a new or expanded case. Add golden coverage when the behavior is user-visible command output or persisted generated artifacts that should remain stable across refactors. Prefer unit tests for narrow helper logic, branchy internals, or cases where a golden snapshot would duplicate a focused package test without proving a CLI-level contract.
 
+Golden verification is byte-level, not compile-level. It can miss generator bugs where a template emits a call without its matching definition, or where the changed branch is not captured by the expected artifact subset. For generator/template changes that can alter emitted Go, also run `scripts/verify-generator-output.sh` so representative generated CLIs are built with `go build ./...`. Pass the specific golden case names that cover the touched variant when the default case set is not enough.
+
 ## Decision rubric
 
 - **No golden update:** code changed but the captured external behavior is intentionally identical. Run `scripts/golden.sh verify`; it should pass unchanged.

--- a/docs/solutions/best-practices/verifying-generator-fixes-at-output-level-2026-05-25.md
+++ b/docs/solutions/best-practices/verifying-generator-fixes-at-output-level-2026-05-25.md
@@ -1,0 +1,64 @@
+---
+title: "Verifying generator fixes at the generated-output level"
+date: 2026-05-25
+category: best-practices
+module: generator
+problem_type: best_practice
+component: generator
+severity: medium
+applies_when:
+  - "Authoring a fix in internal/generator, templates, parser, mcpdesc, naming, or SKILL.md generation skeletons"
+  - "Reviewing or dispatching an agent to fix a generator or template bug"
+tags:
+  - generator
+  - templates
+  - testing
+  - golden
+  - code-review
+  - agent-authoring
+related_components:
+  - generator
+  - templates
+  - testing
+---
+
+# Verifying generator fixes at the generated-output level
+
+## Context
+
+The Printing Press is a two-layer system: templates emit Go source, and the real behavior is in the generated code, not the template text.
+
+Generator/template fixes can compile and pass a scoped unit test while still emitting broken CLI code. The common gap is between "what the template says" and "what the generated code does." Fast gates such as scoped `go test -run ...` and `scripts/golden.sh verify` can under-cover fallback or conditional branches:
+
+- Golden fixtures often carry happy shapes: defaults are present, operations have summaries, and response envelopes are simple.
+- Scoped package tests may pass while another generated package fails to compile.
+- Snapshotting a generated file does not prove all emitted files agree on the same condition.
+
+## Recurring Failure Modes
+
+1. **Half of a two-sided contract.** A fix changes an emitted helper, definition, or data flow but not the consumer under the same condition.
+2. **Hand-rolled behavior where the codebase has an idiom.** Examples include interpolating spec text into Go literals without `oneline` / `printf "%q"`, or using append semantics where sibling branches overwrite.
+3. **Go predicates that do not match template truthiness.** For example, `p.Default == nil` can drift from template `(not .Default)` semantics.
+4. **Over-broad scope.** A CLI-level guard or unconditional branch can break a related surface such as MCP, read commands, or promoted commands.
+5. **Symptom fixes that violate invariants.** A placeholder or fallback may satisfy one review comment while breaking parser, verifier, scorer, or printed-CLI rules.
+
+## Verification Contract
+
+Apply these whenever a change alters what the generator emits:
+
+- Run `go test ./...`, not only a scoped `-run` test.
+- Run `scripts/golden.sh verify` when output shape may change.
+- Run `scripts/verify-generator-output.sh` to generate representative CLI cases and compile the emitted modules with `go build ./...`.
+- Generate from a spec and assert on emitted code or compiled generated output, not only template text.
+- Assert statement kind, not only substrings. For example, check for `return fmt.Errorf(` and `NotContains` the old warning-only form when the behavior is supposed to become fatal.
+- Cover the affected template variants and fallback shapes: endpoint and promoted templates, missing defaults, missing summaries, envelope responses, and every generated file that participates in the contract.
+- When changing an emitted definition, grep for call sites and gate them identically.
+- Use established idioms: `oneline` / `OneLineNormalize` / `printf "%q"` for literals, `text/template.IsTrue` or shared helpers for template truthiness, and sibling-branch semantics for request mutation.
+- Check system invariants before committing to the obvious fix.
+
+## Structural Prevention
+
+- Keep fallback-shape golden fixtures for no-default positionals, summary-less operations, and envelope responses.
+- Prefer generated-output tests that compile or execute emitted code for bug shapes that span multiple generated files.
+- Make PRs name their generated-output evidence in the Output Contract and Verification sections.
+- Treat independent code review as a required guard for generator fixes, not a cleanup step after local green.

--- a/scripts/verify-generator-output.sh
+++ b/scripts/verify-generator-output.sh
@@ -86,6 +86,7 @@ fi
 binary="./cli-printing-press"
 echo "Building $binary"
 go build -o "$binary" ./cmd/cli-printing-press
+trap 'rm -f "$binary"' EXIT
 
 if [[ "$keep" != "true" ]]; then
   rm -rf "$output_root"

--- a/scripts/verify-generator-output.sh
+++ b/scripts/verify-generator-output.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/verify-generator-output.sh [--list] [--keep] [--output-dir DIR] [case ...]
+
+Generates selected golden cases into .gotmp/generator-output-compile, runs
+`go mod tidy`, then runs `go build ./...` inside every generated Go module. Use
+this after generator or template changes to catch emit/call mismatches that
+source-level tests and byte-level goldens can miss.
+
+When no case is supplied, a focused default set covers endpoint templates,
+MCP/code-orchestration, rich auth, GraphQL shared endpoints, and learn-loop
+emission. Pass extra case names when a fix touches another generated variant.
+USAGE
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cases_root="testdata/golden/cases"
+output_root="${GENERATOR_OUTPUT_VERIFY_DIR:-.gotmp/generator-output-compile}"
+keep=false
+golden_owner="printing-press-golden"
+
+# Match the generated-CLI compile-test environment used by Go TestMain files.
+# The generator consults PRINTING_PRESS_AGENTCOOKIE_REPLACE while emitting
+# go.mod, which lets local/CI verification compile without private repo access.
+if [[ -z "${GOPRIVATE:-}" ]]; then
+  export GOPRIVATE="github.com/mvanhorn/*"
+fi
+if [[ -z "${PRINTING_PRESS_AGENTCOOKIE_REPLACE:-}" ]]; then
+  export PRINTING_PRESS_AGENTCOOKIE_REPLACE="$repo_root/internal/testdata/agentcookie"
+fi
+
+default_cases=(
+  generate-golden-api
+  generate-golden-api-rich-auth
+  generate-mcp-api
+  generate-graphql-shared-endpoint
+  generate-learn-loop-api
+)
+
+cases=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --list)
+      find "$cases_root" -mindepth 1 -maxdepth 1 -type d -name 'generate-*' -print |
+        sed "s|^$cases_root/||" |
+        sort
+      exit 0
+      ;;
+    --keep)
+      keep=true
+      shift
+      ;;
+    --output-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "--output-dir requires a value" >&2
+        exit 2
+      fi
+      output_root="$2"
+      shift 2
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      cases+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#cases[@]}" -eq 0 ]]; then
+  cases=("${default_cases[@]}")
+fi
+
+binary="./cli-printing-press"
+echo "Building $binary"
+go build -o "$binary" ./cmd/cli-printing-press
+
+if [[ "$keep" != "true" ]]; then
+  rm -rf "$output_root"
+fi
+mkdir -p "$output_root"
+
+failures=0
+for case_name in "${cases[@]}"; do
+  case_dir="$cases_root/$case_name"
+  command_file="$case_dir/command.txt"
+  case_output="$output_root/$case_name"
+
+  if [[ ! -f "$command_file" ]]; then
+    echo "FAIL $case_name: missing $command_file" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "Generating $case_name"
+  rm -rf "$case_output"
+  mkdir -p "$case_output"
+
+  command_text="$(cat "$command_file")"
+  if ! BINARY="$binary" CASE_ACTUAL_DIR="$case_output" REPO_ROOT="$repo_root" \
+    GIT_CONFIG_COUNT=2 \
+    GIT_CONFIG_KEY_0=github.user \
+    GIT_CONFIG_VALUE_0="$golden_owner" \
+    GIT_CONFIG_KEY_1=user.name \
+    GIT_CONFIG_VALUE_1="$golden_owner" \
+    bash -c "$command_text"; then
+    echo "FAIL $case_name: generation command failed" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  module_count=0
+  while IFS= read -r gomod; do
+    module_count=$((module_count + 1))
+    module_dir="$(dirname "$gomod")"
+    echo "Tidying generated module ${module_dir#$repo_root/}"
+    if ! (cd "$module_dir" && go mod tidy); then
+      echo "FAIL $case_name: go mod tidy failed in $module_dir" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    echo "Building generated module ${module_dir#$repo_root/}"
+    if ! (cd "$module_dir" && go build ./...); then
+      echo "FAIL $case_name: go build ./... failed in $module_dir" >&2
+      failures=$((failures + 1))
+    fi
+  done < <(find "$case_output" -name go.mod -type f -print | sort)
+
+  if [[ "$module_count" -eq 0 ]]; then
+    echo "FAIL $case_name: no generated go.mod found under $case_output" >&2
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "Generated-output verification failed: $failures failure(s)."
+  echo "Outputs: $output_root"
+  exit 1
+fi
+
+echo "Generated-output verification passed for ${#cases[@]} case(s)."


### PR DESCRIPTION
## Intent

Prevent generator/template fixes from reaching review with only source-level or byte-level proof when the failure mode lives in generated Go output.

Issue:

N/A

## Approach

Adds a generated-output verification path that generates representative golden cases, runs `go mod tidy`, and compiles the emitted modules with `go build ./...`. The default case set covers endpoint templates, rich auth, MCP/code orchestration, GraphQL shared endpoints, and learn-loop emission.

Documents the requirement in AGENTS.md and docs/GOLDEN.md, records the recommendation as a solutions doc, and adds PR-template prompts so reviewers can see generated-output evidence explicitly.

Main CI now runs the generated-output compile job for generator/openapi/golden-fixture-shaped changes.

## Scope

Primary area:

CI and generator verification workflow.

Why this belongs in this repo:

This repo owns the Printing Press generator and templates that emit printed CLIs. The failure mode is generator-level: changes can pass local source tests while producing uncompilable or internally inconsistent generated CLI code.

## Catalog Justification

N/A

## Risk

The new CI job adds time for generator-shaped changes. It is path-gated and uses a focused default case set rather than compiling every golden generation case.

Workflow changes were checked with the local supply-chain scanner and actionlint.

## Output Contract

No generated CLI output contract changes. This PR adds a verification command and CI gate for future generator-output changes.

Generator/template evidence added:

- `scripts/verify-generator-output.sh` compiles generated CLI modules from deterministic golden cases.
- Main CI invokes the script when generator/openapi/golden fixture paths change.
- AGENTS.md and the PR template now require generated-output evidence for future generator/template changes.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `scripts/verify-generator-output.sh --list`
- `bash -n scripts/verify-generator-output.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main-ci.yml"); YAML.load_file(".github/workflows/golden.yml"); puts "workflow yaml ok"'`
- `scripts/verify-generator-output.sh generate-graphql-shared-endpoint`
- `scripts/verify-generator-output.sh`
- `python3 .github/scripts/verify-supply-chain/scan.py --base-ref origin/main`
- `cd .github/scripts/verify-supply-chain && python3 -m unittest scan_test`
- `actionlint .github/workflows/main-ci.yml`
- `git diff --check`
- `go test ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
