### PR TITLE
fix(cli): detect turnstile reachability interstitials

### DIFF
--- a/internal/reachability/detect.go
+++ b/internal/reachability/detect.go
@@ -57,8 +57,7 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 		strings.Contains(body, "<html") ||
 		strings.Contains(body, "<script") ||
 		strings.Contains(body, "<div")
-	turnstileBody := htmlBody && (strings.Contains(body, "challenges.cloudflare.com/turnstile") ||
-		strings.Contains(body, "cf-turnstile"))
+	turnstileBody := htmlBody && strings.Contains(body, "challenges.cloudflare.com/turnstile")
 	cfChallengeBody := strings.Contains(body, "cf-chl") ||
 		turnstileBody ||
 		strings.Contains(body, "just a moment") ||

--- a/internal/reachability/detect.go
+++ b/internal/reachability/detect.go
@@ -14,7 +14,7 @@ type Protection struct {
 }
 
 // classifyResponse returns protection signals detected in the response.
-// bodySnippet is expected to be a small (~4KB) lowercased read of the
+// bodySnippet is expected to be a bounded lowercased read of the
 // response body — full body reads would be wasteful for large pages.
 func classifyResponse(status int, headers http.Header, bodySnippet string) []Protection {
 	var out []Protection
@@ -52,10 +52,16 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	// DataDome and PerimeterX header presence stays a strong signal — those
 	// products only ship as bot mitigation, not as plain CDN.
 	cfFingerprint := strings.Contains(server, "cloudflare") || h["cf-ray"] != ""
+	turnstileBody := strings.Contains(body, "challenges.cloudflare.com/turnstile") ||
+		strings.Contains(body, "cf-turnstile")
+	cfInterstitialBody := strings.Contains(body, "you will be forwarded to the requested page") &&
+		(cfFingerprint || turnstileBody)
 	cfChallengeBody := strings.Contains(body, "cf-chl") ||
+		turnstileBody ||
 		strings.Contains(body, "just a moment") ||
 		strings.Contains(body, "checking your browser") ||
-		strings.Contains(body, "ddos protection by cloudflare")
+		strings.Contains(body, "ddos protection by cloudflare") ||
+		cfInterstitialBody
 	akamaiFingerprint := h["x-akamai-transformed"] != ""
 
 	switch {
@@ -71,8 +77,13 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 		out = append(out, Protection{Label: "perimeterx", Evidence: "PerimeterX marker"})
 	}
 
-	if strings.Contains(body, "recaptcha") || strings.Contains(body, "hcaptcha") ||
-		strings.Contains(body, "g-recaptcha") {
+	switch {
+	case turnstileBody || cfInterstitialBody:
+		out = append(out, Protection{Label: "captcha", Evidence: "Cloudflare Turnstile interstitial"})
+	case strings.Contains(body, "fill out the captcha to unblock"):
+		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA unblock shell"})
+	case strings.Contains(body, "recaptcha") || strings.Contains(body, "hcaptcha") ||
+		strings.Contains(body, "g-recaptcha"):
 		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA widget"})
 	}
 

--- a/internal/reachability/detect.go
+++ b/internal/reachability/detect.go
@@ -52,16 +52,18 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	// DataDome and PerimeterX header presence stays a strong signal — those
 	// products only ship as bot mitigation, not as plain CDN.
 	cfFingerprint := strings.Contains(server, "cloudflare") || h["cf-ray"] != ""
-	turnstileBody := strings.Contains(body, "challenges.cloudflare.com/turnstile") ||
-		strings.Contains(body, "cf-turnstile")
-	cfInterstitialBody := strings.Contains(body, "you will be forwarded to the requested page") &&
-		(cfFingerprint || turnstileBody)
+	contentType := h["content-type"]
+	htmlBody := strings.Contains(contentType, "html") ||
+		strings.Contains(body, "<html") ||
+		strings.Contains(body, "<script") ||
+		strings.Contains(body, "<div")
+	turnstileBody := htmlBody && (strings.Contains(body, "challenges.cloudflare.com/turnstile") ||
+		strings.Contains(body, "cf-turnstile"))
 	cfChallengeBody := strings.Contains(body, "cf-chl") ||
 		turnstileBody ||
 		strings.Contains(body, "just a moment") ||
 		strings.Contains(body, "checking your browser") ||
-		strings.Contains(body, "ddos protection by cloudflare") ||
-		cfInterstitialBody
+		strings.Contains(body, "ddos protection by cloudflare")
 	akamaiFingerprint := h["x-akamai-transformed"] != ""
 
 	switch {
@@ -78,7 +80,7 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	}
 
 	switch {
-	case turnstileBody || cfInterstitialBody:
+	case turnstileBody:
 		out = append(out, Protection{Label: "captcha", Evidence: "Cloudflare Turnstile interstitial"})
 	case strings.Contains(body, "fill out the captcha to unblock"):
 		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA unblock shell"})

--- a/internal/reachability/detect_test.go
+++ b/internal/reachability/detect_test.go
@@ -62,6 +62,17 @@ func TestClassifyResponse(t *testing.T) {
 			emptyResult: true,
 		},
 		{
+			name:   "cloudflare forwarding notice without turnstile is not a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Cf-Ray":       {"abc123"},
+				"Server":       {"cloudflare"},
+				"Content-Type": {"text/html"},
+			},
+			body:        "<html><p>You will be forwarded to the requested page shortly.</p></html>",
+			emptyResult: true,
+		},
+		{
 			name:   "cloudflare CDN on error response is a protection signal",
 			status: 503,
 			headers: http.Header{
@@ -85,6 +96,17 @@ func TestClassifyResponse(t *testing.T) {
 			wantLabels: []string{"cloudflare", "captcha"},
 		},
 		{
+			name:   "cloudflare turnstile widget on 200 is a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Cf-Ray":       {"abc123"},
+				"Server":       {"cloudflare"},
+				"Content-Type": {"text/html"},
+			},
+			body:       `<html><div class="cf-turnstile" data-sitekey="site"></div></html>`,
+			wantLabels: []string{"cloudflare", "captcha"},
+		},
+		{
 			name:   "captcha unblock shell on 200 is a protection signal",
 			status: 200,
 			headers: http.Header{
@@ -98,6 +120,13 @@ func TestClassifyResponse(t *testing.T) {
 			status:      200,
 			headers:     http.Header{"Content-Type": {"application/json"}},
 			body:        `{"turnstile":false,"captcha_required":false}`,
+			emptyResult: true,
+		},
+		{
+			name:        "cf-turnstile key in normal json is not a protection signal",
+			status:      200,
+			headers:     http.Header{"Content-Type": {"application/json"}},
+			body:        `{"cf-turnstile":false,"captcha_required":false}`,
 			emptyResult: true,
 		},
 		{

--- a/internal/reachability/detect_test.go
+++ b/internal/reachability/detect_test.go
@@ -73,6 +73,34 @@ func TestClassifyResponse(t *testing.T) {
 			wantLabels: []string{"cloudflare"},
 		},
 		{
+			name:   "cloudflare turnstile interstitial on 200 is a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Cf-Ray":       {"abc123"},
+				"Server":       {"cloudflare"},
+				"Content-Type": {"text/html"},
+			},
+			body: `<html><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+				<p>You will be forwarded to the requested page shortly.</p></html>`,
+			wantLabels: []string{"cloudflare", "captcha"},
+		},
+		{
+			name:   "captcha unblock shell on 200 is a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Content-Type": {"text/html"},
+			},
+			body:       "<html><p>Fill out the captcha to unblock this page.</p></html>",
+			wantLabels: []string{"captcha"},
+		},
+		{
+			name:        "turnstile word in normal json is not a protection signal",
+			status:      200,
+			headers:     http.Header{"Content-Type": {"application/json"}},
+			body:        `{"turnstile":false,"captcha_required":false}`,
+			emptyResult: true,
+		},
+		{
 			name:   "aws waf token",
 			status: 403,
 			headers: http.Header{

--- a/internal/reachability/detect_test.go
+++ b/internal/reachability/detect_test.go
@@ -96,15 +96,15 @@ func TestClassifyResponse(t *testing.T) {
 			wantLabels: []string{"cloudflare", "captcha"},
 		},
 		{
-			name:   "cloudflare turnstile widget on 200 is a protection signal",
+			name:   "cf-turnstile widget markup without script is not a protection signal",
 			status: 200,
 			headers: http.Header{
 				"Cf-Ray":       {"abc123"},
 				"Server":       {"cloudflare"},
 				"Content-Type": {"text/html"},
 			},
-			body:       `<html><div class="cf-turnstile" data-sitekey="site"></div></html>`,
-			wantLabels: []string{"cloudflare", "captcha"},
+			body:        `<html><div class="cf-turnstile" data-sitekey="site"></div></html>`,
+			emptyResult: true,
 		},
 		{
 			name:   "captcha unblock shell on 200 is a protection signal",

--- a/internal/reachability/probe.go
+++ b/internal/reachability/probe.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultTimeout = 15 * time.Second
-	bodyReadCap    = 4 * 1024 // bytes scanned for protection markers
+	bodyReadCap    = 32 * 1024 // bytes scanned for protection markers
 )
 
 // Options configures Probe.

--- a/internal/reachability/probe_test.go
+++ b/internal/reachability/probe_test.go
@@ -82,6 +82,19 @@ func cloudflareChallenge(_ *http.Request) (*http.Response, error) {
 	}, nil
 }
 
+func turnstileInterstitial(_ *http.Request) (*http.Response, error) {
+	body := strings.Repeat(" ", 20*1024) + `<html><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script><p>You will be forwarded to the requested page shortly.</p></html>`
+	return &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"Cf-Ray":       {"abc123"},
+			"Server":       {"cloudflare"},
+			"Content-Type": {"text/html"},
+		},
+		Body: respBody(body),
+	}, nil
+}
+
 func respBody(s string) *bodyCloser {
 	return &bodyCloser{r: strings.NewReader(s)}
 }
@@ -140,6 +153,18 @@ func TestProbe_BothChallenged_RecommendsBrowserCapture(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, ModeBrowserClearanceHTTP, result.Mode)
+	assert.True(t, result.Recommendation.NeedsBrowserCapture)
+	assert.True(t, result.Recommendation.NeedsClearanceCookie)
+}
+
+func TestProbe_BothTurnstileInterstitials_RecommendsBrowserCapture(t *testing.T) {
+	result, err := Probe(context.Background(), "https://example.com", Options{
+		HTTPClientFactory: fakeFactory(turnstileInterstitial, turnstileInterstitial),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ModeBrowserClearanceHTTP, result.Mode)
+	assert.Equal(t, 200, result.Probes[0].Status)
+	assert.NotEmpty(t, result.Probes[0].Evidence)
 	assert.True(t, result.Recommendation.NeedsBrowserCapture)
 	assert.True(t, result.Recommendation.NeedsClearanceCookie)
 }


### PR DESCRIPTION
## Summary

`probe-reachability` now treats HTTP 200 Cloudflare Turnstile and CAPTCHA interstitial bodies as bot-protection evidence instead of a clean `standard_http` pass. That lets the Phase 1.9 gate stop early and route browser-clearance capture when both stdlib and Surf receive the interstitial.

The body scan cap is raised to cover small challenge shells where the signature appears after the first few KiB, while normal JSON that merely mentions Turnstile remains unclassified.

## Tests

- `go test ./internal/reachability`
- `go test ./internal/reachability ./internal/cli`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Closes #2140
