### PR TITLE
fix(cli): platform-conditional --help validation timeout + accurate pipeline.Init doc

### DIFF
--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -85,7 +86,7 @@ func (g *Generator) Validate() error {
 		{
 			name: naming.CLI(g.Spec.Name) + " --help",
 			run: func() error {
-				return validateCommandOutput(g.OutputDir, 15*time.Second, binPath, "--help")
+				return validateCommandOutput(g.OutputDir, helpGateTimeout(runtime.GOOS), binPath, "--help")
 			},
 		},
 		{
@@ -111,6 +112,13 @@ func (g *Generator) Validate() error {
 	}
 
 	return nil
+}
+
+func helpGateTimeout(goos string) time.Duration {
+	if goos == "windows" {
+		return 30 * time.Second
+	}
+	return 15 * time.Second
 }
 
 func validateCommandOutput(dir string, timeout time.Duration, name string, args ...string) error {

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -5,11 +5,42 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/govulncheck"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHelpGateTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		want time.Duration
+	}{
+		{
+			name: "windows",
+			goos: "windows",
+			want: 30 * time.Second,
+		},
+		{
+			name: "linux",
+			goos: "linux",
+			want: 15 * time.Second,
+		},
+		{
+			name: "darwin",
+			goos: "darwin",
+			want: 15 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, helpGateTimeout(tt.goos))
+		})
+	}
+}
 
 func TestGoBuildCacheDirIsShared(t *testing.T) {
 	t.Setenv("GOCACHE", "")

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -57,7 +57,8 @@ type Options struct {
 }
 
 // Init creates the pipeline directory, state file, and plan seeds.
-// It does NOT execute any phases.
+// It does NOT execute pipeline phases, but resolves the API spec via
+// DiscoverSpec, which may involve network I/O.
 func Init(apiName string, opts Options) (*PipelineState, error) {
 	if opts.Resume && StateExists(apiName) {
 		return LoadState(apiName)


### PR DESCRIPTION
## What

Two small generator-internal fixes (no generated-output change).

**#1647 — `--help` validation gate times out on Windows.** The generate-time
`--help` validation gate had a fixed 15s timeout. On Windows, Defender/AV
cold-start scanning of a never-before-seen executable adds 5–20s on first
invocation, so the gate timed out even though the binary returns `--help` in
<200ms once warm (every other gate runs against an already-warm binary). The gate
timeout is now platform-conditional via `helpGateTimeout`: 30s on
`runtime.GOOS == "windows"`, 15s elsewhere. The timeout still fires, so a
genuinely hung `--help` is still caught.

**#2481 — inaccurate `pipeline.Init` doc comment.** The comment claimed `Init`
executes no phases, but it calls `DiscoverSpec`, which may perform network I/O.
Reworded to say so.

## Testing

- New `helpGateTimeout` unit test (windows→30s, linux/darwin→15s).
- Full `go test ./...` green. No golden impact (both files are generate-time
  internal, not emitted into printed CLIs).

Fixes #1647
Fixes #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
