### PR TITLE
fix(cli): handle reserved search resources

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -44,6 +44,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-data-source-strategy` | path item or operation | `Endpoint.DataSourceStrategy` | No |
 | `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-happy-args` | operation | `Endpoint.HappyArgs` | No |
+| `x-pp-resource` | operation | resource name override | No |
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
@@ -1163,6 +1164,34 @@ paths:
     get:
       operationId: listUsers
       x-requires-role: admin
+      responses:
+        "200": {description: ok}
+```
+
+### `x-pp-resource`
+
+Overrides the resource bucket for one OpenAPI operation. Use it when the path
+parser would derive a reserved Printing Press template name such as `search`,
+or when the upstream path shape does not expose the intended resource name.
+
+Parsed field: resource map key in `APISpec.Resources`
+
+Rules:
+- Optional.
+- Must be a string.
+- The value is sanitized to the same resource-name form the parser uses for
+  path-derived names.
+- Non-string values emit a warning and are ignored.
+- Applies only to the operation where it appears.
+
+Example:
+
+```yaml
+paths:
+  /search:
+    post:
+      operationId: searchNotes
+      x-pp-resource: notes_search
       responses:
         "200": {description: ok}
 ```

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -130,6 +130,76 @@ func TestGenerateProjectsCompile(t *testing.T) {
 	}
 }
 
+func TestGenerateReservedResourceRenamesEmitNonCollidingCLI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		specYAML          string
+		wantResourceFiles []string
+	}{
+		{
+			name: "parent prefix",
+			specYAML: `openapi: "3.0.3"
+info:
+  title: Reserved Search Parent
+  version: "1.0"
+servers:
+  - url: https://api.example.com/notes
+paths:
+  /notes/search:
+    post:
+      operationId: run
+      responses:
+        "200":
+          description: ok
+`,
+			wantResourceFiles: []string{"promoted_notes-search.go"},
+		},
+		{
+			name: "x-pp-resource override",
+			specYAML: `openapi: "3.0.3"
+info:
+  title: Reserved Search Override
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /search:
+    post:
+      operationId: run
+      x-pp-resource: global_search
+      responses:
+        "200":
+          description: ok
+`,
+			wantResourceFiles: []string{"promoted_global-search.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt //nolint:modernize // keep parallel subtest capture explicit
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec, err := openapi.Parse([]byte(tt.specYAML))
+			require.NoError(t, err)
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			require.NoError(t, New(apiSpec, outputDir).Generate())
+
+			for _, name := range tt.wantResourceFiles {
+				_, err := os.Stat(filepath.Join(outputDir, "internal", "cli", name))
+				require.NoError(t, err, "expected generated resource file %s", name)
+			}
+			_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "search_run.go"))
+			require.True(t, os.IsNotExist(err), "reserved search resource endpoint file must not be emitted")
+			_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "promoted_search.go"))
+			require.True(t, os.IsNotExist(err), "reserved search promoted command file must not be emitted")
+			runGoCommand(t, outputDir, "build", "./...")
+		})
+	}
+}
+
 func TestGenerateStoreExtrasHook(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5840,7 +5840,7 @@ func reservedTemplateCollisionRenames(doc *openapi3.T, pathKeys []string, basePa
 	type candidateSet map[string]struct{}
 	candidates := map[string]candidateSet{}
 	firstPath := map[string]string{}
-	hardErrors := map[string]struct{}{}
+	hardErrors := map[string]reservedTemplateCollision{}
 	rawResources := map[string]struct{}{}
 
 	for _, path := range pathKeys {
@@ -5861,7 +5861,7 @@ func reservedTemplateCollisionRenames(doc *openapi3.T, pathKeys []string, basePa
 				continue
 			}
 			if resourceOverrideForOperation(op, path) != "" {
-				hardErrors[primaryName] = struct{}{}
+				hardErrors[primaryName] = reservedTemplateCollision{Name: primaryName, FromOverride: true}
 				continue
 			}
 			if candidate := spec.ReservedResourceParentPrefixCandidate(primaryName, path); candidate != "" {
@@ -5873,19 +5873,21 @@ func reservedTemplateCollisionRenames(doc *openapi3.T, pathKeys []string, basePa
 				continue
 			}
 			if spec.ReservedResourcePathTerminatesAt(primaryName, path) {
-				hardErrors[primaryName] = struct{}{}
+				hardErrors[primaryName] = reservedTemplateCollision{Name: primaryName}
 			}
 		}
 	}
 
 	renames := map[string]string{}
-	hardErrorNames := make([]string, 0, len(hardErrors))
-	for name := range hardErrors {
-		hardErrorNames = append(hardErrorNames, name)
+	hardErrorCollisions := make([]reservedTemplateCollision, 0, len(hardErrors))
+	for _, collision := range hardErrors {
+		hardErrorCollisions = append(hardErrorCollisions, collision)
 	}
-	slices.Sort(hardErrorNames)
-	for _, name := range hardErrorNames {
-		return nil, reservedTemplateCollisionError(name, name+"_resource")
+	slices.SortFunc(hardErrorCollisions, func(a, b reservedTemplateCollision) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	if len(hardErrorCollisions) > 0 {
+		return nil, reservedTemplateCollisionErrors(hardErrorCollisions)
 	}
 
 	names := make([]string, 0, len(candidates))
@@ -5914,27 +5916,67 @@ func reservedTemplateCollisionRenames(doc *openapi3.T, pathKeys []string, basePa
 	return renames, nil
 }
 
-func reservedTemplateCollisionError(name, suggestion string) error {
-	return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
-		name, name, name, snakeToPascalForError(name), suggestion)
+type reservedTemplateCollision struct {
+	Name         string
+	Suggestion   string
+	FromOverride bool
 }
 
-func snakeToPascalForError(s string) string {
-	var b strings.Builder
-	upperNext := true
-	for _, r := range s {
-		if r == '_' || r == '-' || r == ' ' {
-			upperNext = true
-			continue
+func reservedTemplateCollisionError(name, suggestion string) error {
+	return reservedTemplateCollisionErrors([]reservedTemplateCollision{{
+		Name:       name,
+		Suggestion: suggestion,
+	}})
+}
+
+func reservedTemplateCollisionErrors(collisions []reservedTemplateCollision) error {
+	if len(collisions) == 1 {
+		collision := collisions[0]
+		suggestion := collision.Suggestion
+		if suggestion == "" {
+			suggestion = collision.Name + "_resource"
 		}
-		if upperNext {
-			b.WriteRune(unicode.ToUpper(r))
-			upperNext = false
-			continue
+		if collision.FromOverride {
+			return fmt.Errorf("%s value %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename %s to %q",
+				extensionPPResource, collision.Name, collision.Name, collision.Name, spec.SnakeToPascal(collision.Name), extensionPPResource, suggestion)
 		}
-		b.WriteRune(r)
+		return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
+			collision.Name, collision.Name, collision.Name, spec.SnakeToPascal(collision.Name), suggestion)
 	}
-	return b.String()
+
+	names := make([]string, 0, len(collisions))
+	files := make([]string, 0, len(collisions))
+	functions := make([]string, 0, len(collisions))
+	suggestions := make([]string, 0, len(collisions))
+	hasOverride := false
+	hasDerived := false
+	for _, collision := range collisions {
+		suggestion := collision.Suggestion
+		if suggestion == "" {
+			suggestion = collision.Name + "_resource"
+		}
+		names = append(names, fmt.Sprintf("%q", collision.Name))
+		files = append(files, "internal/cli/"+collision.Name+".go")
+		functions = append(functions, "`new"+spec.SnakeToPascal(collision.Name)+"Cmd`")
+		suggestions = append(suggestions, fmt.Sprintf("%q", suggestion))
+		if collision.FromOverride {
+			hasOverride = true
+		} else {
+			hasDerived = true
+		}
+	}
+
+	remediation := fmt.Sprintf("Rename them in your spec, e.g. %s", strings.Join(suggestions, ", "))
+	if hasOverride && !hasDerived {
+		remediation = fmt.Sprintf("Rename each %s value, e.g. %s", extensionPPResource, strings.Join(suggestions, ", "))
+	} else if hasOverride {
+		remediation = fmt.Sprintf("Rename each resource or %s value, e.g. %s", extensionPPResource, strings.Join(suggestions, ", "))
+	} else {
+		remediation += ", or set x-pp-resource on each operation"
+	}
+
+	return fmt.Errorf("resource names %s collide with reserved Printing Press templates %s (would overwrite %s and produce duplicate %s functions). %s",
+		strings.Join(names, ", "), strings.Join(names, ", "), strings.Join(files, ", "), strings.Join(functions, ", "), remediation)
 }
 
 func resourceAndSubFromSegments(segments []string) (string, string) {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -64,6 +64,7 @@ const (
 	extensionSyncWalker            = "x-pp-sync-walker"
 	extensionHappyArgs             = "x-happy-args"
 	extensionDispatchParam         = "x-pp-dispatch-param"
+	extensionPPResource            = "x-pp-resource"
 	extensionParamURLName          = "x-url-name"
 	extensionParamURLNames         = "x-param-url-names"
 	extensionAPIName               = "x-api-name"
@@ -2955,6 +2956,10 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 	commonPrefix := detectCommonPrefix(pathKeys, basePath)
 	frameworkRenames := map[string]string{}
 	googleDiscovery := isGoogleDiscoverySpec(doc)
+	reservedTemplateRenames, err := reservedTemplateCollisionRenames(doc, pathKeys, basePath, commonPrefix, googleDiscovery, out)
+	if err != nil {
+		return err
+	}
 
 	// Auto-calibrate endpoint limit unless the user explicitly set it.
 	// Pre-scans the spec to find the largest resource or sub-resource,
@@ -3023,6 +3028,9 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 			if primaryName == "" {
 				warnf("skipping %s %q: could not derive resource name", method, path)
 				continue
+			}
+			if renamed, ok := reservedTemplateRenames[primaryName]; ok {
+				primaryName = renamed
 			}
 			endpointResourceName := primaryName
 			if subName != "" {
@@ -5785,6 +5793,9 @@ func resourceAndSubFromPath(path, basePath string, commonPrefix []string) (strin
 }
 
 func resourceAndSubForOperation(path, basePath string, commonPrefix []string, op *openapi3.Operation, googleDiscovery bool) (string, string) {
+	if override := resourceOverrideForOperation(op, path); override != "" {
+		return override, ""
+	}
 	primary, sub := resourceAndSubFromPath(path, basePath, commonPrefix)
 	if primary != "" && !pathStartsWithCustomVerbParam(path, basePath, commonPrefix) {
 		return primary, sub
@@ -5802,6 +5813,128 @@ func resourceAndSubForOperation(path, basePath string, commonPrefix []string, op
 		return opPrimary, opSub
 	}
 	return primary, sub
+}
+
+func resourceOverrideForOperation(op *openapi3.Operation, path string) string {
+	if op == nil || op.Extensions == nil {
+		return ""
+	}
+	raw, ok := op.Extensions[extensionPPResource]
+	if !ok {
+		return ""
+	}
+	value, ok := raw.(string)
+	if !ok {
+		warnf("path %q: %s must be a string, got %T; ignoring", path, extensionPPResource, raw)
+		return ""
+	}
+	value = sanitizeResourceName(toSnakeCase(value))
+	if value == "" {
+		warnf("path %q: %s is empty after sanitization; ignoring", path, extensionPPResource)
+		return ""
+	}
+	return value
+}
+
+func reservedTemplateCollisionRenames(doc *openapi3.T, pathKeys []string, basePath string, commonPrefix []string, googleDiscovery bool, out *spec.APISpec) (map[string]string, error) {
+	type candidateSet map[string]struct{}
+	candidates := map[string]candidateSet{}
+	firstPath := map[string]string{}
+	hardErrors := map[string]struct{}{}
+	rawResources := map[string]struct{}{}
+
+	for _, path := range pathKeys {
+		pathItem := doc.Paths.Value(path)
+		if pathItem == nil {
+			continue
+		}
+		for _, op := range pathItem.Operations() {
+			primaryName, _ := resourceAndSubForOperation(path, basePath, commonPrefix, op, googleDiscovery)
+			if primaryName == "" {
+				continue
+			}
+			rawResources[primaryName] = struct{}{}
+			if primaryName == "auth" && out != nil && !out.ParseTimeReservedCobraUseName(primaryName) {
+				continue
+			}
+			if _, reserved := spec.ReservedCLIResourceNames[primaryName]; !reserved {
+				continue
+			}
+			if resourceOverrideForOperation(op, path) != "" {
+				hardErrors[primaryName] = struct{}{}
+				continue
+			}
+			if candidate := spec.ReservedResourceParentPrefixCandidate(primaryName, path); candidate != "" {
+				if _, ok := candidates[primaryName]; !ok {
+					candidates[primaryName] = candidateSet{}
+					firstPath[primaryName] = path
+				}
+				candidates[primaryName][candidate] = struct{}{}
+				continue
+			}
+			if spec.ReservedResourcePathTerminatesAt(primaryName, path) {
+				hardErrors[primaryName] = struct{}{}
+			}
+		}
+	}
+
+	renames := map[string]string{}
+	hardErrorNames := make([]string, 0, len(hardErrors))
+	for name := range hardErrors {
+		hardErrorNames = append(hardErrorNames, name)
+	}
+	slices.Sort(hardErrorNames)
+	for _, name := range hardErrorNames {
+		return nil, reservedTemplateCollisionError(name, name+"_resource")
+	}
+
+	names := make([]string, 0, len(candidates))
+	for name := range candidates {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		set := candidates[name]
+		if len(set) != 1 {
+			return nil, reservedTemplateCollisionError(name, name+"_resource")
+		}
+		var candidate string
+		for value := range set {
+			candidate = value
+		}
+		if _, reserved := spec.ReservedCLIResourceNames[candidate]; reserved {
+			return nil, reservedTemplateCollisionError(name, name+"_resource")
+		}
+		if _, exists := rawResources[candidate]; exists {
+			return nil, reservedTemplateCollisionError(name, name+"_resource")
+		}
+		renames[name] = candidate
+		warnf("resource %q from path %q collides with reserved Printing Press template %q; renamed to %q", name, firstPath[name], name, candidate)
+	}
+	return renames, nil
+}
+
+func reservedTemplateCollisionError(name, suggestion string) error {
+	return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
+		name, name, name, snakeToPascalForError(name), suggestion)
+}
+
+func snakeToPascalForError(s string) string {
+	var b strings.Builder
+	upperNext := true
+	for _, r := range s {
+		if r == '_' || r == '-' || r == ' ' {
+			upperNext = true
+			continue
+		}
+		if upperNext {
+			b.WriteRune(unicode.ToUpper(r))
+			upperNext = false
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 func resourceAndSubFromSegments(segments []string) (string, string) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -7656,6 +7656,38 @@ paths:
 	assert.Contains(t, err.Error(), `Rename to "search_resource"`)
 }
 
+func TestParseReservedTemplateCollisionAggregatesHardErrors(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /client:
+    get:
+      operationId: getClient
+      responses:
+        "200":
+          description: ok
+  /search:
+    post:
+      operationId: search
+      responses:
+        "200":
+          description: ok
+`)
+
+	_, err := Parse(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `resource names "client", "search"`)
+	assert.Contains(t, err.Error(), `reserved Printing Press templates "client", "search"`)
+	assert.Contains(t, err.Error(), `newClientCmd`)
+	assert.Contains(t, err.Error(), `newSearchCmd`)
+	assert.Contains(t, err.Error(), `"client_resource"`)
+	assert.Contains(t, err.Error(), `"search_resource"`)
+}
+
 func TestParseXPPResourceOverrideAvoidsReservedTemplateCollision(t *testing.T) {
 	yamlSpec := []byte(`openapi: "3.0.3"
 info:
@@ -7699,7 +7731,8 @@ paths:
 	_, err := Parse(yamlSpec)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `reserved Printing Press template "client"`)
-	assert.Contains(t, err.Error(), `Rename to "client_resource"`)
+	assert.Contains(t, err.Error(), `Rename x-pp-resource to "client_resource"`)
+	assert.NotContains(t, err.Error(), "set x-pp-resource on the operation")
 }
 
 func TestParseFrameworkCollisionAllowsConditionalFrameworkNamesWhenInactive(t *testing.T) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -573,6 +573,14 @@ func TestParseAICLargeSpecCompletes(t *testing.T) {
 	t.Parallel()
 
 	data := readAICLargeSpec(t)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	paths := raw["paths"].(map[string]any)
+	searchPath := paths["/search"].(map[string]any)
+	searchGet := searchPath["get"].(map[string]any)
+	searchGet["x-pp-resource"] = "art_search"
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
 
 	type parseResult struct {
 		spec *spec.APISpec
@@ -3245,6 +3253,7 @@ paths:
   /search:
     get:
       operationId: searchList
+      x-pp-resource: video_search
       parameters:
         - in: query
           name: part
@@ -7567,6 +7576,132 @@ paths:
 	assert.NotContains(t, output, "shadow framework cobra command", "non-colliding spec must not emit a collision warning")
 }
 
+func TestParseReservedTemplateCollisionErrorsWithoutParentPrefix(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /search:
+    post:
+      operationId: search
+      responses:
+        "200":
+          description: ok
+`)
+
+	_, err := Parse(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reserved Printing Press template "search"`)
+	assert.Contains(t, err.Error(), `Rename to "search_resource"`)
+	assert.Contains(t, err.Error(), "x-pp-resource")
+}
+
+func TestParseReservedTemplateCollisionParentPrefixesFromPath(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com/notes
+paths:
+  /notes/search:
+    post:
+      operationId: searchNotes
+      responses:
+        "200":
+          description: ok
+`)
+
+	var parsed *spec.APISpec
+	output := captureWarnings(t, func() {
+		var err error
+		parsed, err = Parse(yamlSpec)
+		require.NoError(t, err)
+	})
+
+	assert.NotContains(t, parsed.Resources, "search")
+	require.Contains(t, parsed.Resources, "notes_search")
+	assert.Contains(t, output, `"notes_search"`)
+	assert.Contains(t, output, "reserved Printing Press template")
+}
+
+func TestParseReservedTemplateCollisionExactPathWinsOverSiblingParentPrefix(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /notes/search:
+    post:
+      operationId: searchNotes
+      responses:
+        "200":
+          description: ok
+  /search:
+    post:
+      operationId: search
+      responses:
+        "200":
+          description: ok
+`)
+
+	_, err := Parse(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reserved Printing Press template "search"`)
+	assert.Contains(t, err.Error(), `Rename to "search_resource"`)
+}
+
+func TestParseXPPResourceOverrideAvoidsReservedTemplateCollision(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /search:
+    post:
+      operationId: searchNotes
+      x-pp-resource: notes_search
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+	assert.NotContains(t, parsed.Resources, "search")
+	require.Contains(t, parsed.Resources, "notes_search")
+}
+
+func TestParseXPPResourceOverrideRejectsReservedTemplateName(t *testing.T) {
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: TestAPI
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      x-pp-resource: client
+      responses:
+        "200":
+          description: ok
+`)
+
+	_, err := Parse(yamlSpec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reserved Printing Press template "client"`)
+	assert.Contains(t, err.Error(), `Rename to "client_resource"`)
+}
+
 func TestParseFrameworkCollisionAllowsConditionalFrameworkNamesWhenInactive(t *testing.T) {
 	yamlSpec := []byte(`openapi: "3.0.3"
 info:
@@ -7869,6 +8004,7 @@ paths:
   /search:
     get:
       operationId: geocoding
+      x-pp-resource: geocoding_search
       servers:
         - url: https://geocoding-api.open-meteo.com/v1
       responses:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2842,7 +2842,7 @@ func (s *APISpec) validateReservedNames() error {
 			continue
 		}
 		if _, reserved := ReservedCLIResourceNames[name]; reserved {
-			return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
+			return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec",
 				name, name, name, SnakeToPascal(name), name+"_resource")
 		}
 	}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2843,7 +2843,7 @@ func (s *APISpec) validateReservedNames() error {
 		}
 		if _, reserved := ReservedCLIResourceNames[name]; reserved {
 			return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
-				name, name, name, snakeToPascal(name), name+"_resource")
+				name, name, name, SnakeToPascal(name), name+"_resource")
 		}
 	}
 	return nil
@@ -2981,12 +2981,12 @@ func isGenericRoutingPrefix(segment string) bool {
 	}
 }
 
-// snakeToPascal converts a snake_case identifier to PascalCase so error
+// SnakeToPascal converts a snake_case identifier to PascalCase so error
 // messages name the same Go function the generator would emit. Mirrors
 // generator.toCamel for snake_case input — kept here so the spec package
 // has no import-cycle dependency on the generator. Empty input → empty
 // output.
-func snakeToPascal(s string) string {
+func SnakeToPascal(s string) string {
 	if s == "" {
 		return s
 	}
@@ -2998,6 +2998,10 @@ func snakeToPascal(s string) string {
 		parts[i] = strings.ToUpper(p[:1]) + p[1:]
 	}
 	return strings.Join(parts, "")
+}
+
+func snakeToPascal(s string) string {
+	return SnakeToPascal(s)
 }
 
 // pathParamRe matches `{name}` placeholders in a path template. Names are

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2557,6 +2557,7 @@ func ParseBytes(data []byte) (*APISpec, error) {
 	s.expandOperations()
 	s.EnrichPathParams()
 	s.promoteParamsToBodyForWriteEndpoints()
+	s.applyReservedResourceParentPrefixes()
 	if err := s.validateReservedNames(); err != nil {
 		return nil, err
 	}
@@ -2700,6 +2701,120 @@ func (s *APISpec) UniqueFrameworkCollisionResourceName(original string) string {
 	}
 }
 
+// applyReservedResourceParentPrefixes renames reserved top-level resources when
+// their endpoint paths provide one clear parent segment, such as
+// resource "search" with path "/notes/search" becoming "notes_search".
+func (s *APISpec) applyReservedResourceParentPrefixes() {
+	if s == nil || len(s.Resources) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(s.Resources))
+	taken := make(map[string]struct{}, len(s.Resources))
+	for name := range s.Resources {
+		keys = append(keys, name)
+		taken[name] = struct{}{}
+	}
+	slices.Sort(keys)
+
+	renames := map[string]string{}
+	for _, name := range keys {
+		if name == "auth" && !s.emitsAuthCommand() {
+			continue
+		}
+		if _, reserved := ReservedCLIResourceNames[name]; !reserved {
+			continue
+		}
+		candidate := s.uniqueReservedResourceParentPrefix(name, s.Resources[name], taken)
+		if candidate == "" {
+			continue
+		}
+		renames[name] = candidate
+		delete(taken, name)
+		taken[candidate] = struct{}{}
+	}
+
+	for _, name := range keys {
+		candidate, ok := renames[name]
+		if !ok {
+			continue
+		}
+		resource := s.Resources[name]
+		delete(s.Resources, name)
+		s.Resources[candidate] = resource
+		s.rewriteResourceReferences(name, candidate)
+	}
+}
+
+func (s *APISpec) uniqueReservedResourceParentPrefix(name string, resource Resource, taken map[string]struct{}) string {
+	candidates := map[string]struct{}{}
+	blocked := false
+	add := func(path string) {
+		if candidate := ReservedResourceParentPrefixCandidate(name, path); candidate != "" {
+			candidates[candidate] = struct{}{}
+			return
+		}
+		if ReservedResourcePathTerminatesAt(name, path) {
+			blocked = true
+		}
+	}
+	add(resource.Path)
+	for _, endpoint := range resource.Endpoints {
+		add(endpoint.Path)
+	}
+	if blocked {
+		return ""
+	}
+	if len(candidates) != 1 {
+		return ""
+	}
+	var candidate string
+	for value := range candidates {
+		candidate = value
+	}
+	if candidate == name {
+		return ""
+	}
+	if _, reserved := ReservedCLIResourceNames[candidate]; reserved {
+		return ""
+	}
+	if _, exists := taken[candidate]; exists {
+		return ""
+	}
+	return candidate
+}
+
+func (s *APISpec) rewriteResourceReferences(oldName, newName string) {
+	if s.Cache.Resources != nil {
+		if value, ok := s.Cache.Resources[oldName]; ok {
+			delete(s.Cache.Resources, oldName)
+			s.Cache.Resources[newName] = value
+		}
+	}
+	for i := range s.Cache.Commands {
+		for j, name := range s.Cache.Commands[i].Resources {
+			if name == oldName {
+				s.Cache.Commands[i].Resources[j] = newName
+			}
+		}
+	}
+	for i := range s.MCP.Intents {
+		for j := range s.MCP.Intents[i].Steps {
+			s.MCP.Intents[i].Steps[j].Endpoint = rewriteEndpointResourceRef(s.MCP.Intents[i].Steps[j].Endpoint, oldName, newName)
+		}
+	}
+}
+
+func rewriteEndpointResourceRef(ref, oldName, newName string) string {
+	if ref == oldName {
+		return newName
+	}
+	prefix := oldName + "."
+	if strings.HasPrefix(ref, prefix) {
+		return newName + strings.TrimPrefix(ref, oldName)
+	}
+	return ref
+}
+
 func (s *APISpec) emitsAuthCommand() bool {
 	if s == nil {
 		return false
@@ -2727,8 +2842,8 @@ func (s *APISpec) validateReservedNames() error {
 			continue
 		}
 		if _, reserved := ReservedCLIResourceNames[name]; reserved {
-			return fmt.Errorf("resource name %q collides with a reserved Printing Press template (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename the resource — e.g. %q",
-				name, name, snakeToPascal(name), name+"_resource")
+			return fmt.Errorf("resource name %q collides with reserved Printing Press template %q (would overwrite internal/cli/%s.go and produce a duplicate `new%sCmd` function). Rename to %q in your spec, or set x-pp-resource on the operation",
+				name, name, name, snakeToPascal(name), name+"_resource")
 		}
 	}
 	return nil
@@ -2755,6 +2870,115 @@ func (s *APISpec) validateFrameworkCobraCollisions() error {
 
 func snakeToKebab(s string) string {
 	return strings.ReplaceAll(strings.ToLower(s), "_", "-")
+}
+
+// ReservedResourceParentPrefixCandidate returns a parent-prefixed replacement
+// for a reserved resource name when path has a concrete parent segment directly
+// before that resource. Generic routing prefixes and versions are ignored.
+func ReservedResourceParentPrefixCandidate(name, path string) string {
+	segments := splitRequestPath(path)
+	if len(segments) < 2 {
+		return ""
+	}
+	for i, segment := range segments {
+		if pathSegmentResourceName(segment) != name {
+			continue
+		}
+		if !onlyPathParamsAfter(segments[i+1:]) {
+			continue
+		}
+		for j := i - 1; j >= 0; j-- {
+			parent := pathSegmentResourceName(segments[j])
+			if parent == "" || isPathParamLikeSegment(segments[j]) || isVersionLikeSegment(segments[j]) || isGenericRoutingPrefix(parent) {
+				continue
+			}
+			return parent + "_" + name
+		}
+	}
+	return ""
+}
+
+func ReservedResourcePathTerminatesAt(name, path string) bool {
+	segments := splitRequestPath(path)
+	for i := len(segments) - 1; i >= 0; i-- {
+		if isPathParamLikeSegment(segments[i]) {
+			continue
+		}
+		return pathSegmentResourceName(segments[i]) == name
+	}
+	return false
+}
+
+func onlyPathParamsAfter(segments []string) bool {
+	for _, segment := range segments {
+		if !isPathParamLikeSegment(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+func splitRequestPath(path string) []string {
+	path = strings.TrimSpace(path)
+	if u, err := url.Parse(path); err == nil && u.Path != "" {
+		path = u.Path
+	}
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	raw := strings.Split(path, "/")
+	segments := make([]string, 0, len(raw))
+	for _, segment := range raw {
+		segment = strings.TrimSpace(segment)
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return segments
+}
+
+func pathSegmentResourceName(segment string) string {
+	segment = strings.Trim(segment, "{}")
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range segment {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+			lastUnderscore = false
+		} else if !lastUnderscore && b.Len() > 0 {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func isPathParamLikeSegment(segment string) bool {
+	return strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}")
+}
+
+func isVersionLikeSegment(segment string) bool {
+	segment = strings.TrimPrefix(strings.ToLower(segment), "v")
+	segment = strings.ReplaceAll(segment, ".", "")
+	if segment == "" {
+		return false
+	}
+	for _, r := range segment {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isGenericRoutingPrefix(segment string) bool {
+	switch segment {
+	case "api", "apis", "rest":
+		return true
+	default:
+		return false
+	}
 }
 
 // snakeToPascal converts a snake_case identifier to PascalCase so error

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4194,7 +4194,7 @@ resources:
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `reserved Printing Press template "search"`)
 		assert.Contains(t, err.Error(), `Rename to "search_resource"`)
-		assert.Contains(t, err.Error(), "x-pp-resource")
+		assert.NotContains(t, err.Error(), "x-pp-resource")
 	})
 
 	t.Run("reserved search resource is parent-prefixed when endpoint path provides one", func(t *testing.T) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4174,6 +4174,100 @@ resources:
 		assert.NotContains(t, err.Error(), "newAgent_contextCmd")
 	})
 
+	t.Run("reserved search resource errors with remediation hint when no parent prefix exists", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+resources:
+  search:
+    description: Search
+    endpoints:
+      run:
+        method: POST
+        path: /search
+        description: Search
+`
+		_, err := ParseBytes([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `reserved Printing Press template "search"`)
+		assert.Contains(t, err.Error(), `Rename to "search_resource"`)
+		assert.Contains(t, err.Error(), "x-pp-resource")
+	})
+
+	t.Run("reserved search resource is parent-prefixed when endpoint path provides one", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+cache:
+  enabled: true
+  resources:
+    search: 5m
+  commands:
+    - name: dashboard
+      resources: [search]
+mcp:
+  intents:
+    - name: note_lookup
+      description: Look up a note
+      steps:
+        - endpoint: search.run
+          capture: note
+      returns: note
+resources:
+  search:
+    description: Note search
+    endpoints:
+      run:
+        method: POST
+        path: /notes/search
+        description: Search notes
+`
+		s, err := ParseBytes([]byte(input))
+		require.NoError(t, err)
+		assert.NotContains(t, s.Resources, "search")
+		require.Contains(t, s.Resources, "notes_search")
+		assert.Contains(t, s.Resources["notes_search"].Endpoints, "run")
+		assert.NotContains(t, s.Cache.Resources, "search")
+		assert.Equal(t, "5m", s.Cache.Resources["notes_search"])
+		require.Len(t, s.Cache.Commands, 1)
+		assert.Equal(t, []string{"notes_search"}, s.Cache.Commands[0].Resources)
+		require.Len(t, s.MCP.Intents, 1)
+		require.Len(t, s.MCP.Intents[0].Steps, 1)
+		assert.Equal(t, "notes_search.run", s.MCP.Intents[0].Steps[0].Endpoint)
+	})
+
+	t.Run("reserved search resource with exact endpoint does not parent-prefix from sibling endpoint", func(t *testing.T) {
+		t.Parallel()
+		input := `name: testapi
+base_url: https://api.example.com
+auth:
+  type: bearer_token
+  env_vars: [TESTAPI_TOKEN]
+resources:
+  search:
+    description: Search
+    endpoints:
+      notes:
+        method: POST
+        path: /notes/search
+        description: Search notes
+      global:
+        method: POST
+        path: /search
+        description: Search everything
+`
+		_, err := ParseBytes([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `reserved Printing Press template "search"`)
+		assert.Contains(t, err.Error(), `Rename to "search_resource"`)
+	})
+
 	t.Run("auth resource name rejected", func(t *testing.T) {
 		t.Parallel()
 		input := `name: testapi


### PR DESCRIPTION
## Summary
- Auto-prefix reserved resource names when endpoint paths provide a clear parent, such as `/notes/search` becoming `notes_search`.
- Keep exact reserved paths like `/search` as actionable parse errors, and add `x-pp-resource` for explicit OpenAPI resource overrides.
- Add parser, generator-output, and docs coverage for the new collision handling.

Closes #1963

## Verification
- `go test ./...`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
