### PR TITLE
fix(cli): rebuild FTS after rowid migration

### DIFF
--- a/internal/generator/fts_rowid_test.go
+++ b/internal/generator/fts_rowid_test.go
@@ -46,11 +46,25 @@ func TestFTSRowIDContract(t *testing.T) {
 func TestGenerateStoreFTSRowIDMigration(t *testing.T) {
 	t.Parallel()
 
-	apiSpec := minimalSpec("fts-rowid-migration")
-	outputDir := filepath.Join(t.TempDir(), "fts-rowid-migration-pp-cli")
-	gen := New(apiSpec, outputDir)
-	gen.VisionSet = VisionTemplateSet{Store: true}
-	require.NoError(t, gen.Generate())
+	for _, tc := range []struct {
+		name         string
+		learnEnabled bool
+	}{
+		{name: "learn-disabled"},
+		{name: "learn-enabled", learnEnabled: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^Test(SchemaVersion_StampedOnFreshDB|Migrate_ResourcesCompositeKeyUpgrade|Migrate_V2ResourcesFTSRowIDUpgrade|Migrate_V3ResourcesFTSNoRebuild)$", "-count=1")
+			apiSpec := minimalSpec("fts-rowid-migration-" + tc.name)
+			apiSpec.Learn.Enabled = tc.learnEnabled
+			outputDir := filepath.Join(t.TempDir(), "fts-rowid-migration-"+tc.name+"-pp-cli")
+			gen := New(apiSpec, outputDir)
+			gen.VisionSet = VisionTemplateSet{Store: true}
+			require.NoError(t, gen.Generate())
+
+			runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^Test(SchemaVersion_StampedOnFreshDB|Migrate_ResourcesCompositeKeyUpgrade|Migrate_V2ResourcesFTSRowIDUpgrade|Migrate_V3ResourcesFTSNoRebuild)$", "-count=1")
+		})
+	}
 }

--- a/internal/generator/fts_rowid_test.go
+++ b/internal/generator/fts_rowid_test.go
@@ -53,7 +53,6 @@ func TestGenerateStoreFTSRowIDMigration(t *testing.T) {
 		{name: "learn-disabled"},
 		{name: "learn-enabled", learnEnabled: true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/generator/fts_rowid_test.go
+++ b/internal/generator/fts_rowid_test.go
@@ -42,3 +42,15 @@ func TestFTSRowIDContract(t *testing.T) {
 
 	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestFTSRowIDContract", "-count=1")
 }
+
+func TestGenerateStoreFTSRowIDMigration(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("fts-rowid-migration")
+	outputDir := filepath.Join(t.TempDir(), "fts-rowid-migration-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^Test(SchemaVersion_StampedOnFreshDB|Migrate_ResourcesCompositeKeyUpgrade|Migrate_V2ResourcesFTSRowIDUpgrade|Migrate_V3ResourcesFTSNoRebuild)$", "-count=1")
+}

--- a/internal/generator/learn_store_test.go
+++ b/internal/generator/learn_store_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 )
 
-func TestGenerateStoreSchemaVersion_DisabledStaysV2(t *testing.T) {
+func TestGenerateStoreSchemaVersion_DisabledAdvancesToV3(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("learn-version-disabled")
@@ -24,7 +24,7 @@ func TestGenerateStoreSchemaVersion_DisabledStaysV2(t *testing.T) {
 	storeGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
 	require.NoError(t, err)
 	src := string(storeGo)
-	require.Contains(t, src, "const StoreSchemaVersion = 2")
+	require.Contains(t, src, "const StoreSchemaVersion = 3")
 	require.NotContains(t, src, "const StoreSchemaVersion = 6")
 	for _, table := range []string{"search_learnings", "search_patterns", "entity_lookups"} {
 		require.NotContains(t, src, table, "learn-disabled spec must not emit %s migration", table)
@@ -135,8 +135,8 @@ func TestGenerateStoreLearnRenamedFromRecipes(t *testing.T) {
 // through `go test -c` to catch any template error that produces valid-shaped
 // but uncompilable Go (mis-placed comma in the migrations slice, malformed
 // string literal, etc.). The -c flag compiles tests without running them, so
-// the new v2->v3 additive-migration assertion in the schema_version_test
-// template is exercised at type-check time without paying the runtime cost.
+// the schema_version_test template is exercised at type-check time without
+// paying the runtime cost.
 func TestGenerateStoreCompilesUnderLearnEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -42,8 +42,10 @@ func IsUUID(s string) bool {
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
 // checked on every open. {{if .Learn.Enabled}}Learn-enabled CLIs advance to v6 for the
-// canonical learn-loop tables ported from prediction-goat.{{else}}Non-learn CLIs stay at v2.{{end}}
-const StoreSchemaVersion = {{if .Learn.Enabled}}6{{else}}2{{end}}
+// canonical learn-loop tables ported from prediction-goat, including the v3
+// resources_fts rowid rehash.{{else}}Non-learn CLIs advance to v3 for the
+// resources_fts rowid rehash.{{end}}
+const StoreSchemaVersion = {{if .Learn.Enabled}}6{{else}}3{{end}}
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -478,6 +480,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources composite key: %w", err)
 			}
 		}
+		if current == 2 {
+			if err := s.migrateResourcesFTSRowIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating resources FTS rowids: %w", err)
+			}
+		}
 
 		if err := s.backfillColumns(ctx, conn); err != nil {
 			return fmt.Errorf("backfilling columns: %w", err)
@@ -542,6 +549,27 @@ func (s *Store) migrateResourcesCompositeKey(ctx context.Context, conn *sql.Conn
 	// Always rebuild FTS during the v2 transition. The resources table may
 	// already have the composite key, but v1 FTS rowids were scoped by id
 	// alone and must be replaced with resource_type + id rowids.
+	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
+		return fmt.Errorf("dropping resources_fts: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, resourcesFTSCreateSQL); err != nil {
+		return fmt.Errorf("creating resources_fts: %w", err)
+	}
+	if err := rebuildResourcesFTS(ctx, conn); err != nil {
+		return fmt.Errorf("rebuilding resources_fts: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) migrateResourcesFTSRowIDs(ctx context.Context, conn *sql.Conn) error {
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
 	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
 		return fmt.Errorf("dropping resources_fts: %w", err)
 	}
@@ -854,6 +882,8 @@ func extractObjectID(obj map[string]any) string {
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
+// Any change to this derivation requires a StoreSchemaVersion bump and a
+// resources_fts rebuild migration for already-stamped databases.
 // modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
 // on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
 func ftsRowID(scope, id string) int64 {

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -581,6 +581,14 @@ func TestMigrate_V2ResourcesFTSRowIDUpgrade(t *testing.T) {
 		t.Fatalf("resources_fts rowid = %d, want %d", rowid, want)
 	}
 
+	data, err := s.Get("biz", "shared")
+	if err != nil {
+		t.Fatalf("get preserved v2 resource after rowid migration: %v", err)
+	}
+	if string(data) != `{"kind":"biz","name":"legacy restaurant"}` {
+		t.Fatalf("preserved v2 resource payload = %s, want original", data)
+	}
+
 	if err := s.Upsert("biz", "shared", []byte(`{"kind":"biz","name":"legacy cafe"}`)); err != nil {
 		t.Fatalf("upsert after rowid migration: %v", err)
 	}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -513,14 +513,155 @@ func TestMigrate_ResourcesCompositeKeyUpgrade(t *testing.T) {
 	}
 }
 
+func TestMigrate_V2ResourcesFTSRowIDUpgrade(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE resources (
+		id TEXT NOT NULL,
+		resource_type TEXT NOT NULL,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (resource_type, id)
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create v2 resources: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE VIRTUAL TABLE resources_fts USING fts5(
+		id, resource_type, content, tokenize='porter unicode61'
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create stale resources_fts: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO resources (id, resource_type, data) VALUES ('shared', 'biz', '{"kind":"biz","name":"legacy restaurant"}')`); err != nil {
+		raw.Close()
+		t.Fatalf("seed v2 resource: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (1, 'shared', 'biz', '{"kind":"biz","name":"legacy restaurant"}')`); err != nil {
+		raw.Close()
+		t.Fatalf("seed stale resources_fts row: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 2`); err != nil {
+		raw.Close()
+		t.Fatalf("stamp v2: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open upgraded db: %v", err)
+	}
+	defer s.Close()
+
+	v, err := s.SchemaVersion()
+	if err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if v != StoreSchemaVersion {
+		t.Fatalf("upgraded version = %d, want %d", v, StoreSchemaVersion)
+	}
+
+	var count int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM resources_fts WHERE id = 'shared' AND resource_type = 'biz'`).Scan(&count); err != nil {
+		t.Fatalf("count rebuilt resources_fts rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("resources_fts row count = %d, want 1", count)
+	}
+
+	var rowid int64
+	if err := s.DB().QueryRow(`SELECT rowid FROM resources_fts WHERE id = 'shared' AND resource_type = 'biz'`).Scan(&rowid); err != nil {
+		t.Fatalf("read rebuilt resources_fts rowid: %v", err)
+	}
+	if want := ftsRowID("biz", "shared"); rowid != want {
+		t.Fatalf("resources_fts rowid = %d, want %d", rowid, want)
+	}
+
+	if err := s.Upsert("biz", "shared", []byte(`{"kind":"biz","name":"legacy cafe"}`)); err != nil {
+		t.Fatalf("upsert after rowid migration: %v", err)
+	}
+	matches, err := s.Search("legacy", 10)
+	if err != nil {
+		t.Fatalf("search rebuilt fts: %v", err)
+	}
+	if len(matches) != 1 || string(matches[0]) != `{"kind":"biz","name":"legacy cafe"}` {
+		t.Fatalf("legacy search = %q, want exactly one updated payload", matches)
+	}
+}
+
+func TestMigrate_V3ResourcesFTSNoRebuild(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE resources (
+		id TEXT NOT NULL,
+		resource_type TEXT NOT NULL,
+		data JSON NOT NULL,
+		synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (resource_type, id)
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create v3 resources: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE VIRTUAL TABLE resources_fts USING fts5(
+		id, resource_type, content, tokenize='porter unicode61'
+	)`); err != nil {
+		raw.Close()
+		t.Fatalf("create v3 resources_fts: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO resources (id, resource_type, data) VALUES ('shared', 'biz', '{"kind":"biz","name":"canonical resource"}')`); err != nil {
+		raw.Close()
+		t.Fatalf("seed v3 resource: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO resources_fts (rowid, id, resource_type, content) VALUES (?, 'shared', 'biz', '{"kind":"biz","name":"sentinel fts"}')`, ftsRowID("biz", "shared")); err != nil {
+		raw.Close()
+		t.Fatalf("seed v3 resources_fts row: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 3`); err != nil {
+		raw.Close()
+		t.Fatalf("stamp v3: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open v3 db: %v", err)
+	}
+	defer s.Close()
+
+	v, err := s.SchemaVersion()
+	if err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if v != StoreSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", v, StoreSchemaVersion)
+	}
+
+	var content string
+	if err := s.DB().QueryRow(`SELECT content FROM resources_fts WHERE id = 'shared' AND resource_type = 'biz'`).Scan(&content); err != nil {
+		t.Fatalf("read resources_fts content: %v", err)
+	}
+	if content != `{"kind":"biz","name":"sentinel fts"}` {
+		t.Fatalf("resources_fts content = %s, want sentinel row preserved", content)
+	}
+}
+
 {{- if .Learn.Enabled}}
-// TestMigrate_V2ToV3IsAdditive verifies that opening a v2-stamped database
-// preserves existing resources rows after the v3 migration runs. The v3
-// migration only adds new tables (learn tables, when the spec enables them)
-// — never drops or rewrites resources. Without this regression coverage, a
-// future refactor that turns the additive step into a destructive one would
-// silently nuke every existing library CLI's local data on first reopen.
-func TestMigrate_V2ToV3IsAdditive(t *testing.T) {
+// TestMigrate_V3ToV6IsAdditive verifies that opening a v3-stamped database
+// preserves existing resources rows after the learn-table migrations run.
+// The learn migrations only add tables when the spec enables them — never
+// drop or rewrite resources. Without this regression coverage, a future
+// refactor that turns the additive step into a destructive one would silently
+// nuke every existing library CLI's local data on first reopen.
+func TestMigrate_V3ToV6IsAdditive(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 
 	raw, err := sql.Open("sqlite", dbPath)
@@ -542,9 +683,9 @@ func TestMigrate_V2ToV3IsAdditive(t *testing.T) {
 		raw.Close()
 		t.Fatalf("seed v2 row: %v", err)
 	}
-	if _, err := raw.Exec(`PRAGMA user_version = 2`); err != nil {
+	if _, err := raw.Exec(`PRAGMA user_version = 3`); err != nil {
 		raw.Close()
-		t.Fatalf("stamp v2: %v", err)
+		t.Fatalf("stamp v3: %v", err)
 	}
 	raw.Close()
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -42,7 +42,8 @@ func IsUUID(s string) bool {
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
 // checked on every open. Learn-enabled CLIs advance to v6 for the
-// canonical learn-loop tables ported from prediction-goat.
+// canonical learn-loop tables ported from prediction-goat, including the v3
+// resources_fts rowid rehash.
 const StoreSchemaVersion = 6
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
@@ -407,6 +408,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources composite key: %w", err)
 			}
 		}
+		if current == 2 {
+			if err := s.migrateResourcesFTSRowIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating resources FTS rowids: %w", err)
+			}
+		}
 
 		if err := s.backfillColumns(ctx, conn); err != nil {
 			return fmt.Errorf("backfilling columns: %w", err)
@@ -471,6 +477,27 @@ func (s *Store) migrateResourcesCompositeKey(ctx context.Context, conn *sql.Conn
 	// Always rebuild FTS during the v2 transition. The resources table may
 	// already have the composite key, but v1 FTS rowids were scoped by id
 	// alone and must be replaced with resource_type + id rowids.
+	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
+		return fmt.Errorf("dropping resources_fts: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, resourcesFTSCreateSQL); err != nil {
+		return fmt.Errorf("creating resources_fts: %w", err)
+	}
+	if err := rebuildResourcesFTS(ctx, conn); err != nil {
+		return fmt.Errorf("rebuilding resources_fts: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) migrateResourcesFTSRowIDs(ctx context.Context, conn *sql.Conn) error {
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
 	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
 		return fmt.Errorf("dropping resources_fts: %w", err)
 	}
@@ -783,6 +810,8 @@ func extractObjectID(obj map[string]any) string {
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
+// Any change to this derivation requires a StoreSchemaVersion bump and a
+// resources_fts rebuild migration for already-stamped databases.
 // modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
 // on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
 func ftsRowID(scope, id string) int64 {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -41,8 +41,9 @@ func IsUUID(s string) bool {
 
 // StoreSchemaVersion is the on-disk schema version this binary understands.
 // It is stamped into SQLite's PRAGMA user_version on fresh databases and
-// checked on every open. Non-learn CLIs stay at v2.
-const StoreSchemaVersion = 2
+// checked on every open. Non-learn CLIs advance to v3 for the
+// resources_fts rowid rehash.
+const StoreSchemaVersion = 3
 
 const resourcesFTSCreateSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS resources_fts USING fts5(
 	id, resource_type, content, tokenize='porter unicode61'
@@ -328,6 +329,11 @@ func (s *Store) migrate(ctx context.Context) error {
 				return fmt.Errorf("migrating resources composite key: %w", err)
 			}
 		}
+		if current == 2 {
+			if err := s.migrateResourcesFTSRowIDs(ctx, conn); err != nil {
+				return fmt.Errorf("migrating resources FTS rowids: %w", err)
+			}
+		}
 
 		if err := s.backfillColumns(ctx, conn); err != nil {
 			return fmt.Errorf("backfilling columns: %w", err)
@@ -392,6 +398,27 @@ func (s *Store) migrateResourcesCompositeKey(ctx context.Context, conn *sql.Conn
 	// Always rebuild FTS during the v2 transition. The resources table may
 	// already have the composite key, but v1 FTS rowids were scoped by id
 	// alone and must be replaced with resource_type + id rowids.
+	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
+		return fmt.Errorf("dropping resources_fts: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, resourcesFTSCreateSQL); err != nil {
+		return fmt.Errorf("creating resources_fts: %w", err)
+	}
+	if err := rebuildResourcesFTS(ctx, conn); err != nil {
+		return fmt.Errorf("rebuilding resources_fts: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) migrateResourcesFTSRowIDs(ctx context.Context, conn *sql.Conn) error {
+	exists, err := tableExists(ctx, conn, "resources")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
 	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS resources_fts`); err != nil {
 		return fmt.Errorf("dropping resources_fts: %w", err)
 	}
@@ -704,6 +731,8 @@ func extractObjectID(obj map[string]any) string {
 }
 
 // ftsRowID derives a deterministic rowid from a string ID for use with FTS5.
+// Any change to this derivation requires a StoreSchemaVersion bump and a
+// resources_fts rebuild migration for already-stamped databases.
 // modernc.org/sqlite's FTS5 implementation may not support DELETE WHERE column=?
 // on virtual tables, so we use explicit rowids and DELETE WHERE rowid=? instead.
 func ftsRowID(scope, id string) int64 {


### PR DESCRIPTION
## Summary

Existing printed CLI databases now get their generic FTS index rebuilt when upgrading past the `ftsRowID` hash change, so search results do not duplicate stale polynomial-hash rows after the first post-upgrade upsert.

This bumps non-learn generated stores to schema v3, runs a v2-only `resources_fts` rebuild before stamping the current schema version, and keeps learn-enabled stores on v6 while applying the same v2 migration. The generated migration tests cover fresh databases, v1 composite-key upgrades, v2 FTS rowid rebuilds, and v3 no-op reopen behavior.

Closes #2417

## Verification

- `go test ./internal/generator -run 'TestGenerateStoreFTSRowIDMigration|TestGenerateStoreSchemaVersion|TestGenerateStoreCompilesUnderLearnEnabled' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `go test ./internal/pipeline -run 'TestLiveCheck_RebuildsStageBinaryWhenInternalSourceIsNewer|TestRunOneFeatureCheck_WarnsOnEntityButStaysPass|TestRunOneFeatureCheck_PopulatesOutputSample' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`

Note: an initial post-rebase `go test ./...` run timed out 3 `internal/pipeline` live-check tests while `scripts/verify-generator-output.sh` was running concurrently. The exact tests passed in isolation, then the full suite passed when rerun by itself.
