### PR TITLE
docs(cli): per-CLI AGENTS points to catalog for patch mechanics, not a copy

### DIFF
--- a/internal/generator/templates/agents.md.tmpl
+++ b/internal/generator/templates/agents.md.tmpl
@@ -52,44 +52,6 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization as one file per patch under `.printing-press-patches/` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader. One file per patch (`.printing-press-patches/<id>.json`) means two concurrent PRs never conflict on patch metadata.
+This directory is **generated output** -- a fresh print can overwrite the whole tree, so ad-hoc hand-edits don't survive on their own. If you modify the generated code, record each change under `.printing-press-patches/` (parallel to `.printing-press.json`) so a regen carries the intent forward instead of silently dropping it.
 
-Minimum shape:
-
-```json
-{
-  "schema_version": 2,
-  "id": "short-identifier",
-  "applied_at": "YYYY-MM-DD",
-  "base_run_id": "<copy from .printing-press.json>",
-  "base_printing_press_version": "<copy from .printing-press.json>",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix."
-}
-```
-
-Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
-
-```json
-{
-  "schema_version": 2,
-  "id": "temporary-bridge",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-  "deferred_to_upstream": [
-    {
-      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
-      "reason": "Why the local patch is temporary or API-specific"
-    }
-  ],
-  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-}
-```
-
-These entries are an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the directory is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
-
-Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.
+The entry shape, and the altitude to write it at -- a durable reprint-guard, not a changelog -- live in the source catalog's `AGENTS.md`, which is the single source of truth; this guide intentionally doesn't duplicate them.

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -561,15 +561,24 @@ func TestAmendSkillRequiresUpstreamBreadcrumbsForTemporaryPatches(t *testing.T) 
 	assert.NotContains(t, skill, "workflow rejects PRs where one is present without the other")
 }
 
-func TestGeneratedAgentsTemplateDocumentsUpstreamPatchHandoff(t *testing.T) {
+func TestGeneratedAgentsTemplatePointsToCatalogForPatchMechanics(t *testing.T) {
 	template := readContractFile(t, filepath.Join("..", "generator", "templates", "agents.md.tmpl"))
-	minimumShape := substringBetween(t, template, "Minimum shape:", "Use `deferred_to_upstream`")
 
-	assert.Contains(t, template, `"deferred_to_upstream": [`)
-	assert.Contains(t, template, `"upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"`)
-	assert.Contains(t, template, "Use `deferred_to_upstream` when a local patch is a temporary bridge")
-	assert.NotContains(t, minimumShape, "deferred_to_upstream")
-	assert.NotContains(t, minimumShape, "upstream_issue")
+	// The per-CLI guide keeps CLI-local orientation plus a pointer to where
+	// customizations are recorded, but must NOT duplicate the patch-entry
+	// mechanics (schema, deferred_to_upstream, upstream_issue) -- those live once
+	// in the source catalog's AGENTS.md, the single source of truth. Duplicating
+	// ecosystem schema into every generated CLI is what let published AGENTS.md
+	// drift to the legacy patch form; a stable pointer cannot rot.
+	assert.Contains(t, template, "## Local Customizations")
+	assert.Contains(t, template, ".printing-press-patches/")
+	assert.Contains(t, template, "source catalog's `AGENTS.md`")
+
+	// Mechanics must not be re-inlined into the per-CLI template.
+	assert.NotContains(t, template, "deferred_to_upstream")
+	assert.NotContains(t, template, "upstream_issue")
+	assert.NotContains(t, template, "schema_version")
+	assert.NotContains(t, template, "Minimum shape:")
 }
 
 func TestPolishSkillHardGatesPublishValidate(t *testing.T) {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/AGENTS.md
@@ -37,44 +37,6 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization as one file per patch under `.printing-press-patches/` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader. One file per patch (`.printing-press-patches/<id>.json`) means two concurrent PRs never conflict on patch metadata.
+This directory is **generated output** -- a fresh print can overwrite the whole tree, so ad-hoc hand-edits don't survive on their own. If you modify the generated code, record each change under `.printing-press-patches/` (parallel to `.printing-press.json`) so a regen carries the intent forward instead of silently dropping it.
 
-Minimum shape:
-
-```json
-{
-  "schema_version": 2,
-  "id": "short-identifier",
-  "applied_at": "YYYY-MM-DD",
-  "base_run_id": "<copy from .printing-press.json>",
-  "base_printing_press_version": "<copy from .printing-press.json>",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix."
-}
-```
-
-Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
-
-```json
-{
-  "schema_version": 2,
-  "id": "temporary-bridge",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-  "deferred_to_upstream": [
-    {
-      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
-      "reason": "Why the local patch is temporary or API-specific"
-    }
-  ],
-  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-}
-```
-
-These entries are an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the directory is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
-
-Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.
+The entry shape, and the altitude to write it at -- a durable reprint-guard, not a changelog -- live in the source catalog's `AGENTS.md`, which is the single source of truth; this guide intentionally doesn't duplicate them.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/AGENTS.md
@@ -37,44 +37,6 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization as one file per patch under `.printing-press-patches/` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader. One file per patch (`.printing-press-patches/<id>.json`) means two concurrent PRs never conflict on patch metadata.
+This directory is **generated output** -- a fresh print can overwrite the whole tree, so ad-hoc hand-edits don't survive on their own. If you modify the generated code, record each change under `.printing-press-patches/` (parallel to `.printing-press.json`) so a regen carries the intent forward instead of silently dropping it.
 
-Minimum shape:
-
-```json
-{
-  "schema_version": 2,
-  "id": "short-identifier",
-  "applied_at": "YYYY-MM-DD",
-  "base_run_id": "<copy from .printing-press.json>",
-  "base_printing_press_version": "<copy from .printing-press.json>",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix."
-}
-```
-
-Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
-
-```json
-{
-  "schema_version": 2,
-  "id": "temporary-bridge",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-  "deferred_to_upstream": [
-    {
-      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
-      "reason": "Why the local patch is temporary or API-specific"
-    }
-  ],
-  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-}
-```
-
-These entries are an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the directory is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
-
-Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.
+The entry shape, and the altitude to write it at -- a durable reprint-guard, not a changelog -- live in the source catalog's `AGENTS.md`, which is the single source of truth; this guide intentionally doesn't duplicate them.

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/AGENTS.md
@@ -50,44 +50,6 @@ For install, auth, examples, and longer product guidance, read `README.md` and `
 
 ## Local Customizations
 
-If you modify this CLI beyond what the generator produced, record each customization as one file per patch under `.printing-press-patches/` at this CLI's root (parallel to `.printing-press.json`) so the change isn't lost on the next regen and is visible to the next reader. One file per patch (`.printing-press-patches/<id>.json`) means two concurrent PRs never conflict on patch metadata.
+This directory is **generated output** -- a fresh print can overwrite the whole tree, so ad-hoc hand-edits don't survive on their own. If you modify the generated code, record each change under `.printing-press-patches/` (parallel to `.printing-press.json`) so a regen carries the intent forward instead of silently dropping it.
 
-Minimum shape:
-
-```json
-{
-  "schema_version": 2,
-  "id": "short-identifier",
-  "applied_at": "YYYY-MM-DD",
-  "base_run_id": "<copy from .printing-press.json>",
-  "base_printing_press_version": "<copy from .printing-press.json>",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix."
-}
-```
-
-Use `deferred_to_upstream` when a local patch is a temporary bridge for a missing public API endpoint, an unofficial-host workaround, a live response-shape drift, or behavior the Printing Press should eventually generate correctly. Search `mvanhorn/cli-printing-press` issues first; reuse a matching issue or open one, then set `upstream_issue` so the next regen knows what must supersede the patch:
-
-```json
-{
-  "schema_version": 2,
-  "id": "temporary-bridge",
-  "summary": "What changed (one sentence).",
-  "reason": "Why this customization was needed (one or two sentences).",
-  "files": ["internal/cli/foo.go"],
-  "validated_outcome": "Optional: non-obvious test result that confirms the fix.",
-  "deferred_to_upstream": [
-    {
-      "feature": "Generator behavior or upstream API capability that should eventually supersede this patch",
-      "reason": "Why the local patch is temporary or API-specific"
-    }
-  ],
-  "upstream_issue": "https://github.com/mvanhorn/cli-printing-press/issues/<n>"
-}
-```
-
-These entries are an **index of customizations**, not a second copy of the diff. Diffs live in `git`; the directory is what tells the next agent (or regeneration tooling) what was customized and why. Keep `summary` and `reason` short -- if you find yourself writing tables of field renames or code transformations, that detail belongs in the commit message, not here.
-
-Inline `// PATCH:` source comments are optional. If you find them helpful as a navigation aid (`grep -rn 'PATCH' .` surfaces customized sites), feel free to add them -- but they aren't required and aren't enforced by any CI.
+The entry shape, and the altitude to write it at -- a durable reprint-guard, not a changelog -- live in the source catalog's `AGENTS.md`, which is the single source of truth; this guide intentionally doesn't duplicate them.


### PR DESCRIPTION
## What

Collapses the per-CLI `AGENTS.md` template's `## Local Customizations` section from a full copy of the `.printing-press-patches/` mechanics down to a short **pointer**.

## Why

The per-CLI guide is a *portable* "how to operate/maintain this CLI" artifact. The patches mechanics it duplicated — schema, `base_run_id`, `deferred_to_upstream → cli-printing-press`, "survives a regen" — are **ecosystem-specific**: someone who copies the CLI standalone never re-runs the Press, so that metadata is meaningless to them (the same reason a contributor-attribution section was pulled earlier in this PR's history).

Duplicating mechanics into generated files also *caused measurable drift*: **219 of 221** library `AGENTS.md` files still describe the legacy single-array patch form, because nothing regenerates `AGENTS.md` after a print. Volatile mechanics in rarely-regenerated generated files rot.

## What stays

- The genuinely CLI-local **orientation**: "this is generated output; hand-edits don't survive a regen on their own; if you customize the code, record it under `.printing-press-patches/`."
- A pointer to the **source catalog's `AGENTS.md`** for the entry shape and reprint-guard altitude — the single source of truth (**mvanhorn/printing-press-library#1024**).

A pointer doesn't drift, so future mechanics changes never require re-sweeping the 221 generated files.

## Validation

`TestGeneratedAgentsGuideRendersPortableAgentContract` passes (output stays ASCII-only). The pre-existing `TestGenerateWithNoAuth` govulncheck failure is a local Go 1.26.3 stdlib-advisory artifact, unrelated to this change.
