### PR TITLE
fix(cli): dedup intentEndpoints map + 0600/0700 cache perms + cobratree shell-arg quoting

### DIFF
--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -59,6 +59,10 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 	require.NotContains(t, client, "os.MkdirAll(c.cacheDir, 0o755)")
 	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
 
+	// minimalSpec does not enable HTML extraction, so the writeCacheContentType
+	// ".meta.json" 0o600 write is not emitted here; that path's permission is
+	// covered by the golden suite's HTML-extraction fixtures. This test guards
+	// the always-emitted cache/client/config perms.
 	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
 	require.NoError(t, err)
 	config := string(configSrc)

--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -36,6 +36,36 @@ func TestClientCacheKeyScopesByBaseURLAndAuthIdentity(t *testing.T) {
 	require.Contains(t, body, `sort.Strings(paramKeys)`, "cache keys should be deterministic for map params")
 }
 
+func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cache-perms")
+	outputDir := filepath.Join(t.TempDir(), "cache-perms-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cacheSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cache", "cache.go"))
+	require.NoError(t, err)
+	cache := string(cacheSrc)
+	require.Contains(t, cache, "os.MkdirAll(s.Dir, 0o700)")
+	require.Contains(t, cache, "os.WriteFile(s.path(key), []byte(value), 0o600)")
+	require.NotContains(t, cache, "os.MkdirAll(s.Dir, 0o755)")
+	require.NotContains(t, cache, "os.WriteFile(s.path(key), []byte(value), 0o644)")
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	client := string(clientSrc)
+	require.Contains(t, client, "os.MkdirAll(c.cacheDir, 0o700)")
+	require.Contains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o600)")
+	require.NotContains(t, client, "os.MkdirAll(c.cacheDir, 0o755)")
+	require.NotContains(t, client, "os.WriteFile(cacheFile, []byte(data), 0o644)")
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	config := string(configSrc)
+	require.Contains(t, config, "os.MkdirAll(dir, 0o700)")
+	require.Contains(t, config, "os.WriteFile(c.Path, data, 0o600)")
+}
+
 func clientCacheKeyBody(t *testing.T, content string) string {
 	t.Helper()
 	start := strings.Index(content, "func (c *Client) cacheKey(")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15261,6 +15261,49 @@ func TestGenerateMCPIntentsEmittedWhenDeclared(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+// TestGenerateMCPIntentsDeduplicatesEndpointMeta proves that overlapping
+// intent steps do not emit duplicate keys in the intentEndpoints map literal.
+func TestGenerateMCPIntentsDeduplicatesEndpointMeta(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := spec.Parse(filepath.Join("..", "..", "testdata", "loops.yaml"))
+	require.NoError(t, err)
+	apiSpec.MCP = spec.MCPConfig{
+		Intents: []spec.Intent{
+			{
+				Name:        "first_contacts_lookup",
+				Description: "First fixture lookup",
+				Steps: []spec.IntentStep{
+					{Endpoint: "contacts.list", Capture: "contacts"},
+				},
+				Returns: "contacts",
+			},
+			{
+				Name:        "second_contacts_lookup",
+				Description: "Second fixture lookup",
+				Steps: []spec.IntentStep{
+					{Endpoint: "contacts.list", Capture: "contacts"},
+				},
+				Returns: "contacts",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	intentsPath := filepath.Join(outputDir, "internal", "mcp", "intents.go")
+	data, err := os.ReadFile(intentsPath)
+	require.NoError(t, err)
+	body := string(data)
+	assert.Equal(t, 1, strings.Count(body, `"contacts.list": {method:`),
+		"shared intent endpoint must be emitted once in intentEndpoints")
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./...")
+}
+
 // TestGenerateMCPEndpointToolsHiddenSuppressesEndpointTools proves that
 // endpoint_tools: hidden removes the raw per-endpoint MCP tools but keeps
 // the intent registration wired in. This is the surface agents see when the

--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -67,6 +67,9 @@ func TestMCPRegistersCobraTreeMirror(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(root), "func RootCmd() *cobra.Command")
 
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "TestSplitShellArgs")
+
 	// main.go calls only RegisterTools; RegisterTools owns endpoint tools and
 	// the runtime command mirror.
 	main, err := os.ReadFile(filepath.Join(outputDir, "cmd", "noveltest-pp-mcp", "main.go"))

--- a/internal/generator/templates/cache.go.tmpl
+++ b/internal/generator/templates/cache.go.tmpl
@@ -44,8 +44,8 @@ func (s *Store) Get(key string) (json.RawMessage, bool) {
 
 // Set stores a value in the cache.
 func (s *Store) Set(key string, value json.RawMessage) {
-	_ = os.MkdirAll(s.Dir, 0o755)
-	_ = os.WriteFile(s.path(key), []byte(value), 0o644)
+	_ = os.MkdirAll(s.Dir, 0o700)
+	_ = os.WriteFile(s.path(key), []byte(value), 0o600)
 }
 
 // Clear removes all cached entries.

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -718,9 +718,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage{{if .HasHTMLExtraction}}, contentType string{{end}}) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 {{- if .HasHTMLExtraction}}
 	c.writeCacheContentType(cacheFile, contentType)
 {{- end}}
@@ -753,7 +753,7 @@ func (c *Client) writeCacheContentType(cacheFile, contentType string) {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(cacheFile+".meta.json", data, 0o644)
+	_ = os.WriteFile(cacheFile+".meta.json", data, 0o600)
 }
 
 {{- end}}

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -99,16 +99,25 @@ func cliArgsFromMCP(args map[string]any) []string {
 	return out
 }
 
-// SplitShellArgs whitespace-splits with double-quoted-token preservation.
+// SplitShellArgs whitespace-splits with shell-style quote preservation.
 func SplitShellArgs(s string) []string {
 	var tokens []string
 	var cur []rune
-	inQuote := false
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
 	for _, r := range s {
 		switch {
-		case r == '"':
-			inQuote = !inQuote
-		case (r == ' ' || r == '\t') && !inQuote:
+		case escaped:
+			cur = append(cur, r)
+			escaped = false
+		case r == '\\' && !inSingleQuote:
+			escaped = true
+		case r == '\'' && !inDoubleQuote:
+			inSingleQuote = !inSingleQuote
+		case r == '"' && !inSingleQuote:
+			inDoubleQuote = !inDoubleQuote
+		case (r == ' ' || r == '\t') && !inSingleQuote && !inDoubleQuote:
 			if len(cur) > 0 {
 				tokens = append(tokens, string(cur))
 				cur = cur[:0]
@@ -116,6 +125,9 @@ func SplitShellArgs(s string) []string {
 		default:
 			cur = append(cur, r)
 		}
+	}
+	if escaped {
+		cur = append(cur, '\\')
 	}
 	if len(cur) > 0 {
 		tokens = append(tokens, string(cur))

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -13,9 +13,9 @@ import (
 	"testing"
 )
 
-// TestSplitShellArgs pins the whitespace + double-quote splitting used by
+// TestSplitShellArgs pins the whitespace + quote splitting used by
 // the args-field passthrough. Behavior we rely on: bare whitespace splits,
-// tabs split, double-quoted spans stay together, empty input yields nil.
+// tabs split, quoted spans stay together, empty input yields nil.
 func TestSplitShellArgs(t *testing.T) {
 	cases := []struct {
 		name string
@@ -29,6 +29,9 @@ func TestSplitShellArgs(t *testing.T) {
 		{"tabs", "foo\tbar", []string{"foo", "bar"}},
 		{"quoted token", `"hello world"`, []string{"hello world"}},
 		{"mixed quoted and bare", `contacts "john doe" active`, []string{"contacts", "john doe", "active"}},
+		{"double quoted apostrophe", `"My Club's Night"`, []string{"My Club's Night"}},
+		{"single quoted span", `'a b' c`, []string{"a b", "c"}},
+		{"escaped whitespace", `a\ b c`, []string{"a b", "c"}},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -312,10 +312,20 @@ type intentEndpointMeta struct {
 // reference a new endpoint must be declared in the spec, which keeps this
 // table in sync with actual usage.
 var intentEndpoints = map[string]intentEndpointMeta{
-{{- range .MCP.Intents}}
-{{- range .Steps}}
+{{- range $intentIndex, $intent := .MCP.Intents}}
+{{- range $stepIndex, $step := $intent.Steps}}
+{{- $seenBefore := false}}
+{{- range $scanIntentIndex, $scanIntent := $.MCP.Intents}}
+{{- range $scanStepIndex, $scanStep := $scanIntent.Steps}}
+{{- if and (eq $scanStep.Endpoint $step.Endpoint) (or (lt $scanIntentIndex $intentIndex) (and (eq $scanIntentIndex $intentIndex) (lt $scanStepIndex $stepIndex)))}}
+{{- $seenBefore = true}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- if not $seenBefore}}
 {{- $ep := lookupEndpoint $.APISpec .Endpoint}}
 	{{printf "%q" .Endpoint}}: {method: {{printf "%q" (upper $ep.Method)}}, path: {{printf "%q" $ep.EffectivePath}}{{if $.HasRequiredRoles}}, requiredRole: {{if $ep.RequiresRole}}cli.Persona{{pascal $ep.RequiresRole}}{{else}}cli.Persona(""){{end}}{{end}}{{if $.HasTierRouting}}, tier: {{printf "%q" $ep.EffectiveTier}}{{end}}{{if $ep.BodyIsArray}}, bodyIsArray: true{{end}}},
+{{- end}}
 {{- end}}
 {{- end}}
 }

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -237,9 +237,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -257,9 +257,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -247,9 +247,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -248,9 +248,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -99,16 +99,25 @@ func cliArgsFromMCP(args map[string]any) []string {
 	return out
 }
 
-// SplitShellArgs whitespace-splits with double-quoted-token preservation.
+// SplitShellArgs whitespace-splits with shell-style quote preservation.
 func SplitShellArgs(s string) []string {
 	var tokens []string
 	var cur []rune
-	inQuote := false
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
 	for _, r := range s {
 		switch {
-		case r == '"':
-			inQuote = !inQuote
-		case (r == ' ' || r == '\t') && !inQuote:
+		case escaped:
+			cur = append(cur, r)
+			escaped = false
+		case r == '\\' && !inSingleQuote:
+			escaped = true
+		case r == '\'' && !inDoubleQuote:
+			inSingleQuote = !inSingleQuote
+		case r == '"' && !inSingleQuote:
+			inDoubleQuote = !inDoubleQuote
+		case (r == ' ' || r == '\t') && !inSingleQuote && !inDoubleQuote:
 			if len(cur) > 0 {
 				tokens = append(tokens, string(cur))
 				cur = cur[:0]
@@ -116,6 +125,9 @@ func SplitShellArgs(s string) []string {
 		default:
 			cur = append(cur, r)
 		}
+	}
+	if escaped {
+		cur = append(cur, '\\')
 	}
 	if len(cur) > 0 {
 		tokens = append(tokens, string(cur))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 )
 
-// TestSplitShellArgs pins the whitespace + double-quote splitting used by
+// TestSplitShellArgs pins the whitespace + quote splitting used by
 // the args-field passthrough. Behavior we rely on: bare whitespace splits,
-// tabs split, double-quoted spans stay together, empty input yields nil.
+// tabs split, quoted spans stay together, empty input yields nil.
 func TestSplitShellArgs(t *testing.T) {
 	cases := []struct {
 		name string
@@ -29,6 +29,9 @@ func TestSplitShellArgs(t *testing.T) {
 		{"tabs", "foo\tbar", []string{"foo", "bar"}},
 		{"quoted token", `"hello world"`, []string{"hello world"}},
 		{"mixed quoted and bare", `contacts "john doe" active`, []string{"contacts", "john doe", "active"}},
+		{"double quoted apostrophe", `"My Club's Night"`, []string{"My Club's Night"}},
+		{"single quoted span", `'a b' c`, []string{"a b", "c"}},
+		{"escaped whitespace", `a\ b c`, []string{"a b", "c"}},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -347,9 +347,9 @@ func (c *Client) readCache(path string, params map[string]string) (json.RawMessa
 }
 
 func (c *Client) writeCache(path string, params map[string]string, data json.RawMessage) {
-	os.MkdirAll(c.cacheDir, 0o755)
+	os.MkdirAll(c.cacheDir, 0o700)
 	cacheFile := filepath.Join(c.cacheDir, c.cacheKey(path, params)+".json")
-	os.WriteFile(cacheFile, []byte(data), 0o644)
+	os.WriteFile(cacheFile, []byte(data), 0o600)
 }
 
 // invalidateCache wholesale-removes the cache directory so the next read


### PR DESCRIPTION
## What

Three independent generated-file correctness fixes, each isolated to a distinct template.

**#2337 — duplicate `intentEndpoints` map keys break the MCP build.** When multiple
MCP intents reference the same endpoint, the generator emitted the same key twice in
the `intentEndpoints` map literal, so `go build ./cmd/<api>-pp-mcp` failed (Go rejects
duplicate keys in a map literal). The template now dedupes by endpoint key, emitting
each only on first occurrence.

**#2623 — insecure cache perms (gosec G301/G306).** The cache and client-cache write
templates emitted `0o755` dirs / `0o644` files, while the config template already uses
`0o700`/`0o600`. Cached API responses may contain user data and were world-readable on
multi-user hosts. Cache writes now use `0o700`/`0o600`, matching the config convention.

**#2424 — cobratree shell-out tokenizer drops single-quote/escape semantics.**
`SplitShellArgs` tracked only double quotes, so single-quoted spans and backslash
escapes leaked through and a multi-word positional value containing an apostrophe
(`My Club's Night`) was misrouted into multiple args. It now tracks single-quote and
double-quote state plus backslash escapes (single-quoted content stays literal). The
paired test template gains the new cases.

## Testing

- New/extended `internal/generator` tests: an overlapping-intent fixture asserts the
  endpoint key appears once and the MCP tree `go build`s; generated cache/client use
  `0o700`/`0o600` (and config is unchanged); the generated `TestSplitShellArgs` runs
  the new quoting cases.
- Golden suite regenerated; full `go test ./...` green.

Fixes #2337
Fixes #2623
Fixes #2424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
