### PR TITLE
fix(cli): recognize Google "Login Required" 401 envelope and rebuild staged binary in dogfood --live

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -406,8 +406,10 @@ func copyLiveDogfoodCredentialFile(src, dst string) (*liveDogfoodCredentialMirro
 }
 
 func liveDogfoodBinaryPath(dir, name string) (string, error) {
-	if _, err := refreshLiveCheckStageBinary(dir, name); err != nil {
+	if refresh, err := refreshLiveCheckStageBinary(dir, name); err != nil {
 		return "", fmt.Errorf("rebuilding staged binary: %w", err)
+	} else if refresh.Action == "failed" {
+		return "", fmt.Errorf("rebuilding staged binary: %s", refresh.Reason)
 	}
 	if path, err := resolveBinaryPath(dir, name); err == nil {
 		return path, nil

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -406,6 +406,9 @@ func copyLiveDogfoodCredentialFile(src, dst string) (*liveDogfoodCredentialMirro
 }
 
 func liveDogfoodBinaryPath(dir, name string) (string, error) {
+	if _, err := refreshLiveCheckStageBinary(dir, name); err != nil {
+		return "", fmt.Errorf("rebuilding staged binary: %w", err)
+	}
 	if path, err := resolveBinaryPath(dir, name); err == nil {
 		return path, nil
 	} else if strings.TrimSpace(name) != "" {
@@ -1501,6 +1504,8 @@ func liveDogfoodAuth401Output(output string) bool {
 	}
 	return strings.Contains(output, "couldn't authenticate") ||
 		strings.Contains(output, "could not authenticate") ||
+		strings.Contains(output, "login required") ||
+		strings.Contains(output, "request is missing required authentication credential") ||
 		strings.Contains(output, "not authenticated")
 }
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -791,6 +791,80 @@ exit 1
 	assert.Equal(t, "2", string(count), "persistent auth-shaped 401 should retry once before skip classification")
 }
 
+func TestRunLiveDogfoodRefreshesStageBinaryBeforeResolving(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the stale staged binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryName := "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/live-dogfood-test\n\ngo 1.23\n"), 0o644))
+	cmdDir := filepath.Join(dir, "cmd", binaryName)
+	require.NoError(t, os.MkdirAll(cmdDir, 0o755))
+	mainPath := filepath.Join(cmdDir, "main.go")
+	agentContext := `{"commands":[{"name":"widgets","subcommands":[{"name":"list"}]}]}`
+	help := `List widgets.
+
+Usage:
+  fixture-pp-cli widgets list [flags]
+
+Examples:
+  fixture-pp-cli widgets list
+
+Flags:
+      --json    Output JSON
+`
+	mainSource := fmt.Sprintf(`package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	switch strings.Join(args, " ") {
+	case "agent-context":
+		fmt.Print(%q)
+	case "widgets list --help":
+		fmt.Print(%q)
+	case "widgets list", "widgets list --json":
+		fmt.Print(%q)
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected args: %%v\n", args)
+		os.Exit(2)
+	}
+}
+`, agentContext, help, `{"ok":true}`)
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainSource), 0o644))
+
+	stagedBinDir := filepath.Join(dir, "build", "stage", "bin")
+	require.NoError(t, os.MkdirAll(stagedBinDir, 0o755))
+	stagedPath := filepath.Join(stagedBinDir, binaryName)
+	require.NoError(t, os.WriteFile(stagedPath, []byte("#!/bin/sh\necho 'stale staged binary' >&2\nexit 2\n"), 0o755))
+	oldTime := time.Now().Add(-2 * time.Hour)
+	newTime := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(stagedPath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(mainPath, newTime, newTime))
+
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "quick",
+		Timeout:    5 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Zero(t, report.Failed)
+	wantBinary, err := filepath.Abs(stagedPath)
+	require.NoError(t, err)
+	assert.Equal(t, wantBinary, report.Binary)
+	happy := findResultByCommandKind(report, "widgets list", LiveDogfoodTestHappy)
+	require.NotNil(t, happy)
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status)
+}
+
 func TestRunLiveDogfoodSkipsRequiresTierMismatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -1616,6 +1690,44 @@ func TestLiveDogfoodUnavailableForRunnerDoesNotHideNotFound(t *testing.T) {
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "your credentials are valid but lack access"}))
 	assert.True(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: `HTTP 401: {"error":"Couldn't authenticate you"}`}))
 	assert.False(t, liveDogfoodUnavailableForRunner(liveDogfoodRun{stderr: "HTTP 404 NotFound"}))
+}
+
+func TestLiveDogfoodAuth401OutputMatchesGooglePhrases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "login required",
+			output: `Error: GET /youtube/v3/videoAbuseReportReasons returned HTTP 401: {
+  "error": {"message": "Login Required."}
+}`,
+			want: true,
+		},
+		{
+			name: "missing required authentication credential",
+			output: `Error: GET /youtube/v3/videoAbuseReportReasons returned HTTP 401: {
+  "error": {"message": "Request is missing required authentication credential."}
+}`,
+			want: true,
+		},
+		{
+			name:   "non 401",
+			output: `Error: GET /widgets returned HTTP 404: {"error":"not found"}`,
+			want:   false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, liveDogfoodAuth401Output(strings.ToLower(tt.output)))
+		})
+	}
 }
 
 func TestLiveDogfoodRequiredParamFixtureReason(t *testing.T) {


### PR DESCRIPTION
## Intent

Two independent scorer-dogfood defects surfaced during a recent printed-CLI dogfood run; both make `dogfood --live` lie about the staged binary's behavior.

Issue: Fixes #2476. Fixes #2448.

## Approach

- **#2476** — `liveDogfoodAuth401Output` now also matches `login required` and `request is missing required authentication credential`, which is the envelope Google APIs return for an unauthenticated call. Previously a real 401 from a Google-backed CLI was misclassified as "ran successfully," masking auth regressions.
- **#2448** — `liveDogfoodBinaryPath` now calls `refreshLiveCheckStageBinary` before `resolveBinaryPath`, so `dogfood --live` stops testing a stale staged binary after a promote-swap. Before this, a post-promote run was happily re-exercising the previous build.

## Scope

Primary area: scorer / dogfood

Why this belongs in this repo: both fixes live in the scorer's live-dogfood pipeline (`internal/scorer/...`), which is generator-owned, not printed-CLI behavior.

## Catalog Justification

N/A

## Risk

Low. Both changes are additive within the live-dogfood path: the 401 matcher only adds new phrases (no existing matches removed); the binary refresh is gated by the same conditions as the rest of the stage flow. No template/manifest surface touched.

## Output Contract

N/A

## Verification

- `go test ./...` (relevant scorer/dogfood packages) green locally.
- Walked through the live-dogfood flow against a stale staged binary to confirm the refresh path now fires before resolve.
- Live 401 phrase matcher exercised against a Google-APIs "Login Required" sample envelope.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(No generator/template surface touched.)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

Implementation generated by an AI coding agent (codex), human-orchestrated and verified end-to-end before submission.
