### PR TITLE
fix(cli): pass context to async job no-cache polling

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14391,7 +14391,7 @@ func TestGenerateWaitForJobBypassesResponseCache(t *testing.T) {
 	require.NoError(t, err)
 	jobsBody := string(jobsData)
 
-	assert.Contains(t, jobsBody, "c.GetNoCache(path, nil)",
+	assert.Contains(t, jobsBody, "c.GetNoCache(ctx, path, nil)",
 		"WaitForJob must poll with GetNoCache to avoid locking on the cached initial response")
 	assert.NotContains(t, jobsBody, "c.Get(ctx, path, nil)",
 		"WaitForJob must not call c.Get(ctx, path, nil); cached non-terminal status would lock the poll")

--- a/internal/generator/templates/jobs.go.tmpl
+++ b/internal/generator/templates/jobs.go.tmpl
@@ -146,7 +146,7 @@ func WaitForJob(ctx context.Context, c *client.Client, statusPath string, jobID 
 		// GetNoCache: the cache is keyed by (path, params), so a cached
 		// non-terminal status would lock the poll on the initial response
 		// for the cache TTL.
-		resp, err := c.GetNoCache(path, nil)
+		resp, err := c.GetNoCache(ctx, path, nil)
 		if err == nil {
 			var body map[string]any
 			if uerr := json.Unmarshal(resp, &body); uerr == nil {

--- a/testdata/golden/expected/generate-async-job-api/async-job-api/internal/cli/jobs.go
+++ b/testdata/golden/expected/generate-async-job-api/async-job-api/internal/cli/jobs.go
@@ -147,7 +147,7 @@ func WaitForJob(ctx context.Context, c *client.Client, statusPath string, jobID 
 		// GetNoCache: the cache is keyed by (path, params), so a cached
 		// non-terminal status would lock the poll on the initial response
 		// for the cache TTL.
-		resp, err := c.GetNoCache(path, nil)
+		resp, err := c.GetNoCache(ctx, path, nil)
 		if err == nil {
 			var body map[string]any
 			if uerr := json.Unmarshal(resp, &body); uerr == nil {


### PR DESCRIPTION
## Intent

Fixes #2450 
Fixes #2458

Generated async job polling currently calls `GetNoCache` with the old two-argument shape even though the generated client now requires a `context.Context`:

```go
c.GetNoCache(path, nil)
```

Without this fix, async-job APIs fail generated-project validation before downstream gates can run.

## Approach

Thread the existing `ctx` already in scope inside `WaitForJob` into the no-cache polling call. Update the generator assertion and async-job golden fixture so the emitted-code contract locks onto the context-aware call shape.

## Scope

Primary area: generator templates and generated-output fixtures.

Why this belongs in this repo:

This is a machine change. The mismatch is emitted by `internal/generator/templates/jobs.go.tmpl` and affects every future generated CLI whose spec triggers async job polling.

## Catalog Justification

Embedded catalog fit: N/A

Distinct blueprint pattern: N/A

Closest existing entries checked: N/A

Source provenance: N/A

Auth and tenant assumptions: N/A

Safe default surface: N/A

Generation path: N/A

Stale-body check: N/A

## Risk

Low. `WaitForJob` already accepts `ctx` and checks `ctx.Err()` immediately before this call. The generated client already exposes the context-aware `GetNoCache` method. This change only makes the emitted call match the emitted method signature.

## Output Contract

Generated `internal/cli/jobs.go` for async-job CLIs now emits:

```go
resp, err := c.GetNoCache(ctx, path, nil)
```

instead of:

```go
resp, err := c.GetNoCache(path, nil)
```

Generated-output evidence:

- `TestGenerateWaitForJobBypassesResponseCache` now asserts the context-aware call.
- `generate-async-job-api` golden output is updated.
- `scripts/verify-generator-output.sh generate-async-job-api` compiles the affected generated module.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

```bash
go test ./...
scripts/golden.sh verify
scripts/verify-generator-output.sh generate-async-job-api
CLI_PRINTING_PRESS_BIN=/private/tmp/cli-printing-press-main-check/cli-printing-press npm run cli:pp:check
```

The final command was an additional downstream OpenAPI-generation smoke test run against a patched local `cli-printing-press` binary. It passed generation, generated CLI tests, CLI/MCP builds, `--help`, `doctor --json`, and `agent-context --json`.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] No AI or automation was used
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
