### PR TITLE
fix(ci): raise Mergify max_parallel_checks to 5 and exclude draft PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,10 @@ queue_rules:
     # skips the bot-owned speculative check branches.
     queue_conditions:
       - base = main
+      # A draft PR can never merge (GitHub blocks it), but a PR converted
+      # back to draft mid-queue keeps its stale Greptile success and would
+      # otherwise hold a speculative-check slot it can never release.
+      - "-draft"
       # All Greptile/human inline review threads must be resolved and no
       # requested-changes review may remain before the PR enters the queue.
       # Greptile Review's check_run going green only reflects the confidence
@@ -89,8 +93,9 @@ merge_queue:
   # Parallel speculation across queued PRs. Mergify creates up to N
   # `mergify/merge-queue/*` draft PRs concurrently and runs CI on each.
   # Free on the OSS plan; the paid feature is `batch_size > 1`, which
-  # groups multiple PRs into one queue position.
-  max_parallel_checks: 3
+  # groups multiple PRs into one queue position. 5 is the OSS-plan
+  # default/ceiling for parallel speculation.
+  max_parallel_checks: 5
   queued_label: queued
   dequeued_label: dequeued
   status_comments: outcomes


### PR DESCRIPTION
The merge queue can now speculate on 5 PRs in parallel instead of 3 — parallel speculative checks are free on Mergify's OSS plan; only `batch_size > 1` (the "Merge Queue Batch" feature) is paywalled, and that stays pinned at 1. Confirmed by Mergify support.

Draft PRs are also excluded from `queue_conditions` (`- "-draft"`). A draft can never merge, but a PR flipped back to draft *after* Greptile already passed and `ready-to-merge` was applied would otherwise keep its stale check, pass queue entry, and hold a speculation slot it can never release — wastier now that there are 5 slots.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
