### PR TITLE
fix(cli): parse comment-led helper call files

### DIFF
--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -792,17 +792,18 @@ func callsHelper(content string, helpers map[string]bool) bool {
 
 func countHelperCalls(content string, weight func(string) int) int {
 	source := content
-	trimmed := strings.TrimSpace(source)
-	if !strings.HasPrefix(trimmed, "package ") {
+	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
+	if err != nil {
+		trimmed := strings.TrimSpace(source)
 		if strings.HasPrefix(trimmed, "{") {
 			source = "package cli\nfunc _() " + trimmed
 		} else {
 			source = "package cli\n" + source
 		}
-	}
-	file, err := parser.ParseFile(token.NewFileSet(), "", source, 0)
-	if err != nil {
-		return 0
+		file, err = parser.ParseFile(token.NewFileSet(), "", source, 0)
+		if err != nil {
+			return 0
+		}
 	}
 	count := 0
 	ast.Inspect(file, func(n ast.Node) bool {

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -845,6 +845,51 @@ func newRestaurantsTopCmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_CommentLedStoreHelperHop_Passes(t *testing.T) {
+	files := map[string]string{
+		"analytics_helpers.go": `package cli
+
+import "example.com/mod/internal/store"
+
+func openStoreForRead() (*store.Store, error) {
+	return store.Open("analytics.db")
+}
+`,
+		"analytics.go": `// Copyright 2026 Example and contributors.
+package cli
+
+import "github.com/spf13/cobra"
+
+// pp:data-source local
+func newRevenueCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "revenue",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s, err := openStoreForRead()
+			if err != nil { return err }
+			_ = s
+			return nil
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Revenue", Command: "revenue"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if got.ExemptedViaStore != 1 {
+		t.Fatalf("ExemptedViaStore: want 1 (comment-led handler calls store helper), got %d", got.ExemptedViaStore)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 func TestCheckReimplementation_HardcodedHelperHop_Flagged(t *testing.T) {
 	files := map[string]string{
 		"novel_helpers.go": `package cli


### PR DESCRIPTION
## Summary

The reimplementation checker now parses helper-call input as a full Go file before falling back to snippet wrapping. Comment-led generated command files that call a package-local store or client helper are no longer misread as having 0 helper calls, while helper-body snippets still use the existing wrapper fallback.

Closes #2422.

## Verification

- `go test ./internal/pipeline -run 'TestCheckReimplementation_(CommentLedStoreHelperHop_Passes|ClientHelperHop_Passes|HardcodedHelperHop_Flagged)' -count=1`
- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- pre-push hook: `golangci-lint run ./...`
