### PR TITLE
fix(cli): skip unfixturable mutating dogfood examples

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -39,6 +39,7 @@ const (
 const reasonDestructiveAtAuth = "destructive-at-auth"
 const reasonMutatingDryRunOnly = "mutating command dry-run only"
 const reasonMutatingErrorPath = "mutating command; error_path would call live API without --dry-run"
+const reasonMutatingRunnableFixture = "blocked-fixture: mutating command requires runnable example"
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
 const reasonUnavailableRunnerCredentials = "unavailable for runner credentials"
 const reasonFileFixtureRequired = "file fixture required"
@@ -693,8 +694,17 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 
 	command.Help = help
+	mutating := liveDogfoodCommandMutates(command)
 	happyArgs, ok := liveDogfoodHappyArgs(command)
 	if !ok {
+		if mutating {
+			results = append(results,
+				skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonMutatingRunnableFixture),
+				skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonMutatingRunnableFixture),
+				skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonMutatingRunnableFixture),
+			)
+			return results
+		}
 		results = append(results,
 			failedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, command.Path, "missing runnable example"),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, "missing runnable example"),
@@ -703,7 +713,6 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		return results
 	}
 
-	mutating := liveDogfoodCommandMutates(command)
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -841,6 +841,41 @@ func TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx(t *testing.T) {
 	assert.Equal(t, reasonRequiredParamFixture, summaryJSON.Reason)
 }
 
+func TestRunLiveDogfoodSkipsMutatingCommandsWithoutRunnableExample(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodMissingRunnableExampleFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	updateHappy := findResultByCommandKind(report, "templates update", LiveDogfoodTestHappy)
+	require.NotNil(t, updateHappy, "expected templates update happy_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, updateHappy.Status)
+	assert.Equal(t, reasonMutatingRunnableFixture, updateHappy.Reason)
+
+	updateJSON := findResultByCommandKind(report, "templates update", LiveDogfoodTestJSON)
+	require.NotNil(t, updateJSON, "expected templates update json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, updateJSON.Status)
+	assert.Equal(t, reasonMutatingRunnableFixture, updateJSON.Reason)
+
+	updateError := findResultByCommandKind(report, "templates update", LiveDogfoodTestError)
+	require.NotNil(t, updateError, "expected templates update error_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, updateError.Status)
+	assert.Equal(t, reasonMutatingRunnableFixture, updateError.Reason)
+
+	detailsHappy := findResultByCommandKind(report, "reports details", LiveDogfoodTestHappy)
+	require.NotNil(t, detailsHappy, "expected reports details happy_path result")
+	assert.Equal(t, LiveDogfoodStatusFail, detailsHappy.Status)
+	assert.Equal(t, "missing runnable example", detailsHappy.Reason)
+}
+
 func TestRunLiveDogfoodKeepsOrdinary4xxFailures(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -988,6 +1023,70 @@ fi
 
 if [ "$1" = "reports" ] && [ "$2" = "summary" ]; then
   echo 'summary'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	writeStubBinary(t, dir, binaryName, script)
+	return dir, binaryName
+}
+
+func writeLiveDogfoodMissingRunnableExampleFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	script := `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"templates","subcommands":[
+      {"name":"update","annotations":{"pp:method":"PUT"}}
+    ]},
+    {"name":"reports","subcommands":[
+      {"name":"details","annotations":{"pp:method":"GET"}}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "templates" ] && [ "$2" = "update" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Update a template.
+
+Usage:
+  fixture-pp-cli templates update [flags]
+
+Examples:
+  # Supply a real template id before running this write command.
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "reports" ] && [ "$2" = "details" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Read report details.
+
+Usage:
+  fixture-pp-cli reports details [flags]
+
+Examples:
+  # No runnable example is documented for this read command.
+
+Flags:
+      --json    Output JSON
+HELP
   exit 0
 fi
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -855,6 +855,10 @@ func TestRunLiveDogfoodSkipsMutatingCommandsWithoutRunnableExample(t *testing.T)
 	})
 	require.NoError(t, err)
 
+	updateHelp := findResultByCommandKind(report, "templates update", LiveDogfoodTestHelp)
+	require.NotNil(t, updateHelp, "expected templates update help result")
+	assert.Equal(t, LiveDogfoodStatusPass, updateHelp.Status)
+
 	updateHappy := findResultByCommandKind(report, "templates update", LiveDogfoodTestHappy)
 	require.NotNil(t, updateHappy, "expected templates update happy_path result")
 	assert.Equal(t, LiveDogfoodStatusSkip, updateHappy.Status)


### PR DESCRIPTION
## Summary
Live dogfood now treats mutating commands without a runnable example as blocked fixture skips instead of failed happy-path rows. The scorer still fails read commands with the same documentation gap, so ordinary missing-example issues continue to surface.

Closes #2120

## Verification
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodSkipsMutatingCommandsWithoutRunnableExample|TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx|TestRunLiveDogfoodKeepsOrdinary4xxFailures|TestLiveDogfoodCommandMutatesPrefersEndpointMethod'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)
