### PR TITLE
fix(cli): gate sync search hint, dogfood-safe tail follow, 400 argument-missing warning

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3114,6 +3114,7 @@ func (g *Generator) renderStoreFiles(schema []TableDef) error {
 
 type visionRenderData struct {
 	*spec.APISpec
+	VisionSet                    VisionTemplateSet
 	SyncableResources            []profiler.SyncableResource
 	DependentSyncResources       []profiler.DependentResource
 	PaginationSupportedResources []string
@@ -3271,6 +3272,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 
 	return visionRenderData{
 		APISpec:                      g.Spec,
+		VisionSet:                    g.VisionSet,
 		SyncableResources:            g.profile.SyncableResources,
 		DependentSyncResources:       g.profile.DependentSyncResources,
 		PaginationSupportedResources: paginationSupportedResources(g.profile.SyncableResources, g.profile.DependentSyncResources),

--- a/internal/generator/template_batch3_test.go
+++ b/internal/generator/template_batch3_test.go
@@ -1,0 +1,185 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedSyncHelpSearchHintTracksEmittedSearchCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		gql     bool
+		search  bool
+		wantTip bool
+	}{
+		{name: "rest without search", search: false, wantTip: false},
+		{name: "rest with search", search: true, wantTip: true},
+		{name: "graphql without search", gql: true, search: false, wantTip: false},
+		{name: "graphql with search", gql: true, search: true, wantTip: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiSpec := batch3SyncSpec("batch3-"+tc.name, tc.gql)
+			outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+			gen := New(apiSpec, outputDir)
+			gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: tc.search}
+			require.NoError(t, gen.Generate())
+
+			syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTip, strings.Contains(string(syncGo), "Once synced, use the 'search' command"),
+				"sync help search hint must match VisionSet.Search")
+
+			_, err = os.Stat(filepath.Join(outputDir, "internal", "cli", "search.go"))
+			if tc.search {
+				require.NoError(t, err, "search.go should be emitted when VisionSet.Search is true")
+			} else {
+				require.ErrorIs(t, err, os.ErrNotExist, "search.go should not be emitted when VisionSet.Search is false")
+			}
+		})
+	}
+}
+
+func TestGeneratedTailShortCircuitsFollowUnderDogfood(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := batch3SyncSpec("batch3-tail", false)
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Tail: true}
+	require.NoError(t, gen.Generate())
+
+	tailGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "tail.go"))
+	require.NoError(t, err)
+	tailSrc := string(tailGo)
+	assert.Contains(t, tailSrc, naming.CLI(apiSpec.Name)+`/internal/cliutil"`)
+	assert.Contains(t, tailSrc, "if cliutil.IsDogfoodEnv() {\n\t\t\t\tfollow = false\n\t\t\t}")
+	assert.Contains(t, tailSrc, "if !follow {\n\t\t\t\treturn nil\n\t\t\t}")
+	assert.Less(t, strings.Index(tailSrc, "if !follow {"), strings.Index(tailSrc, "ticker := time.NewTicker(interval)"),
+		"tail must return after one poll before creating the follow ticker")
+}
+
+func TestGeneratedSyncTreatsArgumentMissing400AsWarning(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := batch3SyncSpec("batch3-argument-missing", false)
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Header:  "Authorization",
+		EnvVars: []string{"BATCH3_TOKEN"},
+	}
+	apiSpec.Config = spec.ConfigSpec{
+		Format: "toml",
+		Path:   "~/.config/batch3-argument-missing-pp-cli/config.toml",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	helpersGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
+	require.NoError(t, err)
+	helpersSrc := string(helpersGo)
+	assert.Contains(t, helpersSrc, "func looksLikeArgumentMissing(body string) bool")
+	assert.Contains(t, helpersSrc, `Reason: "argument_missing"`)
+
+	behaviorTest := fmt.Sprintf(`package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"%s/internal/client"
+)
+
+func TestIsSyncAccessWarningArgumentMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"argument missing", "argument missing: project_id", true},
+		{"required field missing", "required parameter project_id is missing", true},
+		{"missing required", "missing required filter: task_id", true},
+		{"no id provided", "No id to filter notes provided", true},
+		{"unrelated bad request", "invalid cursor", false},
+		{"required field format invalid", "required field 'email' format is invalid and the avatar is missing", false},
+		{"no results provided", "no results were provided by the upstream cache", false},
+		{"payment required receipt missing", "Payment required but the receipt is missing", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, ok := isSyncAccessWarning(fmt.Errorf("sync comments: %%w", &client.APIError{Method: "GET", Path: "/comments", StatusCode: 400, Body: tc.body}))
+			if ok != tc.want {
+				t.Fatalf("ok = %%v, want %%v", ok, tc.want)
+			}
+			if !tc.want {
+				return
+			}
+			if w.Status != 400 {
+				t.Fatalf("status = %%d, want 400", w.Status)
+			}
+			if w.Reason != "argument_missing" {
+				t.Fatalf("reason = %%q, want argument_missing", w.Reason)
+			}
+		})
+	}
+	if _, ok := isSyncAccessWarning(errors.New("plain error")); ok {
+		t.Fatal("plain error classified as sync warning")
+	}
+}
+`, naming.CLI(apiSpec.Name))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_argument_missing_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestIsSyncAccessWarningArgumentMissing")
+}
+
+func batch3SyncSpec(name string, gql bool) *spec.APISpec {
+	path := "/items"
+	responsePath := ""
+	if gql {
+		path = "/graphql"
+		responsePath = "data.items"
+	}
+	return &spec.APISpec{
+		Name:        name,
+		Version:     "0.1.0",
+		Description: "Batch 3 template fixture",
+		BaseURL:     "https://api.example.com",
+		Resources: map[string]spec.Resource{
+			"items": {
+				Description: "Items",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:       "GET",
+						Path:         path,
+						Description:  "List items",
+						ResponsePath: responsePath,
+						Response:     spec.ResponseDef{Type: "array"},
+						Pagination:   &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Item": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "title", Type: "string"},
+				},
+			},
+		},
+	}
+}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -44,9 +44,11 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
+	Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+{{if .VisionSet.Search}}
 Once synced, use the 'search' command for instant full-text search.
+{{end}}
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, HTTP 400 with an

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -46,9 +46,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 	Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
-{{if .VisionSet.Search}}
+{{- if .VisionSet.Search}}
 Once synced, use the 'search' command for instant full-text search.
-{{end}}
+{{- end}}
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, HTTP 400 with an

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -528,6 +528,30 @@ func looksLikeAccessDenial(body string) bool {
 	return false
 }
 
+// argumentMissingPatterns matches API error bodies that indicate the endpoint
+// requires a filter or identifier the vendor spec did not mark as required.
+// Each pattern keeps the missing/required/not-provided signal adjacent to an
+// argument noun so an unrelated 400 (e.g. "required field 'email' format is
+// invalid and the avatar is missing", "no results were provided") is not
+// demoted from a hard failure to a warning.
+var argumentMissingPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bargument(?:\s+is)?\s+missing\b`),
+	regexp.MustCompile(`\bmissing\s+(?:a\s+|an\s+|the\s+)?(?:required\s+)?(?:argument|parameter|param|field|filter|identifier|id)\b`),
+	regexp.MustCompile(`\brequired\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\b(?:is\s+)?(?:missing|not\s+provided|not\s+supplied)\b`),
+	regexp.MustCompile(`\b(?:argument|parameter|param|filter)\s+(?:is\s+)?required\b`),
+	regexp.MustCompile(`\bno\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\bprovided\b`),
+}
+
+func looksLikeArgumentMissing(body string) bool {
+	lower := strings.ToLower(body)
+	for _, p := range argumentMissingPatterns {
+		if p.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSyncAccessWarning classifies err as an access-denial warning suitable for
 // sync's warn-and-continue path. It returns nil, false for any error that
 // should remain a hard sync failure: HTTP 401 (token-level auth failure
@@ -537,6 +561,7 @@ func looksLikeAccessDenial(body string) bool {
 // Recognized warning shapes:
 //   - HTTP 403 (per-resource ACL rejection)
 //   - HTTP 400 + access-denial body keyword (insufficient scope, etc.)
+//   - HTTP 400 + missing required argument body keyword
 //   - GraphQL response carrying only access-denial extension codes
 func isSyncAccessWarning(err error) (*accessWarning, bool) {
 	if err == nil {
@@ -551,6 +576,9 @@ func isSyncAccessWarning(err error) (*accessWarning, bool) {
 		case 400:
 			if looksLikeAccessDenial(apiErr.Body) {
 				return &accessWarning{Status: 400, Reason: "insufficient_access", Message: apiErr.Body}, true
+			}
+			if looksLikeArgumentMissing(apiErr.Body) {
+				return &accessWarning{Status: 400, Reason: "argument_missing", Message: apiErr.Body}, true
 			}
 		}
 	}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -98,9 +98,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 	Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
-{{if .VisionSet.Search}}
+{{- if .VisionSet.Search}}
 Once synced, use the 'search' command for instant full-text search.
-{{end}}
+{{- end}}
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -96,9 +96,11 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
+	Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+{{if .VisionSet.Search}}
 Once synced, use the 'search' command for instant full-text search.
+{{end}}
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -73,7 +73,9 @@ native streaming instead of polling.`,
 
 			enc := json.NewEncoder(os.Stdout)
 
-			fmt.Fprintf(os.Stderr, "Tailing %s every %s (Ctrl+C to stop)\n", resource, interval)
+			if follow {
+				fmt.Fprintf(os.Stderr, "Tailing %s every %s (Ctrl+C to stop)\n", resource, interval)
+			}
 
 			// Initial fetch
 			if err := fetchAndEmit(cmd.Context(), c, path, enc); err != nil {

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"{{modulePath}}/internal/cliutil"
 	"github.com/spf13/cobra"
 )
 
@@ -61,14 +62,14 @@ native streaming instead of polling.`,
 				return err
 			}
 			c.NoCache = true
+			if cliutil.IsDogfoodEnv() {
+				follow = false
+			}
 
 			path := "/" + resource
 
 			sig := make(chan os.Signal, 1)
 			signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
-
-			ticker := time.NewTicker(interval)
-			defer ticker.Stop()
 
 			enc := json.NewEncoder(os.Stdout)
 
@@ -78,6 +79,12 @@ native streaming instead of polling.`,
 			if err := fetchAndEmit(cmd.Context(), c, path, enc); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: initial fetch failed: %v\n", err)
 			}
+			if !follow {
+				return nil
+			}
+
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
 
 			for {
 				select {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -374,6 +374,30 @@ func looksLikeAccessDenial(body string) bool {
 	return false
 }
 
+// argumentMissingPatterns matches API error bodies that indicate the endpoint
+// requires a filter or identifier the vendor spec did not mark as required.
+// Each pattern keeps the missing/required/not-provided signal adjacent to an
+// argument noun so an unrelated 400 (e.g. "required field 'email' format is
+// invalid and the avatar is missing", "no results were provided") is not
+// demoted from a hard failure to a warning.
+var argumentMissingPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bargument(?:\s+is)?\s+missing\b`),
+	regexp.MustCompile(`\bmissing\s+(?:a\s+|an\s+|the\s+)?(?:required\s+)?(?:argument|parameter|param|field|filter|identifier|id)\b`),
+	regexp.MustCompile(`\brequired\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\b(?:is\s+)?(?:missing|not\s+provided|not\s+supplied)\b`),
+	regexp.MustCompile(`\b(?:argument|parameter|param|filter)\s+(?:is\s+)?required\b`),
+	regexp.MustCompile(`\bno\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\bprovided\b`),
+}
+
+func looksLikeArgumentMissing(body string) bool {
+	lower := strings.ToLower(body)
+	for _, p := range argumentMissingPatterns {
+		if p.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSyncAccessWarning classifies err as an access-denial warning suitable for
 // sync's warn-and-continue path. It returns nil, false for any error that
 // should remain a hard sync failure: HTTP 401 (token-level auth failure
@@ -383,6 +407,7 @@ func looksLikeAccessDenial(body string) bool {
 // Recognized warning shapes:
 //   - HTTP 403 (per-resource ACL rejection)
 //   - HTTP 400 + access-denial body keyword (insufficient scope, etc.)
+//   - HTTP 400 + missing required argument body keyword
 //   - GraphQL response carrying only access-denial extension codes
 func isSyncAccessWarning(err error) (*accessWarning, bool) {
 	if err == nil {
@@ -397,6 +422,9 @@ func isSyncAccessWarning(err error) (*accessWarning, bool) {
 		case 400:
 			if looksLikeAccessDenial(apiErr.Body) {
 				return &accessWarning{Status: 400, Reason: "insufficient_access", Message: apiErr.Body}, true
+			}
+			if looksLikeArgumentMissing(apiErr.Body) {
+				return &accessWarning{Status: 400, Reason: "argument_missing", Message: apiErr.Body}, true
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -373,6 +373,30 @@ func looksLikeAccessDenial(body string) bool {
 	return false
 }
 
+// argumentMissingPatterns matches API error bodies that indicate the endpoint
+// requires a filter or identifier the vendor spec did not mark as required.
+// Each pattern keeps the missing/required/not-provided signal adjacent to an
+// argument noun so an unrelated 400 (e.g. "required field 'email' format is
+// invalid and the avatar is missing", "no results were provided") is not
+// demoted from a hard failure to a warning.
+var argumentMissingPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bargument(?:\s+is)?\s+missing\b`),
+	regexp.MustCompile(`\bmissing\s+(?:a\s+|an\s+|the\s+)?(?:required\s+)?(?:argument|parameter|param|field|filter|identifier|id)\b`),
+	regexp.MustCompile(`\brequired\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\b(?:is\s+)?(?:missing|not\s+provided|not\s+supplied)\b`),
+	regexp.MustCompile(`\b(?:argument|parameter|param|filter)\s+(?:is\s+)?required\b`),
+	regexp.MustCompile(`\bno\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\bprovided\b`),
+}
+
+func looksLikeArgumentMissing(body string) bool {
+	lower := strings.ToLower(body)
+	for _, p := range argumentMissingPatterns {
+		if p.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSyncAccessWarning classifies err as an access-denial warning suitable for
 // sync's warn-and-continue path. It returns nil, false for any error that
 // should remain a hard sync failure: HTTP 401 (token-level auth failure
@@ -382,6 +406,7 @@ func looksLikeAccessDenial(body string) bool {
 // Recognized warning shapes:
 //   - HTTP 403 (per-resource ACL rejection)
 //   - HTTP 400 + access-denial body keyword (insufficient scope, etc.)
+//   - HTTP 400 + missing required argument body keyword
 //   - GraphQL response carrying only access-denial extension codes
 func isSyncAccessWarning(err error) (*accessWarning, bool) {
 	if err == nil {
@@ -396,6 +421,9 @@ func isSyncAccessWarning(err error) (*accessWarning, bool) {
 		case 400:
 			if looksLikeAccessDenial(apiErr.Body) {
 				return &accessWarning{Status: 400, Reason: "insufficient_access", Message: apiErr.Body}, true
+			}
+			if looksLikeArgumentMissing(apiErr.Body) {
+				return &accessWarning{Status: 400, Reason: "argument_missing", Message: apiErr.Body}, true
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 67
+    "total": 68
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -449,6 +449,30 @@ func looksLikeAccessDenial(body string) bool {
 	return false
 }
 
+// argumentMissingPatterns matches API error bodies that indicate the endpoint
+// requires a filter or identifier the vendor spec did not mark as required.
+// Each pattern keeps the missing/required/not-provided signal adjacent to an
+// argument noun so an unrelated 400 (e.g. "required field 'email' format is
+// invalid and the avatar is missing", "no results were provided") is not
+// demoted from a hard failure to a warning.
+var argumentMissingPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bargument(?:\s+is)?\s+missing\b`),
+	regexp.MustCompile(`\bmissing\s+(?:a\s+|an\s+|the\s+)?(?:required\s+)?(?:argument|parameter|param|field|filter|identifier|id)\b`),
+	regexp.MustCompile(`\brequired\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\b(?:is\s+)?(?:missing|not\s+provided|not\s+supplied)\b`),
+	regexp.MustCompile(`\b(?:argument|parameter|param|filter)\s+(?:is\s+)?required\b`),
+	regexp.MustCompile(`\bno\s+(?:argument|parameter|param|filter|identifier|id)\b[^.\n]*\bprovided\b`),
+}
+
+func looksLikeArgumentMissing(body string) bool {
+	lower := strings.ToLower(body)
+	for _, p := range argumentMissingPatterns {
+		if p.MatchString(lower) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSyncAccessWarning classifies err as an access-denial warning suitable for
 // sync's warn-and-continue path. It returns nil, false for any error that
 // should remain a hard sync failure: HTTP 401 (token-level auth failure
@@ -458,6 +482,7 @@ func looksLikeAccessDenial(body string) bool {
 // Recognized warning shapes:
 //   - HTTP 403 (per-resource ACL rejection)
 //   - HTTP 400 + access-denial body keyword (insufficient scope, etc.)
+//   - HTTP 400 + missing required argument body keyword
 //   - GraphQL response carrying only access-denial extension codes
 func isSyncAccessWarning(err error) (*accessWarning, bool) {
 	if err == nil {
@@ -472,6 +497,9 @@ func isSyncAccessWarning(err error) (*accessWarning, bool) {
 		case 400:
 			if looksLikeAccessDenial(apiErr.Body) {
 				return &accessWarning{Status: 400, Reason: "insufficient_access", Message: apiErr.Body}, true
+			}
+			if looksLikeArgumentMissing(apiErr.Body) {
+				return &accessWarning{Status: 400, Reason: "argument_missing", Message: apiErr.Body}, true
 			}
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -59,9 +59,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
-
 Once synced, use the 'search' command for instant full-text search.
-
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -59,7 +59,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+
 Once synced, use the 'search' command for instant full-text search.
+
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -59,7 +59,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
-Once synced, use the 'search' command for instant full-text search.
+
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -60,7 +60,6 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
 
-
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an
   access-policy body) are reported as warnings rather than failing the

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -59,7 +59,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
-Once synced, use the 'search' command for instant full-text search.
+
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -60,7 +60,6 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
 
-
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an
   access-policy body) are reported as warnings rather than failing the


### PR DESCRIPTION
fix(cli): gate sync search hint, dogfood-safe tail follow, 400 argument-missing warning

Three generated-CLI fixes:

- sync --help unconditionally referenced the 'search' command even for CLIs that
  don't emit one. Gate the hint (in both the REST and GraphQL sync templates) on
  VisionSet.Search — the same signal that decides whether the search command is
  generated.
- `tail --follow` ran an unbounded ticker loop, so dogfood probes hung. Short-
  circuit to a single poll under the dogfood env (cliutil.IsDogfoodEnv); also wires
  the previously-dead `--follow=false` to exit after the initial poll.
- A 400 whose body indicates a missing required argument/parameter/filter is now
  surfaced as a sync warning (reason argument_missing). Patterns keep the
  missing/required signal adjacent to an argument noun so an unrelated 400 is not
  demoted from a hard failure under --strict.

Fixes #2472.
Fixes #2421.
Fixes #2430.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
