### PR TITLE
fix(ci): bump Go to 1.26.4 to clear GO-2026-5037 / GO-2026-5039 stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mvanhorn/cli-printing-press/v4
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/chromedp/chromedp v0.15.1


### PR DESCRIPTION
## Why

`TestGenerateWithNoAuth` runs `govulncheck` against generated code using the **live** vuln database, so it started failing **repo-wide** the moment two new Go standard-library advisories were published — not because of any code change:

| Advisory | Package | Found in | Fixed in |
|---|---|---|---|
| [`GO-2026-5039`](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` (`ReadMIMEHeader`) | go1.26.3 | **go1.26.4** |
| [`GO-2026-5037`](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` (`VerifyHostname`) | go1.26.3 | **go1.26.4** |

`main`'s currently-green checks are **cached** from before the advisories dropped; a re-run fails identically. The repo is pinned to `go 1.26.3`.

## What

Bump the `go` directive in `go.mod` from `1.26.3` → `1.26.4`. Every CI job (`main-ci`, `lint`, `golden`, `release`, `validate-catalog`) resolves its Go version via `go-version-file: go.mod`, so this single line propagates the patched toolchain to all of them. One file, one line.

## Precedent

Mirrors the public library's [`mvanhorn/printing-press-library#1017`](https://github.com/mvanhorn/printing-press-library/pull/1017) (*"run govulncheck with Go 1.26.4"*), which addressed the same advisory wave.

## Validation

CI is the proof here (local toolchains are mid-migration). Once green, this unblocks every open PR whose CI is currently red on `TestGenerateWithNoAuth` — including #2609.
