### PR TITLE
fix(cli): strip *.test on publish, dedup -pp slug, crowd-sniff drop summary

### DIFF
--- a/internal/cli/crowd_sniff.go
+++ b/internal/cli/crowd_sniff.go
@@ -134,6 +134,7 @@ func runCrowdSniff(ctx context.Context, apiName, baseURL, outputPath string, asJ
 			for _, d := range dropped {
 				fmt.Fprintf(stderr, "  dropped: %s %s (origin(s): %s)\n", d.Method, d.Path, strings.Join(d.OriginBaseURLs, ", "))
 			}
+			fmt.Fprintf(stderr, "WARNING: dropped %d endpoint(s); generated spec covers only target host %s; review the drops above.\n", len(dropped), targetHost)
 		}
 		aggregated = kept
 	}

--- a/internal/cli/crowd_sniff_test.go
+++ b/internal/cli/crowd_sniff_test.go
@@ -233,6 +233,45 @@ func TestRunCrowdSniff_SourceErrorGracefulDegradation(t *testing.T) {
 	assert.Contains(t, string(data), "https://api.example.com")
 }
 
+func TestRunCrowdSniff_HostFilterDropSummary(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+	outputPath := filepath.Join(outputDir, "test-spec.yaml")
+	var stderr bytes.Buffer
+
+	opts := crowdSniffOptions{
+		sources: []crowdSniffSource{
+			&mockSource{result: endpointsResult("https://api.example.com",
+				crowdsniff.DiscoveredEndpoint{
+					Method:        "GET",
+					Path:          "/users",
+					SourceTier:    crowdsniff.TierOfficialSDK,
+					SourceName:    "sdk",
+					OriginBaseURL: "https://api.example.com",
+				},
+				crowdsniff.DiscoveredEndpoint{
+					Method:        "POST",
+					Path:          "/uploads",
+					SourceTier:    crowdsniff.TierOfficialSDK,
+					SourceName:    "sdk",
+					OriginBaseURL: "https://uploads.example.com",
+				},
+			)},
+		},
+		stdout: &bytes.Buffer{},
+		stderr: &stderr,
+	}
+
+	err := runCrowdSniff(context.Background(), "test", "https://api.example.com", outputPath, false, opts)
+	require.NoError(t, err)
+
+	errOut := stderr.String()
+	assert.Contains(t, errOut, "filtered 1 endpoint(s) from other origins (target host: api.example.com)")
+	assert.Contains(t, errOut, "  dropped: POST /uploads (origin(s): https://uploads.example.com)")
+	assert.Contains(t, errOut, "WARNING: dropped 1 endpoint(s); generated spec covers only target host api.example.com; review the drops above.")
+}
+
 func TestRunCrowdSniff_AllSourcesFail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -392,6 +392,17 @@ func newPublishPackageCmd() *cobra.Command {
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged binary %s: %w", name, err)}
 				}
 			}
+			testBinaries, err := filepath.Glob(filepath.Join(outCLIDir, "*.test"))
+			if err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("finding staged test binaries: %w", err)}
+			}
+			for _, path := range testBinaries {
+				if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+					cleanupOnFailure()
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged test binary %s: %w", filepath.Base(path), err)}
+				}
+			}
 
 			// Rewrite go.mod module path if --module-path is set
 			if modulePath != "" {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -905,9 +905,11 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 		"test",        // phantom bare-slug binary
 		"test-pp-cli", // primary CLI binary
 		"test-pp-mcp", // MCP peer binary (now covered by both code-level strip and skill cleanup)
+		"cli.test",    // compiled `go test -c` binary
 	} {
 		require.NoError(t, os.WriteFile(filepath.Join(cliDir, name), []byte("\x7fELF"), 0o755))
 	}
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "root_test.go"), []byte("package main\n"), 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
 	cmd := newPublishCmd()
@@ -920,16 +922,17 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(output), &result))
 
 	// Source binaries stay — we don't mutate the operator's working tree.
-	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp"} {
+	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp", "cli.test", "root_test.go"} {
 		_, srcErr := os.Stat(filepath.Join(cliDir, name))
-		assert.NoError(t, srcErr, "package must not delete source-tree binary %s", name)
+		assert.NoError(t, srcErr, "package must not delete source-tree file %s", name)
 	}
 
 	// Staged tree must have none of them.
-	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp"} {
+	for _, name := range []string{"test", "test-pp-cli", "test-pp-mcp", "cli.test"} {
 		_, stagedErr := os.Stat(filepath.Join(result.StagedDir, name))
 		assert.ErrorIs(t, stagedErr, os.ErrNotExist, "staged dir must not include root-level binary %s", name)
 	}
+	require.FileExists(t, filepath.Join(result.StagedDir, "root_test.go"), "staged dir should keep Go test source files")
 }
 
 func TestStagedBinaryNamesDeduplicates(t *testing.T) {

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -53,11 +53,15 @@ func IsThinCommandShort(s string) bool {
 }
 
 func CLI(name string) string {
-	return name + CurrentCLISuffix
+	return trimPPSuffixToken(name) + CurrentCLISuffix
 }
 
 func MCP(name string) string {
-	return name + MCPSuffix
+	return trimPPSuffixToken(name) + MCPSuffix
+}
+
+func trimPPSuffixToken(name string) string {
+	return strings.TrimSuffix(name, "-pp")
 }
 
 func LegacyCLI(name string) string {

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -40,13 +40,29 @@ func TestLibraryDirName(t *testing.T) {
 
 func TestMCP(t *testing.T) {
 	tests := map[string]string{
-		"stripe":  "stripe-pp-mcp",
-		"cal-com": "cal-com-pp-mcp",
-		"notion":  "notion-pp-mcp",
+		"stripe":        "stripe-pp-mcp",
+		"cal-com":       "cal-com-pp-mcp",
+		"notion":        "notion-pp-mcp",
+		"foo-pp":        "foo-pp-mcp",
+		"foo-pp-events": "foo-pp-events-pp-mcp",
 	}
 	for input, want := range tests {
 		if got := MCP(input); got != want {
 			t.Fatalf("MCP(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCLI(t *testing.T) {
+	tests := map[string]string{
+		"foo":           "foo-pp-cli",
+		"foo-pp":        "foo-pp-cli",
+		"foo-pp-events": "foo-pp-events-pp-cli",
+	}
+
+	for input, want := range tests {
+		if got := CLI(input); got != want {
+			t.Fatalf("CLI(%q) = %q, want %q", input, got, want)
 		}
 	}
 }


### PR DESCRIPTION
fix(cli): strip *.test on publish, dedup -pp slug, crowd-sniff drop summary

Three small, independent fixes:

- publish staged the CLI dir but left compiled `*.test` files behind; remove them
  from the staged root after the named-binary cleanup (source `*_test.go` is
  untouched).
- naming.CLI/MCP produced a doubled slug (`foo-pp` -> `foo-pp-pp-cli`) when the
  base spec name already ended in `-pp`; strip a single trailing `-pp` token first.
  (Narrowly conditioned on an exact trailing `-pp`; names like `foo` and
  `foo-pp-events` are unchanged.)
- crowd-sniff printed per-endpoint drops but no summary, so a user could miss that
  many endpoints were excluded; emit a single stderr summary (count + target-host
  scope) when any were dropped.

Fixes #2425.
Fixes #2335.
Fixes #2392.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
