### PR TITLE
fix(cli): pass --db to data-pipeline sql probes and WARN-skip the sync gate for pure-API CLIs

### DIFF
--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -624,15 +624,22 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 	env = append(env, "HOME="+tmpDir) // so sync uses temp location
 
 	// Test sync (if it exists)
+	var syncErrors []error
 	syncErr := runCLI(binary, []string{"sync", "--db", dbPath, "--resources", "repos", "--full"}, env, 30*time.Second)
 	if syncErr != nil {
+		syncErrors = append(syncErrors, syncErr)
 		syncErr = runCLI(binary, []string{"sync", "--db", dbPath, "--full"}, env, 30*time.Second)
 	}
 	if syncErr != nil {
+		syncErrors = append(syncErrors, syncErr)
 		// Sync might not accept --db flag - try without.
 		syncErr = runCLI(binary, []string{"sync", "--full"}, env, 30*time.Second)
 	}
 	if syncErr != nil {
+		syncErrors = append(syncErrors, syncErr)
+		if allSyncAttemptsWereUnknownCommand(syncErrors) {
+			return true, "WARN: no sync command — data-pipeline check skipped"
+		}
 		return false, "FAIL: sync crashed"
 	}
 
@@ -640,7 +647,7 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 	_ = runCLI(binary, []string{"health", "--db", dbPath}, env, 10*time.Second)
 
 	tableQuery := `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite%' AND name NOT LIKE '%_fts%' AND name != 'sync_state'`
-	tablesOut, sqlErr := runCLIWithOutput(binary, []string{"sql", tableQuery}, env, 10*time.Second)
+	tablesOut, sqlErr := runCLIWithOutput(binary, []string{"sql", "--db", dbPath, tableQuery}, env, 10*time.Second)
 	if sqlErr != nil {
 		return true, "PASS: sync completed (sql unavailable, table validation skipped)"
 	}
@@ -660,7 +667,7 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 	var zeroDataTable string
 	for _, table := range tables {
 		countQuery := fmt.Sprintf("SELECT count(*) FROM \"%s\"", table)
-		countOut, countErr := runCLIWithOutput(binary, []string{"sql", countQuery}, env, 10*time.Second)
+		countOut, countErr := runCLIWithOutput(binary, []string{"sql", "--db", dbPath, countQuery}, env, 10*time.Second)
 		if countErr != nil {
 			continue
 		}
@@ -696,6 +703,23 @@ func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRow
 		return false, fmt.Sprintf("FAIL: %s has 0 rows after sync, expected at least %d (%s mode)", zeroDataTable, expectedRows, mode)
 	}
 	return false, fmt.Sprintf("FAIL: %d domain tables created but 0 rows after sync (%s mode)", len(tables), mode)
+}
+
+func allSyncAttemptsWereUnknownCommand(errs []error) bool {
+	if len(errs) == 0 {
+		return false
+	}
+	for _, err := range errs {
+		if err == nil || !isUnknownSyncCommandError(err) {
+			return false
+		}
+	}
+	return true
+}
+
+func isUnknownSyncCommandError(err error) bool {
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "unknown command") && strings.Contains(text, "sync")
 }
 
 func isAuxiliaryPipelineTable(table string, totalTables int) bool {

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -719,7 +719,7 @@ func allSyncAttemptsWereUnknownCommand(errs []error) bool {
 
 func isUnknownSyncCommandError(err error) bool {
 	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "unknown command") && strings.Contains(text, "sync")
+	return strings.Contains(text, "unknown command \"sync\"")
 }
 
 func isAuxiliaryPipelineTable(table string, totalTables int) bool {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -257,6 +257,24 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 		assert.False(t, pass)
 		assert.Contains(t, detail, "items has 0 rows")
 	})
+
+	t.Run("warns when sync command is absent", func(t *testing.T) {
+		binary := buildNoSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "WARN: no sync command — data-pipeline check skipped", detail)
+	})
+
+	t.Run("fails when sync command exists but crashes", func(t *testing.T) {
+		binary := buildFailingSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Equal(t, "FAIL: sync crashed", detail)
+	})
 }
 
 func TestFinalizeVerifyReportFailsRequiredDataPipeline(t *testing.T) {
@@ -626,12 +644,24 @@ func main() {
 	}
 	switch args[0] {
 	case "sync":
-		return
-	case "sql":
-		if len(args) < 2 {
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
 			os.Exit(1)
 		}
-		query := args[1]
+		if err := os.WriteFile(dbPath+".marker", []byte(dbPath), 0o644); err != nil {
+			os.Exit(1)
+		}
+		return
+	case "sql":
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		usedDB, err := os.ReadFile(dbPath + ".marker")
+		if err != nil || string(usedDB) != dbPath {
+			os.Exit(1)
+		}
+		query := args[len(args)-1]
 		if strings.Contains(query, "sqlite_master") {
 			fmt.Println("items")
 			return
@@ -642,6 +672,15 @@ func main() {
 		}
 	}
 	os.Exit(1)
+}
+
+func dbArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--db" {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 `, rowCount))
 	binaryPath := filepath.Join(dir, "test-cli")
@@ -671,12 +710,24 @@ func main() {
 	}
 	switch args[0] {
 	case "sync":
-		return
-	case "sql":
-		if len(args) < 2 {
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
 			os.Exit(1)
 		}
-		query := args[1]
+		if err := os.WriteFile(dbPath+".marker", []byte(dbPath), 0o644); err != nil {
+			os.Exit(1)
+		}
+		return
+	case "sql":
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		usedDB, err := os.ReadFile(dbPath + ".marker")
+		if err != nil || string(usedDB) != dbPath {
+			os.Exit(1)
+		}
+		query := args[len(args)-1]
 		if strings.Contains(query, "sqlite_master") {
 			fmt.Println("settings")
 			fmt.Println("items")
@@ -696,7 +747,72 @@ func main() {
 	}
 	os.Exit(1)
 }
+
+func dbArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--db" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
 `, settingsRows, itemRows))
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildNoSyncDataPipelineProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "sync" {
+		fmt.Fprintln(os.Stderr, "Error: unknown command \"sync\" for \"test-cli\"")
+		os.Exit(1)
+	}
+	os.Exit(1)
+}
+`)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildFailingSyncDataPipelineProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "sync" {
+		fmt.Fprintln(os.Stderr, "sync failed while contacting mock API")
+		os.Exit(1)
+	}
+	os.Exit(1)
+}
+`)
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()


### PR DESCRIPTION
## Intent

Two related defects in the scorer's data-pipeline check: one makes the check universally false-negative on any CLI whose store doesn't live at the default path, the other FAILs the gate for CLIs that have no sync command at all.

Issue: Fixes #2442. Fixes #2521.

## Approach

- **#2442** — the data-pipeline check called `sync` with `--db <dbPath>` (correctly hitting the run's DB) but the subsequent `sql` table/count probes were invoked WITHOUT `--db`, hitting whatever default-path store the CLI happened to resolve. For any CLI configured to a non-default DB this was a universal false-negative (sync wrote rows, then the probe queried an empty/different DB and reported 0). Both probes now pass `--db <dbPath>` consistently.
- **#2521** — when every sync attempt exits with the cobra "unknown command" code (the CLI has no `sync` command — pure-API CLI), the gate previously FAILed. It now returns WARN with a message that explains why; a real sync failure still FAILs.

## Scope

Primary area: scorer / verify

Why this belongs in this repo: lives in the scorer's data-pipeline runtime, generator-owned.

## Catalog Justification

N/A

## Risk

Low and well-scoped. The `--db` propagation is strictly additive (we were already passing it to sync; the probes now match). The WARN-on-unknown-command path is gated on the specific "unknown command" exit signature (cobra default = 1 with a recognizable stderr message), so real sync failures keep their existing FAIL classification.

## Output Contract

N/A — no scorer rubric/format change. Only verdicts shift in two narrow cases: previously-false-negative data-pipeline runs now show the correct PASS, and pure-API CLIs now show WARN instead of FAIL.

## Verification

- `go test ./...` (relevant scorer packages) green locally.
- Walked through both probe paths on a CLI with a non-default `--db` to confirm parity with sync.
- Verified WARN vs FAIL classification on a pure-API CLI (no sync command) vs a CLI with a real sync error.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(No generator/template surface touched.)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

Implementation generated by an AI coding agent (codex), human-orchestrated and verified end-to-end before submission.
