### PR TITLE
fix(cli): preserve manifest spec name in transient mcp-sync dirs

### DIFF
--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -663,6 +663,30 @@ func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
 	assert.Equal(t, "my-spec.yaml", got.SpecPath)
 }
 
+func TestWriteManifestForGenerateMCPBManifestUsesResolvedMCPBinarySlug(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "foo-bar",
+		OutputDir: dir,
+		Spec: &spec.APISpec{
+			Name:        "foo.bar",
+			Description: "Foo.Bar API",
+			Auth:        spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readMCPBManifest(t, dir)
+	assert.Equal(t, "foo-bar-pp-mcp", got.Name)
+	assert.Equal(t, "bin/foo-bar-pp-mcp", got.Server.EntryPoint)
+	assert.Equal(t, "${__dirname}/bin/foo-bar-pp-mcp", got.Server.MCPConfig.Command)
+
+	data, err := os.ReadFile(filepath.Join(dir, MCPBManifestFilename))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "foo.bar")
+}
+
 func TestWriteManifestForGenerateKeepsCatalogDisplayNameOverTitleFallback(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -80,10 +80,9 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// api_name, manifest.json's name/entry_point, and
 	// cmd/<slug>-pp-{cli,mcp}/ directories under the title-derived slug
 	// — silently flipping a "telegram" CLI to "telegram-bot" mid-sync.
-	manifestNameAuthoritative := manifestAPINameMatchesParsed(cliDir, parsed)
-	if prior := applyManifestNameOverride(cliDir, parsed); prior != "" {
+	prior, manifestNameAuthoritative := applyManifestNameOverride(cliDir, parsed)
+	if prior != "" {
 		fmt.Fprintf(os.Stderr, "mcp-sync: using manifest api_name %q over spec-derived slug %q\n", parsed.Name, prior)
-		manifestNameAuthoritative = true
 	}
 	applyCatalogMetadata(parsed)
 	// Validate that spec.yaml.name matches the directory's basename.
@@ -496,13 +495,17 @@ func newRootCmd(flags *rootFlags) *cobra.Command {
 // roots) are left alone.
 const defaultConfigPathFormat = "~/.config/%s/config.toml"
 
-// applyManifestNameOverride replaces parsed.Name with the existing
-// CLI manifest's api_name when the two diverge. Returns the prior
-// parsed.Name when an override happened, "" otherwise (manifest
-// missing, api_name empty, or values already agreed).
-func applyManifestNameOverride(cliDir string, parsed *spec.APISpec) string {
+// applyManifestNameOverride aligns parsed.Name with the existing CLI manifest's
+// api_name (the operator's chosen identity). It returns the prior parsed.Name
+// when an override actually happened ("" otherwise: manifest missing, api_name
+// empty, or the values already agreed) and authoritative=true when the manifest
+// api_name is the identity of record — i.e. it either overrode parsed.Name or
+// already matched it. The manifest is read exactly once, and the trimmed
+// api_name is used for both the comparison and the assignment so a hand-edited
+// manifest with stray whitespace can't leak a padded name downstream.
+func applyManifestNameOverride(cliDir string, parsed *spec.APISpec) (prior string, authoritative bool) {
 	if parsed == nil {
-		return ""
+		return "", false
 	}
 	m, err := pipeline.ReadCLIManifest(cliDir)
 	if err != nil {
@@ -514,29 +517,22 @@ func applyManifestNameOverride(cliDir string, parsed *spec.APISpec) string {
 		if !errors.Is(err, fs.ErrNotExist) {
 			fmt.Fprintf(os.Stderr, "mcp-sync: could not read .printing-press.json (%v); falling back to spec-derived slug\n", err)
 		}
-		return ""
+		return "", false
 	}
-	if m.APIName == "" || m.APIName == parsed.Name {
-		return ""
+	apiName := strings.TrimSpace(m.APIName)
+	if apiName == "" {
+		return "", false
 	}
-	prior := parsed.Name
+	if apiName == parsed.Name {
+		return "", true
+	}
+	prior = parsed.Name
 	if parsed.Config.Path == fmt.Sprintf(defaultConfigPathFormat, naming.CLI(prior)) {
-		parsed.Config.Path = fmt.Sprintf(defaultConfigPathFormat, naming.CLI(m.APIName))
+		parsed.Config.Path = fmt.Sprintf(defaultConfigPathFormat, naming.CLI(apiName))
 	}
-	catalogmeta.RebaseAuthEnvPrefix(&parsed.Auth, prior, m.APIName)
-	parsed.Name = m.APIName
-	return prior
-}
-
-func manifestAPINameMatchesParsed(cliDir string, parsed *spec.APISpec) bool {
-	if parsed == nil || parsed.Name == "" {
-		return false
-	}
-	m, err := pipeline.ReadCLIManifest(cliDir)
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(m.APIName) == parsed.Name
+	catalogmeta.RebaseAuthEnvPrefix(&parsed.Auth, prior, apiName)
+	parsed.Name = apiName
+	return prior, true
 }
 
 func applyCatalogMetadata(parsed *spec.APISpec) {

--- a/internal/pipeline/mcpsync/sync.go
+++ b/internal/pipeline/mcpsync/sync.go
@@ -80,8 +80,10 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// api_name, manifest.json's name/entry_point, and
 	// cmd/<slug>-pp-{cli,mcp}/ directories under the title-derived slug
 	// — silently flipping a "telegram" CLI to "telegram-bot" mid-sync.
+	manifestNameAuthoritative := manifestAPINameMatchesParsed(cliDir, parsed)
 	if prior := applyManifestNameOverride(cliDir, parsed); prior != "" {
 		fmt.Fprintf(os.Stderr, "mcp-sync: using manifest api_name %q over spec-derived slug %q\n", parsed.Name, prior)
+		manifestNameAuthoritative = true
 	}
 	applyCatalogMetadata(parsed)
 	// Validate that spec.yaml.name matches the directory's basename.
@@ -97,12 +99,14 @@ func Sync(cliDir string, opts Options) (Result, error) {
 	// spec with a stale top-level `name:` field) by rewriting the line in
 	// place. For OpenAPI/GraphQL specs the fix is too invasive, so it
 	// falls through to the validator's --force-required error.
-	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
-	if err != nil && !opts.Force {
-		return Result{}, err
-	}
-	if renamedFrom != "" {
-		fmt.Fprintf(os.Stderr, "mcp-sync: rewrote spec.yaml name from %q to %q to match directory-derived slug\n", renamedFrom, parsed.Name)
+	if !manifestNameAuthoritative {
+		renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+		if err != nil && !opts.Force {
+			return Result{}, err
+		}
+		if renamedFrom != "" {
+			fmt.Fprintf(os.Stderr, "mcp-sync: rewrote spec.yaml name from %q to %q to match directory-derived slug\n", renamedFrom, parsed.Name)
+		}
 	}
 	// Preserve the existing manifest.json's display_name onto the parsed
 	// spec when the spec itself doesn't carry one. Library CLIs printed
@@ -524,6 +528,17 @@ func applyManifestNameOverride(cliDir string, parsed *spec.APISpec) string {
 	return prior
 }
 
+func manifestAPINameMatchesParsed(cliDir string, parsed *spec.APISpec) bool {
+	if parsed == nil || parsed.Name == "" {
+		return false
+	}
+	m, err := pipeline.ReadCLIManifest(cliDir)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(m.APIName) == parsed.Name
+}
+
 func applyCatalogMetadata(parsed *spec.APISpec) {
 	if parsed == nil {
 		return
@@ -656,10 +671,21 @@ var internalSpecNameLine = regexp.MustCompile(`(?m)^name:[ \t]*.*$`)
 // silently. The non-empty renamedFrom return signals the caller to
 // log the rename.
 func reconcileSpecNameWithDir(cliDir string, parsed *spec.APISpec) (renamedFrom string, err error) {
-	if parsed == nil || parsed.Name == "" {
+	if parsed == nil {
 		return "", nil
 	}
 	expected := naming.TrimCLISuffix(filepath.Base(cliDir))
+	if parsed.Name == "" {
+		specPath, data, ok := findInternalYAMLSpec(cliDir)
+		if ok && !internalSpecNameLine.Match(data) {
+			rewritten := append([]byte("name: "+expected+"\n"), data...)
+			if err := writeFileAtomic(specPath, rewritten); err != nil {
+				return "", fmt.Errorf("rewriting %s: %w", specPath, err)
+			}
+		}
+		parsed.Name = expected
+		return "", nil
+	}
 	if expected == parsed.Name {
 		return "", nil
 	}

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -508,6 +508,67 @@ func TestReconcileSpecNameWithDirRejectsDriftEvenOnSuffixedDir(t *testing.T) {
 	assert.NotContains(t, string(after), "weather-goat-pp-cli", "the suffix must never reach the slug-of-record")
 }
 
+func TestReconcileSpecNameWithDirFallsBackToDirSlugWhenNameMissing(t *testing.T) {
+	t.Parallel()
+	cliDir := filepath.Join(t.TempDir(), "nameless-pp-cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	specPath := filepath.Join(cliDir, "spec.yaml")
+	original := "description: Nameless API\nversion: 1.0.0\nbase_url: https://api.example.com\n"
+	require.NoError(t, os.WriteFile(specPath, []byte(original), 0o644))
+
+	parsed := &spec.APISpec{}
+	renamedFrom, err := reconcileSpecNameWithDir(cliDir, parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "", renamedFrom)
+	assert.Equal(t, "nameless", parsed.Name)
+
+	after, err := os.ReadFile(specPath)
+	require.NoError(t, err)
+	assert.Equal(t, "name: nameless\n"+original, string(after))
+}
+
+func TestSyncPreservesManifestSpecNameInTransientRegenDir(t *testing.T) {
+	t.Parallel()
+	apiSpec := &spec.APISpec{
+		Name:        "swell",
+		Description: "Swell API",
+		Version:     "1.0.0",
+		BaseURL:     "https://api.example.com",
+		Auth:        spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/items", Description: "List items"},
+				},
+			},
+		},
+	}
+	cliDir := filepath.Join(t.TempDir(), "swell-pp-cli.regen-test")
+	gen := generator.New(apiSpec, cliDir)
+	require.NoError(t, gen.Generate())
+	specData, err := yaml.Marshal(apiSpec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "spec.yaml"), specData, 0o644))
+	require.NoError(t, pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
+		APIName:   "swell",
+		OutputDir: cliDir,
+		Spec:      apiSpec,
+	}))
+
+	before, err := os.ReadFile(filepath.Join(cliDir, "spec.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(before), "name: swell\n")
+
+	_, err = Sync(cliDir, Options{Force: true})
+	require.NoError(t, err)
+
+	after, err := os.ReadFile(filepath.Join(cliDir, "spec.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "name: swell\n")
+	assert.NotContains(t, string(after), "swell-pp-cli.regen-test")
+}
+
 // TestEnsureMCPGoMinVersionBumpsOldPin — older library CLIs predating
 // the cobratree templates pin a v0.x version that lacks
 // WithReadOnlyHintAnnotation/GetArguments. mcp-sync bumps to the floor
@@ -1494,11 +1555,15 @@ func TestSyncManifestAPINameWinsOverSpecDerivedSlug(t *testing.T) {
 		Name   string `json:"name"`
 		Server struct {
 			EntryPoint string `json:"entry_point"`
+			MCPConfig  struct {
+				Command string `json:"command"`
+			} `json:"mcp_config"`
 		} `json:"server"`
 	}
 	require.NoError(t, json.Unmarshal(manifestData, &manifest))
 	assert.Equal(t, "telegram-pp-mcp", manifest.Name, "MCPB manifest name must derive from manifest api_name")
 	assert.Equal(t, "bin/telegram-pp-mcp", manifest.Server.EntryPoint, "entry_point must derive from manifest api_name, not spec title")
+	assert.Equal(t, "${__dirname}/bin/telegram-pp-mcp", manifest.Server.MCPConfig.Command, "mcp_config.command must derive from manifest api_name, not spec title")
 
 	// No stray cmd/telegram-bot-pp-{cli,mcp}/ directories should have
 	// been created by GenerateMCPSurface.

--- a/internal/pipeline/mcpsync/sync_test.go
+++ b/internal/pipeline/mcpsync/sync_test.go
@@ -1325,7 +1325,7 @@ func TestApplyManifestNameOverrideReplacesParsedName(t *testing.T) {
 			Path:   "~/.config/telegram-bot-pp-cli/config.toml",
 		},
 	}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "telegram-bot", prior, "should report the prior spec-derived slug")
 	assert.Equal(t, "telegram", parsed.Name, "parsed.Name should adopt the manifest's api_name")
 	assert.Equal(t, "~/.config/telegram-pp-cli/config.toml", parsed.Config.Path,
@@ -1379,7 +1379,7 @@ func TestApplyManifestNameOverrideNoOpWhenManifestAgrees(t *testing.T) {
 			Path:   "~/.config/producthunt-pp-cli/config.toml",
 		},
 	}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "", prior, "agreement should report no override")
 	assert.Equal(t, "producthunt", parsed.Name)
 	assert.Equal(t, "~/.config/producthunt-pp-cli/config.toml", parsed.Config.Path)
@@ -1400,7 +1400,7 @@ func TestApplyManifestNameOverrideMissingManifest(t *testing.T) {
 			Path:   "~/.config/legacy-api-pp-cli/config.toml",
 		},
 	}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "", prior, "missing manifest should report no override")
 	assert.Equal(t, "legacy-api", parsed.Name, "parsed.Name must be untouched when manifest is absent")
 	assert.Equal(t, "~/.config/legacy-api-pp-cli/config.toml", parsed.Config.Path)
@@ -1423,7 +1423,7 @@ func TestApplyManifestNameOverrideMalformedJSON(t *testing.T) {
 	))
 
 	parsed := &spec.APISpec{Name: "spec-derived"}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "", prior, "malformed manifest must not produce an override")
 	assert.Equal(t, "spec-derived", parsed.Name, "parsed.Name must be preserved when the manifest cannot be parsed")
 }
@@ -1441,7 +1441,7 @@ func TestApplyManifestNameOverrideEmptyAPIName(t *testing.T) {
 	}))
 
 	parsed := &spec.APISpec{Name: "partial-api"}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "", prior)
 	assert.Equal(t, "partial-api", parsed.Name, "empty api_name must not override")
 }
@@ -1467,7 +1467,7 @@ func TestApplyManifestNameOverridePreservesCustomConfigPath(t *testing.T) {
 			Path:   "$XDG_CONFIG_HOME/telegram/config.toml",
 		},
 	}
-	prior := applyManifestNameOverride(cliDir, parsed)
+	prior, _ := applyManifestNameOverride(cliDir, parsed)
 	assert.Equal(t, "telegram-bot", prior)
 	assert.Equal(t, "telegram", parsed.Name)
 	assert.Equal(t, "$XDG_CONFIG_HOME/telegram/config.toml", parsed.Config.Path,


### PR DESCRIPTION
## What

**#2336 — `mcp-sync` mangles the spec name in transient regen dirs.** `mcp-sync
<cli-dir>` rewrote the spec's `name:` from the working-directory basename, so running
it on a transient dir like `swell-pp-cli.regen-20260525-225102` mangled the spec name
to that timestamp and broke downstream `dogfood`/`validate-narrative` ("narrative refers
to commands under <wrong-name>"). The fix treats a manifest `api_name` that matches the
parsed spec name (or a manifest-name override) as authoritative and skips the
dir-basename rewrite; it only falls back to the dir slug when the spec `name:` is
missing entirely.

## Note on #2604 (regression guard only)

This PR also adds a regression guard pinning the MCPB `manifest.json`
name/entry_point/command to the resolved MCP binary slug. **That behavior is already
correct at HEAD** — `mcpb_manifest.go` derives all three from `m.MCPBinary` — so there
is no production change for #2604 here; the guard simply locks in the renamed/dotted
case (`intervals.icu` → `intervals-icu`) so it cannot silently regress. Filing this as
`Refs #2604`, not `Fixes`.

## Testing

- New tests: `mcp-sync` on a `…regen-test` dir preserves `name: swell`; a spec with no
  `name:` still falls back to the dir slug; the MCPB guard asserts a `--name foo-bar`
  CLI with spec title `foo.bar` yields `foo-bar-pp-mcp` with no `foo.bar` substring.
- Golden suite regenerated; full `go test ./...` green.

Fixes #2336
Refs #2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)
