### PR TITLE
fix(cli): gofmt Go source after publish-time module-path rewrite

### DIFF
--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"fmt"
+	"go/format"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -73,6 +74,20 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 		result = rewriteGitHubRepoURLs(result, oldPath, newPath)
 		if result == string(content) {
 			return nil // no changes needed
+		}
+
+		// Reformat rewritten Go source. Swapping the module path changes
+		// import-path length and alphabetical order, so a string-only
+		// replace leaves the import block out of gofmt order. Without this
+		// pass every published CLI's imports drift from gofmt-clean — the
+		// generator emits clean code, but the publish-time rewrite undoes
+		// it. Reformatting here keeps published output clean by construction.
+		if strings.HasSuffix(path, ".go") {
+			formatted, ferr := format.Source([]byte(result))
+			if ferr != nil {
+				return fmt.Errorf("gofmt after module-path rewrite of %s: %w", path, ferr)
+			}
+			result = string(formatted)
 		}
 
 		return os.WriteFile(path, []byte(result), 0o644)

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"go/format"
 	"os"
 	"path/filepath"
 	"testing"
@@ -196,4 +197,52 @@ brews:
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not contain expected module path")
 	})
+}
+
+// TestRewriteModulePath_ProducesGofmtCleanImports guards the publish-time
+// invariant that drove the library-wide gofmt drift: rewriting the module path
+// via string replacement reorders the import block (the new path sorts
+// differently than the old one), so without a reformat pass every published
+// CLI's imports land out of gofmt order. The input here is gofmt-clean under
+// the old short module path; the rewrite must leave it gofmt-clean under the
+// new path too.
+func TestRewriteModulePath_ProducesGofmtCleanImports(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module acme-pp-cli\n\ngo 1.23\n"), 0o644))
+
+	// Sorted under "acme-pp-cli": the local imports lead the group because
+	// "acme" precedes the stdlib names. After the rewrite to a github.com
+	// path they must move below "fmt", which only happens if the rewrite
+	// reformats.
+	src := `package cli
+
+import (
+	"acme-pp-cli/internal/cliutil"
+	"acme-pp-cli/internal/config"
+	"context"
+	"fmt"
+)
+
+var _ = context.Background
+var _ = fmt.Sprint
+var _ = cliutil.X
+var _ = config.Y
+`
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "cli"), 0o755))
+	goPath := filepath.Join(dir, "internal", "cli", "root.go")
+	require.NoError(t, os.WriteFile(goPath, []byte(src), 0o644))
+
+	const newPath = "github.com/mvanhorn/printing-press-library/library/other/acme-pp-cli"
+	require.NoError(t, RewriteModulePath(dir, "acme-pp-cli", newPath))
+
+	out, err := os.ReadFile(goPath)
+	require.NoError(t, err)
+
+	formatted, err := format.Source(out)
+	require.NoError(t, err)
+	assert.Equal(t, string(formatted), string(out), "rewritten .go file must be gofmt-clean")
+	assert.Contains(t, string(out), newPath+"/internal/cliutil")
 }


### PR DESCRIPTION
## Publish-time rewrite now keeps Go source gofmt-clean

`RewriteModulePath` rewrites the module path in a packaged CLI via plain `strings.Replace`. The published path (`github.com/mvanhorn/printing-press-library/library/<cat>/<slug>`) sorts differently than the generator's original short module path, so after the substitution the import block is out of gofmt order — and nothing reformatted it. The generator emits gofmt-clean code (enforced by `emit_gofmt_test.go`), but the publish step silently undid that, so published CLIs drifted gofmt-dirty across the library.

This was the dominant cause of the gofmt drift found while sweeping the published library (mvanhorn/printing-press-library): a string-only path rewrite reorders imports on **every** publish, regardless of CLI vintage. Fixing it here means published output is gofmt-clean by construction — no CI gate needed to hold the line.

### Change
- Run `go/format.Source` on each rewritten `.go` file before writing it. A parse failure fails loudly rather than emitting unformatted source.
- Applies to both callers (`internal/cli/publish.go` packaging and `regenmerge/apply.go`).
- `TestRewriteModulePath_ProducesGofmtCleanImports` reproduces the sort-order break (local imports lead the group under the short old path, must move below `fmt` under the github path) and asserts the rewritten file equals `format.Source` of itself. Verified fail-first: without the reformat pass, the string-replace output is gofmt-dirty.

### Verification
- `go test ./...` — pass
- `scripts/golden.sh verify` — 25/25 (generate goldens are pre-rewrite, unaffected)
- `golangci-lint run ./internal/pipeline/` — 0 issues

### Follow-up
The existing ~5,077 already-published dirty files are a separate one-time cleanup (library-side sweep) — this fix stops the recurrence so that sweep only has to run once.
