### PR TITLE
fix(cli): re-inject lost registrations into their source function

### DIFF
--- a/internal/pipeline/regenmerge/apply.go
+++ b/internal/pipeline/regenmerge/apply.go
@@ -176,7 +176,7 @@ func Apply(report *MergeReport, opts Options) error {
 	for i := range report.LostRegistrations {
 		lr := &report.LostRegistrations[i]
 		hostPath := filepath.Join(tempDir, lr.HostFile)
-		if err := injectAddCommands(hostPath, lr.Calls); err != nil {
+		if err := injectAddCommands(hostPath, lr.Calls, lr.EnclosingFunc); err != nil {
 			cleanup()
 			return fmt.Errorf("injecting AddCommand into %s: %w", lr.HostFile, err)
 		}
@@ -257,14 +257,17 @@ func readModulePaths(pubDir, freshDir string) (string, string, error) {
 }
 
 // injectAddCommands appends the given AddCommand call expressions to a
-// host file just before the trailing `return ...` statement of the function
+// host file just before the trailing `return ...` statement of the target
+// function. When enclosingFunc is set, the calls go into the function of that
+// name (so a lost call lands back in the function it came from even when a
+// host has more than one registration function); when it is empty (plans
+// produced before the field existed), it falls back to the first function
 // that already contains AddCommand calls.
 //
 // Uses dave/dst to preserve comments and formatting on the surrounding
-// code. If the host file's structure doesn't match expectations (no
-// `Execute` / cobra-Command-returning function, no existing AddCommand
-// calls), the function returns an error so the caller surfaces a warning.
-func injectAddCommands(hostPath string, calls []string) error {
+// code. If the target function can't be found, the function returns an error
+// so the caller surfaces a warning rather than silently misplacing the calls.
+func injectAddCommands(hostPath string, calls []string, enclosingFunc string) error {
 	if len(calls) == 0 {
 		return nil
 	}
@@ -278,17 +281,19 @@ func injectAddCommands(hostPath string, calls []string) error {
 		return fmt.Errorf("parsing %s: %w", hostPath, err)
 	}
 
-	// Find the function containing AddCommand calls. Inject the new calls
-	// just before that function's trailing return statement (or at the end
-	// of its body if no trailing return).
+	// Find the target function. Inject the new calls just before its trailing
+	// return statement (or at the end of its body if no trailing return).
 	injected := false
 	dst.Inspect(file, func(n dst.Node) bool {
 		fn, ok := n.(*dst.FuncDecl)
 		if !ok || fn.Body == nil {
 			return true
 		}
-		// Does this function have any AddCommand call?
-		if !slices.ContainsFunc(fn.Body.List, isAddCommandStmt) {
+		if enclosingFunc != "" {
+			if fn.Name.Name != enclosingFunc {
+				return true
+			}
+		} else if !slices.ContainsFunc(fn.Body.List, isAddCommandStmt) {
 			return true
 		}
 
@@ -317,6 +322,9 @@ func injectAddCommands(hostPath string, calls []string) error {
 	})
 
 	if !injected {
+		if enclosingFunc != "" {
+			return fmt.Errorf("function %q not found in %s for AddCommand re-injection", enclosingFunc, hostPath)
+		}
 		return fmt.Errorf("no function with AddCommand calls found in %s", hostPath)
 	}
 

--- a/internal/pipeline/regenmerge/coverage_test.go
+++ b/internal/pipeline/regenmerge/coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,10 +98,72 @@ func TestInjectAddCommandsFailsWithoutHostFn(t *testing.T) {
 	hostPath := filepath.Join(t.TempDir(), "no_host_fn.go")
 	require.NoError(t, os.WriteFile(hostPath, []byte("package cli\n\nfunc unrelated() {}\n"), 0o644))
 
-	err := injectAddCommands(hostPath, []string{"cmd.AddCommand(newFooCmd(flags))"})
+	err := injectAddCommands(hostPath, []string{"cmd.AddCommand(newFooCmd(flags))"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no function with AddCommand",
 		"missing host function must surface as a clear error")
+}
+
+// TestInjectAddCommandsTargetsEnclosingFunc verifies a lost call is re-injected
+// into the named function, not the first AddCommand-bearing one, when a host
+// file has more than one registration function.
+func TestInjectAddCommandsTargetsEnclosingFunc(t *testing.T) {
+	t.Parallel()
+
+	host := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newAlphaCmd())
+	registerExtras(rootCmd)
+	_ = rootCmd.Execute()
+}
+
+func registerExtras(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(newBetaCmd())
+}
+`
+	hostPath := filepath.Join(t.TempDir(), "root.go")
+	require.NoError(t, os.WriteFile(hostPath, []byte(host), 0o644))
+
+	require.NoError(t, injectAddCommands(hostPath, []string{"rootCmd.AddCommand(newGammaCmd())"}, "registerExtras"))
+
+	out, err := os.ReadFile(hostPath)
+	require.NoError(t, err)
+	src := string(out)
+
+	extrasIdx := strings.Index(src, "func registerExtras")
+	require.GreaterOrEqual(t, extrasIdx, 0)
+	execBlock := src[strings.Index(src, "func Execute"):extrasIdx]
+	assert.NotContains(t, execBlock, "newGammaCmd",
+		"new call must not land in the first AddCommand-bearing function")
+	assert.Contains(t, src[extrasIdx:], "newGammaCmd",
+		"new call must land in the named function")
+}
+
+// TestInjectAddCommandsMissingEnclosingFuncErrors verifies a hard error (rather
+// than silent misplacement) when the recorded function is absent from the host.
+func TestInjectAddCommandsMissingEnclosingFuncErrors(t *testing.T) {
+	t.Parallel()
+
+	host := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newAlphaCmd())
+}
+`
+	hostPath := filepath.Join(t.TempDir(), "root.go")
+	require.NoError(t, os.WriteFile(hostPath, []byte(host), 0o644))
+
+	err := injectAddCommands(hostPath, []string{"rootCmd.AddCommand(newBetaCmd())"}, "registerExtras")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registerExtras")
+	assert.Contains(t, err.Error(), "not found")
 }
 
 // TestMergeReportJSONShapeStable pins the JSON contract for the agent surface.

--- a/internal/pipeline/regenmerge/coverage_test.go
+++ b/internal/pipeline/regenmerge/coverage_test.go
@@ -143,6 +143,43 @@ func registerExtras(rootCmd *cobra.Command) {
 		"new call must land in the named function")
 }
 
+// TestInjectAddCommandsIntoEmptyFunc covers the primary real-world shape: the
+// fresh generator emitted the registration function with an empty body (the
+// lost call was the only thing in it). Injection must still place the call
+// inside that function, exercising the insertAt path for a zero-length body.
+func TestInjectAddCommandsIntoEmptyFunc(t *testing.T) {
+	t.Parallel()
+
+	host := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newAlphaCmd())
+	registerExtras(rootCmd)
+	_ = rootCmd.Execute()
+}
+
+func registerExtras(rootCmd *cobra.Command) {
+}
+`
+	hostPath := filepath.Join(t.TempDir(), "root.go")
+	require.NoError(t, os.WriteFile(hostPath, []byte(host), 0o644))
+
+	require.NoError(t, injectAddCommands(hostPath, []string{"rootCmd.AddCommand(newGammaCmd())"}, "registerExtras"))
+
+	out, err := os.ReadFile(hostPath)
+	require.NoError(t, err)
+	src := string(out)
+
+	extrasIdx := strings.Index(src, "func registerExtras")
+	require.GreaterOrEqual(t, extrasIdx, 0)
+	execBlock := src[strings.Index(src, "func Execute"):extrasIdx]
+	assert.NotContains(t, execBlock, "newGammaCmd", "call must not land in Execute")
+	assert.Contains(t, src[extrasIdx:], "newGammaCmd", "call must land in the emptied registerExtras")
+}
+
 // TestInjectAddCommandsMissingEnclosingFuncErrors verifies a hard error (rather
 // than silent misplacement) when the recorded function is absent from the host.
 func TestInjectAddCommandsMissingEnclosingFuncErrors(t *testing.T) {

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -101,7 +101,7 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 				continue
 			}
 			hostPath := filepath.Join(freshDir, lr.HostFile)
-			if err := injectAddCommands(hostPath, lr.Calls); err != nil {
+			if err := injectAddCommands(hostPath, lr.Calls, lr.EnclosingFunc); err != nil {
 				return fmt.Errorf("re-injecting AddCommand into %s: %w", lr.HostFile, err)
 			}
 			lr.Applied = true

--- a/internal/pipeline/regenmerge/regenmerge.go
+++ b/internal/pipeline/regenmerge/regenmerge.go
@@ -136,6 +136,14 @@ type LostRegistration struct {
 	// internal/cli/category.go.
 	HostFile string `json:"host_file"`
 
+	// EnclosingFunc is the name of the function the lost calls were declared
+	// in (e.g., "Execute"). Re-injection targets the same-named function in
+	// the fresh host so calls land where they belong when a host file has
+	// more than one command-registration function. Empty for plans produced
+	// before this field existed; injection then falls back to the first
+	// AddCommand-bearing function.
+	EnclosingFunc string `json:"enclosing_func,omitempty"`
+
 	// Calls are the source-form `parent.AddCommand(newX(args...))` strings
 	// for each lost registration.
 	Calls []string `json:"calls"`

--- a/internal/pipeline/regenmerge/registrations.go
+++ b/internal/pipeline/regenmerge/registrations.go
@@ -110,7 +110,14 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 		case VerdictTemplatedBodyDrift, VerdictTemplatedWithAdditions, VerdictTemplatedValueDrift, VerdictNovel, VerdictNovelCollision:
 			continue
 		}
-		var lost, skipped []string
+		// Group lost/skipped calls by the function they came from so each
+		// LostRegistration targets a single registration function. A host with
+		// one such function (the common shape) still produces exactly one
+		// registration here.
+		lostByFunc := map[string][]string{}
+		skippedByFunc := map[string][]string{}
+		var funcOrder []string
+		seenFunc := map[string]bool{}
 		for _, call := range pubCalls[host] {
 			if _, present := freshCallSet[call.normalized]; present {
 				continue
@@ -120,23 +127,31 @@ func extractLostRegistrations(publishedDir, freshDir string, pubVerdicts map[str
 					continue
 				}
 			}
+			if !seenFunc[call.enclosingFunc] {
+				seenFunc[call.enclosingFunc] = true
+				funcOrder = append(funcOrder, call.enclosingFunc)
+			}
 			// Referent check.
 			if call.constructorName != "" {
 				if _, ok := freshDeclNames[call.constructorName]; !ok {
-					skipped = append(skipped, call.source)
+					skippedByFunc[call.enclosingFunc] = append(skippedByFunc[call.enclosingFunc], call.source)
 					continue
 				}
 			}
-			lost = append(lost, call.source)
+			lostByFunc[call.enclosingFunc] = append(lostByFunc[call.enclosingFunc], call.source)
 		}
-		if len(lost) == 0 && len(skipped) == 0 {
-			continue
+		for _, fn := range funcOrder {
+			lost, skipped := lostByFunc[fn], skippedByFunc[fn]
+			if len(lost) == 0 && len(skipped) == 0 {
+				continue
+			}
+			out = append(out, LostRegistration{
+				HostFile:                  relPath,
+				EnclosingFunc:             fn,
+				Calls:                     lost,
+				SkippedForMissingReferent: skipped,
+			})
 		}
-		out = append(out, LostRegistration{
-			HostFile:                  filepath.ToSlash(filepath.Join("internal", "cli", filepath.Base(host))),
-			Calls:                     lost,
-			SkippedForMissingReferent: skipped,
-		})
 	}
 	return out, nil
 }
@@ -149,6 +164,7 @@ type addCommandCall struct {
 	normalized      string // identical-ish form for diffing across files
 	parentName      string // e.g. "rootCmd"; empty when receiver shape is unrecognized
 	constructorName string // e.g. "newCanonicalCmd"; empty when arg shape is unrecognized
+	enclosingFunc   string // name of the FuncDecl the call sits in; "" if not inside one
 }
 
 // collectAddCommandCalls walks all .go files under dir and collects calls of
@@ -185,23 +201,38 @@ func collectAddCommandCalls(dir string) (map[string][]addCommandCall, []string, 
 		}
 		var fileCalls []addCommandCall
 		var inspectErr error
-		ast.Inspect(file, func(n ast.Node) bool {
-			ce, ok := n.(*ast.CallExpr)
-			if !ok {
+		// Walk per-function so each call records its enclosing function name.
+		// Re-injection uses that name to put a lost call back into the function
+		// it came from when a host file has more than one registration
+		// function. Calls outside any FuncDecl can't be re-injected into a
+		// function anyway, so they are not collected.
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if inspectErr != nil {
+					return false
+				}
+				ce, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := ce.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil || sel.Sel.Name != "AddCommand" {
+					return true
+				}
+				call, err := formatCallExpr(fset, ce)
+				if err != nil {
+					inspectErr = err
+					return false
+				}
+				call.enclosingFunc = fn.Name.Name
+				fileCalls = append(fileCalls, call)
 				return true
-			}
-			sel, ok := ce.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel == nil || sel.Sel.Name != "AddCommand" {
-				return true
-			}
-			call, err := formatCallExpr(fset, ce)
-			if err != nil {
-				inspectErr = err
-				return false
-			}
-			fileCalls = append(fileCalls, call)
-			return true
-		})
+			})
+		}
 		if inspectErr != nil {
 			return nil, nil, fmt.Errorf("formatting AddCommand calls in %s: %w", path, inspectErr)
 		}

--- a/internal/pipeline/regenmerge/registrations_test.go
+++ b/internal/pipeline/regenmerge/registrations_test.go
@@ -120,6 +120,61 @@ func newHomesCmd() *cobra.Command { return &cobra.Command{Use: "listings"} }
 	assert.Empty(t, regs, "same parent + same Cobra Use should not produce a lost registration even when constructor names differ")
 }
 
+// TestExtractLostRegistrationsRecordsEnclosingFunc covers a host file with two
+// command-registration functions where fresh dropped the call from the second
+// one. The resulting LostRegistration must carry that function's name so
+// re-injection targets it rather than the first registration function.
+func TestExtractLostRegistrationsRecordsEnclosingFunc(t *testing.T) {
+	t.Parallel()
+
+	pubCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newAlphaCmd())
+	registerExtras(rootCmd)
+	_ = rootCmd.Execute()
+}
+
+func registerExtras(rootCmd *cobra.Command) {
+	rootCmd.AddCommand(newBetaCmd())
+}
+
+func newAlphaCmd() *cobra.Command { return &cobra.Command{Use: "alpha"} }
+func newBetaCmd() *cobra.Command { return &cobra.Command{Use: "beta"} }
+`
+	freshCLI := `package cli
+
+import "github.com/spf13/cobra"
+
+func Execute() {
+	rootCmd := &cobra.Command{Use: "x"}
+	rootCmd.AddCommand(newAlphaCmd())
+	registerExtras(rootCmd)
+	_ = rootCmd.Execute()
+}
+
+func registerExtras(rootCmd *cobra.Command) {
+}
+
+func newAlphaCmd() *cobra.Command { return &cobra.Command{Use: "alpha"} }
+func newBetaCmd() *cobra.Command { return &cobra.Command{Use: "beta"} }
+`
+	pubDir, freshDir := buildSyntheticFixture(t,
+		map[string]string{"internal/cli/root.go": pubCLI},
+		map[string]string{"internal/cli/root.go": freshCLI})
+
+	regs, err := extractLostRegistrations(pubDir, freshDir, nil)
+	require.NoError(t, err)
+	require.Len(t, regs, 1)
+	assert.Equal(t, "registerExtras", regs[0].EnclosingFunc,
+		"a lost call from the second registration function must record that function")
+	require.Len(t, regs[0].Calls, 1)
+	assert.True(t, containsConstructor(regs[0].Calls[0], "newBetaCmd"))
+}
+
 func containsConstructor(callSrc, ctorName string) bool {
 	// Hacky but adequate for tests — calls look like
 	// "rootCmd.AddCommand(newCanonicalCmd(flags))"; check the constructor


### PR DESCRIPTION
## Problem

When regen-merge restored an `AddCommand` registration that the fresh tree dropped, `injectAddCommands` inserted it before the trailing `return` of the **first** `AddCommand`-bearing function in the host file. `LostRegistration` carried only the host file — no function anchor — so when a host had **more than one** command-registration function, a call lost from the second was wrongly placed in the first.

## Fix

- `collectAddCommandCalls` records each call's enclosing `FuncDecl` name.
- `extractLostRegistrations` groups lost/skipped calls by that function and emits one `LostRegistration` per `(host, function)`.
- `injectAddCommands` targets the same-named function in the fresh host, and **hard-errors if it's absent** rather than guessing.
- `EnclosingFunc` is an additive, `omitempty` field; an empty value (plans produced before this change) keeps the prior first-function behavior.

## Why it was latent (and the regression test)

Generated CLIs register all commands in a single function (e.g. `Execute`), so the misplacement couldn't trigger on current output — the bug surfaces only with a multi-registration-function host. The postman fixture (all calls in `Execute`) still produces exactly one registration per host, so existing behavior and tests are unchanged. New tests add the multi-function case:
- `TestExtractLostRegistrationsRecordsEnclosingFunc` — a call lost from a second function records that function.
- `TestInjectAddCommandsTargetsEnclosingFunc` — the call is injected into the named function, not the first.
- `TestInjectAddCommandsMissingEnclosingFuncErrors` — absent target function → clear error.

## Verification

- `go test ./...` — green
- `scripts/golden.sh verify` — 25 cases, no diff
- `scripts/verify-generator-output.sh` — 5 cases pass
- `golangci-lint run ./internal/pipeline/regenmerge/` — 0 issues
- Found via automated review; clawpatch revalidate → `fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)