### PR TITLE
fix(cli): keep defaulted high-frequency query params in global filter

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3512,7 +3512,14 @@ func isPathSubstitutionParam(param spec.Param) bool {
 }
 
 func isGlobalFilterCandidate(param spec.Param) bool {
-	return !isPathSubstitutionParam(param) && !param.Required
+	// A param carrying an explicit default expresses deliberate must-send
+	// intent: the author wants that value on the wire, not the API's implicit
+	// server-side default. Exclude such params from the global-frequency filter
+	// so a ubiquitous-but-load-bearing flag (e.g. a supportsAllDrives-style
+	// access scope that defaults true) is not silently stripped, while plain
+	// high-frequency boilerplate (prettyPrint, quotaUser) with no default is
+	// still dropped.
+	return !isPathSubstitutionParam(param) && !param.Required && param.Default == nil
 }
 
 func walkResourceEndpoints(resources map[string]spec.Resource, fn func(endpoint *spec.Endpoint)) {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3155,6 +3155,107 @@ paths:
 	}
 }
 
+func TestParsePreservesDefaultedQueryParamsDuringGlobalFilter(t *testing.T) {
+	t.Parallel()
+
+	// A non-required query param on every endpoint exceeds the 80% global
+	// filter threshold and would normally be stripped as boilerplate. When it
+	// carries an explicit default it is load-bearing — the value must reach the
+	// wire — so it must survive, while a sibling high-frequency param with no
+	// default is still dropped.
+	data := []byte(`
+openapi: 3.0.0
+info:
+  title: All-Drives API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /files:
+    get:
+      operationId: listFiles
+      parameters:
+        - in: query
+          name: supportsAllDrives
+          schema:
+            type: boolean
+            default: true
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: q
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+  /drives:
+    get:
+      operationId: listDrives
+      parameters:
+        - in: query
+          name: supportsAllDrives
+          schema:
+            type: boolean
+            default: true
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+  /teamdrives:
+    get:
+      operationId: listTeamdrives
+      parameters:
+        - in: query
+          name: supportsAllDrives
+          schema:
+            type: boolean
+            default: true
+        - in: query
+          name: prettyPrint
+          schema:
+            type: boolean
+        - in: query
+          name: useDomainAdminAccess
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: ok
+`)
+
+	parsed, err := Parse(data)
+	require.NoError(t, err)
+
+	for _, path := range []string{"/files", "/drives", "/teamdrives"} {
+		endpoint := findEndpoint(t, parsed, path)
+
+		var supports, pretty *spec.Param
+		for i := range endpoint.Params {
+			switch endpoint.Params[i].Name {
+			case "supportsAllDrives":
+				supports = &endpoint.Params[i]
+			case "prettyPrint":
+				pretty = &endpoint.Params[i]
+			}
+		}
+
+		if assert.NotNil(t, supports, "defaulted high-frequency query param should survive global filtering on %s", path) {
+			assert.Equal(t, true, supports.Default, "explicit default should be preserved on %s", path)
+		}
+		assert.Nil(t, pretty, "high-frequency query param without a default should still be filtered on %s", path)
+	}
+}
+
 func TestParsePreservesRequiredQueryParamsDuringGlobalFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

The generator drops load-bearing high-frequency query parameters, so printed CLIs can't use them. Concretely, Google Drive's `supportsAllDrives` is declared on 7/8 operations (>80%), so `filterGlobalParams` strips it — and every printed Drive CLI then 403s on shared-drive operations (`The supportsAllDrives parameter was not set to true`).

Issue: Fixes #2677

## Approach

`filterGlobalParams` treats any non-required query param present on >80% of endpoints as boilerplate and removes it, but it ignored whether a param carries an explicit `default`. A defaulted param expresses deliberate must-send intent, so `isGlobalFilterCandidate` now excludes params with `Default != nil`:

```go
return !isPathSubstitutionParam(param) && !param.Required && param.Default == nil
```

The generator already emits defaulted params as flags and sends them, so a spec sets `default: true` on `supportsAllDrives` and the param flows by default as a visible, overridable `--supports-all-drives` flag. The API-specific value lives in the Drive spec; no API names are hardcoded in the generator.

## Scope

Primary area: generator / OpenAPI parser (`internal/openapi/parser.go`).

Why this belongs in this repo: the global-param filter is blind to load-bearing defaulted params for *any* spec, not just Drive. The symptom surfaced in a printed Drive CLI, but the fix is general — any spec author can mark a ubiquitous param as must-send by giving it a default, and it will no longer be stripped.

## Catalog Justification

N/A

## Risk

Low. The change only affects params that carry an explicit `default` and would otherwise exceed the 80% global-filter threshold — a rare shape. Such params are now retained as flags (and sent with their default) instead of dropped. Real boilerplate params (`prettyPrint`, `quotaUser`, `key`) almost never declare a spec default, so existing CLIs are unaffected. The golden suite is neutral: no fixture has the triggering shape (verified that `golden-api`'s defaulted query params sit below the threshold and its generated output is unchanged).

## Output Contract

Generated output changes only for specs that declare a non-required query param with a `default` on >80% of endpoints: such a param is now retained as a flag and sent on the wire instead of being stripped. No golden fixture exercises this shape, so the golden suite is unchanged.

## Verification

- `go test ./internal/openapi/ -run GlobalFilter -count=1 -v` — pass (new `TestParsePreservesDefaultedQueryParamsDuringGlobalFilter`, plus the existing global-filter tests).
- `go build ./cmd/cli-printing-press` — pass.
- `scripts/golden.sh verify` — no `.go`/`.json` golden output changes attributable to this change (the only diffs on the dev box are pre-existing CRLF / gofmt / spec-checksum drift, independent of this change).
- End-to-end on a printed Google Drive CLI (spec `default: true` on `supportsAllDrives`): live `files list --corpora allDrives` now returns shared-drive files, and `files move` relocates a file into a Shared Drive — both previously returned HTTP 403.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
