### PR TITLE
ci(ci): shard full-test and shallow-clone work jobs to cut merge-queue time

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -159,16 +159,16 @@ jobs:
 
           case "${{ matrix.shard }}" in
             generator)
-              packages=(./internal/generator)
+              packages=(./internal/generator/...)
               ;;
             pipeline)
-              packages=(./internal/pipeline)
+              packages=(./internal/pipeline/...)
               ;;
             cli)
-              packages=(./internal/cli)
+              packages=(./internal/cli/...)
               ;;
             rest)
-              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)$')
+              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)(/|$)')
               ;;
             *)
               echo "unknown test shard: ${{ matrix.shard }}" >&2

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -175,16 +175,16 @@ jobs:
 
           case "${{ matrix.shard }}" in
             generator)
-              packages=(./internal/generator)
+              packages=(./internal/generator/...)
               ;;
             pipeline)
-              packages=(./internal/pipeline)
+              packages=(./internal/pipeline/...)
               ;;
             cli)
-              packages=(./internal/cli)
+              packages=(./internal/cli/...)
               ;;
             rest)
-              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)$')
+              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)(/|$)')
               ;;
             *)
               echo "unknown test shard: ${{ matrix.shard }}" >&2

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -124,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-go@v6
         with:
@@ -136,15 +136,31 @@ jobs:
         run: go build ./...
 
   full-test:
-    name: full-test
+    name: full-test (${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: classify
     if: needs.classify.outputs.needs_tests == 'true'
     timeout-minutes: 20
+    # Shard the full (non-short) suite across the same package partition
+    # lint.yml uses so the queue's speculative re-run isn't pinned to one
+    # ~12m unsharded job. The union of the four shards is `go test ./...`;
+    # sharding by package is semantically identical because `go test`
+    # already runs each package in its own binary. fail-fast: false so one
+    # shard's failure still reports the others. The aggregate result feeds
+    # `build-and-test` via needs.full-test.result, so the required check
+    # name is unchanged.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: generator
+          - shard: pipeline
+          - shard: cli
+          - shard: rest
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-go@v6
         with:
@@ -153,7 +169,35 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Test
-        run: go test -timeout 15m ./...
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ matrix.shard }}" in
+            generator)
+              packages=(./internal/generator)
+              ;;
+            pipeline)
+              packages=(./internal/pipeline)
+              ;;
+            cli)
+              packages=(./internal/cli)
+              ;;
+            rest)
+              mapfile -t packages < <(go list ./... | grep -Ev '/internal/(generator|pipeline|cli)$')
+              ;;
+            *)
+              echo "unknown test shard: ${{ matrix.shard }}" >&2
+              exit 1
+              ;;
+          esac
+
+          printf 'Testing packages:\n'
+          printf '  %s\n' "${packages[@]}"
+
+          # No -short: main-ci is the full-coverage gate, unlike lint.yml's
+          # fast -short shards.
+          go test -timeout 15m "${packages[@]}"
 
   full-golden:
     name: full-golden
@@ -164,7 +208,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-go@v6
         with:
@@ -184,7 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Problem

Merges feel slow. Real data (PR #2581): the **Mergify Merge Queue** check ran **16.1 min**, and **12.2 min of that was a single job — `full-test`** (`go test ./...`, unsharded). In draft_pr mode the queue re-runs the full suite on a speculative branch, so that one job pins merge latency.

It's also pure redundancy: `lint.yml` already shards the same suite (`test (cli)` 5.2m, `test (generator)` 3.3m). The queue was just stuck on the slow unsharded copy.

## Change

1. **Shard `full-test`** across the same partition `lint.yml` uses (`generator` / `pipeline` / `cli` / `rest`), keeping it **non-`-short`** (main-ci is the full-coverage gate). Union of the 4 shards = `go test ./...`; sharding by package is semantically identical since `go test` already runs each package in its own binary. Verified locally: 40 packages = 37 (`rest`) + 3 named, no overlap/gaps.
2. **`fetch-depth: 0 → 1`** on the work jobs (`full-build`/`full-test`/`full-golden`/`generated-output-compile`). Only `classify` needs full history for its base-ref diff; `golden.sh`'s git use (status in update-mode, config injection) is shallow-safe.

## Why it's low-risk

- Job key stays `full-test`, so `build-and-test` aggregates the legs via `needs.full-test.result` — **the required check name is unchanged**, so no `.mergify.yml` / branch-protection edit is needed.
- `actionlint` passes; `full-test` is referenced nowhere outside this file.
- main-ci self-classifies to the full suite when `main-ci.yml` changes, so this PR's own CI exercises the sharded path.

## Expected impact

Queue critical path drops from one ~12m job to the slowest non-short shard (~7–8m), trimming merge latency **~30%** (~16m → ~11m), with the same coverage. Source-PR wall-clock drops the same.

> Deliberately **not** raising `max_parallel_checks: 3→5` here — it only helps multi-PR bursts (not single-PR latency) and, combined with the added shard jobs, risks Actions concurrency saturation. Separate decision once this lands.