### PR TITLE
fix(cli): stop gating promote on ASIN examples

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -118,12 +118,6 @@ var piiDetectors = []piiDetector{
 		pattern: piiplaceholders.OrderIDPattern(),
 	},
 	{
-		kind: PIIKindASIN,
-		// ASIN-shaped product IDs from browser-sniff captures. The
-		// canonical B0EXAMPLE* placeholders are filtered after matching.
-		pattern: piiplaceholders.ASINPattern(),
-	},
-	{
 		kind: PIIKindEmail,
 		// Standard email shape with a TLD of 2+ chars. Word boundaries
 		// guard against capturing surrounding punctuation.

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -131,13 +131,13 @@ func TestFindPII_OrderIDs(t *testing.T) {
 	}
 }
 
-func TestFindPII_ASINs(t *testing.T) {
+func TestFindPII_ASINsAreNotPhase1Findings(t *testing.T) {
 	tests := []struct {
 		name        string
 		line        string
 		expectKinds []string
 	}{
-		{name: "real-asin", line: `"asin": "B012345678"`, expectKinds: []string{PIIKindASIN}},
+		{name: "real-asin", line: `"asin": "B012345678"`, expectKinds: nil},
 		{name: "synthetic-asin", line: `"asin": "B0EXAMPLE1"`, expectKinds: nil},
 		{name: "not-asin", line: `"sku": "A012345678"`, expectKinds: nil},
 	}
@@ -147,6 +147,48 @@ func TestFindPII_ASINs(t *testing.T) {
 			assertKinds(t, got, tt.expectKinds, PIIKindASIN)
 		})
 	}
+}
+
+func TestRunPIIAudit_ASINDocumentationExamplesDoNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "README.md"), strings.Join([]string{
+		"```bash",
+		"amazon-product get --asin B09B93ZDG4",
+		"amazon-product get --asin B0BFC7WQ6R",
+		"amazon-product compare --asin B09B93ZDG4",
+		"amazon-product compare --asin B0BFC7WQ6R",
+		"```",
+	}, "\n"))
+	write(t, filepath.Join(dir, "SKILL.md"), strings.Join([]string{
+		"Use B09B93ZDG4 as the sample product identifier.",
+		"Use B0BFC7WQ6R when showing product comparison.",
+		"Run with B09B93ZDG4 for a speaker example.",
+		"Run with B0BFC7WQ6R for a display example.",
+	}, "\n"))
+	write(t, filepath.Join(dir, ".manuscripts", "run1", "research.json"), strings.Join([]string{
+		`{"example_asin":"B09B93ZDG4"}`,
+		`{"example_asin":"B0BFC7WQ6R"}`,
+		`{"example_asin":"B09B93ZDG4"}`,
+		`{"example_asin":"B0BFC7WQ6R"}`,
+	}, "\n"))
+
+	result, err := RunPIIAudit(dir)
+	require.NoError(t, err)
+	assert.Empty(t, result.Findings)
+	assert.Equal(t, 0, PIIPendingCount(result.Findings))
+	assert.False(t, result.Completion.HasGateFailure())
+}
+
+func TestRunPIIAudit_OrderIDStillBlocks(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, ".manuscripts", "run1", "research.json"), `{"order_id":"123-4567890-1234567"}`)
+
+	result, err := RunPIIAudit(dir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+	assert.Equal(t, PIIKindOrderID, result.Findings[0].Kind)
+	assert.Equal(t, 1, PIIPendingCount(result.Findings))
+	assert.False(t, result.Completion.HasGateFailure())
 }
 
 func TestFindPII_Email(t *testing.T) {

--- a/internal/cli/pii_audit.go
+++ b/internal/cli/pii_audit.go
@@ -32,8 +32,8 @@ func newPIIAuditCmd() *cobra.Command {
 		Long: `Walks <cli-dir>'s high-risk file scope (JSON, YAML, Markdown,
 .manuscripts/**) and reports per-line findings
 that signal PII-shape leaks. Detection is purely mechanical: card
-last-4 with context tokens, email addresses, US-shaped phone numbers,
-ZIP+4, and street-address-line shapes. The agent layer
+last-4 with context tokens, order IDs, email addresses, US-shaped phone
+numbers, ZIP+4, and street-address-line shapes. The agent layer
 (skills/printing-press-polish/references/pii-polish.md) takes these
 findings and applies judgment per item — fix in source or accept with
 pre-decision fields.
@@ -112,9 +112,9 @@ func renderPIIAuditTable(w io.Writer, findings []artifacts.PIIFinding, delta art
 	switch {
 	case pending == 0 && !gateFired:
 		if accepted > 0 {
-			fmt.Fprintf(w, "pii-audit: no pending findings (%d accepted) — phase-1 scope (card/email/phone/zip/postal); order-IDs, ASINs, and standalone names are a future detector class\n", accepted)
+			fmt.Fprintf(w, "pii-audit: no pending findings (%d accepted) — phase-1 scope (order-id/card/email/phone/zip/postal); ASINs and standalone names are a future detector class\n", accepted)
 		} else {
-			fmt.Fprintln(w, "pii-audit: no findings — phase-1 scope (card/email/phone/zip/postal); order-IDs, ASINs, and standalone names are a future detector class")
+			fmt.Fprintln(w, "pii-audit: no findings — phase-1 scope (order-id/card/email/phone/zip/postal); ASINs and standalone names are a future detector class")
 		}
 	case pending == 0 && gateFired:
 		fmt.Fprintf(w, "pii-audit: incomplete (%d accepted, %d gate failure(s))\n",

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -463,7 +463,7 @@ func validatePIIGateForPromote(workingDir string, state *PipelineState) error {
 		msg += "gate failures:\n" + artifacts.FormatPIIGateFailures(result.Completion) + "\n"
 	}
 	msg += fmt.Sprintf("ledger: %s\n", ledgerPath)
-	msg += "scope: phase-1 detectors (order-id, ASIN, card-last-4, email, phone, ZIP+4, postal-address); standalone names are a future detector class.\n"
+	msg += "scope: phase-1 detectors (order-id, card-last-4, email, phone, ZIP+4, postal-address); ASINs and standalone names are a future detector class.\n"
 	command := "cli-printing-press pii-audit <dir>"
 	if opts.ManuscriptsDir != "" {
 		command += " --manuscripts-dir " + shellQuote(opts.ManuscriptsDir)

--- a/skills/printing-press-polish/references/pii-polish.md
+++ b/skills/printing-press-polish/references/pii-polish.md
@@ -2,7 +2,7 @@
 
 **Goal:** clear the PII ledger so promote and publish gates pass. Every pending finding is either real PII (replace with a placeholder in source) or a justified non-PII match (accept in the ledger with pre-decision fields).
 
-**Scope:** Phase 1 detectors are shape-only — card-last-4, email, US phone, ZIP+4, postal-address. Order/transaction IDs, ASINs, and standalone names are a future detector class pending spec-aware detection work. A passing gate is the floor, not "PII-clean."
+**Scope:** Phase 1 detectors are shape-only — order/transaction IDs, card-last-4, email, US phone, ZIP+4, postal-address. ASINs and standalone names are a future detector class pending spec-aware detection work. A passing gate is the floor, not "PII-clean."
 
 ```bash
 cli-printing-press pii-audit <cli-dir>


### PR DESCRIPTION
## Summary

ASIN-shaped product IDs in documentation are no longer phase-1 PII findings, so commerce CLIs with product examples can clear promote without false pending ASINs or all-accepted punt failures. Order IDs and customer PII detectors remain enforced.

Closes #2395

## Verification

- `go fmt ./...`
- `go test ./internal/artifacts -run 'TestFindPII_(OrderIDs|ASINsAreNotPhase1Findings)|TestRunPIIAudit_(ASINDocumentationExamplesDoNotBlock|OrderIDStillBlocks)|TestCheckPIIAllAcceptedNoFixes'`
- `go test ./internal/cli -run TestPIIAudit`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `git diff --check`
- Not run: `golangci-lint run ./...` could not start because another concurrent `golangci-lint` process held the repo-wide lock. The pre-push hook hit the same lock after the required retry.
