### PR TITLE
fix(cli): resolve GraphQL custom root operation types

### DIFF
--- a/internal/graphql/parser.go
+++ b/internal/graphql/parser.go
@@ -64,8 +64,18 @@ func ParseSDLBytes(source string, data []byte) (*spec.APISpec, error) {
 // IsGraphQLSDL checks if the data looks like a GraphQL schema.
 func IsGraphQLSDL(data []byte) bool {
 	s := string(data)
-	return strings.Contains(s, "type Query") || strings.Contains(s, "type Mutation") ||
-		(strings.Contains(s, "type ") && strings.Contains(s, "scalar "))
+	if strings.Contains(s, "type Query") || strings.Contains(s, "type Mutation") {
+		return true
+	}
+	// A `schema { query: ... }` block that maps a root operation is an
+	// unambiguous GraphQL schema definition even when the schema aliases its
+	// roots and defines no scalars. Requiring the operation mapping (not just
+	// the keyword) keeps a literal "schema {" inside an OpenAPI description
+	// from being misclassified.
+	if m := schemaBlockRE.FindStringSubmatch(s); m != nil && schemaOpRE.MatchString(m[1]) {
+		return true
+	}
+	return strings.Contains(s, "type ") && strings.Contains(s, "scalar ")
 }
 
 func parseSDLContent(source, raw string) (*spec.APISpec, error) {
@@ -174,6 +184,13 @@ func parseSDLContent(source, raw string) (*spec.APISpec, error) {
 	}
 
 	for _, typ := range types {
+		// Custom root operation types (resolved above) are not entity types;
+		// suppress them the same way shouldExposeType suppresses the
+		// conventional Query/Mutation names so they don't leak into the
+		// generated type catalogue.
+		if typ.Name == queryRootName || typ.Name == mutationRootName {
+			continue
+		}
 		if !shouldExposeType(typ.Name, typ.Kind) {
 			continue
 		}

--- a/internal/graphql/parser.go
+++ b/internal/graphql/parser.go
@@ -21,6 +21,12 @@ var (
 	blockRE    = regexp.MustCompile(`(?s)\b(type|input|enum)\s+([A-Za-z_][A-Za-z0-9_]*)[^{=]*\{(.*?)\}`)
 	fieldRE    = regexp.MustCompile(`(?s)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\((.*)\))?\s*:\s*([A-Za-z0-9_\[\]!]+)`)
 	scalarRE   = regexp.MustCompile(`(?m)^\s*scalar\s+([A-Za-z_][A-Za-z0-9_]*)\s*$`)
+	// schemaBlockRE captures the body of a top-level `schema { ... }` block.
+	// The `[^{:}]*` between the keyword and the brace forbids a colon so a
+	// field literally named `schema` (e.g. `schema: String`) cannot be
+	// mistaken for the schema definition.
+	schemaBlockRE = regexp.MustCompile(`(?s)\bschema\b[^{:}]*\{(.*?)\}`)
+	schemaOpRE    = regexp.MustCompile(`(?m)^\s*(query|mutation|subscription)\s*:\s*([A-Za-z_][A-Za-z0-9_]*)`)
 )
 
 type gqlType struct {
@@ -114,8 +120,12 @@ func parseSDLContent(source, raw string) (*spec.APISpec, error) {
 	}
 
 	connectionEntities := detectConnections(types)
-	queryType := types["Query"]
-	mutationType := types["Mutation"]
+	queryRootName, mutationRootName := rootOperationTypes(cleaned)
+	queryType, hasQuery := types[queryRootName]
+	mutationType, hasMutation := types[mutationRootName]
+	if !hasQuery && !hasMutation {
+		return nil, fmt.Errorf("no GraphQL root operation types found: looked for query type %q and mutation type %q; define them or map them with a `schema { query: ... }` block", queryRootName, mutationRootName)
+	}
 	resourceEntities := map[string]struct{}{}
 
 	for _, field := range queryType.Fields {
@@ -184,6 +194,29 @@ func stripSDLComments(s string) string {
 	s = docBlockRE.ReplaceAllString(s, "")
 	s = commentRE.ReplaceAllString(s, "")
 	return s
+}
+
+// rootOperationTypes resolves the query and mutation root type names. GraphQL
+// lets a `schema { query: X mutation: Y }` block alias the roots to arbitrary
+// type names; absent that block the roots default to the conventional
+// Query/Mutation. Resolving these rather than hard-coding "Query"/"Mutation"
+// is what lets a schema with aliased roots produce resources instead of an
+// empty API.
+func rootOperationTypes(cleaned string) (queryName, mutationName string) {
+	queryName, mutationName = "Query", "Mutation"
+	block := schemaBlockRE.FindStringSubmatch(cleaned)
+	if block == nil {
+		return queryName, mutationName
+	}
+	for _, op := range schemaOpRE.FindAllStringSubmatch(block[1], -1) {
+		switch op[1] {
+		case "query":
+			queryName = op[2]
+		case "mutation":
+			mutationName = op[2]
+		}
+	}
+	return queryName, mutationName
 }
 
 func parseSDLTypes(s string) (map[string]gqlType, map[string]struct{}, error) {

--- a/internal/graphql/parser_test.go
+++ b/internal/graphql/parser_test.go
@@ -150,6 +150,23 @@ func TestParseSDLCustomRootOperations(t *testing.T) {
 	assert.Equal(t, "GET", get.Method)
 	require.Len(t, get.Params, 1)
 	assert.Equal(t, "id", get.Params[0].Name)
+
+	// Custom root operation types are not entity types and must not leak into
+	// the generated type catalogue, just as conventional Query/Mutation don't.
+	assert.NotContains(t, parsed.Types, "RootQuery")
+	assert.NotContains(t, parsed.Types, "RootMutation")
+	assert.Contains(t, parsed.Types, "Widget")
+}
+
+func TestIsGraphQLSDLDetectsCustomRootSchema(t *testing.T) {
+	// A custom-root schema with no scalars and no `type Query`/`type Mutation`
+	// is still GraphQL SDL by virtue of its schema-operation mapping.
+	customRoot := []byte("schema {\n  query: RootQuery\n}\n\ntype RootQuery {\n  viewer: User!\n}\n")
+	assert.True(t, IsGraphQLSDL(customRoot), "custom-root schema block should be detected")
+
+	// Conventional and clearly-non-GraphQL inputs are unchanged.
+	assert.True(t, IsGraphQLSDL([]byte("type Query {\n  me: User\n}\n")))
+	assert.False(t, IsGraphQLSDL([]byte(`{"openapi":"3.0.0","paths":{"/x":{"get":{"responses":{}}}}}`)))
 }
 
 func TestParseSDLMissingRootOperations(t *testing.T) {

--- a/internal/graphql/parser_test.go
+++ b/internal/graphql/parser_test.go
@@ -95,6 +95,81 @@ type IssueArchivePayload {
 scalar DateTime
 `
 
+const customRootSDL = `
+schema {
+  query: RootQuery
+  mutation: RootMutation
+}
+
+type RootQuery {
+  widgets(first: Int, after: String): WidgetConnection!
+  widget(id: String!): Widget!
+}
+
+type RootMutation {
+  widgetCreate(input: WidgetCreateInput!): WidgetPayload!
+}
+
+type Widget {
+  id: ID!
+  name: String!
+}
+
+type WidgetConnection {
+  nodes: [Widget!]!
+  pageInfo: PageInfo!
+}
+
+type WidgetCreateInput {
+  name: String!
+}
+
+type WidgetPayload {
+  widget: Widget
+}
+
+scalar DateTime
+`
+
+func TestParseSDLCustomRootOperations(t *testing.T) {
+	parsed, err := ParseSDLBytes("widgets-schema.graphql", []byte(customRootSDL))
+	require.NoError(t, err)
+
+	// Roots aliased via `schema { query: RootQuery ... }` must still yield
+	// resources rather than parsing as an empty API.
+	require.NotEmpty(t, parsed.Resources)
+
+	widgets := parsed.Resources["widgets"]
+	require.NotNil(t, widgets.Endpoints)
+
+	list := widgets.Endpoints["list"]
+	assert.Equal(t, "GET", list.Method)
+	require.NotNil(t, list.Pagination)
+
+	get := widgets.Endpoints["get"]
+	assert.Equal(t, "GET", get.Method)
+	require.Len(t, get.Params, 1)
+	assert.Equal(t, "id", get.Params[0].Name)
+}
+
+func TestParseSDLMissingRootOperations(t *testing.T) {
+	// A schema block that aliases the query root to a type that is never
+	// defined has no discoverable operations; the parser must say so clearly
+	// instead of emitting an empty spec.
+	const sdl = `
+schema {
+  query: RootQuery
+}
+
+type Widget {
+  id: ID!
+}
+`
+	_, err := ParseSDLBytes("broken-schema.graphql", []byte(sdl))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GraphQL root operation types found")
+}
+
 func TestParseSDLContent(t *testing.T) {
 	parsed, err := ParseSDLBytes("linear-schema.graphql", []byte(testSDL))
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

The SDL parser hard-coded the query/mutation root type names (`parseSDLContent`: `types["Query"]` / `types["Mutation"]`) and never parsed the optional top-level `schema { ... }` definition. GraphQL lets a schema alias its roots:

```graphql
schema { query: RootQuery mutation: RootMutation }
type RootQuery { ... }
```

A valid schema using aliased root names discovered **zero operations** and parsed as an empty API (then failed `APISpec.Validate` with an opaque message).

## Fix

- Add `rootOperationTypes(cleaned)` to parse the `schema { ... }` block and resolve the query/mutation root type names, defaulting to the conventional `Query`/`Mutation` when the block (or an operation) is absent.
- Use the resolved names for the resource walk instead of the hard-coded literals.
- When neither resolved root type is defined, return a clear error naming what it looked for, instead of emitting an empty spec.
- The schema-block regex forbids a colon between the keyword and the brace, so a field literally named `schema` (e.g. `schema: String`) can't be mistaken for the definition.

## Verification

- `go test ./...` — green (incl. new `TestParseSDLCustomRootOperations` + `TestParseSDLMissingRootOperations`)
- Existing `TestParseSDLContent` (conventional `type Query`/`type Mutation`) still passes — defaults unchanged
- `scripts/golden.sh verify` — 25 cases, no diff
- `scripts/verify-generator-output.sh` — 5 cases pass, incl. `generate-graphql-shared-endpoint`
- `golangci-lint run ./internal/graphql/` — 0 issues
- Found via automated review; clawpatch revalidate → `fixed`

Related (closed, distinct): #910, #669 cover other GraphQL generation gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)