### PR TITLE
docs(skills): require compound tool redirect guidance

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -1595,15 +1595,18 @@ The transcendence table in the manifest (Step 1.5d) renders rows in this shape,
 which mirrors the subagent's `### Survivors` output. The `Buildability` column
 tags each row `spec-emits` or `hand-code` per
 [references/novel-features-subagent.md](references/novel-features-subagent.md)
-so the Phase Gate 1.5 hand-code count has a source of truth in the manifest:
+so the Phase Gate 1.5 hand-code count has a source of truth in the manifest.
+The optional `Long Description` column carries agent-facing disambiguation
+text for Phase 3 Cobra `Long` fields; use `none` when no sibling redirect is
+needed:
 
 ```markdown
 ### Transcendence (only possible with our approach)
-| # | Feature | Command | Buildability | Why Only We Can Do This |
-|---|---------|---------|--------------|------------------------|
-| 1 | Bottleneck detection | bottleneck | hand-code | Requires local join across issues + assignees + cycle data |
-| 2 | Velocity trends | velocity --weeks 4 | hand-code | Requires historical cycle snapshots in SQLite |
-| 3 | What did I miss | since 2h | hand-code | Requires time-windowed aggregation no single API call provides |
+| # | Feature | Command | Buildability | Why Only We Can Do This | Long Description |
+|---|---------|---------|--------------|------------------------|------------------|
+| 1 | Bottleneck detection | bottleneck | hand-code | Requires local join across issues + assignees + cycle data | Use this command to find cross-team work blockage. Do NOT use it for personal recency checks; use 'since' instead. |
+| 2 | Velocity trends | velocity --weeks 4 | hand-code | Requires historical cycle snapshots in SQLite | none |
+| 3 | What did I miss | since 2h | hand-code | Requires time-windowed aggregation no single API call provides | Use this command for recent personal changes. Do NOT use it for backlog bottlenecks; use 'bottleneck' instead. |
 ```
 
 Minimum 5 transcendence features. These are the commands that differentiate the CLI.
@@ -1711,8 +1714,9 @@ For each tool, fill in what you know from the research. Stars and command_count 
 5. `example` is a ready-to-run invocation an agent can copy-paste. Use realistic arguments from the API's domain (e.g. `AAPL`, `customer_42`), not `<placeholder>`. Include the `--agent` flag when the feature benefits from structured output.
 6. `why_it_matters` is a single agent-facing sentence answering "when should I pick this over a generic API call?"
 7. `group` clusters related features under a theme name. Pick 2–5 themes total (e.g. "Local state that compounds", "Agent-native plumbing", "Reachability mitigation"). Use the same `group` string verbatim across features that belong together — exact matches drive README grouping. Leave `group` empty if the CLI has too few novel features to warrant clustering.
-8. If no transcendence features scored >= 5/10, omit the `novel_features` field entirely.
-9. Do not add a feature to `novel_features` merely to expose it through MCP. Any user-facing Cobra command becomes an MCP tool automatically unless it sets `cmd.Annotations["mcp:hidden"] = "true"`.
+8. If the manifest row has a non-`none` `Long Description`, keep that text with the feature implementation notes and use it as the Cobra `Long` field during Phase 3 hand-code. Do not squeeze redirect prose into `description`; `description` stays one-line user-benefit text.
+9. If no transcendence features scored >= 5/10, omit the `novel_features` field entirely.
+10. Do not add a feature to `novel_features` merely to expose it through MCP. Any user-facing Cobra command becomes an MCP tool automatically unless it sets `cmd.Annotations["mcp:hidden"] = "true"`.
 
 **Auth research rule**:
 1. `auth.canonical_env_var` is the single-token credential env var discovered from vendor docs, MCP/source analysis, or dominant SDK/CLI convention (for example `APIFY_TOKEN`, `GITHUB_TOKEN`, `STRIPE_SECRET_KEY`). Omit it when no canonical name is known, when auth is HTTP Basic or another credential pair, or when the auth flow needs richer metadata. Fresh generation reads this env var first and keeps the parser-derived name as a fallback automatically.
@@ -3252,7 +3256,7 @@ func newXxxCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "<leaf-of-Command>",                    // e.g. "stale" for "issues stale"
 		Short:   "<NovelFeature.Description, one line>", // truncate to ~70 chars
-		Long:    "<optional: Description + WhyItMatters>", // omit if Short is enough
+		Long:    "<optional: manifest Long Description, or Description + WhyItMatters>", // omit if Short is enough
 		Example: "  <cli>-pp-cli <Command> --json",       // from NovelFeature.Example
 		Annotations: map[string]string{
 			// Set "mcp:read-only": "true" only when the command does NOT mutate

--- a/skills/printing-press/references/absorb-scoring.md
+++ b/skills/printing-press/references/absorb-scoring.md
@@ -48,9 +48,9 @@ Apply to candidates that survive the kill/keep checks.
 Survivors render as rows in the absorb manifest's transcendence table:
 
 ```markdown
-| # | Feature | Command | Score | Buildability | How It Works | Evidence |
-|---|---------|---------|-------|--------------|--------------|----------|
-| N | Player comparison | compare "LeBron" "Curry" | 8/10 | hand-code | Joins player_stats + team + season tables in local SQLite | ESPN community requests, espn_scraper lacks cross-player queries |
+| # | Feature | Command | Score | Buildability | How It Works | Evidence | Long Description |
+|---|---------|---------|-------|--------------|--------------|----------|------------------|
+| N | Player comparison | compare "LeBron" "Curry" | 8/10 | hand-code | Joins player_stats + team + season tables in local SQLite | ESPN community requests, espn_scraper lacks cross-player queries | Use this command to compare two players. Do NOT use it for team-level comparisons; use 'team compare' instead. |
 ```
 
 The "How It Works" column is the buildability proof — one sentence showing the
@@ -65,6 +65,11 @@ rows from this column when reading out the hand-code commitment.
 
 The "Evidence" column MUST cite specific findings from Phase 1 or Phase 1.5
 research. "Power users would love this" is not evidence.
+
+The "Long Description" column is `none` unless the feature overlaps with a
+sibling command closely enough that an agent may choose the wrong tool. When it
+is populated, it is implementation guidance for the hand-coded Cobra `Long`
+field and must reference only command names that survived the Pass 3 cut.
 
 ## Reprint verdict rules
 

--- a/skills/printing-press/references/novel-features-subagent.md
+++ b/skills/printing-press/references/novel-features-subagent.md
@@ -174,7 +174,8 @@ Sources for candidates (label each candidate with its source):
     suggest.
 
 For each candidate capture: name, command, one-line description, persona
-served, source label from the list above.
+served, source label from the list above, and `Long Description` (`none`
+unless the overlap rule below applies).
 
 When 2+ compound-tool candidates could plausibly match the same natural-language
 request because their input surfaces overlap (for example, user UPN, market ID,
@@ -273,6 +274,11 @@ For EVERY surviving candidate, force-answer these in writing:
      generator emits today (~50-150 LoC per feature plus `root.go`
      wiring). This is the default for transcendence features; most
      candidates fall here.
+6. **Long-description validity:** If the survivor has a planned `Long
+   Description`, confirm every named sibling command still survives with that
+   exact command name. If Pass 3 killed or renamed the sibling, revise the
+   redirect to point at the surviving command, or clear it to `none` when no
+   accurate sibling remains.
 
 Drop ~half. Target output: 4-8 survivors. Score survivors with the rubric's
 4-dimension score; only keep features scoring >= 5/10.
@@ -286,15 +292,18 @@ Return a single markdown document with these top-level sections, in this
 order:
 
 1. `## Customer model` — personas from Pass 1.
-2. `## Candidates (pre-cut)` — full Pass 2 list with source labels and
-   inline kill/keep verdicts from the rubric.
+2. `## Candidates (pre-cut)` — full Pass 2 list with source labels,
+   `Long Description` (`none` when not needed), and inline kill/keep verdicts
+   from the rubric.
 3. `## Survivors and kills`
    - `### Survivors` — features scoring >= 5/10, formatted as a
      transcendence table matching the rubric's "Transcendence Table
      Format" section (which includes the **Buildability** column,
      `spec-emits` or `hand-code` per Pass 3 question 5). Include score,
      persona-served, the one-sentence buildability proof per the rubric,
-     and the buildability tag.
+     the buildability tag, and `Long Description` (`none` when not needed).
+     Any non-`none` `Long Description` MUST reference only surviving command
+     names after Pass 3.
    - `### Killed candidates` — table with columns: feature, kill reason,
      closest-surviving-sibling.
 4. `## Reprint verdicts` (REPRINT ONLY) — per-prior-feature: keep / reframe
@@ -312,9 +321,12 @@ After the subagent returns:
 1. **Parse `### Survivors`** — these become the transcendence rows in the
    absorb manifest (Step 1.5d). The score, buildability proof, and
    `Buildability` tag flow into the transcendence table; the persona-served
-   column is the audit trail. The `Buildability` column drives Phase Gate
-   1.5's hand-code count: rows tagged `hand-code` are the agent's
-   post-generate scope commitment, rows tagged `spec-emits` are not.
+   column is the audit trail. Preserve non-`none` `Long Description` values
+   in the manifest row so Phase 3 hand-code uses them as the Cobra `Long`
+   text instead of losing them in the brainstorm audit trail. The
+   `Buildability` column drives Phase Gate 1.5's hand-code count: rows tagged
+   `hand-code` are the agent's post-generate scope commitment, rows tagged
+   `spec-emits` are not.
 2. **Parse `## Reprint verdicts`** (if present) — record dropped prior features
    under the transcendence table per the rubric's reprint surface rule, so the
    user can override drops at the Phase 1.5 gate review.

--- a/skills/printing-press/references/novel-features-subagent.md
+++ b/skills/printing-press/references/novel-features-subagent.md
@@ -176,6 +176,21 @@ Sources for candidates (label each candidate with its source):
 For each candidate capture: name, command, one-line description, persona
 served, source label from the list above.
 
+When 2+ compound-tool candidates could plausibly match the same natural-language
+request because their input surfaces overlap (for example, user UPN, market ID,
+customer email, or recipe name), plan each overlapping command's `Long:`
+description with an explicit scope redirect:
+
+```text
+Use this command for <matching intent>.
+Do NOT use this command for <nearby but wrong intent>; use '<sibling-command>' instead.
+```
+
+Only skip this pattern for single-tool CLIs or candidates whose inputs and
+operator intent do not overlap with sibling tools. A slightly longer `Long:`
+description is acceptable when it prevents an agent from choosing the wrong
+compound tool.
+
 Apply the rubric's kill/keep checks (LLM dependency, external service, auth
 gap, scope creep, verifiability, reimplementation) inline. Reframe or cut
 obvious failures NOW so they don't waste Pass 3 attention.


### PR DESCRIPTION
## Summary

Novel-feature planning now tells the subagent to disambiguate overlapping compound tools before they are implemented. When sibling tools could plausibly match the same natural-language request, their planned `Long:` descriptions must include a positive use case and an explicit "Do NOT use this for... use ... instead" redirect.

This keeps compound-tool-heavy CLIs from relying on each SKILL author's memory to add agent-routing guardrails.

## Verification

- `./cli-printing-press verify-internal-skill --dir skills/printing-press`
- `go test ./internal/cli -run 'Test.*Verify.*Internal|Test.*InternalSkill'`
- `git diff --check`

Closes #1836

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
