### PR TITLE
chore(cli): ignore built cli-printing-press binary and .clawpatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,12 @@ catalog/specs/*.graphql
 .cache/
 .gotmp/
 .omx/
+.clawpatch/
 .claude/worktrees/
 .claude/local/
 /refactor/artifacts/
 /tests/artifacts/perf/
+/cli-printing-press
 /printing-press
 /press-auth
 library/


### PR DESCRIPTION
The `/printing-press` ignore line dates from the old binary name. The canonical build output is `./cli-printing-press` (from `cmd/cli-printing-press`, exactly the command AGENTS.md prescribes), which was never added to `.gitignore` — so the ~72MB build artifact shows up untracked after every build.

Adds `/cli-printing-press` alongside the existing `/printing-press` (the legacy `cmd/printing-press` output, still valid). Also ignores the `.clawpatch/` tool working dir.

No Go changes; gitignore-only.