### PR TITLE
fix(cli): apply store SQLite pragmas via modernc _pragma= DSN syntax

### DIFF
--- a/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
+++ b/docs/solutions/runtime-errors/modernc-sqlite-dsn-pragma-syntax-silently-ignored.md
@@ -1,0 +1,118 @@
+---
+title: "modernc.org/sqlite ignores mattn-style DSN pragmas (WAL, busy_timeout) silently"
+date: 2026-05-26
+category: runtime-errors
+module: cli-printing-press-generator
+problem_type: runtime_error
+component: store
+symptoms:
+  - "A read concurrent with a write failed immediately with `database is locked (5) (SQLITE_BUSY)` — e.g. an MCP `sql`/`search`/analytics query while `sync` was writing"
+  - "`sqlite3 <data.db> 'PRAGMA journal_mode'` returned `delete`, not `wal`, on every printed CLI's store"
+  - "`PRAGMA busy_timeout` was `0` and `PRAGMA foreign_keys` was `0` despite the DSN appearing to set them"
+root_cause: configuration_error
+resolution_type: code_fix
+severity: high
+tags:
+  - sqlite
+  - modernc
+  - dsn
+  - wal
+  - busy-timeout
+  - silent-failure
+  - store
+related_components:
+  - store
+  - migrate
+  - mcp
+issue: 2394
+pr: 2399
+---
+
+# modernc.org/sqlite ignores mattn-style DSN pragmas silently
+
+## Problem
+
+The store template (`internal/generator/templates/store.go.tmpl`, emitted as `internal/store/store.go` in every printed CLI) opened SQLite with mattn/go-sqlite3-style DSN parameters (`?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON&_synchronous=NORMAL&_temp_store=MEMORY&_mmap_size=…`). The driver is `modernc.org/sqlite`, which recognizes only the `_pragma=<name>(<value>)` form. The mattn-style keys were parsed as unknown query parameters and dropped, so none of the intended pragmas applied — every store ran in default rollback-journal (`delete`) mode with `busy_timeout=0`.
+
+## Symptoms
+
+- A read issued while a write was in flight failed immediately with `database is locked (5) (SQLITE_BUSY)` instead of waiting on the lock.
+- Reading the pragmas back showed defaults: `journal_mode=delete`, `busy_timeout=0`, `foreign_keys=0` — `synchronous`, `temp_store`, and `mmap_size` were likewise no-ops.
+- The template's own comments asserted WAL was in effect ("WAL readers don't normally block on writers"), and one comment actively claimed the underscore-prefixed form "works either way" — both false.
+
+## What Didn't Work
+
+- **Trusting the in-code comment.** A comment in `OpenReadOnly` claimed `_journal_mode`/`_busy_timeout` "work either way; they're parsed out of the DSN by the driver before sqlite3_open_v2." That belief is what let the bug ship. The fix only became obvious after reading the pragmas back empirically.
+- **Reordering pragmas to put `busy_timeout` first** (so the WAL conversion would honor the timeout). Measured no improvement on the concurrent-open race — the connect-time conversion BUSY is not covered by the statement-level busy handler.
+
+## Solution
+
+Switch both opens to the `_pragma=` form (verify with the pinned driver version, here `modernc.org/sqlite v1.37.0`):
+
+```go
+// read-only
+sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
+
+// read-write (adds synchronous)
+sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
+```
+
+Empirical proof with the pinned driver — the mattn-style DSN is byte-for-byte equivalent to passing no parameters:
+
+| DSN | journal_mode | busy_timeout | foreign_keys |
+|---|---|---|---|
+| `?_journal_mode=WAL&_busy_timeout=5000&…` (old) | `delete` | `0` | `0` |
+| no params | `delete` | `0` | `0` |
+| `?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&…` | `wal` | `5000` | `1` |
+
+A `mode=ro` open of a WAL file is fine; `journal_mode(WAL)` on a read-only handle is a harmless no-op. The read-write open performs the one-time `delete`→`wal` conversion, and published CLIs convert automatically on their next read-write open.
+
+### Second bug, exposed by the first fix
+
+Enabling WAL for real surfaced a latent race. The `journal_mode(WAL)` conversion runs at connection-establishment time (when `database/sql` opens a physical connection, modernc executes the DSN `_pragma` directives), which in the migration path happens inside `s.db.Conn(ctx)` — **outside** the existing `retryOnBusy` coverage that wrapped only the user_version read, `BEGIN IMMEDIATE`, and `COMMIT`. Concurrent first-opens of a fresh DB tripped `SQLITE_BUSY` ~40% of the time. Fix: wrap the `Conn()` acquisition in the same `retryOnBusy` helper against the shared migration deadline.
+
+```go
+deadline := time.Now().Add(migrationLockTimeout)
+var conn *sql.Conn
+if err := retryOnBusy(ctx, deadline, "acquiring migration connection", func() error {
+    c, err := s.db.Conn(ctx)
+    if err != nil {
+        return err
+    }
+    conn = c
+    return nil
+}); err != nil {
+    return err
+}
+defer conn.Close()
+```
+
+## Why This Works
+
+`modernc.org/sqlite` is a pure-Go reimplementation, not a binding to the C `sqlite3` library, and it does not parse `mattn/go-sqlite3`'s `_<pragma>=<value>` DSN keys. Its own convention is `_pragma=<name>(<value>)`, applied left-to-right at physical-connection establishment. Unrecognized keys are silently ignored rather than rejected, so a syntactically wrong DSN produces a working connection with the wrong settings — no error anywhere.
+
+## Prevention
+
+- **Two SQLite drivers, two DSN dialects.** When the driver is `modernc.org/sqlite`, pragmas are `_pragma=name(value)`. When it is `mattn/go-sqlite3` (CGO), they are `_journal_mode=…` etc. The two are not interchangeable and the wrong one fails silently. Printed CLIs use modernc (pure Go, no CGO) — see `store.go.tmpl`'s import.
+- **A config string that is silently a no-op can mask a latent bug.** The store had concurrency-hardening machinery (`retryOnBusy`, `BEGIN IMMEDIATE`) that only had to cover statement-level contention because WAL was never actually on. Turning WAL on exposed a connect-time conversion race the no-op had hidden. When you fix a setting that was previously inert, re-test the paths that setting touches — the "fix" can reveal bugs the broken state was suppressing.
+- **Verify pragmas by reading them back, never by trusting the DSN or a comment.** `TestOpenAppliesPragmas` (in `store_schema_version_test.go.tmpl`) opens the store, then asserts `PRAGMA journal_mode == wal` and `PRAGMA busy_timeout == 5000` on both the read-write and read-only handles, so the DSN cannot silently regress:
+
+```go
+func requirePragma(t *testing.T, db *sql.DB, name, want string) {
+    t.Helper()
+    var got string
+    if err := db.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+        t.Fatalf("read pragma %s: %v", name, err)
+    }
+    if got != want {
+        t.Fatalf("PRAGMA %s = %q, want %q", name, got, want)
+    }
+}
+```
+
+  (Reading the value as text covers both string pragmas like `journal_mode` and integer pragmas like `busy_timeout`.)
+
+## Related Issues
+
+- mvanhorn/cli-printing-press#2394 (bug report, with the empirical pragma-readback table)
+- mvanhorn/cli-printing-press#2399 (fix)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -75,11 +75,13 @@ func Open(dbPath string) (*Store, error) {
 // The file: URI prefix is load-bearing: modernc.org/sqlite only honors
 // SQLite's URI query parameters (mode, cache, etc.) when the DSN starts
 // with "file:". Without the prefix, "?mode=ro" is silently dropped and
-// the connection opens read-write. Underscore-prefixed driver pragmas
-// (_journal_mode, _busy_timeout, etc.) work either way; they're parsed
-// out of the DSN by the driver before sqlite3_open_v2.
+// the connection opens read-write. Pragmas use the driver's _pragma=
+// name(value) syntax — modernc.org/sqlite does NOT recognize the
+// mattn/go-sqlite3 _journal_mode=WAL / _busy_timeout=5000 form and drops
+// those keys silently, so the busy_timeout below is what keeps a read
+// concurrent with a writer from failing immediately with SQLITE_BUSY.
 func OpenReadOnly(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database (read-only): %w", err)
 	}
@@ -96,7 +98,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -233,9 +235,23 @@ func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 }
 
 func (s *Store) migrate(ctx context.Context) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("acquiring migration connection: %w", err)
+	// Acquiring the migration connection establishes a physical SQLite
+	// connection, which runs the DSN _pragma directives — including the
+	// journal_mode(WAL) conversion. On a fresh DB opened by several
+	// processes at once, that conversion briefly needs an exclusive lock
+	// and can return SQLITE_BUSY before any statement-level busy handler
+	// applies, so retry the acquisition against the shared deadline.
+	deadline := time.Now().Add(migrationLockTimeout)
+	var conn *sql.Conn
+	if err := retryOnBusy(ctx, deadline, "acquiring migration connection", func() error {
+		c, err := s.db.Conn(ctx)
+		if err != nil {
+			return err
+		}
+		conn = c
+		return nil
+	}); err != nil {
+		return err
 	}
 	defer conn.Close()
 
@@ -243,7 +259,6 @@ func (s *Store) migrate(ctx context.Context) error {
 	// opening a newer-schema DB rejects immediately. WAL readers don't
 	// normally block on writers, but the fresh-DB WAL-init race can BUSY
 	// a SELECT — share the lock's deadline so total budget stays bounded.
-	deadline := time.Now().Add(migrationLockTimeout)
 	var current int
 	if err := retryOnBusy(ctx, deadline, "reading schema version", func() error {
 		return conn.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&current)

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -36,6 +36,50 @@ func TestSchemaVersion_StampedOnFreshDB(t *testing.T) {
 	}
 }
 
+// TestOpenAppliesPragmas pins the connection-string contract: the store
+// must open in WAL journal mode with a non-zero busy_timeout so a read
+// concurrent with a write waits on the lock instead of failing immediately
+// with SQLITE_BUSY. It fails the instant the DSN regresses to the mattn-
+// style _journal_mode=WAL form, which modernc.org/sqlite silently drops —
+// see the OpenReadOnly comment for the driver-syntax detail.
+func TestOpenAppliesPragmas(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	requirePragma(t, s.DB(), "journal_mode", "wal")
+	requirePragma(t, s.DB(), "busy_timeout", "5000")
+
+	// The read-only handle (MCP sql/search, analytics) must see the same WAL
+	// file mode and carry the busy_timeout so it waits on a concurrent writer
+	// rather than erroring.
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open read-only: %v", err)
+	}
+	defer ro.Close()
+
+	requirePragma(t, ro.DB(), "journal_mode", "wal")
+	requirePragma(t, ro.DB(), "busy_timeout", "5000")
+}
+
+// requirePragma fails the test unless `PRAGMA <name>` reports want. It reads
+// the value as text so one helper covers both string pragmas (journal_mode)
+// and integer pragmas (busy_timeout).
+func requirePragma(t *testing.T, db *sql.DB, name, want string) {
+	t.Helper()
+	var got string
+	if err := db.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+		t.Fatalf("read pragma %s: %v", name, err)
+	}
+	if got != want {
+		t.Fatalf("PRAGMA %s = %q, want %q", name, got, want)
+	}
+}
+
 // TestSchemaVersion_StampExistingZeroDB verifies the stamp-and-continue
 // rule for existing deployed databases. A DB that predates the gate has
 // user_version = 0; opening it with this binary should stamp the version
@@ -133,7 +177,7 @@ func TestMigrate_ConcurrentFreshDB(t *testing.T) {
 // to construct contention scenarios in the migration tests.
 func holdWriteLock(t *testing.T, dbPath string) (cleanup func()) {
 	t.Helper()
-	holder, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	holder, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		t.Fatalf("open holder: %v", err)
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -75,11 +75,13 @@ func Open(dbPath string) (*Store, error) {
 // The file: URI prefix is load-bearing: modernc.org/sqlite only honors
 // SQLite's URI query parameters (mode, cache, etc.) when the DSN starts
 // with "file:". Without the prefix, "?mode=ro" is silently dropped and
-// the connection opens read-write. Underscore-prefixed driver pragmas
-// (_journal_mode, _busy_timeout, etc.) work either way; they're parsed
-// out of the DSN by the driver before sqlite3_open_v2.
+// the connection opens read-write. Pragmas use the driver's _pragma=
+// name(value) syntax — modernc.org/sqlite does NOT recognize the
+// mattn/go-sqlite3 _journal_mode=WAL / _busy_timeout=5000 form and drops
+// those keys silently, so the busy_timeout below is what keeps a read
+// concurrent with a writer from failing immediately with SQLITE_BUSY.
 func OpenReadOnly(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database (read-only): %w", err)
 	}
@@ -96,7 +98,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -230,9 +232,23 @@ func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 }
 
 func (s *Store) migrate(ctx context.Context) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("acquiring migration connection: %w", err)
+	// Acquiring the migration connection establishes a physical SQLite
+	// connection, which runs the DSN _pragma directives — including the
+	// journal_mode(WAL) conversion. On a fresh DB opened by several
+	// processes at once, that conversion briefly needs an exclusive lock
+	// and can return SQLITE_BUSY before any statement-level busy handler
+	// applies, so retry the acquisition against the shared deadline.
+	deadline := time.Now().Add(migrationLockTimeout)
+	var conn *sql.Conn
+	if err := retryOnBusy(ctx, deadline, "acquiring migration connection", func() error {
+		c, err := s.db.Conn(ctx)
+		if err != nil {
+			return err
+		}
+		conn = c
+		return nil
+	}); err != nil {
+		return err
 	}
 	defer conn.Close()
 
@@ -240,7 +256,6 @@ func (s *Store) migrate(ctx context.Context) error {
 	// opening a newer-schema DB rejects immediately. WAL readers don't
 	// normally block on writers, but the fresh-DB WAL-init race can BUSY
 	// a SELECT — share the lock's deadline so total budget stays bounded.
-	deadline := time.Now().Add(migrationLockTimeout)
 	var current int
 	if err := retryOnBusy(ctx, deadline, "reading schema version", func() error {
 		return conn.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&current)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -74,11 +74,13 @@ func Open(dbPath string) (*Store, error) {
 // The file: URI prefix is load-bearing: modernc.org/sqlite only honors
 // SQLite's URI query parameters (mode, cache, etc.) when the DSN starts
 // with "file:". Without the prefix, "?mode=ro" is silently dropped and
-// the connection opens read-write. Underscore-prefixed driver pragmas
-// (_journal_mode, _busy_timeout, etc.) work either way; they're parsed
-// out of the DSN by the driver before sqlite3_open_v2.
+// the connection opens read-write. Pragmas use the driver's _pragma=
+// name(value) syntax — modernc.org/sqlite does NOT recognize the
+// mattn/go-sqlite3 _journal_mode=WAL / _busy_timeout=5000 form and drops
+// those keys silently, so the busy_timeout below is what keeps a read
+// concurrent with a writer from failing immediately with SQLITE_BUSY.
 func OpenReadOnly(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database (read-only): %w", err)
 	}
@@ -95,7 +97,7 @@ func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000&_foreign_keys=ON&_temp_store=MEMORY&_mmap_size=268435456")
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)&_pragma=temp_store(MEMORY)&_pragma=mmap_size(268435456)")
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -229,9 +231,23 @@ func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 }
 
 func (s *Store) migrate(ctx context.Context) error {
-	conn, err := s.db.Conn(ctx)
-	if err != nil {
-		return fmt.Errorf("acquiring migration connection: %w", err)
+	// Acquiring the migration connection establishes a physical SQLite
+	// connection, which runs the DSN _pragma directives — including the
+	// journal_mode(WAL) conversion. On a fresh DB opened by several
+	// processes at once, that conversion briefly needs an exclusive lock
+	// and can return SQLITE_BUSY before any statement-level busy handler
+	// applies, so retry the acquisition against the shared deadline.
+	deadline := time.Now().Add(migrationLockTimeout)
+	var conn *sql.Conn
+	if err := retryOnBusy(ctx, deadline, "acquiring migration connection", func() error {
+		c, err := s.db.Conn(ctx)
+		if err != nil {
+			return err
+		}
+		conn = c
+		return nil
+	}); err != nil {
+		return err
 	}
 	defer conn.Close()
 
@@ -239,7 +255,6 @@ func (s *Store) migrate(ctx context.Context) error {
 	// opening a newer-schema DB rejects immediately. WAL readers don't
 	// normally block on writers, but the fresh-DB WAL-init race can BUSY
 	// a SELECT — share the lock's deadline so total budget stays bounded.
-	deadline := time.Now().Add(migrationLockTimeout)
 	var current int
 	if err := retryOnBusy(ctx, deadline, "reading schema version", func() error {
 		return conn.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&current)


### PR DESCRIPTION
## Summary

Every printed CLI's local SQLite store silently ran in `delete` journal mode with `busy_timeout=0` instead of the intended WAL + 5s timeout. A read issued while `sync` was writing — an MCP `sql`/`search`/analytics query, or a second CLI invocation — failed immediately with `database is locked (5) (SQLITE_BUSY)` instead of waiting on the lock.

The store opened SQLite with mattn/go-sqlite3 DSN params (`?_journal_mode=WAL&_busy_timeout=5000&…`), but the driver is `modernc.org/sqlite`, which honors only the `_pragma=name(value)` form. The params were parsed as unknown query keys and dropped, leaving every pragma (WAL, busy_timeout, foreign_keys, synchronous, temp_store, mmap_size) at its default. Verified against the pinned driver (v1.37.0): the old DSN was byte-for-byte equivalent to passing no params at all. Both the read-only and read-write opens now use `_pragma=`, and the comment that wrongly claimed the underscore form "works either way" is corrected.

Enabling WAL surfaced a latent race: the `journal_mode(WAL)` conversion runs at connection-establishment time inside `s.db.Conn` during `migrate()`, outside the existing `retryOnBusy` coverage, so concurrent first-opens of a fresh DB tripped `SQLITE_BUSY` (~40% of runs in `TestMigrate_ConcurrentFreshDB`). The `Conn()` acquisition is now wrapped in `retryOnBusy` against the shared migration deadline.

`TestOpenAppliesPragmas` asserts `journal_mode=wal` and `busy_timeout=5000` on both the read-write and read-only handles so the DSN cannot silently regress again.

Published CLIs auto-convert `delete`→`wal` on their next read-write open, so no library sweep is needed — they pick up the corrected DSN on the next regen. `store.go.tmpl` is not in AGENTS.md's named cross-repo lockstep set.

Fixes #2394

## Test plan
- `go test ./...` — pass
- `scripts/golden.sh verify` — 25/25 (two `store.go` goldens regenerated)
- `scripts/verify-generator-output.sh` — 5/5 cases build
- `TestMigrate_ConcurrentFreshDB` — 0/15 on a freshly generated module (was ~40% flaky once WAL was actually enabled)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
