### PR TITLE
fix(cli): ignore scalar siblings in sync envelope fallback

### DIFF
--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -336,6 +336,104 @@ func TestGenerateSyncDependentErrorNotSilent(t *testing.T) {
 		"dependent-resource sync_error events should use the injected event writer")
 }
 
+// TestGeneratedSyncExtractPageItemsFallbackIgnoresUnknownScalarSiblings
+// executes the emitted fallback extractor. It pins the regression from issue
+// #2416: diagnostic scalar fields such as generated_at and request_id must not
+// cause the only object array in an envelope to be dropped.
+func TestGeneratedSyncExtractPageItemsFallbackIgnoresUnknownScalarSiblings(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("sync-envelope")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	runtimeTest := `package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractPageItemsFallbackIgnoresUnknownScalarSiblings(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantCount  int
+		wantOK     bool
+		wantMore   bool
+		wantCursor string
+		wantID     string
+	}{
+		{
+			name:      "unknown diagnostic scalar siblings",
+			body:      ` + "`" + `{"things":[{"id":"t-1"},{"id":"t-2"}],"generated_at":"2024-01-01T00:00:00Z","request_id":"abc-123","api_version":"v2"}` + "`" + `,
+			wantCount: 2,
+			wantOK:    true,
+			wantID:    "t-1",
+		},
+		{
+			name:       "known cursor metadata siblings",
+			body:       ` + "`" + `{"things":[{"id":"t-1"}],"cursor":"next-1","has_more":true}` + "`" + `,
+			wantCount:  1,
+			wantOK:     true,
+			wantMore:   true,
+			wantCursor: "next-1",
+			wantID:     "t-1",
+		},
+		{
+			name:      "ambiguous double object arrays",
+			body:      ` + "`" + `{"primary":[{"id":"p-1"}],"secondary":[{"id":"s-1"}],"request_id":"abc-123"}` + "`" + `,
+			wantOK:    false,
+		},
+		{
+			name:      "no object array",
+			body:      ` + "`" + `{"generated_at":"2024-01-01T00:00:00Z","request_id":"abc-123","count":2}` + "`" + `,
+			wantOK:    false,
+		},
+		{
+			name:      "known item key remains preferred",
+			body:      ` + "`" + `{"items":[{"id":"canonical"}],"alternate":[{"id":"other"}],"request_id":"abc-123"}` + "`" + `,
+			wantCount: 1,
+			wantOK:    true,
+			wantID:    "canonical",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items, cursor, hasMore := extractPageItems(json.RawMessage(tc.body), "cursor")
+			if tc.wantOK {
+				if len(items) != tc.wantCount {
+					t.Fatalf("len(items) = %d, want %d", len(items), tc.wantCount)
+				}
+				if tc.wantID != "" {
+					var item map[string]string
+					if err := json.Unmarshal(items[0], &item); err != nil {
+						t.Fatalf("unmarshal first item: %v", err)
+					}
+					if item["id"] != tc.wantID {
+						t.Fatalf("first item id = %q, want %q", item["id"], tc.wantID)
+					}
+				}
+			} else if len(items) != 0 {
+				t.Fatalf("len(items) = %d, want 0", len(items))
+			}
+			if cursor != tc.wantCursor {
+				t.Fatalf("cursor = %q, want %q", cursor, tc.wantCursor)
+			}
+			if hasMore != tc.wantMore {
+				t.Fatalf("hasMore = %v, want %v", hasMore, tc.wantMore)
+			}
+		})
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_extract_page_items_test.go"), []byte(runtimeTest), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestExtractPageItemsFallbackIgnoresUnknownScalarSiblings")
+}
+
 // noBulkListSpec mirrors the Allrecipes shape (issue #1156): a resource whose
 // only GET endpoints are a parameterized detail page and a search with a
 // required query param. Neither qualifies as a syncable list endpoint, so

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1318,7 +1318,8 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
 	// Fallback: try every key in the envelope. If exactly one maps to a JSON
 	// array with items, use it. This handles APIs that wrap responses with the
-	// resource name (e.g., {"markets": [...], "cursor": "..."}).
+	// resource name alongside arbitrary scalar metadata
+	// (e.g., {"markets": [...], "request_id": "..."}).
 	var arrayItems []json.RawMessage
 	arrayCount := 0
 	for key, raw := range envelope {
@@ -1333,9 +1334,6 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 		var rawArray []json.RawMessage
 		if json.Unmarshal(raw, &rawArray) == nil && !isJSONNull(raw) {
 			continue
-		}
-		if !pageEnvelopeMetadataKeys[key] {
-			return nil, false
 		}
 	}
 	if arrayCount == 1 {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -819,7 +819,8 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
 	// Fallback: try every key in the envelope. If exactly one maps to a JSON
 	// array with items, use it. This handles APIs that wrap responses with the
-	// resource name (e.g., {"markets": [...], "cursor": "..."}).
+	// resource name alongside arbitrary scalar metadata
+	// (e.g., {"markets": [...], "request_id": "..."}).
 	var arrayItems []json.RawMessage
 	arrayCount := 0
 	for key, raw := range envelope {
@@ -834,9 +835,6 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 		var rawArray []json.RawMessage
 		if json.Unmarshal(raw, &rawArray) == nil && !isJSONNull(raw) {
 			continue
-		}
-		if !pageEnvelopeMetadataKeys[key] {
-			return nil, false
 		}
 	}
 	if arrayCount == 1 {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -815,7 +815,8 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
 	// Fallback: try every key in the envelope. If exactly one maps to a JSON
 	// array with items, use it. This handles APIs that wrap responses with the
-	// resource name (e.g., {"markets": [...], "cursor": "..."}).
+	// resource name alongside arbitrary scalar metadata
+	// (e.g., {"markets": [...], "request_id": "..."}).
 	var arrayItems []json.RawMessage
 	arrayCount := 0
 	for key, raw := range envelope {
@@ -830,9 +831,6 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 		var rawArray []json.RawMessage
 		if json.Unmarshal(raw, &rawArray) == nil && !isJSONNull(raw) {
 			continue
-		}
-		if !pageEnvelopeMetadataKeys[key] {
-			return nil, false
 		}
 	}
 	if arrayCount == 1 {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -784,7 +784,8 @@ func extractItemsByKnownKeys(envelope map[string]json.RawMessage) ([]json.RawMes
 func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]json.RawMessage, bool) {
 	// Fallback: try every key in the envelope. If exactly one maps to a JSON
 	// array with items, use it. This handles APIs that wrap responses with the
-	// resource name (e.g., {"markets": [...], "cursor": "..."}).
+	// resource name alongside arbitrary scalar metadata
+	// (e.g., {"markets": [...], "request_id": "..."}).
 	var arrayItems []json.RawMessage
 	arrayCount := 0
 	for key, raw := range envelope {
@@ -799,9 +800,6 @@ func extractSingleObjectArraySibling(envelope map[string]json.RawMessage) ([]jso
 		var rawArray []json.RawMessage
 		if json.Unmarshal(raw, &rawArray) == nil && !isJSONNull(raw) {
 			continue
-		}
-		if !pageEnvelopeMetadataKeys[key] {
-			return nil, false
 		}
 	}
 	if arrayCount == 1 {


### PR DESCRIPTION
## Summary

Sync fallback extraction now keeps pages when an API returns a single data array alongside diagnostic scalar metadata such as `generated_at`, `request_id`, or `api_version`. The fallback still rejects ambiguous envelopes with multiple object arrays, and the known-key extractor remains the preferred path before fallback.

Closes #2416.

## Verification

- `go test ./internal/generator -run 'TestGeneratedSyncExtractPageItemsFallbackIgnoresUnknownScalarSiblings' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-sync-walker-api generate-tier-routing-api`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
