### PR TITLE
fix(cli): annotate read-only framework MCP commands

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15469,6 +15469,38 @@ func TestProjectManagementWorkflowsEmitReadOnlyAnnotations(t *testing.T) {
 	}
 }
 
+func TestGeneratedFrameworkCommandsEmitReadOnlyAnnotations(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("framework-readonly")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	readFile := func(name string) string {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", name))
+		require.NoError(t, err)
+		return string(data)
+	}
+	readonlyAnnotation := regexp.MustCompile(`"mcp:read-only":\s+"true"`)
+
+	whichSrc := readFile("which.go")
+	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, whichSrc, "func newWhichCmd(flags *rootFlags) *cobra.Command"),
+		"which only reads the generated capability index")
+
+	feedbackSrc := readFile("feedback.go")
+	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, feedbackSrc, "func newFeedbackListCmd(flags *rootFlags) *cobra.Command"),
+		"feedback list only reads the local feedback ledger")
+
+	profileSrc := readFile("profile.go")
+	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, profileSrc, "func newProfileListCmd(flags *rootFlags) *cobra.Command"),
+		"profile list only reads the local profile store")
+	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, profileSrc, "func newProfileShowCmd(flags *rootFlags) *cobra.Command"),
+		"profile show only reads the local profile store")
+	assert.NotRegexp(t, readonlyAnnotation, generatedFunctionBody(t, profileSrc, "func newProfileUseCmd(flags *rootFlags) *cobra.Command"),
+		"profile use must not be emitted as mcp read-only true")
+}
+
 func TestProjectManagementWorkflowsEmitSyncHints(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15491,6 +15491,8 @@ func TestGeneratedFrameworkCommandsEmitReadOnlyAnnotations(t *testing.T) {
 	feedbackSrc := readFile("feedback.go")
 	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, feedbackSrc, "func newFeedbackListCmd(flags *rootFlags) *cobra.Command"),
 		"feedback list only reads the local feedback ledger")
+	assert.NotRegexp(t, readonlyAnnotation, generatedFunctionBody(t, feedbackSrc, "func newFeedbackCmd(flags *rootFlags) *cobra.Command"),
+		"feedback (record/POST) must not be emitted as mcp read-only true")
 
 	profileSrc := readFile("profile.go")
 	assert.Regexp(t, readonlyAnnotation, generatedFunctionBody(t, profileSrc, "func newProfileListCmd(flags *rootFlags) *cobra.Command"),

--- a/internal/generator/templates/feedback.go.tmpl
+++ b/internal/generator/templates/feedback.go.tmpl
@@ -184,6 +184,9 @@ func newFeedbackListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recent feedback entries",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  {{.Name}}-pp-cli feedback list
   {{.Name}}-pp-cli feedback list --limit 5
   {{.Name}}-pp-cli feedback list --json`,

--- a/internal/generator/templates/profile.go.tmpl
+++ b/internal/generator/templates/profile.go.tmpl
@@ -253,6 +253,9 @@ func newProfileListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List saved profiles",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  {{.Name}}-pp-cli profile list
   {{.Name}}-pp-cli profile list --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -292,6 +295,9 @@ func newProfileShowCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <name>",
 		Short: "Show a profile's values as JSON",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  {{.Name}}-pp-cli profile show my-defaults
   {{.Name}}-pp-cli profile show tonight-defaults --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -137,6 +137,7 @@ func newWhichCmd(flags *rootFlags) *cobra.Command {
 		Use:   "which [query]",
 		Short: "Find the command that implements a capability",
 		Annotations: map[string]string{
+			"mcp:read-only":        "true",
 			"pp:typed-exit-codes": "0,2",
 		},
 		Long: `which resolves a natural-language capability query (for example, "search messages" or "stale tickets") to the best matching command from this CLI's curated feature index.

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/feedback.go
@@ -184,6 +184,9 @@ func newFeedbackListCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recent feedback entries",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  printing-press-golden-pp-cli feedback list
   printing-press-golden-pp-cli feedback list --limit 5
   printing-press-golden-pp-cli feedback list --json`,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/profile.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/profile.go
@@ -253,6 +253,9 @@ func newProfileListCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List saved profiles",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  printing-press-golden-pp-cli profile list
   printing-press-golden-pp-cli profile list --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -292,6 +295,9 @@ func newProfileShowCmd(flags *rootFlags) *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <name>",
 		Short: "Show a profile's values as JSON",
+		Annotations: map[string]string{
+			"mcp:read-only": "true",
+		},
 		Example: `  printing-press-golden-pp-cli profile show my-defaults
   printing-press-golden-pp-cli profile show tonight-defaults --json`,
 		Args: cobra.ExactArgs(1),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -140,6 +140,7 @@ func newWhichCmd(flags *rootFlags) *cobra.Command {
 		Use:   "which [query]",
 		Short: "Find the command that implements a capability",
 		Annotations: map[string]string{
+			"mcp:read-only":       "true",
 			"pp:typed-exit-codes": "0,2",
 		},
 		Long: `which resolves a natural-language capability query (for example, "search messages" or "stale tickets") to the best matching command from this CLI's curated feature index.


### PR DESCRIPTION
fix(cli): annotate read-only framework MCP commands

Several generator-emitted framework commands lacked the `mcp:read-only`
annotation the MCP layer uses to mark a tool non-mutating. Add `"mcp:read-only":
"true"` to the read-only commands — `which`, `feedback list`, `profile list`,
`profile show` — following the analytics template's pattern. State-changing
commands are intentionally not marked read-only: `profile use` mutates the active
profile and `feedback` submit writes/POSTs, so they are left unannotated.

Fixes #2597.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
