### PR TITLE
fix(cli): guard empty PROXY_ARGS expansion under bash 3.2

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -286,12 +286,12 @@ check_network() {
     return 0
   fi
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL --connect-timeout 5 "${PROXY_ARGS[@]}" https://github.com >/dev/null || {
+    curl -fsSL --connect-timeout 5 ${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"} https://github.com >/dev/null || {
       err "Network check failed: could not reach github.com."
       exit 1
     }
     if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
-      curl -fsSL --connect-timeout 5 "${PROXY_ARGS[@]}" https://registry.npmjs.org/skills >/dev/null || {
+      curl -fsSL --connect-timeout 5 ${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"} https://registry.npmjs.org/skills >/dev/null || {
         err "Network check failed: could not reach registry.npmjs.org."
         exit 1
       }


### PR DESCRIPTION
## Intent

Fix the documented one-line installer on macOS systems using the stock `/bin/bash` (3.2.x). Currently aborts at the network probe with `PROXY_ARGS[@]: unbound variable`.

Issue: Closes #2438

## Approach

`scripts/install.sh` runs under `set -euo pipefail`. Bash 3.2 treats `"${EMPTY_ARRAY[@]}"` as an unbound reference under `nounset` (Bash 4.4+ fixed it). `PROXY_ARGS=()` is initialized at module scope and again in `setup_proxy`, but the empty-array expansion still trips `nounset` on macOS.

Switch the two `curl` probe sites in `check_network` to the bash-3.2-safe form:

```sh
${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"}
```

This expands to nothing when the array is empty and preserves quoting when `HTTPS_PROXY` / `HTTP_PROXY` populates the array.

## Scope

Primary area: `cli` (installer script).

Why this belongs in this repo: `scripts/install.sh` is the canonical installer for the Go binary and skills, served directly from `main`. The bug blocks the documented quick-start on a major platform.

## Catalog Justification

N/A — no catalog changes.

## Risk

Low. Two-line, single-file change. Behavior under proxy-set environments is unchanged because the quoting form preserves array-element splitting. Behavior on bash 4.4+ is unchanged.

## Output Contract

N/A — installer script, no generated output or templates touched.

## Verification

- Reproduced the failure on macOS `/bin/bash` 3.2.57: installer aborted at `check_network` with the reported message.
- Applied patch; re-ran `./scripts/install.sh`. CLI installed via `go install`, skills installed via the `skills` CLI, and the summary block printed `CLI: installed`, `Skills: installed`.
- Sanity-checked the expansion idiom under `set -euo pipefail` with an empty array on bash 3.2: no `unbound variable` error.
- `bash -n scripts/install.sh` parses clean.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output — N/A
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures — N/A
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates — N/A

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
