### PR TITLE
fix(cli): guard template prose interpolation

### DIFF
--- a/internal/generator/templates/plan_command.go.tmpl
+++ b/internal/generator/templates/plan_command.go.tmpl
@@ -12,7 +12,7 @@ import (
 func new{{pascal .CommandName}}Cmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "{{.CommandName}}",
-		Short: "{{.Description}}",
+		Short: {{printf "%q" .Description}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("{{.CommandName}}: not implemented")
 		},

--- a/internal/generator/templates/plan_parent.go.tmpl
+++ b/internal/generator/templates/plan_parent.go.tmpl
@@ -10,7 +10,7 @@ import (
 func new{{pascal .Name}}Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "{{.Name}}",
-		Short: "{{.Description}}",
+		Short: {{printf "%q" .Description}},
 	}
 
 {{- range .SubCommands}}

--- a/internal/generator/templates/plan_root.go.tmpl
+++ b/internal/generator/templates/plan_root.go.tmpl
@@ -16,7 +16,7 @@ var version = "1.0.0"
 func Execute() error {
 	rootCmd := &cobra.Command{
 		Use:           "{{.CLIName}}-pp-cli",
-		Short:         "{{.Description}}",
+		Short:         {{printf "%q" .Description}},
 		SilenceUsage: true,
 		Version:      version,
 	}

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -131,7 +131,6 @@ func TestIsInsideGoDoubleQuotedStringSkipsTemplateActionSyntax(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, isInsideGoDoubleQuotedString(tt.prefix))

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -62,7 +62,7 @@ func TestGoTemplatesEscapeSpecTextInStringLiterals(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	require.Empty(t, violations, "spec-controlled prose inside Go string literals must use oneline/goRawSafe/printf %%q; unsafe template sites:\n%s", strings.Join(violations, "\n"))
+	require.Empty(t, violations, "spec-controlled prose inside Go string literals must use oneline/printf %%q; unsafe template sites:\n%s", strings.Join(violations, "\n"))
 }
 
 func isInsideGoDoubleQuotedString(prefix string) bool {
@@ -140,8 +140,15 @@ func TestIsInsideGoDoubleQuotedStringSkipsTemplateActionSyntax(t *testing.T) {
 
 func goTemplateActionEscapesSpecText(action string) bool {
 	return strings.Contains(action, "oneline ") ||
-		strings.Contains(action, "printf \"%q\"") ||
-		strings.Contains(action, "goRawSafe")
+		strings.Contains(action, "printf \"%q\"")
+}
+
+func TestGoTemplateActionEscapesSpecTextRejectsRawStringHelper(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, goTemplateActionEscapesSpecText(`{{oneline .Description}}`))
+	assert.True(t, goTemplateActionEscapesSpecText(`{{printf "%q" .Description}}`))
+	assert.False(t, goTemplateActionEscapesSpecText(`{{goRawSafe .Description}}`))
 }
 
 func TestDoctorTemplateRendersKindAwareAuthEnvPresence(t *testing.T) {

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -3,9 +3,12 @@ package generator
 import (
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -13,6 +16,80 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGoTemplatesEscapeSpecTextInStringLiterals(t *testing.T) {
+	t.Parallel()
+
+	specTextField := regexp.MustCompile(`\.(?:[A-Za-z0-9_]*Description|Description|Summary|Instructions)\b`)
+	var violations []string
+
+	err := fs.WalkDir(templateFS, "templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go.tmpl") {
+			return nil
+		}
+
+		data, err := templateFS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for lineNo, line := range strings.Split(string(data), "\n") {
+			for start := strings.Index(line, "{{"); start >= 0; {
+				end := strings.Index(line[start+2:], "}}")
+				if end < 0 {
+					break
+				}
+				end += start + 2
+				action := line[start : end+2]
+				if isInsideGoDoubleQuotedString(line[:start]) &&
+					specTextField.MatchString(action) &&
+					!goTemplateActionEscapesSpecText(action) {
+					violations = append(violations, path+":"+strconv.Itoa(lineNo+1)+": "+strings.TrimSpace(line))
+				}
+				next := end + 2
+				if next >= len(line) {
+					break
+				}
+				if rel := strings.Index(line[next:], "{{"); rel >= 0 {
+					start = next + rel
+				} else {
+					break
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, violations, "spec-controlled prose inside Go string literals must use oneline/goRawSafe/printf %%q; unsafe template sites:\n%s", strings.Join(violations, "\n"))
+}
+
+func isInsideGoDoubleQuotedString(prefix string) bool {
+	inString := false
+	escaped := false
+	for _, r := range prefix {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			if inString {
+				escaped = true
+			}
+		case '"':
+			inString = !inString
+		}
+	}
+	return inString
+}
+
+func goTemplateActionEscapesSpecText(action string) bool {
+	return strings.Contains(action, "oneline ") ||
+		strings.Contains(action, "printf \"%q\"") ||
+		strings.Contains(action, "goRawSafe")
+}
 
 func TestDoctorTemplateRendersKindAwareAuthEnvPresence(t *testing.T) {
 	t.Parallel()

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -68,7 +68,17 @@ func TestGoTemplatesEscapeSpecTextInStringLiterals(t *testing.T) {
 func isInsideGoDoubleQuotedString(prefix string) bool {
 	inString := false
 	escaped := false
-	for _, r := range prefix {
+	for i := 0; i < len(prefix); {
+		if strings.HasPrefix(prefix[i:], "{{") {
+			end := strings.Index(prefix[i+2:], "}}")
+			if end < 0 {
+				break
+			}
+			i += 2 + end + 2
+			continue
+		}
+		r := prefix[i]
+		i++
 		if escaped {
 			escaped = false
 			continue
@@ -83,6 +93,50 @@ func isInsideGoDoubleQuotedString(prefix string) bool {
 		}
 	}
 	return inString
+}
+
+func TestIsInsideGoDoubleQuotedStringSkipsTemplateActionSyntax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prefix string
+		want   bool
+	}{
+		{
+			name:   "inside static string",
+			prefix: `Short: "`,
+			want:   true,
+		},
+		{
+			name:   "inside after template action with escaped quote",
+			prefix: `Short: "{{printf "a\"b" .Foo}} `,
+			want:   true,
+		},
+		{
+			name:   "outside after template action and closing quote",
+			prefix: `Short: "{{printf "a\"b" .Foo}}"`,
+			want:   false,
+		},
+		{
+			name:   "inside static escaped quote",
+			prefix: `fmt.Println("a\"b`,
+			want:   true,
+		},
+		{
+			name:   "outside string",
+			prefix: `fmt.Println(`,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isInsideGoDoubleQuotedString(tt.prefix))
+		})
+	}
 }
 
 func goTemplateActionEscapesSpecText(action string) bool {


### PR DESCRIPTION
## Summary

Generator template reviews now fail fast when spec-controlled prose is interpolated into emitted Go double-quoted string literals without an escaping helper. This turns the quote/backslash compile foot-gun from #2281 into a local test failure before a generated CLI ships broken source.

This also fixes the existing generated plan-command templates that were still embedding descriptions raw in Cobra `Short` fields.

Closes #2281

## Verification

- `go test ./internal/generator -run TestGoTemplatesEscapeSpecTextInStringLiterals`
- `go test ./internal/generator -run 'TestGoTemplatesEscapeSpecTextInStringLiterals|TestGenerateFromPlan'`
- `go test ./...`
- `go fmt ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
