### PR TITLE
fix(cli): inject MCP server version via ldflag instead of hardcoded 1.0.0

### DIFF
--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -2532,10 +2532,13 @@ import (
 	mcptools "{{.ModulePath}}/internal/mcp"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		{{quote .DisplayName}},
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 	mcptools.RegisterTools(s)

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -113,6 +113,7 @@ func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
 	assert.Contains(t, goreleaser, "main: ./cmd/"+naming.CLI(ds.Name))
 	assert.Contains(t, goreleaser, "main: ./cmd/"+naming.MCP(ds.Name))
 	assert.Contains(t, goreleaser, naming.CLI(ds.Name)+"/internal/cli.version=")
+	assert.Contains(t, goreleaser, "-X main.version={{ .Version }}")
 	assert.Contains(t, goreleaser, `description: "`)
 
 	// AGENTS.md is the device-aware variant: it uses BLE/replay concepts and the

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -163,6 +163,15 @@ func TestGeneratedBLEDeviceEmitsMCPSurface(t *testing.T) {
 	assert.FileExists(t, filepath.Join(outputDir, "cmd", naming.MCP(ds.Name), "main.go"))
 	assert.FileExists(t, filepath.Join(outputDir, "internal", "mcp", "cobratree", "walker.go"))
 
+	mcpMainSrc, err := os.ReadFile(filepath.Join(outputDir, "cmd", naming.MCP(ds.Name), "main.go"))
+	require.NoError(t, err)
+	mcpMain := string(mcpMainSrc)
+	// The MCP server version must be an ldflag-overridable var, not a hardcoded
+	// literal — the device .goreleaser injects -X main.version at release time, so
+	// a bare "1.0.0" in NewMCPServer would make that injection a silent no-op.
+	assert.Contains(t, mcpMain, `var version = "1.0.0"`)
+	assert.NotContains(t, mcpMain, "\n\t\t\"1.0.0\",\n\t\tserver.WithToolCapabilities(false),")
+
 	toolsSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)
 	tools := string(toolsSrc)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14551,6 +14551,7 @@ func TestGenerateMCPMainSmallAPIDefaultsHTTP(t *testing.T) {
 	} {
 		assert.Contains(t, body, want, "small-API auto-http default should emit %q", want)
 	}
+	assertMCPMainUsesVersionVar(t, body)
 }
 
 // TestGenerateMCPMainExplicitStdioOnlyHonored covers the negative half of
@@ -14577,6 +14578,7 @@ func TestGenerateMCPMainExplicitStdioOnlyHonored(t *testing.T) {
 	assert.NotContains(t, body, "flag.String", "explicit stdio-only spec must not pull in the flag package")
 	assert.NotContains(t, body, "NewStreamableHTTPServer", "explicit stdio-only spec must not reference the HTTP transport")
 	assert.NotContains(t, body, "PP_MCP_TRANSPORT", "explicit stdio-only spec must not reference the transport env override")
+	assertMCPMainUsesVersionVar(t, body)
 }
 
 // TestGenerateMCPMainLargeAPIDefaultsCodeOrchestration confirms that large
@@ -14705,6 +14707,16 @@ func TestGenerateMCPMainRemoteOptIn(t *testing.T) {
 	} {
 		assert.Contains(t, body, want, "remote-opt-in main should contain %q", want)
 	}
+	assertMCPMainUsesVersionVar(t, body)
+}
+
+func assertMCPMainUsesVersionVar(t *testing.T, body string) {
+	t.Helper()
+
+	assert.Contains(t, body, `var version = "1.0.0"`)
+	assert.Contains(t, body, "server.NewMCPServer(")
+	assert.Contains(t, body, "\n\t\tversion,\n\t\tserver.WithToolCapabilities(false),")
+	assert.NotContains(t, body, "\n\t\t\"1.0.0\",\n\t\tserver.WithToolCapabilities(false),")
 }
 
 // TestGenerateMCPCodeOrchestrationEmitsSearchExecute proves that when the

--- a/internal/generator/templates/goreleaser.yaml.tmpl
+++ b/internal/generator/templates/goreleaser.yaml.tmpl
@@ -24,7 +24,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{"{{"}} .Version {{"}}"}}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/internal/generator/templates/main_mcp.go.tmpl
+++ b/internal/generator/templates/main_mcp.go.tmpl
@@ -25,10 +25,13 @@ const (
 	defaultHTTPAddr = "{{if .MCP.Addr}}{{.MCP.Addr}}{{else}}:7777{{end}}"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"{{.EffectiveDisplayName}}",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 
@@ -78,10 +81,13 @@ import (
 	mcptools "{{modulePath}}/internal/mcp"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"{{.EffectiveDisplayName}}",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/.goreleaser.yaml
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/cmd/ble-temperature-sensor-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/cmd/ble-temperature-sensor-pp-mcp/main.go
@@ -11,10 +11,13 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"BLE Temperature Sensor",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 	mcptools.RegisterTools(s)

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
@@ -23,10 +23,13 @@ const (
 	defaultHTTPAddr = ":7777"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"Café Bistro",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
@@ -23,10 +23,13 @@ const (
 	defaultHTTPAddr = ":7777"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"Printing Press Studio",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
@@ -23,10 +23,13 @@ const (
 	defaultHTTPAddr = ":7777"
 )
 
+// version is the printed MCP server's version, overridable at build time via ldflags.
+var version = "1.0.0"
+
 func main() {
 	s := server.NewMCPServer(
 		"Mcp Cloudflare",
-		"1.0.0",
+		version,
 		server.WithToolCapabilities(false),
 	)
 


### PR DESCRIPTION
fix(cli): inject MCP server version via ldflag instead of hardcoded 1.0.0

The generated MCP server passed a literal "1.0.0" to server.NewMCPServer in both
transport branches, so the MCP binary always reported 1.0.0 regardless of the
release tag. Declare a package-level `var version = "1.0.0"` (overridable at build
time) and inject it on the MCP goreleaser build entry via `-X main.version`,
mirroring how the CLI binary's version is injected. Covers Bug 2 of #2387 (MCP
server-info version); the MCPB-manifest version (#2387 Bug 1) needs
release-tag-at-bundle-time design and is left out.

Fixes #2554.
Refs #2387.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
