### PR TITLE
fix(generator): emit toolchain floor and pin validate govulncheck to module toolchain

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/spf13/cobra"
-	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -1217,26 +1216,8 @@ func runGoVulnCheck(dir string) CheckResult {
 	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err != nil {
 		return CheckResult{Name: govulncheck.Name, Passed: false, Error: "go.mod not found"}
 	}
-	env := govulncheckToolchainEnv(dir)
+	env := govulncheck.ToolchainEnv(dir)
 	return runGoCommandCheckWithEnv(dir, govulncheck.Name, vulnCheckTimeout, env, govulncheck.GoRunArgs("./...")...)
-}
-
-func govulncheckToolchainEnv(dir string) []string {
-	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
-	if err != nil {
-		return nil
-	}
-	mod, err := modfile.Parse("go.mod", data, nil)
-	if err != nil {
-		return nil
-	}
-	if mod.Toolchain != nil && mod.Toolchain.Name != "" {
-		return []string{"GOTOOLCHAIN=" + mod.Toolchain.Name}
-	}
-	if mod.Go != nil && strings.Count(mod.Go.Version, ".") >= 2 {
-		return []string{"GOTOOLCHAIN=go" + mod.Go.Version}
-	}
-	return nil
 }
 
 func checkGoModTidy(dir string) CheckResult {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -614,20 +614,6 @@ exit 42
 	assert.NotContains(t, string(calls), "verbose")
 }
 
-func TestGovulncheckToolchainEnvPrefersToolchainDirective(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.4\n"), 0o644))
-
-	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.4"}, govulncheckToolchainEnv(dir))
-}
-
-func TestGovulncheckToolchainEnvIgnoresLanguageOnlyGoDirective(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
-
-	assert.Nil(t, govulncheckToolchainEnv(dir))
-}
-
 func TestPublishPackageMissingDirFlag(t *testing.T) {
 	cmd := newPublishCmd()
 	cmd.SetArgs([]string{"package", "--json"})

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -326,7 +326,9 @@ func (g *DeviceGenerator) renderEmbedded(relPath, tmplName string, data deviceTe
 
 const deviceGoModTemplate = `module {{.ModulePath}}
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2278,7 +2278,8 @@ func TestGenerateBrowserChromeTransport(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26.4")
+	assert.Contains(t, string(gomod), "go 1.26\n")
+	assert.Contains(t, string(gomod), "toolchain go1.26.4")
 	assert.Contains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
@@ -3464,7 +3465,8 @@ func TestGenerateStandardTransportForOfficialAPI(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26.4")
+	assert.Contains(t, string(gomod), "go 1.26\n")
+	assert.Contains(t, string(gomod), "toolchain go1.26.4")
 	assert.NotContains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -1,6 +1,8 @@
 module {{modulePath}}
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 {{- if .UsesBrowserHTTPTransport}}

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -57,7 +57,8 @@ func (g *Generator) Validate() error {
 		{
 			name: "govulncheck ./...",
 			run: func() error {
-				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", govulncheck.GoRunArgs("./...")...)
+				env := govulncheck.ToolchainEnv(g.OutputDir)
+				_, err := runCommandWithEnv(g.OutputDir, qualityGateTimeout, env, "go", govulncheck.GoRunArgs("./...")...)
 				return err
 			},
 		},
@@ -125,6 +126,10 @@ func validateCommandOutput(dir string, timeout time.Duration, name string, args 
 }
 
 func runCommand(dir string, timeout time.Duration, name string, args ...string) (string, error) {
+	return runCommandWithEnv(dir, timeout, nil, name, args...)
+}
+
+func runCommandWithEnv(dir string, timeout time.Duration, extraEnv []string, name string, args ...string) (string, error) {
 	ctx := context.Background()
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -139,6 +144,7 @@ func runCommand(dir string, timeout time.Duration, name string, args ...string) 
 		return "", err
 	}
 	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	cmd.Env = append(cmd.Env, extraEnv...)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -64,6 +64,7 @@ func TestValidateRunsPinnedDefaultGovulncheckGate(t *testing.T) {
 	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
 if [ "$1" = "run" ]; then
+  printf 'toolchain=%s\n' "$GOTOOLCHAIN" >> "$FAKE_GO_CALLS"
   echo "fake govulncheck failure" >&2
   exit 42
 fi
@@ -71,6 +72,7 @@ exit 0
 `), 0o755))
 	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("FAKE_GO_CALLS", callsPath)
+	t.Setenv("GOTOOLCHAIN", "auto")
 
 	err := gen.Validate()
 	require.Error(t, err)
@@ -80,6 +82,7 @@ exit 0
 	require.NoError(t, err)
 	assert.Contains(t, string(calls), "mod tidy\n")
 	assert.Contains(t, string(calls), "run "+govulncheck.ToolModule+" ./...\n")
+	assert.Contains(t, string(calls), "toolchain=go1.26.4\n")
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
 }

--- a/internal/govulncheck/govulncheck.go
+++ b/internal/govulncheck/govulncheck.go
@@ -1,5 +1,13 @@
 package govulncheck
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
 const (
 	Name        = "govulncheck"
 	ToolVersion = "v1.3.0"
@@ -11,4 +19,27 @@ const (
 func GoRunArgs(args ...string) []string {
 	goArgs := []string{"run", ToolModule}
 	return append(goArgs, args...)
+}
+
+// ToolchainEnv pins GOTOOLCHAIN to the target module's toolchain so the
+// `go run` invocation builds and runs govulncheck under the same Go version
+// the scanned code targets. Without it, x/vuln's own go.mod (a lower floor)
+// decides the toolchain, and a pre-1.26 govulncheck cannot typecheck
+// generated code that uses Go 1.26 features (#2606).
+func ToolchainEnv(dir string) []string {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return nil
+	}
+	mod, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return nil
+	}
+	if mod.Toolchain != nil && mod.Toolchain.Name != "" {
+		return []string{"GOTOOLCHAIN=" + mod.Toolchain.Name}
+	}
+	if mod.Go != nil && strings.Count(mod.Go.Version, ".") >= 2 {
+		return []string{"GOTOOLCHAIN=go" + mod.Go.Version}
+	}
+	return nil
 }

--- a/internal/govulncheck/govulncheck_test.go
+++ b/internal/govulncheck/govulncheck_test.go
@@ -1,10 +1,13 @@
 package govulncheck
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToolModuleIsPinned(t *testing.T) {
@@ -18,4 +21,29 @@ func TestGoRunArgsUsesDefaultMode(t *testing.T) {
 	assert.Equal(t, []string{"run", ToolModule, "./..."}, args)
 	assert.NotContains(t, args, "-show")
 	assert.NotContains(t, args, "verbose")
+}
+
+func TestToolchainEnvPrefersToolchainDirective(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.25.0\ntoolchain go1.26.4\n"), 0o644))
+
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.4"}, ToolchainEnv(dir))
+}
+
+func TestToolchainEnvFallsBackToPatchLevelGoDirective(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.26.4\n"), 0o644))
+
+	assert.Equal(t, []string{"GOTOOLCHAIN=go1.26.4"}, ToolchainEnv(dir))
+}
+
+func TestToolchainEnvIgnoresLanguageOnlyGoDirective(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644))
+
+	assert.Nil(t, ToolchainEnv(dir))
+}
+
+func TestToolchainEnvMissingGoMod(t *testing.T) {
+	assert.Nil(t, ToolchainEnv(t.TempDir()))
 }

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -1,6 +1,8 @@
 module ble-desk-lamp-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -1,6 +1,8 @@
 module ble-opaque-binary-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -1,6 +1,8 @@
 module ble-session-appliance-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -1,6 +1,8 @@
 module ble-temperature-sensor-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -1,6 +1,8 @@
 module golden-api-cookie-auth-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -1,6 +1,8 @@
 module printing-press-golden-pp-cli
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
## Intent

Every CLI generated since Go 1.26 became the codegen target can fail the `generate --validate` govulncheck gate, and every generated go.mod leaves downstream `go install` users on an unpatched stdlib. Third confirmed sighting in the rechtspraak retro (after tenderned and pdok-location, see issue comments).

Issue: Closes #2606

## Approach

Two halves, one root cause (the toolchain that resolves is not the toolchain the generated code targets):

1. **go.mod templates (standard + device) now emit `go 1.26` + `toolchain go1.26.4`** instead of `go 1.26.4` alone. The split shape is deliberate: an equal go/toolchain pair gets stripped by `go mod tidy` (which runs as the first validate gate), while the split form survives and leaves the patch floor as a separately bumpable knob for the next stdlib CVE window. Downstream `go install` resolves go1.26.4+.

2. **The validate govulncheck gate now sets `GOTOOLCHAIN` from the generated module's go.mod.** The logic moved from the publish path (which got this exact fix in #2238) into the shared `internal/govulncheck` package as `ToolchainEnv`, so both gates use it. Without it, x/vuln's own go.mod (`go 1.25.0` floor, no toolchain directive) decides the toolchain, and a pre-1.26 govulncheck cannot load or typecheck generated code using Go 1.26 features.

The vuln pin stays at v1.3.0 deliberately: it is the latest x/vuln release (`go list -m -versions golang.org/x/vuln`), and the failure was never the pin version itself but the toolchain it resolved under. v1.3.0 scans Go 1.26 code fine once GOTOOLCHAIN is pinned to the module's toolchain.

## Scope

Primary area: generator (go.mod templates + validate quality gate), shared govulncheck helper, publish gate refactored to use it.

Why this belongs in this repo: the gate and the templates are both generator-owned; every printed CLI inherits them. The library CI half (`govulncheck.yml` `go-version` pin) lives in printing-press-library, as already noted in the issue.

## Catalog Justification

N/A

## Risk

- Generated go.mod shape changes (`go 1.26` + `toolchain go1.26.4`). Language version is unchanged in practice (patch suffix never gated language features); toolchain resolution is equivalent or stricter for `GOTOOLCHAIN=auto` users.
- `GOTOOLCHAIN=local` users with go ≥1.26.0 but <1.26.4 can now build a generated CLI where before the `go 1.26.4` directive refused; the validate/publish gates still scan under the pinned patched toolchain and flag the stdlib delta.
- Publish-path behavior is unchanged (same logic, relocated; existing fake-go publish test still asserts `toolchain=go1.26.4` pass-through).

## Output Contract

- Emitted-code assertions updated: `generator_test.go` now asserts rendered go.mod contains both `go 1.26` and `toolchain go1.26.4` (two generation paths).
- Gate contract: `validate_test.go` fake-go test now also asserts the govulncheck invocation receives `GOTOOLCHAIN=go1.26.4` derived from the generated go.mod.

## Verification

- [x] `go build ./...`, `go vet` on touched packages
- [x] `go test ./internal/govulncheck/ ./internal/generator/ ./internal/cli/` — all pass
- [x] Repro of the reported failure on a printed CLI (go 1.26.3 floor): `GOTOOLCHAIN=go1.25.11 go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...` → `loading packages: ... go.mod requires go >= 1.26.3 (running go 1.25.11)`
- [x] Patched-gate equivalent on the same CLI (`GOTOOLCHAIN` from module go.mod): deterministic full scan completes and reports real reachable findings instead of crashing
- [x] Printed CLI carrying a `toolchain go1.26.4` directive scans clean: `No vulnerabilities found` (0 stdlib findings)
- [x] `go mod tidy` survival of the split go/toolchain shape verified empirically (equal pair gets stripped; split pair survives)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

🤖 Generated with [Claude Code](https://claude.com/claude-code)