### PR TITLE
fix(cli): preserve module imports on force regen

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -104,6 +104,58 @@ func staleGeneratedCommand() {}
 	runGoCommandForCLITest(t, outputDir, "build", "./cmd/regenapp-pp-cli")
 }
 
+func TestGenerateCmdForcePreservesExistingModulePathForImports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "tenderned")
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: tenderned
+description: Tenderned API
+version: 0.1.0
+base_url: https://api.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/tenderned-pp-cli/config.toml
+resources:
+  tenders:
+    description: Manage tenders
+    endpoints:
+      list:
+        method: GET
+        path: /tenders
+        description: List tenders
+`), 0o644))
+
+	const modulePath = "github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned"
+	require.NoError(t, os.MkdirAll(outputDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.26.3\n"), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+	require.NoError(t, cmd.Execute())
+
+	mainSrc, err := os.ReadFile(filepath.Join(outputDir, "cmd", "tenderned-pp-cli", "main.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(mainSrc), modulePath+"/internal/cli")
+	assert.NotContains(t, string(mainSrc), `"tenderned-pp-cli/internal/cli"`)
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(clientSrc), modulePath+"/internal/config")
+	assert.Contains(t, string(clientSrc), `"tenderned-pp-cli/0.1.0"`)
+
+	runGoCommandForCLITest(t, outputDir, "mod", "tidy")
+	runGoCommandForCLITest(t, outputDir, "build", "./cmd/tenderned-pp-cli")
+}
+
 func TestGenerateCmdForcePreservesManuscriptsAndManifestExtras(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -42,6 +42,17 @@ func RewriteModulePath(dir, oldPath, newPath string) error {
 		return fmt.Errorf("writing go.mod: %w", err)
 	}
 
+	return RewriteModulePathReferences(dir, oldPath, newPath)
+}
+
+// RewriteModulePathReferences rewrites import-style module references without
+// touching the go.mod module declaration. Use this when the caller has already
+// written the final go.mod contents.
+func RewriteModulePathReferences(dir, oldPath, newPath string) error {
+	if oldPath == newPath {
+		return nil
+	}
+
 	// Only replace subpath references: oldPath/internal/... and oldPath/cmd/...
 	// This avoids corrupting command Use strings, User-Agent headers,
 	// config paths, and other runtime literals that contain the CLI name.

--- a/internal/pipeline/regenmerge/gomod.go
+++ b/internal/pipeline/regenmerge/gomod.go
@@ -91,9 +91,23 @@ func planGoModMerge(publishedDir, freshDir string) (*GoModMerge, error) {
 	return plan, nil
 }
 
+type renderedGoMod struct {
+	Bytes               []byte
+	PublishedModulePath string
+	FreshModulePath     string
+}
+
 // renderMergedGoMod produces the actual merged go.mod bytes from the two
 // inputs. Used by U4's Apply step. Caller writes the bytes.
 func renderMergedGoMod(publishedDir, freshDir string) ([]byte, error) {
+	rendered, err := renderMergedGoModWithModulePaths(publishedDir, freshDir)
+	if err != nil {
+		return nil, err
+	}
+	return rendered.Bytes, nil
+}
+
+func renderMergedGoModWithModulePaths(publishedDir, freshDir string) (*renderedGoMod, error) {
 	pubPath := filepath.Join(publishedDir, "go.mod")
 	freshPath := filepath.Join(freshDir, "go.mod")
 	pubData, err := os.ReadFile(pubPath)
@@ -114,6 +128,10 @@ func renderMergedGoMod(publishedDir, freshDir string) ([]byte, error) {
 	}
 	if pubMF.Module == nil {
 		return nil, fmt.Errorf("published go.mod has no module declaration")
+	}
+	freshModulePath := ""
+	if freshMF.Module != nil {
+		freshModulePath = freshMF.Module.Mod.Path
 	}
 
 	// Start with fresh's require/replace/exclude as a base, then graft
@@ -221,7 +239,15 @@ func renderMergedGoMod(publishedDir, freshDir string) ([]byte, error) {
 	}
 
 	merged.Cleanup()
-	return merged.Format()
+	bytes, err := merged.Format()
+	if err != nil {
+		return nil, err
+	}
+	return &renderedGoMod{
+		Bytes:               bytes,
+		PublishedModulePath: pubMF.Module.Mod.Path,
+		FreshModulePath:     freshModulePath,
+	}, nil
 }
 
 // supportsRetract reports whether the merged go directive permits retract

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 )
 
 // regenmergeGeneratorOwnedDirs lists internal/<name>/ subtrees the generator
@@ -110,6 +112,15 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 		mergedBytes, err := renderMergedGoMod(snapshotDir, freshDir)
 		switch {
 		case err == nil:
+			pubModulePath, freshModulePath, moduleErr := readModulePaths(snapshotDir, freshDir)
+			if moduleErr != nil {
+				return fmt.Errorf("reading module paths: %w", moduleErr)
+			}
+			if pubModulePath != "" && freshModulePath != "" && pubModulePath != freshModulePath {
+				if err := pipeline.RewriteModulePath(freshDir, freshModulePath, pubModulePath); err != nil {
+					return fmt.Errorf("rewriting module path: %w", err)
+				}
+			}
 			if writeErr := writeFileAtomic(filepath.Join(freshDir, "go.mod"), mergedBytes); writeErr != nil {
 				return fmt.Errorf("writing merged go.mod: %w", writeErr)
 			}

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -109,20 +109,16 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 	}
 
 	if report.GoMod != nil {
-		mergedBytes, err := renderMergedGoMod(snapshotDir, freshDir)
+		merged, err := renderMergedGoModWithModulePaths(snapshotDir, freshDir)
 		switch {
 		case err == nil:
-			pubModulePath, freshModulePath, moduleErr := readModulePaths(snapshotDir, freshDir)
-			if moduleErr != nil {
-				return fmt.Errorf("reading module paths: %w", moduleErr)
-			}
-			if pubModulePath != "" && freshModulePath != "" && pubModulePath != freshModulePath {
-				if err := pipeline.RewriteModulePath(freshDir, freshModulePath, pubModulePath); err != nil {
-					return fmt.Errorf("rewriting module path: %w", err)
-				}
-			}
-			if writeErr := writeFileAtomic(filepath.Join(freshDir, "go.mod"), mergedBytes); writeErr != nil {
+			if writeErr := writeFileAtomic(filepath.Join(freshDir, "go.mod"), merged.Bytes); writeErr != nil {
 				return fmt.Errorf("writing merged go.mod: %w", writeErr)
+			}
+			if merged.PublishedModulePath != "" && merged.FreshModulePath != "" && merged.PublishedModulePath != merged.FreshModulePath {
+				if err := pipeline.RewriteModulePathReferences(freshDir, merged.FreshModulePath, merged.PublishedModulePath); err != nil {
+					return fmt.Errorf("rewriting module path references: %w", err)
+				}
 			}
 			report.GoMod.Merged = true
 		case errors.Is(err, fs.ErrNotExist):

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -261,6 +261,52 @@ require (
 		"hand-added require must survive merge into fresh's go.mod")
 }
 
+func TestMergeIntoFreshTreeRewritesImportsAfterWritingMergedGoMod(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	pubGoMod := []byte(`module github.com/acme/library/demo-pp-cli
+
+go 1.22
+
+require (
+	github.com/spf13/cobra v1.8.0
+	modernc.org/sqlite v1.30.0
+)
+`)
+	freshGoMod := []byte(`module demo-pp-cli
+
+go 1.22
+
+require github.com/spf13/cobra v1.8.0
+`)
+	const rel = "internal/cli/root.go"
+	freshRoot := []byte(`package cli
+
+import "demo-pp-cli/internal/client"
+
+var _ = client.New
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(snap, "go.mod"), pubGoMod, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, "go.mod"), freshGoMod, 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), freshRoot, 0o644))
+
+	report := &MergeReport{GoMod: &GoModMerge{}}
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true}))
+
+	gotGoMod, err := os.ReadFile(filepath.Join(fresh, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(gotGoMod), "module github.com/acme/library/demo-pp-cli")
+	assert.Contains(t, string(gotGoMod), "modernc.org/sqlite")
+
+	gotRoot, err := os.ReadFile(filepath.Join(fresh, rel))
+	require.NoError(t, err)
+	assert.Contains(t, string(gotRoot), `"github.com/acme/library/demo-pp-cli/internal/client"`)
+	assert.NotContains(t, string(gotRoot), `"demo-pp-cli/internal/client"`)
+	assert.True(t, report.GoMod.Merged)
+}
+
 // TestMergeIntoFreshTreeSweepsNonClassifiedFiles exercises R8: README and
 // other non-Go files survive merge.
 func TestMergeIntoFreshTreeSweepsNonClassifiedFiles(t *testing.T) {


### PR DESCRIPTION
## Intent

Closes #2411.

`generate --force` can now reprint an existing monorepo CLI without leaving generated Go imports rooted at the bare `<api>-pp-cli` module while the preserved `go.mod` declares the full library module path.

## Approach

The force-merge path now applies the same module-path rewrite used by the regen-merge apply path when the snapshot and fresh `go.mod` module paths differ. The rewrite runs before the merged `go.mod` is written back, so import-style `<old>/internal/...` references are updated while User-Agent strings and config path literals stay unchanged.

## Scope

Primary area: force regeneration module-path preservation.

Why this belongs in this repo: the symptom appears in printed CLIs, but the root cause is the Printing Press force-regeneration merge path combining a fresh generated tree with an existing monorepo module declaration.

## Catalog Justification

N/A

## Risk

Low. The change reuses the existing `RewriteModulePath` helper, which only rewrites import-style internal module references and install-path references. The new regression test covers the monorepo module shape, generated import output, generated CLI compilation, and unchanged short User-Agent literals.

## Output Contract

Force regeneration output changes when an existing `go.mod` declares a module path different from the generated bare CLI name: generated Go imports now match the preserved module. Covered by `TestGenerateCmdForcePreservesExistingModulePathForImports`, which asserts emitted imports and compiles the generated CLI.

## Verification

- `go test ./internal/cli -run '^TestGenerateCmdForcePreservesExistingModulePathForImports$' -count=1`
- Reproduced `generate --force` into a directory with `module github.com/mvanhorn/printing-press-library/library/sales-and-crm/tenderned`: short internal import count `0`, long internal import count `33`, User-Agent literals unchanged, generated `go test ./...` passed
- `go test ./internal/pipeline/regenmerge ./internal/cli -run 'TestGenerateCmdForcePreserves|TestGenerateCmdForcePreservesExistingModulePathForImports|TestRewriteModulePath' -count=1`
- `go fmt ./...`
- `go test ./...` (6054 passed, 1 unrelated `TestRunLiveDogfoodProcessRetriesTransientAuth401` failure; the exact test passed on rerun)
- `go test ./internal/pipeline -run '^TestRunLiveDogfoodProcessRetriesTransientAuth401$' -count=1`
- `go test ./internal/pipeline/regenmerge ./internal/cli ./internal/pipeline -count=1`
- `scripts/golden.sh verify`
- Push hook: `golangci-lint` reported `0 issues`
