### PR TITLE
fix(cli): respect live dogfood auth tiers

### DIFF
--- a/internal/cli/dogfood.go
+++ b/internal/cli/dogfood.go
@@ -23,6 +23,7 @@ func newDogfoodCmd() *cobra.Command {
 	var timeout time.Duration
 	var writeAcceptance string
 	var authEnv string
+	var authTier string
 	var allowDestructive bool
 
 	cmd := &cobra.Command{
@@ -42,6 +43,7 @@ func newDogfoodCmd() *cobra.Command {
 					Timeout:             timeout,
 					WriteAcceptancePath: writeAcceptance,
 					AuthEnv:             authEnv,
+					AuthTier:            authTier,
 					AllowDestructive:    allowDestructive,
 				})
 				if err != nil {
@@ -95,6 +97,7 @@ func newDogfoodCmd() *cobra.Command {
 	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Second, "Timeout for each live dogfood test")
 	cmd.Flags().StringVar(&writeAcceptance, "write-acceptance", "", "Write phase5-acceptance.json to this path on every outcome (status:pass on success, status:fail with a failure_summary block on failure)")
 	cmd.Flags().StringVar(&authEnv, "auth-env", "", "Environment variable that proves an API credential was available for the acceptance marker")
+	cmd.Flags().StringVar(&authTier, "auth-tier", "", "Credential tier for live dogfood; falls back to PP_AUTH_TIER and skips commands annotated pp:requires-tier on mismatch")
 	cmd.Flags().BoolVar(&allowDestructive, "allow-destructive", false, "Re-enable testing of endpoints classified as destructive-at-auth. Default skips them to prevent runner-credential rotation.")
 	_ = cmd.MarkFlagRequired("dir")
 	return cmd

--- a/internal/cli/dogfood_test.go
+++ b/internal/cli/dogfood_test.go
@@ -90,6 +90,7 @@ func TestDogfoodHelpIncludesLiveFlags(t *testing.T) {
 
 	assert.Contains(t, output, "--live")
 	assert.Contains(t, output, "--level")
+	assert.Contains(t, output, "--auth-tier")
 	assert.Contains(t, output, "--write-acceptance")
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -720,14 +720,21 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
 	tierSkip := liveDogfoodRequiresTierSkipReason(command.Annotations, ctx.authTier)
-	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
-	resolvedArgs, resolveSkipped, resolveReason := resolveCommandPositionals(command, happyArgs, ctx)
-	switch {
-	case tierSkip != "":
+	if tierSkip != "" {
 		results = append(results,
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, tierSkip),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, tierSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, tierSkip),
 		)
+		if useDryRun {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, tierSkip))
+		}
+		return results
+	}
+
+	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
+	resolvedArgs, resolveSkipped, resolveReason := resolveCommandPositionals(command, happyArgs, ctx)
+	switch {
 	case fixtureSkip != "":
 		results = append(results,
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, fixtureSkip),

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -52,6 +52,7 @@ const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
 // honor a smaller --limit) so the matrix's per-command timeout
 // doesn't kill an otherwise healthy run.
 const dogfoodEnvVar = "PRINTING_PRESS_DOGFOOD"
+const liveDogfoodAuthTierEnvVar = "PP_AUTH_TIER"
 const liveDogfoodAuthRetryDelay = time.Second
 
 type LiveDogfoodOptions struct {
@@ -61,6 +62,7 @@ type LiveDogfoodOptions struct {
 	Timeout             time.Duration
 	WriteAcceptancePath string
 	AuthEnv             string
+	AuthTier            string
 	// AllowDestructive re-enables testing of endpoints classified as
 	// destructive-at-auth. Default skips them to prevent runner-credential
 	// rotation.
@@ -155,6 +157,7 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		siblings:         buildSiblingMap(commands),
 		cache:            newCompanionCache(),
 		timeout:          timeout,
+		authTier:         resolveLiveDogfoodAuthTier(opts.AuthTier),
 		allowDestructive: opts.AllowDestructive,
 	}
 
@@ -311,6 +314,7 @@ type resolveCtx struct {
 	siblings         map[string][]liveDogfoodCommand
 	cache            *companionCache
 	timeout          time.Duration
+	authTier         string
 	allowDestructive bool
 }
 
@@ -715,9 +719,15 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
+	tierSkip := liveDogfoodRequiresTierSkipReason(command.Annotations, ctx.authTier)
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
 	resolvedArgs, resolveSkipped, resolveReason := resolveCommandPositionals(command, happyArgs, ctx)
 	switch {
+	case tierSkip != "":
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, tierSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, tierSkip),
+		)
 	case fixtureSkip != "":
 		results = append(results,
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, fixtureSkip),
@@ -1017,6 +1027,7 @@ const (
 	mcpReadOnlyAnnotation      = "mcp:read-only"
 	destructiveAuthAnnotation  = "pp:destructive-auth"
 	noErrorPathProbeAnnotation = "pp:no-error-path-probe"
+	requiresTierAnnotation     = "pp:requires-tier"
 	liveDogfoodMaxOutputBytes  = 10 << 20
 )
 
@@ -1217,6 +1228,24 @@ func liveDogfoodRequiredParamFixtureReason(run liveDogfoodRun) string {
 		return reasonRequiredParamFixture
 	}
 	return ""
+}
+
+func resolveLiveDogfoodAuthTier(flagValue string) string {
+	if tier := strings.TrimSpace(flagValue); tier != "" {
+		return tier
+	}
+	return strings.TrimSpace(os.Getenv(liveDogfoodAuthTierEnvVar))
+}
+
+func liveDogfoodRequiresTierSkipReason(annotations map[string]string, activeTier string) string {
+	requiredTier := strings.TrimSpace(annotations[requiresTierAnnotation])
+	if requiredTier == "" {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(activeTier), requiredTier) {
+		return ""
+	}
+	return fmt.Sprintf("blocked-fixture: requires auth tier %q", requiredTier)
 }
 
 func liveDogfoodAuth401(run liveDogfoodRun) bool {
@@ -1473,10 +1502,42 @@ func resolveLiveDogfoodAcceptanceIdentity(cliDir string) (apiName, runID, authTy
 }
 
 func liveDogfoodQuickCommands(commands []liveDogfoodCommand) []liveDogfoodCommand {
-	if len(commands) <= 2 {
+	const quickTarget = 6
+	if len(commands) <= quickTarget {
 		return commands
 	}
-	return commands[:2]
+	selected := make([]liveDogfoodCommand, 0, quickTarget)
+	selectedIndex := make(map[int]bool, quickTarget)
+	seenFamily := map[string]bool{}
+	for i, command := range commands {
+		family := liveDogfoodCommandFamily(command)
+		if seenFamily[family] {
+			continue
+		}
+		seenFamily[family] = true
+		selected = append(selected, command)
+		selectedIndex[i] = true
+		if len(selected) == quickTarget {
+			return selected
+		}
+	}
+	for i, command := range commands {
+		if selectedIndex[i] {
+			continue
+		}
+		selected = append(selected, command)
+		if len(selected) == quickTarget {
+			return selected
+		}
+	}
+	return selected
+}
+
+func liveDogfoodCommandFamily(command liveDogfoodCommand) string {
+	if len(command.Path) == 0 {
+		return ""
+	}
+	return command.Path[0]
 }
 
 func normalizeLiveDogfoodLevel(level string) (string, error) {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -699,6 +699,21 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 	command.Help = help
 	mutating := liveDogfoodCommandMutates(command)
+	useDryRun := mutating && commandSupportsDryRun(command.Help)
+
+	tierSkip := liveDogfoodRequiresTierSkipReason(command.Annotations, ctx.authTier)
+	if tierSkip != "" {
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, tierSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, tierSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, tierSkip),
+		)
+		if useDryRun {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, tierSkip))
+		}
+		return results
+	}
+
 	happyArgs, ok := liveDogfoodHappyArgs(command)
 	if !ok {
 		if mutating {
@@ -714,21 +729,6 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, "missing runnable example"),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, "missing runnable example"),
 		)
-		return results
-	}
-
-	useDryRun := mutating && commandSupportsDryRun(command.Help)
-
-	tierSkip := liveDogfoodRequiresTierSkipReason(command.Annotations, ctx.authTier)
-	if tierSkip != "" {
-		results = append(results,
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, tierSkip),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, tierSkip),
-			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, tierSkip),
-		)
-		if useDryRun {
-			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, tierSkip))
-		}
 		return results
 	}
 
@@ -1518,10 +1518,12 @@ func liveDogfoodQuickCommands(commands []liveDogfoodCommand) []liveDogfoodComman
 	seenFamily := map[string]bool{}
 	for i, command := range commands {
 		family := liveDogfoodCommandFamily(command)
-		if seenFamily[family] {
-			continue
+		if family != "" {
+			if seenFamily[family] {
+				continue
+			}
+			seenFamily[family] = true
 		}
-		seenFamily[family] = true
 		selected = append(selected, command)
 		selectedIndex[i] = true
 		if len(selected) == quickTarget {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -469,6 +469,82 @@ exit 1
 	assert.Equal(t, "2", string(count), "persistent auth-shaped 401 should retry once before skip classification")
 }
 
+func TestRunLiveDogfoodSkipsRequiresTierMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName, argvLog := writeLiveDogfoodTierFixture(t, true, false)
+	t.Setenv("PRINTING_PRESS_TEST_ARGV_LOG", argvLog)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+	happy := findResultByCommandKind(report, "administration get", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Equal(t, `blocked-fixture: requires auth tier "accountant"`, happy.Reason)
+
+	jsonResult := findResultByCommandKind(report, "administration get", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusSkip, jsonResult.Status)
+	assert.Equal(t, happy.Reason, jsonResult.Reason)
+
+	lines := readArgvLog(t, argvLog)
+	assert.Equal(t, 0, countArgvLines(lines, "administration get --json"),
+		"json_fidelity must not invoke tier-gated endpoints when active auth tier mismatches")
+	assert.Equal(t, 0, countArgvLines(lines, "administration get")-countArgvLines(lines, "administration get --help"),
+		"happy_path must not invoke tier-gated endpoints when active auth tier mismatches")
+}
+
+func TestRunLiveDogfoodRunsRequiresTierMatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+		AuthTier:   "accountant",
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "administration get", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	jsonResult := findResultByCommandKind(report, "administration get", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+}
+
+func TestRunLiveDogfoodRequiresTierAbsentDoesNotSkip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, false, false)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "administration get", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusFail, happy.Status)
+	assert.Contains(t, happy.OutputSample, "EP_001")
+}
+
 func TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -1511,6 +1587,34 @@ func TestFinalizeLiveDogfoodReportVerdictGate(t *testing.T) {
 	}
 }
 
+func TestLiveDogfoodQuickCommandsSamplesAcrossFamilies(t *testing.T) {
+	commands := []liveDogfoodCommand{
+		{Path: []string{"across-admins"}},
+		{Path: []string{"administration", "get"}},
+		{Path: []string{"administration", "list"}},
+		{Path: []string{"contacts", "get"}},
+		{Path: []string{"contacts", "list"}},
+		{Path: []string{"invoices", "get"}},
+		{Path: []string{"ledger", "get"}},
+		{Path: []string{"mutations", "create"}},
+		{Path: []string{"relations", "get"}},
+		{Path: []string{"reports", "list"}},
+		{Path: []string{"transactions", "get"}},
+		{Path: []string{"transactions", "list"}},
+	}
+
+	got := liveDogfoodQuickCommands(commands)
+
+	require.Len(t, got, 6)
+	families := map[string]bool{}
+	for _, command := range got {
+		families[liveDogfoodCommandFamily(command)] = true
+	}
+	assert.GreaterOrEqual(t, len(families), 3)
+	assert.NotEqual(t, commands[:2], got,
+		"quick sampling should not collapse to the first two sorted commands")
+}
+
 func TestExtractFirstIDFromJSON(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -2045,6 +2149,101 @@ exit 99
 `
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
 	return dir, binaryName
+}
+
+func writeLiveDogfoodTierFixture(t *testing.T, annotate bool, adminPass bool) (dir string, binaryName string, argvLog string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	argvLog = filepath.Join(t.TempDir(), "argv.log")
+	writeTestManifestForLiveDogfood(t, dir)
+
+	annotation := ""
+	if annotate {
+		annotation = `,"annotations":{"pp:requires-tier":"accountant"}`
+	}
+	adminBody := `echo 'Error: GET /v1/administration returned HTTP 400: {"type":"badrequest","code":"EP_001","title":"This endpoint is only available to accountants.","status":400}' >&2
+exit 5`
+	if adminPass {
+		adminBody = `if [ "${3:-}" = "--json" ]; then
+  echo '{"id":"administration"}'
+  exit 0
+fi
+echo 'administration'
+exit 0`
+	}
+
+	binPath := filepath.Join(dir, binaryName)
+	script := `#!/bin/sh
+set -u
+
+if [ -n "${PRINTING_PRESS_TEST_ARGV_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$PRINTING_PRESS_TEST_ARGV_LOG"
+fi
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"administration","subcommands":[
+      {"name":"get"` + annotation + `}
+    ]},
+    {"name":"public","subcommands":[
+      {"name":"list"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "administration" ] && [ "$2" = "get" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Get administration details.
+
+Usage:
+  fixture-pp-cli administration get [flags]
+
+Examples:
+  fixture-pp-cli administration get
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "public" ] && [ "$2" = "list" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List public records.
+
+Usage:
+  fixture-pp-cli public list [flags]
+
+Examples:
+  fixture-pp-cli public list --json
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "administration" ] && [ "$2" = "get" ]; then
+` + adminBody + `
+fi
+
+if [ "$1" = "public" ] && [ "$2" = "list" ]; then
+  echo '{"results":[{"id":"pub_1"}]}'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName, argvLog
 }
 
 func writeLiveDogfoodHomeProbeFixture(t *testing.T, probe string) (dir string, binaryName string) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -474,7 +474,7 @@ func TestRunLiveDogfoodSkipsRequiresTierMismatch(t *testing.T) {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
 
-	dir, binaryName, argvLog := writeLiveDogfoodTierFixture(t, true, false)
+	dir, binaryName, argvLog := writeLiveDogfoodTierFixture(t, true, false, true)
 	t.Setenv("PRINTING_PRESS_TEST_ARGV_LOG", argvLog)
 	report, err := RunLiveDogfood(LiveDogfoodOptions{
 		CLIDir:     dir,
@@ -509,12 +509,33 @@ func TestRunLiveDogfoodSkipsRequiresTierMismatch(t *testing.T) {
 		"error_path must not invoke tier-gated endpoints when active auth tier mismatches")
 }
 
+func TestRunLiveDogfoodSkipsRequiresTierMismatchWithoutRunnableExample(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, false, false)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "administration get", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Equal(t, `blocked-fixture: requires auth tier "accountant"`, happy.Reason)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+}
+
 func TestRunLiveDogfoodRunsRequiresTierMatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
 
-	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true)
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true, true)
 	report, err := RunLiveDogfood(LiveDogfoodOptions{
 		CLIDir:     dir,
 		BinaryName: binaryName,
@@ -537,7 +558,7 @@ func TestRunLiveDogfoodRunsRequiresTierMatchFromEnv(t *testing.T) {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
 
-	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true)
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true, true)
 	t.Setenv("PP_AUTH_TIER", "accountant")
 	report, err := RunLiveDogfood(LiveDogfoodOptions{
 		CLIDir:     dir,
@@ -560,7 +581,7 @@ func TestRunLiveDogfoodRequiresTierAbsentDoesNotSkip(t *testing.T) {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
 	}
 
-	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, false, false)
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, false, false, true)
 	report, err := RunLiveDogfood(LiveDogfoodOptions{
 		CLIDir:     dir,
 		BinaryName: binaryName,
@@ -1645,6 +1666,31 @@ func TestLiveDogfoodQuickCommandsSamplesAcrossFamilies(t *testing.T) {
 		"quick sampling should not collapse to the first two sorted commands")
 }
 
+func TestLiveDogfoodQuickCommandsDoesNotDeduplicateEmptyFamily(t *testing.T) {
+	commands := []liveDogfoodCommand{
+		{Path: nil},
+		{Path: []string{}},
+		{Path: []string{"administration", "get"}},
+		{Path: []string{"administration", "list"}},
+		{Path: []string{"contacts", "get"}},
+		{Path: []string{"contacts", "list"}},
+		{Path: []string{"invoices", "get"}},
+		{Path: []string{"invoices", "list"}},
+	}
+
+	got := liveDogfoodQuickCommands(commands)
+
+	require.Len(t, got, 6)
+	assert.Equal(t, []liveDogfoodCommand{
+		commands[0],
+		commands[1],
+		commands[2],
+		commands[4],
+		commands[6],
+		commands[3],
+	}, got)
+}
+
 func TestExtractFirstIDFromJSON(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -2181,7 +2227,7 @@ exit 99
 	return dir, binaryName
 }
 
-func writeLiveDogfoodTierFixture(t *testing.T, annotate bool, adminPass bool) (dir string, binaryName string, argvLog string) {
+func writeLiveDogfoodTierFixture(t *testing.T, annotate bool, adminPass bool, runnableExample bool) (dir string, binaryName string, argvLog string) {
 	t.Helper()
 
 	dir = t.TempDir()
@@ -2192,6 +2238,10 @@ func writeLiveDogfoodTierFixture(t *testing.T, annotate bool, adminPass bool) (d
 	annotation := ""
 	if annotate {
 		annotation = `,"annotations":{"pp:requires-tier":"accountant"}`
+	}
+	adminExample := "  fixture-pp-cli administration get adm_1"
+	if !runnableExample {
+		adminExample = "  fixture-pp-cli administration list --json"
 	}
 	adminBody := `echo 'Error: GET /v1/administration returned HTTP 400: {"type":"badrequest","code":"EP_001","title":"This endpoint is only available to accountants.","status":400}' >&2
 exit 5`
@@ -2241,7 +2291,7 @@ Usage:
   fixture-pp-cli administration get <id> [flags]
 
 Examples:
-  fixture-pp-cli administration get adm_1
+` + adminExample + `
 
 Flags:
       --json    Output JSON

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -495,11 +495,18 @@ func TestRunLiveDogfoodSkipsRequiresTierMismatch(t *testing.T) {
 	assert.Equal(t, LiveDogfoodStatusSkip, jsonResult.Status)
 	assert.Equal(t, happy.Reason, jsonResult.Reason)
 
+	errorResult := findResultByCommandKind(report, "administration get", LiveDogfoodTestError)
+	require.NotNil(t, errorResult)
+	assert.Equal(t, LiveDogfoodStatusSkip, errorResult.Status)
+	assert.Equal(t, happy.Reason, errorResult.Reason)
+
 	lines := readArgvLog(t, argvLog)
-	assert.Equal(t, 0, countArgvLines(lines, "administration get --json"),
+	assert.Equal(t, 0, countArgvLines(lines, "administration get", "--json"),
 		"json_fidelity must not invoke tier-gated endpoints when active auth tier mismatches")
 	assert.Equal(t, 0, countArgvLines(lines, "administration get")-countArgvLines(lines, "administration get --help"),
 		"happy_path must not invoke tier-gated endpoints when active auth tier mismatches")
+	assert.Equal(t, 0, countArgvLines(lines, "administration get", "__printing_press_invalid__"),
+		"error_path must not invoke tier-gated endpoints when active auth tier mismatches")
 }
 
 func TestRunLiveDogfoodRunsRequiresTierMatch(t *testing.T) {
@@ -514,6 +521,29 @@ func TestRunLiveDogfoodRunsRequiresTierMatch(t *testing.T) {
 		Level:      "quick",
 		Timeout:    2 * time.Second,
 		AuthTier:   "accountant",
+	})
+	require.NoError(t, err)
+
+	happy := findResultByCommandKind(report, "administration get", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	jsonResult := findResultByCommandKind(report, "administration get", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+}
+
+func TestRunLiveDogfoodRunsRequiresTierMatchFromEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName, _ := writeLiveDogfoodTierFixture(t, true, true)
+	t.Setenv("PP_AUTH_TIER", "accountant")
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    2 * time.Second,
 	})
 	require.NoError(t, err)
 
@@ -2166,7 +2196,11 @@ func writeLiveDogfoodTierFixture(t *testing.T, annotate bool, adminPass bool) (d
 	adminBody := `echo 'Error: GET /v1/administration returned HTTP 400: {"type":"badrequest","code":"EP_001","title":"This endpoint is only available to accountants.","status":400}' >&2
 exit 5`
 	if adminPass {
-		adminBody = `if [ "${3:-}" = "--json" ]; then
+		adminBody = `if [ "${3:-}" = "__printing_press_invalid__" ]; then
+  echo 'invalid id' >&2
+  exit 2
+fi
+if [ "${4:-}" = "--json" ]; then
   echo '{"id":"administration"}'
   exit 0
 fi
@@ -2185,12 +2219,13 @@ fi
 if [ "$1" = "agent-context" ]; then
   cat <<'JSON'
 {
-  "commands": [
-    {"name":"administration","subcommands":[
-      {"name":"get"` + annotation + `}
-    ]},
-    {"name":"public","subcommands":[
-      {"name":"list"}
+	"commands": [
+	    {"name":"administration","subcommands":[
+	      {"name":"get"` + annotation + `},
+	      {"name":"list"}
+	    ]},
+	    {"name":"public","subcommands":[
+	      {"name":"list"}
     ]}
   ]
 }
@@ -2203,13 +2238,30 @@ if [ "$1" = "administration" ] && [ "$2" = "get" ] && [ "${3:-}" = "--help" ]; t
 Get administration details.
 
 Usage:
-  fixture-pp-cli administration get [flags]
+  fixture-pp-cli administration get <id> [flags]
 
 Examples:
-  fixture-pp-cli administration get
+  fixture-pp-cli administration get adm_1
 
 Flags:
       --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "administration" ] && [ "$2" = "list" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List administration records.
+
+Usage:
+  fixture-pp-cli administration list [flags]
+
+Examples:
+  fixture-pp-cli administration list --json
+
+Flags:
+      --json       Output JSON
+      --limit int  Limit results
 HELP
   exit 0
 fi
@@ -2232,6 +2284,11 @@ fi
 
 if [ "$1" = "administration" ] && [ "$2" = "get" ]; then
 ` + adminBody + `
+fi
+
+if [ "$1" = "administration" ] && [ "$2" = "list" ]; then
+  echo '{"results":[{"id":"adm_1"}]}'
+  exit 0
 fi
 
 if [ "$1" = "public" ] && [ "$2" = "list" ]; then


### PR DESCRIPTION
## Summary

Quick live dogfood now samples up to six command leaves across resource families instead of the first two sorted commands, so one gated endpoint is less likely to dominate a quick matrix.

Commands annotated `pp:requires-tier` now skip happy-path and JSON-fidelity probes when the active tier from `--auth-tier` or `PP_AUTH_TIER` does not match. Unannotated endpoints keep the existing fail behavior, and matching tiers run normally.

## Tests

- `go test ./internal/pipeline ./internal/cli -run 'TestRunLiveDogfood(SkipsRequiresTierMismatch|RunsRequiresTierMatch|RequiresTierAbsentDoesNotSkip)|TestLiveDogfoodQuickCommandsSamplesAcrossFamilies|TestDogfoodHelpIncludesLiveFlags'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push hook: `golangci-lint` passed with 0 issues

Closes #2261

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)