### PR TITLE
fix(cli): honor explicit has_more:false in sync page-int fallback + add metadata envelope key

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3935,10 +3935,6 @@ func TestSyncExtractPaginationNestedCursor(t *testing.T) {
 		"pageItemKeys must include features (GeoJSON support)")
 	assert.Contains(t, src, `"Features"`,
 		"pageItemKeys must include Features (PascalCase GeoJSON support)")
-	assert.Contains(t, src, `"metadata": true`,
-		"pageEnvelopeMetadataKeys must skip lowercase metadata wrapper objects")
-	assert.Contains(t, src, `"Metadata": true`,
-		"pageEnvelopeMetadataKeys must skip PascalCase metadata wrapper objects")
 
 	// Tier 2: behavioral test, written into the generated tree as a
 	// same-package _test.go so it can call the unexported helper.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3935,6 +3935,10 @@ func TestSyncExtractPaginationNestedCursor(t *testing.T) {
 		"pageItemKeys must include features (GeoJSON support)")
 	assert.Contains(t, src, `"Features"`,
 		"pageItemKeys must include Features (PascalCase GeoJSON support)")
+	assert.Contains(t, src, `"metadata": true`,
+		"pageEnvelopeMetadataKeys must skip lowercase metadata wrapper objects")
+	assert.Contains(t, src, `"Metadata": true`,
+		"pageEnvelopeMetadataKeys must skip PascalCase metadata wrapper objects")
 
 	// Tier 2: behavioral test, written into the generated tree as a
 	// same-package _test.go so it can call the unexported helper.
@@ -4121,12 +4125,52 @@ func TestExtractPageItemsNoCursor(t *testing.T) {
 		t.Fatalf("want hasMore=false when no cursor present")
 	}
 }
+
+func TestExtractPageItemsMetadataEnvelope(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"items": [{"id":1},{"id":2}],
+		"metadata": {"total": 42}
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("metadata object envelope: want 2 items, got %d", len(items))
+	}
+}
+
+func TestExtractPageItemsMetadataArrayStillData(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"metadata": [{"id":1},{"id":2}]
+	}` + "`" + `)
+	items, _, _ := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("metadata array envelope: want 2 items, got %d", len(items))
+	}
+}
+
+func TestPageAllowsPageIntFallback(t *testing.T) {
+	withFalse := json.RawMessage(` + "`" + `{"results":[{"id":1}],"has_more":false}` + "`" + `)
+	if pageAllowsPageIntFallback(withFalse) {
+		t.Fatalf("want explicit has_more:false to block page-int fallback")
+	}
+	omitted := json.RawMessage(` + "`" + `{"results":[{"id":1}]}` + "`" + `)
+	if !pageAllowsPageIntFallback(omitted) {
+		t.Fatalf("want omitted has_more to allow page-int fallback")
+	}
+	withTrue := json.RawMessage(` + "`" + `{"results":[{"id":1}],"has_more":true}` + "`" + `)
+	if !pageAllowsPageIntFallback(withTrue) {
+		t.Fatalf("want explicit has_more:true to allow page-int fallback")
+	}
+	nestedFalse := json.RawMessage(` + "`" + `{"data":{"results":[{"id":1}],"has_more":false}}` + "`" + `)
+	if pageAllowsPageIntFallback(nestedFalse) {
+		t.Fatalf("want nested explicit has_more:false to block page-int fallback")
+	}
+}
 `
 	testPath := filepath.Join(outputDir, "internal", "cli", "sync_pagination_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")
-	runGoCommandRequired(t, outputDir, "test", "-run", "TestExtractPageItems", "./internal/cli")
+	runGoCommandRequired(t, outputDir, "test", "-run", "Test(ExtractPageItems|PageAllowsPageIntFallback)", "./internal/cli")
 }
 
 // TestSyncPageIntPaginationAdvancesAfterFullPage guards #1296: APIs that
@@ -4200,6 +4244,8 @@ func TestSyncPageIntPaginationAdvancesAfterFullPage(t *testing.T) {
 			// page[number]) fires the fallback.
 			assert.Contains(t, src, `pageSize.cursorType == "page"`,
 				"sync.go must guard the page-int fallback on cursorType, not the raw param name")
+			assert.Contains(t, src, `&& pageAllowsPageIntFallback(data)`,
+				"sync.go must not synthesize page+1 when the envelope explicitly parsed has_more")
 			assert.Contains(t, src, `strconv.Itoa(currentPage + 1)`,
 				"page-int fallback must increment the integer cursor")
 			assert.Contains(t, src, `cursorType:  "page"`,

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2542,7 +2542,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
+	"links": true, "meta": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -723,7 +723,7 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -1674,6 +1674,48 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	return nextCursor, hasMore
 }
 
+func pageAllowsPageIntFallback(data json.RawMessage) bool {
+	hasMore, parsed := pageExplicitHasMore(data)
+	return !parsed || hasMore
+}
+
+func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false, false
+	}
+	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
+		return hasMore, true
+	}
+	for _, key := range dataEnvelopeKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(raw, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	return false, false
+}
+
+func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
+	for _, key := range []string{"has_more", "hasMore", "has_next", "hasNext", "next_page"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var hasMore bool
+		if json.Unmarshal(raw, &hasMore) == nil {
+			return hasMore, true
+		}
+	}
+	return false, false
+}
+
 // nextCursorFromLinks extracts JSON:API-style pagination cursors from
 // {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
@@ -2241,7 +2283,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
 			// Guard on cursorType to cover every canonical spelling.
-			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 				currentPage, _ := strconv.Atoi(cursor)
 				if currentPage < 1 {
 					currentPage = 1
@@ -2500,7 +2542,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "pagination": true,
+	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -530,7 +530,7 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -1059,6 +1059,48 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	return nextCursor, hasMore
 }
 
+func pageAllowsPageIntFallback(data json.RawMessage) bool {
+	hasMore, parsed := pageExplicitHasMore(data)
+	return !parsed || hasMore
+}
+
+func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false, false
+	}
+	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
+		return hasMore, true
+	}
+	for _, key := range dataEnvelopeKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(raw, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	return false, false
+}
+
+func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
+	for _, key := range []string{"has_more", "hasMore", "has_next", "hasNext", "next_page"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var hasMore bool
+		if json.Unmarshal(raw, &hasMore) == nil {
+			return hasMore, true
+		}
+	}
+	return false, false
+}
+
 // nextCursorFromLinks extracts JSON:API-style pagination cursors from
 // {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
@@ -1443,7 +1485,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
 			// Guard on cursorType to cover every canonical spelling.
-			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 				currentPage, _ := strconv.Atoi(cursor)
 				if currentPage < 1 {
 					currentPage = 1
@@ -1691,7 +1733,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "pagination": true,
+	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1733,7 +1733,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
+	"links": true, "meta": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -530,7 +530,7 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -1055,6 +1055,48 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	return nextCursor, hasMore
 }
 
+func pageAllowsPageIntFallback(data json.RawMessage) bool {
+	hasMore, parsed := pageExplicitHasMore(data)
+	return !parsed || hasMore
+}
+
+func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false, false
+	}
+	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
+		return hasMore, true
+	}
+	for _, key := range dataEnvelopeKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(raw, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	return false, false
+}
+
+func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
+	for _, key := range []string{"has_more", "hasMore", "has_next", "hasNext", "next_page"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var hasMore bool
+		if json.Unmarshal(raw, &hasMore) == nil {
+			return hasMore, true
+		}
+	}
+	return false, false
+}
+
 // nextCursorFromLinks extracts JSON:API-style pagination cursors from
 // {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
@@ -1428,7 +1470,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
 			// Guard on cursorType to cover every canonical spelling.
-			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+			if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 				currentPage, _ := strconv.Atoi(cursor)
 				if currentPage < 1 {
 					currentPage = 1
@@ -1675,7 +1717,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "pagination": true,
+	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1717,7 +1717,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
+	"links": true, "meta": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -497,7 +497,7 @@ func syncResource(ctx context.Context, c interface {
 		// 1 even though more pages exist (the original symptom in #1296).
 		// Guard on cursorType, not cursorParam name, so all canonical
 		// spellings (page / page_number / pageNumber / page[number]) work.
-		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit {
+		if pageSize.cursorType == "page" && nextCursor == "" && len(items) >= pageSize.limit && pageAllowsPageIntFallback(data) {
 			currentPage, _ := strconv.Atoi(cursor)
 			if currentPage < 1 {
 				currentPage = 1
@@ -1024,6 +1024,48 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 	return nextCursor, hasMore
 }
 
+func pageAllowsPageIntFallback(data json.RawMessage) bool {
+	hasMore, parsed := pageExplicitHasMore(data)
+	return !parsed || hasMore
+}
+
+func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return false, false
+	}
+	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
+		return hasMore, true
+	}
+	for _, key := range dataEnvelopeKeys {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(raw, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	return false, false
+}
+
+func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
+	for _, key := range []string{"has_more", "hasMore", "has_next", "hasNext", "next_page"} {
+		raw, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var hasMore bool
+		if json.Unmarshal(raw, &hasMore) == nil {
+			return hasMore, true
+		}
+	}
+	return false, false
+}
+
 // nextCursorFromLinks extracts JSON:API-style pagination cursors from
 // {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
@@ -1291,7 +1333,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "pagination": true,
+	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1333,7 +1333,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"success": true, "status": true, "message": true, "error": true, "errors": true,
 	"warnings": true, "Warnings": true, "ok": true, "Ok": true,
 	// wrapper objects
-	"links": true, "meta": true, "metadata": true, "Metadata": true, "pagination": true,
+	"links": true, "meta": true, "pagination": true,
 	"response_metadata": true, "paging": true,
 	// links shape
 	"next": true, "prev": true, "previous": true, "first": true, "last": true,


### PR DESCRIPTION
## What

**#2413 — page-int fallback overrides explicit `has_more:false`.** The page-int
paginator fallback in the generated sync template unconditionally set `hasMore=true`
on a full page with no body cursor, overriding an explicit `has_more:false` parsed
from the envelope — so a page-int API returning a full final page with
`has_more:false` was advanced into a guaranteed-empty extra fetch. `hasMore` is
zero-value `false` and the envelope parse doesn't distinguish present-false from
absent, so a bare `&& hasMore` would break the silent-omit case (the #1296 regression
fix). The fallback is now guarded by `pageAllowsPageIntFallback(data)`: it runs only
when `has_more` is absent or explicitly true, and honors an explicit `has_more:false`.
Applied at both fallback sites (`syncResource` and `syncDependentResource`).

## Note on #2414 (already fixed at HEAD — not re-fixed here)

#2414's symptom (a `{"items":[...],"metadata":{...}}` envelope bailing early in
`extractSingleObjectArraySibling`) was already resolved by #2532, which removed the
`if !pageEnvelopeMetadataKeys[key] { return nil, false }` early-bail. That left
`pageEnvelopeMetadataKeys` a dead variable, so this PR does not touch it — adding
`"metadata"` there has no runtime effect, and adding it to the *live*
`pageMetadataArrayKeys` would wrongly skip a `{"metadata":[...]}` data carrier
(the issue's own negative case). Filing as `Refs #2414`, not `Fixes`. The behavioral
regression tests for both metadata-envelope shapes are kept.

## Testing

- New generator tests compile inline `internal/cli` helpers and assert: explicit
  `has_more:false` (top-level and nested) blocks the fallback; omitted `has_more`
  still triggers it; explicit `has_more:true` allows it; and `metadata` object/array
  envelopes surface items correctly.
- Golden suite regenerated; full `go test ./...` + `golden.sh verify` +
  `verify-generator-output.sh` green.

Fixes #2413
Refs #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
