### PR TITLE
fix(cli): exclude scalar-array and sampler endpoints from sync selection

### DIFF
--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -482,12 +482,15 @@ func Profile(s *spec.APISpec) *APIProfile {
 				} else if standaloneList {
 					addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
 				}
-			} else if method == "GET" && (!strings.Contains(endpoint.Path, "{") || pathParamsAllTemplateVars(endpoint.Path, s)) && !hasRequiredScopeParams(endpoint) && looksLikeCollectionEndpoint(endpointNameLower) {
+			} else if method == "GET" && (!strings.Contains(endpoint.Path, "{") || pathParamsAllTemplateVars(endpoint.Path, s)) && !hasRequiredScopeParams(endpoint) && looksLikeCollectionEndpoint(endpointNameLower) && !isSamplerEndpoint(endpoint) && !isScalarItemArray(endpoint.Response) {
 				// Catch-all for simple GET collection endpoints that isListEndpoint
 				// didn't recognise (e.g., response is an untyped object with no
 				// wrapper field defined in the spec's types map).
 				// Only include endpoints whose name suggests a collection (list, all,
 				// index, etc.) — exclude singular getters like "get" or "show".
+				// Re-apply the sampler and scalar-array guards here: this branch runs
+				// when isListEndpoint returned false, so without them a collection-named
+				// sampler/scalar-array endpoint would be re-admitted past those gates.
 				addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
 			}
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -857,8 +857,38 @@ func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
 	return false
 }
 
+// samplerPathSegments mark endpoints that return a non-deterministic sample
+// rather than a stable, ordered collection. Each call yields a fresh full set,
+// so page-based pagination never reaches a natural end and a sync loop runs
+// forever. They are excluded from syncable list selection.
+var samplerPathSegments = []string{"random", "shuffle", "sample"}
+
+// isSamplerEndpoint reports whether the endpoint path marks a non-deterministic
+// sampler (e.g. /assets/random) that must not be treated as a paginated list.
+func isSamplerEndpoint(endpoint spec.Endpoint) bool {
+	for _, segment := range staticPathSegments(endpoint.Path) {
+		if slices.Contains(samplerPathSegments, strings.ToLower(segment)) {
+			return true
+		}
+	}
+	return false
+}
+
 func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
 	method := strings.ToUpper(endpoint.Method)
+
+	// A sampler endpoint returns a fresh random page every call; paginating it
+	// never terminates. Exclude it regardless of response shape or pagination.
+	if isSamplerEndpoint(endpoint) {
+		return false
+	}
+
+	// An array of scalars has no extractable primary key, so it can never
+	// populate the store. Exclude it even when paginated, since the
+	// Pagination short-circuit below would otherwise admit it.
+	if isScalarItemArray(endpoint.Response) {
+		return false
+	}
 
 	if method == "POST" {
 		return endpoint.Pagination != nil &&
@@ -879,8 +909,29 @@ func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.T
 	return looksLikeBasicGetListEndpoint(strings.ToLower(name))
 }
 
+// scalarItemTypes are the response-array element type names the parser emits
+// for primitive (non-object) items via schemaTypeName. An array of these has no
+// extractable primary key, so syncing it stores zero rows
+// (all_items_failed_id_extraction). The empty string is excluded: an unset Item
+// means an object array whose type was not registered, which still syncs.
+var scalarItemTypes = map[string]bool{
+	"string": true,
+	"int":    true,
+	"bool":   true,
+	"float":  true,
+}
+
+// isScalarItemArray reports whether the response is an array whose declared
+// element type is a primitive. Such arrays carry no object IDs and must not be
+// selected as syncable list resources.
+func isScalarItemArray(response spec.ResponseDef) bool {
+	return response.Type == "array" && scalarItemTypes[response.Item]
+}
+
 func hasListShapedResponse(name string, endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
 	if endpoint.Response.Type == "array" {
+		// Scalar-element arrays are rejected upstream in isListEndpoint; a
+		// bare object array is list-shaped.
 		return true
 	}
 

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2621,3 +2621,77 @@ func TestProfileMixedPlaceholdersNotPromoted(t *testing.T) {
 	assert.NotContains(t, flatNames, "messages",
 		"a path containing {channel_id} alongside the template var must not flatten into SyncableResources")
 }
+
+// TestProfileExcludesScalarArrayAndSamplerEndpoints covers two profiler
+// selection bugs: a scalar-element array (no extractable ID -> empty store) and
+// a non-deterministic sampler (paginating it loops forever) must not become
+// syncable resources, while a sibling object-array list on the same resource
+// still syncs.
+func TestProfileExcludesScalarArrayAndSamplerEndpoints(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "media",
+		Resources: map[string]spec.Resource{
+			"assets": {
+				Endpoints: map[string]spec.Endpoint{
+					// Valid object-array list — must remain syncable.
+					"list": {
+						Method:   "GET",
+						Path:     "/assets",
+						Response: spec.ResponseDef{Type: "array", Item: "Asset"},
+					},
+					// Non-deterministic sampler — must be excluded even though
+					// the response is a valid object array.
+					"random": {
+						Method:   "GET",
+						Path:     "/assets/random",
+						Response: spec.ResponseDef{Type: "array", Item: "Asset"},
+					},
+				},
+			},
+			"view": {
+				Endpoints: map[string]spec.Endpoint{
+					// Array of scalar strings — no extractable ID, must be excluded.
+					"unique-paths": {
+						Method:   "GET",
+						Path:     "/view/folder/unique-paths",
+						Response: spec.ResponseDef{Type: "array", Item: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	var names []string
+	for _, r := range profile.SyncableResources {
+		names = append(names, r.Name)
+	}
+
+	assert.Contains(t, names, "assets",
+		"a valid object-array list endpoint must stay syncable")
+	assert.NotContains(t, names, "assets-random",
+		"a /random sampler endpoint must not be selected as a syncable list (it never terminates under pagination)")
+	assert.NotContains(t, names, "view",
+		"an array-of-scalars endpoint must not be selected as a syncable list (no extractable primary key)")
+}
+
+func TestIsScalarItemArray(t *testing.T) {
+	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "string"}))
+	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "int"}))
+	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "bool"}))
+	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "float"}))
+	// Empty Item means an unregistered object array, which still syncs.
+	assert.False(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: ""}))
+	assert.False(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "Asset"}))
+	assert.False(t, isScalarItemArray(spec.ResponseDef{Type: "object", Item: "string"}))
+}
+
+func TestIsSamplerEndpoint(t *testing.T) {
+	assert.True(t, isSamplerEndpoint(spec.Endpoint{Path: "/assets/random"}))
+	assert.True(t, isSamplerEndpoint(spec.Endpoint{Path: "/photos/shuffle"}))
+	assert.True(t, isSamplerEndpoint(spec.Endpoint{Path: "/tracks/sample"}))
+	assert.False(t, isSamplerEndpoint(spec.Endpoint{Path: "/assets"}))
+	// "random" must match as a whole path segment, not a substring of another word.
+	assert.False(t, isSamplerEndpoint(spec.Endpoint{Path: "/randomizer-configs"}))
+}


### PR DESCRIPTION
## Intent

The profiler selected two classes of endpoint as syncable list resources that break `sync` in the printed CLI (both observed in the Immich CLI, both generic — not Immich-specific):

- **Scalar-element arrays** (`GET /view/folder/unique-paths` → array of strings): no extractable primary key, so 100% of items fail ID extraction and 0 rows land (`all_items_failed_id_extraction`).
- **Random/sampler endpoints** (`GET /assets/random`): returns a fresh full page every call; combined with the page-int pagination fallback the sync loop never terminates (endless `sync_progress`).

Issue: Closes #2546

## Approach

Both fixes gate at the top of `isListEndpoint` (`internal/profiler/profiler.go`), so the paginated and non-paginated selection paths are both covered in one place:

- `isScalarItemArray` — rejects an `array` response whose `Item` is a scalar type name (`string`/`int`/`bool`/`float`). The parser already emits these literals for primitive-element arrays via `schemaTypeName`. An **empty** `Item` (unregistered object array) is deliberately not rejected, so existing object-array list endpoints are unaffected.
- `isSamplerEndpoint` — rejects endpoints whose path has a `random`/`shuffle`/`sample` segment (whole-segment match, so `/randomizer-configs` is not caught).

## Scope

Primary area: profiler list-endpoint selection (`internal/profiler/profiler.go`).

Why this belongs in this repo: machine change. The symptom appears in printed CLIs' `sync`, but the cause is the generator's profiler choosing non-collection endpoints as syncable resources. Fixing it here prevents every future CLI from mis-syncing scalar-array and sampler endpoints.

## Catalog Justification

N/A

## Risk

Low. The guards only exclude endpoints that could never sync correctly today (scalar arrays store nothing; samplers loop forever). Object-array lists, wrapper-object lists, and empty-`Item` arrays are untouched. `scripts/golden.sh verify` passes with no fixture changes, confirming no existing golden spec has these shapes — the change is inert for all current cases.

## Output Contract

Generator/profiler change. Evidence:
- New profiler unit tests: an end-to-end `Profile()` case asserting a valid object-array list stays syncable while `assets-random` (sampler) and `view` (scalar array) are excluded, plus `isScalarItemArray` / `isSamplerEndpoint` unit tests with negative cases.
- `scripts/golden.sh verify` — pass, 25 cases, no diff.
- `scripts/verify-generator-output.sh` — pass, 5 forks tidy + build.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — pass (25 cases, no changes)
- `scripts/verify-generator-output.sh` — pass (5 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
