### PR TITLE
docs(generator): emit OpenClaw bin-dir install guidance

### DIFF
--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -505,8 +505,8 @@ func Execute() error {
 
 // TestVerifySkill_IgnoresExternalToolFlags is the regression guard for
 // the trigger-dev / linear SKILL.md slip: the install instructions contain
-// `npx -y @mvanhorn/printing-press-library install <api> --cli-only`. --cli-only
-// belongs to the outer Printing Press installer, not to <api>-pp-cli, so
+// `npx -y @mvanhorn/printing-press-library install <api> --cli-only --bin-dir ~/.local/bin`.
+// --cli-only and --bin-dir belong to the outer Printing Press installer, not to <api>-pp-cli, so
 // it must not be reported as an undeclared flag-names finding. Before the
 // scoping fix, flag-names regex-scanned the whole SKILL.md and fired on
 // every external-tool flag, which led an automation loop to strip the
@@ -518,10 +518,10 @@ func TestVerifySkill_IgnoresExternalToolFlags(t *testing.T) {
 	bin := buildPrintingPressBinary(t)
 	dir := t.TempDir()
 
-	// SKILL.md uses --cli-only on an npx invocation (not on fixture-pp-cli)
+	// SKILL.md uses installer flags on an npx invocation (not on fixture-pp-cli)
 	// and uses only declared flags on its own binary's recipes.
 	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n## Prerequisites\n\n" +
-		"```bash\nnpx -y @mvanhorn/printing-press-library install fixture --cli-only\n```\n\n" +
+		"```bash\nnpx -y @mvanhorn/printing-press-library install fixture --cli-only --bin-dir ~/.local/bin\n```\n\n" +
 		"## Usage\n\n```bash\nfixture-pp-cli search --limit 5\n```\n"
 	writeVerifySkillFixture(t, dir, map[string]string{
 		"search.go": `package cli
@@ -546,6 +546,7 @@ func Execute() error {
 	out, err := exec.Command(bin, "verify-skill", "--dir", dir).CombinedOutput()
 	require.NoError(t, err, "external-tool flags must not produce a flag-names finding: %s", string(out))
 	require.NotContains(t, string(out), "--cli-only", "verifier must not mention an external-tool flag")
+	require.NotContains(t, string(out), "--bin-dir", "verifier must not mention an external-tool flag")
 }
 
 // TestVerifySkill_DetectsUnquotedShellVariable is the regression guard for

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -38,7 +38,7 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 // canonicalSkillInstallSectionGoFallbackFormat is appended only once the
 // catalog category is known. Before publish, the category-agnostic installer is
 // the only canonical path; emitting library/other/<slug> creates drift.
-const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):\n" +
+const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
 	"\n" +
 	"```bash\n" +
 	"go install github.com/mvanhorn/printing-press-library/library/%[2]s/%[1]s/cmd/%[1]s-pp-cli@latest\n" +

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -27,12 +27,12 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 	"\n" +
 	"This skill drives the `%[1]s-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:\n" +
 	"\n" +
-	"1. Install via the Printing Press installer:\n" +
+	"1. Install via the Printing Press installer into a user bin directory:\n" +
 	"   ```bash\n" +
-	"   npx -y @mvanhorn/printing-press-library install %[1]s --cli-only\n" +
+	"   npx -y @mvanhorn/printing-press-library install %[1]s --cli-only --bin-dir ~/.local/bin\n" +
 	"   ```\n" +
 	"2. Verify: `%[1]s-pp-cli --version`\n" +
-	"3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.\n" +
+	"3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.\n" +
 	"\n"
 
 // canonicalSkillInstallSectionGoFallbackFormat is appended only once the
@@ -48,7 +48,7 @@ const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails
 const canonicalSkillInstallSectionPrepublishFallback = "If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.\n" +
 	"\n"
 
-const canonicalSkillInstallSectionEnd = "If `--version` reports \"command not found\" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.\n"
+const canonicalSkillInstallSectionEnd = "If `--version` reports \"command not found\" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.\n"
 
 // CanonicalSkillInstallSection returns the exact text of the install/
 // prerequisites section that the generator emits into a printed CLI's

--- a/internal/generator/readme_test.go
+++ b/internal/generator/readme_test.go
@@ -308,8 +308,8 @@ func TestReadmeEmitsHermesAndOpenClawInstallSections(t *testing.T) {
 
 	// OpenClaw section: copyable code-fenced agent instruction.
 	assert.Contains(t, content, "## Install for OpenClaw")
-	assert.Contains(t, content, "https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-hermes-install",
-		"OpenClaw URL must point at the cli-skills directory")
+	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install hermes-install --agent openclaw --bin-dir ~/.local/bin",
+		"OpenClaw form must install both the focused skill and binary into runtime-visible locations")
 }
 
 // TestReadmeFallsBackWhenNarrativeAbsent asserts the generic description

--- a/internal/generator/skill_test.go
+++ b/internal/generator/skill_test.go
@@ -708,7 +708,7 @@ func TestSkillFrontmatterMetadataOmitsUnknownCategoryInstall(t *testing.T) {
 
 	assert.NotContains(t, content, "library/other/uncategorized",
 		"empty Category should not bake a placeholder category into install metadata")
-	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install uncategorized --cli-only",
+	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install uncategorized --cli-only --bin-dir ~/.local/bin",
 		"empty Category should keep the category-agnostic installer path")
 }
 

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -86,12 +86,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install {{.Name}} --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-{{.Name}} skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-{{.Name}}. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -34,7 +34,7 @@ This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is in
 2. Verify: `{{.Name}}-pp-cli --version`
 3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 {{ if .Category}}
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -27,12 +27,12 @@ allowed-tools: "Read Bash"
 
 This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install {{.Name}} --cli-only
+   npx -y @mvanhorn/printing-press-library install {{.Name}} --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `{{.Name}}-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 {{ if .Category}}
 If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer):
 
@@ -42,7 +42,7 @@ go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.N
 {{ else}}
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 {{ end}}
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 {{- if and .Narrative .Narrative.ValueProp}}
 
 {{.Narrative.ValueProp}}

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
@@ -55,12 +55,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-oauth2 --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-printing-press-oauth2 skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-printing-press-oauth2. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/SKILL.md
@@ -18,16 +18,16 @@ metadata:
 
 This skill drives the `printing-press-oauth2-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install printing-press-oauth2 --cli-only
+   npx -y @mvanhorn/printing-press-library install printing-press-oauth2 --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `printing-press-oauth2-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 Purpose-built fixture for the OAuth2 device-code auth shape.
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -55,12 +55,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-rich --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-printing-press-rich skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-printing-press-rich. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/SKILL.md
@@ -18,16 +18,16 @@ metadata:
 
 This skill drives the `printing-press-rich-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install printing-press-rich --cli-only
+   npx -y @mvanhorn/printing-press-library install printing-press-rich --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `printing-press-rich-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 Purpose-built fixture for rich auth env-var model coverage.
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -55,12 +55,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-golden --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-printing-press-golden skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-printing-press-golden. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/SKILL.md
@@ -18,16 +18,16 @@ metadata:
 
 This skill drives the `printing-press-golden-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install printing-press-golden --cli-only
+   npx -y @mvanhorn/printing-press-library install printing-press-golden --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `printing-press-golden-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 Purpose-built fixture for golden generation coverage.
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
@@ -66,12 +66,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install learn-loop-example --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-learn-loop-example skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-learn-loop-example. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/SKILL.md
@@ -18,16 +18,16 @@ metadata:
 
 This skill drives the `learn-loop-example-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install learn-loop-example --cli-only
+   npx -y @mvanhorn/printing-press-library install learn-loop-example --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `learn-loop-example-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 Golden fixture exercising the spec-declared self-learning loop. Demonstrates
 the shape every printed CLI gets when its spec declares a `learn:` block:

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -55,12 +55,13 @@ Inside a Hermes chat session:
 ```
 
 ## Install for OpenClaw
+Install both the CLI binary and the focused OpenClaw skill into runtime-visible locations:
 
-Tell your OpenClaw agent (copy this):
+```bash
+npx -y @mvanhorn/printing-press-library install public-param-golden --agent openclaw --bin-dir ~/.local/bin
+```
 
-```
-Install the pp-public-param-golden skill from https://github.com/mvanhorn/printing-press-library/tree/main/cli-skills/pp-public-param-golden. The skill defines how its required CLI can be installed.
-```
+Restart the OpenClaw session or gateway if the newly installed skill is not visible immediately.
 
 ## Use with Claude Desktop
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/SKILL.md
@@ -18,16 +18,16 @@ metadata:
 
 This skill drives the `public-param-golden-pp-cli` binary. **You must verify the CLI is installed before invoking any command from this skill.** If it is missing, install it first:
 
-1. Install via the Printing Press installer:
+1. Install via the Printing Press installer into a user bin directory:
    ```bash
-   npx -y @mvanhorn/printing-press-library install public-param-golden --cli-only
+   npx -y @mvanhorn/printing-press-library install public-param-golden --cli-only --bin-dir ~/.local/bin
    ```
 2. Verify: `public-param-golden-pp-cli --version`
-3. Ensure `$GOPATH/bin` (or `$HOME/go/bin`) is on `$PATH`.
+3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 
 If the `npx` install fails before this CLI has a public-library category, install Node or use the category-specific Go fallback after publish.
 
-If `--version` reports "command not found" after install, the install step did not put the binary on `$PATH`. Do not proceed with skill commands until verification succeeds.
+If `--version` reports "command not found" after install, the runtime cannot see the binary directory on `$PATH`. Do not proceed with skill commands until verification succeeds.
 
 Public parameter name golden fixture
 


### PR DESCRIPTION
## Summary
- update generated SKILL prerequisites to install CLI binaries with `--bin-dir ~/.local/bin`
- update generated README OpenClaw instructions to use the library installer with `--agent openclaw --bin-dir ~/.local/bin`
- update generator/verify-skill tests for the new installer flags

## Tests
- `go test ./internal/generator ./internal/cli`

## Follow-up
- Companion library PR retrofits existing catalog entries and adds the npm `--bin-dir` installer flag.

Refs: mvanhorn/printing-press-library#631