### PR TITLE
fix(cli): filter raw HARs from publishable manuscripts

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -367,6 +367,13 @@ func newPublishPackageCmd() *cobra.Command {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping build dir: %w", err)}
 			}
+			// CopyDir preserves the source CLI tree, but publish package owns
+			// the bundled manuscript set. Strip any embedded copy first, then
+			// re-add manuscripts through the publishable filter below.
+			if err := os.RemoveAll(filepath.Join(outCLIDir, ".manuscripts")); err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged manuscripts: %w", err)}
+			}
 
 			// Strip root-level binaries that local `go build ./cmd/...` (or
 			// `make build` / `make build-mcp` without `-o bin/...`) drops at
@@ -401,11 +408,18 @@ func newPublishPackageCmd() *cobra.Command {
 			}
 
 			msDir, runID := resolveManuscripts(cliName, vResult.APIName)
+			if runID == "" {
+				embeddedMsDir := filepath.Join(dir, ".manuscripts")
+				if embeddedRunID, err := findMostRecentRun(embeddedMsDir); err == nil && embeddedRunID != "" {
+					msDir = embeddedMsDir
+					runID = embeddedRunID
+				}
+			}
 			if runID != "" {
 				result.RunID = runID
 				srcMsDir := filepath.Join(msDir, runID)
 				dstMsDir := filepath.Join(outCLIDir, ".manuscripts", runID)
-				if err := pipeline.CopyDir(srcMsDir, dstMsDir); err != nil {
+				if err := pipeline.CopyPublishableManuscriptDir(srcMsDir, dstMsDir); err != nil {
 					cleanupOnFailure()
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("copying manuscripts: %w", err)}
 				} else {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -916,14 +916,21 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	cliDir := filepath.Join(home, "library", "test-pp-cli")
 	writePublishableTestCLI(t, cliDir)
 
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, ".manuscripts", "stale-run", "discovery"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, ".manuscripts", "stale-run", "discovery", "stale-capture.har"), []byte("cookie: stale\n"), 0o644))
+
 	// Create manuscripts at the archived location where publish package looks
 	runID := "20260329-100000"
 	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
 	proofsDir := filepath.Join(home, "manuscripts", "test", runID, "proofs")
+	discoveryDir := filepath.Join(home, "manuscripts", "test", runID, "discovery")
 	require.NoError(t, os.MkdirAll(researchDir, 0o755))
 	require.NoError(t, os.MkdirAll(proofsDir, 0o755))
+	require.NoError(t, os.MkdirAll(discoveryDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "brief.md"), []byte("# Research Brief"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(proofsDir, "shipcheck.md"), []byte("# Shipcheck"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "browser-sniff-capture.har"), []byte("cookie: session=secret\nemail: user@example.com\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
@@ -940,12 +947,63 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	// Verify manuscripts are in the staged package
 	stagedResearch := filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "brief.md")
 	stagedProofs := filepath.Join(result.StagedDir, ".manuscripts", runID, "proofs", "shipcheck.md")
+	stagedHAR := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "browser-sniff-capture.har")
+	stagedTrafficAnalysis := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "traffic-analysis.json")
 
 	_, err = os.Stat(stagedResearch)
 	assert.NoError(t, err, "research brief should be in staged package")
 
 	_, err = os.Stat(stagedProofs)
 	assert.NoError(t, err, "shipcheck proofs should be in staged package")
+	assert.NoFileExists(t, stagedHAR, "raw HAR captures should not be bundled into publishable manuscripts")
+
+	_, err = os.Stat(stagedTrafficAnalysis)
+	assert.NoError(t, err, "auth-stripped traffic analysis should remain in staged package")
+	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", "stale-run", "discovery", "stale-capture.har"))
+}
+
+func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	runID := "20260301-000000"
+	require.NoError(t, os.RemoveAll(filepath.Join(home, "manuscripts", "test")))
+	embeddedDiscovery := filepath.Join(cliDir, ".manuscripts", runID, "discovery")
+	embeddedProofs := filepath.Join(cliDir, ".manuscripts", runID, "proofs")
+	embeddedResearch := filepath.Join(cliDir, ".manuscripts", runID, "research")
+	require.NoError(t, os.MkdirAll(embeddedDiscovery, 0o755))
+	require.NoError(t, os.MkdirAll(embeddedProofs, 0o755))
+	require.NoError(t, os.MkdirAll(embeddedResearch, 0o755))
+	writeTestPhase5GateMarker(t, embeddedProofs, pipeline.Phase5AcceptanceFilename, pipeline.Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         runID,
+		Status:        "pass",
+		Level:         "full",
+		MatrixSize:    1,
+		TestsPassed:   1,
+		TestsFailed:   0,
+		AuthContext:   pipeline.Phase5AuthContext{Type: "none"},
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "browser-sniff-capture.har"), []byte("cookie: session=secret\nemail: user@example.com\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedResearch, "brief.md"), []byte("# Research Brief"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.True(t, result.ManuscriptsIncluded, "embedded manuscripts should be included when archive root is absent")
+	assert.Equal(t, runID, result.RunID)
+	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "browser-sniff-capture.har"))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "traffic-analysis.json"))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "brief.md"))
 }
 
 func TestPublishPackageRejectsVendorPrefixSecretsInStagedCLI(t *testing.T) {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -885,6 +885,12 @@ func TestArchiveRunArtifactsCopiesDiscovery(t *testing.T) {
 	require.NoError(t, os.MkdirAll(state.DiscoveryDir(), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "browser-sniff-report.md"), []byte("report"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "browser-sniff-unique-paths.txt"), []byte("/api/v1\n/api/v2"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "browser-sniff-capture.har"), []byte(`{"request":{"headers":[{"name":"Cookie","value":"session=secret"}]}}`), 0o644))
+	largeCapture := filepath.Join(state.DiscoveryDir(), "browser-sniff-capture.json")
+	largeFile, err := os.Create(largeCapture)
+	require.NoError(t, err)
+	require.NoError(t, largeFile.Truncate(101*1024*1024))
+	require.NoError(t, largeFile.Close())
 
 	archiveDir, err := ArchiveRunArtifacts(state)
 	require.NoError(t, err)
@@ -899,6 +905,8 @@ func TestArchiveRunArtifactsCopiesDiscovery(t *testing.T) {
 	paths, err := os.ReadFile(filepath.Join(archivedDiscovery, "browser-sniff-unique-paths.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1\n/api/v2", string(paths))
+	assert.NoFileExists(t, filepath.Join(archivedDiscovery, "browser-sniff-capture.har"))
+	assert.NoFileExists(t, filepath.Join(archivedDiscovery, "browser-sniff-capture.json"))
 
 	// Verify research/ was also copied
 	assert.DirExists(t, ArchivedResearchDir(state.APIName, state.RunID))

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -394,7 +394,7 @@ func stageRunstateManuscripts(stagingDir string, state *PipelineState) error {
 		} else if !os.IsNotExist(statErr) {
 			return fmt.Errorf("checking %s in staging: %w", target, statErr)
 		}
-		if err := CopyDir(src, target); err != nil {
+		if err := CopyPublishableManuscriptDir(src, target); err != nil {
 			return fmt.Errorf("copying runstate %s: %w", name, err)
 		}
 	}

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -650,6 +650,8 @@ func TestPromoteWorkingCLI_StagesRunstateManuscripts(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(state.ResearchDir(), "notes.md"), []byte("research notes\n"), 0o644))
 	require.NoError(t, os.MkdirAll(state.DiscoveryDir(), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "endpoints.json"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "browser-sniff-capture.har"), []byte("cookie: session=secret\nemail: user@example.com\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(state.DiscoveryDir(), "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
 
 	err = PromoteWorkingCLI("test-pp-cli", workDir, state)
 	require.NoError(t, err)
@@ -673,6 +675,11 @@ func TestPromoteWorkingCLI_StagesRunstateManuscripts(t *testing.T) {
 	data, err = os.ReadFile(filepath.Join(manuRoot, "discovery", "endpoints.json"))
 	require.NoError(t, err)
 	assert.Equal(t, "{}\n", string(data))
+
+	assert.NoFileExists(t, filepath.Join(manuRoot, "discovery", "browser-sniff-capture.har"))
+	data, err = os.ReadFile(filepath.Join(manuRoot, "discovery", "traffic-analysis.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "{\"auth_stripped\":true}\n", string(data))
 }
 
 func TestPromoteWorkingCLI_PreservesPreexistingManuscripts(t *testing.T) {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -703,6 +703,18 @@ func copyDirFiltered(src, dst string, skipFile func(path string, info fs.FileInf
 			if !ok {
 				return fmt.Errorf("symlink %s points outside source tree", path)
 			}
+			if skipFile != nil {
+				info, err := d.Info()
+				if err != nil {
+					return err
+				}
+				if skipFile(path, info) {
+					return nil
+				}
+				if targetInfo, err := os.Stat(path); err == nil && skipFile(path, targetInfo) {
+					return nil
+				}
+			}
 			return os.Symlink(link, target)
 		}
 

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -161,7 +161,7 @@ func ArchiveRunArtifacts(state *PipelineState) (string, error) {
 		if !info.IsDir() {
 			continue
 		}
-		if err := CopyDir(item.src, item.dst); err != nil {
+		if err := CopyPublishableManuscriptDir(item.src, item.dst); err != nil {
 			return "", fmt.Errorf("archiving %s: %w", item.src, err)
 		}
 	}
@@ -620,6 +620,26 @@ func pickNovelFeaturesForManifest(research *ResearchResult) []NovelFeature {
 }
 
 func CopyDir(src, dst string) error {
+	return copyDirFiltered(src, dst, nil)
+}
+
+const publishableManuscriptMaxCaptureBytes int64 = 100 * 1024 * 1024
+
+// CopyPublishableManuscriptDir copies manuscript artifacts that may be bundled
+// into published CLIs. Raw HAR captures and huge capture files stay in local
+// runstate only because they can carry cookies, session identifiers, and PII.
+func CopyPublishableManuscriptDir(src, dst string) error {
+	return copyDirFiltered(src, dst, shouldSkipPublishableManuscriptFile)
+}
+
+func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo) bool {
+	if strings.EqualFold(filepath.Ext(path), ".har") {
+		return true
+	}
+	return info.Size() >= publishableManuscriptMaxCaptureBytes
+}
+
+func copyDirFiltered(src, dst string, skipFile func(path string, info fs.FileInfo) bool) error {
 	info, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -697,6 +717,9 @@ func CopyDir(src, dst string) error {
 		info, err := d.Info()
 		if err != nil {
 			return err
+		}
+		if skipFile != nil && skipFile(path, info) {
+			return nil
 		}
 		return copyFile(path, target, info.Mode())
 	})

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -711,7 +711,11 @@ func copyDirFiltered(src, dst string, skipFile func(path string, info fs.FileInf
 				if skipFile(path, info) {
 					return nil
 				}
-				if targetInfo, err := os.Stat(path); err == nil && skipFile(path, targetInfo) {
+				resolvedTarget := link
+				if !filepath.IsAbs(resolvedTarget) {
+					resolvedTarget = filepath.Join(filepath.Dir(path), resolvedTarget)
+				}
+				if targetInfo, err := os.Stat(path); err == nil && skipFile(resolvedTarget, targetInfo) {
 					return nil
 				}
 			}

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -191,6 +191,33 @@ func TestCopyDirRejectsExternalSymlinks(t *testing.T) {
 	}
 }
 
+func TestCopyPublishableManuscriptDirFiltersSymlinks(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(src, "notes.txt"), []byte("notes"), 0o644))
+	require.NoError(t, os.Symlink("notes.txt", filepath.Join(src, "notes-link.txt")))
+	require.NoError(t, os.Symlink("notes.txt", filepath.Join(src, "capture.har")))
+
+	largeCapture := filepath.Join(src, "large-capture.bin")
+	largeFile, err := os.Create(largeCapture)
+	require.NoError(t, err)
+	require.NoError(t, largeFile.Truncate(publishableManuscriptMaxCaptureBytes))
+	require.NoError(t, largeFile.Close())
+	require.NoError(t, os.Symlink("large-capture.bin", filepath.Join(src, "large-link.bin")))
+
+	require.NoError(t, CopyPublishableManuscriptDir(src, dst))
+
+	linkInfo, err := os.Lstat(filepath.Join(dst, "notes-link.txt"))
+	require.NoError(t, err)
+	assert.NotZero(t, linkInfo.Mode()&os.ModeSymlink, "ordinary internal symlink should be preserved")
+	assert.FileExists(t, filepath.Join(dst, "notes.txt"))
+	assert.NoFileExists(t, filepath.Join(dst, "capture.har"))
+	assert.NoFileExists(t, filepath.Join(dst, "large-capture.bin"))
+	assert.NoFileExists(t, filepath.Join(dst, "large-link.bin"))
+}
+
 // publishManifestEnvSetup wires PRINTING_PRESS_HOME/SCOPE/REPO_ROOT to a temp dir
 // so RunRoot()/PipelineDir()/PublishedLibraryRoot() resolve under the test sandbox.
 // Returns the temp root and a state seeded with the given run ID.

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -199,6 +199,8 @@ func TestCopyPublishableManuscriptDirFiltersSymlinks(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(src, "notes.txt"), []byte("notes"), 0o644))
 	require.NoError(t, os.Symlink("notes.txt", filepath.Join(src, "notes-link.txt")))
 	require.NoError(t, os.Symlink("notes.txt", filepath.Join(src, "capture.har")))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "raw-capture.har"), []byte("cookie: secret"), 0o644))
+	require.NoError(t, os.Symlink("raw-capture.har", filepath.Join(src, "raw-capture-link.txt")))
 
 	largeCapture := filepath.Join(src, "large-capture.bin")
 	largeFile, err := os.Create(largeCapture)
@@ -214,6 +216,8 @@ func TestCopyPublishableManuscriptDirFiltersSymlinks(t *testing.T) {
 	assert.NotZero(t, linkInfo.Mode()&os.ModeSymlink, "ordinary internal symlink should be preserved")
 	assert.FileExists(t, filepath.Join(dst, "notes.txt"))
 	assert.NoFileExists(t, filepath.Join(dst, "capture.har"))
+	assert.NoFileExists(t, filepath.Join(dst, "raw-capture.har"))
+	assert.NoFileExists(t, filepath.Join(dst, "raw-capture-link.txt"))
 	assert.NoFileExists(t, filepath.Join(dst, "large-capture.bin"))
 	assert.NoFileExists(t, filepath.Join(dst, "large-link.bin"))
 }


### PR DESCRIPTION
## Summary

Publishable manuscripts no longer carry raw browser-sniff HAR captures or huge capture files. Archive, lock promote, and publish package now all copy manuscript trees through the same publishable filter, while derived artifacts such as research notes, proofs, traffic analysis, and unique-path reports remain bundled.

`publish package` also strips any `.manuscripts` directory copied from the source CLI before re-adding manuscripts through that filter, with a fallback for embedded manuscript runs when the archive root is unavailable.

Closes #2321

## Verification

- `go test ./internal/pipeline -run 'TestArchiveRunArtifactsCopiesDiscovery|TestPromoteWorkingCLI_StagesRunstateManuscripts' -count=1`
- `go test ./internal/cli -run 'TestPublishPackageIncludesManuscripts|TestPublishPackageFiltersEmbeddedManuscriptsFallback' -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
