### PR TITLE
fix(cli): preserve sync cursor on max-pages cap

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11230,6 +11230,8 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 		"syncResource must choose the final saved cursor based on the exit reason")
 	assert.Contains(t, syncContent, "finalCursor = capExitCursor",
 		"syncResource must preserve the resume cursor on --max-pages cap exit")
+	assert.Contains(t, syncContent, "truncatedByCap && capExitCursor != cursor",
+		"syncResource must not preserve a self-referential cursor when the cap fires before sticky-cursor detection")
 
 	// (c) Sticky-cursor detection on the flat path. The check must compare
 	// against a tracked lastNextCursor and emit the structured warning when
@@ -11270,6 +11272,7 @@ import (
 
 type resumeCursorClient struct {
 	cursors []string
+	stuck   bool
 }
 
 func (c *resumeCursorClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
@@ -11283,6 +11286,9 @@ func (c *resumeCursorClient) Get(ctx context.Context, path string, params map[st
 		"page-4": "page-5",
 	}
 	next := nextByCursor[cursor]
+	if c.stuck {
+		next = cursor
+	}
 	page := cursor
 	if page == "" {
 		page = "page-1"
@@ -11385,9 +11391,37 @@ func TestSyncResourceClearsCursorWhenCapEqualsFinalPage(t *testing.T) {
 		t.Fatalf("cursor after exact-boundary capped run = %q, want empty", cursor)
 	}
 }
+
+func TestSyncResourceClearsSelfReferentialCursorOnMaxPagesCap(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.SaveSyncState("channels", "stuck", 100); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+
+	client := &resumeCursorClient{stuck: true}
+	res := syncResource(context.Background(), client, db, "channels", "", false, 1, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(client.cursors, ","); got != "stuck" {
+		t.Fatalf("run cursors = %q, want %q", got, "stuck")
+	}
+	cursor, _, _, err := db.GetSyncState("channels")
+	if err != nil {
+		t.Fatalf("get sync state after self-referential capped run: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("cursor after self-referential capped run = %q, want empty", cursor)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_resume_cursor_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage)$")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage|ClearsSelfReferentialCursorOnMaxPagesCap)$")
 
 	// Build the generated CLI to catch template-syntax / import errors that
 	// substring assertions miss.
@@ -11515,7 +11549,7 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 		"GraphQL sync.go must track whether --max-pages stopped the loop")
 	assert.Contains(t, string(syncGo), "finalCursor = capExitCursor",
 		"GraphQL sync.go must preserve the resume cursor on --max-pages cap exit")
-	assert.Contains(t, string(syncGo), "conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != \"\"",
+	assert.Contains(t, string(syncGo), "conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != \"\" && conn.PageInfo.EndCursor != cursor",
 		"GraphQL sync.go must only preserve a cap-exit cursor when another page exists")
 
 	behaviorTest := `package cli
@@ -11538,6 +11572,7 @@ import (
 
 type gqlResumeHandler struct {
 	cursors []string
+	stuck   bool
 }
 
 func (h *gqlResumeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -11558,6 +11593,9 @@ func (h *gqlResumeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"page-4": "page-5",
 	}
 	next := nextByCursor[cursor]
+	if h.stuck {
+		next = cursor
+	}
 	page := cursor
 	if page == "" {
 		page = "page-1"
@@ -11660,9 +11698,33 @@ func TestGraphQLSyncResourceClearsCursorWhenCapEqualsFinalPage(t *testing.T) {
 		t.Fatalf("cursor after exact-boundary capped run = %q, want empty", cursor)
 	}
 }
+
+func TestGraphQLSyncResourceClearsSelfReferentialCursorOnMaxPagesCap(t *testing.T) {
+	handler := &gqlResumeHandler{stuck: true}
+	c, db, cleanup := newGraphQLSyncClient(t, handler)
+	defer cleanup()
+
+	if err := db.SaveSyncState("issues", "stuck", 100); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	res := syncResource(context.Background(), c, db, "issues", "", false, 1, false)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(handler.cursors, ","); got != "stuck" {
+		t.Fatalf("run cursors = %q, want %q", got, "stuck")
+	}
+	cursor, _, _, err := db.GetSyncState("issues")
+	if err != nil {
+		t.Fatalf("get sync state after self-referential capped run: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("cursor after self-referential capped run = %q, want empty", cursor)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "graphql_sync_resume_cursor_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestGraphQLSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage)$")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestGraphQLSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage|ClearsSelfReferentialCursorOnMaxPagesCap)$")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11224,6 +11224,12 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 	assert.Contains(t, syncContent,
 		"maxPages, effectiveLatestOnly, parentFilter",
 		"syncDependentResources call must pass effectiveLatestOnly, not the raw --latest-only flag (issue #928 Greptile follow-up)")
+	assert.Contains(t, syncContent, "capExitHit := false",
+		"syncResource must track whether the loop stopped because --max-pages was reached")
+	assert.Contains(t, syncContent, "finalCursor := \"\"",
+		"syncResource must choose the final saved cursor based on the exit reason")
+	assert.Contains(t, syncContent, "finalCursor = capExitCursor",
+		"syncResource must preserve the resume cursor on --max-pages cap exit")
 
 	// (c) Sticky-cursor detection on the flat path. The check must compare
 	// against a tracked lastNextCursor and emit the structured warning when
@@ -11248,6 +11254,140 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 	assert.NotContains(t, syncContent,
 		`"reason":%q,"message"`,
 		"sync_warning must use literal %s interpolation, not %q Go-escaping")
+
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type resumeCursorClient struct {
+	cursors []string
+}
+
+func (c *resumeCursorClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	cursor := params["after"]
+	c.cursors = append(c.cursors, cursor)
+
+	nextByCursor := map[string]string{
+		"":       "page-2",
+		"page-2": "page-3",
+		"page-3": "page-4",
+		"page-4": "page-5",
+	}
+	next := nextByCursor[cursor]
+	page := cursor
+	if page == "" {
+		page = "page-1"
+	}
+	items := make([]map[string]string, 100)
+	for i := range items {
+		items[i] = map[string]string{"id": page + "-" + strconv.Itoa(i)}
+	}
+	return json.Marshal(map[string]any{
+		"items":       items,
+		"has_more":    next != "",
+		"next_cursor": next,
+	})
+}
+
+func (c *resumeCursorClient) RateLimit() float64 {
+	return 0
+}
+
+func TestSyncResourcePreservesCursorOnMaxPagesCap(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	first := &resumeCursorClient{}
+	res := syncResource(context.Background(), first, db, "channels", "", false, 2, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("first syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(first.cursors, ","); got != ",page-2" {
+		t.Fatalf("first run cursors = %q, want %q", got, ",page-2")
+	}
+	cursor, _, _, err := db.GetSyncState("channels")
+	if err != nil {
+		t.Fatalf("get sync state after first run: %v", err)
+	}
+	if cursor != "page-3" {
+		t.Fatalf("cursor after first capped run = %q, want page-3", cursor)
+	}
+
+	second := &resumeCursorClient{}
+	res = syncResource(context.Background(), second, db, "channels", "", false, 2, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("second syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(second.cursors, ","); got != "page-3,page-4" {
+		t.Fatalf("second run cursors = %q, want %q", got, "page-3,page-4")
+	}
+	cursor, _, _, err = db.GetSyncState("channels")
+	if err != nil {
+		t.Fatalf("get sync state after second run: %v", err)
+	}
+	if cursor != "page-5" {
+		t.Fatalf("cursor after second capped run = %q, want page-5", cursor)
+	}
+
+	final := &resumeCursorClient{}
+	res = syncResource(context.Background(), final, db, "channels", "", false, 0, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("final syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(final.cursors, ","); got != "page-5" {
+		t.Fatalf("final run cursors = %q, want page-5", got)
+	}
+	cursor, _, _, err = db.GetSyncState("channels")
+	if err != nil {
+		t.Fatalf("get sync state after natural completion: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("cursor after natural completion = %q, want empty", cursor)
+	}
+}
+
+func TestSyncResourceClearsCursorWhenCapEqualsFinalPage(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.SaveSyncState("channels", "page-3", 200); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+
+	client := &resumeCursorClient{}
+	res := syncResource(context.Background(), client, db, "channels", "", false, 3, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(client.cursors, ","); got != "page-3,page-4,page-5" {
+		t.Fatalf("run cursors = %q, want %q", got, "page-3,page-4,page-5")
+	}
+	cursor, _, _, err := db.GetSyncState("channels")
+	if err != nil {
+		t.Fatalf("get sync state after exact-boundary capped run: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("cursor after exact-boundary capped run = %q, want empty", cursor)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_resume_cursor_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage)$")
 
 	// Build the generated CLI to catch template-syntax / import errors that
 	// substring assertions miss.
@@ -11371,6 +11511,158 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 		"GraphQL sync.go dogfood cap must still bound generated syncs to 10 pages")
 	assert.NotContains(t, string(syncGo), `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
 		"GraphQL sync.go must not retain the old 10-page default")
+	assert.Contains(t, string(syncGo), "capExitHit := false",
+		"GraphQL sync.go must track whether --max-pages stopped the loop")
+	assert.Contains(t, string(syncGo), "finalCursor = capExitCursor",
+		"GraphQL sync.go must preserve the resume cursor on --max-pages cap exit")
+	assert.Contains(t, string(syncGo), "conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != \"\"",
+		"GraphQL sync.go must only preserve a cap-exit cursor when another page exists")
+
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"` + naming.CLI(gqlSpec.Name) + `/internal/client"
+	"` + naming.CLI(gqlSpec.Name) + `/internal/config"
+	"` + naming.CLI(gqlSpec.Name) + `/internal/store"
+)
+
+type gqlResumeHandler struct {
+	cursors []string
+}
+
+func (h *gqlResumeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Variables map[string]any ` + "`json:\"variables\"`" + `
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	cursor, _ := req.Variables["after"].(string)
+	h.cursors = append(h.cursors, cursor)
+
+	nextByCursor := map[string]string{
+		"":       "page-2",
+		"page-2": "page-3",
+		"page-3": "page-4",
+		"page-4": "page-5",
+	}
+	next := nextByCursor[cursor]
+	page := cursor
+	if page == "" {
+		page = "page-1"
+	}
+	endCursor := next
+	if endCursor == "" {
+		endCursor = page + "-end"
+	}
+	nodes := make([]map[string]string, 50)
+	for i := range nodes {
+		nodes[i] = map[string]string{
+			"id":    page + "-" + strconv.Itoa(i),
+			"title": page + " issue " + strconv.Itoa(i),
+		}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"issues": map[string]any{
+				"nodes": nodes,
+				"pageInfo": map[string]any{
+					"hasNextPage": next != "",
+					"endCursor":   endCursor,
+				},
+			},
+		},
+	})
+}
+
+func newGraphQLSyncClient(t *testing.T, h *gqlResumeHandler) (*client.Client, *store.Store, func()) {
+	t.Helper()
+	server := httptest.NewServer(h)
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	c := client.New(&config.Config{BaseURL: server.URL}, time.Second, 0)
+	return c, db, func() {
+		db.Close()
+		server.Close()
+	}
+}
+
+func TestGraphQLSyncResourcePreservesCursorOnMaxPagesCap(t *testing.T) {
+	handler := &gqlResumeHandler{}
+	c, db, cleanup := newGraphQLSyncClient(t, handler)
+	defer cleanup()
+
+	res := syncResource(context.Background(), c, db, "issues", "", false, 2, false)
+	if res.Err != nil {
+		t.Fatalf("first syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(handler.cursors, ","); got != ",page-2" {
+		t.Fatalf("first run cursors = %q, want %q", got, ",page-2")
+	}
+	cursor, _, _, err := db.GetSyncState("issues")
+	if err != nil {
+		t.Fatalf("get sync state after first run: %v", err)
+	}
+	if cursor != "page-3" {
+		t.Fatalf("cursor after first capped run = %q, want page-3", cursor)
+	}
+
+	handler.cursors = nil
+	res = syncResource(context.Background(), c, db, "issues", "", false, 2, false)
+	if res.Err != nil {
+		t.Fatalf("second syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(handler.cursors, ","); got != "page-3,page-4" {
+		t.Fatalf("second run cursors = %q, want %q", got, "page-3,page-4")
+	}
+	cursor, _, _, err = db.GetSyncState("issues")
+	if err != nil {
+		t.Fatalf("get sync state after second run: %v", err)
+	}
+	if cursor != "page-5" {
+		t.Fatalf("cursor after second capped run = %q, want page-5", cursor)
+	}
+}
+
+func TestGraphQLSyncResourceClearsCursorWhenCapEqualsFinalPage(t *testing.T) {
+	handler := &gqlResumeHandler{}
+	c, db, cleanup := newGraphQLSyncClient(t, handler)
+	defer cleanup()
+
+	if err := db.SaveSyncState("issues", "page-3", 100); err != nil {
+		t.Fatalf("seed sync state: %v", err)
+	}
+	res := syncResource(context.Background(), c, db, "issues", "", false, 3, false)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if got := strings.Join(handler.cursors, ","); got != "page-3,page-4,page-5" {
+		t.Fatalf("run cursors = %q, want %q", got, "page-3,page-4,page-5")
+	}
+	cursor, _, _, err := db.GetSyncState("issues")
+	if err != nil {
+		t.Fatalf("get sync state after exact-boundary capped run: %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("cursor after exact-boundary capped run = %q, want empty", cursor)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "graphql_sync_resume_cursor_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestGraphQLSyncResource(PreservesCursorOnMaxPagesCap|ClearsCursorWhenCapEqualsFinalPage)$")
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/templates/auto_refresh.go.tmpl
+++ b/internal/generator/templates/auto_refresh.go.tmpl
@@ -210,7 +210,7 @@ func runAutoRefresh(ctx context.Context, flags *rootFlags, db *store.Store, reso
 			return ctx.Err()
 		default:
 		}
-		result := syncResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, "", false, 1{{if not (isGraphQL .APISpec)}}, true{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, os.Stderr{{end}})
+		result := syncResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, "", false, 1, true{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, os.Stderr{{end}})
 		if result.Err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", resource, result.Err))
 		}

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -296,7 +296,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 
 			for _, resource := range resources {
-				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100{{if not (isGraphQL .APISpec)}}, false{{end}}{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
+				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100, false{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
 				if res.Err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)
 					continue

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -153,7 +153,7 @@ Exit codes & warnings:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages)
+						res := syncResource(cmd.Context(), c, db, resource, sinceTS, full, maxPages, latestOnly && since == "")
 						results <- res
 					}
 				}()
@@ -269,7 +269,7 @@ func graphqlSyncDefs() map[string]graphqlSyncDef {
 }
 
 // syncResource handles the full paginated sync of a single resource via GraphQL.
-func syncResource(ctx context.Context, c *client.Client, db *store.Store, resource, sinceTS string, full bool, maxPages int) syncResult {
+func syncResource(ctx context.Context, c *client.Client, db *store.Store, resource, sinceTS string, full bool, maxPages int, latestOnly bool) syncResult {
 	started := time.Now()
 
 	if !humanFriendly {
@@ -295,6 +295,8 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 	consumedTotal := 0
 	extractFailureTotal := 0
 	anomalyEmitted := false
+	capExitHit := false
+	capExitCursor := ""
 	pageSize := def.PageSize
 	if pageSize <= 0 {
 		pageSize = 50
@@ -407,7 +409,12 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 
 		// Enforce page ceiling
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if humanFriendly {
+			capExitHasMore := conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != ""
+			if capExitHasMore && !latestOnly {
+				capExitHit = true
+				capExitCursor = conn.PageInfo.EndCursor
+			}
+			if capExitHasMore && !latestOnly && humanFriendly {
 				fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
 			}
 			break
@@ -421,8 +428,13 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 		cursor = conn.PageInfo.EndCursor
 	}
 
-	// Final sync state: clear cursor (sync is complete), update count
-	_ = db.SaveSyncState(resource, "", totalCount)
+	// Final sync state: clear cursor on natural completion, but preserve the
+	// resume cursor when an operator intentionally capped the page budget.
+	finalCursor := ""
+	if capExitHit {
+		finalCursor = capExitCursor
+	}
+	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: rows extracted successfully but none landed.
 	// Likely cause is below the PK-extraction layer (FTS5 trigger,

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -409,7 +409,7 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 
 		// Enforce page ceiling
 		if maxPages > 0 && pagesFetched >= maxPages {
-			capExitHasMore := conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != ""
+			capExitHasMore := conn.PageInfo.HasNextPage && conn.PageInfo.EndCursor != "" && conn.PageInfo.EndCursor != cursor
 			if capExitHasMore && !latestOnly {
 				capExitHit = true
 				capExitCursor = conn.PageInfo.EndCursor

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -844,7 +844,7 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap {
+			if truncatedByCap && capExitCursor != cursor {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -608,6 +608,8 @@ func syncResource(ctx context.Context, c interface {
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
+	capExitHit := false
+	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -825,11 +827,31 @@ func syncResource(ctx context.Context, c interface {
 		// warning per paginated resource would mask real sync_anomaly /
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if !latestOnly {
-				if humanFriendly {
-					fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			truncatedByCap := resourceSupportsPagination(resource) && hasMore
+{{- if $hasIDWalk}}
+			truncatedByCap = truncatedByCap && len(items) >= activePageLimit
+{{- else}}
+			truncatedByCap = truncatedByCap && len(items) >= pageSize.limit
+{{- end}}
+			if truncatedByCap {
+				capExitCursor = nextCursor
+			}
+			if truncatedByCap && capExitCursor == "" {
+				if pageSize.cursorParam == "offset" {
+					currentOffset, _ := strconv.Atoi(cursor)
+					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					truncatedByCap = false
+				}
+			}
+			if truncatedByCap {
+				if !latestOnly {
+					capExitHit = true
+					if humanFriendly {
+						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+					} else {
+						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					}
 				}
 			}
 			break
@@ -884,8 +906,13 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Final sync state: clear cursor (sync is complete), update count
-	_ = db.SaveSyncState(resource, "", totalCount)
+	// Final sync state: clear cursor on natural completion, but preserve the
+	// resume cursor when an operator intentionally capped the page budget.
+	finalCursor := ""
+	if capExitHit {
+		finalCursor = capExitCursor
+	}
+	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -459,6 +459,8 @@ func syncResource(ctx context.Context, c interface {
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
+	capExitHit := false
+	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -627,11 +629,27 @@ func syncResource(ctx context.Context, c interface {
 		// warning per paginated resource would mask real sync_anomaly /
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if !latestOnly {
-				if humanFriendly {
-					fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			truncatedByCap := resourceSupportsPagination(resource) && hasMore
+			truncatedByCap = truncatedByCap && len(items) >= pageSize.limit
+			if truncatedByCap {
+				capExitCursor = nextCursor
+			}
+			if truncatedByCap && capExitCursor == "" {
+				if pageSize.cursorParam == "offset" {
+					currentOffset, _ := strconv.Atoi(cursor)
+					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					truncatedByCap = false
+				}
+			}
+			if truncatedByCap {
+				if !latestOnly {
+					capExitHit = true
+					if humanFriendly {
+						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+					} else {
+						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					}
 				}
 			}
 			break
@@ -682,8 +700,13 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Final sync state: clear cursor (sync is complete), update count
-	_ = db.SaveSyncState(resource, "", totalCount)
+	// Final sync state: clear cursor on natural completion, but preserve the
+	// resume cursor when an operator intentionally capped the page budget.
+	finalCursor := ""
+	if capExitHit {
+		finalCursor = capExitCursor
+	}
+	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -642,7 +642,7 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap {
+			if truncatedByCap && capExitCursor != cursor {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -459,6 +459,8 @@ func syncResource(ctx context.Context, c interface {
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
+	capExitHit := false
+	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -627,11 +629,27 @@ func syncResource(ctx context.Context, c interface {
 		// warning per paginated resource would mask real sync_anomaly /
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if !latestOnly {
-				if humanFriendly {
-					fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			truncatedByCap := resourceSupportsPagination(resource) && hasMore
+			truncatedByCap = truncatedByCap && len(items) >= pageSize.limit
+			if truncatedByCap {
+				capExitCursor = nextCursor
+			}
+			if truncatedByCap && capExitCursor == "" {
+				if pageSize.cursorParam == "offset" {
+					currentOffset, _ := strconv.Atoi(cursor)
+					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					truncatedByCap = false
+				}
+			}
+			if truncatedByCap {
+				if !latestOnly {
+					capExitHit = true
+					if humanFriendly {
+						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+					} else {
+						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					}
 				}
 			}
 			break
@@ -682,8 +700,13 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Final sync state: clear cursor (sync is complete), update count
-	_ = db.SaveSyncState(resource, "", totalCount)
+	// Final sync state: clear cursor on natural completion, but preserve the
+	// resume cursor when an operator intentionally capped the page budget.
+	finalCursor := ""
+	if capExitHit {
+		finalCursor = capExitCursor
+	}
+	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -642,7 +642,7 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap {
+			if truncatedByCap && capExitCursor != cursor {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -609,7 +609,7 @@ func syncResource(ctx context.Context, c interface {
 					truncatedByCap = false
 				}
 			}
-			if truncatedByCap {
+			if truncatedByCap && capExitCursor != cursor {
 				if !latestOnly {
 					capExitHit = true
 					if humanFriendly {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -426,6 +426,8 @@ func syncResource(ctx context.Context, c interface {
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
+	capExitHit := false
+	capExitCursor := ""
 	// extractFailureTotal accumulates per-item primary-key extraction
 	// misses across pages within this resource sync. Resource-level
 	// concurrency is 1 (one goroutine per resource via the work channel)
@@ -594,11 +596,27 @@ func syncResource(ctx context.Context, c interface {
 		// warning per paginated resource would mask real sync_anomaly /
 		// sync_error output in the same stream.
 		if maxPages > 0 && pagesFetched >= maxPages {
-			if !latestOnly {
-				if humanFriendly {
-					fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+			truncatedByCap := resourceSupportsPagination(resource) && hasMore
+			truncatedByCap = truncatedByCap && len(items) >= pageSize.limit
+			if truncatedByCap {
+				capExitCursor = nextCursor
+			}
+			if truncatedByCap && capExitCursor == "" {
+				if pageSize.cursorParam == "offset" {
+					currentOffset, _ := strconv.Atoi(cursor)
+					capExitCursor = strconv.Itoa(currentOffset + pageSize.limit)
 				} else {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					truncatedByCap = false
+				}
+			}
+			if truncatedByCap {
+				if !latestOnly {
+					capExitHit = true
+					if humanFriendly {
+						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items)\n", resource, maxPages, totalCount)
+					} else {
+						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","reason":"max_pages_cap_hit","message":"reached --max-pages cap of %d; data may be truncated. Re-run with --max-pages 0 (unlimited) or higher to verify."}`+"\n", resource, maxPages)
+					}
 				}
 			}
 			break
@@ -649,8 +667,13 @@ func syncResource(ctx context.Context, c interface {
 		cursor = nextCursor
 	}
 
-	// Final sync state: clear cursor (sync is complete), update count
-	_ = db.SaveSyncState(resource, "", totalCount)
+	// Final sync state: clear cursor on natural completion, but preserve the
+	// resume cursor when an operator intentionally capped the page budget.
+	finalCursor := ""
+	if capExitHit {
+		finalCursor = capExitCursor
+	}
+	_ = db.SaveSyncState(resource, finalCursor, totalCount)
 
 	// F4b symptom probe: if items were consumed and successfully
 	// extracted (extractFailures < consumed) but nothing landed in


### PR DESCRIPTION
## Summary

Generated sync now preserves a resume cursor when `--max-pages` truly truncates a paginated run, so repeated budget-capped syncs advance instead of restarting from page 1. Natural completion still clears the cursor, including the boundary where `--max-pages` equals the final page count.

This applies the cap-aware final cursor behavior to REST and GraphQL sync paths. `--latest-only` refreshes continue to avoid preserving cap cursors.

## Output Contract

- REST sync records a cap cursor only when the response indicates more data remains.
- GraphQL sync records a cap cursor only when `hasNextPage` and `endCursor` indicate a real next page.
- Generated runtime tests cover capped resume and exact-final-page clearing for REST and GraphQL.
- Generated REST `sync.go` golden fixtures reflect the new emitted shape.

## Verification

- `go test ./internal/generator -run 'TestGeneratedSyncMaxPagesAndStickyCursor|TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`

Closes #2415
