### PR TITLE
docs(generator): install binaries for Hermes skills

### DIFF
--- a/internal/generator/readme_test.go
+++ b/internal/generator/readme_test.go
@@ -298,9 +298,13 @@ func TestReadmeEmitsHermesAndOpenClawInstallSections(t *testing.T) {
 	assert.Contains(t, content, "<!-- pp-hermes-install-anchor -->",
 		"sweep-tool anchor must be present so retrofit can locate the insertion point")
 
-	// Hermes section: both forms (CLI + chat) use the full
-	// mvanhorn/printing-press-library/cli-skills path.
+	// Hermes section: install the binary as well as the focused skill; both
+	// skill-install forms use the full mvanhorn/printing-press-library/cli-skills path.
 	assert.Contains(t, content, "## Install for Hermes")
+	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install hermes-install --cli-only",
+		"Hermes section must install the CLI binary before installing the focused skill")
+	assert.NotContains(t, content, "hermes-install --cli-only --bin-dir",
+		"Hermes binary install should rely on the installer default bin directory unless explicitly overridden")
 	assert.Contains(t, content, "hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",
 		"Hermes CLI form must use mvanhorn/printing-press-library/cli-skills (the short mvanhorn/cli-skills form was wrong)")
 	assert.Contains(t, content, "/skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",

--- a/internal/generator/readme_test.go
+++ b/internal/generator/readme_test.go
@@ -298,23 +298,32 @@ func TestReadmeEmitsHermesAndOpenClawInstallSections(t *testing.T) {
 	assert.Contains(t, content, "<!-- pp-hermes-install-anchor -->",
 		"sweep-tool anchor must be present so retrofit can locate the insertion point")
 
+	hermesStart := strings.Index(content, "## Install for Hermes")
+	require.NotEqual(t, -1, hermesStart, "README must include the Hermes install section")
+	hermesEnd := strings.Index(content[hermesStart:], "## Install for OpenClaw")
+	require.NotEqual(t, -1, hermesEnd, "Hermes section must be followed by the OpenClaw install section")
+	hermesSection := content[hermesStart : hermesStart+hermesEnd]
+
+	openClawStart := hermesStart + hermesEnd
+	openClawEnd := strings.Index(content[openClawStart:], "## Use with Claude Desktop")
+	require.NotEqual(t, -1, openClawEnd, "OpenClaw section must be followed by the Claude Desktop section")
+	openClawSection := content[openClawStart : openClawStart+openClawEnd]
+
 	// Hermes section: install the binary as well as the focused skill; both
 	// skill-install forms use the full mvanhorn/printing-press-library/cli-skills path.
-	assert.Contains(t, content, "## Install for Hermes")
-	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install hermes-install --cli-only",
+	assert.Contains(t, hermesSection, "npx -y @mvanhorn/printing-press-library install hermes-install --cli-only",
 		"Hermes section must install the CLI binary before installing the focused skill")
-	assert.NotContains(t, content, "hermes-install --cli-only --bin-dir",
+	assert.NotContains(t, hermesSection, "hermes-install --cli-only --bin-dir",
 		"Hermes binary install should rely on the installer default bin directory unless explicitly overridden")
-	assert.Contains(t, content, "hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",
+	assert.Contains(t, hermesSection, "hermes skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",
 		"Hermes CLI form must use mvanhorn/printing-press-library/cli-skills (the short mvanhorn/cli-skills form was wrong)")
-	assert.Contains(t, content, "/skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",
+	assert.Contains(t, hermesSection, "/skills install mvanhorn/printing-press-library/cli-skills/pp-hermes-install --force",
 		"Hermes chat form must use mvanhorn/printing-press-library/cli-skills")
 
 	// OpenClaw section: copyable code-fenced agent instruction.
-	assert.Contains(t, content, "## Install for OpenClaw")
-	assert.Contains(t, content, "npx -y @mvanhorn/printing-press-library install hermes-install --agent openclaw",
+	assert.Contains(t, openClawSection, "npx -y @mvanhorn/printing-press-library install hermes-install --agent openclaw",
 		"OpenClaw form must install both the focused skill and binary using the installer default bin directory")
-	assert.NotContains(t, content, "--agent openclaw --bin-dir",
+	assert.NotContains(t, openClawSection, "--agent openclaw --bin-dir",
 		"OpenClaw form should rely on the installer default bin directory unless explicitly overridden")
 }
 

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -73,6 +73,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install {{.Name}} --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -84,6 +92,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-{{.Name}} --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/README.md
@@ -42,6 +42,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-oauth2 --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -53,6 +61,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-printing-press-oauth2 --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/README.md
@@ -42,6 +42,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-rich --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -53,6 +61,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-printing-press-rich --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/README.md
@@ -42,6 +42,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install printing-press-golden --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -53,6 +61,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-printing-press-golden --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/README.md
@@ -53,6 +53,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install learn-loop-example --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -64,6 +72,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-learn-loop-example --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/README.md
@@ -42,6 +42,14 @@ Download a pre-built binary for your platform from the [latest release](https://
 <!-- pp-hermes-install-anchor -->
 ## Install for Hermes
 
+Install the CLI binary first. The installer writes binaries to a per-user managed bin directory by default: `$HOME/.local/bin` on macOS/Linux and `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows.
+
+```bash
+npx -y @mvanhorn/printing-press-library install public-param-golden --cli-only
+```
+
+Then install the focused Hermes skill.
+
 From the Hermes CLI:
 
 ```bash
@@ -53,6 +61,8 @@ Inside a Hermes chat session:
 ```bash
 /skills install mvanhorn/printing-press-library/cli-skills/pp-public-param-golden --force
 ```
+
+Restart the Hermes session or gateway if the newly installed skill is not visible immediately.
 
 ## Install for OpenClaw
 Install both the CLI binary and the focused OpenClaw skill. The installer defaults binaries to a per-user bin directory (`$HOME/.local/bin` on macOS/Linux, `%LOCALAPPDATA%\Programs\PrintingPress\bin` on Windows):


### PR DESCRIPTION
## Summary
- add the binary install step to generated README Hermes instructions before installing the focused skill
- keep Hermes on the official `hermes skills install` flow for skill installation
- rely on the installer default per-user bin directory instead of hardcoding `--bin-dir`

## Verification
- `scripts/golden.sh verify`
- `go test ./internal/generator`
- `git diff --check`

Follow-up to #2654: the OpenClaw section installed both binary and skill, but the Hermes section only installed the skill.