### PR TITLE
fix(cli): live dogfood happy-path honors pp:happy-args

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1372,6 +1372,20 @@ func fileExistsRelativeTo(p, cliDir string) bool {
 }
 
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
+	// pp:happy-args supplies real happy-path args, overriding the Example-derived
+	// placeholders (e.g. "--ids example-value") that strict upstream validators
+	// reject with HTTP 400. Same `;`-separated `--flag=value` / `<name>=value`
+	// grammar the runtime layer uses (parseHappyArgsAnnotation), so a single
+	// annotation drives both surfaces.
+	if raw := strings.TrimSpace(command.Annotations[happyArgsAnnotation]); raw != "" {
+		parsed := parseHappyArgsAnnotation(raw)
+		args := append([]string{}, command.Path...)
+		args = append(args, parsed.positionals...)
+		args = append(args, parsed.flags...)
+		if len(args) > len(command.Path) {
+			return args, true
+		}
+	}
 	examples := extractExamplesSection(command.Help)
 	for line := range strings.SplitSeq(examples, "\n") {
 		candidate := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -560,6 +560,13 @@ func findListCompanion(candidates []liveDogfoodCommand) *liveDogfoodCommand {
 //   - (nil, true, reason)    — chain broke; caller must skip happy_path + json_fidelity
 //   - (happyArgs, false, "") — no positionals at all; pass-through unchanged
 func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string) {
+	// pp:happy-args already supplies real positional values, so the args are
+	// authoritative — skip placeholder re-resolution, which would otherwise
+	// overwrite them via the list companion or skip the command when no
+	// companion is reachable.
+	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) != "" {
+		return happyArgs, false, ""
+	}
 	placeholders := extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))
 	if len(placeholders) == 0 {
 		return happyArgs, false, ""

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4329,13 +4329,20 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 		"flag-form pp:happy-args must override the Example placeholder")
 
 	// Positional form: <name>=value contributes the value as a positional arg.
+	// resolveCommandPositionals must NOT re-resolve (or skip) it even when the
+	// Usage line carries an <id> placeholder and no list companion is reachable.
 	posCmd := liveDogfoodCommand{
 		Path:        []string{"tweets", "get"},
+		Help:        "Usage:\n  cli tweets get <id> [flags]\n",
 		Annotations: map[string]string{happyArgsAnnotation: "<id>=1750000000000000000"},
 	}
 	args, ok = liveDogfoodHappyArgs(posCmd)
 	require.True(t, ok)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, args)
+	resolved, skipped, reason := resolveCommandPositionals(posCmd, args, resolveCtx{})
+	assert.False(t, skipped, "pp:happy-args positional must not be skipped: %s", reason)
+	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, resolved,
+		"resolveCommandPositionals must preserve the pp:happy-args positional value")
 
 	// Empty annotation falls through to the Example-derivation path.
 	emptyCmd := liveDogfoodCommand{

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4314,3 +4314,37 @@ func TestRunLiveDogfoodErrorPathRealReportContribution(t *testing.T) {
 		"MatrixSize should equal Passed + Failed (skipped entries do not contribute)")
 	assert.Equal(t, 0, report.Failed)
 }
+
+func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
+	// pp:happy-args supplies a real value, overriding the Example placeholder
+	// ("example-value") that strict upstream validators reject with HTTP 400.
+	flagCmd := liveDogfoodCommand{
+		Path:        []string{"users", "get-by-ids"},
+		Help:        "Usage:\n  cli users get-by-ids [flags]\n\nExamples:\n  cli users get-by-ids --ids example-value\n",
+		Annotations: map[string]string{happyArgsAnnotation: "--ids=12"},
+	}
+	args, ok := liveDogfoodHappyArgs(flagCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "12"}, args,
+		"flag-form pp:happy-args must override the Example placeholder")
+
+	// Positional form: <name>=value contributes the value as a positional arg.
+	posCmd := liveDogfoodCommand{
+		Path:        []string{"tweets", "get"},
+		Annotations: map[string]string{happyArgsAnnotation: "<id>=1750000000000000000"},
+	}
+	args, ok = liveDogfoodHappyArgs(posCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, args)
+
+	// Empty annotation falls through to the Example-derivation path.
+	emptyCmd := liveDogfoodCommand{
+		Path:        []string{"users", "get-by-ids"},
+		Help:        "Usage:\n  cli users get-by-ids [flags]\n\nExamples:\n  cli users get-by-ids --ids example-value\n",
+		Annotations: map[string]string{happyArgsAnnotation: ""},
+	}
+	args, ok = liveDogfoodHappyArgs(emptyCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "example-value"}, args,
+		"empty pp:happy-args must fall through to Example derivation")
+}


### PR DESCRIPTION
## What
The Phase 5 live dogfood derives each command's happy-path args from its `Example`, which carries placeholder values (`example-value`). APIs that validate IDs/usernames strictly (e.g. X) return **HTTP 400** for those placeholders, so endpoint-read commands fail the acceptance through no fault of the CLI.

`liveDogfoodHappyArgs` now honors the **`pp:happy-args`** annotation: when set, its real `--flag=value` / `<name>=value` tokens (parsed by the existing `parseHappyArgsAnnotation`, already used by the runtime layer) override the Example placeholders for both `happy_path` and `json_fidelity`.

## Why
Surfaced while publishing a strict-validation CLI — 8 endpoint-read failures were all the harness sending `example-value`. Annotating those commands with real fixtures dropped the acceptance from 9 → 1 failure.

Addresses the **runner side of #2636**; the generator-emit side (auto-deriving `pp:happy-args` from spec `example`s) remains open there.

## Tests
`TestLiveDogfoodHappyArgsHonorsPPHappyArgs` (flag form, positional form, empty→Example fallback). `go test ./internal/pipeline/` green.