### PR TITLE
fix(cli): ASCII-fold in CamelIdentifier so non-ASCII names don't corrupt identifiers

### DIFF
--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -191,7 +191,12 @@ func JoinFlag(prefix, name string) string {
 // CamelIdentifier converts a public or wire name into the CamelCase identifier
 // suffix used by generated Go variables and structs.
 func CamelIdentifier(s string) string {
-	s = strings.TrimLeft(s, "$")
+	// ASCII-fold first, like the other identifier producers here
+	// (SnakeIdentifier, EnvPrefix, Snake): this keeps generated identifiers
+	// ASCII and makes the first-byte slicing below safe, so accented or
+	// non-Latin names ("éclair", "東京") fold to clean identifiers instead of
+	// being sliced mid-codepoint.
+	s = ASCIIFold(strings.TrimLeft(s, "$"))
 	parts := strings.FieldsFunc(s, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -95,6 +95,29 @@ func TestEnvPrefix(t *testing.T) {
 	}
 }
 
+func TestCamelIdentifier(t *testing.T) {
+	tests := map[string]string{
+		// ASCII inputs are unaffected by the fold (fast path), so existing
+		// generated identifiers are unchanged.
+		"user_name": "UserName",
+		"user-id":   "UserId",
+		"$ref":      "Ref",
+		"123abc":    "V123abc",
+		"":          "",
+		// Non-ASCII names fold to clean ASCII identifiers instead of being
+		// sliced mid-codepoint (the prior byte-indexed bug corrupted these).
+		"éclair":  "Eclair",
+		"café_id": "CafeId",
+		"東京":      "DongJing",
+		"русский": "Russkii",
+	}
+	for input, want := range tests {
+		if got := CamelIdentifier(input); got != want {
+			t.Fatalf("CamelIdentifier(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestASCIIFold(t *testing.T) {
 	tests := map[string]string{
 		"":              "",


### PR DESCRIPTION
## Problem

`internal/naming.CamelIdentifier` is the only identifier producer in the package that does **not** ASCII-fold its input. Its siblings — `SnakeIdentifier`, `EnvPrefix`, `Snake`, `Slug` — all call `ASCIIFold` first, which the `ASCIIFold` doc comment names as *the* chokepoint for turning spec strings into Go identifiers.

Skipping the fold left it capitalizing via `p[:1]` (first **byte**) and testing `result[0]` (first byte) for the leading-letter rule. A multi-byte leading rune was sliced mid-codepoint, so a spec field/param/enum name like `éclair` or `東京` produced a **corrupted, invalid-UTF-8 Go identifier** in generated code.

Affected call sites: `internal/spec/spec.go` (`templateVar…` fields), `internal/paramnames/body.go` (param idents), `internal/generator/generator.go` (the `camelIdentifier` template helper).

## Fix

Fold first, exactly like the siblings:

| input | before | after |
|---|---|---|
| `éclair` | corrupted bytes | `Eclair` |
| `café_id` | corrupted bytes | `CafeId` |
| `東京` | corrupted bytes | `DongJing` |
| `user_name` | `UserName` | `UserName` (unchanged) |

`ASCIIFold` has a pure-ASCII fast path, so every existing ASCII spec is byte-for-byte unchanged.

## Verification

- `go test ./...` — green
- `scripts/golden.sh verify` — 25 cases, **no diff** (confirms ASCII output unchanged)
- `scripts/verify-generator-output.sh` — 5 cases pass
- New `TestCamelIdentifier` covering ASCII (unchanged), folded non-ASCII, leading-digit `V` prefix, and `$` trim
- Found via automated review; clawpatch revalidate → `fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)