### PR TITLE
fix(cli): preserve dispatch param defaults in examples

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -45,6 +45,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
+| `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
 
 ## `info` Extensions
 
@@ -981,6 +982,34 @@ components:
 
 In this example both endpoints keep the same public `locationId` input, but
 only `/opportunities/search` sends `?location_id=` on the wire.
+
+### `x-pp-dispatch-param`
+
+Marks a query parameter as a fixed dispatch discriminator whose `default` value
+selects the upstream route rather than tuning the request. Generated runnable
+examples keep that default instead of substituting a synthetic dogfood value.
+
+Parsed field: `Param.DispatchParam`
+
+Use this for shared-path APIs where a query parameter such as `type` or
+`action` selects the report or operation. Do not use it for ordinary filters,
+limits, page sizes, or other tunable inputs.
+
+Example:
+
+```yaml
+paths:
+  /:
+    get:
+      operationId: getDomainRank
+      parameters:
+        - name: report
+          in: query
+          x-pp-dispatch-param: true
+          schema:
+            type: string
+            default: domain_rank
+```
 
 ## Path Item Extensions
 

--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -104,7 +104,7 @@ func requiredFlagExampleParts(ep spec.Endpoint) []string {
 		if p.Positional || !p.Required {
 			continue
 		}
-		val := exampleValue(p)
+		val := requiredFlagExampleValue(ep, p)
 		if val == "" {
 			val = "value"
 		}
@@ -125,6 +125,71 @@ func requiredFlagExampleParts(ep spec.Endpoint) []string {
 		}
 	}
 	return parts
+}
+
+func requiredFlagExampleValue(ep spec.Endpoint, p spec.Param) string {
+	if val, ok := dispatchParamDefaultValue(ep, p); ok {
+		return val
+	}
+	return exampleValue(p)
+}
+
+func dispatchParamDefaultValue(ep spec.Endpoint, p spec.Param) (string, bool) {
+	defaultValue, ok := p.Default.(string)
+	if !ok {
+		return "", false
+	}
+	defaultValue = strings.TrimSpace(defaultValue)
+	if defaultValue == "" {
+		return "", false
+	}
+	if p.DispatchParam || pathUsesDispatchDefault(ep.Path, p, defaultValue) || isDispatchStyleParam(p) {
+		return defaultValue, true
+	}
+	return "", false
+}
+
+func pathUsesDispatchDefault(path string, p spec.Param, defaultValue string) bool {
+	names := []string{p.Name, p.WireName()}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if strings.Contains(path, "{"+name+"}") {
+			return true
+		}
+		if queryParamDefaultInPath(path, name, defaultValue) {
+			return true
+		}
+	}
+	return false
+}
+
+func queryParamDefaultInPath(path, name, defaultValue string) bool {
+	idx := strings.Index(path, "?")
+	if idx < 0 || idx == len(path)-1 {
+		return false
+	}
+	for part := range strings.SplitSeq(path[idx+1:], "&") {
+		key, val, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == name && strings.TrimSpace(val) == defaultValue {
+			return true
+		}
+	}
+	return false
+}
+
+func isDispatchStyleParam(p spec.Param) bool {
+	switch strings.ToLower(strings.TrimSpace(p.WireName())) {
+	case "type", "action":
+		return true
+	default:
+		return false
+	}
 }
 
 // skillExamplePositionalValue resolves one positional param to the value

--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -143,7 +143,13 @@ func dispatchParamDefaultValue(ep spec.Endpoint, p spec.Param) (string, bool) {
 	if defaultValue == "" {
 		return "", false
 	}
-	if p.DispatchParam || pathUsesDispatchDefault(ep.Path, p, defaultValue) || isDispatchStyleParam(p) {
+	if p.DispatchParam {
+		return defaultValue, true
+	}
+	if p.DispatchParamSet {
+		return "", false
+	}
+	if pathUsesDispatchDefault(ep.Path, p, defaultValue) || isDispatchStyleParam(p) {
 		return defaultValue, true
 	}
 	return "", false
@@ -155,9 +161,6 @@ func pathUsesDispatchDefault(path string, p spec.Param, defaultValue string) boo
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
-		}
-		if strings.Contains(path, "{"+name+"}") {
-			return true
 		}
 		if queryParamDefaultInPath(path, name, defaultValue) {
 			return true

--- a/internal/generator/first_command_example_test.go
+++ b/internal/generator/first_command_example_test.go
@@ -246,6 +246,79 @@ func TestFirstCommandExampleHonorsPromotion(t *testing.T) {
 			want: "search list --search-query example-value",
 		},
 		{
+			name: "required dispatch type param keeps string default",
+			resources: map[string]spec.Resource{
+				"domain": {
+					Endpoints: map[string]spec.Endpoint{
+						"rank": {
+							Method: "GET",
+							Path:   "/",
+							Params: []spec.Param{
+								{Name: "type", Required: true, Type: "string", Default: "domain_rank"},
+								{Name: "domain", Required: true, Type: "string"},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/domain/refresh"},
+					},
+				},
+			},
+			want: "domain rank --type domain_rank --domain example-value",
+		},
+		{
+			name: "explicit dispatch param keeps string default",
+			resources: map[string]spec.Resource{
+				"reports": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/reports",
+							Params: []spec.Param{
+								{Name: "mode", Required: true, Type: "string", Default: "summary", DispatchParam: true},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/reports/refresh"},
+					},
+				},
+			},
+			want: "reports list --mode summary",
+		},
+		{
+			name: "non-dispatch string default still uses synthetic value",
+			resources: map[string]spec.Resource{
+				"search": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/search",
+							Params: []spec.Param{
+								{Name: "query", Required: true, Type: "string", Default: "cats"},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/search/refresh"},
+					},
+				},
+			},
+			want: "search list --query example-value",
+		},
+		{
+			name: "numeric default still uses synthetic value",
+			resources: map[string]spec.Resource{
+				"items": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/items",
+							Params: []spec.Param{
+								{Name: "limit", Required: true, Type: "integer", Default: 100},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/items/refresh"},
+					},
+				},
+			},
+			want: "items list --limit 50",
+		},
+		{
 			name: "required body field uses public flag name",
 			resources: map[string]spec.Resource{
 				"stores": {

--- a/internal/generator/first_command_example_test.go
+++ b/internal/generator/first_command_example_test.go
@@ -283,6 +283,60 @@ func TestFirstCommandExampleHonorsPromotion(t *testing.T) {
 			want: "reports list --mode summary",
 		},
 		{
+			name: "explicit dispatch false suppresses action heuristic",
+			resources: map[string]spec.Resource{
+				"jobs": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/jobs",
+							Params: []spec.Param{
+								{Name: "action", Required: true, Type: "string", Default: "create", DispatchParamSet: true},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/jobs/refresh"},
+					},
+				},
+			},
+			want: "jobs list --action example-value",
+		},
+		{
+			name: "path placeholder sharing query param name does not keep default",
+			resources: map[string]spec.Resource{
+				"reports": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/items/{mode}/reports",
+							Params: []spec.Param{
+								{Name: "mode", Required: true, Type: "string", Default: "summary"},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/reports/refresh"},
+					},
+				},
+			},
+			want: "reports list --mode example-value",
+		},
+		{
+			name: "path query default keeps required param default",
+			resources: map[string]spec.Resource{
+				"reports": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET",
+							Path:   "/reports?mode=summary",
+							Params: []spec.Param{
+								{Name: "mode", Required: true, Type: "string", Default: "summary"},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/reports/refresh"},
+					},
+				},
+			},
+			want: "reports list --mode summary",
+		},
+		{
 			name: "non-dispatch string default still uses synthetic value",
 			resources: map[string]spec.Resource{
 				"search": {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7920,6 +7920,46 @@ func TestExampleLineUsesRenderedCommandAndFlagNames(t *testing.T) {
 	assert.NotContains(t, got, "--idempotencyKey")
 }
 
+func TestGeneratedCommandExampleKeepsDispatchParamDefault(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("dispatch-default")
+	apiSpec.Resources["domain"] = spec.Resource{
+		Description: "Domain reports",
+		Endpoints: map[string]spec.Endpoint{
+			"rank": {
+				Method:      "GET",
+				Path:        "/",
+				Description: "Fetch a domain rank report",
+				Params: []spec.Param{
+					{Name: "type", Type: "string", Required: true, Default: "domain_rank", Description: "Report type"},
+					{Name: "domain", Type: "string", Required: true, Description: "Domain"},
+				},
+			},
+			"list": {
+				Method:      "GET",
+				Path:        "/domains",
+				Description: "List domains",
+				Params: []spec.Param{
+					{Name: "limit", Type: "integer", Required: true, Default: 100, Description: "Limit"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "dispatch-default-pp-cli")
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	rankSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "domain_rank.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(rankSrc), `dispatch-default-pp-cli domain rank --type domain_rank --domain example-value`)
+
+	listSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "domain_list.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(listSrc), `dispatch-default-pp-cli domain list --limit 50`)
+}
+
 func TestGeneratedCommandExamplePrefersNarrativeQuickStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mcpdesc/compose.go
+++ b/internal/mcpdesc/compose.go
@@ -15,6 +15,7 @@ package mcpdesc
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -172,8 +173,8 @@ func singularResourceName(path string) string {
 
 func resourceSegmentFromPath(path string) string {
 	parts := strings.Split(path, "/")
-	for i := len(parts) - 1; i >= 0; i-- {
-		segment := strings.TrimSpace(parts[i])
+	for _, part := range slices.Backward(parts) {
+		segment := strings.TrimSpace(part)
 		if segment == "" || strings.HasPrefix(segment, "{") {
 			continue
 		}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -61,6 +61,7 @@ const (
 	extensionCache                 = "x-cache"
 	extensionStreaming             = "x-streaming"
 	extensionSyncWalker            = "x-pp-sync-walker"
+	extensionDispatchParam         = "x-pp-dispatch-param"
 	extensionParamURLName          = "x-url-name"
 	extensionParamURLNames         = "x-param-url-names"
 	extensionAPIName               = "x-api-name"
@@ -3946,6 +3947,9 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 				urlNameOverridesRead = true
 			}
 			param.URLName = paramURLName(paramName, parameter.Extensions, urlNameOverrides)
+			if dispatch, ok := boolExtension(parameter.Extensions, extensionDispatchParam); ok {
+				param.DispatchParam = dispatch
+			}
 		}
 		if parameter.In == openapi3.ParameterInQuery && isFieldSelectorParameter(paramName, description) {
 			param.Purpose = spec.ParamPurposeFieldSelector

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3949,6 +3949,7 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 			param.URLName = paramURLName(paramName, parameter.Extensions, urlNameOverrides)
 			if dispatch, ok := boolExtension(parameter.Extensions, extensionDispatchParam); ok {
 				param.DispatchParam = dispatch
+				param.DispatchParamSet = true
 			}
 		}
 		if parameter.In == openapi3.ParameterInQuery && isFieldSelectorParameter(paramName, description) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8408,6 +8408,12 @@ paths:
           schema:
             type: integer
             default: 100
+        - name: action
+          in: query
+          x-pp-dispatch-param: false
+          schema:
+            type: string
+            default: create
       responses:
         "200":
           description: ok
@@ -8417,9 +8423,13 @@ paths:
 	require.NoError(t, err)
 
 	endpoint := findParsedEndpointByPath(t, parsed, "GET", "/reports")
-	require.Len(t, endpoint.Params, 2)
+	require.Len(t, endpoint.Params, 3)
 	assert.True(t, endpoint.Params[0].DispatchParam)
+	assert.True(t, endpoint.Params[0].DispatchParamSet)
 	assert.False(t, endpoint.Params[1].DispatchParam)
+	assert.False(t, endpoint.Params[1].DispatchParamSet)
+	assert.False(t, endpoint.Params[2].DispatchParam)
+	assert.True(t, endpoint.Params[2].DispatchParamSet)
 }
 
 // TestParseJSONPreferredOverFormUrlencoded asserts the parser still picks

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -8383,6 +8383,45 @@ components:
 	assert.Equal(t, "acct_id", sharedDelete.Params[0].URLName)
 }
 
+func TestParseDispatchParamExtension(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+openapi: 3.0.3
+info:
+  title: Dispatch Param API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /reports:
+    get:
+      operationId: getDomainRank
+      parameters:
+        - name: mode
+          in: query
+          x-pp-dispatch-param: true
+          schema:
+            type: string
+            default: domain_rank
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+
+	endpoint := findParsedEndpointByPath(t, parsed, "GET", "/reports")
+	require.Len(t, endpoint.Params, 2)
+	assert.True(t, endpoint.Params[0].DispatchParam)
+	assert.False(t, endpoint.Params[1].DispatchParam)
+}
+
 // TestParseJSONPreferredOverFormUrlencoded asserts the parser still picks
 // application/json when the spec offers both content types — keeping JSON-
 // declared specs byte-identical and letting form-only OAuth/legacy endpoints

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2100,6 +2100,18 @@ func (p *Param) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+func (p Param) MarshalYAML() (any, error) {
+	type paramAlias Param
+	var node yaml.Node
+	if err := node.Encode(paramAlias(p)); err != nil {
+		return nil, err
+	}
+	if !p.DispatchParamSet && !p.DispatchParam {
+		return yamlMappingWithoutKey(&node, "dispatch_param"), nil
+	}
+	return &node, nil
+}
+
 func (p *Param) UnmarshalJSON(data []byte) error {
 	type paramAlias Param
 	var out paramAlias
@@ -2120,6 +2132,23 @@ func (p *Param) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+func (p Param) MarshalJSON() ([]byte, error) {
+	type paramAlias Param
+	data, err := json.Marshal(paramAlias(p))
+	if err != nil {
+		return nil, err
+	}
+	if p.DispatchParamSet || p.DispatchParam {
+		return data, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	delete(raw, "dispatch_param")
+	return json.Marshal(raw)
 }
 
 func yamlMappingHasKey(value *yaml.Node, key string) bool {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2019,10 +2019,14 @@ type Param struct {
 	// DispatchParam marks a fixed discriminator such as type=domain_rank.
 	// Generated runnable examples keep its default instead of substituting
 	// synthetic dogfood values that would address a different upstream route.
-	DispatchParam bool   `yaml:"dispatch_param,omitempty" json:"dispatch_param,omitempty"`
-	ItemType      string `yaml:"item_type,omitempty" json:"item_type,omitempty"`
-	ItemTemplate  any    `yaml:"item_template,omitempty" json:"item_template,omitempty"`
-	Purpose       string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	DispatchParam bool `yaml:"dispatch_param,omitempty" json:"dispatch_param,omitempty"`
+	// DispatchParamSet is true when the spec explicitly contained
+	// dispatch_param, pp:dispatch-param, or x-pp-dispatch-param. It lets
+	// generator heuristics distinguish an omitted value from an explicit false.
+	DispatchParamSet bool   `yaml:"-" json:"-"`
+	ItemType         string `yaml:"item_type,omitempty" json:"item_type,omitempty"`
+	ItemTemplate     any    `yaml:"item_template,omitempty" json:"item_template,omitempty"`
+	Purpose          string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
 	// FieldSelectorDefault is a sync-time default for field-selector params
 	// such as opt_fields, fields, expand, include, or select. It stays separate
 	// from Default so generated endpoint commands do not silently change their
@@ -2088,8 +2092,10 @@ func (p *Param) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*p = Param(out)
 	p.FlagNameSet = yamlMappingHasKey(value, "flag_name")
+	p.DispatchParamSet = yamlMappingHasKey(value, "dispatch_param")
 	if dispatch, ok := yamlMappingBool(value, "pp:dispatch-param"); ok {
 		p.DispatchParam = dispatch
+		p.DispatchParamSet = true
 	}
 	return nil
 }
@@ -2104,10 +2110,12 @@ func (p *Param) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err == nil {
 		_, p.FlagNameSet = raw["flag_name"]
+		_, p.DispatchParamSet = raw["dispatch_param"]
 		if rawDispatch, ok := raw["pp:dispatch-param"]; ok {
 			var dispatch bool
 			if err := json.Unmarshal(rawDispatch, &dispatch); err == nil {
 				p.DispatchParam = dispatch
+				p.DispatchParamSet = true
 			}
 		}
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2002,23 +2002,27 @@ func (h *HTMLExtract) EffectiveScriptSelector() string {
 }
 
 type Param struct {
-	Name         string   `yaml:"name" json:"name"`
-	FlagName     string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
-	URLName      string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
-	BodyName     string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
-	Aliases      []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
-	Type         string   `yaml:"type" json:"type"`
-	Required     bool     `yaml:"required" json:"required"`
-	Positional   bool     `yaml:"positional" json:"positional"`
-	PathParam    bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
-	Default      any      `yaml:"default" json:"default"`
-	Description  string   `yaml:"description" json:"description"`
-	Fields       []Param  `yaml:"fields" json:"fields"`                     // for nested objects
-	Enum         []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
-	Format       string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
-	ItemType     string   `yaml:"item_type,omitempty" json:"item_type,omitempty"`
-	ItemTemplate any      `yaml:"item_template,omitempty" json:"item_template,omitempty"`
-	Purpose      string   `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	Name        string   `yaml:"name" json:"name"`
+	FlagName    string   `yaml:"flag_name,omitempty" json:"flag_name,omitempty"`
+	URLName     string   `yaml:"url_name,omitempty" json:"url_name,omitempty"`   // optional override for URL query-key emission (e.g., "$limit" for Socrata while keeping --limit flag)
+	BodyName    string   `yaml:"body_name,omitempty" json:"body_name,omitempty"` // optional override for request-body field emission while keeping the public name
+	Aliases     []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	Type        string   `yaml:"type" json:"type"`
+	Required    bool     `yaml:"required" json:"required"`
+	Positional  bool     `yaml:"positional" json:"positional"`
+	PathParam   bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
+	Default     any      `yaml:"default" json:"default"`
+	Description string   `yaml:"description" json:"description"`
+	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
+	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
+	Format      string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
+	// DispatchParam marks a fixed discriminator such as type=domain_rank.
+	// Generated runnable examples keep its default instead of substituting
+	// synthetic dogfood values that would address a different upstream route.
+	DispatchParam bool   `yaml:"dispatch_param,omitempty" json:"dispatch_param,omitempty"`
+	ItemType      string `yaml:"item_type,omitempty" json:"item_type,omitempty"`
+	ItemTemplate  any    `yaml:"item_template,omitempty" json:"item_template,omitempty"`
+	Purpose       string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
 	// FieldSelectorDefault is a sync-time default for field-selector params
 	// such as opt_fields, fields, expand, include, or select. It stays separate
 	// from Default so generated endpoint commands do not silently change their
@@ -2084,6 +2088,9 @@ func (p *Param) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*p = Param(out)
 	p.FlagNameSet = yamlMappingHasKey(value, "flag_name")
+	if dispatch, ok := yamlMappingBool(value, "pp:dispatch-param"); ok {
+		p.DispatchParam = dispatch
+	}
 	return nil
 }
 
@@ -2097,6 +2104,12 @@ func (p *Param) UnmarshalJSON(data []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err == nil {
 		_, p.FlagNameSet = raw["flag_name"]
+		if rawDispatch, ok := raw["pp:dispatch-param"]; ok {
+			var dispatch bool
+			if err := json.Unmarshal(rawDispatch, &dispatch); err == nil {
+				p.DispatchParam = dispatch
+			}
+		}
 	}
 	return nil
 }
@@ -2111,6 +2124,23 @@ func yamlMappingHasKey(value *yaml.Node, key string) bool {
 		}
 	}
 	return false
+}
+
+func yamlMappingBool(value *yaml.Node, key string) (bool, bool) {
+	if value == nil || value.Kind != yaml.MappingNode {
+		return false, false
+	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		if value.Content[i].Value != key {
+			continue
+		}
+		var out bool
+		if err := value.Content[i+1].Decode(&out); err != nil {
+			return false, false
+		}
+		return out, true
+	}
+	return false, false
 }
 
 func yamlMappingValue(value *yaml.Node, key string) *yaml.Node {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2019,7 +2019,7 @@ type Param struct {
 	// DispatchParam marks a fixed discriminator such as type=domain_rank.
 	// Generated runnable examples keep its default instead of substituting
 	// synthetic dogfood values that would address a different upstream route.
-	DispatchParam bool `yaml:"dispatch_param,omitempty" json:"dispatch_param,omitempty"`
+	DispatchParam bool `yaml:"dispatch_param" json:"dispatch_param"`
 	// DispatchParamSet is true when the spec explicitly contained
 	// dispatch_param, pp:dispatch-param, or x-pp-dispatch-param. It lets
 	// generator heuristics distinguish an omitted value from an explicit false.

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -89,6 +89,10 @@ resources:
             pp:dispatch-param: true
             type: string
             description: Street address
+          - name: action
+            dispatch_param: false
+            type: string
+            description: Search action
       search:
         method: POST
         path: /stores/search
@@ -105,6 +109,11 @@ resources:
 	assert.Equal(t, "address", param.FlagName)
 	assert.Equal(t, []string{"s"}, param.Aliases)
 	assert.True(t, param.DispatchParam)
+	assert.True(t, param.DispatchParamSet)
+	param = s.Resources["stores"].Endpoints["find"].Params[1]
+	assert.Equal(t, "action", param.Name)
+	assert.False(t, param.DispatchParam)
+	assert.True(t, param.DispatchParamSet)
 	bodyParam := s.Resources["stores"].Endpoints["search"].Body[0]
 	assert.Equal(t, "startAfter", bodyParam.Name)
 	assert.Equal(t, "searchAfter", bodyParam.BodyName)
@@ -120,7 +129,8 @@ resources:
           "method": "GET",
           "path": "/stores",
           "params": [
-            {"name": "c", "flag_name": "city", "aliases": ["c"], "pp:dispatch-param": true, "type": "string"}
+            {"name": "c", "flag_name": "city", "aliases": ["c"], "pp:dispatch-param": true, "type": "string"},
+            {"name": "action", "pp:dispatch-param": false, "type": "string"}
           ]
         }
       }
@@ -134,6 +144,11 @@ resources:
 	assert.Equal(t, "city", param.FlagName)
 	assert.Equal(t, []string{"c"}, param.Aliases)
 	assert.True(t, param.DispatchParam)
+	assert.True(t, param.DispatchParamSet)
+	param = s.Resources["stores"].Endpoints["find"].Params[1]
+	assert.Equal(t, "action", param.Name)
+	assert.False(t, param.DispatchParam)
+	assert.True(t, param.DispatchParamSet)
 }
 
 func TestParseStreamingConfig(t *testing.T) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -179,6 +179,32 @@ func TestDispatchParamFalseSurvivesRoundTrip(t *testing.T) {
 	assert.True(t, jsonParam.DispatchParamSet)
 }
 
+func TestUnannotatedDispatchParamSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Param{
+		Name:    "action",
+		Type:    "string",
+		Default: "create",
+	}
+
+	yamlData, err := yaml.Marshal(original)
+	require.NoError(t, err)
+	assert.NotContains(t, string(yamlData), "dispatch_param")
+	var yamlParam Param
+	require.NoError(t, yaml.Unmarshal(yamlData, &yamlParam))
+	assert.False(t, yamlParam.DispatchParam)
+	assert.False(t, yamlParam.DispatchParamSet)
+
+	jsonData, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.NotContains(t, string(jsonData), "dispatch_param")
+	var jsonParam Param
+	require.NoError(t, json.Unmarshal(jsonData, &jsonParam))
+	assert.False(t, jsonParam.DispatchParam)
+	assert.False(t, jsonParam.DispatchParamSet)
+}
+
 func TestParseStreamingConfig(t *testing.T) {
 	yamlSpec := []byte(`
 name: streaming-api

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -149,6 +150,33 @@ resources:
 	assert.Equal(t, "action", param.Name)
 	assert.False(t, param.DispatchParam)
 	assert.True(t, param.DispatchParamSet)
+}
+
+func TestDispatchParamFalseSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Param{
+		Name:             "action",
+		Type:             "string",
+		DispatchParam:    false,
+		DispatchParamSet: true,
+	}
+
+	yamlData, err := yaml.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(yamlData), "dispatch_param: false")
+	var yamlParam Param
+	require.NoError(t, yaml.Unmarshal(yamlData, &yamlParam))
+	assert.False(t, yamlParam.DispatchParam)
+	assert.True(t, yamlParam.DispatchParamSet)
+
+	jsonData, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(jsonData), `"dispatch_param":false`)
+	var jsonParam Param
+	require.NoError(t, json.Unmarshal(jsonData, &jsonParam))
+	assert.False(t, jsonParam.DispatchParam)
+	assert.True(t, jsonParam.DispatchParamSet)
 }
 
 func TestParseStreamingConfig(t *testing.T) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -86,6 +86,7 @@ resources:
           - name: s
             flag_name: address
             aliases: [s]
+            pp:dispatch-param: true
             type: string
             description: Street address
       search:
@@ -103,6 +104,7 @@ resources:
 	assert.Equal(t, "s", param.Name)
 	assert.Equal(t, "address", param.FlagName)
 	assert.Equal(t, []string{"s"}, param.Aliases)
+	assert.True(t, param.DispatchParam)
 	bodyParam := s.Resources["stores"].Endpoints["search"].Body[0]
 	assert.Equal(t, "startAfter", bodyParam.Name)
 	assert.Equal(t, "searchAfter", bodyParam.BodyName)
@@ -118,7 +120,7 @@ resources:
           "method": "GET",
           "path": "/stores",
           "params": [
-            {"name": "c", "flag_name": "city", "aliases": ["c"], "type": "string"}
+            {"name": "c", "flag_name": "city", "aliases": ["c"], "pp:dispatch-param": true, "type": "string"}
           ]
         }
       }
@@ -131,6 +133,7 @@ resources:
 	assert.Equal(t, "c", param.Name)
 	assert.Equal(t, "city", param.FlagName)
 	assert.Equal(t, []string{"c"}, param.Aliases)
+	assert.True(t, param.DispatchParam)
 }
 
 func TestParseStreamingConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfood-generated happy-path examples now keep fixed dispatch defaults like `--type domain_rank` instead of substituting synthetic values, so shared-path APIs no longer fail live matrix runs by calling the wrong upstream report type. Ordinary tunable defaults still use synthetic coverage values, and specs can mark edge cases with `pp:dispatch-param` or OpenAPI `x-pp-dispatch-param`.

## Verification

- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

Closes #2182.
