### PR TITLE
feat(cli): add oauth2_refresh auth type

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -247,6 +247,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"authCommandShort":                   authCommandShort,
 		"authHarvestedEnvHint":               authHarvestedEnvHint,
 		"oauth2AccessTokenAuth":              oauth2AccessTokenAuth,
+		"oauth2AuthSource":                   oauth2AuthSource,
 		"basicAuthEnvVars":                   basicAuthEnvVars,
 		"clientCredentialsEnvVars":           clientCredentialsEnvVars,
 		"deviceCodeEnvVars":                  deviceCodeEnvVars,
@@ -1028,7 +1029,7 @@ func authHarvestedEnvHint(auth spec.AuthConfig) string {
 }
 
 func oauth2AccessTokenAuth(auth spec.AuthConfig) bool {
-	if auth.Type == "oauth2" {
+	if auth.Type == "oauth2" || auth.Type == spec.AuthTypeOAuth2Refresh {
 		return true
 	}
 	if auth.Type != "bearer_token" {
@@ -1040,6 +1041,13 @@ func oauth2AccessTokenAuth(auth spec.AuthConfig) bool {
 	default:
 		return false
 	}
+}
+
+func oauth2AuthSource(auth spec.AuthConfig) string {
+	if auth.Type == spec.AuthTypeOAuth2Refresh {
+		return spec.AuthTypeOAuth2Refresh
+	}
+	return "oauth2"
 }
 
 func authFormatIsBasic(auth spec.AuthConfig) bool {

--- a/internal/generator/oauth2_refresh_test.go
+++ b/internal/generator/oauth2_refresh_test.go
@@ -1,0 +1,183 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateOAuth2RefreshAuth(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-refresh")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:     spec.AuthTypeOAuth2Refresh,
+		Header:   "Authorization",
+		TokenURL: "https://auth.example.com/oauth/token",
+		EnvVars: []string{
+			"OAUTH_REFRESH_CLIENT_ID",
+			"OAUTH_REFRESH_CLIENT_SECRET",
+			"OAUTH_REFRESH_REFRESH_TOKEN",
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth2-refresh-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
+	readme := readGeneratedFile(t, outputDir, "README.md")
+	skill := readGeneratedFile(t, outputDir, "SKILL.md")
+
+	assert.Contains(t, configSrc, `c.AuthSource = "oauth2_refresh"`)
+	assert.Contains(t, configSrc, `return "Bearer " + c.AccessToken`)
+	assert.NotContains(t, configSrc, `c.AuthSource = "bearer_refresh"`)
+	assert.Contains(t, clientSrc, `"grant_type":    {"refresh_token"}`)
+	assert.Contains(t, clientSrc, `tokenURL = "https://auth.example.com/oauth/token"`)
+	assert.Contains(t, doctorSrc, `report["auth"] = "configured (oauth2 refresh)"`)
+	assert.Contains(t, doctorSrc, `report["auth_source"] = cfg.AuthSource`)
+	assert.Contains(t, readme, "This CLI uses OAuth2 with refresh-token rotation.")
+	assert.Contains(t, skill, "This CLI uses OAuth2 with refresh-token rotation.")
+
+	writeOAuth2RefreshRuntimeTest(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestOAuth2RefreshTokenUsedBeforeRequest$")
+}
+
+func TestOAuth2RefreshDefaultsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-refresh-defaults")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:     spec.AuthTypeOAuth2Refresh,
+		Header:   "Authorization",
+		TokenURL: "https://auth.example.com/oauth/token",
+	}
+
+	require.NoError(t, apiSpec.Validate())
+	require.Equal(t, []spec.AuthEnvVar{
+		{
+			Name:        "OAUTH2_REFRESH_DEFAULTS_CLIENT_ID",
+			Kind:        spec.AuthEnvVarKindAuthFlowInput,
+			Required:    true,
+			Sensitive:   false,
+			Description: "OAuth client ID.",
+			Inferred:    true,
+		},
+		{
+			Name:        "OAUTH2_REFRESH_DEFAULTS_CLIENT_SECRET",
+			Kind:        spec.AuthEnvVarKindAuthFlowInput,
+			Required:    false,
+			Sensitive:   true,
+			Description: "OAuth client secret.",
+			Inferred:    true,
+		},
+		{
+			Name:        "OAUTH2_REFRESH_DEFAULTS_REFRESH_TOKEN",
+			Kind:        spec.AuthEnvVarKindAuthFlowInput,
+			Required:    true,
+			Sensitive:   true,
+			Description: "OAuth refresh token.",
+			Inferred:    true,
+		},
+	}, apiSpec.Auth.EnvVarSpecs)
+}
+
+func TestOAuth2RefreshRequiresTokenURL(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-refresh-missing-token-url")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   spec.AuthTypeOAuth2Refresh,
+		Header: "Authorization",
+	}
+
+	err := apiSpec.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `auth.token_url is required when auth.type is "oauth2_refresh"`)
+}
+
+func writeOAuth2RefreshRuntimeTest(t *testing.T, outputDir string) {
+	t.Helper()
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	modulePath := strings.TrimSpace(strings.TrimPrefix(strings.SplitN(goMod, "\n", 2)[0], "module "))
+	require.NotEmpty(t, modulePath)
+
+	runtimeTest := strings.ReplaceAll(`package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"__MODULE_PATH__/internal/config"
+)
+
+func TestOAuth2RefreshTokenUsedBeforeRequest(t *testing.T) {
+	var gotGrant string
+	var gotRefreshToken string
+	var gotClientID string
+	var gotClientSecret string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("token request method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Fatalf("content-type = %q, want application/x-www-form-urlencoded", ct)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		gotGrant = r.Form.Get("grant_type")
+		gotRefreshToken = r.Form.Get("refresh_token")
+		gotClientID = r.Form.Get("client_id")
+		gotClientSecret = r.Form.Get("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `+"`"+`{"access_token":"access-123","refresh_token":"refresh-456","expires_in":3600}`+"`"+`)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		BaseURL:       "https://api.example.com",
+		TokenURL:      srv.URL,
+		RefreshToken:  "refresh-123",
+		ClientID:      "client-123",
+		ClientSecret:  "secret-123",
+		TokenExpiry:   time.Now().Add(-time.Minute),
+		Path:          filepath.Join(t.TempDir(), "config.toml"),
+	}
+	c := New(cfg, time.Second, 0)
+	c.HTTPClient = srv.Client()
+
+	header, err := c.authHeader(context.Background())
+	if err != nil {
+		t.Fatalf("authHeader: %v", err)
+	}
+	if header != "Bearer access-123" {
+		t.Fatalf("auth header = %q, want Bearer access-123", header)
+	}
+	if gotGrant != "refresh_token" || gotRefreshToken != "refresh-123" || gotClientID != "client-123" || gotClientSecret != "secret-123" {
+		t.Fatalf("refresh form = grant:%q refresh:%q client_id:%q client_secret:%q", gotGrant, gotRefreshToken, gotClientID, gotClientSecret)
+	}
+	if cfg.RefreshToken != "refresh-456" {
+		t.Fatalf("rotated refresh token = %q, want refresh-456", cfg.RefreshToken)
+	}
+	if cfg.AuthSource != "oauth2_refresh" {
+		t.Fatalf("auth source = %q, want oauth2_refresh", cfg.AuthSource)
+	}
+}
+`, "__MODULE_PATH__", modulePath)
+
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "oauth2_refresh_test.go"), []byte(runtimeTest), 0o644))
+}

--- a/internal/generator/oauth2_refresh_test.go
+++ b/internal/generator/oauth2_refresh_test.go
@@ -42,6 +42,8 @@ func TestGenerateOAuth2RefreshAuth(t *testing.T) {
 	assert.Contains(t, clientSrc, `tokenURL = "https://auth.example.com/oauth/token"`)
 	assert.Contains(t, doctorSrc, `report["auth"] = "configured (oauth2 refresh)"`)
 	assert.Contains(t, doctorSrc, `report["auth_source"] = cfg.AuthSource`)
+	assert.Contains(t, doctorSrc, `report["auth_hint"] = "export OAUTH_REFRESH_REFRESH_TOKEN=<your-oauth-refresh-value>"`)
+	assert.NotContains(t, doctorSrc, `report["auth_hint"] = "export OAUTH_REFRESH_CLIENT_ID=<your-oauth-refresh-value>"`)
 	assert.Contains(t, readme, "This CLI uses OAuth2 with refresh-token rotation.")
 	assert.Contains(t, skill, "This CLI uses OAuth2 with refresh-token rotation.")
 
@@ -86,6 +88,49 @@ func TestOAuth2RefreshDefaultsEnvVars(t *testing.T) {
 			Inferred:    true,
 		},
 	}, apiSpec.Auth.EnvVarSpecs)
+}
+
+func TestOAuth2RefreshExplicitEnvVarsKeepClientSecretOptional(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-refresh-explicit")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:     spec.AuthTypeOAuth2Refresh,
+		Header:   "Authorization",
+		TokenURL: "https://auth.example.com/oauth/token",
+		EnvVars: []string{
+			"OAUTH2_REFRESH_EXPLICIT_CLIENT_ID",
+			"OAUTH2_REFRESH_EXPLICIT_CLIENT_SECRET",
+			"OAUTH2_REFRESH_EXPLICIT_REFRESH_TOKEN",
+		},
+	}
+
+	require.NoError(t, apiSpec.Validate())
+	require.Equal(t, []spec.AuthEnvVar{
+		{
+			Name:      "OAUTH2_REFRESH_EXPLICIT_CLIENT_ID",
+			Kind:      spec.AuthEnvVarKindAuthFlowInput,
+			Required:  true,
+			Sensitive: false,
+			Inferred:  true,
+		},
+		{
+			Name:      "OAUTH2_REFRESH_EXPLICIT_CLIENT_SECRET",
+			Kind:      spec.AuthEnvVarKindAuthFlowInput,
+			Required:  false,
+			Sensitive: true,
+			Inferred:  true,
+		},
+		{
+			Name:      "OAUTH2_REFRESH_EXPLICIT_REFRESH_TOKEN",
+			Kind:      spec.AuthEnvVarKindAuthFlowInput,
+			Required:  true,
+			Sensitive: true,
+			Inferred:  true,
+		},
+	}, apiSpec.Auth.EnvVarSpecs)
+	require.NotNil(t, apiSpec.Auth.OAuth2RefreshTokenEnvVar())
+	assert.Equal(t, "OAUTH2_REFRESH_EXPLICIT_REFRESH_TOKEN", apiSpec.Auth.OAuth2RefreshTokenEnvVar().Name)
 }
 
 func TestOAuth2RefreshRequiresTokenURL(t *testing.T) {

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -60,11 +60,18 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "Then set:")
 {{- range .Auth.EnvVarSpecs}}
-{{- if isRequestAuthEnvVar .}}
+{{- if eq $.Auth.Type "oauth2_refresh"}}
+			fmt.Fprintln(w, "  export {{.Name}}=\"{{authEnvPlaceholder .}}\"")
+{{- else if isRequestAuthEnvVar .}}
 			fmt.Fprintln(w, "  export {{.Name}}=\"<your-token>\"")
 {{- end}}
 {{- end}}
+{{- if eq .Auth.Type "oauth2_refresh"}}
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "OAuth2 refresh-token credentials are exchanged automatically before API calls.")
+{{- else}}
 			fmt.Fprintln(w, "  {{.Name}}-pp-cli auth set-token <token>")
+{{- end}}
 {{- else if .Auth.EnvVars}}
 			fmt.Fprintln(w, "")
 			fmt.Fprintln(w, "Then set:")
@@ -129,6 +136,12 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 			w := cmd.OutOrStdout()
 			header := cfg.AuthHeader()
 			authed := header != ""
+{{- if eq .Auth.Type "oauth2_refresh"}}
+			if cfg.RefreshToken != "" {
+				authed = true
+				cfg.AuthSource = "oauth2_refresh"
+			}
+{{- end}}
 			// JSON envelope: {authenticated, verified, source, config}. When not
 			// authenticated, write the envelope first then return authErr
 			// so exit code carries the auth-failure signal.
@@ -153,7 +166,7 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				fmt.Fprintln(w, "Set your token:")
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
-{{- if isRequestAuthEnvVar .}}
+{{- if or (isRequestAuthEnvVar .) (eq $.Auth.Type "oauth2_refresh")}}
 {{- $hint := authEnvHintComment .}}
 				fmt.Fprintln(w, "  export {{.Name}}=\"{{authEnvPlaceholder .}}\"{{if $hint}} # {{$hint}}{{end}}")
 {{- end}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1837,7 +1837,11 @@ func (c *Client) authHeader(ctx context.Context) (string, error) {
 		c.ccMu.Unlock()
 	}
 {{- else if and .HasAuthCommand (ne .Auth.TokenURL "")}}
+{{- if eq .Auth.Type "oauth2_refresh"}}
+	if ((c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry)) || c.Config.AccessToken == "") && c.Config.RefreshToken != "" && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+{{- else}}
 	if c.Config.AccessToken != "" && !c.Config.TokenExpiry.IsZero() && time.Now().After(c.Config.TokenExpiry) && c.Config.RefreshToken != "" && !(cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv()) {
+{{- end}}
 		if authHeaderLooksLikePlaceholderCredential(c.Config.AccessToken) || authHeaderLooksLikePlaceholderCredential(c.Config.RefreshToken) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientID) || authHeaderLooksLikePlaceholderCredential(c.Config.ClientSecret) {
 			return "", authPlaceholderCredentialError(c.Config)
 		}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -170,6 +170,11 @@ func Load(configPath string) (*Config, error) {
 	if cfg.AuthSource == "" && (cfg.AuthHeaderVal != ""{{- if .HasAuthCommand}} || cfg.AccessToken != ""{{- end}}) {
 		cfg.AuthSource = "config"
 	}
+{{- if eq .Auth.Type "oauth2_refresh"}}
+	if cfg.RefreshToken != "" {
+		cfg.AuthSource = "oauth2_refresh"
+	}
+{{- end}}
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 {{- if not (envVarIsBuiltinField .Name)}}
@@ -404,7 +409,7 @@ func (c *Config) AuthHeader() string {
 	return ""
 	{{- end}}
 {{- end}}
-{{- else if or (eq .Auth.Type "bearer_token") (eq .Auth.Type "oauth2")}}
+{{- else if or (eq .Auth.Type "bearer_token") (eq .Auth.Type "oauth2") (eq .Auth.Type "oauth2_refresh")}}
 {{- if oauth2AccessTokenAuth .Auth}}
 	// Under OAuth2 (and bearer_token specs running OAuth grants such as
 	// client_credentials or device_code) the configured env vars hold flow
@@ -413,7 +418,7 @@ func (c *Config) AuthHeader() string {
 	// the API.
 	if c.AccessToken != "" {
 		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
-			c.AuthSource = "oauth2"
+			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
@@ -441,7 +446,7 @@ func (c *Config) AuthHeader() string {
 	// AccessToken, so it must win before considering any per-call fallbacks.
 	if c.AccessToken != "" {
 		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
-			c.AuthSource = "oauth2"
+			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
@@ -520,7 +525,7 @@ func (c *Config) AuthHeader() string {
 {{- if and (not .BearerRefresh.Enabled) (not $hasNonRequestEnvVars)}}
 	if c.AccessToken != "" {
 		if c.AuthSource == "" || strings.HasPrefix(c.AuthSource, "env:") {
-			c.AuthSource = "oauth2"
+			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
 		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -281,6 +281,32 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			if !cookieToolFound {
 				report["cookie_tool"] = "not found (install: pip install pycookiecheat)"
 			}
+{{- else if eq .Auth.Type "oauth2_refresh"}}
+			if cfg != nil {
+				if cfg.RefreshToken == "" {
+{{- if .Auth.Optional}}
+					report["auth"] = "optional — not configured"
+{{- else}}
+					report["auth"] = "not configured"
+{{- end}}
+{{- with $canonicalEnvVar}}
+					report["auth_hint"] = "export {{.Name}}=<your-oauth-refresh-value>"
+{{- end}}
+{{- if .Auth.KeyURL}}
+					report["auth_key_url"] = "{{.Auth.KeyURL}}"
+{{- else if .WebsiteURL}}
+					report["auth_docs_url"] = "{{.WebsiteURL}}"
+{{- end}}
+{{- if .Auth.Instructions}}
+					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
+{{- end}}
+				} else {
+					authConfigured = true
+					report["auth"] = "configured (oauth2 refresh)"
+					cfg.AuthSource = "oauth2_refresh"
+					report["auth_source"] = cfg.AuthSource
+				}
+			}
 {{- else}}
 			if cfg != nil {
 				header := cfg.AuthHeader()

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -289,7 +289,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- else}}
 					report["auth"] = "not configured"
 {{- end}}
-{{- with $canonicalEnvVar}}
+{{- with .Auth.OAuth2RefreshTokenEnvVar}}
 					report["auth_hint"] = "export {{.Name}}=<your-oauth-refresh-value>"
 {{- end}}
 {{- if .Auth.KeyURL}}

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -119,6 +119,15 @@ The bundle reuses your local OAuth tokens — authenticate first if you haven't:
 ```bash
 {{.Name}}-pp-cli auth login
 ```
+{{- else if eq .Auth.Type "oauth2_refresh"}}
+
+The bundle reuses your local OAuth2 refresh-token credentials — configure them first if you haven't:
+
+```bash
+{{- range .Auth.EnvVarSpecs}}
+export {{.Name}}="{{authEnvPlaceholder .}}"
+{{- end}}
+```
 {{- else if and (eq .Auth.Type "bearer_token") (not $canonicalEnvVar)}}
 
 Store your token first if you haven't:
@@ -248,6 +257,17 @@ Authorize via your browser:
 ```
 
 This opens a browser window to complete the OAuth2 flow. Your tokens are stored locally and refreshed automatically.
+{{- else if eq .Auth.Type "oauth2_refresh"}}
+
+### 2. Set Up OAuth2 Refresh Credentials
+
+This CLI uses OAuth2 with refresh-token rotation. Provide the client credentials and refresh token; access tokens are refreshed automatically.
+
+```bash
+{{- range .Auth.EnvVarSpecs}}
+export {{.Name}}="{{authEnvPlaceholder .}}"
+{{- end}}
+```
 {{- else if eq .Auth.Type "bearer_token"}}
 
 ### 2. Set Up Credentials

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -246,6 +246,17 @@ Run `{{.Name}}-pp-cli auth setup` for the registration URL and steps (add `--lau
 ```
 
 Tokens are stored locally and refreshed automatically.
+{{- else if eq .Auth.Type "oauth2_refresh"}}
+
+This CLI uses OAuth2 with refresh-token rotation. Configure the client credentials and refresh token:
+
+```bash
+{{- range .Auth.EnvVarSpecs}}
+export {{.Name}}="{{authEnvPlaceholder .}}"
+{{- end}}
+```
+
+Access tokens are refreshed automatically before API calls.
 {{- else if eq .Auth.Type "bearer_token"}}
 
 Run `{{.Name}}-pp-cli auth setup` for the URL and steps to obtain a token (add `--launch` to open the URL). Then store it:

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -950,6 +950,7 @@ func TestComputeMCPReady(t *testing.T) {
 		{"api_key", "api_key", "full"},
 		{"bearer_token", "bearer_token", "full"},
 		{"oauth2 defaults to full", "oauth2", "full"},
+		{"oauth2_refresh defaults to full", "oauth2_refresh", "full"},
 		{"cookie always partial", "cookie", "partial"},
 		{"composed always partial", "composed", "partial"},
 		{"empty auth type", "", "full"},
@@ -1324,6 +1325,28 @@ func TestWriteMCPBManifest(t *testing.T) {
 			v, ok := got.UserConfig[key]
 			require.True(t, ok, "user_config must include %q", key)
 			assert.False(t, v.Required, "auth_type=none keeps env vars optional")
+		}
+	})
+
+	t.Run("oauth2_refresh env vars are required", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifest(t, dir, CLIManifest{
+			APIName:     "exact-online",
+			DisplayName: "Exact Online",
+			MCPBinary:   "exact-online-pp-mcp",
+			MCPReady:    "full",
+			AuthType:    "oauth2_refresh",
+			AuthEnvVars: []string{"EXACT_ONLINE_CLIENT_ID", "EXACT_ONLINE_CLIENT_SECRET", "EXACT_ONLINE_REFRESH_TOKEN"},
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Len(t, got.UserConfig, 3)
+		for _, key := range []string{"exact_online_client_id", "exact_online_client_secret", "exact_online_refresh_token"} {
+			v, ok := got.UserConfig[key]
+			require.True(t, ok, "user_config must include %q", key)
+			assert.True(t, v.Required, "oauth2_refresh credentials gate API calls")
 		}
 	})
 

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -20,9 +20,10 @@ const (
 	mcpbServerTypeBinary = "binary"
 	mcpbVarTypeString    = "string"
 
-	authTypeAPIKey      = "api_key"
-	authTypeBearerToken = "bearer_token"
-	authTypeOAuth2      = "oauth2"
+	authTypeAPIKey        = "api_key"
+	authTypeBearerToken   = "bearer_token"
+	authTypeOAuth2        = "oauth2"
+	authTypeOAuth2Refresh = "oauth2_refresh"
 )
 
 // defaultMCPBPlatforms is the set of host platforms our generated bundles
@@ -484,12 +485,12 @@ func envVarDescription(m CLIManifest, envVar spec.AuthEnvVar, required bool) str
 }
 
 // authRequiresCredential decides whether a user_config field is required.
-// api_key/bearer_token/oauth2 gate every API call on the credential.
+// api_key/bearer_token/oauth2/oauth2_refresh gate every API call on the credential.
 // cookie/composed flows have unauth fallbacks for some tools, so we let
 // the user skip and hit the parts that work without credentials.
 func authRequiresCredential(authType string) bool {
 	switch authType {
-	case authTypeAPIKey, authTypeBearerToken, authTypeOAuth2:
+	case authTypeAPIKey, authTypeBearerToken, authTypeOAuth2, authTypeOAuth2Refresh:
 		return true
 	default:
 		return false

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -77,6 +77,7 @@ const (
 	TierAuthTypeNone        = "none"
 	TierAuthTypeAPIKey      = "api_key"
 	TierAuthTypeBearerToken = "bearer_token"
+	AuthTypeOAuth2Refresh   = "oauth2_refresh"
 
 	TierAuthPlacementHeader = "header"
 	TierAuthPlacementQuery  = "query"
@@ -899,7 +900,7 @@ func (c BearerRefreshConfig) Enabled() bool {
 }
 
 type AuthConfig struct {
-	Type                   string       `yaml:"type" json:"type"`                           // api_key, oauth2, bearer_token, cookie, composed, session_handshake, none
+	Type                   string       `yaml:"type" json:"type"`                           // api_key, oauth2, oauth2_refresh, bearer_token, cookie, composed, session_handshake, none
 	Subtype                string       `yaml:"subtype,omitempty" json:"subtype,omitempty"` // optional refinement of Type. Currently used for "auth0_spa_in_memory": bearer_token whose JWT lives in JS heap (Auth0 SPA SDK v2+ with cacheLocation: memory) and is reachable only via CDP runtime interception, not via cookie/localStorage extraction. Mirrors x-auth-subtype on the OpenAPI security scheme.
 	Header                 string       `yaml:"header" json:"header"`
 	Prefix                 string       `yaml:"prefix,omitempty" json:"prefix,omitempty"` // Authorization scheme word (e.g., "Token", "PRIVATE-TOKEN"); empty defaults to "Bearer". Ignored when Format is set.
@@ -1233,11 +1234,17 @@ func (c *AuthConfig) NormalizeEnvVarSpecs(context string) {
 		c.EnvVarSpecs = make([]AuthEnvVar, 0, len(c.EnvVars))
 		for _, name := range c.EnvVars {
 			if name = strings.TrimSpace(name); name != "" {
+				kind := AuthEnvVarKindPerCall
+				sensitive := true
+				if c.Type == AuthTypeOAuth2Refresh {
+					kind = AuthEnvVarKindAuthFlowInput
+					sensitive = naming.EnvVarPlaceholder(name) != "client_id"
+				}
 				c.EnvVarSpecs = append(c.EnvVarSpecs, AuthEnvVar{
 					Name:      name,
-					Kind:      AuthEnvVarKindPerCall,
+					Kind:      kind,
 					Required:  true,
-					Sensitive: true,
+					Sensitive: sensitive,
 					Inferred:  true,
 				})
 			}
@@ -1479,6 +1486,19 @@ func validateOAuth2Grant(c AuthConfig) error {
 		return fmt.Errorf("auth.oauth2_grant %q is not recognized (valid: %q, %q, %q)",
 			c.OAuth2Grant, OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials, OAuth2GrantDeviceCode)
 	}
+}
+
+func validateOAuth2Refresh(c AuthConfig) error {
+	if c.Type != AuthTypeOAuth2Refresh {
+		return nil
+	}
+	if strings.TrimSpace(c.TokenURL) == "" {
+		return fmt.Errorf("auth.token_url is required when auth.type is %q", AuthTypeOAuth2Refresh)
+	}
+	if err := validateHTTPSURL("auth.token_url", c.TokenURL); err != nil {
+		return err
+	}
+	return nil
 }
 
 // validateSessionHandshake enforces fail-fast on session_handshake auth specs
@@ -2976,6 +2996,9 @@ func (s *APISpec) Validate() error {
 	if err := validateOAuth2Grant(s.Auth); err != nil {
 		return err
 	}
+	if err := validateOAuth2Refresh(s.Auth); err != nil {
+		return err
+	}
 	if err := validateAuthPrefix(s.Auth); err != nil {
 		return err
 	}
@@ -3129,6 +3152,35 @@ func validateReservedPlaceholderHost(label, rawURL string) error {
 func (s *APISpec) NormalizeAuthEnvVarSpecs() {
 	if s == nil {
 		return
+	}
+	if s.Auth.Type == AuthTypeOAuth2Refresh && len(s.Auth.EnvVars) == 0 && len(s.Auth.EnvVarSpecs) == 0 {
+		prefix := naming.EnvPrefix(s.Name)
+		s.Auth.EnvVarSpecs = []AuthEnvVar{
+			{
+				Name:        prefix + "_CLIENT_ID",
+				Kind:        AuthEnvVarKindAuthFlowInput,
+				Required:    true,
+				Sensitive:   false,
+				Description: "OAuth client ID.",
+				Inferred:    true,
+			},
+			{
+				Name:        prefix + "_CLIENT_SECRET",
+				Kind:        AuthEnvVarKindAuthFlowInput,
+				Required:    false,
+				Sensitive:   true,
+				Description: "OAuth client secret.",
+				Inferred:    true,
+			},
+			{
+				Name:        prefix + "_REFRESH_TOKEN",
+				Kind:        AuthEnvVarKindAuthFlowInput,
+				Required:    true,
+				Sensitive:   true,
+				Description: "OAuth refresh token.",
+				Inferred:    true,
+			},
+		}
 	}
 	s.Auth.NormalizeEnvVarSpecs("auth")
 	if !s.HasTierRouting() {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1105,6 +1105,21 @@ func (v AuthEnvVar) IsRequestCredential() bool {
 	return v.EffectiveKind() == AuthEnvVarKindPerCall
 }
 
+func isOAuthClientIDEnvVar(name string) bool {
+	placeholder := naming.EnvVarPlaceholder(name)
+	return placeholder == "client_id" || strings.HasSuffix(placeholder, "_client_id")
+}
+
+func isOAuthClientSecretEnvVar(name string) bool {
+	placeholder := naming.EnvVarPlaceholder(name)
+	return placeholder == "client_secret" || strings.HasSuffix(placeholder, "_client_secret")
+}
+
+func isOAuthRefreshTokenEnvVar(name string) bool {
+	placeholder := naming.EnvVarPlaceholder(name)
+	return placeholder == "refresh_token" || strings.HasSuffix(placeholder, "_refresh_token")
+}
+
 func (k AuthEnvVarKind) SensitivePlaceholder() string {
 	switch k {
 	case AuthEnvVarKindPerCall:
@@ -1153,6 +1168,26 @@ func (c *AuthConfig) CanonicalEnvVar() *AuthEnvVar {
 		return &c.EnvVarSpecs[0]
 	}
 	return nil
+}
+
+// OAuth2RefreshTokenEnvVar returns the env var a user should set with the
+// long-lived refresh token for oauth2_refresh auth.
+func (c *AuthConfig) OAuth2RefreshTokenEnvVar() *AuthEnvVar {
+	if c == nil || c.Type != AuthTypeOAuth2Refresh {
+		return nil
+	}
+	c.NormalizeEnvVarSpecs("")
+	for i := range c.EnvVarSpecs {
+		if isOAuthRefreshTokenEnvVar(c.EnvVarSpecs[i].Name) {
+			return &c.EnvVarSpecs[i]
+		}
+	}
+	for i := len(c.EnvVarSpecs) - 1; i >= 0; i-- {
+		if c.EnvVarSpecs[i].EffectiveKind() == AuthEnvVarKindAuthFlowInput {
+			return &c.EnvVarSpecs[i]
+		}
+	}
+	return c.CanonicalEnvVar()
 }
 
 // NewORCaseEnvVarSpecs builds the canonical EnvVarSpecs slice for the OR-case
@@ -1235,15 +1270,17 @@ func (c *AuthConfig) NormalizeEnvVarSpecs(context string) {
 		for _, name := range c.EnvVars {
 			if name = strings.TrimSpace(name); name != "" {
 				kind := AuthEnvVarKindPerCall
+				required := true
 				sensitive := true
 				if c.Type == AuthTypeOAuth2Refresh {
 					kind = AuthEnvVarKindAuthFlowInput
-					sensitive = naming.EnvVarPlaceholder(name) != "client_id"
+					required = !isOAuthClientSecretEnvVar(name)
+					sensitive = !isOAuthClientIDEnvVar(name)
 				}
 				c.EnvVarSpecs = append(c.EnvVarSpecs, AuthEnvVar{
 					Name:      name,
 					Kind:      kind,
-					Required:  true,
+					Required:  required,
 					Sensitive: sensitive,
 					Inferred:  true,
 				})

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -17,7 +17,7 @@ required_headers:                 # []RequiredHeader optional headers sent on ev
     value: "Mozilla/5.0 ..."
 
 auth:                             # object (AuthConfig)
-  type: api_key                   # string: api_key | oauth2 | bearer_token | none
+  type: api_key                   # string: api_key | oauth2 | oauth2_refresh | bearer_token | none
   header: "Authorization"        # string header name to set
   format: "Bearer {token}"       # string format template for auth header value
   oauth2_grant: device_code       # string optional: authorization_code | client_credentials | device_code
@@ -109,6 +109,12 @@ types:                            # map[string]TypeDef named response/body model
       - name: user_id             # string field name
         type: string              # string field type (typically string/int/bool/float)
 ```
+
+For OAuth2 refresh-token rotation without an interactive browser flow, use
+`auth.type: oauth2_refresh` with `auth.token_url`. When `env_vars` is omitted,
+the generator defaults to `<API>_CLIENT_ID`, `<API>_CLIENT_SECRET`, and
+`<API>_REFRESH_TOKEN`; access tokens are refreshed automatically before API
+calls.
 
 **`response_format` must be one of `json`, `html`, or `binary`.** Use `json`
 when the response body is JSON and can be parsed directly. Use `html` only for


### PR DESCRIPTION
## Summary

Generated CLIs can now model OAuth2 refresh-token rotation directly with `auth.type: oauth2_refresh`, so APIs that need client credentials plus a long-lived refresh token no longer have to masquerade as bearer-refresh auth.

The generated config, client, setup/status, doctor, README, SKILL.md, and MCPB credential metadata now understand the refresh-token credential shape. The client also uses the refresh token before the first request when no access token is present, then preserves rotated refresh tokens from the token endpoint.

Closes #1575

## Verification

- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
