### PR TITLE
fix(cli): gate novel-feature Help guard on positional + non-placeholder parent Short

### DIFF
--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -235,7 +235,22 @@ func novelFeatureCommandParts(command string) []string {
 }
 
 func novelFeatureHasPositional(command string) bool {
-	return strings.Contains(command, "<") || strings.Contains(command, "[")
+	// Only tokens before the first flag are positional arguments; a `<`/`[`
+	// inside a flag-value hint (e.g. "search --filter [active|inactive]") is
+	// not a positional and must not re-arm the args-based Help guard (#2592).
+	for token := range strings.FieldsSeq(command) {
+		token = strings.Trim(token, `"'`)
+		if token == "" {
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			break
+		}
+		if novelFeatureTokenIsPositional(token) {
+			return true
+		}
+	}
+	return false
 }
 
 func novelFeatureTokenIsPositional(token string) bool {
@@ -246,8 +261,13 @@ func novelFeatureUse(segment, command string) string {
 	var positional []string
 	for token := range strings.FieldsSeq(command) {
 		token = strings.Trim(token, `"'`)
-		if token == "" || strings.HasPrefix(token, "-") {
+		if token == "" {
 			continue
+		}
+		// Stop at the first flag: placeholders after a flag are value hints,
+		// not positional args, and must not leak into the cobra Use string.
+		if strings.HasPrefix(token, "-") {
+			break
 		}
 		if novelFeatureTokenIsPositional(token) {
 			positional = append(positional, token)
@@ -260,23 +280,14 @@ func novelFeatureUse(segment, command string) string {
 }
 
 func novelFeatureParentShort(node *novelFeatureStubNode) string {
+	// Only called from the else-if len(node.children) > 0 branch, so children
+	// is always non-empty here.
 	children := sortedNovelChildren(node)
-	if len(children) == 0 {
-		return novelFeatureTitleSegment(node.segment) + " commands"
-	}
 	leafNames := make([]string, 0, len(children))
 	for _, child := range children {
 		leafNames = append(leafNames, child.segment)
 	}
 	return fmt.Sprintf("%s subcommands: %s", node.segment, strings.Join(leafNames, ", "))
-}
-
-func novelFeatureTitleSegment(segment string) string {
-	segment = strings.TrimSpace(segment)
-	if segment == "" {
-		return "Novel"
-	}
-	return strings.ToUpper(segment[:1]) + segment[1:]
 }
 
 func novelFeatureStubIdent(parts []string) string {

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -19,6 +19,7 @@ type novelFeatureCommandRender struct {
 	Short          string
 	CommandPath    string
 	ReadOnlyString string
+	HasPositional  bool
 	Feature        bool
 	Flags          []novelFeatureFlagRender
 	Children       []novelFeatureChildRender
@@ -160,6 +161,8 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, topLevel 
 func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFeatureCommandRender {
 	commandPath := strings.Join(node.path, " ")
 	short := "TODO: implement " + commandPath
+	use := node.segment
+	hasPositional := false
 	readOnly := true
 	var flags []novelFeatureFlagRender
 	if node.feature != nil {
@@ -172,6 +175,10 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 		}
 		readOnly = novelFeatureReadOnly(*node.feature)
 		flags = novelFeatureFlags(*node.feature, node.path, g.Spec.Name)
+		hasPositional = novelFeatureHasPositional(node.feature.Command)
+		use = novelFeatureUse(node.segment, node.feature.Command)
+	} else if len(node.children) > 0 {
+		short = novelFeatureParentShort(node)
 	}
 	children := sortedNovelChildren(node)
 	childData := make([]novelFeatureChildRender, 0, len(children))
@@ -185,10 +192,11 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 	return novelFeatureCommandRender{
 		Owner:          g.Spec.Owner,
 		Ident:          novelFeatureStubIdent(node.path),
-		Use:            node.segment,
+		Use:            use,
 		Short:          short,
 		CommandPath:    commandPath,
 		ReadOnlyString: readOnlyString,
+		HasPositional:  hasPositional,
 		Feature:        node.feature != nil,
 		Flags:          flags,
 		Children:       childData,
@@ -212,19 +220,63 @@ func sortedNovelChildren(node *novelFeatureStubNode) []*novelFeatureStubNode {
 }
 
 func novelFeatureCommandParts(command string) []string {
-	tokens := strings.Fields(strings.ToLower(command))
-	parts := make([]string, 0, len(tokens))
-	for _, token := range tokens {
+	parts := make([]string, 0)
+	for token := range strings.FieldsSeq(strings.ToLower(command)) {
 		token = strings.Trim(token, `"'`)
 		if token == "" {
 			continue
 		}
-		if strings.HasPrefix(token, "-") {
+		if strings.HasPrefix(token, "-") || novelFeatureTokenIsPositional(token) {
 			break
 		}
 		parts = append(parts, toKebab(token))
 	}
 	return parts
+}
+
+func novelFeatureHasPositional(command string) bool {
+	return strings.Contains(command, "<") || strings.Contains(command, "[")
+}
+
+func novelFeatureTokenIsPositional(token string) bool {
+	return strings.Contains(token, "<") || strings.Contains(token, "[")
+}
+
+func novelFeatureUse(segment, command string) string {
+	var positional []string
+	for token := range strings.FieldsSeq(command) {
+		token = strings.Trim(token, `"'`)
+		if token == "" || strings.HasPrefix(token, "-") {
+			continue
+		}
+		if novelFeatureTokenIsPositional(token) {
+			positional = append(positional, token)
+		}
+	}
+	if len(positional) == 0 {
+		return segment
+	}
+	return strings.Join(append([]string{segment}, positional...), " ")
+}
+
+func novelFeatureParentShort(node *novelFeatureStubNode) string {
+	children := sortedNovelChildren(node)
+	if len(children) == 0 {
+		return novelFeatureTitleSegment(node.segment) + " commands"
+	}
+	leafNames := make([]string, 0, len(children))
+	for _, child := range children {
+		leafNames = append(leafNames, child.segment)
+	}
+	return fmt.Sprintf("%s subcommands: %s", node.segment, strings.Join(leafNames, ", "))
+}
+
+func novelFeatureTitleSegment(segment string) string {
+	segment = strings.TrimSpace(segment)
+	if segment == "" {
+		return "Novel"
+	}
+	return strings.ToUpper(segment[:1]) + segment[1:]
 }
 
 func novelFeatureStubIdent(parts []string) string {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -111,3 +111,86 @@ func TestGeneratorSkipsNovelFeatureStubsWhenNoCommandPath(t *testing.T) {
 	_, err := os.Stat(filepath.Join(outputDir, "internal", "cli", "global_search.go"))
 	assert.True(t, os.IsNotExist(err))
 }
+
+func TestGeneratorNovelFeatureHelpGuardRequiresPositionalUse(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("novelargs")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Inspect item",
+			Command:     "inspect <id>",
+			Description: "Inspect one item.",
+			Example:     "novelargs-pp-cli inspect item-123 --format json",
+		},
+		{
+			Name:        "Metric report",
+			Command:     "report",
+			Description: "Report metrics selected by flags.",
+			Example:     "novelargs-pp-cli report --metric latency",
+		},
+		{
+			Name:        "Audit",
+			Command:     "audit",
+			Description: "Audit local cache state.",
+			Example:     "novelargs-pp-cli audit",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	inspect := readGeneratedFile(t, outputDir, "internal", "cli", "inspect.go")
+	assert.Contains(t, inspect, `Use:         "inspect <id>"`)
+	assert.Contains(t, inspect, "if len(args) == 0 {")
+	assert.Contains(t, inspect, "return cmd.Help()")
+
+	report := readGeneratedFile(t, outputDir, "internal", "cli", "report.go")
+	assert.NotContains(t, report, "return cmd.Help()")
+	assert.Contains(t, report, "// validate required flags here")
+	assert.Contains(t, report, "if dryRunOK(flags) {")
+	assert.Contains(t, report, `TODO: implement novel feature %q", "report"`)
+
+	audit := readGeneratedFile(t, outputDir, "internal", "cli", "audit.go")
+	assert.NotContains(t, audit, "return cmd.Help()")
+	assert.Contains(t, audit, "// validate required flags here")
+	assert.Contains(t, audit, "if dryRunOK(flags) {")
+	assert.Contains(t, audit, `TODO: implement novel feature %q", "audit"`)
+}
+
+func TestGeneratorNovelFeatureParentShortHasNoTODO(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("novelparent")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Snapshot diff",
+			Command:     "snapshot diff",
+			Description: "Compare two snapshots.",
+			Example:     "novelparent-pp-cli snapshot diff before after",
+		},
+		{
+			Name:        "Snapshot list",
+			Command:     "snapshot list",
+			Description: "List snapshots.",
+			Example:     "novelparent-pp-cli snapshot list",
+		},
+		{
+			Name:        "Single command",
+			Command:     "single",
+			Description: "A single-segment novel command.",
+			Example:     "novelparent-pp-cli single",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	parent := readGeneratedFile(t, outputDir, "internal", "cli", "snapshot.go")
+	assert.Contains(t, parent, `Short:       "snapshot subcommands: diff, list"`)
+	assert.NotContains(t, parent, `Short:       "TODO`)
+
+	single := readGeneratedFile(t, outputDir, "internal", "cli", "single.go")
+	assert.Contains(t, single, `Short:       "A single-segment novel command."`)
+	assert.NotContains(t, single, `subcommands:`)
+}

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -137,6 +137,12 @@ func TestGeneratorNovelFeatureHelpGuardRequiresPositionalUse(t *testing.T) {
 			Description: "Audit local cache state.",
 			Example:     "novelargs-pp-cli audit",
 		},
+		{
+			Name:        "Search",
+			Command:     "search --filter [active|inactive]",
+			Description: "Search items, filtered by flag.",
+			Example:     "novelargs-pp-cli search --filter active",
+		},
 	}
 	require.NoError(t, gen.Generate())
 
@@ -156,6 +162,14 @@ func TestGeneratorNovelFeatureHelpGuardRequiresPositionalUse(t *testing.T) {
 	assert.Contains(t, audit, "// validate required flags here")
 	assert.Contains(t, audit, "if dryRunOK(flags) {")
 	assert.Contains(t, audit, `TODO: implement novel feature %q", "audit"`)
+
+	// A bracket/angle placeholder inside a flag-value hint is NOT a positional
+	// (#2592 regression guard): no args-based Help guard, and the flag-value
+	// hint must not leak into the cobra Use string.
+	search := readGeneratedFile(t, outputDir, "internal", "cli", "search.go")
+	assert.NotContains(t, search, "return cmd.Help()")
+	assert.Contains(t, search, "// validate required flags here")
+	assert.NotContains(t, search, "[active|inactive]")
 }
 
 func TestGeneratorNovelFeatureParentShortHasNoTODO(t *testing.T) {

--- a/internal/generator/templates/novel_feature_command.go.tmpl
+++ b/internal/generator/templates/novel_feature_command.go.tmpl
@@ -28,9 +28,13 @@ func newNovel{{.Ident}}Cmd(flags *rootFlags) *cobra.Command {
 		Annotations: map[string]string{"mcp:read-only": {{printf "%q" .ReadOnlyString}}},
 {{- if .Feature}}
 		RunE: func(cmd *cobra.Command, args []string) error {
+{{- if .HasPositional}}
 			if len(args) == 0 {
 				return cmd.Help()
 			}
+{{- else}}
+			// validate required flags here
+{{- end}}
 			if dryRunOK(flags) {
 				return nil
 			}


### PR DESCRIPTION
## What

Two generator fixes for novel-feature command emission.

**#2592 — Help guard breaks flag-driven / no-arg novel commands.** Generated
novel-feature command stubs emitted an unconditional `if len(args)==0 { return
cmd.Help() }` as the first `RunE` line, so flag-driven (`report --metric`) and
no-arg (`audit`) novel commands always printed help and never executed.
verify/dogfood couldn't catch it because `cmd.Help()` returns nil (a `--dry-run`
probe exits 0). The Help guard is now emitted only when the feature's command
declares a positional placeholder (`<...>`/`[...]`); flag-only / no-arg features
get a `// validate required flags here` comment and keep the existing `dryRunOK`
short-circuit. The placeholder is also surfaced in the cobra `Use` string and no
longer leaks into the generated command path.

**#2459 — placeholder parent `Short`.** Novel-feature parent group files shipped
`Short: "TODO: implement <parent>"` into `--help` and the dogfood help matrix.
They now derive a real `Short` (`"<parent> subcommands: <children>"`). Scope is
limited to novel-feature parents — spec-derived resource-group parents and emitted
children are untouched.

## Testing

- New `internal/generator` unit tests cover: positional command keeps the guard;
  flag-only / no-arg commands drop it (and reach real logic); multi-segment novel
  command emits a parent `Short` with no `TODO`.
- Golden suite regenerated; full `go test ./...` green.

Fixes #2592
Fixes #2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
