### PR TITLE
fix(cli): bump emitted go directive to 1.26.4

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2277,7 +2277,7 @@ func TestGenerateBrowserChromeTransport(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26.3")
+	assert.Contains(t, string(gomod), "go 1.26.4")
 	assert.Contains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
@@ -3463,7 +3463,7 @@ func TestGenerateStandardTransportForOfficialAPI(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26.3")
+	assert.Contains(t, string(gomod), "go 1.26.4")
 	assert.NotContains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))

--- a/internal/generator/install_section.go
+++ b/internal/generator/install_section.go
@@ -38,7 +38,7 @@ const canonicalSkillInstallSectionStartFormat = "## Prerequisites: Install the C
 // canonicalSkillInstallSectionGoFallbackFormat is appended only once the
 // catalog category is known. Before publish, the category-agnostic installer is
 // the only canonical path; emitting library/other/<slug> creates drift.
-const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
+const canonicalSkillInstallSectionGoFallbackFormat = "If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:\n" +
 	"\n" +
 	"```bash\n" +
 	"go install github.com/mvanhorn/printing-press-library/library/%[2]s/%[1]s/cmd/%[1]s-pp-cli@latest\n" +

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -1,6 +1,6 @@
 module {{modulePath}}
 
-go 1.26.3
+go 1.26.4
 
 require (
 {{- if .UsesBrowserHTTPTransport}}

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -53,7 +53,7 @@ npx -y @mvanhorn/printing-press-library install {{.Name}} --agent claude-code --
 {{ if .Category}}
 ### Without Node (Go fallback)
 
-If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.3 or newer):
+If `npx` isn't available (no Node, offline), install the CLI directly via Go (requires Go 1.26.4 or newer):
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -34,7 +34,7 @@ This skill drives the `{{.Name}}-pp-cli` binary. **You must verify the CLI is in
 2. Verify: `{{.Name}}-pp-cli --version`
 3. Ensure `~/.local/bin` is on `$PATH` for the agent/runtime that will invoke this skill.
 {{ if .Category}}
-If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.3 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
+If the `npx` install fails (no Node, offline, etc.), fall back to a direct Go install (requires Go 1.26.4 or newer). This installs into `$GOPATH/bin` (default `$HOME/go/bin`), so add that directory to `$PATH` instead:
 
 ```bash
 go install github.com/mvanhorn/printing-press-library/library/{{.Category}}/{{.Name}}/cmd/{{.Name}}-pp-cli@latest

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -1,6 +1,6 @@
 module golden-api-cookie-auth-pp-cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -1,6 +1,6 @@
 module printing-press-golden-pp-cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## What

Bump the generated `go.mod` `go` directive and the install-floor text in the generated README/SKILL from 1.26.3 to 1.26.4.

## Why

Go 1.26.3's stdlib carries advisories GO-2026-5037 / GO-2026-5039, so `govulncheck` flags **every freshly-printed CLI** until the user upgrades their toolchain. This mirrors the CI Go bump in #2612 on the emission side, so fresh prints clear the govulncheck quality gate out of the box.

## Surface
- `internal/generator/templates/go.mod.tmpl` — emitted `go` directive
- `internal/generator/install_section.go`, `templates/readme.md.tmpl`, `templates/skill.md.tmpl` — install-floor instructions
- `internal/generator/generator_test.go` — assertions
- 2 golden `go.mod` fixtures regenerated

## Verification
- `scripts/golden.sh verify` — 25/25 pass
- `scripts/verify-generator-output.sh` — 5/5 pass
- `go test ./...` — green

Discovered while reprinting a CLI under 4.20.1; govulncheck failed on the fresh print's 1.26.3 stdlib.

Note: the advisory "Go 1.26.3 or newer" prerequisite text in the Press's own skills (`skills/printing-press*/SKILL.md`) is a separate `skills`-scope follow-up, not bundled here.