### PR TITLE
feat(catalog): add Plane project-management catalog entry

### DIFF
--- a/catalog/plane.yaml
+++ b/catalog/plane.yaml
@@ -10,7 +10,7 @@ spec_source: official
 verified_date: "2026-05-11"
 homepage: https://developers.plane.so/api-reference/introduction
 auth_key_url: https://app.plane.so/profile/api-tokens
-auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`)."
+auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`). Self-hosted base/server URL must be the full workspace prefix `https://<host>/api/v1/workspaces/<slug>`, not the bare host."
 auth_env_vars:
   - PLANE_API_KEY
 notes: >
@@ -24,4 +24,9 @@ notes: >
   In this form the profiler auto-detects the `workspace → projects → children`
   sync model with project fan-out, plus an `updated_at__gt` incremental
   since-param — a stock `generate` reproduces a working `sync` with no post-print
-  annotation. Rate limit: 60 req/min per token.
+  annotation. Because the workspace scope lives in the server URL, self-hosted
+  users must set the base/server URL to the full workspace prefix
+  `https://<host>/api/v1/workspaces/<slug>` (NOT the bare `https://<host>`); a
+  bare host resolves the relative workspace paths to the web app, which answers
+  with the SPA `index.html` at HTTP 200 instead of JSON, making `sync` silently
+  store 0 rows. Rate limit: 60 req/min per token.

--- a/catalog/plane.yaml
+++ b/catalog/plane.yaml
@@ -11,6 +11,8 @@ verified_date: "2026-05-11"
 homepage: https://developers.plane.so/api-reference/introduction
 auth_key_url: https://app.plane.so/profile/api-tokens
 auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`)."
+auth_env_vars:
+  - PLANE_API_KEY
 notes: >
   Vendored spec captured from Plane v1.3.0 CE (drf-spectacular at /api/schema/),
   which open-source Plane serves dynamically on every instance — upstream

--- a/catalog/plane.yaml
+++ b/catalog/plane.yaml
@@ -1,0 +1,25 @@
+name: plane
+display_name: Plane
+description: Open-source project management — issues, cycles, modules, sub-issues, and workspaces. A self-hostable Jira/Linear/ClickUp alternative.
+category: project-management
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/plane-spec.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: community
+spec_source: official
+verified_date: "2026-05-11"
+homepage: https://developers.plane.so/api-reference/introduction
+auth_key_url: https://app.plane.so/profile/api-tokens
+auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`)."
+notes: >
+  Vendored spec captured from Plane v1.3.0 CE (drf-spectacular at /api/schema/),
+  which open-source Plane serves dynamically on every instance — upstream
+  github.com/makeplane/plane does not publish a static OpenAPI file. The spec is
+  re-expressed so the workspace scope lives in `servers:` as a `{slug}` variable
+  (instead of being baked into every path); workspace-scoped paths are relative
+  (`/projects/{project_id}/issues/`, `/cycles/`, `/modules/`, `/labels/`,
+  `/states/`), while `/api/v1/users/` and `/api/v1/assets/` stay non-workspace.
+  In this form the profiler auto-detects the `workspace → projects → children`
+  sync model with project fan-out, plus an `updated_at__gt` incremental
+  since-param — a stock `generate` reproduces a working `sync` with no post-print
+  annotation. Rate limit: 60 req/min per token.

--- a/catalog/specs/plane-spec.yaml
+++ b/catalog/specs/plane-spec.yaml
@@ -1,0 +1,11072 @@
+openapi: 3.0.3
+info:
+  title: The Plane REST API
+  version: 0.0.1
+  description: |-
+    The Plane REST API
+
+    Visit our quick start guide and full API documentation at [developers.plane.so](https://developers.plane.so/api-reference/introduction).
+  contact:
+    name: Plane
+    url: https://plane.so
+    email: support@plane.so
+  license:
+    name: GNU AGPLv3
+    url: https://github.com/makeplane/plane/blob/preview/LICENSE.txt
+paths:
+  /api/v1/assets/user-assets/:
+    post:
+      operationId: create_user_asset_upload
+      description: Generate presigned URL for user asset upload
+      summary: Generate presigned URL for user asset upload
+      tags:
+      - Assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserAssetUploadRequest'
+            examples:
+              UserAvatarUpload:
+                value:
+                  name: profile.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_AVATAR
+                summary: User Avatar Upload
+                description: Example request for uploading a user avatar
+              UserCoverUpload:
+                value:
+                  name: cover.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_COVER
+                summary: User Cover Upload
+                description: Example request for uploading a user cover
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserAssetUploadRequest'
+            examples:
+              UserAvatarUpload:
+                value:
+                  name: profile.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_AVATAR
+                summary: User Avatar Upload
+                description: Example request for uploading a user avatar
+              UserCoverUpload:
+                value:
+                  name: cover.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_COVER
+                summary: User Cover Upload
+                description: Example request for uploading a user cover
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserAssetUploadRequest'
+            examples:
+              UserAvatarUpload:
+                value:
+                  name: profile.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_AVATAR
+                summary: User Avatar Upload
+                description: Example request for uploading a user avatar
+              UserCoverUpload:
+                value:
+                  name: cover.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  entity_type: USER_COVER
+                summary: User Cover Upload
+                description: Example request for uploading a user cover
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '200':
+          description: Presigned URL generated successfully
+        '400':
+          description: Validation error occurred with the provided data.
+    servers:
+    - url: https://api.plane.so
+  /api/v1/assets/user-assets/{asset_id}/:
+    patch:
+      operationId: update_user_asset
+      description: Mark user asset as uploaded
+      summary: Mark user asset as uploaded
+      parameters:
+      - in: path
+        name: asset_id
+        schema:
+          type: string
+          format: uuid
+        description: Asset ID
+        required: true
+        examples:
+          ExampleAssetID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example asset ID
+            description: A typical asset UUID
+      tags:
+      - Assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetUpdateRequest'
+            examples:
+              UpdateAssetAttributes:
+                value:
+                  attributes:
+                    name: updated_profile.jpg
+                    type: image/jpeg
+                    size: 1024000
+                  entity_type: USER_AVATAR
+                summary: Update Asset Attributes
+                description: Example request for updating asset attributes
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetUpdateRequest'
+            examples:
+              UpdateAssetAttributes:
+                value:
+                  attributes:
+                    name: updated_profile.jpg
+                    type: image/jpeg
+                    size: 1024000
+                  entity_type: USER_AVATAR
+                summary: Update Asset Attributes
+                description: Example request for updating asset attributes
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedAssetUpdateRequest'
+            examples:
+              UpdateAssetAttributes:
+                value:
+                  attributes:
+                    name: updated_profile.jpg
+                    type: image/jpeg
+                    size: 1024000
+                  entity_type: USER_AVATAR
+                summary: Update Asset Attributes
+                description: Example request for updating asset attributes
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '204':
+          description: Asset updated successfully
+        '404':
+          description: The requested resource was not found.
+    delete:
+      operationId: delete_user_asset
+      description: |-
+        Delete user asset.
+
+        Delete a user profile asset (avatar or cover image) and remove its reference from the user profile.
+        This performs a soft delete by marking the asset as deleted and updating the user's profile.
+      summary: Delete user asset
+      parameters:
+      - in: path
+        name: asset_id
+        schema:
+          type: string
+          format: uuid
+        description: Asset ID
+        required: true
+        examples:
+          ExampleAssetID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example asset ID
+            description: A typical asset UUID
+      tags:
+      - Assets
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '204':
+          description: Asset deleted successfully
+        '404':
+          description: The requested resource was not found.
+    servers:
+    - url: https://api.plane.so
+  /api/v1/users/me/:
+    get:
+      operationId: get_current_user
+      description: Retrieve the authenticated user's profile information including basic details.
+      summary: Get current user
+      tags:
+      - Users
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserLite'
+              examples:
+                User:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    first_name: John
+                    last_name: Doe
+                    email: john.doe@example.com
+                    avatar: https://example.com/avatar.jpg
+                    avatar_url: https://example.com/avatar.jpg
+                    display_name: John Doe
+          description: Current user profile
+    servers:
+    - url: https://api.plane.so
+  /assets/:
+    post:
+      operationId: create_generic_asset_upload
+      description: Generate presigned URL for generic asset upload
+      summary: Generate presigned URL for generic asset upload
+      tags:
+      - Assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenericAssetUploadRequest'
+            examples:
+              GenericAssetUploadSerializer:
+                value:
+                  name: image.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  project_id: 123e4567-e89b-12d3-a456-426614174000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for uploading a generic asset
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/GenericAssetUploadRequest'
+            examples:
+              GenericAssetUploadSerializer:
+                value:
+                  name: image.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  project_id: 123e4567-e89b-12d3-a456-426614174000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for uploading a generic asset
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/GenericAssetUploadRequest'
+            examples:
+              GenericAssetUploadSerializer:
+                value:
+                  name: image.jpg
+                  type: image/jpeg
+                  size: 1024000
+                  project_id: 123e4567-e89b-12d3-a456-426614174000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for uploading a generic asset
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '200':
+          description: Presigned URL generated successfully
+        '400':
+          description: Validation error
+        '404':
+          description: The requested resource was not found.
+        '409':
+          description: Asset with same external ID already exists
+  /assets/{asset_id}/:
+    get:
+      operationId: get_generic_asset
+      description: Get presigned URL for asset download
+      summary: Get presigned URL for asset download
+      parameters:
+      - in: path
+        name: asset_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - Assets
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '200':
+          description: Presigned download URL generated successfully
+        '400':
+          description: Bad request
+        '404':
+          description: Asset not found
+    patch:
+      operationId: update_generic_asset
+      description: Update generic asset after upload completion
+      summary: Update generic asset after upload completion
+      parameters:
+      - in: path
+        name: asset_id
+        schema:
+          type: string
+          format: uuid
+        description: Asset ID
+        required: true
+        examples:
+          ExampleAssetID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example asset ID
+            description: A typical asset UUID
+      tags:
+      - Assets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedGenericAssetUpdateRequest'
+            examples:
+              GenericAssetUpdateSerializer:
+                value:
+                  is_uploaded: true
+                description: Example request for updating a generic asset
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedGenericAssetUpdateRequest'
+            examples:
+              GenericAssetUpdateSerializer:
+                value:
+                  is_uploaded: true
+                description: Example request for updating a generic asset
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedGenericAssetUpdateRequest'
+            examples:
+              GenericAssetUpdateSerializer:
+                value:
+                  is_uploaded: true
+                description: Example request for updating a generic asset
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '204':
+          description: Asset updated successfully
+        '404':
+          description: Asset not found
+  /invitations/:
+    get:
+      operationId: workspaces_invitations_list
+      description: List all workspace invites for a workspace
+      summary: List workspace invites
+      tags:
+      - workspaces
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceInvite'
+          description: Workspace invites
+    post:
+      operationId: workspaces_invitations_create
+      description: Create a workspace invite
+      summary: Create workspace invite
+      tags:
+      - workspaces
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkspaceInviteRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/WorkspaceInviteRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/WorkspaceInviteRequest'
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceInvite'
+          description: Workspace invite
+  /invitations/{pk}/:
+    get:
+      operationId: workspaces_invitations_retrieve
+      description: Get a workspace invite by ID
+      summary: Get workspace invite
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Workspace invite ID
+        required: true
+      tags:
+      - workspaces
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceInvite'
+          description: Workspace invite
+    patch:
+      operationId: workspaces_invitations_partial_update
+      description: Update a workspace invite
+      summary: Update workspace invite
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Workspace invite ID
+        required: true
+      tags:
+      - workspaces
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedWorkspaceInviteRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedWorkspaceInviteRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedWorkspaceInviteRequest'
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceInvite'
+          description: Workspace invite
+    delete:
+      operationId: workspaces_invitations_destroy
+      description: Delete a workspace invite
+      summary: Delete workspace invite
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Workspace invite ID
+        required: true
+      tags:
+      - workspaces
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '204':
+          description: Workspace invite deleted
+  /issues/{project_identifier}-{issue_identifier}/:
+    get:
+      operationId: get_workspace_work_item
+      description: Retrieve a specific work item using workspace slug, project identifier, and issue identifier.
+      summary: Retrieve work item by identifiers
+      parameters:
+      - in: path
+        name: issue_identifier
+        schema:
+          type: integer
+        description: Issue sequence ID (numeric identifier within project)
+        required: true
+        examples:
+          ExampleIssueIdentifier:
+            value: 123
+            summary: Example issue identifier
+            description: A typical issue sequence ID
+      - in: path
+        name: project_identifier
+        schema:
+          type: string
+        description: Project identifier (unique string within workspace)
+        required: true
+        examples:
+          ExampleProjectIdentifier:
+            value: PROJ
+            summary: Example project identifier
+            description: A typical project identifier
+      tags:
+      - Work Items
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+              examples:
+                Issue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Implement user authentication
+                    description: Add OAuth 2.0 authentication flow
+                    sequence_id: 1
+                    priority: high
+                    assignees:
+                    - 550e8400-e29b-41d4-a716-446655440001
+                    labels:
+                    - 550e8400-e29b-41d4-a716-446655440002
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Work item details
+        '404':
+          description: Work item not found
+  /issues/search/:
+    get:
+      operationId: search_work_items
+      description: Perform semantic search across issue names, sequence IDs, and project identifiers.
+      parameters:
+      - in: query
+        name: limit
+        schema:
+          type: integer
+        description: Maximum number of results to return
+        examples:
+          Default:
+            value: 10
+          MoreResults:
+            value: 50
+            summary: More results
+      - in: query
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID for filtering results within a specific project
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: Filter results for this project
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Search query to filter results by name, description, or identifier
+        required: true
+        examples:
+          NameSearch:
+            value: bug fix
+            summary: Name search
+            description: Search for items containing 'bug fix'
+          SequenceID:
+            value: '123'
+            summary: Sequence ID
+            description: Search by sequence ID number
+      - in: query
+        name: workspace_search
+        schema:
+          type: string
+        description: Whether to search across entire workspace or within specific project
+        examples:
+          ProjectOnly:
+            value: 'false'
+            summary: Project only
+            description: Search within specific project only
+          WorkspaceWide:
+            value: 'true'
+            summary: Workspace wide
+            description: Search across entire workspace
+      tags:
+      - Work Items
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueSearch'
+              examples:
+                IssueSearchResults:
+                  value:
+                    issues:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Fix authentication bug in user login
+                      sequence_id: 123
+                      project__identifier: MAB
+                      project_id: 550e8400-e29b-41d4-a716-446655440001
+                      workspace__slug: my-workspace
+                    - id: 550e8400-e29b-41d4-a716-446655440002
+                      name: Add authentication middleware
+                      sequence_id: 124
+                      project__identifier: MAB
+                      project_id: 550e8400-e29b-41d4-a716-446655440001
+                      workspace__slug: my-workspace
+          description: Work item search results
+        '400':
+          description: Bad request - invalid search parameters
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Workspace not found
+  /members/:
+    get:
+      operationId: get_workspace_members
+      description: Retrieve all users who are members of the specified workspace.
+      summary: List workspace members
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  allOf:
+                  - $ref: '#/components/schemas/UserLite'
+                  - type: object
+                    properties:
+                      role:
+                        type: integer
+                        description: Member role in the workspace
+              examples:
+                WorkspaceMembers:
+                  value:
+                  - id: 550e8400-e29b-41d4-a716-446655440000
+                    first_name: John
+                    last_name: Doe
+                    display_name: John Doe
+                    email: john.doe@example.com
+                    avatar: https://example.com/avatar.jpg
+                    role: 20
+                  - id: 550e8400-e29b-41d4-a716-446655440001
+                    first_name: Jane
+                    last_name: Smith
+                    display_name: Jane Smith
+                    email: jane.smith@example.com
+                    avatar: https://example.com/avatar2.jpg
+                    role: 15
+          description: List of workspace members with their roles
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Workspace not found
+  /projects/:
+    get:
+      operationId: list_projects
+      description: Retrieve all projects in a workspace or get details of a specific project.
+      summary: List or retrieve projects
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Projects
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedProjectResponse'
+              examples:
+                PaginatedProjects:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Mobile App Backend
+                      description: Backend services for the mobile application
+                      identifier: MAB
+                      network: 2
+                  summary: Paginated Projects
+          description: Paginated list of projects
+    post:
+      operationId: create_project
+      description: Create a new project in the workspace with default states and member assignments.
+      summary: Create project
+      tags:
+      - Projects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectCreateRequest'
+            examples:
+              ProjectCreateSerializer:
+                value:
+                  name: New Project
+                  description: New project description
+                  identifier: new-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for creating a project
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ProjectCreateRequest'
+            examples:
+              ProjectCreateSerializer:
+                value:
+                  name: New Project
+                  description: New project description
+                  identifier: new-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for creating a project
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ProjectCreateRequest'
+            examples:
+              ProjectCreateSerializer:
+                value:
+                  name: New Project
+                  description: New project description
+                  identifier: new-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for creating a project
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Workspace not found
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+              examples:
+                Project:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Mobile App Development
+                    description: Development of the mobile application
+                    identifier: MAD
+                    network: 2
+                    project_lead: 550e8400-e29b-41d4-a716-446655440001
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Project created successfully
+        '409':
+          description: Project name already taken
+  /projects/{pk}/:
+    get:
+      operationId: retrieve_project
+      description: Retrieve details of a specific project.
+      summary: Retrieve project
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Projects
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+              examples:
+                Project:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Mobile App Development
+                    description: Development of the mobile application
+                    identifier: MAD
+                    network: 2
+                    project_lead: 550e8400-e29b-41d4-a716-446655440001
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Project details
+    patch:
+      operationId: update_project
+      description: Partially update an existing project's properties like name, description, or settings.
+      summary: Update project
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Projects
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectUpdateRequest'
+            examples:
+              ProjectUpdateSerializer:
+                value:
+                  name: Updated Project
+                  description: Updated project description
+                  identifier: updated-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a project
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectUpdateRequest'
+            examples:
+              ProjectUpdateSerializer:
+                value:
+                  name: Updated Project
+                  description: Updated project description
+                  identifier: updated-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a project
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectUpdateRequest'
+            examples:
+              ProjectUpdateSerializer:
+                value:
+                  name: Updated Project
+                  description: Updated project description
+                  identifier: updated-project
+                  project_lead: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a project
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+              examples:
+                Project:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Mobile App Development
+                    description: Development of the mobile application
+                    identifier: MAD
+                    network: 2
+                    project_lead: 550e8400-e29b-41d4-a716-446655440001
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Project updated successfully
+        '409':
+          description: Project name already taken
+    delete:
+      operationId: delete_project
+      description: Permanently remove a project and all its associated data from the workspace.
+      summary: Delete project
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Projects
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/archive/:
+    post:
+      operationId: archive_project
+      description: Move a project to archived status, hiding it from active project lists.
+      summary: Archive project
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Projects
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource archived successfully
+    delete:
+      operationId: unarchive_project
+      description: Restore an archived project to active status, making it available in regular workflows.
+      summary: Unarchive project
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Projects
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource unarchived successfully
+  /projects/{project_id}/archived-cycles/:
+    get:
+      operationId: list_archived_cycles
+      description: Retrieve all cycles that have been archived in the project.
+      summary: List archived cycles
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArchivedCycleResponse'
+              examples:
+                PaginatedArchivedCycles:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Archived Cycles
+          description: Paginated list of archived cycles
+  /projects/{project_id}/archived-cycles/{cycle_id}/unarchive/:
+    delete:
+      operationId: unarchive_cycle
+      description: Restore an archived cycle to active status, making it available for regular use.
+      summary: Unarchive cycle
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource unarchived successfully
+  /projects/{project_id}/archived-modules/:
+    get:
+      operationId: list_archived_modules
+      description: Retrieve all modules that have been archived in the project.
+      summary: List archived modules
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArchivedModuleResponse'
+              examples:
+                PaginatedArchivedModules:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Archived Modules
+          description: Paginated list of archived modules
+  /projects/{project_id}/archived-modules/{pk}/unarchive/:
+    delete:
+      operationId: unarchive_module
+      description: Restore an archived module to active status, making it available for regular use.
+      summary: Unarchive module
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '204':
+          description: No response body
+  /projects/{project_id}/cycles/:
+    get:
+      operationId: list_cycles
+      description: Retrieve all cycles in a project. Supports filtering by cycle status like current, upcoming, completed, or draft.
+      summary: List cycles
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: cycle_view
+        schema:
+          type: string
+        description: Filter cycles by status
+        examples:
+          AllCycles:
+            value: all
+            summary: All cycles
+          CurrentCycles:
+            value: current
+            summary: Current cycles
+          UpcomingCycles:
+            value: upcoming
+            summary: Upcoming cycles
+          CompletedCycles:
+            value: completed
+            summary: Completed cycles
+          DraftCycles:
+            value: draft
+            summary: Draft cycles
+          IncompleteCycles:
+            value: incomplete
+            summary: Incomplete cycles
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCycleResponse'
+              examples:
+                PaginatedCycles:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sprint 1 - Q1 2024
+                      description: First sprint of the quarter focusing on core features
+                      start_date: '2024-01-01'
+                      end_date: '2024-01-14'
+                      status: current
+                  summary: Paginated Cycles
+          description: Paginated list of cycles
+    post:
+      operationId: create_cycle
+      description: Create a new development cycle with specified name, description, and date range. Supports external ID tracking for integration purposes.
+      summary: Create cycle
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CycleCreateRequest'
+            examples:
+              CycleCreateSerializer:
+                value:
+                  name: Cycle 1
+                  description: Cycle 1 description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a cycle
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CycleCreateRequest'
+            examples:
+              CycleCreateSerializer:
+                value:
+                  name: Cycle 1
+                  description: Cycle 1 description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a cycle
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CycleCreateRequest'
+            examples:
+              CycleCreateSerializer:
+                value:
+                  name: Cycle 1
+                  description: Cycle 1 description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a cycle
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+              examples:
+                Cycle:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sprint 1 - Q1 2024
+                    description: First sprint of the quarter focusing on core features
+                    start_date: '2024-01-01'
+                    end_date: '2024-01-14'
+                    status: current
+                    total_issues: 15
+                    completed_issues: 8
+                    cancelled_issues: 1
+                    started_issues: 4
+                    unstarted_issues: 2
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Cycle created
+  /projects/{project_id}/cycles/{cycle_id}/archive/:
+    post:
+      operationId: archive_cycle
+      description: Move a completed cycle to archived status for historical tracking. Only cycles that have ended can be archived.
+      summary: Archive cycle
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource archived successfully
+        '400':
+          description: Cycle cannot be archived
+  /projects/{project_id}/cycles/{cycle_id}/cycle-issues/:
+    get:
+      operationId: list_cycle_work_items
+      description: Retrieve all work items assigned to a cycle.
+      summary: List cycle work items
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCycleIssueResponse'
+              examples:
+                PaginatedCycleWorkItems:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      cycle: 550e8400-e29b-41d4-a716-446655440001
+                      issue: 550e8400-e29b-41d4-a716-446655440002
+                      sub_issues_count: 3
+                      created_at: '2024-01-01T10:30:00Z'
+                  summary: Paginated Cycle Work Items
+          description: Paginated list of cycle work items
+    post:
+      operationId: add_cycle_work_items
+      description: Assign multiple work items to a cycle. Automatically handles bulk creation and updates with activity tracking.
+      summary: Add Work Items to Cycle
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CycleIssueRequestRequest'
+            examples:
+              CycleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding cycle issues
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CycleIssueRequestRequest'
+            examples:
+              CycleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding cycle issues
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CycleIssueRequestRequest'
+            examples:
+              CycleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding cycle issues
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CycleIssue'
+              examples:
+                CycleIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    cycle: 550e8400-e29b-41d4-a716-446655440001
+                    issue: 550e8400-e29b-41d4-a716-446655440002
+                    sub_issues_count: 3
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Cycle work items added
+        '400':
+          description: Required fields are missing
+  /projects/{project_id}/cycles/{cycle_id}/cycle-issues/{issue_id}/:
+    get:
+      operationId: retrieve_cycle_work_item
+      description: Retrieve details of a specific cycle work item.
+      summary: Retrieve cycle work item
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CycleIssue'
+              examples:
+                CycleIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    cycle: 550e8400-e29b-41d4-a716-446655440001
+                    issue: 550e8400-e29b-41d4-a716-446655440002
+                    sub_issues_count: 3
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Cycle work items
+    delete:
+      operationId: delete_cycle_work_item
+      description: Remove a work item from a cycle while keeping the work item in the project.
+      summary: Delete cycle work item
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/cycles/{cycle_id}/transfer-issues/:
+    post:
+      operationId: transfer_cycle_work_items
+      description: Move incomplete work items from the current cycle to a new target cycle. Captures progress snapshot and transfers only unfinished work items.
+      summary: Transfer cycle work items
+      parameters:
+      - in: path
+        name: cycle_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferCycleIssueRequestRequest'
+            examples:
+              TransferCycleIssueRequestSerializer:
+                value:
+                  new_cycle_id: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for transferring cycle issues
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TransferCycleIssueRequestRequest'
+            examples:
+              TransferCycleIssueRequestSerializer:
+                value:
+                  new_cycle_id: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for transferring cycle issues
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TransferCycleIssueRequestRequest'
+            examples:
+              TransferCycleIssueRequestSerializer:
+                value:
+                  new_cycle_id: 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for transferring cycle issues
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success message
+                    example: Success
+              examples:
+                TransferCycleIssueSuccess:
+                  value:
+                    message: Success
+                  summary: Transfer Cycle Issue Success
+                  description: Successful transfer of cycle issues to new cycle
+          description: Work items transferred successfully
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+                    example: New Cycle Id is required
+              examples:
+                TransferCycleIssueError:
+                  value:
+                    error: New Cycle Id is required
+                  summary: Transfer Cycle Issue Error
+                  description: Error when required cycle ID is missing
+                TransferToCompletedCycleError:
+                  value:
+                    error: The cycle where the issues are transferred is already completed
+                  summary: Transfer to Completed Cycle Error
+                  description: Error when trying to transfer to a completed cycle
+          description: Bad request
+  /projects/{project_id}/cycles/{pk}/:
+    get:
+      operationId: retrieve_cycle
+      description: Retrieve details of a specific cycle by its ID. Supports cycle status filtering.
+      summary: Retrieve cycle
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+              examples:
+                Cycle:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sprint 1 - Q1 2024
+                    description: First sprint of the quarter focusing on core features
+                    start_date: '2024-01-01'
+                    end_date: '2024-01-14'
+                    status: current
+                    total_issues: 15
+                    completed_issues: 8
+                    cancelled_issues: 1
+                    started_issues: 4
+                    unstarted_issues: 2
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Cycles
+    patch:
+      operationId: update_cycle
+      description: Modify an existing cycle's properties like name, description, or date range. Completed cycles can only have their sort order changed.
+      summary: Update cycle
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedCycleUpdateRequest'
+            examples:
+              CycleUpdateSerializer:
+                value:
+                  name: Updated Cycle
+                  description: Updated cycle description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a cycle
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedCycleUpdateRequest'
+            examples:
+              CycleUpdateSerializer:
+                value:
+                  name: Updated Cycle
+                  description: Updated cycle description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a cycle
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedCycleUpdateRequest'
+            examples:
+              CycleUpdateSerializer:
+                value:
+                  name: Updated Cycle
+                  description: Updated cycle description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a cycle
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+              examples:
+                Cycle:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sprint 1 - Q1 2024
+                    description: First sprint of the quarter focusing on core features
+                    start_date: '2024-01-01'
+                    end_date: '2024-01-14'
+                    status: current
+                    total_issues: 15
+                    completed_issues: 8
+                    cancelled_issues: 1
+                    started_issues: 4
+                    unstarted_issues: 2
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Cycle updated
+    delete:
+      operationId: delete_cycle
+      description: Permanently remove a cycle and all its associated issue relationships
+      summary: Delete cycle
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Cycles
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/intake-issues/:
+    get:
+      operationId: get_intake_work_items_list
+      description: Retrieve all work items in the project's intake queue. Returns paginated results when listing all intake work items.
+      summary: List intake work items
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Intake
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedIntakeIssueResponse'
+              examples:
+                PaginatedIntakeWorkItems:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Intake Work Items
+          description: Paginated list of intake work items
+    post:
+      operationId: create_intake_work_item
+      description: Submit a new work item to the project's intake queue for review and triage. Automatically creates the work item with default triage state and tracks activity.
+      summary: Create intake work item
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntakeIssueCreateRequest'
+            examples:
+              IntakeIssueCreateSerializer:
+                value:
+                  issue:
+                    name: New Issue
+                    description: New issue description
+                    priority: medium
+                description: Example request for creating an intake issue
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IntakeIssueCreateRequest'
+            examples:
+              IntakeIssueCreateSerializer:
+                value:
+                  issue:
+                    name: New Issue
+                    description: New issue description
+                    priority: medium
+                description: Example request for creating an intake issue
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IntakeIssueCreateRequest'
+            examples:
+              IntakeIssueCreateSerializer:
+                value:
+                  issue:
+                    name: New Issue
+                    description: New issue description
+                    priority: medium
+                description: Example request for creating an intake issue
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntakeIssue'
+              examples:
+                IntakeIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    status: 0
+                    source: in_app
+                    issue:
+                      id: 550e8400-e29b-41d4-a716-446655440001
+                      name: 'Feature request: Dark mode'
+                      description: Add dark mode support to the application
+                      priority: medium
+                      sequence_id: 124
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Intake work item created
+        '400':
+          description: Invalid request data provided
+  /projects/{project_id}/intake-issues/{issue_id}/:
+    get:
+      operationId: retrieve_intake_work_item
+      description: Retrieve details of a specific intake work item.
+      summary: Retrieve intake work item
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Intake
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntakeIssue'
+              examples:
+                IntakeIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    status: 0
+                    source: in_app
+                    issue:
+                      id: 550e8400-e29b-41d4-a716-446655440001
+                      name: 'Feature request: Dark mode'
+                      description: Add dark mode support to the application
+                      priority: medium
+                      sequence_id: 124
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Intake work item
+    patch:
+      operationId: update_intake_work_item
+      description: Modify an existing intake work item's properties or status for triage processing. Supports status changes like accept, reject, or mark as duplicate.
+      summary: Update intake work item
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedIntakeIssueUpdateRequest'
+            examples:
+              IntakeIssueUpdateSerializer:
+                value:
+                  status: 1
+                  issue:
+                    name: Updated Issue
+                    description: Updated issue description
+                    priority: high
+                description: Example request for updating an intake issue
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedIntakeIssueUpdateRequest'
+            examples:
+              IntakeIssueUpdateSerializer:
+                value:
+                  status: 1
+                  issue:
+                    name: Updated Issue
+                    description: Updated issue description
+                    priority: high
+                description: Example request for updating an intake issue
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedIntakeIssueUpdateRequest'
+            examples:
+              IntakeIssueUpdateSerializer:
+                value:
+                  status: 1
+                  issue:
+                    name: Updated Issue
+                    description: Updated issue description
+                    priority: high
+                description: Example request for updating an intake issue
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntakeIssue'
+              examples:
+                IntakeIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    status: 0
+                    source: in_app
+                    issue:
+                      id: 550e8400-e29b-41d4-a716-446655440001
+                      name: 'Feature request: Dark mode'
+                      description: Add dark mode support to the application
+                      priority: medium
+                      sequence_id: 124
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Intake work item updated
+        '400':
+          description: Invalid request data provided
+    delete:
+      operationId: delete_intake_work_item
+      description: Permanently remove an intake work item from the triage queue. Also deletes the underlying work item if it hasn't been accepted yet.
+      summary: Delete intake work item
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Intake
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/issues/:
+    get:
+      operationId: list_work_items
+      description: Retrieve a paginated list of all work items in a project. Supports filtering, ordering, and field selection through query parameters.
+      summary: List work items
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: external_id
+        schema:
+          type: string
+        description: External system identifier for filtering or lookup
+        examples:
+          GitHubIssue:
+            value: '1234567890'
+            summary: GitHub Issue
+            description: GitHub issue number
+      - in: query
+        name: external_source
+        schema:
+          type: string
+        description: External system source name for filtering or lookup
+        examples:
+          GitHub:
+            value: github
+            description: GitHub integration source
+          Jira:
+            value: jira
+            description: Jira integration source
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Work Items
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedWorkItemResponse'
+              examples:
+                PaginatedWorkItems:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Fix authentication bug in user login
+                      description: Users are unable to log in due to authentication service timeout
+                      priority: high
+                      sequence_id: 123
+                      state:
+                        id: 550e8400-e29b-41d4-a716-446655440001
+                        name: In Progress
+                        group: started
+                      assignees: []
+                      labels: []
+                      created_at: '2024-01-15T10:30:00Z'
+                  summary: Paginated Work Items
+          description: Paginated list of work items
+        '400':
+          description: Invalid request data provided
+    post:
+      operationId: create_work_item
+      description: Create a new work item in the specified project with the provided details.
+      summary: Create work item
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Items
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+            examples:
+              IssueCreateSerializer:
+                value:
+                  name: New Issue
+                  description: New issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a work item
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+            examples:
+              IssueCreateSerializer:
+                value:
+                  name: New Issue
+                  description: New issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a work item
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+            examples:
+              IssueCreateSerializer:
+                value:
+                  name: New Issue
+                  description: New issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a work item
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+              examples:
+                Issue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Implement user authentication
+                    description: Add OAuth 2.0 authentication flow
+                    sequence_id: 1
+                    priority: high
+                    assignees:
+                    - 550e8400-e29b-41d4-a716-446655440001
+                    labels:
+                    - 550e8400-e29b-41d4-a716-446655440002
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Work Item created successfully
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+  /projects/{project_id}/issues/{issue_id}/activities/:
+    get:
+      operationId: list_work_item_activities
+      description: Retrieve all activities for a work item. Supports filtering by activity type and date range.
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Work Item Activity
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedIssueActivityResponse'
+              examples:
+                PaginatedIssueActivities:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Issue Activities
+          description: Paginated list of issue activities
+        '400':
+          description: Invalid request data provided
+  /projects/{project_id}/issues/{issue_id}/comments/:
+    get:
+      operationId: list_work_item_comments
+      description: Retrieve all comments for a work item.
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Work Item Comments
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedIssueCommentResponse'
+              examples:
+                PaginatedWorkItemComments:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Work Item Comments
+          description: Paginated list of work item comments
+    post:
+      operationId: create_work_item_comment
+      description: Add a new comment to a work item with HTML content.
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Item Comments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueCommentCreateRequest'
+            examples:
+              IssueCommentCreateSerializer:
+                value:
+                  comment_html: <p>New comment content</p>
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue comment
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IssueCommentCreateRequest'
+            examples:
+              IssueCommentCreateSerializer:
+                value:
+                  comment_html: <p>New comment content</p>
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue comment
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IssueCommentCreateRequest'
+            examples:
+              IssueCommentCreateSerializer:
+                value:
+                  comment_html: <p>New comment content</p>
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue comment
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue not found
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueComment'
+              examples:
+                IssueComment:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    comment_html: <p>This issue has been resolved by implementing OAuth 2.0 flow.</p>
+                    comment_json:
+                      type: doc
+                      content:
+                      - type: paragraph
+                        content:
+                        - type: text
+                          text: This issue has been resolved by implementing OAuth 2.0 flow.
+                    actor:
+                      id: 550e8400-e29b-41d4-a716-446655440001
+                      first_name: John
+                      last_name: Doe
+                      display_name: John Doe
+                      avatar: https://example.com/avatar.jpg
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Work item comment created successfully
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+  /projects/{project_id}/issues/{issue_id}/issue-attachments/:
+    get:
+      operationId: list_work_item_attachments
+      description: Retrieve all attachments for a work item.
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Work Item Attachments
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Attachment not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueAttachment'
+              examples:
+                IssueAttachment:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: screenshot.png
+                    size: 1024000
+                    asset_url: https://s3.amazonaws.com/bucket/screenshot.png?signed-url
+                    attributes:
+                      name: screenshot.png
+                      type: image/png
+                      size: 1024000
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Work item attachment
+        '400':
+          description: Invalid request data provided
+    post:
+      operationId: create_work_item_attachment
+      description: Generate presigned URL for uploading file attachments to a work item.
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Item Attachments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueAttachmentUploadRequest'
+            examples:
+              IssueAttachmentUploadSerializer:
+                value:
+                  name: document.pdf
+                  type: application/pdf
+                  size: 1024000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue attachment
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IssueAttachmentUploadRequest'
+            examples:
+              IssueAttachmentUploadSerializer:
+                value:
+                  name: document.pdf
+                  type: application/pdf
+                  size: 1024000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue attachment
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IssueAttachmentUploadRequest'
+            examples:
+              IssueAttachmentUploadSerializer:
+                value:
+                  name: document.pdf
+                  type: application/pdf
+                  size: 1024000
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating an issue attachment
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue or Project or Workspace not found
+        '200':
+          description: Presigned download URL generated successfully
+        '400':
+          description: Validation error
+  /projects/{project_id}/issues/{issue_id}/links/:
+    get:
+      operationId: list_work_item_links
+      description: Retrieve all links associated with a work item. Supports filtering by URL, title, and metadata.
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Work Item Links
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedIssueLinkResponse'
+              examples:
+                PaginatedWorkItemLinks:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Work Item Links
+          description: Paginated list of work item links
+        '400':
+          description: Invalid request data provided
+    post:
+      operationId: create_work_item_link
+      description: Add a new external link to a work item with URL, title, and metadata.
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Item Links
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueLinkCreateRequest'
+            examples:
+              IssueLinkCreateSerializer:
+                value:
+                  url: https://example.com
+                  title: Example Link
+                description: Example request for creating an issue link
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IssueLinkCreateRequest'
+            examples:
+              IssueLinkCreateSerializer:
+                value:
+                  url: https://example.com
+                  title: Example Link
+                description: Example request for creating an issue link
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IssueLinkCreateRequest'
+            examples:
+              IssueLinkCreateSerializer:
+                value:
+                  url: https://example.com
+                  title: Example Link
+                description: Example request for creating an issue link
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Issue not found
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueLink'
+              examples:
+                IssueLink:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    url: https://github.com/example/repo/pull/123
+                    title: Fix authentication bug
+                    metadata:
+                      title: Fix authentication bug
+                      description: Pull request to fix authentication timeout issue
+                      image: https://github.com/example/repo/avatar.png
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Work item link created successfully
+        '400':
+          description: Invalid request data provided
+  /projects/{project_id}/issues/{pk}/:
+    get:
+      operationId: retrieve_work_item
+      description: Retrieve details of a specific work item.
+      summary: Retrieve work item
+      parameters:
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: external_id
+        schema:
+          type: string
+        description: External system identifier for filtering or lookup
+        examples:
+          GitHubIssue:
+            value: '1234567890'
+            summary: GitHub Issue
+            description: GitHub issue number
+      - in: query
+        name: external_source
+        schema:
+          type: string
+        description: External system source name for filtering or lookup
+        examples:
+          GitHub:
+            value: github
+            description: GitHub integration source
+          Jira:
+            value: jira
+            description: Jira integration source
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Items
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Work item not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+              examples:
+                Issue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Implement user authentication
+                    description: Add OAuth 2.0 authentication flow
+                    sequence_id: 1
+                    priority: high
+                    assignees:
+                    - 550e8400-e29b-41d4-a716-446655440001
+                    labels:
+                    - 550e8400-e29b-41d4-a716-446655440002
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: List of issues or issue details
+        '400':
+          description: Invalid request data provided
+    patch:
+      operationId: update_work_item
+      description: Partially update an existing work item with the provided fields. Supports external ID validation to prevent conflicts.
+      summary: Partially update work item
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Items
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedIssueRequest'
+            examples:
+              IssueUpdateSerializer:
+                value:
+                  name: Updated Issue
+                  description: Updated issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a work item
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedIssueRequest'
+            examples:
+              IssueUpdateSerializer:
+                value:
+                  name: Updated Issue
+                  description: Updated issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a work item
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedIssueRequest'
+            examples:
+              IssueUpdateSerializer:
+                value:
+                  name: Updated Issue
+                  description: Updated issue description
+                  priority: medium
+                  state: 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  assignees:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  labels:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for updating a work item
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Work item not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+              examples:
+                Issue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Implement user authentication
+                    description: Add OAuth 2.0 authentication flow
+                    sequence_id: 1
+                    priority: high
+                    assignees:
+                    - 550e8400-e29b-41d4-a716-446655440001
+                    labels:
+                    - 550e8400-e29b-41d4-a716-446655440002
+                    created_at: '2024-01-15T10:30:00Z'
+                    updated_at: '2024-01-15T10:30:00Z'
+          description: Work Item patched successfully
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+    delete:
+      operationId: delete_work_item
+      description: Permanently delete an existing work item from the project. Only admins or the item creator can perform this action.
+      summary: Delete work item
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Work Items
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Only admin or creator can perform this action
+        '404':
+          description: Work item not found
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/labels/:
+    get:
+      operationId: list_labels
+      description: Retrieve all labels in a project. Supports filtering by name and color.
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Labels
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedLabelResponse'
+              examples:
+                PaginatedLabels:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: bug
+                      color: '#ff4444'
+                      description: Issues that represent bugs in the system
+                  summary: Paginated Labels
+          description: Paginated list of labels
+        '400':
+          description: Invalid request data provided
+    post:
+      operationId: create_label
+      description: Create a new label in the specified project with name, color, and description.
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Labels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: New Label
+                  color: '#ff0000'
+                  description: New label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a label
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: New Label
+                  color: '#ff0000'
+                  description: New label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a label
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: New Label
+                  color: '#ff0000'
+                  description: New label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a label
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Label'
+              examples:
+                Label:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: bug
+                    color: '#ff4444'
+                    description: Issues that represent bugs in the system
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Label created successfully
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Label with the same name already exists
+  /projects/{project_id}/labels/{pk}/:
+    get:
+      operationId: get_labels
+      description: Retrieve details of a specific label.
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Label ID
+        required: true
+        examples:
+          ExampleLabelID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example label ID
+            description: A typical label UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Labels
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Label not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Label'
+              examples:
+                Label:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: bug
+                    color: '#ff4444'
+                    description: Issues that represent bugs in the system
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Labels
+    patch:
+      operationId: update_label
+      description: Partially update an existing label's properties like name, color, or description.
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Label ID
+        required: true
+        examples:
+          ExampleLabelID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example label ID
+            description: A typical label UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Labels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedLabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: Updated Label
+                  color: '#00ff00'
+                  description: Updated label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a label
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedLabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: Updated Label
+                  color: '#00ff00'
+                  description: Updated label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a label
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedLabelCreateUpdateRequest'
+            examples:
+              LabelCreateUpdateSerializer:
+                value:
+                  name: Updated Label
+                  color: '#00ff00'
+                  description: Updated label description
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a label
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Label not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Label'
+              examples:
+                Label:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: bug
+                    color: '#ff4444'
+                    description: Issues that represent bugs in the system
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Label updated successfully
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+    delete:
+      operationId: delete_label
+      description: Permanently remove a label from the project. This action cannot be undone.
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Label ID
+        required: true
+        examples:
+          ExampleLabelID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example label ID
+            description: A typical label UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Labels
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Label not found
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/members/:
+    get:
+      operationId: get_project_members
+      description: Retrieve all users who are members of the specified project.
+      summary: List project members
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserLite'
+              examples:
+                ProjectMembers:
+                  value:
+                  - id: 550e8400-e29b-41d4-a716-446655440000
+                    first_name: John
+                    last_name: Doe
+                    display_name: John Doe
+                    email: john.doe@example.com
+                    avatar: https://example.com/avatar.jpg
+                  - id: 550e8400-e29b-41d4-a716-446655440001
+                    first_name: Jane
+                    last_name: Smith
+                    display_name: Jane Smith
+                    email: jane.smith@example.com
+                    avatar: https://example.com/avatar2.jpg
+          description: List of project members with their roles
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+    post:
+      operationId: create_project_member
+      description: Create a new project member
+      summary: Create project member
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member created
+  /projects/{project_id}/members/{pk}/:
+    get:
+      operationId: get_project_member
+      description: Retrieve a project member by ID.
+      summary: Get project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+    patch:
+      operationId: update_project_member
+      description: Update a project member
+      summary: Update project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member updated
+    delete:
+      operationId: delete_project_member
+      description: Delete a project member
+      summary: Delete project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '204':
+          description: Project member deleted
+  /projects/{project_id}/modules/:
+    get:
+      operationId: list_modules
+      description: Retrieve all modules in a project.
+      summary: List modules
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedModuleResponse'
+              examples:
+                PaginatedModules:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Authentication Module
+                      description: User authentication and authorization features
+                      start_date: '2024-01-01'
+                      target_date: '2024-02-15'
+                      status: in_progress
+                  summary: Paginated Modules
+          description: Paginated list of modules
+    post:
+      operationId: create_module
+      description: Create a new project module with specified name, description, and timeline.
+      summary: Create module
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModuleCreateRequest'
+            examples:
+              ModuleCreateSerializer:
+                value:
+                  name: New Module
+                  description: New module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a module
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ModuleCreateRequest'
+            examples:
+              ModuleCreateSerializer:
+                value:
+                  name: New Module
+                  description: New module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a module
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ModuleCreateRequest'
+            examples:
+              ModuleCreateSerializer:
+                value:
+                  name: New Module
+                  description: New module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a module
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Module'
+              examples:
+                Module:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Authentication Module
+                    description: User authentication and authorization features
+                    start_date: '2024-01-01'
+                    target_date: '2024-02-15'
+                    status: in-progress
+                    total_issues: 12
+                    completed_issues: 5
+                    cancelled_issues: 0
+                    started_issues: 4
+                    unstarted_issues: 3
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Module created
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+  /projects/{project_id}/modules/{module_id}/module-issues/:
+    get:
+      operationId: list_module_work_items
+      description: Retrieve all work items assigned to a module with detailed information.
+      summary: List module work items
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: path
+        name: module_id
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: query
+        name: order_by
+        schema:
+          type: string
+        description: Field to order results by. Prefix with '-' for descending order
+        examples:
+          CreatedDateDescending:
+            value: -created_at
+            summary: Created date descending
+            description: Most recent items first
+          PriorityAscending:
+            value: priority
+            summary: Priority ascending
+            description: Order by priority (urgent, high, medium, low, none)
+          StateGroup:
+            value: state__group
+            summary: State group
+            description: Order by state group (backlog, unstarted, started, completed, cancelled)
+          AssigneeName:
+            value: assignees__first_name
+            summary: Assignee name
+            description: Order by assignee first name
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedModuleIssueResponse'
+              examples:
+                PaginatedModuleWorkItems:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sample Item
+                      created_at: '2024-01-15T12:00:00Z'
+                  summary: Paginated Module Work Items
+          description: Paginated list of module work items
+    post:
+      operationId: add_module_work_items
+      description: Assign multiple work items to a module or move them from another module. Automatically handles bulk creation and updates with activity tracking.
+      summary: Add Work Items to Module
+      parameters:
+      - in: path
+        name: module_id
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModuleIssueRequestRequest'
+            examples:
+              ModuleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding module issues
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ModuleIssueRequestRequest'
+            examples:
+              ModuleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding module issues
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ModuleIssueRequestRequest'
+            examples:
+              ModuleIssueRequestSerializer:
+                value:
+                  issues:
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41cd
+                  - 0ec6cfa4-e906-4aad-9390-2df0303a41ce
+                description: Example request for adding module issues
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModuleIssue'
+              examples:
+                ModuleIssue:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    module: 550e8400-e29b-41d4-a716-446655440001
+                    issue: 550e8400-e29b-41d4-a716-446655440002
+                    sub_issues_count: 2
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Module issues added
+        '400':
+          description: Required fields are missing
+  /projects/{project_id}/modules/{module_id}/module-issues/{issue_id}/:
+    delete:
+      operationId: delete_module_work_item
+      description: Remove a work item from a module while keeping the work item in the project.
+      summary: Delete module work item
+      parameters:
+      - in: path
+        name: issue_id
+        schema:
+          type: string
+          format: uuid
+        description: Issue ID
+        required: true
+        examples:
+          ExampleIssueID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example issue ID
+            description: A typical issue UUID
+      - in: path
+        name: module_id
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module issue not found
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/modules/{pk}/:
+    get:
+      operationId: retrieve_module
+      description: Retrieve details of a specific module.
+      summary: Retrieve module
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Module'
+              examples:
+                Module:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Authentication Module
+                    description: User authentication and authorization features
+                    start_date: '2024-01-01'
+                    target_date: '2024-02-15'
+                    status: in-progress
+                    total_issues: 12
+                    completed_issues: 5
+                    cancelled_issues: 0
+                    started_issues: 4
+                    unstarted_issues: 3
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Module
+    patch:
+      operationId: update_module
+      description: Modify an existing module's properties like name, description, status, or timeline.
+      summary: Update module
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedModuleUpdateRequest'
+            examples:
+              ModuleUpdateSerializer:
+                value:
+                  name: Updated Module
+                  description: Updated module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a module
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedModuleUpdateRequest'
+            examples:
+              ModuleUpdateSerializer:
+                value:
+                  name: Updated Module
+                  description: Updated module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a module
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedModuleUpdateRequest'
+            examples:
+              ModuleUpdateSerializer:
+                value:
+                  name: Updated Module
+                  description: Updated module description
+                  start_date: '2021-01-01'
+                  end_date: '2021-01-31'
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a module
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Module'
+              examples:
+                Module:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Authentication Module
+                    description: User authentication and authorization features
+                    start_date: '2024-01-01'
+                    target_date: '2024-02-15'
+                    status: in-progress
+                    total_issues: 12
+                    completed_issues: 5
+                    cancelled_issues: 0
+                    started_issues: 4
+                    unstarted_issues: 3
+                    backlog_issues: 0
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: Module updated successfully
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Module'
+              examples:
+                ModuleUpdateSerializer:
+                  value:
+                    name: Updated Module
+                    description: Updated module description
+                    start_date: '2021-01-01'
+                    end_date: '2021-01-31'
+                    external_id: '1234567890'
+                    external_source: github
+                  description: Example request for updating a module
+          description: Invalid request data
+        '409':
+          description: Module with same external ID already exists
+    delete:
+      operationId: delete_module
+      description: Permanently remove a module and all its associated issue relationships.
+      summary: Delete module
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Only admin or creator can perform this action
+        '404':
+          description: Module not found
+        '204':
+          description: Resource deleted successfully
+  /projects/{project_id}/modules/{pk}/archive/:
+    post:
+      operationId: archive_module
+      description: Move a module to archived status for historical tracking.
+      summary: Archive module
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: Module ID
+        required: true
+        examples:
+          ExampleModuleID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example module ID
+            description: A typical module UUID
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Modules
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Module not found
+        '204':
+          description: No response body
+        '400':
+          description: Resource cannot be archived in current state
+  /projects/{project_id}/project-members/:
+    get:
+      operationId: get_project_members_2
+      description: Retrieve all users who are members of the specified project.
+      summary: List project members
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserLite'
+              examples:
+                ProjectMembers:
+                  value:
+                  - id: 550e8400-e29b-41d4-a716-446655440000
+                    first_name: John
+                    last_name: Doe
+                    display_name: John Doe
+                    email: john.doe@example.com
+                    avatar: https://example.com/avatar.jpg
+                  - id: 550e8400-e29b-41d4-a716-446655440001
+                    first_name: Jane
+                    last_name: Smith
+                    display_name: Jane Smith
+                    email: jane.smith@example.com
+                    avatar: https://example.com/avatar2.jpg
+          description: List of project members with their roles
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+    post:
+      operationId: create_project_member_2
+      description: Create a new project member
+      summary: Create project member
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ProjectMemberRequest'
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member created
+  /projects/{project_id}/project-members/{pk}/:
+    get:
+      operationId: get_project_member_2
+      description: Retrieve a project member by ID.
+      summary: Get project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: Project not found
+    patch:
+      operationId: update_project_member_2
+      description: Update a project member
+      summary: Update project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedProjectMemberRequest'
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectMember'
+          description: Project member updated
+    delete:
+      operationId: delete_project_member_2
+      description: Delete a project member
+      summary: Delete project member
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - Members
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '204':
+          description: Project member deleted
+  /projects/{project_id}/states/:
+    get:
+      operationId: list_states
+      description: Retrieve all workflow states for a project.
+      summary: List states
+      parameters:
+      - in: query
+        name: cursor
+        schema:
+          type: string
+        description: Pagination cursor for getting next set of results
+        examples:
+          NextPageCursor:
+            value: '20:1:0'
+            summary: Next page cursor
+            description: 'Cursor format: ''page_size:page_number:offset'''
+      - in: query
+        name: expand
+        schema:
+          type: string
+        description: Comma-separated list of related fields to expand in response
+        examples:
+          ExpandAssignees:
+            value: assignees
+            summary: Expand assignees
+            description: Include full assignee details
+          MultipleExpansions:
+            value: assignees,labels,state
+            summary: Multiple expansions
+            description: Include details for multiple relations
+      - in: query
+        name: fields
+        schema:
+          type: string
+        description: Comma-separated list of fields to include in response
+        examples:
+          BasicFields:
+            value: id,name,description
+            summary: Basic fields
+            description: Include only basic fields
+          WithRelations:
+            value: id,name,assignees,state
+            summary: With relations
+            description: Include fields with relationships
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+        description: 'Number of results per page (default: 20, max: 100)'
+        examples:
+          Default:
+            value: 20
+          Maximum:
+            value: 100
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+      tags:
+      - States
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedStateResponse'
+              examples:
+                PaginatedStates:
+                  value:
+                    grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: In Progress
+                      color: '#ffa500'
+                      group: started
+                      sequence: 2
+                  summary: Paginated States
+          description: Paginated list of states
+    post:
+      operationId: create_state
+      description: Create a new workflow state for a project with specified name, color, and group.
+      summary: Create state
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      tags:
+      - States
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StateRequest'
+            examples:
+              StateCreateSerializer:
+                value:
+                  name: New State
+                  color: '#ff0000'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a state
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/StateRequest'
+            examples:
+              StateCreateSerializer:
+                value:
+                  name: New State
+                  color: '#ff0000'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a state
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/StateRequest'
+            examples:
+              StateCreateSerializer:
+                value:
+                  name: New State
+                  color: '#ff0000'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for creating a state
+        required: true
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/State'
+              examples:
+                State:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: In Progress
+                    color: '#f39c12'
+                    group: started
+                    sequence: 2
+                    default: false
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: State created
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: State with the same name already exists
+  /projects/{project_id}/states/{state_id}/:
+    get:
+      operationId: retrieve_state
+      description: Retrieve details of a specific state.
+      summary: Retrieve state
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - in: path
+        name: state_id
+        schema:
+          type: string
+          format: uuid
+        description: State ID
+        required: true
+        examples:
+          ExampleStateID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example state ID
+            description: A typical state UUID
+      tags:
+      - States
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/State'
+              examples:
+                State:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: In Progress
+                    color: '#f39c12'
+                    group: started
+                    sequence: 2
+                    default: false
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: State retrieved
+    patch:
+      operationId: update_state
+      description: Partially update an existing workflow state's properties like name, color, or group.
+      summary: Update state
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - in: path
+        name: state_id
+        schema:
+          type: string
+          format: uuid
+        description: State ID
+        required: true
+        examples:
+          ExampleStateID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example state ID
+            description: A typical state UUID
+      tags:
+      - States
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedStateRequest'
+            examples:
+              StateUpdateSerializer:
+                value:
+                  name: Updated State
+                  color: '#00ff00'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a state
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedStateRequest'
+            examples:
+              StateUpdateSerializer:
+                value:
+                  name: Updated State
+                  color: '#00ff00'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a state
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedStateRequest'
+            examples:
+              StateUpdateSerializer:
+                value:
+                  name: Updated State
+                  color: '#00ff00'
+                  group: backlog
+                  external_id: '1234567890'
+                  external_source: github
+                description: Example request for updating a state
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/State'
+              examples:
+                State:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: In Progress
+                    color: '#f39c12'
+                    group: started
+                    sequence: 2
+                    default: false
+                    created_at: '2024-01-01T10:30:00Z'
+                    updated_at: '2024-01-10T15:45:00Z'
+          description: State updated
+        '400':
+          description: Invalid request data provided
+        '409':
+          description: Resource with same external ID already exists
+    delete:
+      operationId: delete_state
+      description: Permanently remove a workflow state from a project. Default states and states with existing work items cannot be deleted.
+      summary: Delete state
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        description: Project ID
+        required: true
+        examples:
+          ExampleProjectID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example project ID
+            description: A typical project UUID
+      - in: path
+        name: state_id
+        schema:
+          type: string
+          format: uuid
+        description: State ID
+        required: true
+        examples:
+          ExampleStateID:
+            value: 550e8400-e29b-41d4-a716-446655440000
+            summary: Example state ID
+            description: A typical state UUID
+      tags:
+      - States
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+        '400':
+          description: State cannot be deleted
+  /projects/{project_id}/summary/:
+    get:
+      operationId: workspaces_projects_summary_retrieve
+      description: |-
+        Get project summary
+
+        Get the summary of a project
+      parameters:
+      - in: path
+        name: project_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - workspaces
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '200':
+          description: No response body
+  /stickies/:
+    get:
+      operationId: list_stickies
+      description: List all stickies in the workspace
+      summary: List stickies
+      tags:
+      - Stickies
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Sticky'
+              examples:
+                ListOfStickies:
+                  value:
+                  - grouped_by: state
+                    sub_grouped_by: priority
+                    total_count: 150
+                    next_cursor: '20:1:0'
+                    prev_cursor: '20:0:0'
+                    next_page_results: true
+                    prev_page_results: false
+                    count: 20
+                    total_pages: 8
+                    total_results: 150
+                    extra_stats:
+                    results:
+                    - id: 550e8400-e29b-41d4-a716-446655440000
+                      name: Sticky 1
+                      description_html: <p>Sticky 1 description</p>
+                      created_at: '2024-01-01T10:30:00Z'
+                  summary: List of stickies
+          description: List of stickies
+      parameters:
+      - name: updated_at__gt
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+        description: Incremental filter — return items updated after this RFC3339 timestamp.
+    post:
+      operationId: create_sticky
+      description: Create a new sticky in the workspace
+      summary: Create a new sticky
+      tags:
+      - Stickies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StickyRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/StickyRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/StickyRequest'
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sticky'
+              examples:
+                Sticky:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sticky 1
+                    description_html: <p>Sticky 1 description</p>
+                    created_at: '2024-01-01T10:30:00Z'
+          description: Sticky created
+  /stickies/{pk}/:
+    get:
+      operationId: retrieve_sticky
+      description: Retrieve a sticky by its ID
+      summary: Retrieve a sticky
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Sticky.
+        required: true
+      tags:
+      - Stickies
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sticky'
+              examples:
+                Sticky:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sticky 1
+                    description_html: <p>Sticky 1 description</p>
+                    created_at: '2024-01-01T10:30:00Z'
+          description: Sticky
+    patch:
+      operationId: update_sticky
+      description: Update a sticky by its ID
+      summary: Update a sticky
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Sticky.
+        required: true
+      tags:
+      - Stickies
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedStickyRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedStickyRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedStickyRequest'
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sticky'
+              examples:
+                Sticky:
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Sticky 1
+                    description_html: <p>Sticky 1 description</p>
+                    created_at: '2024-01-01T10:30:00Z'
+          description: Sticky
+    delete:
+      operationId: delete_sticky
+      description: Delete a sticky by its ID
+      summary: Delete a sticky
+      parameters:
+      - in: path
+        name: pk
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Sticky.
+        required: true
+      tags:
+      - Stickies
+      security:
+      - ApiKeyAuthentication: []
+      responses:
+        '401':
+          description: Authentication credentials were not provided or are invalid.
+        '403':
+          description: Permission denied. User lacks required permissions.
+        '404':
+          description: The requested resource was not found.
+        '204':
+          description: Resource deleted successfully
+components:
+  schemas:
+    AccessEnum:
+      enum:
+      - INTERNAL
+      - EXTERNAL
+      type: string
+      description: |-
+        * `INTERNAL` - INTERNAL
+        * `EXTERNAL` - EXTERNAL
+    Cycle:
+      type: object
+      description: |-
+        Cycle serializer with comprehensive project metrics and time tracking.
+
+        Provides cycle details including work item counts by status, progress estimates,
+        and time-bound iteration data for project management and sprint planning.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        total_issues:
+          type: integer
+          readOnly: true
+        cancelled_issues:
+          type: integer
+          readOnly: true
+        completed_issues:
+          type: integer
+          readOnly: true
+        started_issues:
+          type: integer
+          readOnly: true
+        unstarted_issues:
+          type: integer
+          readOnly: true
+        backlog_issues:
+          type: integer
+          readOnly: true
+        total_estimates:
+          type: number
+          format: double
+          readOnly: true
+        completed_estimates:
+          type: number
+          format: double
+          readOnly: true
+        started_estimates:
+          type: number
+          format: double
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          title: Cycle Name
+          maxLength: 255
+        description:
+          type: string
+          title: Cycle Description
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        view_props: {}
+        sort_order:
+          type: number
+          format: double
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        progress_snapshot: {}
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        logo_props: {}
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+        version:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        owned_by:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - name
+    CycleCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating cycles with timezone handling and date validation.
+
+        Manages cycle creation including project timezone conversion, date range validation,
+        and UTC normalization for time-bound iteration planning and sprint management.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Cycle Name
+          maxLength: 255
+        description:
+          type: string
+          title: Cycle Description
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        owned_by:
+          type: string
+          format: uuid
+          nullable: true
+          description: User who owns the cycle. If not provided, defaults to the current user.
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+      required:
+      - name
+    CycleIssue:
+      type: object
+      description: |-
+        Serializer for cycle-issue relationships with sub-issue counting.
+
+        Manages the association between cycles and work items, including
+        hierarchical issue tracking for nested work item structures.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        sub_issues_count:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        issue:
+          type: string
+          format: uuid
+        cycle:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - deleted_at
+      - issue
+    CycleIssueRequestRequest:
+      type: object
+      description: |-
+        Serializer for bulk work item assignment to cycles.
+
+        Validates work item ID lists for batch operations including
+        cycle assignment and sprint planning workflows.
+      properties:
+        issues:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs to add to the cycle
+      required:
+      - issues
+    CycleLite:
+      type: object
+      description: |-
+        Lightweight cycle serializer for minimal data transfer.
+
+        Provides essential cycle information without computed metrics,
+        optimized for list views and reference lookups.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        name:
+          type: string
+          title: Cycle Name
+          maxLength: 255
+        description:
+          type: string
+          title: Cycle Description
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        view_props: {}
+        sort_order:
+          type: number
+          format: double
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        progress_snapshot: {}
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        logo_props: {}
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+        version:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+        workspace:
+          type: string
+          format: uuid
+        owned_by:
+          type: string
+          format: uuid
+      required:
+      - name
+      - owned_by
+      - project
+      - workspace
+    EntityTypeEnum:
+      enum:
+      - USER_AVATAR
+      - USER_COVER
+      type: string
+      description: |-
+        * `USER_AVATAR` - User Avatar
+        * `USER_COVER` - User Cover
+    GenericAssetUploadRequest:
+      type: object
+      description: |-
+        Serializer for generic asset upload requests with project association.
+
+        Validates metadata for generating presigned URLs for workspace assets including
+        project association, external system tracking, and file validation for
+        document management and content storage workflows.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Original filename of the asset
+        type:
+          type: string
+          minLength: 1
+          description: MIME type of the file
+        size:
+          type: integer
+          description: File size in bytes
+        project_id:
+          type: string
+          format: uuid
+          description: UUID of the project to associate with the asset
+        external_id:
+          type: string
+          minLength: 1
+          description: External identifier for the asset (for integration tracking)
+        external_source:
+          type: string
+          minLength: 1
+          description: External source system (for integration tracking)
+      required:
+      - name
+      - size
+    GroupEnum:
+      enum:
+      - backlog
+      - unstarted
+      - started
+      - completed
+      - cancelled
+      - triage
+      type: string
+      description: |-
+        * `backlog` - Backlog
+        * `unstarted` - Unstarted
+        * `started` - Started
+        * `completed` - Completed
+        * `cancelled` - Cancelled
+        * `triage` - Triage
+    IntakeIssue:
+      type: object
+      description: |-
+        Comprehensive serializer for intake work items with expanded issue details.
+
+        Provides full intake work item data including embedded issue information,
+        status tracking, and triage metadata for issue queue management.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        issue_detail:
+          allOf:
+          - $ref: '#/components/schemas/IssueExpand'
+          readOnly: true
+        inbox:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/IntakeWorkItemStatusEnum'
+          minimum: -2147483648
+          maximum: 2147483647
+        snoozed_till:
+          type: string
+          format: date-time
+          nullable: true
+        source:
+          type: string
+          nullable: true
+          maxLength: 255
+        source_email:
+          type: string
+          nullable: true
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        extra: {}
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        intake:
+          type: string
+          format: uuid
+        issue:
+          type: string
+          format: uuid
+          readOnly: true
+        duplicate_to:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - intake
+    IntakeIssueCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating intake work items with embedded issue data.
+
+        Manages intake work item creation including nested issue creation,
+        status assignment, and source tracking for issue queue management.
+      properties:
+        issue:
+          allOf:
+          - $ref: '#/components/schemas/IssueForIntakeRequest'
+          description: Issue data for the intake issue
+      required:
+      - issue
+    IntakeWorkItemStatusEnum:
+      enum:
+      - -2
+      - -1
+      - 0
+      - 1
+      - 2
+      type: integer
+      description: |-
+        * `-2` - Pending
+        * `-1` - Rejected
+        * `0` - Snoozed
+        * `1` - Accepted
+        * `2` - Duplicate
+    Issue:
+      type: object
+      description: |-
+        Comprehensive work item serializer with full relationship management.
+
+        Handles complete work item lifecycle including assignees, labels, validation,
+        and related model updates. Supports dynamic field expansion and HTML content
+        processing.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        type_id:
+          type: string
+          format: uuid
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        point:
+          type: integer
+          maximum: 12
+          minimum: 0
+          nullable: true
+        name:
+          type: string
+          title: Issue Name
+          maxLength: 255
+        description_html:
+          type: string
+        description_binary:
+          type: string
+          format: byte
+          readOnly: true
+          nullable: true
+        priority:
+          allOf:
+          - $ref: '#/components/schemas/PriorityEnum'
+          title: Issue Priority
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        sequence_id:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          title: Issue Sequence ID
+        sort_order:
+          type: number
+          format: double
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        archived_at:
+          type: string
+          format: date
+          nullable: true
+        is_draft:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          type: string
+          format: uuid
+          nullable: true
+        estimate_point:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - name
+    IssueActivity:
+      type: object
+      description: |-
+        Serializer for work item activity and change history.
+
+        Tracks and represents work item modifications, state changes,
+        and user interactions for audit trails and activity feeds.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        verb:
+          type: string
+          title: Action
+          maxLength: 255
+        field:
+          type: string
+          nullable: true
+          title: Field Name
+          maxLength: 255
+        old_value:
+          type: string
+          nullable: true
+        new_value:
+          type: string
+          nullable: true
+        comment:
+          type: string
+        attachments:
+          type: array
+          items:
+            type: string
+            format: uri
+            maxLength: 200
+          maxItems: 10
+        old_identifier:
+          type: string
+          format: uuid
+          nullable: true
+        new_identifier:
+          type: string
+          format: uuid
+          nullable: true
+        epoch:
+          type: number
+          format: double
+          nullable: true
+        project:
+          type: string
+          format: uuid
+        workspace:
+          type: string
+          format: uuid
+        issue:
+          type: string
+          format: uuid
+          nullable: true
+        issue_comment:
+          type: string
+          format: uuid
+          nullable: true
+        actor:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - project
+      - workspace
+    IssueAttachment:
+      type: object
+      description: |-
+        Serializer for work item file attachments.
+
+        Manages file asset associations with work items including metadata,
+        storage information, and access control for document management.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        attributes: {}
+        asset:
+          type: string
+          format: uri
+        entity_type:
+          type: string
+          nullable: true
+          maxLength: 255
+        entity_identifier:
+          type: string
+          nullable: true
+          maxLength: 255
+        is_deleted:
+          type: boolean
+        is_archived:
+          type: boolean
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        size:
+          type: number
+          format: double
+        is_uploaded:
+          type: boolean
+        storage_metadata:
+          nullable: true
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        user:
+          type: string
+          format: uuid
+          nullable: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        draft_issue:
+          type: string
+          format: uuid
+          nullable: true
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        issue:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        comment:
+          type: string
+          format: uuid
+          nullable: true
+        page:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - asset
+    IssueAttachmentUploadRequest:
+      type: object
+      description: |-
+        Serializer for work item attachment upload request validation.
+
+        Handles file upload metadata validation including size, type, and external
+        integration tracking for secure work item document attachment workflows.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Original filename of the asset
+        type:
+          type: string
+          minLength: 1
+          description: MIME type of the file
+        size:
+          type: integer
+          description: File size in bytes
+        external_id:
+          type: string
+          minLength: 1
+          description: External identifier for the asset (for integration tracking)
+        external_source:
+          type: string
+          minLength: 1
+          description: External source system (for integration tracking)
+      required:
+      - name
+      - size
+    IssueComment:
+      type: object
+      description: |-
+        Full serializer for work item comments with membership context.
+
+        Provides complete comment data including member status, content formatting,
+        and edit tracking for collaborative work item discussions.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        is_member:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        comment_html:
+          type: string
+        attachments:
+          type: array
+          items:
+            type: string
+            format: uri
+            maxLength: 200
+          maxItems: 10
+        access:
+          $ref: '#/components/schemas/AccessEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        edited_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        description:
+          type: string
+          format: uuid
+          nullable: true
+        issue:
+          type: string
+          format: uuid
+          readOnly: true
+        actor:
+          type: string
+          format: uuid
+          nullable: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+    IssueCommentCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating work item comments.
+
+        Handles comment creation with JSON and HTML content support,
+        access control, and external integration tracking.
+      properties:
+        comment_json: {}
+        comment_html:
+          type: string
+        access:
+          $ref: '#/components/schemas/AccessEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+    IssueExpand:
+      type: object
+      description: |-
+        Extended work item serializer with full relationship expansion.
+
+        Provides work items with expanded related data including cycles, modules,
+        labels, assignees, and states for comprehensive data representation.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        cycle:
+          allOf:
+          - $ref: '#/components/schemas/CycleLite'
+          readOnly: true
+        module:
+          allOf:
+          - $ref: '#/components/schemas/ModuleLite'
+          readOnly: true
+        labels:
+          type: string
+          readOnly: true
+        assignees:
+          type: string
+          readOnly: true
+        state:
+          allOf:
+          - $ref: '#/components/schemas/StateLite'
+          readOnly: true
+        description:
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        point:
+          type: integer
+          maximum: 12
+          minimum: 0
+          nullable: true
+        name:
+          type: string
+          title: Issue Name
+          maxLength: 255
+        description_json: {}
+        description_html:
+          type: string
+        description_stripped:
+          type: string
+          nullable: true
+        description_binary:
+          type: string
+          format: byte
+          readOnly: true
+          nullable: true
+        priority:
+          allOf:
+          - $ref: '#/components/schemas/PriorityEnum'
+          title: Issue Priority
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        sequence_id:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          title: Issue Sequence ID
+        sort_order:
+          type: number
+          format: double
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        archived_at:
+          type: string
+          format: date
+          nullable: true
+        is_draft:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        estimate_point:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - name
+    IssueForIntakeRequest:
+      type: object
+      description: |-
+        Serializer for work item data within intake submissions.
+
+        Handles essential work item fields for intake processing including
+        content validation and priority assignment for triage workflows.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Issue Name
+          maxLength: 255
+        description:
+          nullable: true
+        description_json: {}
+        description_html:
+          type: string
+        priority:
+          allOf:
+          - $ref: '#/components/schemas/PriorityEnum'
+          title: Issue Priority
+      required:
+      - name
+    IssueLink:
+      type: object
+      description: |-
+        Full serializer for work item external links.
+
+        Provides complete link information including metadata and timestamps
+        for managing external resource associations with work items.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        title:
+          type: string
+          nullable: true
+          maxLength: 255
+        url:
+          type: string
+        metadata: {}
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        issue:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - url
+    IssueLinkCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating work item external links with validation.
+
+        Handles URL validation, format checking, and duplicate prevention
+        for attaching external resources to work items.
+      properties:
+        title:
+          type: string
+          nullable: true
+          maxLength: 255
+        url:
+          type: string
+          minLength: 1
+      required:
+      - url
+    IssueRelation:
+      type: object
+      description: |-
+        Serializer for issue relationships showing related issue details.
+
+        Provides comprehensive information about related issues including
+        project context, sequence ID, and relationship type.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        project_id:
+          type: string
+          format: uuid
+          readOnly: true
+        sequence_id:
+          type: integer
+          readOnly: true
+        relation_type:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        state_id:
+          type: string
+          format: uuid
+          readOnly: true
+        priority:
+          type: string
+          readOnly: true
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+    IssueRelationCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating issue relations.
+
+        Creates issue relations with the specified relation type and issues.
+        Validates relation types and ensures proper issue ID format.
+      properties:
+        relation_type:
+          allOf:
+          - $ref: '#/components/schemas/RelationTypeEnum'
+          description: |-
+            Type of relationship between work items
+
+            * `blocking` - Blocking
+            * `blocked_by` - Blocked By
+            * `duplicate` - Duplicate
+            * `relates_to` - Relates To
+            * `start_before` - Start Before
+            * `start_after` - Start After
+            * `finish_before` - Finish Before
+            * `finish_after` - Finish After
+        issues:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Array of work item IDs to create relations with
+          minItems: 1
+      required:
+      - issues
+      - relation_type
+    IssueRelationResponse:
+      type: object
+      description: |-
+        Serializer for issue relations response showing grouped relation types.
+
+        Returns issue IDs organized by relation type for efficient client-side processing.
+      properties:
+        blocking:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that are blocking this issue
+        blocked_by:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that this issue is blocked by
+        duplicate:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that are duplicates of this issue
+        relates_to:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that relate to this issue
+        start_after:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that start after this issue
+        start_before:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that start before this issue
+        finish_after:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that finish after this issue
+        finish_before:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs that finish before this issue
+      required:
+      - blocked_by
+      - blocking
+      - duplicate
+      - finish_after
+      - finish_before
+      - relates_to
+      - start_after
+      - start_before
+    IssueRequest:
+      type: object
+      description: |-
+        Comprehensive work item serializer with full relationship management.
+
+        Handles complete work item lifecycle including assignees, labels, validation,
+        and related model updates. Supports dynamic field expansion and HTML content
+        processing.
+      properties:
+        assignees:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        labels:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        type_id:
+          type: string
+          format: uuid
+          nullable: true
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        point:
+          type: integer
+          maximum: 12
+          minimum: 0
+          nullable: true
+        name:
+          type: string
+          minLength: 1
+          title: Issue Name
+          maxLength: 255
+        description_html:
+          type: string
+        priority:
+          allOf:
+          - $ref: '#/components/schemas/PriorityEnum'
+          title: Issue Priority
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        sequence_id:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          title: Issue Sequence ID
+        sort_order:
+          type: number
+          format: double
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        archived_at:
+          type: string
+          format: date
+          nullable: true
+        is_draft:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          type: string
+          format: uuid
+          nullable: true
+        estimate_point:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - name
+    IssueSearch:
+      type: object
+      description: |-
+        Serializer for work item search result data formatting.
+
+        Provides standardized search result structure including work item identifiers,
+        project context, and workspace information for search API responses.
+      properties:
+        id:
+          type: string
+          description: Issue ID
+        name:
+          type: string
+          description: Issue name
+        sequence_id:
+          type: string
+          description: Issue sequence ID
+        project__identifier:
+          type: string
+          description: Project identifier
+        project_id:
+          type: string
+          description: Project ID
+        workspace__slug:
+          type: string
+          description: Workspace slug
+      required:
+      - id
+      - name
+      - project__identifier
+      - project_id
+      - sequence_id
+      - workspace__slug
+    Label:
+      type: object
+      description: |-
+        Full serializer for work item labels with complete metadata.
+
+        Provides comprehensive label information including hierarchical relationships,
+        visual properties, and organizational data for work item tagging.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        color:
+          type: string
+          maxLength: 255
+        sort_order:
+          type: number
+          format: double
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - name
+    LabelCreateUpdateRequest:
+      type: object
+      description: |-
+        Serializer for creating and updating work item labels.
+
+        Manages label metadata including colors, descriptions, hierarchy,
+        and sorting for work item categorization and filtering.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        color:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        sort_order:
+          type: number
+          format: double
+      required:
+      - name
+    Module:
+      type: object
+      description: |-
+        Comprehensive module serializer with work item metrics and member management.
+
+        Provides complete module data including work item counts by status, member
+        relationships, and progress tracking for feature-based project organization.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        total_issues:
+          type: integer
+          readOnly: true
+        cancelled_issues:
+          type: integer
+          readOnly: true
+        completed_issues:
+          type: integer
+          readOnly: true
+        started_issues:
+          type: integer
+          readOnly: true
+        unstarted_issues:
+          type: integer
+          readOnly: true
+        backlog_issues:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          title: Module Name
+          maxLength: 255
+        description:
+          type: string
+          title: Module Description
+        description_text:
+          nullable: true
+          title: Module Description RT
+        description_html:
+          nullable: true
+          title: Module Description HTML
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/ModuleStatusEnum'
+        view_props: {}
+        sort_order:
+          type: number
+          format: double
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        logo_props: {}
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        lead:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - name
+    ModuleCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating modules with member validation and date checking.
+
+        Handles module creation including member assignment validation, date range
+        verification, and duplicate name prevention for feature-based
+        project organization setup.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Module Name
+          maxLength: 255
+        description:
+          type: string
+          title: Module Description
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/ModuleStatusEnum'
+        lead:
+          type: string
+          format: uuid
+          nullable: true
+        members:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+      required:
+      - name
+    ModuleIssue:
+      type: object
+      description: |-
+        Serializer for module-work item relationships with sub-item counting.
+
+        Manages the association between modules and work items, including
+        hierarchical issue tracking for nested work item structures.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        sub_issues_count:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        module:
+          type: string
+          format: uuid
+          readOnly: true
+        issue:
+          type: string
+          format: uuid
+      required:
+      - deleted_at
+      - issue
+    ModuleIssueRequestRequest:
+      type: object
+      description: |-
+        Serializer for bulk work item assignment to modules.
+
+        Validates work item ID lists for batch operations including
+        module assignment and work item organization workflows.
+      properties:
+        issues:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of issue IDs to add to the module
+      required:
+      - issues
+    ModuleLite:
+      type: object
+      description: |-
+        Lightweight module serializer for minimal data transfer.
+
+        Provides essential module information without computed metrics,
+        optimized for list views and reference lookups.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        name:
+          type: string
+          title: Module Name
+          maxLength: 255
+        description:
+          type: string
+          title: Module Description
+        description_text:
+          nullable: true
+          title: Module Description RT
+        description_html:
+          nullable: true
+          title: Module Description HTML
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/ModuleStatusEnum'
+        view_props: {}
+        sort_order:
+          type: number
+          format: double
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        logo_props: {}
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+        workspace:
+          type: string
+          format: uuid
+        lead:
+          type: string
+          format: uuid
+          nullable: true
+        members:
+          type: array
+          items:
+            type: string
+            format: uuid
+          readOnly: true
+      required:
+      - deleted_at
+      - name
+      - project
+      - workspace
+    ModuleStatusEnum:
+      enum:
+      - backlog
+      - planned
+      - in-progress
+      - paused
+      - completed
+      - cancelled
+      type: string
+      description: |-
+        * `backlog` - Backlog
+        * `planned` - Planned
+        * `in-progress` - In Progress
+        * `paused` - Paused
+        * `completed` - Completed
+        * `cancelled` - Cancelled
+    NetworkEnum:
+      enum:
+      - 0
+      - 2
+      type: integer
+      description: |-
+        * `0` - Secret
+        * `2` - Public
+    PaginatedArchivedCycleResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cycle'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedArchivedModuleResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Module'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedCycleIssueResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Issue'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedCycleResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Cycle'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIntakeIssueResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IntakeIssue'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIssueActivityDetailResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IssueActivity'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIssueActivityResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IssueActivity'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIssueCommentResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IssueComment'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIssueLinkDetailResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IssueLink'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedIssueLinkResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/IssueLink'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedLabelResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Label'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedModuleIssueResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Issue'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedModuleResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Module'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedProjectResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Project'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedStateResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/State'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PaginatedWorkItemResponse:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Issue'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    PatchedAssetUpdateRequest:
+      type: object
+      description: |-
+        Serializer for asset status updates after successful upload completion.
+
+        Handles post-upload asset metadata updates including attribute modifications
+        and upload confirmation for S3-based file storage workflows.
+      properties:
+        attributes:
+          description: Additional attributes to update for the asset
+    PatchedCycleUpdateRequest:
+      type: object
+      description: |-
+        Serializer for updating cycles with enhanced ownership management.
+
+        Extends cycle creation with update-specific features including ownership
+        assignment and modification tracking for cycle lifecycle management.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Cycle Name
+          maxLength: 255
+        description:
+          type: string
+          title: Cycle Description
+        start_date:
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+        owned_by:
+          type: string
+          format: uuid
+          nullable: true
+          description: User who owns the cycle. If not provided, defaults to the current user.
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+    PatchedGenericAssetUpdateRequest:
+      type: object
+      description: |-
+        Serializer for generic asset upload confirmation and status management.
+
+        Handles post-upload status updates for workspace assets including
+        upload completion marking and metadata finalization.
+      properties:
+        is_uploaded:
+          type: boolean
+          default: true
+          description: Whether the asset has been successfully uploaded
+    PatchedIntakeIssueUpdateRequest:
+      type: object
+      description: |-
+        Serializer for updating intake work items and their associated issues.
+
+        Handles intake work item modifications including status changes, triage decisions,
+        and embedded issue updates for issue queue processing workflows.
+      properties:
+        status:
+          allOf:
+          - $ref: '#/components/schemas/IntakeWorkItemStatusEnum'
+          minimum: -2147483648
+          maximum: 2147483647
+        snoozed_till:
+          type: string
+          format: date-time
+          nullable: true
+        duplicate_to:
+          type: string
+          format: uuid
+          nullable: true
+        source:
+          type: string
+          nullable: true
+          maxLength: 255
+        source_email:
+          type: string
+          nullable: true
+        issue:
+          allOf:
+          - $ref: '#/components/schemas/IssueForIntakeRequest'
+          description: Issue data to update in the intake issue
+    PatchedIssueCommentCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating work item comments.
+
+        Handles comment creation with JSON and HTML content support,
+        access control, and external integration tracking.
+      properties:
+        comment_json: {}
+        comment_html:
+          type: string
+        access:
+          $ref: '#/components/schemas/AccessEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+    PatchedIssueLinkUpdateRequest:
+      type: object
+      description: |-
+        Serializer for updating work item external links.
+
+        Extends link creation with update-specific validation to prevent
+        URL conflicts and maintain link integrity during modifications.
+      properties:
+        title:
+          type: string
+          nullable: true
+          maxLength: 255
+        url:
+          type: string
+          minLength: 1
+    PatchedIssueRequest:
+      type: object
+      description: |-
+        Comprehensive work item serializer with full relationship management.
+
+        Handles complete work item lifecycle including assignees, labels, validation,
+        and related model updates. Supports dynamic field expansion and HTML content
+        processing.
+      properties:
+        assignees:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        labels:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        type_id:
+          type: string
+          format: uuid
+          nullable: true
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        point:
+          type: integer
+          maximum: 12
+          minimum: 0
+          nullable: true
+        name:
+          type: string
+          minLength: 1
+          title: Issue Name
+          maxLength: 255
+        description_html:
+          type: string
+        priority:
+          allOf:
+          - $ref: '#/components/schemas/PriorityEnum'
+          title: Issue Priority
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        sequence_id:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          title: Issue Sequence ID
+        sort_order:
+          type: number
+          format: double
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        archived_at:
+          type: string
+          format: date
+          nullable: true
+        is_draft:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          type: string
+          format: uuid
+          nullable: true
+        estimate_point:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          type: string
+          format: uuid
+          nullable: true
+    PatchedLabelCreateUpdateRequest:
+      type: object
+      description: |-
+        Serializer for creating and updating work item labels.
+
+        Manages label metadata including colors, descriptions, hierarchy,
+        and sorting for work item categorization and filtering.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        color:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        parent:
+          type: string
+          format: uuid
+          nullable: true
+        sort_order:
+          type: number
+          format: double
+    PatchedModuleUpdateRequest:
+      type: object
+      description: |-
+        Serializer for updating modules with enhanced validation and member management.
+
+        Extends module creation with update-specific validations including
+        member reassignment, name conflict checking,
+        and relationship management for module modifications.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Module Name
+          maxLength: 255
+        description:
+          type: string
+          title: Module Description
+        start_date:
+          type: string
+          format: date
+          nullable: true
+        target_date:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/ModuleStatusEnum'
+        lead:
+          type: string
+          format: uuid
+          nullable: true
+        members:
+          type: array
+          items:
+            type: string
+            format: uuid
+          writeOnly: true
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+    PatchedProjectMemberRequest:
+      type: object
+      description: Serializer for project members.
+      properties:
+        member:
+          type: string
+          format: uuid
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+    PatchedProjectUpdateRequest:
+      type: object
+      description: |-
+        Serializer for updating projects with enhanced state and estimation management.
+
+        Extends project creation with update-specific validations including default state
+        assignment, estimation configuration, and project setting modifications.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Project Name
+          maxLength: 255
+        description:
+          type: string
+          title: Project Description
+        project_lead:
+          type: string
+          format: uuid
+          nullable: true
+        default_assignee:
+          type: string
+          format: uuid
+          nullable: true
+        identifier:
+          type: string
+          minLength: 1
+          title: Project Identifier
+          maxLength: 12
+        icon_prop:
+          nullable: true
+        emoji:
+          type: string
+          nullable: true
+          maxLength: 255
+        cover_image:
+          type: string
+          nullable: true
+        module_view:
+          type: boolean
+        cycle_view:
+          type: boolean
+        issue_views_view:
+          type: boolean
+        page_view:
+          type: boolean
+        intake_view:
+          type: boolean
+        guest_view_all_features:
+          type: boolean
+        archive_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        close_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        is_issue_type_enabled:
+          type: boolean
+        is_time_tracking_enabled:
+          type: boolean
+        default_state:
+          type: string
+          format: uuid
+          nullable: true
+        estimate:
+          type: string
+          format: uuid
+          nullable: true
+    PatchedStateRequest:
+      type: object
+      description: |-
+        Serializer for work item states with default state management.
+
+        Handles state creation and updates including default state validation
+        and automatic default state switching for workflow management.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: State Name
+          maxLength: 255
+        description:
+          type: string
+          title: State Description
+        color:
+          type: string
+          minLength: 1
+          title: State Color
+          maxLength: 255
+        sequence:
+          type: number
+          format: double
+        group:
+          $ref: '#/components/schemas/GroupEnum'
+        is_triage:
+          type: boolean
+        default:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+    PatchedStickyRequest:
+      type: object
+      description: |-
+        Base serializer providing common functionality for all model serializers.
+
+        Features field filtering, dynamic expansion of related fields, and standardized
+        primary key handling for consistent API responses across the application.
+      properties:
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        description: {}
+        description_html:
+          type: string
+        description_stripped:
+          type: string
+          nullable: true
+        logo_props: {}
+        color:
+          type: string
+          nullable: true
+          maxLength: 255
+        background_color:
+          type: string
+          nullable: true
+          maxLength: 255
+        sort_order:
+          type: number
+          format: double
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          nullable: true
+          title: Last Modified By
+    PatchedWorkspaceInviteRequest:
+      type: object
+      description: Serializer for workspace invites.
+      properties:
+        email:
+          type: string
+          minLength: 1
+          maxLength: 255
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+    PriorityEnum:
+      enum:
+      - urgent
+      - high
+      - medium
+      - low
+      - none
+      type: string
+      description: |-
+        * `urgent` - Urgent
+        * `high` - High
+        * `medium` - Medium
+        * `low` - Low
+        * `none` - None
+    Project:
+      type: object
+      description: |-
+        Comprehensive project serializer with metrics and member context.
+
+        Provides complete project data including member counts, cycle/module totals,
+        deployment status, and user-specific context for project management.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        total_members:
+          type: integer
+          readOnly: true
+        total_cycles:
+          type: integer
+          readOnly: true
+        total_modules:
+          type: integer
+          readOnly: true
+        is_member:
+          type: boolean
+          readOnly: true
+        sort_order:
+          type: number
+          format: double
+          readOnly: true
+        member_role:
+          type: integer
+          readOnly: true
+        is_deployed:
+          type: boolean
+          readOnly: true
+        cover_image_url:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          title: Project Name
+          maxLength: 255
+        description:
+          type: string
+          title: Project Description
+        description_text:
+          nullable: true
+          title: Project Description RT
+        description_html:
+          nullable: true
+          title: Project Description HTML
+        network:
+          allOf:
+          - $ref: '#/components/schemas/NetworkEnum'
+          minimum: 0
+          maximum: 32767
+        identifier:
+          type: string
+          title: Project Identifier
+          maxLength: 12
+        emoji:
+          type: string
+          readOnly: true
+          nullable: true
+        icon_prop:
+          nullable: true
+        module_view:
+          type: boolean
+        cycle_view:
+          type: boolean
+        issue_views_view:
+          type: boolean
+        page_view:
+          type: boolean
+        intake_view:
+          type: boolean
+        is_time_tracking_enabled:
+          type: boolean
+        is_issue_type_enabled:
+          type: boolean
+        guest_view_all_features:
+          type: boolean
+        cover_image:
+          type: string
+          nullable: true
+        archive_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        close_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        logo_props: {}
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+        default_assignee:
+          type: string
+          format: uuid
+          nullable: true
+        project_lead:
+          type: string
+          format: uuid
+          nullable: true
+        cover_image_asset:
+          type: string
+          format: uuid
+          nullable: true
+        estimate:
+          type: string
+          format: uuid
+          nullable: true
+        default_state:
+          type: string
+          format: uuid
+          nullable: true
+      required:
+      - identifier
+      - name
+    ProjectCreateRequest:
+      type: object
+      description: |-
+        Serializer for creating projects with workspace validation.
+
+        Handles project creation including identifier validation, member verification,
+        and workspace association for new project initialization.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: Project Name
+          maxLength: 255
+        description:
+          type: string
+          title: Project Description
+        project_lead:
+          type: string
+          format: uuid
+          nullable: true
+        default_assignee:
+          type: string
+          format: uuid
+          nullable: true
+        identifier:
+          type: string
+          minLength: 1
+          title: Project Identifier
+          maxLength: 12
+        icon_prop:
+          nullable: true
+        emoji:
+          type: string
+          nullable: true
+          maxLength: 255
+        cover_image:
+          type: string
+          nullable: true
+        module_view:
+          type: boolean
+        cycle_view:
+          type: boolean
+        issue_views_view:
+          type: boolean
+        page_view:
+          type: boolean
+        intake_view:
+          type: boolean
+        guest_view_all_features:
+          type: boolean
+        archive_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        close_in:
+          type: integer
+          maximum: 12
+          minimum: 0
+        timezone:
+          $ref: '#/components/schemas/TimezoneEnum'
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        is_issue_type_enabled:
+          type: boolean
+        is_time_tracking_enabled:
+          type: boolean
+      required:
+      - identifier
+      - name
+    ProjectMember:
+      type: object
+      description: Serializer for project members.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        member:
+          type: string
+          format: uuid
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+      required:
+      - member
+    ProjectMemberRequest:
+      type: object
+      description: Serializer for project members.
+      properties:
+        member:
+          type: string
+          format: uuid
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+      required:
+      - member
+    RelationTypeEnum:
+      enum:
+      - blocking
+      - blocked_by
+      - duplicate
+      - relates_to
+      - start_before
+      - start_after
+      - finish_before
+      - finish_after
+      type: string
+      description: |-
+        * `blocking` - Blocking
+        * `blocked_by` - Blocked By
+        * `duplicate` - Duplicate
+        * `relates_to` - Relates To
+        * `start_before` - Start Before
+        * `start_after` - Start After
+        * `finish_before` - Finish Before
+        * `finish_after` - Finish After
+    RoleEnum:
+      enum:
+      - 20
+      - 15
+      - 5
+      type: integer
+      description: |-
+        * `20` - Admin
+        * `15` - Member
+        * `5` - Guest
+    State:
+      type: object
+      description: |-
+        Serializer for work item states with default state management.
+
+        Handles state creation and updates including default state validation
+        and automatic default state switching for workflow management.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        deleted_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          title: State Name
+          maxLength: 255
+        description:
+          type: string
+          title: State Description
+        color:
+          type: string
+          title: State Color
+          maxLength: 255
+        slug:
+          type: string
+          readOnly: true
+          pattern: ^[-a-zA-Z0-9_]+$
+        sequence:
+          type: number
+          format: double
+        group:
+          $ref: '#/components/schemas/GroupEnum'
+        is_triage:
+          type: boolean
+        default:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+        created_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+          title: Last Modified By
+        project:
+          type: string
+          format: uuid
+          readOnly: true
+        workspace:
+          type: string
+          format: uuid
+          readOnly: true
+      required:
+      - color
+      - name
+    StateLite:
+      type: object
+      description: |-
+        Lightweight state serializer for minimal data transfer.
+
+        Provides essential state information including visual properties
+        and grouping data optimized for UI display and filtering.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+          title: State Name
+        color:
+          type: string
+          readOnly: true
+          title: State Color
+        group:
+          allOf:
+          - $ref: '#/components/schemas/GroupEnum'
+          readOnly: true
+    StateRequest:
+      type: object
+      description: |-
+        Serializer for work item states with default state management.
+
+        Handles state creation and updates including default state validation
+        and automatic default state switching for workflow management.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          title: State Name
+          maxLength: 255
+        description:
+          type: string
+          title: State Description
+        color:
+          type: string
+          minLength: 1
+          title: State Color
+          maxLength: 255
+        sequence:
+          type: number
+          format: double
+        group:
+          $ref: '#/components/schemas/GroupEnum'
+        is_triage:
+          type: boolean
+        default:
+          type: boolean
+        external_source:
+          type: string
+          nullable: true
+          maxLength: 255
+        external_id:
+          type: string
+          nullable: true
+          maxLength: 255
+      required:
+      - color
+      - name
+    Sticky:
+      type: object
+      properties:
+        grouped_by:
+          type: string
+          nullable: true
+        sub_grouped_by:
+          type: string
+          nullable: true
+        total_count:
+          type: integer
+        next_cursor:
+          type: string
+        prev_cursor:
+          type: string
+        next_page_results:
+          type: boolean
+        prev_page_results:
+          type: boolean
+        count:
+          type: integer
+        total_pages:
+          type: integer
+        total_results:
+          type: integer
+        extra_stats:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sticky'
+      required:
+      - count
+      - extra_stats
+      - grouped_by
+      - next_cursor
+      - next_page_results
+      - prev_cursor
+      - prev_page_results
+      - results
+      - sub_grouped_by
+      - total_count
+      - total_pages
+      - total_results
+    StickyRequest:
+      type: object
+      description: |-
+        Base serializer providing common functionality for all model serializers.
+
+        Features field filtering, dynamic expansion of related fields, and standardized
+        primary key handling for consistent API responses across the application.
+      properties:
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        description: {}
+        description_html:
+          type: string
+        description_stripped:
+          type: string
+          nullable: true
+        logo_props: {}
+        color:
+          type: string
+          nullable: true
+          maxLength: 255
+        background_color:
+          type: string
+          nullable: true
+          maxLength: 255
+        sort_order:
+          type: number
+          format: double
+        created_by:
+          type: string
+          format: uuid
+          nullable: true
+        updated_by:
+          type: string
+          format: uuid
+          nullable: true
+          title: Last Modified By
+    TimezoneEnum:
+      enum:
+      - Africa/Abidjan
+      - Africa/Accra
+      - Africa/Addis_Ababa
+      - Africa/Algiers
+      - Africa/Asmara
+      - Africa/Bamako
+      - Africa/Bangui
+      - Africa/Banjul
+      - Africa/Bissau
+      - Africa/Blantyre
+      - Africa/Brazzaville
+      - Africa/Bujumbura
+      - Africa/Cairo
+      - Africa/Casablanca
+      - Africa/Ceuta
+      - Africa/Conakry
+      - Africa/Dakar
+      - Africa/Dar_es_Salaam
+      - Africa/Djibouti
+      - Africa/Douala
+      - Africa/El_Aaiun
+      - Africa/Freetown
+      - Africa/Gaborone
+      - Africa/Harare
+      - Africa/Johannesburg
+      - Africa/Juba
+      - Africa/Kampala
+      - Africa/Khartoum
+      - Africa/Kigali
+      - Africa/Kinshasa
+      - Africa/Lagos
+      - Africa/Libreville
+      - Africa/Lome
+      - Africa/Luanda
+      - Africa/Lubumbashi
+      - Africa/Lusaka
+      - Africa/Malabo
+      - Africa/Maputo
+      - Africa/Maseru
+      - Africa/Mbabane
+      - Africa/Mogadishu
+      - Africa/Monrovia
+      - Africa/Nairobi
+      - Africa/Ndjamena
+      - Africa/Niamey
+      - Africa/Nouakchott
+      - Africa/Ouagadougou
+      - Africa/Porto-Novo
+      - Africa/Sao_Tome
+      - Africa/Tripoli
+      - Africa/Tunis
+      - Africa/Windhoek
+      - America/Adak
+      - America/Anchorage
+      - America/Anguilla
+      - America/Antigua
+      - America/Araguaina
+      - America/Argentina/Buenos_Aires
+      - America/Argentina/Catamarca
+      - America/Argentina/Cordoba
+      - America/Argentina/Jujuy
+      - America/Argentina/La_Rioja
+      - America/Argentina/Mendoza
+      - America/Argentina/Rio_Gallegos
+      - America/Argentina/Salta
+      - America/Argentina/San_Juan
+      - America/Argentina/San_Luis
+      - America/Argentina/Tucuman
+      - America/Argentina/Ushuaia
+      - America/Aruba
+      - America/Asuncion
+      - America/Atikokan
+      - America/Bahia
+      - America/Bahia_Banderas
+      - America/Barbados
+      - America/Belem
+      - America/Belize
+      - America/Blanc-Sablon
+      - America/Boa_Vista
+      - America/Bogota
+      - America/Boise
+      - America/Cambridge_Bay
+      - America/Campo_Grande
+      - America/Cancun
+      - America/Caracas
+      - America/Cayenne
+      - America/Cayman
+      - America/Chicago
+      - America/Chihuahua
+      - America/Ciudad_Juarez
+      - America/Costa_Rica
+      - America/Creston
+      - America/Cuiaba
+      - America/Curacao
+      - America/Danmarkshavn
+      - America/Dawson
+      - America/Dawson_Creek
+      - America/Denver
+      - America/Detroit
+      - America/Dominica
+      - America/Edmonton
+      - America/Eirunepe
+      - America/El_Salvador
+      - America/Fort_Nelson
+      - America/Fortaleza
+      - America/Glace_Bay
+      - America/Goose_Bay
+      - America/Grand_Turk
+      - America/Grenada
+      - America/Guadeloupe
+      - America/Guatemala
+      - America/Guayaquil
+      - America/Guyana
+      - America/Halifax
+      - America/Havana
+      - America/Hermosillo
+      - America/Indiana/Indianapolis
+      - America/Indiana/Knox
+      - America/Indiana/Marengo
+      - America/Indiana/Petersburg
+      - America/Indiana/Tell_City
+      - America/Indiana/Vevay
+      - America/Indiana/Vincennes
+      - America/Indiana/Winamac
+      - America/Inuvik
+      - America/Iqaluit
+      - America/Jamaica
+      - America/Juneau
+      - America/Kentucky/Louisville
+      - America/Kentucky/Monticello
+      - America/Kralendijk
+      - America/La_Paz
+      - America/Lima
+      - America/Los_Angeles
+      - America/Lower_Princes
+      - America/Maceio
+      - America/Managua
+      - America/Manaus
+      - America/Marigot
+      - America/Martinique
+      - America/Matamoros
+      - America/Mazatlan
+      - America/Menominee
+      - America/Merida
+      - America/Metlakatla
+      - America/Mexico_City
+      - America/Miquelon
+      - America/Moncton
+      - America/Monterrey
+      - America/Montevideo
+      - America/Montserrat
+      - America/Nassau
+      - America/New_York
+      - America/Nome
+      - America/Noronha
+      - America/North_Dakota/Beulah
+      - America/North_Dakota/Center
+      - America/North_Dakota/New_Salem
+      - America/Nuuk
+      - America/Ojinaga
+      - America/Panama
+      - America/Paramaribo
+      - America/Phoenix
+      - America/Port-au-Prince
+      - America/Port_of_Spain
+      - America/Porto_Velho
+      - America/Puerto_Rico
+      - America/Punta_Arenas
+      - America/Rankin_Inlet
+      - America/Recife
+      - America/Regina
+      - America/Resolute
+      - America/Rio_Branco
+      - America/Santarem
+      - America/Santiago
+      - America/Santo_Domingo
+      - America/Sao_Paulo
+      - America/Scoresbysund
+      - America/Sitka
+      - America/St_Barthelemy
+      - America/St_Johns
+      - America/St_Kitts
+      - America/St_Lucia
+      - America/St_Thomas
+      - America/St_Vincent
+      - America/Swift_Current
+      - America/Tegucigalpa
+      - America/Thule
+      - America/Tijuana
+      - America/Toronto
+      - America/Tortola
+      - America/Vancouver
+      - America/Whitehorse
+      - America/Winnipeg
+      - America/Yakutat
+      - Antarctica/Casey
+      - Antarctica/Davis
+      - Antarctica/DumontDUrville
+      - Antarctica/Macquarie
+      - Antarctica/Mawson
+      - Antarctica/McMurdo
+      - Antarctica/Palmer
+      - Antarctica/Rothera
+      - Antarctica/Syowa
+      - Antarctica/Troll
+      - Antarctica/Vostok
+      - Arctic/Longyearbyen
+      - Asia/Aden
+      - Asia/Almaty
+      - Asia/Amman
+      - Asia/Anadyr
+      - Asia/Aqtau
+      - Asia/Aqtobe
+      - Asia/Ashgabat
+      - Asia/Atyrau
+      - Asia/Baghdad
+      - Asia/Bahrain
+      - Asia/Baku
+      - Asia/Bangkok
+      - Asia/Barnaul
+      - Asia/Beirut
+      - Asia/Bishkek
+      - Asia/Brunei
+      - Asia/Chita
+      - Asia/Choibalsan
+      - Asia/Colombo
+      - Asia/Damascus
+      - Asia/Dhaka
+      - Asia/Dili
+      - Asia/Dubai
+      - Asia/Dushanbe
+      - Asia/Famagusta
+      - Asia/Gaza
+      - Asia/Hebron
+      - Asia/Ho_Chi_Minh
+      - Asia/Hong_Kong
+      - Asia/Hovd
+      - Asia/Irkutsk
+      - Asia/Jakarta
+      - Asia/Jayapura
+      - Asia/Jerusalem
+      - Asia/Kabul
+      - Asia/Kamchatka
+      - Asia/Karachi
+      - Asia/Kathmandu
+      - Asia/Khandyga
+      - Asia/Kolkata
+      - Asia/Krasnoyarsk
+      - Asia/Kuala_Lumpur
+      - Asia/Kuching
+      - Asia/Kuwait
+      - Asia/Macau
+      - Asia/Magadan
+      - Asia/Makassar
+      - Asia/Manila
+      - Asia/Muscat
+      - Asia/Nicosia
+      - Asia/Novokuznetsk
+      - Asia/Novosibirsk
+      - Asia/Omsk
+      - Asia/Oral
+      - Asia/Phnom_Penh
+      - Asia/Pontianak
+      - Asia/Pyongyang
+      - Asia/Qatar
+      - Asia/Qostanay
+      - Asia/Qyzylorda
+      - Asia/Riyadh
+      - Asia/Sakhalin
+      - Asia/Samarkand
+      - Asia/Seoul
+      - Asia/Shanghai
+      - Asia/Singapore
+      - Asia/Srednekolymsk
+      - Asia/Taipei
+      - Asia/Tashkent
+      - Asia/Tbilisi
+      - Asia/Tehran
+      - Asia/Thimphu
+      - Asia/Tokyo
+      - Asia/Tomsk
+      - Asia/Ulaanbaatar
+      - Asia/Urumqi
+      - Asia/Ust-Nera
+      - Asia/Vientiane
+      - Asia/Vladivostok
+      - Asia/Yakutsk
+      - Asia/Yangon
+      - Asia/Yekaterinburg
+      - Asia/Yerevan
+      - Atlantic/Azores
+      - Atlantic/Bermuda
+      - Atlantic/Canary
+      - Atlantic/Cape_Verde
+      - Atlantic/Faroe
+      - Atlantic/Madeira
+      - Atlantic/Reykjavik
+      - Atlantic/South_Georgia
+      - Atlantic/St_Helena
+      - Atlantic/Stanley
+      - Australia/Adelaide
+      - Australia/Brisbane
+      - Australia/Broken_Hill
+      - Australia/Darwin
+      - Australia/Eucla
+      - Australia/Hobart
+      - Australia/Lindeman
+      - Australia/Lord_Howe
+      - Australia/Melbourne
+      - Australia/Perth
+      - Australia/Sydney
+      - Canada/Atlantic
+      - Canada/Central
+      - Canada/Eastern
+      - Canada/Mountain
+      - Canada/Newfoundland
+      - Canada/Pacific
+      - Europe/Amsterdam
+      - Europe/Andorra
+      - Europe/Astrakhan
+      - Europe/Athens
+      - Europe/Belgrade
+      - Europe/Berlin
+      - Europe/Bratislava
+      - Europe/Brussels
+      - Europe/Bucharest
+      - Europe/Budapest
+      - Europe/Busingen
+      - Europe/Chisinau
+      - Europe/Copenhagen
+      - Europe/Dublin
+      - Europe/Gibraltar
+      - Europe/Guernsey
+      - Europe/Helsinki
+      - Europe/Isle_of_Man
+      - Europe/Istanbul
+      - Europe/Jersey
+      - Europe/Kaliningrad
+      - Europe/Kirov
+      - Europe/Kyiv
+      - Europe/Lisbon
+      - Europe/Ljubljana
+      - Europe/London
+      - Europe/Luxembourg
+      - Europe/Madrid
+      - Europe/Malta
+      - Europe/Mariehamn
+      - Europe/Minsk
+      - Europe/Monaco
+      - Europe/Moscow
+      - Europe/Oslo
+      - Europe/Paris
+      - Europe/Podgorica
+      - Europe/Prague
+      - Europe/Riga
+      - Europe/Rome
+      - Europe/Samara
+      - Europe/San_Marino
+      - Europe/Sarajevo
+      - Europe/Saratov
+      - Europe/Simferopol
+      - Europe/Skopje
+      - Europe/Sofia
+      - Europe/Stockholm
+      - Europe/Tallinn
+      - Europe/Tirane
+      - Europe/Ulyanovsk
+      - Europe/Vaduz
+      - Europe/Vatican
+      - Europe/Vienna
+      - Europe/Vilnius
+      - Europe/Volgograd
+      - Europe/Warsaw
+      - Europe/Zagreb
+      - Europe/Zurich
+      - GMT
+      - Indian/Antananarivo
+      - Indian/Chagos
+      - Indian/Christmas
+      - Indian/Cocos
+      - Indian/Comoro
+      - Indian/Kerguelen
+      - Indian/Mahe
+      - Indian/Maldives
+      - Indian/Mauritius
+      - Indian/Mayotte
+      - Indian/Reunion
+      - Pacific/Apia
+      - Pacific/Auckland
+      - Pacific/Bougainville
+      - Pacific/Chatham
+      - Pacific/Chuuk
+      - Pacific/Easter
+      - Pacific/Efate
+      - Pacific/Fakaofo
+      - Pacific/Fiji
+      - Pacific/Funafuti
+      - Pacific/Galapagos
+      - Pacific/Gambier
+      - Pacific/Guadalcanal
+      - Pacific/Guam
+      - Pacific/Honolulu
+      - Pacific/Kanton
+      - Pacific/Kiritimati
+      - Pacific/Kosrae
+      - Pacific/Kwajalein
+      - Pacific/Majuro
+      - Pacific/Marquesas
+      - Pacific/Midway
+      - Pacific/Nauru
+      - Pacific/Niue
+      - Pacific/Norfolk
+      - Pacific/Noumea
+      - Pacific/Pago_Pago
+      - Pacific/Palau
+      - Pacific/Pitcairn
+      - Pacific/Pohnpei
+      - Pacific/Port_Moresby
+      - Pacific/Rarotonga
+      - Pacific/Saipan
+      - Pacific/Tahiti
+      - Pacific/Tarawa
+      - Pacific/Tongatapu
+      - Pacific/Wake
+      - Pacific/Wallis
+      - US/Alaska
+      - US/Arizona
+      - US/Central
+      - US/Eastern
+      - US/Hawaii
+      - US/Mountain
+      - US/Pacific
+      - UTC
+      type: string
+      description: |-
+        * `Africa/Abidjan` - Africa/Abidjan
+        * `Africa/Accra` - Africa/Accra
+        * `Africa/Addis_Ababa` - Africa/Addis_Ababa
+        * `Africa/Algiers` - Africa/Algiers
+        * `Africa/Asmara` - Africa/Asmara
+        * `Africa/Bamako` - Africa/Bamako
+        * `Africa/Bangui` - Africa/Bangui
+        * `Africa/Banjul` - Africa/Banjul
+        * `Africa/Bissau` - Africa/Bissau
+        * `Africa/Blantyre` - Africa/Blantyre
+        * `Africa/Brazzaville` - Africa/Brazzaville
+        * `Africa/Bujumbura` - Africa/Bujumbura
+        * `Africa/Cairo` - Africa/Cairo
+        * `Africa/Casablanca` - Africa/Casablanca
+        * `Africa/Ceuta` - Africa/Ceuta
+        * `Africa/Conakry` - Africa/Conakry
+        * `Africa/Dakar` - Africa/Dakar
+        * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam
+        * `Africa/Djibouti` - Africa/Djibouti
+        * `Africa/Douala` - Africa/Douala
+        * `Africa/El_Aaiun` - Africa/El_Aaiun
+        * `Africa/Freetown` - Africa/Freetown
+        * `Africa/Gaborone` - Africa/Gaborone
+        * `Africa/Harare` - Africa/Harare
+        * `Africa/Johannesburg` - Africa/Johannesburg
+        * `Africa/Juba` - Africa/Juba
+        * `Africa/Kampala` - Africa/Kampala
+        * `Africa/Khartoum` - Africa/Khartoum
+        * `Africa/Kigali` - Africa/Kigali
+        * `Africa/Kinshasa` - Africa/Kinshasa
+        * `Africa/Lagos` - Africa/Lagos
+        * `Africa/Libreville` - Africa/Libreville
+        * `Africa/Lome` - Africa/Lome
+        * `Africa/Luanda` - Africa/Luanda
+        * `Africa/Lubumbashi` - Africa/Lubumbashi
+        * `Africa/Lusaka` - Africa/Lusaka
+        * `Africa/Malabo` - Africa/Malabo
+        * `Africa/Maputo` - Africa/Maputo
+        * `Africa/Maseru` - Africa/Maseru
+        * `Africa/Mbabane` - Africa/Mbabane
+        * `Africa/Mogadishu` - Africa/Mogadishu
+        * `Africa/Monrovia` - Africa/Monrovia
+        * `Africa/Nairobi` - Africa/Nairobi
+        * `Africa/Ndjamena` - Africa/Ndjamena
+        * `Africa/Niamey` - Africa/Niamey
+        * `Africa/Nouakchott` - Africa/Nouakchott
+        * `Africa/Ouagadougou` - Africa/Ouagadougou
+        * `Africa/Porto-Novo` - Africa/Porto-Novo
+        * `Africa/Sao_Tome` - Africa/Sao_Tome
+        * `Africa/Tripoli` - Africa/Tripoli
+        * `Africa/Tunis` - Africa/Tunis
+        * `Africa/Windhoek` - Africa/Windhoek
+        * `America/Adak` - America/Adak
+        * `America/Anchorage` - America/Anchorage
+        * `America/Anguilla` - America/Anguilla
+        * `America/Antigua` - America/Antigua
+        * `America/Araguaina` - America/Araguaina
+        * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires
+        * `America/Argentina/Catamarca` - America/Argentina/Catamarca
+        * `America/Argentina/Cordoba` - America/Argentina/Cordoba
+        * `America/Argentina/Jujuy` - America/Argentina/Jujuy
+        * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja
+        * `America/Argentina/Mendoza` - America/Argentina/Mendoza
+        * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos
+        * `America/Argentina/Salta` - America/Argentina/Salta
+        * `America/Argentina/San_Juan` - America/Argentina/San_Juan
+        * `America/Argentina/San_Luis` - America/Argentina/San_Luis
+        * `America/Argentina/Tucuman` - America/Argentina/Tucuman
+        * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia
+        * `America/Aruba` - America/Aruba
+        * `America/Asuncion` - America/Asuncion
+        * `America/Atikokan` - America/Atikokan
+        * `America/Bahia` - America/Bahia
+        * `America/Bahia_Banderas` - America/Bahia_Banderas
+        * `America/Barbados` - America/Barbados
+        * `America/Belem` - America/Belem
+        * `America/Belize` - America/Belize
+        * `America/Blanc-Sablon` - America/Blanc-Sablon
+        * `America/Boa_Vista` - America/Boa_Vista
+        * `America/Bogota` - America/Bogota
+        * `America/Boise` - America/Boise
+        * `America/Cambridge_Bay` - America/Cambridge_Bay
+        * `America/Campo_Grande` - America/Campo_Grande
+        * `America/Cancun` - America/Cancun
+        * `America/Caracas` - America/Caracas
+        * `America/Cayenne` - America/Cayenne
+        * `America/Cayman` - America/Cayman
+        * `America/Chicago` - America/Chicago
+        * `America/Chihuahua` - America/Chihuahua
+        * `America/Ciudad_Juarez` - America/Ciudad_Juarez
+        * `America/Costa_Rica` - America/Costa_Rica
+        * `America/Creston` - America/Creston
+        * `America/Cuiaba` - America/Cuiaba
+        * `America/Curacao` - America/Curacao
+        * `America/Danmarkshavn` - America/Danmarkshavn
+        * `America/Dawson` - America/Dawson
+        * `America/Dawson_Creek` - America/Dawson_Creek
+        * `America/Denver` - America/Denver
+        * `America/Detroit` - America/Detroit
+        * `America/Dominica` - America/Dominica
+        * `America/Edmonton` - America/Edmonton
+        * `America/Eirunepe` - America/Eirunepe
+        * `America/El_Salvador` - America/El_Salvador
+        * `America/Fort_Nelson` - America/Fort_Nelson
+        * `America/Fortaleza` - America/Fortaleza
+        * `America/Glace_Bay` - America/Glace_Bay
+        * `America/Goose_Bay` - America/Goose_Bay
+        * `America/Grand_Turk` - America/Grand_Turk
+        * `America/Grenada` - America/Grenada
+        * `America/Guadeloupe` - America/Guadeloupe
+        * `America/Guatemala` - America/Guatemala
+        * `America/Guayaquil` - America/Guayaquil
+        * `America/Guyana` - America/Guyana
+        * `America/Halifax` - America/Halifax
+        * `America/Havana` - America/Havana
+        * `America/Hermosillo` - America/Hermosillo
+        * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis
+        * `America/Indiana/Knox` - America/Indiana/Knox
+        * `America/Indiana/Marengo` - America/Indiana/Marengo
+        * `America/Indiana/Petersburg` - America/Indiana/Petersburg
+        * `America/Indiana/Tell_City` - America/Indiana/Tell_City
+        * `America/Indiana/Vevay` - America/Indiana/Vevay
+        * `America/Indiana/Vincennes` - America/Indiana/Vincennes
+        * `America/Indiana/Winamac` - America/Indiana/Winamac
+        * `America/Inuvik` - America/Inuvik
+        * `America/Iqaluit` - America/Iqaluit
+        * `America/Jamaica` - America/Jamaica
+        * `America/Juneau` - America/Juneau
+        * `America/Kentucky/Louisville` - America/Kentucky/Louisville
+        * `America/Kentucky/Monticello` - America/Kentucky/Monticello
+        * `America/Kralendijk` - America/Kralendijk
+        * `America/La_Paz` - America/La_Paz
+        * `America/Lima` - America/Lima
+        * `America/Los_Angeles` - America/Los_Angeles
+        * `America/Lower_Princes` - America/Lower_Princes
+        * `America/Maceio` - America/Maceio
+        * `America/Managua` - America/Managua
+        * `America/Manaus` - America/Manaus
+        * `America/Marigot` - America/Marigot
+        * `America/Martinique` - America/Martinique
+        * `America/Matamoros` - America/Matamoros
+        * `America/Mazatlan` - America/Mazatlan
+        * `America/Menominee` - America/Menominee
+        * `America/Merida` - America/Merida
+        * `America/Metlakatla` - America/Metlakatla
+        * `America/Mexico_City` - America/Mexico_City
+        * `America/Miquelon` - America/Miquelon
+        * `America/Moncton` - America/Moncton
+        * `America/Monterrey` - America/Monterrey
+        * `America/Montevideo` - America/Montevideo
+        * `America/Montserrat` - America/Montserrat
+        * `America/Nassau` - America/Nassau
+        * `America/New_York` - America/New_York
+        * `America/Nome` - America/Nome
+        * `America/Noronha` - America/Noronha
+        * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah
+        * `America/North_Dakota/Center` - America/North_Dakota/Center
+        * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem
+        * `America/Nuuk` - America/Nuuk
+        * `America/Ojinaga` - America/Ojinaga
+        * `America/Panama` - America/Panama
+        * `America/Paramaribo` - America/Paramaribo
+        * `America/Phoenix` - America/Phoenix
+        * `America/Port-au-Prince` - America/Port-au-Prince
+        * `America/Port_of_Spain` - America/Port_of_Spain
+        * `America/Porto_Velho` - America/Porto_Velho
+        * `America/Puerto_Rico` - America/Puerto_Rico
+        * `America/Punta_Arenas` - America/Punta_Arenas
+        * `America/Rankin_Inlet` - America/Rankin_Inlet
+        * `America/Recife` - America/Recife
+        * `America/Regina` - America/Regina
+        * `America/Resolute` - America/Resolute
+        * `America/Rio_Branco` - America/Rio_Branco
+        * `America/Santarem` - America/Santarem
+        * `America/Santiago` - America/Santiago
+        * `America/Santo_Domingo` - America/Santo_Domingo
+        * `America/Sao_Paulo` - America/Sao_Paulo
+        * `America/Scoresbysund` - America/Scoresbysund
+        * `America/Sitka` - America/Sitka
+        * `America/St_Barthelemy` - America/St_Barthelemy
+        * `America/St_Johns` - America/St_Johns
+        * `America/St_Kitts` - America/St_Kitts
+        * `America/St_Lucia` - America/St_Lucia
+        * `America/St_Thomas` - America/St_Thomas
+        * `America/St_Vincent` - America/St_Vincent
+        * `America/Swift_Current` - America/Swift_Current
+        * `America/Tegucigalpa` - America/Tegucigalpa
+        * `America/Thule` - America/Thule
+        * `America/Tijuana` - America/Tijuana
+        * `America/Toronto` - America/Toronto
+        * `America/Tortola` - America/Tortola
+        * `America/Vancouver` - America/Vancouver
+        * `America/Whitehorse` - America/Whitehorse
+        * `America/Winnipeg` - America/Winnipeg
+        * `America/Yakutat` - America/Yakutat
+        * `Antarctica/Casey` - Antarctica/Casey
+        * `Antarctica/Davis` - Antarctica/Davis
+        * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville
+        * `Antarctica/Macquarie` - Antarctica/Macquarie
+        * `Antarctica/Mawson` - Antarctica/Mawson
+        * `Antarctica/McMurdo` - Antarctica/McMurdo
+        * `Antarctica/Palmer` - Antarctica/Palmer
+        * `Antarctica/Rothera` - Antarctica/Rothera
+        * `Antarctica/Syowa` - Antarctica/Syowa
+        * `Antarctica/Troll` - Antarctica/Troll
+        * `Antarctica/Vostok` - Antarctica/Vostok
+        * `Arctic/Longyearbyen` - Arctic/Longyearbyen
+        * `Asia/Aden` - Asia/Aden
+        * `Asia/Almaty` - Asia/Almaty
+        * `Asia/Amman` - Asia/Amman
+        * `Asia/Anadyr` - Asia/Anadyr
+        * `Asia/Aqtau` - Asia/Aqtau
+        * `Asia/Aqtobe` - Asia/Aqtobe
+        * `Asia/Ashgabat` - Asia/Ashgabat
+        * `Asia/Atyrau` - Asia/Atyrau
+        * `Asia/Baghdad` - Asia/Baghdad
+        * `Asia/Bahrain` - Asia/Bahrain
+        * `Asia/Baku` - Asia/Baku
+        * `Asia/Bangkok` - Asia/Bangkok
+        * `Asia/Barnaul` - Asia/Barnaul
+        * `Asia/Beirut` - Asia/Beirut
+        * `Asia/Bishkek` - Asia/Bishkek
+        * `Asia/Brunei` - Asia/Brunei
+        * `Asia/Chita` - Asia/Chita
+        * `Asia/Choibalsan` - Asia/Choibalsan
+        * `Asia/Colombo` - Asia/Colombo
+        * `Asia/Damascus` - Asia/Damascus
+        * `Asia/Dhaka` - Asia/Dhaka
+        * `Asia/Dili` - Asia/Dili
+        * `Asia/Dubai` - Asia/Dubai
+        * `Asia/Dushanbe` - Asia/Dushanbe
+        * `Asia/Famagusta` - Asia/Famagusta
+        * `Asia/Gaza` - Asia/Gaza
+        * `Asia/Hebron` - Asia/Hebron
+        * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh
+        * `Asia/Hong_Kong` - Asia/Hong_Kong
+        * `Asia/Hovd` - Asia/Hovd
+        * `Asia/Irkutsk` - Asia/Irkutsk
+        * `Asia/Jakarta` - Asia/Jakarta
+        * `Asia/Jayapura` - Asia/Jayapura
+        * `Asia/Jerusalem` - Asia/Jerusalem
+        * `Asia/Kabul` - Asia/Kabul
+        * `Asia/Kamchatka` - Asia/Kamchatka
+        * `Asia/Karachi` - Asia/Karachi
+        * `Asia/Kathmandu` - Asia/Kathmandu
+        * `Asia/Khandyga` - Asia/Khandyga
+        * `Asia/Kolkata` - Asia/Kolkata
+        * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk
+        * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur
+        * `Asia/Kuching` - Asia/Kuching
+        * `Asia/Kuwait` - Asia/Kuwait
+        * `Asia/Macau` - Asia/Macau
+        * `Asia/Magadan` - Asia/Magadan
+        * `Asia/Makassar` - Asia/Makassar
+        * `Asia/Manila` - Asia/Manila
+        * `Asia/Muscat` - Asia/Muscat
+        * `Asia/Nicosia` - Asia/Nicosia
+        * `Asia/Novokuznetsk` - Asia/Novokuznetsk
+        * `Asia/Novosibirsk` - Asia/Novosibirsk
+        * `Asia/Omsk` - Asia/Omsk
+        * `Asia/Oral` - Asia/Oral
+        * `Asia/Phnom_Penh` - Asia/Phnom_Penh
+        * `Asia/Pontianak` - Asia/Pontianak
+        * `Asia/Pyongyang` - Asia/Pyongyang
+        * `Asia/Qatar` - Asia/Qatar
+        * `Asia/Qostanay` - Asia/Qostanay
+        * `Asia/Qyzylorda` - Asia/Qyzylorda
+        * `Asia/Riyadh` - Asia/Riyadh
+        * `Asia/Sakhalin` - Asia/Sakhalin
+        * `Asia/Samarkand` - Asia/Samarkand
+        * `Asia/Seoul` - Asia/Seoul
+        * `Asia/Shanghai` - Asia/Shanghai
+        * `Asia/Singapore` - Asia/Singapore
+        * `Asia/Srednekolymsk` - Asia/Srednekolymsk
+        * `Asia/Taipei` - Asia/Taipei
+        * `Asia/Tashkent` - Asia/Tashkent
+        * `Asia/Tbilisi` - Asia/Tbilisi
+        * `Asia/Tehran` - Asia/Tehran
+        * `Asia/Thimphu` - Asia/Thimphu
+        * `Asia/Tokyo` - Asia/Tokyo
+        * `Asia/Tomsk` - Asia/Tomsk
+        * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar
+        * `Asia/Urumqi` - Asia/Urumqi
+        * `Asia/Ust-Nera` - Asia/Ust-Nera
+        * `Asia/Vientiane` - Asia/Vientiane
+        * `Asia/Vladivostok` - Asia/Vladivostok
+        * `Asia/Yakutsk` - Asia/Yakutsk
+        * `Asia/Yangon` - Asia/Yangon
+        * `Asia/Yekaterinburg` - Asia/Yekaterinburg
+        * `Asia/Yerevan` - Asia/Yerevan
+        * `Atlantic/Azores` - Atlantic/Azores
+        * `Atlantic/Bermuda` - Atlantic/Bermuda
+        * `Atlantic/Canary` - Atlantic/Canary
+        * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde
+        * `Atlantic/Faroe` - Atlantic/Faroe
+        * `Atlantic/Madeira` - Atlantic/Madeira
+        * `Atlantic/Reykjavik` - Atlantic/Reykjavik
+        * `Atlantic/South_Georgia` - Atlantic/South_Georgia
+        * `Atlantic/St_Helena` - Atlantic/St_Helena
+        * `Atlantic/Stanley` - Atlantic/Stanley
+        * `Australia/Adelaide` - Australia/Adelaide
+        * `Australia/Brisbane` - Australia/Brisbane
+        * `Australia/Broken_Hill` - Australia/Broken_Hill
+        * `Australia/Darwin` - Australia/Darwin
+        * `Australia/Eucla` - Australia/Eucla
+        * `Australia/Hobart` - Australia/Hobart
+        * `Australia/Lindeman` - Australia/Lindeman
+        * `Australia/Lord_Howe` - Australia/Lord_Howe
+        * `Australia/Melbourne` - Australia/Melbourne
+        * `Australia/Perth` - Australia/Perth
+        * `Australia/Sydney` - Australia/Sydney
+        * `Canada/Atlantic` - Canada/Atlantic
+        * `Canada/Central` - Canada/Central
+        * `Canada/Eastern` - Canada/Eastern
+        * `Canada/Mountain` - Canada/Mountain
+        * `Canada/Newfoundland` - Canada/Newfoundland
+        * `Canada/Pacific` - Canada/Pacific
+        * `Europe/Amsterdam` - Europe/Amsterdam
+        * `Europe/Andorra` - Europe/Andorra
+        * `Europe/Astrakhan` - Europe/Astrakhan
+        * `Europe/Athens` - Europe/Athens
+        * `Europe/Belgrade` - Europe/Belgrade
+        * `Europe/Berlin` - Europe/Berlin
+        * `Europe/Bratislava` - Europe/Bratislava
+        * `Europe/Brussels` - Europe/Brussels
+        * `Europe/Bucharest` - Europe/Bucharest
+        * `Europe/Budapest` - Europe/Budapest
+        * `Europe/Busingen` - Europe/Busingen
+        * `Europe/Chisinau` - Europe/Chisinau
+        * `Europe/Copenhagen` - Europe/Copenhagen
+        * `Europe/Dublin` - Europe/Dublin
+        * `Europe/Gibraltar` - Europe/Gibraltar
+        * `Europe/Guernsey` - Europe/Guernsey
+        * `Europe/Helsinki` - Europe/Helsinki
+        * `Europe/Isle_of_Man` - Europe/Isle_of_Man
+        * `Europe/Istanbul` - Europe/Istanbul
+        * `Europe/Jersey` - Europe/Jersey
+        * `Europe/Kaliningrad` - Europe/Kaliningrad
+        * `Europe/Kirov` - Europe/Kirov
+        * `Europe/Kyiv` - Europe/Kyiv
+        * `Europe/Lisbon` - Europe/Lisbon
+        * `Europe/Ljubljana` - Europe/Ljubljana
+        * `Europe/London` - Europe/London
+        * `Europe/Luxembourg` - Europe/Luxembourg
+        * `Europe/Madrid` - Europe/Madrid
+        * `Europe/Malta` - Europe/Malta
+        * `Europe/Mariehamn` - Europe/Mariehamn
+        * `Europe/Minsk` - Europe/Minsk
+        * `Europe/Monaco` - Europe/Monaco
+        * `Europe/Moscow` - Europe/Moscow
+        * `Europe/Oslo` - Europe/Oslo
+        * `Europe/Paris` - Europe/Paris
+        * `Europe/Podgorica` - Europe/Podgorica
+        * `Europe/Prague` - Europe/Prague
+        * `Europe/Riga` - Europe/Riga
+        * `Europe/Rome` - Europe/Rome
+        * `Europe/Samara` - Europe/Samara
+        * `Europe/San_Marino` - Europe/San_Marino
+        * `Europe/Sarajevo` - Europe/Sarajevo
+        * `Europe/Saratov` - Europe/Saratov
+        * `Europe/Simferopol` - Europe/Simferopol
+        * `Europe/Skopje` - Europe/Skopje
+        * `Europe/Sofia` - Europe/Sofia
+        * `Europe/Stockholm` - Europe/Stockholm
+        * `Europe/Tallinn` - Europe/Tallinn
+        * `Europe/Tirane` - Europe/Tirane
+        * `Europe/Ulyanovsk` - Europe/Ulyanovsk
+        * `Europe/Vaduz` - Europe/Vaduz
+        * `Europe/Vatican` - Europe/Vatican
+        * `Europe/Vienna` - Europe/Vienna
+        * `Europe/Vilnius` - Europe/Vilnius
+        * `Europe/Volgograd` - Europe/Volgograd
+        * `Europe/Warsaw` - Europe/Warsaw
+        * `Europe/Zagreb` - Europe/Zagreb
+        * `Europe/Zurich` - Europe/Zurich
+        * `GMT` - GMT
+        * `Indian/Antananarivo` - Indian/Antananarivo
+        * `Indian/Chagos` - Indian/Chagos
+        * `Indian/Christmas` - Indian/Christmas
+        * `Indian/Cocos` - Indian/Cocos
+        * `Indian/Comoro` - Indian/Comoro
+        * `Indian/Kerguelen` - Indian/Kerguelen
+        * `Indian/Mahe` - Indian/Mahe
+        * `Indian/Maldives` - Indian/Maldives
+        * `Indian/Mauritius` - Indian/Mauritius
+        * `Indian/Mayotte` - Indian/Mayotte
+        * `Indian/Reunion` - Indian/Reunion
+        * `Pacific/Apia` - Pacific/Apia
+        * `Pacific/Auckland` - Pacific/Auckland
+        * `Pacific/Bougainville` - Pacific/Bougainville
+        * `Pacific/Chatham` - Pacific/Chatham
+        * `Pacific/Chuuk` - Pacific/Chuuk
+        * `Pacific/Easter` - Pacific/Easter
+        * `Pacific/Efate` - Pacific/Efate
+        * `Pacific/Fakaofo` - Pacific/Fakaofo
+        * `Pacific/Fiji` - Pacific/Fiji
+        * `Pacific/Funafuti` - Pacific/Funafuti
+        * `Pacific/Galapagos` - Pacific/Galapagos
+        * `Pacific/Gambier` - Pacific/Gambier
+        * `Pacific/Guadalcanal` - Pacific/Guadalcanal
+        * `Pacific/Guam` - Pacific/Guam
+        * `Pacific/Honolulu` - Pacific/Honolulu
+        * `Pacific/Kanton` - Pacific/Kanton
+        * `Pacific/Kiritimati` - Pacific/Kiritimati
+        * `Pacific/Kosrae` - Pacific/Kosrae
+        * `Pacific/Kwajalein` - Pacific/Kwajalein
+        * `Pacific/Majuro` - Pacific/Majuro
+        * `Pacific/Marquesas` - Pacific/Marquesas
+        * `Pacific/Midway` - Pacific/Midway
+        * `Pacific/Nauru` - Pacific/Nauru
+        * `Pacific/Niue` - Pacific/Niue
+        * `Pacific/Norfolk` - Pacific/Norfolk
+        * `Pacific/Noumea` - Pacific/Noumea
+        * `Pacific/Pago_Pago` - Pacific/Pago_Pago
+        * `Pacific/Palau` - Pacific/Palau
+        * `Pacific/Pitcairn` - Pacific/Pitcairn
+        * `Pacific/Pohnpei` - Pacific/Pohnpei
+        * `Pacific/Port_Moresby` - Pacific/Port_Moresby
+        * `Pacific/Rarotonga` - Pacific/Rarotonga
+        * `Pacific/Saipan` - Pacific/Saipan
+        * `Pacific/Tahiti` - Pacific/Tahiti
+        * `Pacific/Tarawa` - Pacific/Tarawa
+        * `Pacific/Tongatapu` - Pacific/Tongatapu
+        * `Pacific/Wake` - Pacific/Wake
+        * `Pacific/Wallis` - Pacific/Wallis
+        * `US/Alaska` - US/Alaska
+        * `US/Arizona` - US/Arizona
+        * `US/Central` - US/Central
+        * `US/Eastern` - US/Eastern
+        * `US/Hawaii` - US/Hawaii
+        * `US/Mountain` - US/Mountain
+        * `US/Pacific` - US/Pacific
+        * `UTC` - UTC
+    TransferCycleIssueRequestRequest:
+      type: object
+      description: |-
+        Serializer for transferring work items between cycles.
+
+        Handles work item migration between cycles including validation
+        and relationship updates for sprint reallocation workflows.
+      properties:
+        new_cycle_id:
+          type: string
+          format: uuid
+          description: ID of the target cycle to transfer issues to
+      required:
+      - new_cycle_id
+    TypeEnum:
+      enum:
+      - image/jpeg
+      - image/png
+      - image/webp
+      - image/jpg
+      - image/gif
+      type: string
+      description: |-
+        * `image/jpeg` - JPEG
+        * `image/png` - PNG
+        * `image/webp` - WebP
+        * `image/jpg` - JPG
+        * `image/gif` - GIF
+    UserAssetUploadRequest:
+      type: object
+      description: |-
+        Serializer for user asset upload requests.
+
+        This serializer validates the metadata required to generate a presigned URL
+        for uploading user profile assets (avatar or cover image) directly to S3 storage.
+        Supports JPEG, PNG, WebP, JPG, and GIF image formats with size validation.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Original filename of the asset
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TypeEnum'
+          default: image/jpeg
+          description: |-
+            MIME type of the file
+
+            * `image/jpeg` - JPEG
+            * `image/png` - PNG
+            * `image/webp` - WebP
+            * `image/jpg` - JPG
+            * `image/gif` - GIF
+        size:
+          type: integer
+          description: File size in bytes
+        entity_type:
+          allOf:
+          - $ref: '#/components/schemas/EntityTypeEnum'
+          description: |-
+            Type of user asset
+
+            * `USER_AVATAR` - User Avatar
+            * `USER_COVER` - User Cover
+      required:
+      - entity_type
+      - name
+      - size
+    UserLite:
+      type: object
+      description: |-
+        Lightweight user serializer for minimal data transfer.
+
+        Provides essential user information including names, avatar, and contact details
+        optimized for member lists, assignee displays, and user references.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        email:
+          type: string
+          readOnly: true
+          nullable: true
+        avatar:
+          type: string
+          readOnly: true
+        avatar_url:
+          type: string
+          readOnly: true
+          description: Avatar URL
+        display_name:
+          type: string
+          readOnly: true
+    WorkspaceInvite:
+      type: object
+      description: Serializer for workspace invites.
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        email:
+          type: string
+          maxLength: 255
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          title: Last Modified At
+        responded_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        accepted:
+          type: boolean
+          readOnly: true
+      required:
+      - email
+    WorkspaceInviteRequest:
+      type: object
+      description: Serializer for workspace invites.
+      properties:
+        email:
+          type: string
+          minLength: 1
+          maxLength: 255
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          minimum: 0
+          maximum: 32767
+      required:
+      - email
+  securitySchemes:
+    ApiKeyAuthentication:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API key authentication. Provide your API key in the X-API-Key header.
+servers:
+- url: https://api.plane.so/api/v1/workspaces/{slug}
+  description: Production (workspace-scoped; set slug via config)
+  variables:
+    slug:
+      default: my-workspace
+      description: Workspace slug
+tags:
+- name: Assets
+  description: |-
+    **File Upload & Presigned URLs**
+
+    Generate presigned URLs for direct file uploads to cloud storage. Handle user avatars, cover images, and generic project assets with secure upload workflows.
+
+    *Key Features:*
+    - Generate presigned URLs for S3 uploads
+    - Support for user avatars and cover images
+    - Generic asset upload for projects
+    - File validation and size limits
+
+    *Use Cases:* User profile images, project file uploads, secure direct-to-cloud uploads.
+- name: Cycles
+  description: |-
+    **Sprint & Development Cycles**
+
+    Create and manage development cycles (sprints) to organize work into time-boxed iterations. Track progress, assign work items, and monitor team velocity.
+
+    *Key Features:*
+    - Create and configure development cycles
+    - Assign work items to cycles
+    - Track cycle progress and completion
+    - Generate cycle analytics and reports
+
+    *Use Cases:* Sprint planning, iterative development, progress tracking, team velocity.
+- name: Intake
+  description: |-
+    **Work Item Intake Queue**
+
+    Manage incoming work items through a dedicated intake queue for triage and review. Submit, update, and process work items before they enter the main project workflow.
+
+    *Key Features:*
+    - Submit work items to intake queue
+    - Review and triage incoming work items
+    - Update intake work item status and properties
+    - Accept, reject, or modify work items before approval
+
+    *Use Cases:* Work item triage, external submissions, quality review, approval workflows.
+- name: Labels
+  description: |-
+    **Labels & Tags**
+
+    Create and manage labels to categorize and organize work items. Use color-coded labels for easy identification, filtering, and project organization.
+
+    *Key Features:*
+    - Create custom labels with colors and descriptions
+    - Apply labels to work items for categorization
+    - Filter and search by labels
+    - Organize labels across projects
+
+    *Use Cases:* Priority marking, feature categorization, bug classification, team organization.
+- name: Members
+  description: |-
+    **Team Member Management**
+
+    Manage team members, roles, and permissions within projects and workspaces. Control access levels and track member participation.
+
+    *Key Features:*
+    - Invite and manage team members
+    - Assign roles and permissions
+    - Control project and workspace access
+    - Track member activity and participation
+
+    *Use Cases:* Team setup, access control, role management, collaboration.
+- name: Modules
+  description: |-
+    **Feature Modules**
+
+    Group related work items into modules for better organization and tracking. Plan features, track progress, and manage deliverables at a higher level.
+
+    *Key Features:*
+    - Create and organize feature modules
+    - Group work items by module
+    - Track module progress and completion
+    - Manage module leads and assignments
+
+    *Use Cases:* Feature planning, release organization, progress tracking, team coordination.
+- name: Projects
+  description: |-
+    **Project Management**
+
+    Create and manage projects to organize your development work. Configure project settings, manage team access, and control project visibility.
+
+    *Key Features:*
+    - Create, update, and delete projects
+    - Configure project settings and preferences
+    - Manage team access and permissions
+    - Control project visibility and sharing
+
+    *Use Cases:* Project setup, team collaboration, access control, project configuration.
+- name: States
+  description: |-
+    **Workflow States**
+
+    Define custom workflow states for work items to match your team's process. Configure state transitions and track work item progress through different stages.
+
+    *Key Features:*
+    - Create custom workflow states
+    - Configure state transitions and rules
+    - Track work item progress through states
+    - Set state-based permissions and automation
+
+    *Use Cases:* Custom workflows, status tracking, process automation, progress monitoring.
+- name: Users
+  description: |-
+    **Current User Information**
+
+    Get information about the currently authenticated user including profile details and account settings.
+
+    *Key Features:*
+    - Retrieve current user profile
+    - Access user account information
+    - View user preferences and settings
+    - Get authentication context
+
+    *Use Cases:* Profile display, user context, account information, authentication status.
+- name: Work Item Activity
+  description: |-
+    **Activity History & Search**
+
+    View activity history and search for work items across the workspace. Get detailed activity logs and find work items using text search.
+
+    *Key Features:*
+    - View work item activity history
+    - Search work items across workspace
+    - Track changes and modifications
+    - Filter search results by project
+
+    *Use Cases:* Activity tracking, work item discovery, change history, workspace search.
+- name: Work Item Attachments
+  description: |-
+    **Work Item File Attachments**
+
+    Generate presigned URLs for uploading files directly to specific work items. Upload and manage attachments associated with work items.
+
+    *Key Features:*
+    - Generate presigned URLs for work item attachments
+    - Upload files directly to work items
+    - Retrieve and manage attachment metadata
+    - Delete attachments from work items
+
+    *Use Cases:* Screenshots, error logs, design files, supporting documents.
+- name: Work Item Comments
+  description: |-
+    **Comments & Discussions**
+
+    Add comments and discussions to work items for team collaboration. Support threaded conversations, mentions, and rich text formatting.
+
+    *Key Features:*
+    - Add comments to work items
+    - Thread conversations and replies
+    - Mention users and trigger notifications
+    - Rich text and markdown support
+
+    *Use Cases:* Team discussions, progress updates, code reviews, decision tracking.
+- name: Work Item Links
+  description: |-
+    **External Links & References**
+
+    Link work items to external resources like documentation, repositories, or design files. Maintain connections between work items and external systems.
+
+    *Key Features:*
+    - Add external URL links to work items
+    - Validate and preview linked resources
+    - Organize links by type and category
+    - Track link usage and access
+
+    *Use Cases:* Documentation links, repository connections, design references, external tools.
+- name: Work Items
+  description: |-
+    **Work Items & Tasks**
+
+    Create and manage work items like tasks, bugs, features, and user stories. The core entities for tracking work in your projects.
+
+    *Key Features:*
+    - Create, update, and manage work items
+    - Assign to team members and set priorities
+    - Track progress through workflow states
+    - Set due dates, estimates, and relationships
+
+    *Use Cases:* Bug tracking, task management, feature development, sprint planning.

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -43,6 +43,7 @@ productivity:
 project-management:
   asana                Work management and project tracking API
   jira                 Issue tracking and project management API for Jira Cloud
+  plane                Open-source project management — issues, cycles, modules, sub-issues, and workspaces. A self-hostable Jira/Linear/ClickUp alternative.
 
 sales-and-crm:
   hubspot              CRM contacts API


### PR DESCRIPTION
## Intent

Add [Plane](https://plane.so) to the catalog (category `project-management`). Plane is open-source project management — issues, cycles, modules, sub-issues, workspaces — a self-hostable Jira / Linear / ClickUp alternative.

Issue: Refs #2599, #2600 (engine follow-ups surfaced by this entry)

## Approach

Catalog + spec data only — **no engine changes.**

- `catalog/plane.yaml` — catalog entry (`tier: community`, header auth `X-API-Key`).
- `catalog/specs/plane-spec.yaml` — vendored OpenAPI 3.0 spec.
- `testdata/golden/expected/catalog-list/stdout.txt` — golden updated for the new `catalog list` row.

The spec is captured from **Plane v1.3.0 CE** (drf-spectacular at `/api/schema/`, served by every OSS instance; upstream `makeplane/plane` ships no static OpenAPI file). Two deliberate shaping decisions:

1. **Workspace scope re-expressed into `servers:`.** As captured, every endpoint is `/api/v1/workspaces/{slug}/...`; stock `generate` against that yields **zero** syncable resources, because `standaloneList` rejects any path containing `{` and tenant scope is recognized only via `servers:` + a server variable (`resolveServerURL`). So the scope is moved into `servers:` as a `{slug}` variable and workspace paths are made relative; `/api/v1/users/` and `/api/v1/assets/` stay non-workspace. In this form a stock `generate` auto-detects the `workspace → projects → children` sync model plus an `updated_at__gt` since-param. (Filed as engine enhancement #2599; this PR is the worked example.)

2. **Pruned the redundant `work-items` alias family + nested `{pk}` item-detail endpoints.** Plane exposes both `/issues/` and its newer `/work-items/` alias, plus per-item detail endpoints (`.../links/{pk}/`, `.../activities/{pk}/`, …). The profiler names those deep `{pk}` detail paths after their first-level parent, colliding with the real list resource and emitting a Go `switch` with duplicate `case` strings → the generated CLI **does not compile** (engine bug #2600). Until #2600 is fixed there is no `x-` knob to pin the canonical list, so the only spec-level lever is to drop the duplicates. Removed 17 of 64 paths (the whole `work-items` alias, which duplicates `issues`, and the four nested `issues/.../{pk}/` detail endpoints). The kept `issues` family matches the historically-canonical resource name.

## Scope

Primary area: catalog (`catalog/*.yaml`, `catalog/specs/**`).

Why this belongs in this repo: it adds a catalog entry to the engine so anyone can `printing-press generate plane`. No generator/template/runtime code is touched.

## Catalog Justification

Embedded catalog fit: Plane is a mainstream open-source project-management tool (issues, cycles, modules, sub-issues, workspaces); fits the existing `project-management` category alongside `asana` and `jira`, and is the first **self-hostable** entry there.

Distinct blueprint pattern: workspace-tenant API where the tenant (`{slug}`) is a server variable rather than a path/query param, combined with a drf-spectacular full-path source spec that must be re-expressed before the profiler can model it. This tenancy+re-expression shape is not represented by `asana` or `jira`.

Closest existing entries checked: `asana` and `jira` (both `project-management`). Plane differs: self-hosted deployment, workspace-slug tenancy carried in a `servers:` variable, drf-spectacular pagination wrappers, and `X-API-Key` header auth (not Bearer).

Source provenance: Plane v1.3.0 CE drf-spectacular schema (`/api/schema/`); no static upstream OpenAPI file exists, so the schema is vendored and re-expressed (workspace scope → `servers: {slug}`, relative workspace paths). `spec_url` points at the in-repo copy.

Auth and tenant assumptions: header `X-API-Key: <token>` (Plane rejects `Authorization: Bearer`). Workspace slug is supplied via the `{slug}` server variable (`PLANE_WORKSPACE_SLUG` at runtime). `/api/v1/users/` and `/api/v1/assets/` are non-workspace and stay on the bare base.

Safe default surface: read-heavy sync model (`projects` + members/invitations/stickies flat, with project-scoped fan-out to cycles, modules, labels, states, intake-issues, archived cycles/modules, and issues + their comments/links/activities). The generated CLI compiles, vets, and its unit tests pass.

Generation path: stock `printing-press generate --spec catalog/specs/plane-spec.yaml --name plane` auto-detects the sync model and `updated_at__gt` since-param. Verified locally on `main` (engine 4.20.1): `go build ./...` and `go vet ./...` exit 0 and `go test ./...` passes on the generated tree. The only `--validate` gate that fails is `govulncheck` on **Go standard-library** advisories GO-2026-5037 / GO-2026-5039 (`go.mod` pins `go 1.26.3`; fixed in 1.26.4) — a toolchain issue independent of this entry, reproducible on any catalog PR.

Stale-body check: this body matches the committed files — 47 paths after pruning the `work-items` alias family and the nested `issues/.../{pk}/` detail endpoints; `issues` family retained.

## Risk

Catalog-only. A consumer running `generate plane` gets a compilable, working CLI with a narrower endpoint surface than Plane's full API (no `work-items` alias commands, no per-item sub-CRUD for issue comments/links/attachments). Those can be restored once engine #2600 lands a canonical-list knob. No effect on existing entries, the generator, or the publish flow.

## Output Contract

N/A (no template/generator changes). The only generated-output-adjacent change is the `catalog-list` golden, regenerated to include the new `plane` row.

## Verification

- [x] `go build ./...` / `go vet ./...` exit 0 on the generated CLI; `go test ./...` passes
- [x] `printing-press catalog list` renders the new entry; `catalog-list` golden updated to match
- [x] `go test ./internal/catalog/...` (catalog schema) passes
- [x] Pure-deletion spec diff verified (all kept lines present in original order; histogram diff = 0 insertions)
- Known red: `govulncheck` on Go 1.26.3 stdlib (GO-2026-5037/5039) — toolchain, not this entry

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
