### PR TITLE
fix(cli): generate working dependent-resource sync for nested sub-collections

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -350,6 +350,62 @@ func TestGenerateFreshnessHelperEmitted(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli/...", "./internal/cliutil/...")
 }
 
+// TestGenerateDependentResourceInjectsParentScopeColumn reproduces the Plane
+// "fan-out stores zero rows" bug. A project-scoped child (cycles under projects)
+// yields a sub-resource table whose parent scope column (<parent>_id, here
+// projects_id) is NOT NULL, and the typed upsert reads that column from a
+// same-named item field. Plane API items carry "project", never "projects_id",
+// so unless the dependent-sync fan-out injects the scope column, every upsert
+// fails the NOT NULL constraint and the resource silently syncs zero rows.
+func TestGenerateDependentResourceInjectsParentScopeColumn(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name: "plane-fanout",
+		Resources: map[string]spec.Resource{
+			"projects": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/projects/",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "per_page"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"cycles": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/projects/{project_id}/cycles/",
+								Response:   spec.ResponseDef{Type: "array"},
+								Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "per_page"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	// The cycles sub-resource table requires a non-null projects_id scope column.
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(storeSrc), "projects_id TEXT NOT NULL",
+		"sub-resource table must declare the NOT NULL parent scope column")
+
+	// The dependent-sync fan-out must inject that scope column, or every upsert
+	// violates the NOT NULL constraint and the resource silently syncs zero rows.
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(syncSrc), `obj[dep.ParentTable+"_id"] = parentIDJSON`,
+		"fan-out must inject the parent scope column (<parent>_id) so the NOT NULL typed-upsert column is populated, not just parent_id")
+}
+
 func TestGenerateFreshnessOptOutUsesASCIIPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1166,12 +1166,20 @@ func syncDependentResource(c interface {
 				break
 			}
 
-			// Inject parent_id into each item before upserting
+			// Inject the parent linkage into each item before upserting. Two
+			// columns carry it: the generic nullable parent_id, and the typed
+			// sub-resource scope column <parent_table>_id, which buildSubResourceTable
+			// declares NOT NULL and the typed upsert reads by that name. The API
+			// item itself never carries <parent_table>_id (e.g. Plane returns
+			// "project", not "projects_id"), so without this injection every
+			// dependent upsert violates the NOT NULL constraint and the resource
+			// silently syncs zero rows.
 			for i, item := range items {
 				var obj map[string]json.RawMessage
 				if err := json.Unmarshal(item, &obj); err == nil {
 					parentIDJSON, _ := json.Marshal(parentID)
 					obj["parent_id"] = parentIDJSON
+					obj[dep.ParentTable+"_id"] = parentIDJSON
 					if modified, err := json.Marshal(obj); err == nil {
 						items[i] = modified
 					}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -357,8 +357,15 @@ func Profile(s *spec.APISpec) *APIProfile {
 						// annotations on a child path-item flow into the override
 						// and critical-resource maps. Store raw names so
 						// detectDependentResources can snake-case downstream.
+						// Multiple parameterized list endpoints can share one
+						// resource key (e.g. /projects/{project_id}/cycles/ and the
+						// nested /projects/{project_id}/cycles/{cycle_id}/cycle-issues/).
+						// Keep the most canonical collection deterministically so a
+						// deeper sub-collection — which needs an id unavailable during
+						// per-parent fan-out, and would sync zero records — never
+						// hijacks the slot via Go map iteration order.
 						key := parentName + "/" + name
-						if _, ok := parameterized[key]; !ok {
+						if existing, ok := parameterized[key]; !ok || moreCanonicalListPath(endpoint.Path, existing.meta.Path) {
 							parameterized[key] = parameterizedEntry{
 								name:       name,
 								parentName: parentName,
@@ -998,6 +1005,22 @@ func detectDependentResources(parameterized map[string]parameterizedEntry, synca
 		return deps[i].Name < deps[j].Name
 	})
 	return deps
+}
+
+// moreCanonicalListPath reports whether candidate is a better canonical list
+// path than existing for the same resource key. The most canonical collection
+// has the fewest path parameters (shallowest); ties break by shorter then
+// lexical path so the choice is deterministic regardless of Go map iteration
+// order.
+func moreCanonicalListPath(candidate, existing string) bool {
+	cp, ep := strings.Count(candidate, "{"), strings.Count(existing, "{")
+	if cp != ep {
+		return cp < ep
+	}
+	if len(candidate) != len(existing) {
+		return len(candidate) < len(existing)
+	}
+	return candidate < existing
 }
 
 // firstPathParam returns the name of the first {param} in a path template.

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -175,6 +175,70 @@ func TestProfileSiblingListEndpoints(t *testing.T) {
 	assert.Equal(t, "/portfolio/settlements", syncPaths["portfolio-settlements"])
 }
 
+// TestProfileNestedSubCollectionDoesNotHijackParentList reproduces the Plane
+// "cycles" sync bug. A resource exposes both a shallow collection list
+// (/projects/{project_id}/cycles/) and a deeper nested sub-collection
+// (/projects/{project_id}/cycles/{cycle_id}/cycle-issues/). Both are parameterized
+// list endpoints under the same resource, so they collide on one parameterized
+// key. The resource's canonical dependent-resource list MUST always be the shallow
+// collection: the deep sub-collection needs a {cycle_id} that is unavailable during
+// per-parent fan-out, so if it hijacks the slot the resource syncs zero records.
+//
+// The selection must be deterministic. Go randomizes map iteration order, so a
+// first-wins selection picks the deep path on a fraction of runs; loop to expose it.
+func TestProfileNestedSubCollectionDoesNotHijackParentList(t *testing.T) {
+	makeSpec := func() *spec.APISpec {
+		return &spec.APISpec{
+			Name: "plane",
+			Resources: map[string]spec.Resource{
+				"projects": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:     "GET",
+							Path:       "/projects/",
+							Response:   spec.ResponseDef{Type: "array"},
+							Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "per_page"},
+						},
+					},
+				},
+				"cycles": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:     "GET",
+							Path:       "/projects/{project_id}/cycles/",
+							Response:   spec.ResponseDef{Type: "array"},
+							Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "per_page"},
+						},
+						"cycle-issues": {
+							Method:     "GET",
+							Path:       "/projects/{project_id}/cycles/{cycle_id}/cycle-issues/",
+							Response:   spec.ResponseDef{Type: "array"},
+							Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "per_page"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	for i := 0; i < 50; i++ {
+		profile := Profile(makeSpec())
+
+		var cyclesPath string
+		found := false
+		for _, dr := range profile.DependentSyncResources {
+			if dr.Name == "cycles" {
+				cyclesPath = dr.Path
+				found = true
+			}
+		}
+
+		require.True(t, found, "run %d: expected a 'cycles' dependent resource", i)
+		assert.Equal(t, "/projects/{project_id}/cycles/", cyclesPath,
+			"run %d: 'cycles' must adopt the shallow collection, not the nested sub-collection", i)
+	}
+}
+
 func TestProfileDiscriminatorDispatchFromResponseTypeEnum(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-network",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1059,12 +1059,20 @@ func syncDependentResource(c interface {
 				break
 			}
 
-			// Inject parent_id into each item before upserting
+			// Inject the parent linkage into each item before upserting. Two
+			// columns carry it: the generic nullable parent_id, and the typed
+			// sub-resource scope column <parent_table>_id, which buildSubResourceTable
+			// declares NOT NULL and the typed upsert reads by that name. The API
+			// item itself never carries <parent_table>_id (e.g. Plane returns
+			// "project", not "projects_id"), so without this injection every
+			// dependent upsert violates the NOT NULL constraint and the resource
+			// silently syncs zero rows.
 			for i, item := range items {
 				var obj map[string]json.RawMessage
 				if err := json.Unmarshal(item, &obj); err == nil {
 					parentIDJSON, _ := json.Marshal(parentID)
 					obj["parent_id"] = parentIDJSON
+					obj[dep.ParentTable+"_id"] = parentIDJSON
 					if modified, err := json.Marshal(obj); err == nil {
 						items[i] = modified
 					}


### PR DESCRIPTION
## Intent

Issue: Refs #1736 (the canonical-list-selection half; this does not fully resolve it)

A spec with project-scoped nested resources (parent → child fan-out) generated a CLI whose `sync` silently wrote **zero** dependent rows. Two independent root causes, both in the generator/profiler:

1. **Non-deterministic list-endpoint selection.** When several parameterized list paths share one resource key — e.g. `/projects/{project_id}/cycles/` and the deeper `/projects/{project_id}/cycles/{cycle_id}/cycle-issues/` — Go map iteration order could let the deeper sub-collection win the slot. That sub-collection needs an id that isn't available during per-parent fan-out, so the resource synced nothing.
2. **Missing typed parent-scope column on fan-out.** `buildSubResourceTable` declares the scope column `<parent_table>_id` as `NOT NULL` and the typed upsert reads by that name, but the fan-out only injected the generic `parent_id`. The API item never carries `<parent_table>_id` (e.g. Plane returns `"project"`, not `"projects_id"`), so every dependent upsert hit `NOT NULL constraint failed` and stored nothing — silently, in non-strict mode.

## Approach

- **profiler** (`profiler.go`): add `moreCanonicalListPath` and apply it at the parameterized-list collision point. The most canonical collection is the shallowest (fewest path params); ties break by shorter then lexical path, so selection is deterministic regardless of map order.
- **sync template** (`templates/sync.go.tmpl`): during fan-out, inject `obj[dep.ParentTable+"_id"]` alongside the existing `obj["parent_id"]`, so the typed `NOT NULL` scope column is populated.

Both are general generator behavior, not specific to any one API.

## Scope

Primary area: `cli` (generator + profiler)

Why this belongs in this repo: these are bugs in the Printing Press generator/profiler that affect every spec with project-scoped nested (dependent) resources — the symptom surfaced on a printed CLI, but the cause and fix are general machine behavior, not printed-CLI-local.

## Risk

The template change adds one injection line to generated `sync.go` for dependent resources; every fan-out recipe's generated output gains that line on next regen. No documented command, flag, or manifest surface is removed or renamed. The profiler change only makes an already-existing selection deterministic (shallowest path), which is the behavior fan-out already assumed.

## Output Contract

Template change: generated `sync.go` now writes `obj[dep.ParentTable+"_id"] = parentIDJSON` in addition to `obj["parent_id"]` for dependent resources, and carries an expanded explanatory comment. The `generate-golden-api` fixture's generated `sync.go` is updated to match (the only golden whose case exercises a dependent/fan-out resource). No other golden behavior changed.

## Verification

- `go build ./...` — passes.
- `go test ./internal/profiler/ ./internal/generator/` — the two new tests (`TestProfileNestedSubCollectionDoesNotHijackParentList`, `TestGenerateDependentResourceInjectsParentScopeColumn`) pass RED→GREEN. Pre-existing failures on the author's machine are Windows-only environment issues (generated-binary exec / `%PATH%`) and are byte-identical on the unmodified tree (confirmed by stashing the change); zero new failures.
- `scripts/golden.sh update` then inspected the diff: the only behavioral change is `generate-golden-api/.../internal/cli/sync.go` (the injection line). Other regenerated diffs were Windows-only normalization artifacts (backslash paths bypassing `normalize_text`, `.exe` binary suffix, CRLF-based `spec_checksum`) and were deliberately **not** included. A clean full `scripts/golden.sh verify` cannot run on Windows for those normalization reasons; Linux CI will verify the suite.
- End-to-end sanity (downstream, self-hosted Plane): fresh generate → sync populated dependent tables with real UUID scope columns where it previously stored zero.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
