### PR TITLE
feat(catalog): add vestaboard multi-host blueprint

### DIFF
--- a/catalog/specs/vestaboard-spec.yaml
+++ b/catalog/specs/vestaboard-spec.yaml
@@ -1,0 +1,95 @@
+name: vestaboard
+description: "Read and write messages on a Vestaboard split-flap display, with transition control and VBML text formatting."
+version: "0.1.0"
+spec_source: docs
+category: devices
+# New Cloud API (verified at docs.vestaboard.com/docs/read-write-api/endpoints).
+base_url: "https://cloud.vestaboard.com"
+
+auth:
+  type: api_key
+  header: "X-Vestaboard-Token"
+  env_vars: [VESTABOARD_API_KEY]
+
+# The VBML formatter lives on a different origin and takes no credentials.
+# Modeling it as a no-auth tier is what actually suppresses X-Vestaboard-Token
+# on the second host at request time (a plain resource `base_url` + `no_auth`
+# does NOT — no_auth is not consumed by the client request path). Untiered
+# resources (message, transition) fall through to the default: cloud host + api_key.
+tier_routing:
+  tiers:
+    vbml:
+      base_url: "https://vbml.vestaboard.com"
+      auth:
+        type: none
+
+config:
+  format: toml
+  path: "~/.config/vestaboard-pp-cli/config.toml"
+
+resources:
+  message:
+    description: "The message currently shown on the Vestaboard."
+    endpoints:
+      get:
+        method: GET
+        path: "/"
+        description: "Read the message currently displayed on the board. The layout is a JSON-encoded 2D array of character codes whose dimensions depend on the board type."
+      send:
+        method: POST
+        path: "/"
+        description: "Send a new message to the board. Provide --text (plain text / VBML) or --characters (a JSON 2D array of character codes). Rate limited to 1 message per 15 seconds."
+        # Body accepts {text} | {characters:[[int]]} | {text,forced}. The generated
+        # --body-json / --stdin flags take a JSON object (the documented {text}/{characters}
+        # shapes); the bare top-level array form is not exposed as a flag.
+        body_json_fallback: true
+        body:
+          - name: text
+            type: string
+            description: "Plain text or VBML to display."
+          - name: characters
+            type: array
+            description: "A board-sized 2D array of Vestaboard character codes (JSON), e.g. [[0,8,5,...],...]."
+          - name: forced
+            type: boolean
+            description: "Send even during configured quiet hours."
+  transition:
+    description: "Transition animation settings for the board (Flagship and Note devices)."
+    endpoints:
+      get:
+        method: GET
+        path: "/transition"
+        description: "Get the current transition style and speed."
+      set:
+        method: PUT
+        path: "/transition"
+        description: "Set the transition style and speed. Both fields are required."
+        body_required: true
+        body:
+          - name: transition
+            type: string
+            required: true
+            description: "Transition style: classic, wave, drift, or curtain."
+          - name: transitionSpeed
+            type: string
+            required: true
+            description: "Transition speed: gentle or fast."
+  vbml:
+    # Routed to the no-auth second-host tier above.
+    tier: vbml
+    description: "Vestaboard Markup Language (VBML) text formatting service."
+    endpoints:
+      format:
+        method: POST
+        path: "/format"
+        description: "Convert a text string into a 2D array of Vestaboard character codes."
+        # /format is a pure transform on a POST verb: route it through doRead()
+        # (bypassing the verify-mode write gate) and emit readOnlyHint on the MCP tool.
+        meta:
+          "mcp:read-only": "true"
+        body_required: true
+        body:
+          - name: message
+            type: string
+            required: true
+            description: "The text string to format into character codes."

--- a/catalog/vestaboard.yaml
+++ b/catalog/vestaboard.yaml
@@ -1,0 +1,43 @@
+name: vestaboard
+display_name: Vestaboard
+description: Read and write messages on a Vestaboard split-flap display, with transition control and VBML text formatting.
+category: devices
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/vestaboard-spec.yaml
+spec_format: custom
+tier: community
+spec_source: docs
+verified_date: "2026-05-29"
+homepage: https://www.vestaboard.com
+auth_key_url: https://web.vestaboard.com
+auth_required: true
+auth_instructions: Create a Cloud API token in the API tab on web.vestaboard.com (or in the mobile app under Settings -> Advanced Settings). Pass it as the X-Vestaboard-Token header.
+auth_env_vars:
+  - VESTABOARD_API_KEY
+notes: |
+  First catalog entry exercising a multi-host generated client: the VBML
+  formatter (vbml.vestaboard.com/format) sits on a different origin than the
+  Cloud API (cloud.vestaboard.com) and takes no credentials. The spec models
+  it as a no-auth tier so the generated client suppresses X-Vestaboard-Token on
+  the second host while still sending it to the Cloud API — verified via
+  --dry-run. A plain resource base_url override would NOT suppress the header
+  (no_auth is not consumed by the client request path), so tier routing is the
+  correct mechanism here.
+
+  Surface (Cloud API, X-Vestaboard-Token header):
+    - message get      — GET /         read the current layout (a 2D char-code grid)
+    - message send     — POST /        {text} | {characters:[[int]]} | {forced}; 1 msg / 15s
+    - transition get   — GET /transition
+    - transition set   — PUT /transition   classic|wave|drift|curtain × gentle|fast
+    - vbml format      — POST vbml.vestaboard.com/format (no auth)  text -> char codes
+
+  Hand-written novel agent features (the board speaks in 6x22 integer grids that
+  are unreadable/unwritable without tooling):
+    - message preview  — render the current board as a bordered block of glyphs
+    - characters       — the character-code table (code -> glyph) for building payloads
+
+  Spec sourcing: catalog/specs/vestaboard-spec.yaml is an internal-format spec
+  transcribed from the public docs at
+  https://docs.vestaboard.com/docs/read-write-api/endpoints and
+  https://docs.vestaboard.com/docs/charactercodes (verified 2026-05-29). This
+  covers the Cloud Read/Write API; the Local API (LAN) and Subscription API are
+  intentionally out of scope.

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -13,6 +13,9 @@ developer-tools:
   launchdarkly         Feature flag management - flags, environments, segments, experiments, audit logs
   postman-explore      Public API network directory for discovering community collections, workspaces, and APIs
 
+devices:
+  vestaboard           Read and write messages on a Vestaboard split-flap display, with transition control and VBML text formatting.
+
 example:
   petstore             Canonical OpenAPI example - pet store management
 


### PR DESCRIPTION
## Intent

Add Vestaboard (the internet-connected split-flap display) to the embedded catalog so `cli-printing-press generate vestaboard` produces a CLI for the Cloud Read/Write API.

Issue: N/A

## CLI Shape

What `cli-printing-press generate vestaboard` produces:

```text
$ vestaboard-pp-cli --help
Vestaboard CLI — Read, render, and write your Vestaboard from the terminal — with a
board preview and character-code table no other Vestaboard tool ships.

Highlights (not in the official API docs):
  • message preview   See what's on your Vestaboard right now as readable text instead of a raw integer grid.
  • characters        Print the full Vestaboard character-code table (code → glyph) for hand-building a character-array message.

Available Commands:
  message       The message currently shown on the Vestaboard
  transition    Transition animation settings (Flagship and Note devices)
  vbml          Convert a text string into a 2D array of Vestaboard character codes
  characters    Show the Vestaboard character-code table (code → glyph)   [novel, read-only]
  doctor        Check CLI health
  auth          Manage authentication for Vestaboard
  ... (agent-context, api, export, import, profile, which, version)
```

Command surface:

| Command | Maps to | Notes |
|---|---|---|
| `message get` | `GET cloud.vestaboard.com/` | read current layout |
| `message send` | `POST cloud.vestaboard.com/` | `--body-json` / `--stdin`; text or character-array; 1 msg / 15s |
| `message preview` | `GET /` + local render | **novel**: renders the code grid as readable text (`mcp:read-only`) |
| `transition get` | `GET /transition` | read-only |
| `transition set` | `PUT /transition` | `--transition` (classic/wave/drift/curtain) `--transition-speed` (gentle/fast) |
| `vbml` | `POST vbml.vestaboard.com/format` | **second host, no auth**; text → char-code grid (`mcp:read-only`) |
| `characters` | curated static table | **novel**: code → glyph table for hand-building payloads (`mcp:read-only`) |

## Approach

Docs-derived internal-format spec at `catalog/specs/vestaboard-spec.yaml` (the API has no published OpenAPI), wired through the catalog entry `catalog/vestaboard.yaml`. The VBML formatter lives on a different host (`vbml.vestaboard.com`) and takes no credentials, so it is modeled as a no-auth `tier_routing` tier — the generated client sends `X-Vestaboard-Token` to the Cloud API but never to the formatter (verified via `--dry-run`).

## Scope

Primary area: catalog

Why this belongs in this repo: it is a reusable generation blueprint (embedded catalog), not a printed-CLI-only fix.

## Catalog Justification

Embedded catalog fit: First catalog entry exercising a generated **multi-host client** — a secondary API host reached through a no-auth `tier_routing` tier, with per-host credential scoping verified at the request layer (`--dry-run` shows the token on `cloud.vestaboard.com` and absent on `vbml.vestaboard.com`).

Distinct blueprint pattern: Multi-host tier routing + a board-as-character-grid data-shaping problem. No existing entry ships a CLI that talks to two API hosts with different auth.

Closest existing entries checked: `openrouteservice` (docs-derived internal spec, but single-host); `elevenlabs` (custom-header api_key, but single-host). Neither exercises a second host or per-host auth scoping.

Source provenance: Transcribed from the official docs at https://docs.vestaboard.com/docs/read-write-api/endpoints, https://docs.vestaboard.com/docs/read-write-api/authentication, and https://docs.vestaboard.com/docs/charactercodes (verified 2026-05-29). Source type: docs. Live-smoke verified against a real board: read, send (text + character array), VBML format, and transition get all succeeded.

Auth and tenant assumptions: Custom-header api_key (`X-Vestaboard-Token`), one token per board, from web.vestaboard.com → API tab. The VBML formatter requires no credentials. Cloud Read/Write API only; the Local (LAN) and Subscription APIs are out of scope.

Safe default surface: Read paths are read-only. Write paths (`POST /` send, `PUT /transition`) are included because the generated CLI gates mutating verbs under verify-mode and prints-by-default; the board enforces a 1-message/15s rate limit.

Generation path: `cli-printing-press generate vestaboard` resolves the in-repo spec via the raw-`main` `spec_url` (resolves once merged). Pre-merge, generation was verified from the local spec path.

Stale-body check: PR body reflects the final spec/entry; no stale endpoint counts or tenant-specific instructions.

## Risk

Adds one embedded catalog entry and one internal spec; updates the `catalog-list` golden (one new `devices:` row). No generator/template code changed, so emitted-output contracts for other CLIs are unaffected.

## Output Contract

Catalog rendering: `testdata/golden/expected/catalog-list/stdout.txt` gains the `devices:` section with the vestaboard row. `scripts/golden.sh verify` passes (25 cases) after the intentional update; `go test ./internal/catalog/` passes.

## Verification

- `go test ./...` green; `scripts/golden.sh verify` green; `golangci-lint`/`go fmt` clean.
- `cli-printing-press catalog list` shows Vestaboard under `devices`; `internal/catalog` validation passes.
- Generated CLI (from this spec) live-verified against a real Vestaboard: read, send, VBML format, transition get.
