### PR TITLE
fix(cli): honor docs batch filter flags client-side

### DIFF
--- a/internal/generator/client_side_filter_test.go
+++ b/internal/generator/client_side_filter_test.go
@@ -1,0 +1,318 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointClientSideFilters(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("filterdocs")
+	apiSpec.SpecSource = "docs"
+	apiSpec.Types = map[string]spec.TypeDef{
+		"FundingRate": {
+			Fields: []spec.TypeField{
+				{Name: "symbol", Type: "string"},
+				{Name: "query", Type: "string"},
+				{Name: "rate", Type: "string"},
+			},
+		},
+	}
+	endpoint := spec.Endpoint{
+		Method: "GET",
+		Path:   "/funding_rate/batch",
+		Params: []spec.Param{
+			{Name: "symbols", Type: "string"},
+			{Name: "limit", Type: "integer"},
+			{Name: "query", Type: "string"},
+		},
+		Response: spec.ResponseDef{Type: "array", Item: "FundingRate"},
+	}
+
+	filters := endpointClientSideFilters(apiSpec, endpoint)
+	require.Len(t, filters, 1)
+	assert.Equal(t, "symbols", filters[0].Param.Name)
+	assert.Equal(t, "symbol", filters[0].Field)
+
+	apiSpec.SpecSource = "official"
+	assert.Empty(t, endpointClientSideFilters(apiSpec, endpoint), "official specs should keep trusting server-side filter semantics")
+
+	apiSpec.SpecSource = "docs"
+	endpoint.Pagination = &spec.Pagination{Type: "cursor"}
+	assert.Empty(t, endpointClientSideFilters(apiSpec, endpoint), "paged endpoints cannot be safely narrowed after fetching one page")
+
+	endpoint.Pagination = nil
+	endpoint.Response.Type = "object"
+	assert.Empty(t, endpointClientSideFilters(apiSpec, endpoint), "object responses should not use list filtering")
+
+	endpoint.Response.Type = "array"
+	endpoint.Path = "/funding_rates"
+	assert.Empty(t, endpointClientSideFilters(apiSpec, endpoint), "ordinary docs-derived list endpoints should keep trusting server-side filters")
+}
+
+func TestGeneratedDocsClientSideFilterNarrowsIgnoredBatchParam(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("filterdocs")
+	apiSpec.SpecSource = "docs"
+	apiSpec.Types = map[string]spec.TypeDef{
+		"FundingRate": {
+			Fields: []spec.TypeField{
+				{Name: "symbol", Type: "string"},
+				{Name: "rate", Type: "string"},
+			},
+		},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"market": {
+			Description: "Market data",
+			Endpoints: map[string]spec.Endpoint{
+				"get-funding-rate-batch": {
+					Method:      "GET",
+					Path:        "/api/v1/futures/market/funding_rate/batch",
+					Description: "Get all funding rates",
+					Params: []spec.Param{{
+						Name:        "symbols",
+						Type:        "string",
+						Description: "Comma-separated symbols",
+					}, {
+						Name:        "limit",
+						Type:        "integer",
+						Description: "Maximum rows",
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "FundingRate"},
+				},
+				"get-funding-rate": {
+					Method:      "GET",
+					Path:        "/api/v1/futures/market/funding_rate",
+					Description: "Get one funding rate",
+					Params: []spec.Param{{
+						Name:        "symbol",
+						Type:        "string",
+						Required:    true,
+						Positional:  true,
+						Description: "Symbol",
+					}},
+					Response: spec.ResponseDef{Type: "object", Item: "FundingRate"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "filterdocs-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDocsClientSideFilterNarrowsIgnoredBatchParam(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("symbols"); got != "BTCUSDT" {
+			t.Fatalf("symbols query = %q, want BTCUSDT", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"code":0,"data":[{"symbol":"BTCUSDT","rate":"0.01"},{"symbol":"ETHUSDT","rate":"0.02"}],"msg":"success"}` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("FILTERDOCS_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"market", "get-funding-rate-batch", "--symbols", "BTCUSDT", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Results struct {
+			Data []struct {
+				Symbol string ` + "`" + `json:"symbol"` + "`" + `
+			} ` + "`" + `json:"data"` + "`" + `
+		} ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(payload.Results.Data) != 1 || payload.Results.Data[0].Symbol != "BTCUSDT" {
+		t.Fatalf("filtered data = %+v, want only BTCUSDT; stdout=%s", payload.Results.Data, stdout.String())
+	}
+}
+
+func TestDocsClientSideFilterRunsBeforeLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("symbols"); got != "BTCUSDT" {
+			t.Fatalf("symbols query = %q, want BTCUSDT", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Fatalf("limit query = %q, want 1", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `[{"symbol":"ETHUSDT","rate":"0.02"},{"symbol":"BTCUSDT","rate":"0.01"}]` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("FILTERDOCS_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"market", "get-funding-rate-batch", "--symbols", "BTCUSDT", "--limit", "1", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Results []struct {
+			Symbol string ` + "`" + `json:"symbol"` + "`" + `
+		} ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(payload.Results) != 1 || payload.Results[0].Symbol != "BTCUSDT" {
+		t.Fatalf("filtered data = %+v, want only BTCUSDT; stdout=%s", payload.Results, stdout.String())
+	}
+}
+
+func TestDocsClientSideFilterFailsOpenWhenResponseFieldIsAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("symbols"); got != "BTCUSDT" {
+			t.Fatalf("symbols query = %q, want BTCUSDT", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `{"data":[{"pair":"BTCUSDT","rate":"0.01"},{"pair":"ETHUSDT","rate":"0.02"}]}` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("FILTERDOCS_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"market", "get-funding-rate-batch", "--symbols", "BTCUSDT", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Results []struct {
+			Pair string ` + "`" + `json:"pair"` + "`" + `
+		} ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(payload.Results) != 2 {
+		t.Fatalf("filtered data = %+v, want original two rows; stdout=%s", payload.Results, stdout.String())
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "docs_client_side_filter_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestDocsClientSideFilter", "-count=1")
+}
+
+func TestGeneratedPromotedDocsClientSideFilterRunsBeforeLimit(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promotedfilterdocs")
+	apiSpec.SpecSource = "docs"
+	apiSpec.Types = map[string]spec.TypeDef{
+		"FundingRate": {
+			Fields: []spec.TypeField{
+				{Name: "symbol", Type: "string"},
+				{Name: "rate", Type: "string"},
+			},
+		},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"market": {
+			Description: "Market data",
+			Endpoints: map[string]spec.Endpoint{
+				"get-funding-rate-batch": {
+					Method:      "GET",
+					Path:        "/api/v1/futures/market/funding_rate/batch",
+					Description: "Get all funding rates",
+					Params: []spec.Param{{
+						Name:        "symbols",
+						Type:        "string",
+						Description: "Comma-separated symbols",
+					}, {
+						Name:        "limit",
+						Type:        "integer",
+						Description: "Maximum rows",
+					}},
+					Response: spec.ResponseDef{Type: "array", Item: "FundingRate"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "promotedfilterdocs-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	inlineTest := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPromotedDocsClientSideFilterRunsBeforeLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("symbols"); got != "BTCUSDT" {
+			t.Fatalf("symbols query = %q, want BTCUSDT", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Fatalf("limit query = %q, want 1", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `[{"symbol":"ETHUSDT","rate":"0.02"},{"symbol":"BTCUSDT","rate":"0.01"}]` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("PROMOTEDFILTERDOCS_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"market", "--symbols", "BTCUSDT", "--limit", "1", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Results []struct {
+			Symbol string ` + "`" + `json:"symbol"` + "`" + `
+		} ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(payload.Results) != 1 || payload.Results[0].Symbol != "BTCUSDT" {
+		t.Fatalf("filtered data = %+v, want only BTCUSDT; stdout=%s", payload.Results, stdout.String())
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "promoted_docs_client_side_filter_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestPromotedDocsClientSideFilterRunsBeforeLimit", "-count=1")
+}

--- a/internal/generator/client_side_filter_test.go
+++ b/internal/generator/client_side_filter_test.go
@@ -56,6 +56,44 @@ func TestEndpointClientSideFilters(t *testing.T) {
 	assert.Empty(t, endpointClientSideFilters(apiSpec, endpoint), "ordinary docs-derived list endpoints should keep trusting server-side filters")
 }
 
+func TestEndpointClientSideFiltersTriesLaterCandidatesAfterSeenField(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("filterdocs")
+	apiSpec.SpecSource = "docs"
+	apiSpec.Types = map[string]spec.TypeDef{
+		"CurrencyRate": {
+			Fields: []spec.TypeField{
+				{Name: "currencies", Type: "string"},
+				{Name: "currency", Type: "string"},
+			},
+		},
+	}
+	endpoint := spec.Endpoint{
+		Method: "GET",
+		Path:   "/currency/batch",
+		Params: []spec.Param{
+			{Name: "currency_list", URLName: "currencies", Type: "string"},
+			{Name: "currencies", Type: "string"},
+		},
+		Response: spec.ResponseDef{Type: "array", Item: "CurrencyRate"},
+	}
+
+	filters := endpointClientSideFilters(apiSpec, endpoint)
+	require.Len(t, filters, 2)
+	assert.Equal(t, "currency_list", filters[0].Param.Name)
+	assert.Equal(t, "currencies", filters[0].Field)
+	assert.Equal(t, "currencies", filters[1].Param.Name)
+	assert.Equal(t, "currency", filters[1].Field)
+}
+
+func TestSingularClientSideFilterNameLeavesBareSuffixes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ses", singularClientSideFilterName("ses"))
+	assert.Equal(t, "class", singularClientSideFilterName("classes"))
+}
+
 func TestGeneratedDocsClientSideFilterNarrowsIgnoredBatchParam(t *testing.T) {
 	t.Parallel()
 
@@ -221,7 +259,41 @@ func TestDocsClientSideFilterFailsOpenWhenResponseFieldIsAbsent(t *testing.T) {
 		t.Fatalf("filtered data = %+v, want original two rows; stdout=%s", payload.Results, stdout.String())
 	}
 }
-`
+
+func TestDocsClientSideFilterKeepsRowsWithMissingField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("symbols"); got != "BTCUSDT" {
+			t.Fatalf("symbols query = %q, want BTCUSDT", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(` + "`" + `[{"symbol":"BTCUSDT","rate":"0.01"},{"pair":"legacy","rate":"0.02"},{"symbol":"ETHUSDT","rate":"0.03"}]` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("FILTERDOCS_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"market", "get-funding-rate-batch", "--symbols", "BTCUSDT", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+
+	var payload struct {
+		Results []map[string]string ` + "`" + `json:"results"` + "`" + `
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(payload.Results) != 2 {
+		t.Fatalf("filtered data = %+v, want matching row plus row without symbol; stdout=%s", payload.Results, stdout.String())
+	}
+	if payload.Results[0]["symbol"] != "BTCUSDT" || payload.Results[1]["pair"] != "legacy" {
+		t.Fatalf("filtered data = %+v, want BTCUSDT plus legacy row; stdout=%s", payload.Results, stdout.String())
+	}
+}
+	`
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "docs_client_side_filter_test.go"), []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "TestDocsClientSideFilter", "-count=1")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -375,8 +375,9 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		// `?limit=N` query param without honoring it; truncating client-
 		// side means the user-facing --limit flag works regardless.
 		// Surfaced by hackernews retro #350 finding F6.
-		"endpointNeedsClientLimit": endpointNeedsClientLimit,
-		"envName":                  naming.EnvPrefix,
+		"endpointNeedsClientLimit":  endpointNeedsClientLimit,
+		"endpointClientSideFilters": endpointClientSideFilters,
+		"envName":                   naming.EnvPrefix,
 		// endpointTemplateEnvName resolves the env-var name for a
 		// {placeholder} in EndpointTemplateVars. Returns the spec-declared
 		// override (e.g. ST_TENANT_ID for {tenant}) when one exists, else
@@ -656,6 +657,7 @@ type HelperFlags struct {
 	HasDataLayer         bool // CLI has a local store (sync/search) → emit provenance helpers
 	HasSyncHelpers       bool // generated sync implementation calls sync-only helpers
 	HasClientLimit       bool // at least one endpoint needs client-side limit truncation → emit truncateJSONArray
+	HasClientFilters     bool // at least one docs-derived endpoint needs client-side response filtering
 	HasEmbeddedPaged     bool // at least one GET endpoint has detected embedded paged sub-resources → emit fetchEmbeddedPagedSubresource
 	HasResponseUnwrap    bool // at least one generated command can call extractResponseData
 	HasMutationEndpoints bool // spec has any non-GET/HEAD endpoint → emit partial-failure helpers + --allow-partial-failure flag
@@ -680,6 +682,9 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 				}
 				if endpointNeedsClientLimit(e) {
 					flags.HasClientLimit = true
+				}
+				if len(endpointClientSideFilters(s, e)) > 0 {
+					flags.HasClientFilters = true
 				}
 				if len(e.EmbeddedPagedSubresources) > 0 {
 					flags.HasEmbeddedPaged = true
@@ -4667,6 +4672,148 @@ func endpointNeedsClientLimit(endpoint spec.Endpoint) bool {
 		}
 	}
 	return false
+}
+
+type clientSideFilter struct {
+	Param spec.Param
+	Field string
+}
+
+// endpointClientSideFilters reports best-effort response filters for
+// docs-derived batch GET endpoints. Docs-derived specs sometimes expose
+// a documented query flag that the API accepts but ignores; when the flag name
+// matches a scalar response item field (including simple plural-to-singular
+// forms like symbols -> symbol), generated commands locally narrow the returned
+// JSON so the public flag stays truthful.
+func endpointClientSideFilters(apiSpec *spec.APISpec, endpoint spec.Endpoint) []clientSideFilter {
+	if apiSpec == nil || strings.TrimSpace(apiSpec.SpecSource) != "docs" {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(endpoint.Method), "GET") || endpoint.Pagination != nil {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(endpoint.Response.Type), "array") {
+		return nil
+	}
+	if !endpointLooksLikeClientFilteredBatch(endpoint) {
+		return nil
+	}
+	if endpoint.Response.Item == "" {
+		return nil
+	}
+	itemType, ok := apiSpec.Types[endpoint.Response.Item]
+	if !ok || len(itemType.Fields) == 0 {
+		return nil
+	}
+
+	fieldsByKey := map[string]string{}
+	for _, field := range itemType.Fields {
+		if strings.TrimSpace(field.Name) == "" {
+			continue
+		}
+		fieldsByKey[normalizeClientSideFilterKey(field.Name)] = field.Name
+	}
+
+	var filters []clientSideFilter
+	seenFields := map[string]struct{}{}
+	for _, param := range endpoint.Params {
+		if !clientSideFilterParamEligible(param) {
+			continue
+		}
+		for _, candidate := range clientSideFilterFieldCandidates(param) {
+			field, ok := fieldsByKey[normalizeClientSideFilterKey(candidate)]
+			if !ok {
+				continue
+			}
+			if _, seen := seenFields[field]; seen {
+				break
+			}
+			filters = append(filters, clientSideFilter{Param: param, Field: field})
+			seenFields[field] = struct{}{}
+			break
+		}
+	}
+	return filters
+}
+
+func endpointLooksLikeClientFilteredBatch(endpoint spec.Endpoint) bool {
+	for _, value := range []string{endpoint.Path, endpoint.Description} {
+		parts := strings.FieldsFunc(strings.ToLower(value), func(r rune) bool {
+			return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+		})
+		if slices.Contains(parts, "batch") {
+			return true
+		}
+	}
+	return false
+}
+
+func clientSideFilterParamEligible(param spec.Param) bool {
+	if param.Positional || param.PathParam {
+		return false
+	}
+	if param.Purpose == spec.ParamPurposeFieldSelector {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(param.Type)) {
+	case "", "string", "string_csv_array":
+	default:
+		return false
+	}
+	name := normalizeClientSideFilterKey(param.WireName())
+	switch name {
+	case "", "limit", "page", "pagesize", "perpage", "offset", "cursor", "after", "before", "next", "sort", "order", "orderby", "fields", "field", "select", "include", "expand", "q", "query", "search":
+		return false
+	default:
+		return true
+	}
+}
+
+func clientSideFilterFieldCandidates(param spec.Param) []string {
+	names := []string{param.WireName(), param.Name}
+	var out []string
+	seen := map[string]struct{}{}
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		for _, candidate := range []string{trimmed, singularClientSideFilterName(trimmed)} {
+			key := normalizeClientSideFilterKey(candidate)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func singularClientSideFilterName(name string) string {
+	if strings.HasSuffix(name, "ies") && len(name) > len("ies") {
+		return strings.TrimSuffix(name, "ies") + "y"
+	}
+	if strings.HasSuffix(name, "ses") && len(name) > len("es") {
+		return strings.TrimSuffix(name, "es")
+	}
+	if strings.HasSuffix(name, "s") && len(name) > 1 {
+		return strings.TrimSuffix(name, "s")
+	}
+	return name
+}
+
+func normalizeClientSideFilterKey(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // maxBodyFlagDepth caps how many levels of nested-object recursion the

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4726,7 +4726,7 @@ func endpointClientSideFilters(apiSpec *spec.APISpec, endpoint spec.Endpoint) []
 				continue
 			}
 			if _, seen := seenFields[field]; seen {
-				break
+				continue
 			}
 			filters = append(filters, clientSideFilter{Param: param, Field: field})
 			seenFields[field] = struct{}{}
@@ -4797,8 +4797,11 @@ func singularClientSideFilterName(name string) string {
 	if strings.HasSuffix(name, "ies") && len(name) > len("ies") {
 		return strings.TrimSuffix(name, "ies") + "y"
 	}
-	if strings.HasSuffix(name, "ses") && len(name) > len("es") {
-		return strings.TrimSuffix(name, "es")
+	if strings.HasSuffix(name, "ses") {
+		if len(name) > len("ses") {
+			return strings.TrimSuffix(name, "es")
+		}
+		return name
 	}
 	if strings.HasSuffix(name, "s") && len(name) > 1 {
 		return strings.TrimSuffix(name, "s")

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -593,6 +593,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			_, err = cmd.OutOrStdout().Write(data)
 			return err
 {{- else}}
+{{- range endpointClientSideFilters .APISpec .Endpoint}}
+			if flag{{camel (paramIdent .Param)}} != {{zeroValForParamRequired .Param.Name .Param.Type .Param.Required (hasDefault .Param)}} {
+				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, fmt.Sprintf("%v", flag{{camel (paramIdent .Param)}}))
+			}
+{{- end}}
 {{- if endpointNeedsClientLimit .Endpoint}}
 			// Honor --limit when the API accepts but ignores ?limit=N.
 			data = truncateJSONArray(data, flagLimit)

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -321,6 +321,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			_, err = cmd.OutOrStdout().Write(data)
 			return err
 {{- else}}
+{{- range endpointClientSideFilters .APISpec .Endpoint}}
+			if flag{{camel (paramIdent .Param)}} != {{zeroValForParamRequired .Param.Name .Param.Type .Param.Required (hasDefault .Param)}} {
+				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, fmt.Sprintf("%v", flag{{camel (paramIdent .Param)}}))
+			}
+{{- end}}
 {{- if endpointNeedsClientLimit .Endpoint}}
 			// Honor --limit when the API accepts but ignores ?limit=N.
 			data = truncateJSONArray(data, flagLimit)

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2295,6 +2295,7 @@ func filterJSONArrayByFieldValues(data json.RawMessage, field string, targets ma
 	for _, item := range items {
 		raw, ok := lookupClientSideFilterField(item, field)
 		if !ok {
+			filtered = append(filtered, item)
 			continue
 		}
 		sawField = true

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2235,6 +2235,132 @@ func truncateJSONArray(data json.RawMessage, n int) json.RawMessage {
 	return out
 }
 {{- end}}
+{{- if .HasClientFilters}}
+
+// filterJSONByFieldValues returns data narrowed to items whose field value
+// matches one of the comma-separated filter values. It supports both bare JSON
+// arrays and common list envelopes such as {"data":[...]} so docs-derived
+// batch endpoints can keep filter flags honest even when the server ignores
+// the corresponding query param.
+func filterJSONByFieldValues(data json.RawMessage, field string, rawValues string) json.RawMessage {
+	targets := clientSideFilterTargets(rawValues)
+	if len(targets) == 0 {
+		return data
+	}
+	if filtered, ok := filterJSONArrayByFieldValues(data, field, targets); ok {
+		return filtered
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return data
+	}
+	for _, key := range []string{"data", "results", "items"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		filtered, ok := filterJSONArrayByFieldValues(raw, field, targets)
+		if !ok {
+			continue
+		}
+		envelope[key] = filtered
+		out, err := json.Marshal(envelope)
+		if err != nil {
+			return data
+		}
+		return out
+	}
+	return data
+}
+
+func clientSideFilterTargets(rawValues string) map[string]struct{} {
+	targets := map[string]struct{}{}
+	for _, value := range strings.Split(rawValues, ",") {
+		normalized := normalizeClientSideFilterValue(value)
+		if normalized == "" {
+			continue
+		}
+		targets[normalized] = struct{}{}
+	}
+	return targets
+}
+
+func filterJSONArrayByFieldValues(data json.RawMessage, field string, targets map[string]struct{}) (json.RawMessage, bool) {
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, false
+	}
+	sawField := false
+	filtered := make([]map[string]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		raw, ok := lookupClientSideFilterField(item, field)
+		if !ok {
+			continue
+		}
+		sawField = true
+		if jsonValueMatchesClientSideFilter(raw, targets) {
+			filtered = append(filtered, item)
+		}
+	}
+	if !sawField {
+		return data, false
+	}
+	out, err := json.Marshal(filtered)
+	if err != nil {
+		return data, true
+	}
+	return out, true
+}
+
+func lookupClientSideFilterField(item map[string]json.RawMessage, field string) (json.RawMessage, bool) {
+	if raw, ok := item[field]; ok {
+		return raw, true
+	}
+	want := normalizeClientSideFilterField(field)
+	for key, raw := range item {
+		if normalizeClientSideFilterField(key) == want {
+			return raw, true
+		}
+	}
+	return nil, false
+}
+
+func jsonValueMatchesClientSideFilter(raw json.RawMessage, targets map[string]struct{}) bool {
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	switch v := value.(type) {
+	case string:
+		_, ok := targets[normalizeClientSideFilterValue(v)]
+		return ok
+	case float64, bool:
+		_, ok := targets[normalizeClientSideFilterValue(fmt.Sprintf("%v", v))]
+		return ok
+	case []any:
+		for _, item := range v {
+			if _, ok := targets[normalizeClientSideFilterValue(fmt.Sprintf("%v", item))]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeClientSideFilterField(field string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(field)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func normalizeClientSideFilterValue(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+{{- end}}
 
 // defaultDBPath returns the canonical path for the local SQLite database.
 func defaultDBPath(name string) string {


### PR DESCRIPTION
## Summary

Docs-derived batch commands now keep simple filter flags honest when the upstream endpoint accepts but ignores the corresponding query parameter. For batch/all GET endpoints whose filter flag maps to a response item field, generated CLIs still send the documented query param and then narrow the returned JSON locally, including common `{data:[...]}` envelopes.

The filtering runs before client-side `--limit` truncation, fails open when the actual response shape does not contain the expected field, and is limited to docs-derived batch list endpoints so ordinary list endpoints keep trusting server-side filter semantics.

## Tests

- `go test ./internal/generator -run 'TestEndpointClientSideFilters|TestGeneratedDocsClientSideFilterNarrowsIgnoredBatchParam|TestGeneratedPromotedDocsClientSideFilterRunsBeforeLimit' -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push hook: `golangci-lint` passed with 0 issues

Closes #2092

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
