### PR TITLE
docs(skills): document kebab-case novel flags

### DIFF
--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3277,6 +3277,8 @@ func newXxxCmd(flags *rootFlags) *cobra.Command {
 //   issuesCmd.AddCommand(newIssuesStaleCmd(flags))
 //   rootCmd.AddCommand(issuesCmd)
 // Leaf commands must declare every non-root flag used in their examples.
+// Use kebab-case flag names, such as --max-age instead of --maxAge, so the
+// generated CLI convention and verify-skill flag scanner stay aligned.
 // Do not rely on parent-local flags like --org or --project being accepted by
 // child commands unless the parent registered them with PersistentFlags().
 // Single-word Commands register directly: rootCmd.AddCommand(newXxxCmd(flags)).


### PR DESCRIPTION
Agents hand-authoring novel-feature commands now see the kebab-case flag convention directly in the Phase 3 starter template, before copying the Cobra skeleton. This prevents camelCase API parameter names from becoming CLI flags that later trip verify-skill's cross-file flag scanner.

Validation: `git diff --check`

Closes #2260

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
