### PR TITLE
feat(catalog): add google-colab entry backed by Drive API

### DIFF
--- a/catalog/google-colab.yaml
+++ b/catalog/google-colab.yaml
@@ -1,0 +1,35 @@
+name: google-colab
+display_name: Google Colab
+description: Manage Colab notebooks stored in Google Drive (Drive API v3) - list, open, copy, and share .ipynb / colaboratory files
+category: developer-tools
+spec_url: https://api.apis.guru/v2/specs/googleapis.com/drive/v3/openapi.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: community
+spec_source: community
+verified_date: "2026-06-01"
+homepage: https://developers.google.com/drive/api/reference/rest/v3
+auth_env_vars:
+  - GOOGLE_COLAB_ACCESS_TOKEN
+auth_key_url: https://console.cloud.google.com/apis/credentials
+auth_instructions: "Use a Drive-scoped OAuth2 token: gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/drive"
+notes: |
+  Consumer Google Colab (colab.research.google.com) has no official public REST
+  API. Colab notebooks are Google Drive files with mimeType
+  application/vnd.google.colaboratory, openable in the browser at
+  https://colab.research.google.com/drive/<fileId>. This entry backs a Colab CLI
+  with the Drive API v3, the official, stable surface for managing those files.
+
+  The OpenAPI 3.0 spec is community-maintained on apis.guru, converted from
+  Google's Drive Discovery document (same provenance as google-cloud-run).
+
+  Auth is OAuth2 and the token must carry the Drive scope
+  (https://www.googleapis.com/auth/drive). A default
+  `gcloud auth print-access-token` (cloud-platform scope only) is rejected by the
+  Drive API; pass --scopes as shown in auth_instructions, or complete the
+  generated `login` OAuth flow.
+
+  Scope note: `generate google-colab` produces the Drive file/permission/comment
+  surface. The Colab-specific convenience commands (`colab list`, `colab open`)
+  are a hand-authored novel-feature layer added to the printed CLI after
+  generation, not generator output.

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -10,6 +10,7 @@ cloud:
 
 developer-tools:
   github               Software development platform API
+  google-colab         Manage Colab notebooks stored in Google Drive (Drive API v3) - list, open, copy, and share .ipynb / colaboratory files
   launchdarkly         Feature flag management - flags, environments, segments, experiments, audit logs
   postman-explore      Public API network directory for discovering community collections, workspaces, and APIs
 


### PR DESCRIPTION
## Intent

There is no catalog entry for Google Colab. Consumer Colab has no official public REST API; Colab notebooks are Google Drive files (`mimeType: application/vnd.google.colaboratory`) openable at `colab.research.google.com/drive/<fileId>`. The official, stable surface for managing them is the Drive API v3. This entry makes a Colab CLI reproducible from the catalog and corrects two derivation defaults.

Issue: Closes #2579

## Approach

Add `catalog/google-colab.yaml` backed by the apis.guru Drive v3 OpenAPI spec (same provenance as `google-cloud-run`). Use the auth-override fields to fix what the bare spec derives wrong:

- `auth_env_vars: [GOOGLE_COLAB_ACCESS_TOKEN]` — replaces the garbled `GOOGLE_COLAB_OAUTH2C` derived from the OAuth2 securityScheme name.
- `auth_key_url: https://console.cloud.google.com/apis/credentials` — replaces the generic `https://google.com` doctor fallback.
- `auth_instructions:` Drive-scoped gcloud token command (a default cloud-platform token is rejected by the Drive API).

## Scope

Primary area: catalog

Why this belongs in this repo: it adds an embedded blueprint, not a printed-CLI fix. The override trio flows through `enrichSpecFromCatalogEntry` into every future `generate` of this target.

## Catalog Justification

Embedded catalog fit: real user workflow (manage Colab notebooks in Drive), reachable maintained source (apis.guru Drive v3), reproducible generation route (community OpenAPI 3.0).

Distinct blueprint pattern: first catalog entry to exercise the `auth_env_vars` + `auth_key_url` + `auth_instructions` override trio together (cloud-run uses none of them and relies on derived defaults). Also demonstrates the product-name → different-official-API mapping (a "Colab" CLI whose real backing is the Drive API).

Closest existing entries checked: `google-cloud-run` — shares the apis.guru/Google-Discovery provenance, but is a different API (Drive vs Cloud Run), category (`developer-tools` vs `cloud`), and domain. Surfacing the overlap honestly: if maintainers consider this too close to the cloud-run sourcing pattern to warrant a second Google entry, the auth-override demonstration is the distinguishing value; happy to convert to docs/example instead.

Source provenance: `https://api.apis.guru/v2/specs/googleapis.com/drive/v3/openapi.yaml` (community conversion of Google's Drive Discovery doc), OpenAPI 3.0, spec_source `community`, verified 2026-06-01.

Auth and tenant assumptions: OAuth2; token must carry the Drive scope (`https://www.googleapis.com/auth/drive`). No tenant/region/base-URL assumptions (spec carries `servers:`).

Safe default surface: read + standard file/permission/comment CRUD from the Drive spec. No novel side-effect commands are generator output.

Generation path: `generate --spec https://api.apis.guru/v2/specs/googleapis.com/drive/v3/openapi.yaml --name google-colab` (entry matches by name and by spec_url).

Stale-body check: confirmed — no stale diffs, secrets, tenant data, or outdated counts in this body.

Scope note (in the entry's `notes`): `generate google-colab` reproduces the Drive surface only. The `colab list` / `colab open` convenience commands are a hand-authored novel-feature layer, not generator output — stated so the entry does not read as aspirational.

## Risk

Adding a catalog YAML changes `catalog list` rendering only. The catalog-list golden fixture is updated. No generator/template/MCP/auth-emission code changed.

## Output Contract

Catalog rendering changes: `catalog list` gains one `developer-tools` row. Evidence: `testdata/golden/expected/catalog-list/stdout.txt` updated (single added line) and `go test ./internal/catalog/...` passes. No emitted-code change.

## Verification

- Run: `go test ./internal/catalog/...` — PASS.
- Run: `cli-printing-press catalog list` — shows the entry under `developer-tools`.
- Run: generated to a throwaway dir with `--name google-colab` — confirmed emitted `config.go` uses `GOOGLE_COLAB_ACCESS_TOKEN` (not `OAUTH2C`) and `doctor.go`/`auth.go`/`helpers.go` carry the credentials URL + Drive-scoped instructions.
- `golden.sh verify` not used to update fixtures; the catalog-list fixture was edited by hand (line-ending preserved) because this Windows checkout shows pre-existing CRLF-vs-LF diffs across unrelated cases. `git diff` shows exactly one added line.
- [ ] Generator/template change: N/A — no generator or template code changed.
- [ ] Generator/template change: N/A.
- [ ] Generator/template change: N/A.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission

(Directed by the repo owner's collaborator; diff not yet line-reviewed by a human at submission time.)