### PR TITLE
fix(cli): verify-skill detects alias-receiver flags and fixes positional/flag-value tokenization

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -462,6 +462,55 @@ def iter_flag_declarations(text: str) -> Iterable[tuple[bool, str]]:
         yield aliases[m.group(1)], m.group(3)
 
 
+def _iter_bool_flag_names(text: str) -> Iterable[str]:
+    """Long-names of boolean flags declared in text (BoolVar/BoolVarP and the
+    alias-receiver form). Mirrors iter_flag_declarations' direct + alias scan but
+    keeps only the boolean methods, so the recipe tokenizer can tell a value-less
+    boolean flag (`--json <positional>`) from a value-bearing one
+    (`--filter <value>`)."""
+    for m in FLAG_DECL_RE.finditer(text):
+        _persistent, method, name = m.groups()
+        if method in ("BoolVar", "BoolSliceVar"):
+            yield name
+
+    aliases = {
+        m.group(1): m.group(2) == "Persistent"
+        for m in FLAG_ALIAS_RE.finditer(text)
+    }
+    if not aliases:
+        return
+
+    alias_decl_re = re.compile(
+        r'\b(' + "|".join(re.escape(alias) for alias in aliases) + r')\.'
+        r'(' + FLAG_METHOD_PATTERN + r')P?\('
+        r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
+    )
+    for m in alias_decl_re.finditer(text):
+        if m.group(2) in ("BoolVar", "BoolSliceVar"):
+            yield m.group(3)
+
+
+@lru_cache(maxsize=None)
+def _boolean_flag_names(cli_dir: Path) -> frozenset[str]:
+    """Long-names of every boolean flag declared in the CLI's internal/cli/*.go
+    (cached per cli_dir). The recipe tokenizer consults this so it never consumes
+    the token after a value-less boolean flag as that flag's value — doing so
+    would silently drop a real positional. A CLI-wide scan (rather than
+    per-command) deliberately includes persistent/root booleans like --json or
+    --verbose, which are the common case a recipe writes before a positional."""
+    cli_pkg = cli_dir / "internal" / "cli"
+    if not cli_pkg.is_dir():
+        return frozenset()
+    names: set[str] = set()
+    for path in sorted(cli_pkg.glob("*.go")):
+        try:
+            text = read_utf8(path)
+        except Exception:
+            continue
+        names.update(_iter_bool_flag_names(text))
+    return frozenset(names)
+
+
 def flag_declared_in(files: Iterable[Path], flag_name: str) -> bool:
     for f in files:
         try:
@@ -680,11 +729,24 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flags.append(t.split("=", 1)[0])
-            # Skip a space-separated value (`--flag value`), but NOT when the
-            # value is inline (`--flag=value`) — there the next token is a
-            # positional, not this flag's value.
-            if "=" not in t and i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+            flag_name = t.split("=", 1)[0]
+            flags.append(flag_name)
+            # Skip a space-separated value (`--flag value`), but NOT when:
+            #  - the value is inline (`--flag=value`) — the next token is a
+            #    positional, not this flag's value; or
+            #  - the flag is a known boolean flag, which takes no value, so the
+            #    next token is a positional (consuming it would under-count the
+            #    recipe's positional args).
+            is_bool = (
+                cli_dir is not None
+                and flag_name.lstrip("-") in _boolean_flag_names(cli_dir)
+            )
+            if (
+                "=" not in t
+                and not is_bool
+                and i + 1 < len(tokens)
+                and not tokens[i + 1].startswith("-")
+            ):
                 i += 2
                 continue
         elif t.startswith("-"):

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -87,15 +87,19 @@ USE_RE = re.compile(r'Use:\s*"([^"]+)"')
 ARGS_RE = re.compile(
     r'Args:\s*cobra\.(ExactArgs|MinimumNArgs|MaximumNArgs|RangeArgs|NoArgs|OnlyValidArgs|ExactValidArgs)\s*\(([^)]*)\)'
 )
-FLAG_DECL_RE = re.compile(
-    r'(Persistent)?Flags\(\)\.'
-    r'(StringVar|BoolVar|IntVar|Int32Var|Int64Var|Float32Var|Float64Var|DurationVar|'
+FLAG_METHOD_PATTERN = (
+    r'StringVar|BoolVar|IntVar|Int32Var|Int64Var|Float32Var|Float64Var|DurationVar|'
     r'StringSliceVar|StringArrayVar|IntSliceVar|Int32SliceVar|Int64SliceVar|'
     r'Float64SliceVar|BoolSliceVar|DurationSliceVar|'
     r'UintVar|Uint32Var|Uint64Var|UintSliceVar|IPVar|IPSliceVar|Float32SliceVar|'
-    r'StringToStringVar|StringToIntVar|StringToInt64Var)P?\('
+    r'StringToStringVar|StringToIntVar|StringToInt64Var'
+)
+FLAG_DECL_RE = re.compile(
+    r'(Persistent)?Flags\(\)\.'
+    r'(' + FLAG_METHOD_PATTERN + r')P?\('
     r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
 )
+FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*cmd\.(Persistent)?Flags\(\)')
 @dataclass
 class Finding:
     check: str
@@ -437,14 +441,35 @@ def _legacy_find_command_source(cli_dir: Path, cmd_path: list[str]):
     return top_files, candidates[0][2], candidates[0][3]
 
 
+def iter_flag_declarations(text: str) -> Iterable[tuple[bool, str]]:
+    for m in FLAG_DECL_RE.finditer(text):
+        persistent, _, name = m.groups()
+        yield persistent == "Persistent", name
+
+    aliases = {
+        m.group(1): m.group(2) == "Persistent"
+        for m in FLAG_ALIAS_RE.finditer(text)
+    }
+    if not aliases:
+        return
+
+    alias_decl_re = re.compile(
+        r'\b(' + "|".join(re.escape(alias) for alias in aliases) + r')\.'
+        r'(' + FLAG_METHOD_PATTERN + r')P?\('
+        r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
+    )
+    for m in alias_decl_re.finditer(text):
+        yield aliases[m.group(1)], m.group(3)
+
+
 def flag_declared_in(files: Iterable[Path], flag_name: str) -> bool:
     for f in files:
         try:
             text = read_utf8(f)
         except Exception:
             continue
-        for m in FLAG_DECL_RE.finditer(text):
-            if m.group(3) == flag_name:
+        for _, name in iter_flag_declarations(text):
+            if name == flag_name:
                 return True
     return False
 
@@ -580,8 +605,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
             continue
         for m in func_re.finditer(text):
             body = go_block_body(text, m.end() - 1)
-            for fm in FLAG_DECL_RE.finditer(body):
-                if fm.group(3) == flag_name:
+            for _, name in iter_flag_declarations(body):
+                if name == flag_name:
                     return True
     return False
 
@@ -595,9 +620,8 @@ def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
             text = read_utf8(go_file)
         except Exception:
             continue
-        for m in FLAG_DECL_RE.finditer(text):
-            persistent, _, name = m.groups()
-            if name == flag_name and persistent == "Persistent":
+        for persistent, name in iter_flag_declarations(text):
+            if name == flag_name and persistent:
                 return True
     return False
 
@@ -630,6 +654,12 @@ def _cli_invocation_from_tokens(
         ):
             break
         if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
+            if cli_dir is not None:
+                _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
+                if use_str:
+                    _, _, optional, variadic = parse_use(use_str)
+                    if optional > 0 or variadic:
+                        break
             # Verify adding this token still maps to a valid command. If the
             # extended path has no source match, this token is an argument.
             if cli_dir is not None:

--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -99,7 +99,7 @@ FLAG_DECL_RE = re.compile(
     r'(' + FLAG_METHOD_PATTERN + r')P?\('
     r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
 )
-FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*cmd\.(Persistent)?Flags\(\)')
+FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*[A-Za-z_][\w.]*\.(Persistent)?Flags\(\)')
 @dataclass
 class Finding:
     check: str

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -391,6 +391,51 @@ func newRrCmd() *cobra.Command {
         self.assertEqual(["item-123"], positional)
         self.assertEqual(["--filter"], flags)
 
+    def test_boolean_long_flag_does_not_swallow_following_positional(self):
+        """A value-less boolean flag (e.g. `--json`) takes no value, so the
+        token after it is a positional and must not be consumed as the flag's
+        value. A value-bearing flag in the same CLI still consumes its value."""
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newGetCmd())
+    return rootCmd.Execute()
+}
+''',
+                "get.go": '''package cli
+import "github.com/spf13/cobra"
+func newGetCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "get <id>"}
+    var asJSON bool
+    var filter string
+    cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+    cmd.Flags().StringVar(&filter, "filter", "", "filter expression")
+    return cmd
+}
+''',
+            })
+
+            # Boolean flag: the next token is a positional, not the flag's value.
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["get", "--json", "item-123"], cli_dir,
+            )
+            self.assertEqual(["get"], cmd_path)
+            self.assertEqual(
+                ["item-123"], positional,
+                "a positional after a boolean flag must not be swallowed as its value",
+            )
+            self.assertEqual(["--json"], flags)
+
+            # Value-bearing flag still consumes its space-separated value.
+            cmd_path, positional, flags = _cli_invocation_from_tokens(
+                ["get", "--filter", "active", "item-123"], cli_dir,
+            )
+            self.assertEqual(["item-123"], positional)
+            self.assertEqual(["--filter"], flags)
+
 
 class UTF8ReadTest(unittest.TestCase):
     def test_read_text_uses_explicit_utf8_encoding(self):

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -23,6 +23,8 @@ from verify_skill import (  # noqa: E402
     resolve_command_path,
     find_command_source,
     run_checks,
+    extract_recipes,
+    _cli_invocation_from_tokens,
     _extract_function_body,
 )
 
@@ -242,6 +244,43 @@ func newSearchCmd() *cobra.Command {
 
 
 class TestFlagChecks(unittest.TestCase):
+    def test_alias_receiver_flags_are_recognized(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newSearchCmd())
+    return rootCmd.Execute()
+}
+''',
+                "search.go": '''package cli
+import "github.com/spf13/cobra"
+func newSearchCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "search"}
+    var level string
+    f := cmd.Flags()
+    f.StringVar(&level, "level", "", "filter level")
+    return cmd
+}
+''',
+            })
+            cli_binary = f"{cli_dir.name}-pp-cli"
+            (cli_dir / "SKILL.md").write_text(
+                f"""# Fixture
+
+```bash
+{cli_binary} search --level high
+```
+""",
+                encoding="utf-8",
+            )
+
+            report = run_checks(cli_dir, {"flag-names", "flag-commands"})
+
+            self.assertEqual([], report.findings)
+
     def test_missing_limit_flag_is_reported(self):
         with tempfile.TemporaryDirectory() as td:
             cli_dir = _write_cli(Path(td), {
@@ -293,6 +332,64 @@ func newSearchCmd() *cobra.Command {
                     and f.detail == "--limit is not declared anywhere"
                 ),
             )
+
+
+class TestInvocationParsing(unittest.TestCase):
+    def test_optional_positionals_are_bound_before_sibling_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            cli_dir = _write_cli(Path(td), {
+                "root.go": '''package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+    rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+    rootCmd.AddCommand(newIssuancesCmd())
+    rootCmd.AddCommand(newRrCmd())
+    return rootCmd.Execute()
+}
+''',
+                "issuances.go": '''package cli
+import "github.com/spf13/cobra"
+func newIssuancesCmd() *cobra.Command {
+    cmd := &cobra.Command{Use: "issuances"}
+    cmd.AddCommand(newCitedByCmd())
+    return cmd
+}
+func newCitedByCmd() *cobra.Command {
+    return &cobra.Command{Use: "cited-by [type] [number-year]"}
+}
+''',
+                "rr.go": '''package cli
+import "github.com/spf13/cobra"
+func newRrCmd() *cobra.Command {
+    return &cobra.Command{Use: "rr"}
+}
+''',
+            })
+            cli_binary = f"{cli_dir.name}-pp-cli"
+            skill = cli_dir / "SKILL.md"
+            skill.write_text(
+                f"""# Fixture
+
+```bash
+{cli_binary} issuances cited-by rr 7-2003
+```
+""",
+                encoding="utf-8",
+            )
+
+            recipes = extract_recipes(skill, cli_binary, cli_dir)
+
+            self.assertEqual([(["issuances", "cited-by"], ["rr", "7-2003"], [])], recipes)
+
+    def test_space_separated_long_flag_value_is_not_positional(self):
+        cmd_path, positional, flags = _cli_invocation_from_tokens(
+            ["search", "--filter", "status=active", "item-123"],
+            None,
+        )
+
+        self.assertEqual(["search"], cmd_path)
+        self.assertEqual(["item-123"], positional)
+        self.assertEqual(["--filter"], flags)
 
 
 class UTF8ReadTest(unittest.TestCase):

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -462,6 +462,55 @@ def iter_flag_declarations(text: str) -> Iterable[tuple[bool, str]]:
         yield aliases[m.group(1)], m.group(3)
 
 
+def _iter_bool_flag_names(text: str) -> Iterable[str]:
+    """Long-names of boolean flags declared in text (BoolVar/BoolVarP and the
+    alias-receiver form). Mirrors iter_flag_declarations' direct + alias scan but
+    keeps only the boolean methods, so the recipe tokenizer can tell a value-less
+    boolean flag (`--json <positional>`) from a value-bearing one
+    (`--filter <value>`)."""
+    for m in FLAG_DECL_RE.finditer(text):
+        _persistent, method, name = m.groups()
+        if method in ("BoolVar", "BoolSliceVar"):
+            yield name
+
+    aliases = {
+        m.group(1): m.group(2) == "Persistent"
+        for m in FLAG_ALIAS_RE.finditer(text)
+    }
+    if not aliases:
+        return
+
+    alias_decl_re = re.compile(
+        r'\b(' + "|".join(re.escape(alias) for alias in aliases) + r')\.'
+        r'(' + FLAG_METHOD_PATTERN + r')P?\('
+        r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
+    )
+    for m in alias_decl_re.finditer(text):
+        if m.group(2) in ("BoolVar", "BoolSliceVar"):
+            yield m.group(3)
+
+
+@lru_cache(maxsize=None)
+def _boolean_flag_names(cli_dir: Path) -> frozenset[str]:
+    """Long-names of every boolean flag declared in the CLI's internal/cli/*.go
+    (cached per cli_dir). The recipe tokenizer consults this so it never consumes
+    the token after a value-less boolean flag as that flag's value — doing so
+    would silently drop a real positional. A CLI-wide scan (rather than
+    per-command) deliberately includes persistent/root booleans like --json or
+    --verbose, which are the common case a recipe writes before a positional."""
+    cli_pkg = cli_dir / "internal" / "cli"
+    if not cli_pkg.is_dir():
+        return frozenset()
+    names: set[str] = set()
+    for path in sorted(cli_pkg.glob("*.go")):
+        try:
+            text = read_utf8(path)
+        except Exception:
+            continue
+        names.update(_iter_bool_flag_names(text))
+    return frozenset(names)
+
+
 def flag_declared_in(files: Iterable[Path], flag_name: str) -> bool:
     for f in files:
         try:
@@ -680,11 +729,24 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flags.append(t.split("=", 1)[0])
-            # Skip a space-separated value (`--flag value`), but NOT when the
-            # value is inline (`--flag=value`) — there the next token is a
-            # positional, not this flag's value.
-            if "=" not in t and i + 1 < len(tokens) and not tokens[i + 1].startswith("-"):
+            flag_name = t.split("=", 1)[0]
+            flags.append(flag_name)
+            # Skip a space-separated value (`--flag value`), but NOT when:
+            #  - the value is inline (`--flag=value`) — the next token is a
+            #    positional, not this flag's value; or
+            #  - the flag is a known boolean flag, which takes no value, so the
+            #    next token is a positional (consuming it would under-count the
+            #    recipe's positional args).
+            is_bool = (
+                cli_dir is not None
+                and flag_name.lstrip("-") in _boolean_flag_names(cli_dir)
+            )
+            if (
+                "=" not in t
+                and not is_bool
+                and i + 1 < len(tokens)
+                and not tokens[i + 1].startswith("-")
+            ):
                 i += 2
                 continue
         elif t.startswith("-"):

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -87,15 +87,19 @@ USE_RE = re.compile(r'Use:\s*"([^"]+)"')
 ARGS_RE = re.compile(
     r'Args:\s*cobra\.(ExactArgs|MinimumNArgs|MaximumNArgs|RangeArgs|NoArgs|OnlyValidArgs|ExactValidArgs)\s*\(([^)]*)\)'
 )
-FLAG_DECL_RE = re.compile(
-    r'(Persistent)?Flags\(\)\.'
-    r'(StringVar|BoolVar|IntVar|Int32Var|Int64Var|Float32Var|Float64Var|DurationVar|'
+FLAG_METHOD_PATTERN = (
+    r'StringVar|BoolVar|IntVar|Int32Var|Int64Var|Float32Var|Float64Var|DurationVar|'
     r'StringSliceVar|StringArrayVar|IntSliceVar|Int32SliceVar|Int64SliceVar|'
     r'Float64SliceVar|BoolSliceVar|DurationSliceVar|'
     r'UintVar|Uint32Var|Uint64Var|UintSliceVar|IPVar|IPSliceVar|Float32SliceVar|'
-    r'StringToStringVar|StringToIntVar|StringToInt64Var)P?\('
+    r'StringToStringVar|StringToIntVar|StringToInt64Var'
+)
+FLAG_DECL_RE = re.compile(
+    r'(Persistent)?Flags\(\)\.'
+    r'(' + FLAG_METHOD_PATTERN + r')P?\('
     r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
 )
+FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*cmd\.(Persistent)?Flags\(\)')
 @dataclass
 class Finding:
     check: str
@@ -437,14 +441,35 @@ def _legacy_find_command_source(cli_dir: Path, cmd_path: list[str]):
     return top_files, candidates[0][2], candidates[0][3]
 
 
+def iter_flag_declarations(text: str) -> Iterable[tuple[bool, str]]:
+    for m in FLAG_DECL_RE.finditer(text):
+        persistent, _, name = m.groups()
+        yield persistent == "Persistent", name
+
+    aliases = {
+        m.group(1): m.group(2) == "Persistent"
+        for m in FLAG_ALIAS_RE.finditer(text)
+    }
+    if not aliases:
+        return
+
+    alias_decl_re = re.compile(
+        r'\b(' + "|".join(re.escape(alias) for alias in aliases) + r')\.'
+        r'(' + FLAG_METHOD_PATTERN + r')P?\('
+        r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
+    )
+    for m in alias_decl_re.finditer(text):
+        yield aliases[m.group(1)], m.group(3)
+
+
 def flag_declared_in(files: Iterable[Path], flag_name: str) -> bool:
     for f in files:
         try:
             text = read_utf8(f)
         except Exception:
             continue
-        for m in FLAG_DECL_RE.finditer(text):
-            if m.group(3) == flag_name:
+        for _, name in iter_flag_declarations(text):
+            if name == flag_name:
                 return True
     return False
 
@@ -580,8 +605,8 @@ def flag_declared_via_helper(cli_dir: Path, cmd_files: Iterable[Path], flag_name
             continue
         for m in func_re.finditer(text):
             body = go_block_body(text, m.end() - 1)
-            for fm in FLAG_DECL_RE.finditer(body):
-                if fm.group(3) == flag_name:
+            for _, name in iter_flag_declarations(body):
+                if name == flag_name:
                     return True
     return False
 
@@ -595,9 +620,8 @@ def persistent_flag_declared(cli_dir: Path, flag_name: str) -> bool:
             text = read_utf8(go_file)
         except Exception:
             continue
-        for m in FLAG_DECL_RE.finditer(text):
-            persistent, _, name = m.groups()
-            if name == flag_name and persistent == "Persistent":
+        for persistent, name in iter_flag_declarations(text):
+            if name == flag_name and persistent:
                 return True
     return False
 
@@ -630,6 +654,12 @@ def _cli_invocation_from_tokens(
         ):
             break
         if len(cmd_path) < 3 and re.match(r"^[a-z][a-z0-9-]*$", t):
+            if cli_dir is not None:
+                _files, use_str, _args_info = find_command_source(cli_dir, cmd_path)
+                if use_str:
+                    _, _, optional, variadic = parse_use(use_str)
+                    if optional > 0 or variadic:
+                        break
             # Verify adding this token still maps to a valid command. If the
             # extended path has no source match, this token is an argument.
             if cli_dir is not None:

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -99,7 +99,7 @@ FLAG_DECL_RE = re.compile(
     r'(' + FLAG_METHOD_PATTERN + r')P?\('
     r'&[^,]+,\s*"([a-z][a-z0-9-]*)"'
 )
-FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*cmd\.(Persistent)?Flags\(\)')
+FLAG_ALIAS_RE = re.compile(r'\b([A-Za-z_]\w*)\s*(?::=|=)\s*[A-Za-z_][\w.]*\.(Persistent)?Flags\(\)')
 @dataclass
 class Finding:
     check: str


### PR DESCRIPTION
## Intent

Three independent verify-skill defects, each surfaced as a false-negative against a real printed-CLI cookbook recipe.

Issue: Fixes #2452. Fixes #2412. Fixes #2428.

## Approach

- **#2452** — verify-skill's flag-discovery walked `cmd.Flags().StringVar(...)` (inline-receiver) but missed the very common `f := cmd.Flags(); f.StringVar(...)` form (alias-receiver). The walker now resolves alias receivers back to the underlying `*pflag.FlagSet`, so alias-form flags are discovered alongside inline-form ones.
- **#2412** — the command-path walker previously attempted sibling-command descent before binding optional positionals on the current command, mis-resolving recipes that legitimately use a positional + a sibling-shadow name. It now binds optionals first, then descends.
- **#2428** — the tokenizer treated `--flag value` as `--flag` + a positional `value`, which broke filter-example parsing (e.g. `--filter 'venue=brooklyn'`). The tokenizer now consumes the next token as the flag's value when the flag is value-bearing.

Updates the canonical `scripts/verify-skill/verify_skill.py` and the bundled `internal/cli/verify_skill_bundled.py` in lockstep — `TestVerifySkillScriptInSync` covers drift between the two. The library repo's `.github/scripts` copy will need the same update; the existing `verify-skill-drift-check` workflow tracks that.

## Scope

Primary area: scorer / verify-skill

Why this belongs in this repo: verify-skill itself lives here (the generator's scorer). The library repo carries a synced copy that will follow via drift-check.

## Catalog Justification

N/A

## Risk

Moderate-low. All three fixes are inside the Python walker/tokenizer; existing behavior is preserved (no flag/positional shape that previously parsed now stops parsing — we only resolve cases that previously didn't). The canonical-vs-bundled drift test pins parity.

## Output Contract

N/A — verdicts shift only where previously false-negative (three specific tokenizer/walker gaps); no schema/output format change.

## Verification

- `go test ./internal/cli/...` — `TestVerifySkillScriptInSync` green (canonical + bundled stay in lockstep).
- `python scripts/verify-skill/verify_skill.py …` exercised against the cookbook examples that originally surfaced each bug; all three now resolve correctly.
- Walked the alias-receiver, positional-vs-sibling, and `--flag value` cases by hand against the new walker.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(No generator/template surface touched.)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

Implementation generated by an AI coding agent (codex), human-orchestrated and verified end-to-end before submission.
