### PR TITLE
test(cli): guard dependent-resource searchability via generic FTS

### DIFF
--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -472,11 +472,12 @@ func TestUpsertBatch_Sets{{pascal .Name}}ParentID(t *testing.T) {
 // TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS verifies that a
 // dependent-resource row stored via UpsertBatch — the exact path dependent
 // sync uses (upsertResourceBatch -> UpsertBatch) — is reachable through the
-// generic resources_fts index. `search "<term>"` queries that index, and
-// `search "<term>" --type {{.Resource}}` falls through to it for dependents
-// that declare no per-resource FTS5 table, so both surfaces return the row.
-// Regression for issue #2629, which reported dependent resources as silently
-// unsearchable (stored in the typed table but absent from any FTS index).
+// generic resources_fts index via Store.Search. That index is the substrate
+// both `search` surfaces query (the empty-type search directly, and the
+// non-FTS5 `--type {{.Resource}}` fallback), so populating it is the
+// precondition issue #2629 reported missing — dependent resources stored in
+// the typed table but absent from any FTS index. This asserts the store layer
+// where the claimed defect lived; it does not exercise the CLI search wiring.
 func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "data.db")
 	s, err := Open(dbPath)
@@ -491,8 +492,15 @@ func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
 	items := []json.RawMessage{
 		json.RawMessage(`{"id": "search-001", "pp_fts_probe": "` + probe + `"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}, "parent_id": "parent-A"}`),
 	}
-	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+	stored, _, err := s.UpsertBatch("{{.Resource}}", items)
+	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
+	}
+	// Assert the probe row actually landed before searching for it: a PK
+	// extraction miss would leave stored == 0, and the FTS check below would
+	// then fail with a misleading "stored but not searchable" message.
+	if stored != 1 {
+		t.Fatalf("UpsertBatch stored %d rows, want 1 (probe row dropped before the FTS check)", stored)
 	}
 
 	results, err := s.Search(probe, 50)

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -468,6 +468,41 @@ func TestUpsertBatch_Sets{{pascal .Name}}ParentID(t *testing.T) {
 		t.Fatalf("parent_id=parent-A count = %d, want 2 (parent_id column not populated)", matchedA)
 	}
 }
+
+// TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS verifies that a
+// dependent-resource row stored via UpsertBatch — the exact path dependent
+// sync uses (upsertResourceBatch -> UpsertBatch) — is reachable through the
+// generic resources_fts index. `search "<term>"` queries that index, and
+// `search "<term>" --type {{.Resource}}` falls through to it for dependents
+// that declare no per-resource FTS5 table, so both surfaces return the row.
+// Regression for issue #2629, which reported dependent resources as silently
+// unsearchable (stored in the typed table but absent from any FTS index).
+func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// resources_fts indexes the full JSON blob, so a distinctive token in any
+	// field is matchable regardless of which columns {{.Name}} declares.
+	const probe = "zqxjpp2629probe"
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "search-001", "pp_fts_probe": "` + probe + `"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}, "parent_id": "parent-A"}`),
+	}
+	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+
+	results, err := s.Search(probe, 50)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("dependent resource %q stored but not searchable via generic resources_fts (issue #2629)", "{{.Resource}}")
+	}
+}
 {{- end}}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
## Summary

Adds a regression guard for the behavior reported in #2629. **The described bug does not exist in current code** — this PR locks in the already-correct behavior so it cannot silently regress.

#2629 (filed today from a retro) claimed synced *dependent* resources land in typed tables with no FTS reach, so `search` / `search --type <dep>` silently return zero. Tracing the actual path:

- Dependent sync writes rows via `upsertResourceBatch` → `Store.UpsertBatch` (`sync.go.tmpl` → `store.go.tmpl`).
- `UpsertBatch` calls `upsertGenericResourceTx` for **every** item *before* the typed dispatch, populating `resources` **and** `resources_fts` (full JSON as content).
- `search "<term>"` queries the generic index (since #1462); `search "<term>" --type <dep>` falls through to the generic index for non-FTS5 dependents.

The "direct `upsert…Tx` bypass" the issue describes has no call site — both callers of `upsert…Tx` write the generic FTS first. The enabling fixes (#268/#271, #503, #1462) all predate the issue by weeks; the retro mis-traced already-fixed code.

## What this adds

`store_upsert_batch_test.go.tmpl` now emits `TestUpsertBatch_<Name>SearchableViaGenericFTS` for every dependent resource (those with a `parent_id` column). It stores a row via `UpsertBatch` and asserts `Store.Search` returns it through `resources_fts`. The probe token is embedded in the JSON blob, so the guard is parameterized off the resource — no hardcoded API/resource names.

## Verification

- New emitted test compiles + passes against a freshly-generated CLI (`sync-walker` fixture, dependent resource `leagues`); gofmt-clean.
- `go test ./...` — all packages green.
- `scripts/golden.sh verify` (25 cases) + `scripts/verify-generator-output.sh` (5 cases) pass. Goldens omit `*_test.go`, so no golden churn.

Refs #2629