### PR TITLE
fix(cli): preserve live dogfood refresh credentials

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -169,9 +169,6 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	}
 
 	finalizeLiveDogfoodReport(report)
-	if err := homeScope.syncBack(); err != nil {
-		return nil, err
-	}
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
 	// every outcome": pass → promote, fail → hold-path, missing → "Phase 5
 	// was skipped or not recorded." Writing only on PASS forced operators to
@@ -182,6 +179,9 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		if err := writeLiveDogfoodAcceptance(opts, report); err != nil {
 			return nil, err
 		}
+	}
+	if err := homeScope.syncBack(); err != nil {
+		return report, err
 	}
 	return report, nil
 }
@@ -287,21 +287,61 @@ func syncLiveDogfoodCredentialMirrors(mirrors []liveDogfoodCredentialMirror) err
 		if bytes.Equal(updated, mirror.original) {
 			continue
 		}
-		current, err := os.ReadFile(mirror.src)
-		if err != nil {
-			return fmt.Errorf("reading operator credential file before sync-back %s: %w", mirror.src, err)
-		}
-		if !bytes.Equal(current, mirror.original) {
-			return fmt.Errorf("refusing to sync refreshed live dogfood credentials to %s: operator config changed during dogfood", mirror.src)
-		}
-		if err := writeLiveDogfoodCredentialFile(mirror.src, updated, mirror.mode); err != nil {
+		if err := writeLiveDogfoodCredentialFileIfUnchanged(mirror, updated); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func writeLiveDogfoodCredentialFile(dst string, data []byte, mode os.FileMode) error {
+func writeLiveDogfoodCredentialFileIfUnchanged(mirror liveDogfoodCredentialMirror, updated []byte) error {
+	dir := filepath.Dir(mirror.src)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating live dogfood credential mirror directory for %s: %w", mirror.src, err)
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(mirror.src)+".dogfood-sync-*")
+	if err != nil {
+		return fmt.Errorf("creating live dogfood credential sync temp file for %s: %w", mirror.src, err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(updated); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing live dogfood credential sync temp file %s: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(mirror.mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("setting live dogfood credential sync temp file mode %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing live dogfood credential sync temp file %s: %w", tmpName, err)
+	}
+
+	// Best-effort compare-and-swap: generated printed CLIs do not share a file
+	// lock with live dogfood, so a non-cooperating writer can still race after
+	// this final read. The temp-file rename keeps the sync-back atomic and this
+	// last comparison catches operator edits made before live dogfood commits
+	// the rotated credential.
+	current, err := os.ReadFile(mirror.src)
+	if err != nil {
+		return fmt.Errorf("reading operator credential file before sync-back %s: %w", mirror.src, err)
+	}
+	if !bytes.Equal(current, mirror.original) {
+		return fmt.Errorf("refusing to sync refreshed live dogfood credentials to %s: operator config changed during dogfood", mirror.src)
+	}
+	if err := os.Rename(tmpName, mirror.src); err != nil {
+		return fmt.Errorf("writing live dogfood credential file %s: %w", mirror.src, err)
+	}
+	cleanup = false
+	return nil
+}
+
+func writeLiveDogfoodCredentialMirrorFile(dst string, data []byte, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("creating live dogfood credential mirror directory for %s: %w", dst, err)
 	}
@@ -334,7 +374,7 @@ func copyLiveDogfoodCredentialFile(src, dst string) (*liveDogfoodCredentialMirro
 		return nil, fmt.Errorf("reading live dogfood credential file %s: %w", src, err)
 	}
 	mode := info.Mode().Perm()
-	if err := writeLiveDogfoodCredentialFile(dst, data, mode); err != nil {
+	if err := writeLiveDogfoodCredentialMirrorFile(dst, data, mode); err != nil {
 		return nil, err
 	}
 	return &liveDogfoodCredentialMirror{

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,11 +112,11 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	if strings.TrimSpace(opts.CLIDir) == "" {
 		return nil, fmt.Errorf("CLIDir is required")
 	}
-	releaseHome, err := scopeLiveDogfoodSubprocessHome(opts.CLIDir)
+	homeScope, err := scopeLiveDogfoodSubprocessHome(opts.CLIDir, opts.BinaryName)
 	if err != nil {
 		return nil, err
 	}
-	defer releaseHome()
+	defer homeScope.release()
 
 	level, err := normalizeLiveDogfoodLevel(opts.Level)
 	if err != nil {
@@ -168,6 +169,9 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	}
 
 	finalizeLiveDogfoodReport(report)
+	if err := homeScope.syncBack(); err != nil {
+		return nil, err
+	}
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
 	// every outcome": pass → promote, fail → hold-path, missing → "Phase 5
 	// was skipped or not recorded." Writing only on PASS forced operators to
@@ -182,12 +186,163 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 	return report, nil
 }
 
-func scopeLiveDogfoodSubprocessHome(cliDir string) (func(), error) {
+type liveDogfoodHomeScope struct {
+	release  func()
+	syncBack func() error
+}
+
+func noopLiveDogfoodHomeScope() *liveDogfoodHomeScope {
+	return &liveDogfoodHomeScope{
+		release:  func() {},
+		syncBack: func() error { return nil },
+	}
+}
+
+func scopeLiveDogfoodSubprocessHome(cliDir, binaryName string) (*liveDogfoodHomeScope, error) {
 	manifest, err := ReadCLIManifest(cliDir)
 	if err == nil && manifest.IsLocalDatastore() && strings.EqualFold(strings.TrimSpace(manifest.AuthType), "none") {
-		return func() {}, nil
+		return noopLiveDogfoodHomeScope(), nil
 	}
-	return scopeSubprocessHome()
+	cliName := strings.TrimSpace(manifest.CLIName)
+	if cliName == "" {
+		cliName = strings.TrimSpace(binaryName)
+	}
+	if cliName == "" {
+		cliName = findCLIName(cliDir)
+	}
+	syncConfigBack := strings.EqualFold(strings.TrimSpace(manifest.AuthType), "oauth2_refresh")
+	return scopeSubprocessHomeWithCredentialMirror(cliName, syncConfigBack)
+}
+
+func scopeSubprocessHomeWithCredentialMirror(cliName string, syncConfigBack bool) (*liveDogfoodHomeScope, error) {
+	homeDir, removeHome, err := newScopedConfigHome()
+	if err != nil {
+		return nil, err
+	}
+	mirrors, err := mirrorLiveDogfoodCredentialFiles(homeDir, cliName, syncConfigBack)
+	if err != nil {
+		removeHome()
+		return nil, err
+	}
+	restore := installScopedSubprocessHome(homeDir)
+	return &liveDogfoodHomeScope{
+		release: func() {
+			restore()
+			removeHome()
+		},
+		syncBack: func() error {
+			return syncLiveDogfoodCredentialMirrors(mirrors)
+		},
+	}, nil
+}
+
+type liveDogfoodCredentialMirror struct {
+	src      string
+	dst      string
+	original []byte
+	mode     os.FileMode
+}
+
+func mirrorLiveDogfoodCredentialFiles(scopedHome, cliName string, syncConfigBack bool) ([]liveDogfoodCredentialMirror, error) {
+	cliName = strings.TrimSpace(cliName)
+	if scopedHome == "" || cliName == "" {
+		return nil, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil, nil
+	}
+	paths := []struct {
+		rel      string
+		syncBack bool
+	}{
+		{rel: filepath.Join(".config", cliName, "config.toml"), syncBack: syncConfigBack},
+		{rel: filepath.Join(".config", cliName, "config.json"), syncBack: syncConfigBack},
+		{rel: filepath.Join(".local", "share", cliName, "cookies.json")},
+	}
+	var mirrors []liveDogfoodCredentialMirror
+	for _, path := range paths {
+		src := filepath.Join(home, path.rel)
+		dst := filepath.Join(scopedHome, path.rel)
+		mirror, err := copyLiveDogfoodCredentialFile(src, dst)
+		if err != nil {
+			return nil, err
+		}
+		if path.syncBack && mirror != nil {
+			mirrors = append(mirrors, *mirror)
+		}
+	}
+	return mirrors, nil
+}
+
+func syncLiveDogfoodCredentialMirrors(mirrors []liveDogfoodCredentialMirror) error {
+	for _, mirror := range mirrors {
+		updated, err := os.ReadFile(mirror.dst)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("reading live dogfood credential mirror %s: %w", mirror.dst, err)
+		}
+		if bytes.Equal(updated, mirror.original) {
+			continue
+		}
+		current, err := os.ReadFile(mirror.src)
+		if err != nil {
+			return fmt.Errorf("reading operator credential file before sync-back %s: %w", mirror.src, err)
+		}
+		if !bytes.Equal(current, mirror.original) {
+			return fmt.Errorf("refusing to sync refreshed live dogfood credentials to %s: operator config changed during dogfood", mirror.src)
+		}
+		if err := writeLiveDogfoodCredentialFile(mirror.src, updated, mirror.mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeLiveDogfoodCredentialFile(dst string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("creating live dogfood credential mirror directory for %s: %w", dst, err)
+	}
+	if err := os.WriteFile(dst, data, mode); err != nil {
+		return fmt.Errorf("writing live dogfood credential file %s: %w", dst, err)
+	}
+	return nil
+}
+
+func copyLiveDogfoodCredentialFile(src, dst string) (*liveDogfoodCredentialMirror, error) {
+	in, err := os.Open(src)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("opening live dogfood credential file %s: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("checking live dogfood credential file %s: %w", src, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("live dogfood credential file %s is not a regular file", src)
+	}
+
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return nil, fmt.Errorf("reading live dogfood credential file %s: %w", src, err)
+	}
+	mode := info.Mode().Perm()
+	if err := writeLiveDogfoodCredentialFile(dst, data, mode); err != nil {
+		return nil, err
+	}
+	return &liveDogfoodCredentialMirror{
+		src:      src,
+		dst:      dst,
+		original: data,
+		mode:     mode,
+	}, nil
 }
 
 func liveDogfoodBinaryPath(dir, name string) (string, error) {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -564,6 +564,108 @@ exit 99
 	assert.Equal(t, configRotatedBody, string(gotConfig), "rotated OAuth refresh tokens must survive live dogfood cleanup")
 }
 
+func TestRunLiveDogfoodSyncBackConflictStillReturnsReportAndWritesAcceptance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName         = "fixture-pp-cli"
+		configOriginalBody = "access_token = \"expired-access\"\nrefresh_token = \"old-refresh\"\n"
+		configRotatedBody  = "access_token = \"fresh-access\"\nrefresh_token = \"new-refresh\"\n"
+		configConflictBody = "access_token = \"operator-edit\"\nrefresh_token = \"operator-refresh\"\n"
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	configPath := filepath.Join(operatorHome, ".config", binaryName, "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, os.WriteFile(configPath, []byte(configOriginalBody), 0o600))
+	t.Setenv("OPERATOR_CONFIG_PATH", configPath)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		RunID:         "run-live-dogfood",
+		AuthType:      "oauth2_refresh",
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  config_path="$HOME/.config/fixture-pp-cli/config.toml"
+  if ! grep -Eq 'old-refresh|new-refresh' "$config_path"; then
+    echo "missing mirrored refresh token" >&2
+    exit 1
+  fi
+  printf 'access_token = "operator-edit"\nrefresh_token = "operator-refresh"\n' > "$OPERATOR_CONFIG_PATH"
+  printf 'access_token = "fresh-access"\nrefresh_token = "new-refresh"\n' > "$config_path"
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	markerPath := filepath.Join(t.TempDir(), Phase5AcceptanceFilename)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:              dir,
+		BinaryName:          binaryName,
+		Level:               "full",
+		Timeout:             2 * time.Second,
+		WriteAcceptancePath: markerPath,
+	})
+	require.Error(t, err)
+	require.NotNil(t, report, "sync-back errors must not discard the completed live dogfood report")
+	assert.Contains(t, err.Error(), "operator config changed during dogfood")
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	gotConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, configConflictBody, string(gotConfig), "sync-back conflict must preserve the operator edit")
+
+	data, err := os.ReadFile(markerPath)
+	require.NoError(t, err, "sync-back errors must not suppress the Phase 5 acceptance marker")
+	var marker Phase5GateMarker
+	require.NoError(t, json.Unmarshal(data, &marker))
+	assert.Equal(t, "pass", marker.Status)
+	assert.Equal(t, report.MatrixSize, marker.MatrixSize)
+	assert.Equal(t, report.Passed, marker.TestsPassed)
+}
+
 func TestSyncLiveDogfoodCredentialMirrorsRejectsOperatorConfigConflict(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "operator", "config.toml")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -369,6 +369,226 @@ func TestRunLiveDogfoodAuthenticatedLocalDatastoreRetainsScopedHome(t *testing.T
 	assert.Equal(t, "PASS", report.Verdict, report.Tests)
 }
 
+func TestRunLiveDogfoodMirrorsConfigAndCookieCredentialsIntoScopedHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName         = "fixture-pp-cli"
+		configCredential   = "real-config-token"
+		cookieCredential   = "real-cookie-token"
+		configOriginalBody = "auth_header = \"" + configCredential + "\"\n"
+		cookieOriginalBody = `[{"name":"session","value":"` + cookieCredential + `","domain":".example.test","path":"/","secure":true}]`
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	configPath := filepath.Join(operatorHome, ".config", binaryName, "config.toml")
+	cookiePath := filepath.Join(operatorHome, ".local", "share", binaryName, "cookies.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cookiePath), 0o700))
+	require.NoError(t, os.WriteFile(configPath, []byte(configOriginalBody), 0o600))
+	require.NoError(t, os.WriteFile(cookiePath, []byte(cookieOriginalBody), 0o600))
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		RunID:         "run-live-dogfood",
+		AuthType:      "composed",
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  config_path="$HOME/.config/fixture-pp-cli/config.toml"
+  cookie_path="$HOME/.local/share/fixture-pp-cli/cookies.json"
+  if ! grep -q 'real-config-token' "$config_path"; then
+    echo "missing mirrored config credential" >&2
+    exit 1
+  fi
+  if ! grep -q 'real-cookie-token' "$cookie_path"; then
+    echo "missing mirrored cookie credential" >&2
+    exit 1
+  fi
+  printf 'auth_header = "real-config-token-mutated"\n' > "$config_path"
+  printf '[{"name":"session","value":"real-cookie-token-mutated","domain":".example.test","path":"/","secure":true}]' > "$cookie_path"
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	happy := findResultByCommandKind(report, "account show", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	jsonResult := findResultByCommandKind(report, "account show", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult)
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+
+	gotConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, configOriginalBody, string(gotConfig), "live dogfood must not mutate the operator's real config")
+	gotCookies, err := os.ReadFile(cookiePath)
+	require.NoError(t, err)
+	assert.Equal(t, cookieOriginalBody, string(gotCookies), "live dogfood must not mutate the operator's real cookies")
+}
+
+func TestRunLiveDogfoodSyncsOAuth2RefreshConfigBackToOperatorHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const (
+		binaryName         = "fixture-pp-cli"
+		configOriginalBody = "access_token = \"expired-access\"\nrefresh_token = \"old-refresh\"\n"
+		configRotatedBody  = "access_token = \"fresh-access\"\nrefresh_token = \"new-refresh\"\n"
+	)
+
+	operatorHome := t.TempDir()
+	t.Setenv("HOME", operatorHome)
+	configPath := filepath.Join(operatorHome, ".config", binaryName, "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, os.WriteFile(configPath, []byte(configOriginalBody), 0o600))
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		RunID:         "run-live-dogfood",
+		AuthType:      "oauth2_refresh",
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  config_path="$HOME/.config/fixture-pp-cli/config.toml"
+  if ! grep -Eq 'old-refresh|new-refresh' "$config_path"; then
+    echo "missing mirrored refresh token" >&2
+    exit 1
+  fi
+  printf 'access_token = "fresh-access"\nrefresh_token = "new-refresh"\n' > "$config_path"
+  if [ "${3:-}" = "--json" ]; then
+    echo '{"ok":true}'
+    exit 0
+  fi
+  echo 'ok'
+  exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	gotConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, configRotatedBody, string(gotConfig), "rotated OAuth refresh tokens must survive live dogfood cleanup")
+}
+
+func TestSyncLiveDogfoodCredentialMirrorsRejectsOperatorConfigConflict(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "operator", "config.toml")
+	dst := filepath.Join(dir, "scoped", "config.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o700))
+	require.NoError(t, os.WriteFile(src, []byte("refresh_token = \"old\"\n"), 0o600))
+	require.NoError(t, os.WriteFile(dst, []byte("refresh_token = \"new\"\n"), 0o600))
+
+	mirror := liveDogfoodCredentialMirror{
+		src:      src,
+		dst:      dst,
+		original: []byte("refresh_token = \"original\"\n"),
+		mode:     0o600,
+	}
+
+	err := syncLiveDogfoodCredentialMirrors([]liveDogfoodCredentialMirror{mirror})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operator config changed during dogfood")
+
+	got, readErr := os.ReadFile(src)
+	require.NoError(t, readErr)
+	assert.Equal(t, "refresh_token = \"old\"\n", string(got))
+}
+
 func TestRunLiveDogfoodProcessRetriesTransientAuth401(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")


### PR DESCRIPTION
## Summary

`dogfood --live` can now exercise authenticated CLIs that depend on persisted config or browser-cookie credentials while still running commands inside a scoped subprocess home. Config and cookie files are mirrored into that temporary home so live checks can authenticate without exposing real operator files to routine dogfood mutations.

OAuth refresh-token CLIs get stricter handling: when a live request rotates a refresh token, the updated config is synced back only if the original operator config has not changed concurrently. That preserves the replacement credential instead of deleting it with the temp home, while refusing to overwrite a live local edit.

Fixes #2635.

## Verification

- `go fmt ./...`
- `golangci-lint run ./...`
- `go test ./internal/pipeline -run 'TestRunLiveDogfood(MirrorsConfigAndCookieCredentialsIntoScopedHome|SyncsOAuth2RefreshConfigBackToOperatorHome|APICLIRetainsScopedHome|LocalDatastoreManifestPreservesOperatorHome|AuthenticatedLocalDatastoreRetainsScopedHome)|TestSyncLiveDogfoodCredentialMirrorsRejectsOperatorConfigConflict'`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
