### PR TITLE
fix(cli): emit valid JSON for sync_warning events

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -11001,8 +11001,9 @@ func TestGeneratedSyncTreatsAccessDeniedAsWarning(t *testing.T) {
 
 	// Sync emits the structured warn event and routes to the warn-aware exit branch.
 	assert.Contains(t, syncContent, `Warn     error`)
-	assert.Contains(t, syncContent, `{"event":"sync_warning"`)
-	assert.Contains(t, syncContent, `"status":%d,"reason":"%s"`)
+	// The access-denied warning is marshaled via syncWarningJSON (escaping the
+	// embedded upstream error body) rather than raw fmt.Fprintf interpolation.
+	assert.Contains(t, syncContent, `syncWarningJSON(resource, "", w.Status, w.Reason, w.Message)`)
 	assert.Contains(t, syncContent, `{"event":"sync_summary"`)
 	assert.Contains(t, syncContent, `Sync complete: %d records across %d resources (%d warned, %.1fs)`)
 	assert.Contains(t, syncContent, `successCount == 0`)
@@ -17028,4 +17029,61 @@ paths:
 		assert.Regexp(t, `Short:\s+"List and get invoices"`, string(invoicesSrc))
 		assert.NotRegexp(t, `Coordinate commerce workflows`, string(invoicesSrc))
 	})
+}
+
+// TestSyncWarningEmitsValidJSON guards the contract that sync_warning events
+// are emitted as valid single-line JSON. The message field carries an upstream
+// error body that can be multi-line pretty-printed JSON; the old raw
+// fmt.Fprintf path escaped only quotes, so embedded newlines broke the NDJSON
+// stream (dogfood json_fidelity rejected it). The generated code must route
+// warnings through syncWarningJSON, which marshals the event.
+func TestSyncWarningEmitsValidJSON(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "warnjson",
+		Version: "0.1.0",
+		BaseURL: "https://warnjson.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/warnjson-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"messages": {
+				Description: "Messages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/messages",
+						Description: "List messages",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	helpersSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(helpersSrc), "func syncWarningJSON(",
+		"helpers.go must define syncWarningJSON")
+	assert.Contains(t, string(helpersSrc), "json.Marshal(payload)",
+		"syncWarningJSON must marshal the event rather than interpolate it")
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(syncSrc), "syncWarningJSON(",
+		"sync.go must route sync_warning events through syncWarningJSON")
+	assert.NotContains(t, string(syncSrc), `ReplaceAll(w.Message`,
+		"sync.go must not quote-only-escape the warning message (drops newline escaping)")
+	// Compile-level proof for the emitted sync.go + helpers.go is covered by
+	// scripts/verify-generator-output.sh (which builds the generate-golden-api
+	// module, exercising the syncWarningJSON call site); asserting the contract
+	// here keeps the canary close to the template change.
 }

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -358,9 +358,12 @@ func syncWarningJSON(resource, parent string, status int, reason, message string
 		Event    string `json:"event"`
 		Resource string `json:"resource"`
 		Parent   string `json:"parent,omitempty"`
-		Status   int    `json:"status,omitempty"`
-		Reason   string `json:"reason,omitempty"`
-		Message  string `json:"message,omitempty"`
+		// status/reason/message are always present (matching the prior raw
+		// fmt.Fprintf shape); only parent was conditional. No omitempty so
+		// consumers parsing the event don't see fields disappear on zero values.
+		Status  int    `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
 	}{
 		Event:    "sync_warning",
 		Resource: resource,

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -349,6 +349,30 @@ func syncErrorJSON(resource, parent string, err error) string {
 	return string(out)
 }
 
+// syncWarningJSON renders a sync_warning event as a single valid JSON line.
+// Marshaling (rather than fmt.Fprintf string interpolation) escapes the
+// message field, whose value is an upstream error body that may be
+// pretty-printed multi-line JSON — embedding it raw broke the NDJSON stream.
+func syncWarningJSON(resource, parent string, status int, reason, message string) string {
+	payload := struct {
+		Event    string `json:"event"`
+		Resource string `json:"resource"`
+		Parent   string `json:"parent,omitempty"`
+		Status   int    `json:"status,omitempty"`
+		Reason   string `json:"reason,omitempty"`
+		Message  string `json:"message,omitempty"`
+	}{
+		Event:    "sync_warning",
+		Resource: resource,
+		Parent:   parent,
+		Status:   status,
+		Reason:   reason,
+		Message:  message,
+	}
+	out, _ := json.Marshal(payload)
+	return string(out)
+}
+
 // syncUserParams carries user-supplied query parameters injected into sync
 // HTTP requests. flatGlobal entries come from --param and inject into
 // flat-list requests only; trueGlobal entries come from --global-param and

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -678,8 +678,7 @@ func syncResource(ctx context.Context, c interface {
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-						resource, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
 				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 			}
@@ -2210,8 +2209,7 @@ func syncDependentResource(ctx context.Context, c interface {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: access denied for parent %s: %s\n", dep.Name, parentID, w.Reason)
 					} else {
-						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-							dep.Name, parentID, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -198,6 +198,30 @@ func syncErrorJSON(resource, parent string, err error) string {
 	return string(out)
 }
 
+// syncWarningJSON renders a sync_warning event as a single valid JSON line.
+// Marshaling (rather than fmt.Fprintf string interpolation) escapes the
+// message field, whose value is an upstream error body that may be
+// pretty-printed multi-line JSON — embedding it raw broke the NDJSON stream.
+func syncWarningJSON(resource, parent string, status int, reason, message string) string {
+	payload := struct {
+		Event    string `json:"event"`
+		Resource string `json:"resource"`
+		Parent   string `json:"parent,omitempty"`
+		Status   int    `json:"status,omitempty"`
+		Reason   string `json:"reason,omitempty"`
+		Message  string `json:"message,omitempty"`
+	}{
+		Event:    "sync_warning",
+		Resource: resource,
+		Parent:   parent,
+		Status:   status,
+		Reason:   reason,
+		Message:  message,
+	}
+	out, _ := json.Marshal(payload)
+	return string(out)
+}
+
 // syncUserParams carries user-supplied query parameters injected into sync
 // HTTP requests. flatGlobal entries come from --param and inject into
 // flat-list requests only; trueGlobal entries come from --global-param and

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -207,9 +207,12 @@ func syncWarningJSON(resource, parent string, status int, reason, message string
 		Event    string `json:"event"`
 		Resource string `json:"resource"`
 		Parent   string `json:"parent,omitempty"`
-		Status   int    `json:"status,omitempty"`
-		Reason   string `json:"reason,omitempty"`
-		Message  string `json:"message,omitempty"`
+		// status/reason/message are always present (matching the prior raw
+		// fmt.Fprintf shape); only parent was conditional. No omitempty so
+		// consumers parsing the event don't see fields disappear on zero values.
+		Status  int    `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
 	}{
 		Event:    "sync_warning",
 		Resource: resource,

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -197,6 +197,30 @@ func syncErrorJSON(resource, parent string, err error) string {
 	return string(out)
 }
 
+// syncWarningJSON renders a sync_warning event as a single valid JSON line.
+// Marshaling (rather than fmt.Fprintf string interpolation) escapes the
+// message field, whose value is an upstream error body that may be
+// pretty-printed multi-line JSON — embedding it raw broke the NDJSON stream.
+func syncWarningJSON(resource, parent string, status int, reason, message string) string {
+	payload := struct {
+		Event    string `json:"event"`
+		Resource string `json:"resource"`
+		Parent   string `json:"parent,omitempty"`
+		Status   int    `json:"status,omitempty"`
+		Reason   string `json:"reason,omitempty"`
+		Message  string `json:"message,omitempty"`
+	}{
+		Event:    "sync_warning",
+		Resource: resource,
+		Parent:   parent,
+		Status:   status,
+		Reason:   reason,
+		Message:  message,
+	}
+	out, _ := json.Marshal(payload)
+	return string(out)
+}
+
 // syncUserParams carries user-supplied query parameters injected into sync
 // HTTP requests. flatGlobal entries come from --param and inject into
 // flat-list requests only; trueGlobal entries come from --global-param and

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -206,9 +206,12 @@ func syncWarningJSON(resource, parent string, status int, reason, message string
 		Event    string `json:"event"`
 		Resource string `json:"resource"`
 		Parent   string `json:"parent,omitempty"`
-		Status   int    `json:"status,omitempty"`
-		Reason   string `json:"reason,omitempty"`
-		Message  string `json:"message,omitempty"`
+		// status/reason/message are always present (matching the prior raw
+		// fmt.Fprintf shape); only parent was conditional. No omitempty so
+		// consumers parsing the event don't see fields disappear on zero values.
+		Status  int    `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
 	}{
 		Event:    "sync_warning",
 		Resource: resource,

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 66
+    "total": 67
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -273,6 +273,30 @@ func syncErrorJSON(resource, parent string, err error) string {
 	return string(out)
 }
 
+// syncWarningJSON renders a sync_warning event as a single valid JSON line.
+// Marshaling (rather than fmt.Fprintf string interpolation) escapes the
+// message field, whose value is an upstream error body that may be
+// pretty-printed multi-line JSON — embedding it raw broke the NDJSON stream.
+func syncWarningJSON(resource, parent string, status int, reason, message string) string {
+	payload := struct {
+		Event    string `json:"event"`
+		Resource string `json:"resource"`
+		Parent   string `json:"parent,omitempty"`
+		Status   int    `json:"status,omitempty"`
+		Reason   string `json:"reason,omitempty"`
+		Message  string `json:"message,omitempty"`
+	}{
+		Event:    "sync_warning",
+		Resource: resource,
+		Parent:   parent,
+		Status:   status,
+		Reason:   reason,
+		Message:  message,
+	}
+	out, _ := json.Marshal(payload)
+	return string(out)
+}
+
 // syncUserParams carries user-supplied query parameters injected into sync
 // HTTP requests. flatGlobal entries come from --param and inject into
 // flat-list requests only; trueGlobal entries come from --global-param and

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -282,9 +282,12 @@ func syncWarningJSON(resource, parent string, status int, reason, message string
 		Event    string `json:"event"`
 		Resource string `json:"resource"`
 		Parent   string `json:"parent,omitempty"`
-		Status   int    `json:"status,omitempty"`
-		Reason   string `json:"reason,omitempty"`
-		Message  string `json:"message,omitempty"`
+		// status/reason/message are always present (matching the prior raw
+		// fmt.Fprintf shape); only parent was conditional. No omitempty so
+		// consumers parsing the event don't see fields disappear on zero values.
+		Status  int    `json:"status"`
+		Reason  string `json:"reason"`
+		Message string `json:"message"`
 	}{
 		Event:    "sync_warning",
 		Resource: resource,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -497,8 +497,7 @@ func syncResource(ctx context.Context, c interface {
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-						resource, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
 				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 			}
@@ -1426,8 +1425,7 @@ func syncDependentResource(ctx context.Context, c interface {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: access denied for parent %s: %s\n", dep.Name, parentID, w.Reason)
 					} else {
-						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-							dep.Name, parentID, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -497,8 +497,7 @@ func syncResource(ctx context.Context, c interface {
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-						resource, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
 				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 			}
@@ -1411,8 +1410,7 @@ func syncDependentResource(ctx context.Context, c interface {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: access denied for parent %s: %s\n", dep.Name, parentID, w.Reason)
 					} else {
-						fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-							dep.Name, parentID, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -464,8 +464,7 @@ func syncResource(ctx context.Context, c interface {
 		if err != nil {
 			if w, ok := isSyncAccessWarning(err); ok {
 				if !humanFriendly {
-					fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","status":%d,"reason":"%s","message":"%s"}`+"\n",
-						resource, w.Status, w.Reason, strings.ReplaceAll(w.Message, `"`, `\"`))
+					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
 				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
 			}


### PR DESCRIPTION
## What
`sync_warning` events for access-denied resources embedded the upstream error body into the `message` field via raw `fmt.Fprintf` with **quote-only** escaping (`strings.ReplaceAll(w.Message, '"', '\\"')`). Upstream error bodies are often pretty-printed **multi-line** JSON, so the unescaped newlines broke each event across physical lines — making `sync --json` an invalid NDJSON stream.

Both `sync_warning` emit sites (top-level + dependent-resource) now route through a new **`syncWarningJSON`** helper that marshals the event struct (mirroring the existing `syncErrorJSON`), so the message is fully escaped and every emitted line is valid JSON.

## Why
`dogfood --live`'s `json_fidelity` check rejected `sync --json` as 'invalid JSON' — confirmed **66 of 101** emitted lines were unparseable due to the multi-line message bodies. This was the last failure blocking a strict-validation CLI's Phase 5 acceptance.

Closes #1254.

## Tests / gates
- `TestSyncWarningEmitsValidJSON` (generated `helpers.go` defines `syncWarningJSON`/marshals; `sync.go` calls it and no longer uses the quote-only `ReplaceAll`).
- Updated `TestGeneratedSyncTreatsAccessDeniedAsWarning` for the new emission path.
- `scripts/golden.sh verify` (25/25, goldens updated), `scripts/verify-generator-output.sh` (5/5, compiles the call site), `go test ./internal/generator/ ./internal/pipeline/` green.

Note: a pre-existing `govulncheck` finding on `main` (GO-2026-5026, golang.org/x/net v0.53.0 → v0.55.0) is unrelated.