### PR TITLE
feat(catalog): add shipping tracker blueprint

### DIFF
--- a/catalog/shipping-tracker.yaml
+++ b/catalog/shipping-tracker.yaml
@@ -1,0 +1,56 @@
+name: shipping-tracker
+display_name: Shipping Tracker
+description: Multi-carrier package tracking status for common parcel carriers through Shippo.
+category: commerce
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/shipping-tracker-shippo.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: community
+spec_source: docs
+verified_date: "2026-06-05"
+homepage: https://goshippo.com
+auth_key_url: https://portal.goshippo.com/
+auth_required: true
+auth_instructions: "Generate a Shippo test or live token from Developer keys. The CLI sends it as Authorization: ShippoToken <token>."
+auth_env_vars:
+  - SHIPPO_API_TOKEN
+  - SHIPPO_TOKEN
+  - SHIPPO_API_KEY
+regions: ["*"]
+api_language: en
+notes: |
+  Focused tracking blueprint derived from Shippo's official OpenAPI reference
+  and tracking documentation. The checked-in spec intentionally exposes the
+  package tracking workflow, not Shippo's full shipping-label, rates, pickups,
+  orders, carrier-account, and billing surface.
+
+  Primary safe workflow:
+    - GET /tracks/{carrier}/{tracking_number} returns normalized current status
+      and tracking history for a package.
+
+  Mutating workflow:
+    - POST /tracks registers a tracking number for webhook-backed updates.
+      Shippo documents that tracking non-Shippo labels can incur tracking fees,
+      so generated tools should keep the default mutating permission posture.
+
+  Common carrier tokens covered by examples and the spec enum include usps, ups,
+  fedex, dhl_express, dhl_ecommerce, canada_post, royal_mail, australia_post,
+  lasership, ontrac, purolator, dpd_uk, deutsche_post, colissimo, and
+  new_zealand_post. The `shippo` test carrier token is included for Shippo test
+  tracking fixtures such as SHIPPO_TRANSIT and SHIPPO_DELIVERED.
+
+  Carrier restrictions are real: some carriers require a connected Shippo
+  carrier account, and some only permit tracking shipments created through
+  Shippo. Treat the carrier-token list as broad common coverage, not a promise
+  that every account can track every historical package.
+
+  Source notes:
+    - Official API reference and YAML:
+      https://docs.goshippo.com/api-reference/overview
+      https://docs.goshippo.com/spec/shippoapi/public-api.yaml
+    - Tracking guide:
+      https://docs.goshippo.com/docs/Tracking/Tracking
+    - Carrier tokens:
+      https://docs.goshippo.com/docs/Tracking/TrackingCarriers
+    - Authentication:
+      https://docs.goshippo.com/docs/Guides_general/authentication

--- a/catalog/specs/shipping-tracker-shippo.yaml
+++ b/catalog/specs/shipping-tracker-shippo.yaml
@@ -284,10 +284,28 @@ components:
           format: date-time
           nullable: true
         substatus:
-          type: string
+          allOf:
+            - $ref: '#/components/schemas/TrackingSubstatus'
           nullable: true
         location:
           $ref: '#/components/schemas/TrackingLocation'
+
+    TrackingSubstatus:
+      type: object
+      description: Finer-grained classification of the tracking event.
+      properties:
+        code:
+          type: string
+          description: Machine-readable tracking substatus code.
+          example: information_received
+        text:
+          type: string
+          description: Human-readable tracking substatus description.
+          example: Information about the package received.
+        action_required:
+          type: boolean
+          description: Whether the substatus requires action from the shipper or recipient.
+          example: false
 
     TrackingAddress:
       type: object

--- a/catalog/specs/shipping-tracker-shippo.yaml
+++ b/catalog/specs/shipping-tracker-shippo.yaml
@@ -173,6 +173,23 @@ components:
           type: string
           description: Shippo carrier token.
           example: usps
+          enum:
+            - usps
+            - ups
+            - fedex
+            - dhl_express
+            - dhl_ecommerce
+            - canada_post
+            - royal_mail
+            - australia_post
+            - lasership
+            - ontrac
+            - purolator
+            - dpd_uk
+            - deutsche_post
+            - colissimo
+            - new_zealand_post
+            - shippo
         tracking_number:
           type: string
           description: Carrier tracking number.
@@ -230,13 +247,13 @@ components:
           items:
             type: string
         weight:
-          type: array
-          items:
-            $ref: '#/components/schemas/PackageWeight'
+          allOf:
+            - $ref: '#/components/schemas/PackageWeight'
+          nullable: true
         dimensions:
-          type: array
-          items:
-            $ref: '#/components/schemas/PackageDimensions'
+          allOf:
+            - $ref: '#/components/schemas/PackageDimensions'
+          nullable: true
 
     TrackingStatus:
       type: object

--- a/catalog/specs/shipping-tracker-shippo.yaml
+++ b/catalog/specs/shipping-tracker-shippo.yaml
@@ -1,0 +1,348 @@
+openapi: "3.0.3"
+info:
+  title: Shipping Tracker API
+  version: "2018-02-08"
+  description: |
+    Multi-carrier parcel tracking API derived from Shippo's official OpenAPI
+    reference and tracking documentation. The focused surface covers package
+    status lookup and optional webhook-backed tracking registration across
+    common carriers through Shippo carrier tokens.
+
+    Common carrier tokens include `usps`, `ups`, `fedex`, `dhl_express`,
+    `dhl_ecommerce`, `canada_post`, `royal_mail`, `australia_post`,
+    `lasership`, `ontrac`, `purolator`, `dpd_uk`, `deutsche_post`,
+    `colissimo`, and `new_zealand_post`.
+
+    Some carriers require a connected Shippo carrier account or only allow
+    tracking shipments created through Shippo. See the catalog entry notes and
+    Shippo tracking docs before relying on a token in production.
+  contact:
+    name: Shippo Developer Platform
+    url: https://goshippo.com/contact/
+
+servers:
+  - url: https://api.goshippo.com
+    description: Shippo production and test API
+
+security:
+  - apiKey: []
+
+tags:
+  - name: tracking-status
+    description: Current and historical tracking state for a package.
+
+paths:
+  /tracks/{carrier}/{tracking_number}:
+    get:
+      operationId: getTrackingStatus
+      summary: Get a tracking status
+      description: |
+        Returns current tracking status and complete tracking history for a
+        shipment using a Shippo carrier token and tracking number.
+      tags: [tracking-status]
+      parameters:
+        - $ref: '#/components/parameters/Carrier'
+        - $ref: '#/components/parameters/TrackingNumber'
+        - $ref: '#/components/parameters/ShippoApiVersion'
+      responses:
+        '200':
+          description: Tracking status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Track'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /tracks:
+    post:
+      operationId: registerTrackingWebhook
+      summary: Register a tracking webhook
+      description: |
+        Registers a package for tracking updates. Shippo sends future
+        `track_updated` events to configured webhooks. This is a mutating
+        workflow and may incur tracking charges for packages not shipped
+        through Shippo.
+      tags: [tracking-status]
+      parameters:
+        - $ref: '#/components/parameters/ShippoApiVersion'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrackingRegistrationRequest'
+      responses:
+        '200':
+          description: Tracking registration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Track'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      x-prefix: ShippoToken
+      x-auth-env-vars:
+        - SHIPPO_API_TOKEN
+        - SHIPPO_TOKEN
+        - SHIPPO_API_KEY
+      x-auth-key-url: https://portal.goshippo.com/
+      x-auth-instructions: Generate a test or live token from Shippo Developer keys.
+      x-auth-title: Shippo API Token
+      x-auth-description: "Shippo test or live API token. The CLI sends it as Authorization: ShippoToken <token>."
+      description: |
+        Shippo API token. Send as `Authorization: ShippoToken <token>`.
+
+  parameters:
+    Carrier:
+      in: path
+      name: carrier
+      required: true
+      description: Shippo carrier token, such as `usps`, `ups`, `fedex`, or `dhl_express`.
+      schema:
+        type: string
+        enum:
+          - usps
+          - ups
+          - fedex
+          - dhl_express
+          - dhl_ecommerce
+          - canada_post
+          - royal_mail
+          - australia_post
+          - lasership
+          - ontrac
+          - purolator
+          - dpd_uk
+          - deutsche_post
+          - colissimo
+          - new_zealand_post
+          - shippo
+      example: usps
+    TrackingNumber:
+      in: path
+      name: tracking_number
+      required: true
+      description: Carrier tracking number.
+      schema:
+        type: string
+      example: "9205590164917312751089"
+    ShippoApiVersion:
+      in: header
+      name: Shippo-API-Version
+      required: false
+      description: Shippo API version. Defaults to the version represented by this spec.
+      schema:
+        type: string
+        default: "2018-02-08"
+
+  responses:
+    BadRequest:
+      description: Invalid tracking request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Missing, deleted, or expired Shippo API token.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Tracking record was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    TrackingRegistrationRequest:
+      type: object
+      required: [carrier, tracking_number]
+      properties:
+        carrier:
+          type: string
+          description: Shippo carrier token.
+          example: usps
+        tracking_number:
+          type: string
+          description: Carrier tracking number.
+          example: "9205590164917312751089"
+        metadata:
+          type: string
+          description: Optional user metadata, such as an order number.
+          example: "Order 000123"
+        include_package_details:
+          type: boolean
+          description: |
+            Request package weight and dimensions when carrier support exists.
+            Shippo documents this as currently supported only for UPS and FedEx.
+          default: false
+
+    Track:
+      type: object
+      description: Normalized package tracking state.
+      properties:
+        carrier:
+          type: string
+          example: usps
+        tracking_number:
+          type: string
+          example: "9205590164917312751089"
+        address_from:
+          $ref: '#/components/schemas/TrackingAddress'
+        address_to:
+          $ref: '#/components/schemas/TrackingAddress'
+        eta:
+          type: string
+          format: date-time
+          nullable: true
+        original_eta:
+          type: string
+          format: date-time
+          nullable: true
+        servicelevel:
+          $ref: '#/components/schemas/ServiceLevel'
+        metadata:
+          type: string
+          nullable: true
+        tracking_status:
+          $ref: '#/components/schemas/TrackingStatus'
+        tracking_history:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackingStatus'
+        tracking_url_provider:
+          type: string
+          format: uri
+          nullable: true
+        messages:
+          type: array
+          items:
+            type: string
+        weight:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageWeight'
+        dimensions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageDimensions'
+
+    TrackingStatus:
+      type: object
+      properties:
+        object_created:
+          type: string
+          format: date-time
+        object_updated:
+          type: string
+          format: date-time
+        object_id:
+          type: string
+        status:
+          type: string
+          description: Normalized status.
+          enum:
+            - UNKNOWN
+            - PRE_TRANSIT
+            - TRANSIT
+            - DELIVERED
+            - RETURNED
+            - FAILURE
+        status_details:
+          type: string
+          nullable: true
+        status_date:
+          type: string
+          format: date-time
+          nullable: true
+        substatus:
+          type: string
+          nullable: true
+        location:
+          $ref: '#/components/schemas/TrackingLocation'
+
+    TrackingAddress:
+      type: object
+      properties:
+        city:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+        zip:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+
+    TrackingLocation:
+      allOf:
+        - $ref: '#/components/schemas/TrackingAddress'
+        - type: object
+          properties:
+            latitude:
+              type: number
+              nullable: true
+            longitude:
+              type: number
+              nullable: true
+
+    ServiceLevel:
+      type: object
+      properties:
+        token:
+          type: string
+          example: usps_priority
+        name:
+          type: string
+          example: Priority Mail
+
+    PackageWeight:
+      type: object
+      properties:
+        value:
+          type: string
+          example: "2.2"
+        unit:
+          type: string
+          example: LB
+
+    PackageDimensions:
+      type: object
+      properties:
+        length:
+          type: string
+          example: "1"
+        width:
+          type: string
+          example: "2"
+        height:
+          type: string
+          example: "3"
+        unit:
+          type: string
+          example: in
+
+    ErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: string
+          example: Authentication credentials were not provided.
+        messages:
+          type: array
+          items:
+            type: string

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -8,6 +8,9 @@ cloud:
   digitalocean         Cloud infrastructure and developer platform API
   google-cloud-run     Cloud Run Admin API for deploying and managing serverless container services, revisions, jobs, and executions
 
+commerce:
+  shipping-tracker     Multi-carrier package tracking status for common parcel carriers through Shippo.
+
 developer-tools:
   github               Software development platform API
   launchdarkly         Feature flag management - flags, environments, segments, experiments, audit logs


### PR DESCRIPTION
## Intent

Add a focused Shipping Tracker catalog blueprint for generating a multi-carrier package tracking CLI through the Printing Press.

Issue: Closes #2648

## Approach

This adds a curated catalog entry plus a focused in-repo OpenAPI 3.0 spec derived from Shippo's official API reference and tracking docs. The spec intentionally exposes package tracking status lookup and webhook-backed tracking registration, rather than Shippo's full labels/rates/accounts surface, so the printed CLI stays aligned with the shipping-tracker use case.

The auth scheme uses the existing `x-prefix` support so generated clients send `Authorization: ShippoToken <token>` while accepting bare token values from `SHIPPO_API_TOKEN`, `SHIPPO_TOKEN`, or `SHIPPO_API_KEY`.

## Scope

Primary area: catalog

Why this belongs in this repo:

This is a Printing Press catalog/spec blueprint, not a printed-CLI patch. It broadens the embedded catalog with a reusable multi-carrier tracking API pattern and generated-output proof.

## Catalog Justification

Embedded catalog fit:

This entry belongs in the embedded curated catalog because it adds a commerce/logistics tracking blueprint with a focused, directly generatable OpenAPI spec. It is not a public-library reprint and does not duplicate an existing catalog shape.

Distinct blueprint pattern:

Multi-carrier parcel tracking through one normalized API surface, with a custom Authorization scheme prefix and a read-first tracking workflow plus one mutating webhook-registration endpoint.

Closest existing entries checked:

- `openrouteservice`: in-repo docs-derived spec with catalog metadata and scoped API surface.
- `producthunt`: focused non-vendor-full-surface catalog entry.
- `kayak` / `google-flights`: aggregator examples, but wrapper/scrape-backed rather than direct OpenAPI.
- `stripe` / `plaid`: commerce/payments entries, but not logistics tracking.

Source provenance:

- Source type: docs-derived from official Shippo docs and official OpenAPI.
- Official API reference and YAML: https://docs.goshippo.com/api-reference/overview and https://docs.goshippo.com/spec/shippoapi/public-api.yaml
- Tracking guide: https://docs.goshippo.com/docs/Tracking/Tracking
- Carrier token list: https://docs.goshippo.com/docs/Tracking/TrackingCarriers
- Auth guide: https://docs.goshippo.com/docs/Guides_general/authentication

Auth and tenant assumptions:

Shippo API token is required. The generated CLI reads `SHIPPO_API_TOKEN`, `SHIPPO_TOKEN`, or `SHIPPO_API_KEY` and sends `Authorization: ShippoToken <token>`. No tenant-specific base URL is assumed; base URL is `https://api.goshippo.com`.

Safe default surface:

Primary safe workflow is `GET /tracks/{carrier}/{tracking_number}`. `POST /tracks` remains mutating because Shippo documents webhook registration and possible tracking fees for non-Shippo labels.

Generation path:

The catalog entry points to `catalog/specs/shipping-tracker-shippo.yaml` via raw GitHub URL. The generated proof used the checked-in spec path directly and passed generated-project validation.

Stale-body check:

PR body refreshed after final code, golden, and generated-output verification.

## Risk

Low-to-moderate. The change adds a catalog entry and focused spec, plus the catalog-list golden. The main risk is overpromising carrier coverage, mitigated by notes that some Shippo carriers require connected carrier accounts or Shippo-created shipments. The mutating tracking registration endpoint is not marked read-only.

## Output Contract

Catalog rendering changes intentionally: `catalog list` now includes a commerce section with `shipping-tracker`. `testdata/golden/expected/catalog-list/stdout.txt` was updated.

Generated-output evidence: `cli-printing-press generate --spec catalog/specs/shipping-tracker-shippo.yaml --name shipping-tracker --output /private/tmp/shipping-tracker-final-proof --force --validate` passed and produced a compiled generated CLI/MCP bundle.

## Verification

- [x] `go test ./internal/catalog`
- [x] `scripts/golden.sh verify`
- [x] `go test ./...`
- [x] `./cli-printing-press generate --spec catalog/specs/shipping-tracker-shippo.yaml --name shipping-tracker --output /private/tmp/shipping-tracker-final-proof --force --validate`
- [x] `SHIPPO_API_TOKEN=test_token /private/tmp/shipping-tracker-final-proof/build/stage/bin/shipping-tracker-pp-cli tracks get-tracking-status SHIPPO_TRANSIT --carrier shippo --dry-run --json`
- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

Generator/template checkboxes are not applicable; this PR does not change generator code or templates.

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
