### PR TITLE
fix(cli): preserve typed tables for paginated union resources

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15795,6 +15795,139 @@ func TestStoreSkipsDeadTablesForResourcesWithoutTypedUpsert(t *testing.T) {
 		"UpsertBatch must still call upsertGenericResourceTx so renamed resources land in `resources`")
 }
 
+func TestGenerateStoreKeepsBareResourceTableForPaginatedUnionListWithActionSiblings(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Todoish
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /projects:
+    get:
+      tags: [Projects]
+      operationId: list_projects
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedProjects"
+  /projects/{project_id}/archive:
+    post:
+      tags: [Projects]
+      operationId: archive_project
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/PersonalProject"
+                  - $ref: "#/components/schemas/WorkspaceProject"
+                title: Project object
+  /sections:
+    get:
+      tags: [Sections]
+      operationId: list_sections
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Section"
+  /sections/{section_id}/archive:
+    post:
+      tags: [Sections]
+      operationId: archive_section
+      parameters:
+        - name: section_id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Section"
+components:
+  schemas:
+    PaginatedProjects:
+      type: object
+      required: [results, next_cursor]
+      properties:
+        results:
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/PersonalProject"
+              - $ref: "#/components/schemas/WorkspaceProject"
+            title: Project object
+        next_cursor:
+          anyOf:
+            - type: string
+            - type: "null"
+    PersonalProject:
+      type: object
+      required: [id, name]
+      properties:
+        id: {type: string}
+        name: {type: string}
+        color: {type: string}
+    WorkspaceProject:
+      type: object
+      required: [id, name, workspace_id]
+      properties:
+        id: {type: string}
+        name: {type: string}
+        workspace_id: {type: string}
+    Section:
+      type: object
+      required: [id, name, project_id]
+      properties:
+        id: {type: string}
+        name: {type: string}
+        project_id: {type: string}
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	store := string(storeSrc)
+
+	assert.Contains(t, store, `CREATE TABLE IF NOT EXISTS "projects"`,
+		"bare projects list resource must keep its typed table even when archive action siblings shard")
+	assert.Contains(t, store, `"name" TEXT`,
+		"projects table should derive columns from the paginated union list items, not from the envelope")
+	assert.Contains(t, store, "func (s *Store) UpsertProjects(",
+		"projects rows synced from the list endpoint must have a typed upsert")
+	assert.Contains(t, store, `case "projects":`,
+		"UpsertBatch must dispatch projects rows into the typed projects table")
+	assert.Contains(t, store, `CREATE TABLE IF NOT EXISTS "projects_archive"`,
+		"action sibling sharding should remain distinct from the bare resource table")
+
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestUpsertBatch_PopulatesProjectsTable")
+}
+
 func TestGenerateStoreWideResourceFallsBackToJSONOnlyTable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -5204,6 +5204,11 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 	if itemSchema == nil {
 		return ""
 	}
+	itemFields := collectIDSchemaFields(&openapi3.SchemaRef{Value: itemSchema})
+	itemSchema = &openapi3.Schema{
+		Properties: itemFields.properties,
+		Required:   itemFields.required,
+	}
 
 	// Tier 2: explicit `id` (required or optional)
 	if _, ok := itemSchema.Properties["id"]; ok {
@@ -5258,6 +5263,57 @@ func resolveIDFieldFromResponseSchema(op *openapi3.Operation, resourceName strin
 	}
 
 	return ""
+}
+
+type idSchemaFields struct {
+	properties map[string]*openapi3.SchemaRef
+	required   []string
+}
+
+func collectIDSchemaFields(schemaRef *openapi3.SchemaRef) idSchemaFields {
+	fields := idSchemaFields{properties: map[string]*openapi3.SchemaRef{}}
+	seenRequired := map[string]struct{}{}
+	collectIDSchemaFieldsInto(schemaRef, &fields, seenRequired, map[*openapi3.Schema]struct{}{})
+	return fields
+}
+
+func collectIDSchemaFieldsInto(schemaRef *openapi3.SchemaRef, fields *idSchemaFields, seenRequired map[string]struct{}, visited map[*openapi3.Schema]struct{}) {
+	if schemaRef == nil || fields == nil {
+		return
+	}
+	schema := schemaRefValue(schemaRef)
+	if schema == nil {
+		return
+	}
+	if _, ok := visited[schema]; ok {
+		return
+	}
+	visited[schema] = struct{}{}
+
+	for name, prop := range schema.Properties {
+		if prop == nil {
+			continue
+		}
+		if _, exists := fields.properties[name]; !exists {
+			fields.properties[name] = prop
+		}
+	}
+	for _, name := range schema.Required {
+		if _, exists := seenRequired[name]; exists {
+			continue
+		}
+		seenRequired[name] = struct{}{}
+		fields.required = append(fields.required, name)
+	}
+	for _, sub := range schema.AllOf {
+		collectIDSchemaFieldsInto(sub, fields, seenRequired, visited)
+	}
+	for _, sub := range schema.OneOf {
+		collectIDSchemaFieldsInto(sub, fields, seenRequired, visited)
+	}
+	for _, sub := range schema.AnyOf {
+		collectIDSchemaFieldsInto(sub, fields, seenRequired, visited)
+	}
 }
 
 // resourcePrefixedIDField returns the first property whose snake-cased name
@@ -5397,10 +5453,6 @@ func singleArrayPropertyRef(schema *openapi3.Schema) (*openapi3.SchemaRef, strin
 		return items, name
 	}
 	return nil, ""
-}
-
-func hasCollectableTypeFields(schema *openapi3.Schema) bool {
-	return isObjectSchema(schema) || len(schema.OneOf) > 0 || len(schema.AnyOf) > 0
 }
 
 // isScalarSchema reports whether the schema's type is a scalar — string,
@@ -5543,7 +5595,11 @@ func registerInlineSchemaType(out *spec.APISpec, itemRef *openapi3.SchemaRef, fa
 		return
 	}
 	itemSchema := schemaRefValue(itemRef)
-	if itemSchema == nil || !hasCollectableTypeFields(itemSchema) {
+	if itemSchema == nil {
+		return
+	}
+	fields := buildTypeFields(itemRef)
+	if len(fields) == 0 {
 		return
 	}
 	typeName := schemaTypeName(itemRef, fallbackName)
@@ -5556,7 +5612,7 @@ func registerInlineSchemaType(out *spec.APISpec, itemRef *openapi3.SchemaRef, fa
 	if _, exists := out.Types[typeName]; exists {
 		return
 	}
-	out.Types[typeName] = spec.TypeDef{Fields: buildTypeFields(itemRef)}
+	out.Types[typeName] = spec.TypeDef{Fields: fields}
 }
 
 func mapResponseDiscriminator(schemaRef *openapi3.SchemaRef) *spec.ResponseDiscriminator {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -4747,6 +4747,15 @@ func mapResponse(op *openapi3.Operation, fallbackName string, out *spec.APISpec)
 				Discriminator: mapResponseDiscriminator(itemRef),
 			}, "data"
 		}
+		if itemRef, path := singleArrayPropertyRef(schema); itemRef != nil {
+			itemFallback := fallbackName + "Item"
+			registerInlineSchemaType(out, itemRef, itemFallback)
+			return spec.ResponseDef{
+				Type:          "array",
+				Item:          schemaTypeName(itemRef, itemFallback),
+				Discriminator: mapResponseDiscriminator(itemRef),
+			}, path
+		}
 	}
 
 	if isArraySchema(schema) {
@@ -5357,34 +5366,41 @@ func unwrapItemSchema(schema *openapi3.Schema) *openapi3.Schema {
 	// wrapper key matches the resource name. Without this, the PK profiler
 	// would walk the wrapper itself and pick a scalar sibling (cursor,
 	// has_more) as the resource ID.
-	if items := singleArrayProperty(schema); items != nil {
-		return items
+	if itemRef, _ := singleArrayPropertyRef(schema); itemRef != nil {
+		return schemaRefValue(itemRef)
 	}
 	return schema
 }
 
-// singleArrayProperty returns the items schema of an object's sole
-// array-typed property, or nil if zero or multiple array properties exist.
+// singleArrayPropertyRef returns the items schema ref and property name of an
+// object's sole array-typed property, or nil if zero or multiple array
+// properties exist.
 // Non-array siblings (scalars, objects) are ignored — they're typically
 // pagination metadata.
-func singleArrayProperty(schema *openapi3.Schema) *openapi3.Schema {
-	var items *openapi3.Schema
+func singleArrayPropertyRef(schema *openapi3.Schema) (*openapi3.SchemaRef, string) {
+	var items *openapi3.SchemaRef
+	var name string
 	count := 0
-	for _, propRef := range schema.Properties {
+	for propName, propRef := range schema.Properties {
 		prop := schemaRefValue(propRef)
 		if !isArraySchema(prop) || prop.Items == nil {
 			continue
 		}
 		count++
 		if count > 1 {
-			return nil
+			return nil, ""
 		}
-		items = schemaRefValue(prop.Items)
+		name = propName
+		items = prop.Items
 	}
 	if count == 1 {
-		return items
+		return items, name
 	}
-	return nil
+	return nil, ""
+}
+
+func hasCollectableTypeFields(schema *openapi3.Schema) bool {
+	return isObjectSchema(schema) || len(schema.OneOf) > 0 || len(schema.AnyOf) > 0
 }
 
 // isScalarSchema reports whether the schema's type is a scalar — string,
@@ -5527,7 +5543,7 @@ func registerInlineSchemaType(out *spec.APISpec, itemRef *openapi3.SchemaRef, fa
 		return
 	}
 	itemSchema := schemaRefValue(itemRef)
-	if itemSchema == nil || !isObjectSchema(itemSchema) {
+	if itemSchema == nil || !hasCollectableTypeFields(itemSchema) {
 		return
 	}
 	typeName := schemaTypeName(itemRef, fallbackName)
@@ -5597,6 +5613,12 @@ func collectTypeProperties(schemaRef *openapi3.SchemaRef, properties map[string]
 		properties[naming.ASCIIFold(name)] = prop
 	}
 	for _, sub := range schema.AllOf {
+		collectTypeProperties(sub, properties, visited)
+	}
+	for _, sub := range schema.OneOf {
+		collectTypeProperties(sub, properties, visited)
+	}
+	for _, sub := range schema.AnyOf {
 		collectTypeProperties(sub, properties, visited)
 	}
 }

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -6756,6 +6756,34 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
 			wantID: "id",
 		},
 		{
+			name: "tier 2: id inside anyOf still wins",
+			schemaYAML: `                  anyOf:
+                    - type: object
+                      properties:
+                        id: {type: string}
+                        label: {type: string}
+                    - type: object
+                      properties:
+                        id: {type: string}
+                        workspace_id: {type: string}
+`,
+			wantID: "id",
+		},
+		{
+			name: "tier 3.5: gid inside oneOf wins over name",
+			schemaYAML: `                  oneOf:
+                    - type: object
+                      properties:
+                        gid: {type: string}
+                        name: {type: string}
+                    - type: object
+                      properties:
+                        gid: {type: string}
+                        email: {type: string}
+`,
+			wantID: "gid",
+		},
+		{
 			name: "tier 3.5: gid wins over name (Asana shape)",
 			schemaYAML: `                  type: object
                   properties:
@@ -6829,6 +6857,22 @@ func TestParseIDFieldFallbackChain(t *testing.T) {
                     market: {type: string}
                     ticker: {type: string}
                     description: {type: string}
+`,
+			wantID: "ticker",
+		},
+		{
+			name: "tier 4: required scalar inside anyOf is considered",
+			schemaYAML: `                  anyOf:
+                    - type: object
+                      required: [ticker]
+                      properties:
+                        ticker: {type: string}
+                        price: {type: number}
+                    - type: object
+                      required: [market]
+                      properties:
+                        market: {type: string}
+                        description: {type: string}
 `,
 			wantID: "ticker",
 		},
@@ -6962,6 +7006,44 @@ paths:
 			assert.False(t, ep.Critical)
 		})
 	}
+}
+
+func TestParseScalarUnionArrayDoesNotRegisterEmptyInlineType(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`openapi: "3.0.3"
+info:
+  title: Test
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      anyOf:
+                        - type: string
+                        - type: number
+                  cursor:
+                    type: string
+`)
+	parsed, err := Parse(yamlSpec)
+	require.NoError(t, err)
+
+	ep := findEndpoint(t, parsed, "/things")
+	assert.Equal(t, "array", ep.Response.Type)
+	assert.Empty(t, parsed.Types, "scalar anyOf list items must not register a zero-field synthetic type")
 }
 
 // TestParseIDFieldEnvelopeUnwrapping covers list responses whose payload is an


### PR DESCRIPTION
## Summary

Paginated list resources whose items are inline union schemas now keep their typed SQLite tables even when action endpoints under the same parent produce sharded sibling tables. Todoist-style project rows now dispatch through `UpsertProjects` instead of landing only in the generic `resources` table.

## Approach

The OpenAPI response mapper now treats strict single-array envelopes such as `{results: [...]}` as list responses and preserves the response path. Inline `oneOf` and `anyOf` item schemas contribute merged object fields to the synthetic response type, so store schema derivation sees the actual row shape while the existing dead-table guard remains tied to typed upsert emission.

## Output Contract

Generated-output proof covers the affected fallback shape: the regression test asserts the emitted `projects` table, `UpsertProjects`, and `UpsertBatch` dispatch, then compiles the generated store test for that table. I also regenerated Todoist from its OpenAPI spec locally and verified `projects`, `UpsertProjects`, and the `projects` dispatch are present.

## Verification

- `go test ./internal/generator -run TestGenerateStoreKeepsBareResourceTableForPaginatedUnionListWithActionSiblings -count=1`
- `go test ./internal/openapi ./internal/generator -run 'Test(Parse|GenerateStoreKeepsBareResourceTableForPaginatedUnionListWithActionSiblings)' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`

Closes #2429
