### PR TITLE
fix(cli): normalize publish package metadata

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -1077,7 +1077,6 @@ func normalizePackagedPublishMetadata(dir, category string) error {
 		if err := os.WriteFile(manifestPath, updated, info.Mode()); err != nil {
 			return err
 		}
-		manifest.Category = category
 	}
 
 	return pipeline.WritePatchesIndex(dir, manifest.RunID, manifest.PrintingPressVersion)

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -357,6 +357,10 @@ func newPublishPackageCmd() *cobra.Command {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("backfilling printer attribution: %w", err)}
 			}
+			if err := normalizePackagedPublishMetadata(outCLIDir, category); err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("normalizing publish metadata: %w", err)}
+			}
 
 			// Strip build/ from the staged tree. autoBundleForHost writes
 			// host-platform .mcpb bundles + staged binaries there as a
@@ -1038,6 +1042,45 @@ func backfillPackagedManifestAttribution(dir string) error {
 		return err
 	}
 	return os.WriteFile(manifestPath, updated, info.Mode())
+}
+
+func normalizePackagedPublishMetadata(dir, category string) error {
+	manifestPath := filepath.Join(dir, pipeline.CLIManifestFilename)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var manifest pipeline.CLIManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(manifest.Category) != category {
+		encoded, err := json.Marshal(category)
+		if err != nil {
+			return err
+		}
+		raw["category"] = encoded
+		updated, err := json.MarshalIndent(raw, "", "  ")
+		if err != nil {
+			return err
+		}
+		updated = append(updated, '\n')
+		info, err := os.Stat(manifestPath)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(manifestPath, updated, info.Mode()); err != nil {
+			return err
+		}
+		manifest.Category = category
+	}
+
+	return pipeline.WritePatchesIndex(dir, manifest.RunID, manifest.PrintingPressVersion)
 }
 
 func isPublishPrinterSentinel(printer string) bool {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -732,6 +732,75 @@ func TestPublishPackageRejectsUnknownCategory(t *testing.T) {
 	assert.Contains(t, err.Error(), "--category must be one of:")
 }
 
+func TestPublishPackageBackfillsPatchesIndexForLegacyCLI(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	require.NoFileExists(t, filepath.Join(cliDir, pipeline.PatchesIndexFilename))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	data, err := os.ReadFile(filepath.Join(result.StagedDir, pipeline.PatchesIndexFilename))
+	require.NoError(t, err)
+
+	var idx pipeline.PatchesIndex
+	require.NoError(t, json.Unmarshal(data, &idx))
+	assert.Equal(t, pipeline.CurrentPatchesIndexSchemaVersion, idx.SchemaVersion)
+	assert.Equal(t, "20260301-000000", idx.BaseRunID)
+	assert.Equal(t, "test-version", idx.BasePrintingPressVersion)
+	assert.NotNil(t, idx.Patches)
+	assert.Empty(t, idx.Patches)
+	assert.Contains(t, string(data), `"patches": []`)
+}
+
+func TestPublishPackageNormalizesManifestCategoryToPublishCategory(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	manifestPath := filepath.Join(cliDir, pipeline.CLIManifestFilename)
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	var manifest map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &manifest))
+	manifest["category"] = json.RawMessage(`"productivity"`)
+	data, err = json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifestPath, append(data, '\n'), 0o644))
+	skillInstall := generator.CanonicalSkillInstallSection("test", "productivity")
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "SKILL.md"), []byte("# Test CLI\n\n"+skillInstall+"\n## Command Reference\n\n- `test-pp-cli insight` — Show test insight\n\n## Usage\n\n```bash\ntest-pp-cli insight --agent\n```\n"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	data, err = os.ReadFile(filepath.Join(result.StagedDir, pipeline.CLIManifestFilename))
+	require.NoError(t, err)
+	var got pipeline.CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "other", got.Category)
+
+	data, err = os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	var source pipeline.CLIManifest
+	require.NoError(t, json.Unmarshal(data, &source))
+	assert.Equal(t, "productivity", source.Category, "publish package should normalize only the staged copy")
+}
+
 func TestPublishPackageFailsWhenSkillReferencesUnknownCommand(t *testing.T) {
 	home := setLibraryTestEnv(t)
 	cliDir := filepath.Join(home, "library", "test-pp-cli")


### PR DESCRIPTION
## Summary

`publish package` now normalizes staged package metadata before a published CLI reaches public-library CI. Legacy-generated CLIs that do not yet have `.printing-press-patches.json` get an empty patch index from the manifest run and Printing Press version, and the staged manifest category is rewritten to the user-selected public category without mutating the source CLI.

Closes #2390

## Testing

- `go test ./internal/cli -run 'TestPublishPackage(BackfillsPatchesIndexForLegacyCLI|NormalizesManifestCategoryToPublishCategory|RejectsUnknownCategory)$'`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
