### PR TITLE
fix(cli): always emit RequestBaseURL() so novel commands keep BasePath

### DIFF
--- a/internal/generator/client_basepath_test.go
+++ b/internal/generator/client_basepath_test.go
@@ -46,6 +46,13 @@ func TestClientHonorsSpecBasePath(t *testing.T) {
 	assert.Contains(t, client, "c.BaseURL + c.BasePath + path",
 		"do() should construct request URLs as BaseURL+BasePath+path")
 
+	// RequestBaseURL() must be emitted for every printed CLI (not just HTML-
+	// extraction ones) so novel commands have a safe accessor and cannot drop
+	// BasePath by open-coding c.BaseURL. This spec has no HTML extraction.
+	requestBaseURL := regexp.MustCompile(`func \(c \*Client\) RequestBaseURL\(\) string \{\s*return c\.BaseURL \+ c\.BasePath\s*\}`)
+	assert.Regexp(t, requestBaseURL, client,
+		"RequestBaseURL() should be emitted and return BaseURL+BasePath even without HTML extraction")
+
 	cacheKeyBody := clientCacheKeyBody(t, client)
 	assert.Contains(t, cacheKeyBody, `"|base_path=" + c.BasePath`,
 		"cache key should include BasePath so a config change invalidates correctly")
@@ -82,6 +89,11 @@ func TestClientWithoutBasePathByteIdentical(t *testing.T) {
 		"client.go must not emit BasePath when the spec doesn't declare base_path")
 	assert.NotContains(t, client, "normalizeBasePath",
 		"client.go must not emit the normalizeBasePath helper when unused")
+	// RequestBaseURL() is still emitted (returning just c.BaseURL) so novel
+	// commands have a consistent accessor regardless of BasePath.
+	requestBaseURL := regexp.MustCompile(`func \(c \*Client\) RequestBaseURL\(\) string \{\s*return c\.BaseURL\s*\}`)
+	assert.Regexp(t, requestBaseURL, client,
+		"RequestBaseURL() should be emitted and return c.BaseURL when there is no BasePath")
 
 	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
 	require.NoError(t, err)

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -181,9 +181,10 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
-// RequestBaseURL returns the base URL used for the current request, including
-// any BasePath. Novel commands that build request URLs by hand should use this
-// instead of concatenating c.BaseURL directly, so they cannot drop BasePath.
+// RequestBaseURL returns the base URL used for the current request (including
+// BasePath for tiers that use the default base URL). Novel commands that build
+// request URLs by hand should use this instead of concatenating c.BaseURL
+// directly, so they cannot drop BasePath on tiers that inherit it.
 func (c *Client) RequestBaseURL() string {
 	return c.baseURLForRequest()
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -181,12 +181,14 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
-{{- if .HasHTMLExtraction}}
-
-// RequestBaseURL returns the base URL used by the current request tier.
+// RequestBaseURL returns the base URL used for the current request, including
+// any BasePath. Novel commands that build request URLs by hand should use this
+// instead of concatenating c.BaseURL directly, so they cannot drop BasePath.
 func (c *Client) RequestBaseURL() string {
 	return c.baseURLForRequest()
 }
+
+{{- if .HasHTMLExtraction}}
 
 // LastContentType returns the last response Content-Type observed by this client.
 func (c *Client) LastContentType() string {
@@ -259,12 +261,18 @@ func applyTierAuthFormat(format string, replacements map[string]string) string {
 
 {{- end}}
 
-{{- if and (not .HasTierRouting) .HasHTMLExtraction}}
+{{- if not .HasTierRouting}}
 
-// RequestBaseURL returns the base URL used for requests.
+// RequestBaseURL returns the base URL used for requests{{if .BasePath}}, including the
+// configured BasePath. Novel commands that build request URLs by hand should use
+// this instead of concatenating c.BaseURL directly, so they cannot drop BasePath.{{else}}.
+// Novel commands that build request URLs by hand should use this instead of
+// concatenating c.BaseURL directly.{{end}}
 func (c *Client) RequestBaseURL() string {
 	return c.BaseURL{{if .BasePath}} + c.BasePath{{end}}
 }
+
+{{- if .HasHTMLExtraction}}
 
 // LastContentType returns the last response Content-Type observed by this client.
 func (c *Client) LastContentType() string {
@@ -274,6 +282,7 @@ func (c *Client) LastContentType() string {
 	return c.lastContentType
 }
 
+{{- end}}
 {{- end}}
 
 {{if eq .ClientPattern "proxy-envelope"}}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -39,6 +39,13 @@ type Client struct {
 	limiter    *cliutil.AdaptiveLimiter
 }
 
+// RequestBaseURL returns the base URL used for requests.
+// Novel commands that build request URLs by hand should use this instead of
+// concatenating c.BaseURL directly.
+func (c *Client) RequestBaseURL() string {
+	return c.BaseURL
+}
+
 // APIError carries HTTP status information for structured exit codes.
 type APIError struct {
 	Method     string

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -44,6 +44,13 @@ type Client struct {
 	ccMu *sync.Mutex
 }
 
+// RequestBaseURL returns the base URL used for requests.
+// Novel commands that build request URLs by hand should use this instead of
+// concatenating c.BaseURL directly.
+func (c *Client) RequestBaseURL() string {
+	return c.BaseURL
+}
+
 // APIError carries HTTP status information for structured exit codes.
 type APIError struct {
 	Method     string

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -39,6 +39,13 @@ type Client struct {
 	limiter    *cliutil.AdaptiveLimiter
 }
 
+// RequestBaseURL returns the base URL used for requests.
+// Novel commands that build request URLs by hand should use this instead of
+// concatenating c.BaseURL directly.
+func (c *Client) RequestBaseURL() string {
+	return c.BaseURL
+}
+
 // APIError carries HTTP status information for structured exit codes.
 type APIError struct {
 	Method     string

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -40,6 +40,13 @@ type Client struct {
 	limiter    *cliutil.AdaptiveLimiter
 }
 
+// RequestBaseURL returns the base URL used for requests.
+// Novel commands that build request URLs by hand should use this instead of
+// concatenating c.BaseURL directly.
+func (c *Client) RequestBaseURL() string {
+	return c.BaseURL
+}
+
 // APIError carries HTTP status information for structured exit codes.
 type APIError struct {
 	Method     string

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -91,9 +91,10 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
-// RequestBaseURL returns the base URL used for the current request, including
-// any BasePath. Novel commands that build request URLs by hand should use this
-// instead of concatenating c.BaseURL directly, so they cannot drop BasePath.
+// RequestBaseURL returns the base URL used for the current request (including
+// BasePath for tiers that use the default base URL). Novel commands that build
+// request URLs by hand should use this instead of concatenating c.BaseURL
+// directly, so they cannot drop BasePath on tiers that inherit it.
 func (c *Client) RequestBaseURL() string {
 	return c.baseURLForRequest()
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -91,6 +91,13 @@ func (c *Client) baseURLForRequest() string {
 	}
 }
 
+// RequestBaseURL returns the base URL used for the current request, including
+// any BasePath. Novel commands that build request URLs by hand should use this
+// instead of concatenating c.BaseURL directly, so they cannot drop BasePath.
+func (c *Client) RequestBaseURL() string {
+	return c.baseURLForRequest()
+}
+
 func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 	switch c.requestTier {
 	case "enterprise":


### PR DESCRIPTION
## Intent

Printed CLIs for APIs with a `BasePath` trap hand-written novel commands into open-coding `c.BaseURL + c.BasePath` when building request URLs, because the safe accessor (`RequestBaseURL()`) was emitted only for HTML-extraction CLIs. Forgetting `BasePath` there is the easy mistake.

Observed in the Immich CLI: `grab`'s `streamDownload` built `c.BaseURL + path`, dropped `/api`, and got Immich's SvelteKit SPA `index.html` (HTTP 200) written into every downloaded image file.

Issue: Closes #2519

## Approach

Emit `RequestBaseURL()` **unconditionally**, decoupled from `.HasHTMLExtraction`:
- Tier-routing CLIs delegate to the existing `baseURLForRequest()`.
- Non-tier CLIs return `c.BaseURL` (+ `c.BasePath` when present).

`LastContentType()` / `lastContentType` stay gated on `.HasHTMLExtraction` (genuinely HTML-extraction concerns) by splitting them out of the previously-bundled block. The non-tier doc comment is conditional on `.BasePath` so the no-BasePath client stays free of the word "BasePath" (keeps `TestClientWithoutBasePathByteIdentical` honest).

Now every printed CLI exposes one canonical accessor for the request base, so novel commands cannot drop `BasePath` by hand.

## Scope

Primary area: generator template (`internal/generator/templates/client.go.tmpl`).

Why this belongs in this repo: this is a machine change — the symptom surfaced in a printed CLI, but the cause is that the generator only emitted the safe URL-building helper for one CLI variant. The fix makes `RequestBaseURL()` available in every printed client, so the whole class of "novel command forgot BasePath" bugs is prevented at generation time rather than patched per CLI.

## Catalog Justification

N/A

## Risk

Low. The only generated-output change is the addition of the `RequestBaseURL()` accessor (and a relocation of `LastContentType` within its conditional). Golden diffs show exactly the new helper and nothing else across all five client.go fixtures; generated-output verification confirms every auth fork still compiles. No MCP, auth, catalog, publish, scorer, or release surface is touched. A CLI that already had `RequestBaseURL()` (HTML-extraction) is unchanged.

## Output Contract

Generator/template change. Evidence:
- Golden fixtures updated for 5 `client.go` cases (each adds only the new accessor); `scripts/golden.sh verify` passes.
- `scripts/verify-generator-output.sh` passes — all 5 forks tidy + build.
- New emitted-code assertions in `internal/generator/client_basepath_test.go` for both the BasePath path (`return c.BaseURL + c.BasePath`) and the no-BasePath path (`return c.BaseURL`); the existing live-request test already proves runtime routing.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases)
- `scripts/verify-generator-output.sh` — pass (5 cases)
- Rebuilt the local Immich CLI against this helper (`c.RequestBaseURL() + path` in `streamDownload`); `grab` now writes real JPEGs instead of the SPA HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
