### PR TITLE
fix(cli): skip unsynced local live-check samples

### DIFF
--- a/internal/cli/scorecard.go
+++ b/internal/cli/scorecard.go
@@ -86,7 +86,7 @@ func newScorecardCmd() *cobra.Command {
 				if live.Unable {
 					fmt.Printf("  Unable to run: %s\n", live.Reason)
 				} else {
-					fmt.Printf("  Passed: %d/%d  (%d%% pass rate)\n", live.Passed, live.Checked(), int(live.PassRate*100+0.5))
+					fmt.Printf("  Passed: %d/%d  (%d%% pass rate, %d skipped)\n", live.Passed, live.Evaluated(), int(live.PassRate*100+0.5), live.Skipped)
 					if live.Failed > 0 {
 						fmt.Println("  Failures:")
 						for _, f := range live.Features {

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -611,10 +611,9 @@ func novelCommandDataSourceStrategies(cliDir string) map[string]string {
 		if strategy != "auto" && strategy != "local" && strategy != "live" {
 			continue
 		}
-		for _, use := range cobraUseLeafRe.FindAllStringSubmatch(content, -1) {
-			if len(use) >= 2 {
-				out[strings.ToLower(strings.TrimSpace(use[1]))] = strategy
-			}
+		use := cobraUseLeafRe.FindStringSubmatch(content)
+		if len(use) >= 2 {
+			out[strings.ToLower(strings.TrimSpace(use[1]))] = strategy
 		}
 	}
 	return out
@@ -783,7 +782,8 @@ func runOneFeatureCheckWithDataSource(cliDir, binaryPath string, f liveCheckFeat
 
 func isUnsyncedLocalStoreFailure(stderr string) bool {
 	lower := strings.ToLower(stderr)
-	return strings.Contains(lower, "unable to open database file")
+	return strings.Contains(lower, "unable to open database file") ||
+		strings.Contains(lower, "no such file or directory")
 }
 
 // sampleOutput truncates captured output to outputSampleMaxBytes for

--- a/internal/pipeline/live_check.go
+++ b/internal/pipeline/live_check.go
@@ -27,9 +27,10 @@ import (
 type LiveStatus string
 
 const (
-	StatusPass LiveStatus = "pass"
-	StatusFail LiveStatus = "fail"
-	StatusSkip LiveStatus = "skip"
+	StatusPass                 LiveStatus = "pass"
+	StatusFail                 LiveStatus = "fail"
+	StatusSkip                 LiveStatus = "skip"
+	StatusPrerequisiteUnsynced LiveStatus = "prerequisite_unsynced"
 )
 
 // Default bounds for RunLiveCheck. Exported so callers can override via
@@ -75,6 +76,16 @@ func (r *LiveCheckResult) Checked() int {
 		return 0
 	}
 	return r.Passed + r.Failed + r.Skipped
+}
+
+// Evaluated returns the number of feature samples that reached a pass/fail
+// verdict. Skipped samples are reported, but do not count against pass-rate
+// math because their prerequisites were not available to live-check.
+func (r *LiveCheckResult) Evaluated() int {
+	if r == nil {
+		return 0
+	}
+	return r.Passed + r.Failed
 }
 
 // LiveFeatureResult is one feature's outcome.
@@ -227,7 +238,7 @@ func RunLiveCheck(opts LiveCheckOptions) *LiveCheckResult {
 		concurrency = len(features)
 	}
 
-	results := runFeaturesConcurrent(opts.CLIDir, binaryPath, features, timeout, concurrency)
+	results := runFeaturesConcurrent(opts.CLIDir, binaryPath, annotateLiveCheckFeatures(opts.CLIDir, features), timeout, concurrency)
 	out.Features = results
 	for _, r := range results {
 		switch r.Status {
@@ -239,7 +250,7 @@ func RunLiveCheck(opts LiveCheckOptions) *LiveCheckResult {
 			out.Skipped++
 		}
 	}
-	if total := out.Checked(); total > 0 {
+	if total := out.Evaluated(); total > 0 {
 		out.PassRate = float64(out.Passed) / float64(total)
 	}
 	return out
@@ -557,10 +568,62 @@ func liveCheckBinaryCandidatePathsForName(cliDir, candidate, goos string) []stri
 	return deduped
 }
 
+type liveCheckFeature struct {
+	NovelFeature
+	DataSourceStrategy string
+}
+
+func annotateLiveCheckFeatures(cliDir string, features []NovelFeature) []liveCheckFeature {
+	strategies := novelCommandDataSourceStrategies(cliDir)
+	out := make([]liveCheckFeature, 0, len(features))
+	for _, f := range features {
+		leaf := lastPathSegment(commandPath(f.Command))
+		out = append(out, liveCheckFeature{
+			NovelFeature:       f,
+			DataSourceStrategy: strategies[leaf],
+		})
+	}
+	return out
+}
+
+func novelCommandDataSourceStrategies(cliDir string) map[string]string {
+	out := map[string]string{}
+	cliFilesDir := filepath.Join(cliDir, "internal", "cli")
+	entries, err := os.ReadDir(cliFilesDir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(cliFilesDir, name))
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		m := dataSourceDirectiveRe.FindStringSubmatch(content)
+		if len(m) < 2 {
+			continue
+		}
+		strategy := strings.ToLower(strings.TrimSpace(m[1]))
+		if strategy != "auto" && strategy != "local" && strategy != "live" {
+			continue
+		}
+		for _, use := range cobraUseLeafRe.FindAllStringSubmatch(content, -1) {
+			if len(use) >= 2 {
+				out[strings.ToLower(strings.TrimSpace(use[1]))] = strategy
+			}
+		}
+	}
+	return out
+}
+
 // runFeaturesConcurrent distributes the per-feature checks across a worker
 // pool. Results are collected in-order so LiveCheckResult.Features stays
 // stable across runs.
-func runFeaturesConcurrent(cliDir, binaryPath string, features []NovelFeature, timeout time.Duration, concurrency int) []LiveFeatureResult {
+func runFeaturesConcurrent(cliDir, binaryPath string, features []liveCheckFeature, timeout time.Duration, concurrency int) []LiveFeatureResult {
 	results := make([]LiveFeatureResult, len(features))
 	type job struct{ idx int }
 	jobs := make(chan job, len(features))
@@ -573,7 +636,7 @@ func runFeaturesConcurrent(cliDir, binaryPath string, features []NovelFeature, t
 	for range concurrency {
 		wg.Go(func() {
 			for j := range jobs {
-				results[j.idx] = runOneFeatureCheck(cliDir, binaryPath, features[j.idx], timeout)
+				results[j.idx] = runOneFeatureCheckWithDataSource(cliDir, binaryPath, features[j.idx], timeout)
 			}
 		})
 	}
@@ -637,6 +700,10 @@ func pickGeneratedCommandFeatures(binaryPath string) ([]NovelFeature, error) {
 // messaging) and needs structured access to *exec.ExitError +
 // DeadlineExceeded, so it runs exec inline.
 func runOneFeatureCheck(cliDir, binaryPath string, f NovelFeature, timeout time.Duration) LiveFeatureResult {
+	return runOneFeatureCheckWithDataSource(cliDir, binaryPath, liveCheckFeature{NovelFeature: f}, timeout)
+}
+
+func runOneFeatureCheckWithDataSource(cliDir, binaryPath string, f liveCheckFeature, timeout time.Duration) LiveFeatureResult {
 	result := LiveFeatureResult{Name: f.Name, Command: f.Command, Example: f.Example}
 	fail := func(reason string) LiveFeatureResult {
 		result.Status = StatusFail
@@ -672,6 +739,11 @@ func runOneFeatureCheck(cliDir, binaryPath string, f NovelFeature, timeout time.
 		var exitErr *exec.ExitError
 		if errors.As(runErr, &exitErr) {
 			stderr := stderrCap.String()
+			if f.DataSourceStrategy == "local" && isUnsyncedLocalStoreFailure(stderr) {
+				result.Status = StatusPrerequisiteUnsynced
+				result.Reason = "prerequisite_unsynced: local store is not populated; run sync before probing this command"
+				return result
+			}
 			if isGracefulEmptyResponse(stderr, args) {
 				// CLI exited non-zero gracefully on "no record matches this
 				// input" — that's the CORRECT behavior for an unknown slug
@@ -707,6 +779,11 @@ func runOneFeatureCheck(cliDir, binaryPath string, f NovelFeature, timeout time.
 		result.Warnings = append(result.Warnings, msg)
 	}
 	return result
+}
+
+func isUnsyncedLocalStoreFailure(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "unable to open database file")
 }
 
 // sampleOutput truncates captured output to outputSampleMaxBytes for
@@ -1091,12 +1168,12 @@ func containsAnyOf(s string, needles []string) bool {
 // receive given its live-check pass rate. A CLI whose flagships return
 // broken output shouldn't earn a Grade A scorecard.
 //
-//   - Unable or zero checked: no cap (nil return)
+//   - Unable or zero evaluated samples: no cap (nil return)
 //   - PassRate >= 0.8: no cap
 //   - PassRate >= 0.5: cap at 7
 //   - PassRate <  0.5: cap at 4
 func InsightCapFromLiveCheck(r *LiveCheckResult) *int {
-	if r == nil || r.Unable || r.Checked() == 0 {
+	if r == nil || r.Unable || r.Evaluated() == 0 {
 		return nil
 	}
 	var cap int
@@ -1120,10 +1197,12 @@ func (r *LiveCheckResult) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		*alias
 		Checked     int `json:"checked"`
+		Evaluated   int `json:"evaluated"`
 		PassRatePct int `json:"pass_rate_pct"`
 	}{
 		alias:       (*alias)(r),
 		Checked:     r.Checked(),
+		Evaluated:   r.Evaluated(),
 		PassRatePct: int(r.PassRate*100 + 0.5),
 	})
 }

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -305,29 +305,72 @@ func TestLiveCheck_FailOnExitError(t *testing.T) {
 }
 
 func TestLiveCheck_LocalDataSourceUnsyncedFailureSkipsAndExcludesPassRate(t *testing.T) {
-	dir := t.TempDir()
-	writeNovelCommandFile(t, dir, "tasks.go", `package cli
+	for _, tc := range []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "sqlite open failure",
+			stderr: "Error: querying tasks: unable to open database file: out of memory (14)",
+		},
+		{
+			name:   "missing db file",
+			stderr: "Error: querying tasks: open /tmp/tasks.db: no such file or directory",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeNovelCommandFile(t, dir, "tasks.go", `package cli
 
 // pp:data-source local
 func newNovelTasksCmd() *cobra.Command {
 	return &cobra.Command{Use: "tasks"}
 }
 `)
-	writeStubBinary(t, dir, "stub", `echo "Error: querying tasks: unable to open database file: out of memory (14)" >&2; exit 1`)
+			writeStubBinary(t, dir, "stub", fmt.Sprintf("echo %q >&2; exit 1", tc.stderr))
+			writeTestResearchJSON(t, dir, []NovelFeature{
+				{Name: "Tasks", Command: "tasks", Example: `stub tasks --json`},
+			})
+
+			result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: "stub", Timeout: 5 * time.Second})
+
+			require.False(t, result.Unable, "result was Unable: %s", result.Reason)
+			require.Equal(t, 1, result.Checked())
+			require.Zero(t, result.Evaluated(), "skipped local prerequisites must not count in pass-rate denominator")
+			require.Zero(t, result.Failed)
+			require.Equal(t, 1, result.Skipped)
+			require.Equal(t, StatusPrerequisiteUnsynced, result.Features[0].Status)
+			require.Contains(t, result.Features[0].Reason, "prerequisite_unsynced")
+			require.Nil(t, InsightCapFromLiveCheck(result), "all-skipped live-check should not cap scorecard Insight")
+		})
+	}
+}
+
+func TestLiveCheck_LocalDataSourceStrategyDoesNotLeakFromNestedLeaf(t *testing.T) {
+	dir := t.TempDir()
+	writeNovelCommandFile(t, dir, "tasks.go", `package cli
+
+// pp:data-source local
+func newNovelTasksCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "tasks"}
+	cmd.AddCommand(&cobra.Command{Use: "list"})
+	return cmd
+}
+`)
+	writeStubBinary(t, dir, "stub", `echo "Error: querying projects: unable to open database file: out of memory (14)" >&2; exit 1`)
 	writeTestResearchJSON(t, dir, []NovelFeature{
-		{Name: "Tasks", Command: "tasks", Example: `stub tasks --json`},
+		{Name: "Project list", Command: "projects list", Example: `stub projects list --json`},
 	})
 
 	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: "stub", Timeout: 5 * time.Second})
 
 	require.False(t, result.Unable, "result was Unable: %s", result.Reason)
 	require.Equal(t, 1, result.Checked())
-	require.Zero(t, result.Evaluated(), "skipped local prerequisites must not count in pass-rate denominator")
-	require.Zero(t, result.Failed)
-	require.Equal(t, 1, result.Skipped)
-	require.Equal(t, StatusPrerequisiteUnsynced, result.Features[0].Status)
-	require.Contains(t, result.Features[0].Reason, "prerequisite_unsynced")
-	require.Nil(t, InsightCapFromLiveCheck(result), "all-skipped live-check should not cap scorecard Insight")
+	require.Equal(t, 1, result.Evaluated())
+	require.Equal(t, 1, result.Failed)
+	require.Zero(t, result.Skipped)
+	require.Equal(t, StatusFail, result.Features[0].Status)
+	require.NotContains(t, result.Features[0].Reason, "prerequisite_unsynced")
 }
 
 func TestLiveCheck_LocalDataSourceRealFailureStillFails(t *testing.T) {

--- a/internal/pipeline/live_check_test.go
+++ b/internal/pipeline/live_check_test.go
@@ -41,6 +41,13 @@ func writeTestResearchJSON(t *testing.T, cliDir string, features []NovelFeature)
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "research.json"), body, 0o644))
 }
 
+func writeNovelCommandFile(t *testing.T, cliDir, name, body string) {
+	t.Helper()
+	path := filepath.Join(cliDir, "internal", "cli", name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
 func writeLiveCheckGoCLI(t *testing.T, cliDir, binaryName, output string) string {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "go.mod"), []byte("module example.com/live-check-test\n\ngo 1.23\n"), 0o644))
@@ -297,6 +304,68 @@ func TestLiveCheck_FailOnExitError(t *testing.T) {
 	require.Contains(t, result.Features[0].Reason, "exit 5")
 }
 
+func TestLiveCheck_LocalDataSourceUnsyncedFailureSkipsAndExcludesPassRate(t *testing.T) {
+	dir := t.TempDir()
+	writeNovelCommandFile(t, dir, "tasks.go", `package cli
+
+// pp:data-source local
+func newNovelTasksCmd() *cobra.Command {
+	return &cobra.Command{Use: "tasks"}
+}
+`)
+	writeStubBinary(t, dir, "stub", `echo "Error: querying tasks: unable to open database file: out of memory (14)" >&2; exit 1`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Tasks", Command: "tasks", Example: `stub tasks --json`},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: "stub", Timeout: 5 * time.Second})
+
+	require.False(t, result.Unable, "result was Unable: %s", result.Reason)
+	require.Equal(t, 1, result.Checked())
+	require.Zero(t, result.Evaluated(), "skipped local prerequisites must not count in pass-rate denominator")
+	require.Zero(t, result.Failed)
+	require.Equal(t, 1, result.Skipped)
+	require.Equal(t, StatusPrerequisiteUnsynced, result.Features[0].Status)
+	require.Contains(t, result.Features[0].Reason, "prerequisite_unsynced")
+	require.Nil(t, InsightCapFromLiveCheck(result), "all-skipped live-check should not cap scorecard Insight")
+}
+
+func TestLiveCheck_LocalDataSourceRealFailureStillFails(t *testing.T) {
+	dir := t.TempDir()
+	writeNovelCommandFile(t, dir, "tasks.go", `package cli
+
+// pp:data-source local
+func newNovelTasksCmd() *cobra.Command {
+	return &cobra.Command{Use: "tasks"}
+}
+`)
+	writeStubBinary(t, dir, "stub", `echo "Error: querying tasks: invalid aggregation column" >&2; exit 1`)
+	writeTestResearchJSON(t, dir, []NovelFeature{
+		{Name: "Tasks", Command: "tasks", Example: `stub tasks --json`},
+	})
+
+	result := RunLiveCheck(LiveCheckOptions{CLIDir: dir, BinaryName: "stub", Timeout: 5 * time.Second})
+
+	require.Equal(t, 1, result.Checked())
+	require.Equal(t, 1, result.Evaluated())
+	require.Equal(t, 1, result.Failed)
+	require.Zero(t, result.Skipped)
+	require.Equal(t, StatusFail, result.Features[0].Status)
+	require.Contains(t, result.Features[0].Reason, "invalid aggregation column")
+}
+
+func TestLiveCheck_PassRateExcludesSkippedSamples(t *testing.T) {
+	result := &LiveCheckResult{Passed: 1, Failed: 1, Skipped: 8}
+
+	require.Equal(t, 10, result.Checked())
+	require.Equal(t, 2, result.Evaluated())
+
+	if total := result.Evaluated(); total > 0 {
+		result.PassRate = float64(result.Passed) / float64(total)
+	}
+	require.Equal(t, 0.5, result.PassRate)
+}
+
 // TestLiveCheck_FailOnEmptyOutput ensures stdout must be non-empty.
 func TestLiveCheck_FailOnEmptyOutput(t *testing.T) {
 	dir := t.TempDir()
@@ -440,6 +509,7 @@ func TestLiveCheckMarshalJSON(t *testing.T) {
 	body, err := json.Marshal(r)
 	require.NoError(t, err)
 	require.Contains(t, string(body), `"pass_rate_pct":67`)
+	require.Contains(t, string(body), `"evaluated":2`)
 	require.NotContains(t, string(body), "0.6666")
 }
 
@@ -970,6 +1040,22 @@ func TestChecked_DerivedFromCounters(t *testing.T) {
 	// Also: nil receiver must not panic.
 	var nilRes *LiveCheckResult
 	require.Zero(t, nilRes.Checked())
+}
+
+func TestEvaluated_ExcludesSkippedCounters(t *testing.T) {
+	cases := []struct {
+		r    LiveCheckResult
+		want int
+	}{
+		{LiveCheckResult{}, 0},
+		{LiveCheckResult{Passed: 3}, 3},
+		{LiveCheckResult{Passed: 1, Failed: 2, Skipped: 3}, 3},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, tc.r.Evaluated())
+	}
+	var nilRes *LiveCheckResult
+	require.Zero(t, nilRes.Evaluated())
 }
 
 // --- detectRawHTMLEntities (Wave B / R3) ---


### PR DESCRIPTION
## Summary

- Teach scorecard live-check to read `// pp:data-source` annotations from novel command files.
- Classify fresh local-store prerequisite failures as `prerequisite_unsynced` skips instead of sampled output failures.
- Keep real local command failures in the pass-rate denominator and surface skipped counts in human and JSON live-check output.

Closes #2427

## Verification

- `go test ./internal/pipeline ./internal/cli -run 'TestLiveCheck|TestInsightCap|TestScorecardJSONKeepsLiveCheckSeparateFromLiveVerification|TestLiveCheckFatalReasonReportsFailedBinaryRefresh'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`
- headless code review: no findings
