### PR TITLE
fix(cli): require explicit global scope flags

### DIFF
--- a/internal/generator/global_scope_param_test.go
+++ b/internal/generator/global_scope_param_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateGlobalScopeParamUsesEnvDefault(t *testing.T) {
+func TestGenerateGlobalScopeParamRequiresExplicitFlag(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("cipp")
@@ -28,7 +30,22 @@ func TestGenerateGlobalScopeParamUsesEnvDefault(t *testing.T) {
 						Description: "Tenant scope",
 						Required:    true,
 						GlobalScope: true,
-						EnvVar:      "CIPP_TENANT_FILTER",
+					}, {
+						Name:        "limit",
+						Type:        "integer",
+						Description: "Maximum results",
+					}},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/users/{id}",
+					Description: "Get user",
+					Params: []spec.Param{{
+						Name:        "id",
+						Type:        "string",
+						Required:    true,
+						Positional:  true,
+						Description: "User ID",
 					}},
 				},
 			},
@@ -38,11 +55,24 @@ func TestGenerateGlobalScopeParamUsesEnvDefault(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "cipp-pp-cli")
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
-	content := generatedCLISourceContaining(t, outputDir, "flagTenantFilter")
+	contentBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "users_list.go"))
+	require.NoError(t, err)
+	content := string(contentBytes)
 
-	assert.Contains(t, content, `StringVar(&flagTenantFilter, "tenant-filter", os.Getenv("CIPP_TENANT_FILTER"), "Tenant scope (defaults from CIPP_TENANT_FILTER)")`)
-	assert.Contains(t, content, `if !cmd.Flags().Changed("tenant-filter") && flagTenantFilter == "" && !flags.dryRun {`)
-	assert.Contains(t, content, `return fmt.Errorf("required flag \"%s\" not set (or set %s)", "tenant-filter", "CIPP_TENANT_FILTER")`)
+	assert.Contains(t, content, `func newUsersListCmd`)
+	assert.Contains(t, content, `StringVar(&flagTenantFilter, "tenant-filter", "", "Tenant scope")`)
+	assert.Contains(t, content, `return fmt.Errorf("required flag \"%s\" not set", "tenant-filter")`)
 	assert.Contains(t, content, `params["TenantFilter"] = fmt.Sprintf("%v", flagTenantFilter)`)
+	assert.NotContains(t, content, `CIPP_TENANT_FILTER`)
+	assert.NotContains(t, content, `defaults from`)
 	assert.NotContains(t, strings.ToLower(content), `markflagrequired`)
+
+	binaryPath := filepath.Join(outputDir, "cipp-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/cipp-pp-cli")
+
+	cmd := exec.Command(binaryPath, "users", "list", "--json", "--limit", "10")
+	cmd.Env = append(os.Environ(), "CIPP_TENANT_FILTER=tenant-a")
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	assert.Contains(t, string(out), `required flag "tenant-filter" not set`)
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -84,15 +84,9 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
-{{- if .EnvVar}}
-			if !{{flagChangedExpr .}} && flag{{camel (paramIdent .)}} == {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set (or set %s)", "{{publicFlagName .}}", "{{.EnvVar}}")
-			}
-{{- else}}
 			if !{{flagChangedExpr .}} && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
 			}
-{{- end}}
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
@@ -863,20 +857,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- range .Endpoint.Params}}
 {{- if not .Positional}}
 {{- $param := .}}
-{{- if .EnvVar}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired .Name .Type .Required (hasDefault .)}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", os.Getenv("{{.EnvVar}}"), "{{oneline .Description}}{{enumDescriptionHint .Enum}} (defaults from {{.EnvVar}})")
-{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired .Name .Type .Required (hasDefault .)}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", {{defaultValForParamRequired . .Required (hasDefault .)}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
-{{- end}}
 {{- if isConstDefault .}}
 	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
 {{- end}}
 {{- range publicFlagAliases $param}}
-{{- if $param.EnvVar}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", os.Getenv("{{$param.EnvVar}}"), "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}} (defaults from {{$param.EnvVar}})")
-{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
-{{- end}}
 	_ = cmd.Flags().MarkHidden("{{.}}")
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -66,15 +66,9 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
-{{- if .EnvVar}}
-			if !{{flagChangedExpr .}} && flag{{camel (paramIdent .)}} == {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} && !flags.dryRun {
-				return fmt.Errorf("required flag \"%s\" not set (or set %s)", "{{publicFlagName .}}", "{{.EnvVar}}")
-			}
-{{- else}}
 			if !{{flagChangedExpr .}} && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
 			}
-{{- end}}
 {{- end}}
 {{- end}}
 {{- bodyRequiredChecks .Endpoint "\t\t\t"}}
@@ -421,20 +415,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- range .Endpoint.Params}}
 {{- if not .Positional}}
 {{- $param := .}}
-{{- if .EnvVar}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired .Name .Type .Required (hasDefault .)}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", os.Getenv("{{.EnvVar}}"), "{{oneline .Description}}{{enumDescriptionHint .Enum}} (defaults from {{.EnvVar}})")
-{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired .Name .Type .Required (hasDefault .)}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", {{defaultValForParamRequired . .Required (hasDefault .)}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
-{{- end}}
 {{- if isConstDefault .}}
 	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
 {{- end}}
 {{- range publicFlagAliases $param}}
-{{- if $param.EnvVar}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", os.Getenv("{{$param.EnvVar}}"), "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}} (defaults from {{$param.EnvVar}})")
-{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
-{{- end}}
 	_ = cmd.Flags().MarkHidden("{{.}}")
 {{- end}}
 {{- end}}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3194,7 +3194,7 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 	}
 
 	assignEndpointAliases(out.Resources)
-	classifyGlobalParams(out.Name, out.Resources)
+	classifyGlobalParams(out.Resources)
 	return nil
 }
 
@@ -3671,7 +3671,7 @@ func computeAlias(method, path, endpointName string) string {
 	}
 }
 
-func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
+func classifyGlobalParams(resources map[string]spec.Resource) {
 	totalEndpoints := 0
 	paramCounts := map[string]*globalParamCount{}
 
@@ -3761,10 +3761,9 @@ func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
 		for _, param := range endpoint.Params {
 			key := strings.ToLower(param.Name)
 			if isGlobalFilterCandidate(param) {
-				if scopeParam, ok := scopeParams[key]; ok {
+				if _, ok := scopeParams[key]; ok {
 					param.Required = true
 					param.GlobalScope = true
-					param.EnvVar = globalScopeParamEnvVar(apiName, scopeParam.name)
 				} else if _, ok := filteredParams[key]; ok {
 					droppedCounts[key]++
 					continue
@@ -3783,7 +3782,7 @@ func classifyGlobalParams(apiName string, resources map[string]spec.Resource) {
 
 	for _, name := range scopeNames {
 		key := strings.ToLower(name)
-		warnf("promoted global scope query param %q to required env-backed flag: present on %d/%d endpoints", name, scopeParams[key].count, totalEndpoints)
+		warnf("promoted global scope query param %q to required flag: present on %d/%d endpoints", name, scopeParams[key].count, totalEndpoints)
 	}
 
 	filteredNames := make([]string, 0, len(droppedCounts))
@@ -3829,18 +3828,6 @@ func isGlobalScopeParamName(name string) bool {
 	default:
 		return false
 	}
-}
-
-func globalScopeParamEnvVar(apiName, paramName string) string {
-	prefix := naming.EnvPrefix(apiName)
-	param := strings.ToUpper(naming.Snake(paramName))
-	if prefix == "" {
-		return param
-	}
-	if param == "" {
-		return prefix
-	}
-	return prefix + "_" + param
 }
 
 func walkResourceEndpoints(resources map[string]spec.Resource, fn func(endpoint *spec.Endpoint)) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3605,7 +3605,6 @@ paths:
 		require.Equal(t, "TenantFilter", tenant.Name, "%s should keep TenantFilter", resourceName)
 		assert.True(t, tenant.Required)
 		assert.True(t, tenant.GlobalScope)
-		assert.Equal(t, "CIPP_TENANT_FILTER", tenant.EnvVar)
 		for _, param := range endpoint.Params {
 			assert.NotEqual(t, "limit", param.Name, "%s should still filter non-scope global params", resourceName)
 		}
@@ -3618,7 +3617,6 @@ paths:
 	assert.Equal(t, "workspace", single.Params[0].Name)
 	assert.False(t, single.Params[0].Required)
 	assert.False(t, single.Params[0].GlobalScope)
-	assert.Empty(t, single.Params[0].EnvVar)
 }
 
 func TestIsGlobalScopeParamNameAvoidsSubstringMatches(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2143,7 +2143,6 @@ type Param struct {
 	Positional  bool     `yaml:"positional" json:"positional"`
 	PathParam   bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
 	GlobalScope bool     `yaml:"global_scope,omitempty" json:"global_scope,omitempty"`
-	EnvVar      string   `yaml:"env_var,omitempty" json:"env_var,omitempty"`
 	Default     any      `yaml:"default" json:"default"`
 	Description string   `yaml:"description" json:"description"`
 	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects


### PR DESCRIPTION
## Summary

Global scope parameters now stay per-call inputs: the generator promotes them to required flags, but no longer creates env-var defaults, config bindings, or user-config-style parameter surfaces for them. Credential env vars and OAuth setup inputs continue to flow through the auth env-var model, while request scope values must be supplied explicitly on each command invocation.

This also removes the now-unused parameter-level `env_var` field so hand-authored specs cannot declare a flag default that generated commands ignore.

## Verification

- `go test ./internal/openapi -run 'TestPromoteGlobalScopeQueryParams|TestIsGlobalScopeParamNameAvoidsSubstringMatches' -count=1`
- `go test ./internal/generator -run 'TestGenerateGlobalScopeParamRequiresExplicitFlag' -count=1`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`

Closes #2383
