### PR TITLE
fix(cli): pin golang.org/x/net to a patched version after generation

### DIFF
--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -236,6 +236,12 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 		return fmt.Errorf("running go mod tidy: %w", err)
 	}
 
+	// Pin golang.org/x/net to a patched release when it resolved transitively
+	// below the safe version (see ensureSafeXNet).
+	if err := ensureSafeXNet(outputDir); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -49,6 +49,12 @@ func (g *Generator) Validate() error {
 			},
 		},
 		{
+			name: "ensure safe golang.org/x/net",
+			run: func() error {
+				return ensureSafeXNet(g.OutputDir)
+			},
+		},
+		{
 			name: "govulncheck ./...",
 			run: func() error {
 				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", govulncheck.GoRunArgs("./...")...)

--- a/internal/generator/xnet_guard.go
+++ b/internal/generator/xnet_guard.go
@@ -1,0 +1,47 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// safeXNetVersion is the lowest golang.org/x/net release without the 2026
+// advisories (GO-2026-5025..5030). Keep in sync with the explicit pin in
+// templates/go.mod.tmpl.
+const safeXNetVersion = "v0.55.0"
+
+// ensureSafeXNet bumps golang.org/x/net to safeXNetVersion when the generated
+// module resolves it below that version. x/net is dragged in transitively by
+// several optional features — surf (browser HTTP transport), goquery (search
+// backends), kooky (cookie auth), chromedp, and net/html extraction — that
+// live in different templates and copied-in packages. Enumerating every puller
+// as a go.mod.tmpl condition is fragile (it has already missed surf/goquery/
+// kooky once) and a too-broad condition breaks the `go mod tidy` gate by
+// leaving an unused require in CLIs that don't pull x/net at all.
+//
+// Bumping after tidy is exact: it runs only when x/net is actually in the
+// resolved build graph, so it never adds an unused dependency and never misses
+// a puller (current or future). Runs before the govulncheck gate so a freshly
+// printed CLI ships with the patched version. No-op when x/net is absent or
+// already at/above safeXNetVersion.
+func ensureSafeXNet(dir string) error {
+	out, err := runCommand(dir, qualityGateTimeout, "go", "list", "-m", "-f", "{{.Version}}", "golang.org/x/net")
+	if err != nil {
+		// `go list -m` exits non-zero when x/net is not a dependency of the
+		// module — nothing to pin.
+		return nil
+	}
+	current := strings.TrimSpace(out)
+	if !semver.IsValid(current) || semver.Compare(current, safeXNetVersion) >= 0 {
+		return nil
+	}
+	if _, err := runCommand(dir, qualityGateTimeout, "go", "get", "golang.org/x/net@"+safeXNetVersion); err != nil {
+		return fmt.Errorf("bumping golang.org/x/net to %s: %w", safeXNetVersion, err)
+	}
+	if _, err := runCommand(dir, qualityGateTimeout, "go", "mod", "tidy"); err != nil {
+		return fmt.Errorf("re-running go mod tidy after golang.org/x/net bump: %w", err)
+	}
+	return nil
+}

--- a/internal/generator/xnet_guard.go
+++ b/internal/generator/xnet_guard.go
@@ -33,7 +33,12 @@ func ensureSafeXNet(dir string) error {
 		// module — nothing to pin.
 		return nil
 	}
-	current := strings.TrimSpace(out)
+	// go list -m writes the version to stdout; runCommand joins stdout+stderr,
+	// so take only the first line to ignore any progress/download messages that
+	// the toolchain emits to stderr (e.g. "go: downloading golang.org/x/net …")
+	// in fresh-cache environments.
+	current := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
+	current = strings.TrimSpace(current)
 	if !semver.IsValid(current) || semver.Compare(current, safeXNetVersion) >= 0 {
 		return nil
 	}

--- a/internal/generator/xnet_guard_test.go
+++ b/internal/generator/xnet_guard_test.go
@@ -1,0 +1,56 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureSafeXNet exercises the post-tidy x/net pin against real modules.
+// It needs network (go get / go mod tidy), so it skips in -short.
+func TestEnsureSafeXNet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("ensureSafeXNet runs go get / go mod tidy (network)")
+	}
+
+	t.Run("bumps a transitively-old x/net to the safe version", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module xnetbump\n\ngo 1.23\n\nrequire golang.org/x/net v0.43.0\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+			[]byte("package main\n\nimport _ \"golang.org/x/net/html\"\n\nfunc main() {}\n"), 0o644))
+		if _, err := runCommand(dir, qualityGateTimeout, "go", "mod", "tidy"); err != nil {
+			t.Skipf("initial go mod tidy failed (offline?): %v", err)
+		}
+
+		require.NoError(t, ensureSafeXNet(dir))
+
+		out, err := runCommand(dir, qualityGateTimeout, "go", "list", "-m", "-f", "{{.Version}}", "golang.org/x/net")
+		require.NoError(t, err)
+		assert.Equal(t, safeXNetVersion, out, "x/net should be bumped to the safe version")
+
+		// The bump must leave the module tidy so the publish `go mod tidy`
+		// gate stays a no-op.
+		before, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+		require.NoError(t, err)
+		_, err = runCommand(dir, qualityGateTimeout, "go", "mod", "tidy")
+		require.NoError(t, err)
+		after, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+		require.NoError(t, err)
+		assert.Equal(t, string(before), string(after), "go.mod must be tidy after the bump")
+	})
+
+	t.Run("no-op when x/net is not a dependency", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+			[]byte("module noxnet\n\ngo 1.23\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+			[]byte("package main\n\nfunc main() {}\n"), 0o644))
+
+		// Must not error when go list -m reports x/net is unknown.
+		require.NoError(t, ensureSafeXNet(dir))
+	})
+}


### PR DESCRIPTION
## Pin `golang.org/x/net` to a patched version in fresh prints

Printed CLIs pull `golang.org/x/net` transitively through several optional features — `surf` (browser HTTP transport), `goquery` (search backends), `kooky` (cookie auth), `chromedp`, and `net/html` extraction — spread across different templates and copied-in packages. The only explicit pin in `go.mod.tmpl` was gated on `HasHTMLExtraction`, so the *other* pullers resolved whatever `x/net` version their dependency happened to require, which has drifted below the patched release as new advisories landed (GO-2026-5025..5030, fixed in `v0.55.0`). This is the source of the govulncheck failures seen across the published library.

### Why not just broaden the template condition
Two reasons enumeration doesn't work:
1. **It's fragile** — pullers live in copied-in packages (search backends, auth helpers), not just `go.mod.tmpl`. The `HasHTMLExtraction`-only gate already silently missed `surf`/`goquery`/`kooky`.
2. **A too-broad condition breaks the `go mod tidy` gate.** Pinning `x/net` for a config that doesn't actually pull it leaves an unused `require`, which `go mod tidy` strips — and the publish tidy-check fails. (The cookie-auth golden, for instance, pulls no `x/net`.)

### The fix
`ensureSafeXNet` runs **after** `go mod tidy` resolves the real graph (and before the `govulncheck` gate): if `x/net` is present below `v0.55.0`, it runs `go get golang.org/x/net@v0.55.0` + re-tidy. Exact by construction — it acts only when `x/net` is actually in the resolved graph, so it never adds an unused dependency and never misses a puller (current or future). No-op when `x/net` is absent or already patched. Wired into both the validation gate sequence and the plan-generation tidy.

The existing `HasHTMLExtraction` template pin is left in place (harmless; `ensureSafeXNet` is a no-op when it's already `v0.55.0`).

### Verification
- `TestEnsureSafeXNet` (network-gated): bumps a transitively-old `x/net` to `v0.55.0` **and** asserts the module stays tidy afterward (so the publish `go mod tidy` gate remains a no-op); plus a no-op case when `x/net` is absent. Verified end-to-end against the pinned driver: `v0.43.0 → v0.55.0`, tidy stable.
- `go test ./...` pass · `scripts/golden.sh verify` 25/25 (no emit/template change, so goldens unaffected) · `golangci-lint` 0 issues.

### Follow-up
A one-time library bump retrofits the ~37 already-published CLIs whose committed `go.mod` carries a vulnerable `x/net` (separate PR).
