### PR TITLE
fix(generator): resolve three silent sync data-loss paths (#2327, #2569, #2621)

### DIFF
--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -122,6 +122,28 @@ func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
 		}
 	}
 
+	// Soft-e plurals (#2713): the singular ends in a silent "e", so the plural
+	// adds only "s" (cases->case, databases->database, licenses->license). The
+	// id-base depluralizer must strip just "s", not "es", or the <singular>_id
+	// probe misses and the row is silently dropped.
+	if got := ExtractResourceID("cases", map[string]any{"case_id": "C-1"}); got != "C-1" {
+		t.Fatalf("soft-e plural cases: id = %q, want C-1", got)
+	}
+	if got := ExtractResourceID("databases", map[string]any{"database_id": "DB-1"}); got != "DB-1" {
+		t.Fatalf("soft-e plural databases: id = %q, want DB-1", got)
+	}
+	if got := ExtractResourceID("licenses", map[string]any{"license_key": "LK-1"}); got != "LK-1" {
+		t.Fatalf("soft-e plural licenses: id = %q, want LK-1", got)
+	}
+	// Genuine "-es" plurals of a sibilant base still strip "es": classes->class
+	// (sses), boxes->box (xes).
+	if got := ExtractResourceID("classes", map[string]any{"class_id": "CL-1"}); got != "CL-1" {
+		t.Fatalf("sses plural classes: id = %q, want CL-1", got)
+	}
+	if got := ExtractResourceID("boxes", map[string]any{"box_code": "BX-1"}); got != "BX-1" {
+		t.Fatalf("xes plural boxes: id = %q, want BX-1", got)
+	}
+
 	db, err := Open(filepath.Join(t.TempDir(), "data.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -196,6 +218,14 @@ func TestSyncExtractIDSuffixFallbackIsGuarded(t *testing.T) {
 	}
 	if got := extractID("currencies", map[string]any{"currency_code": map[string]any{"nested": "USD"}}); got != "" {
 		t.Fatalf("non-scalar suffix fallback id = %q, want empty", got)
+	}
+	// Soft-e plural depluralization on the sync side too (#2713): cases->case,
+	// not cas — otherwise case_id never resolves and items are dropped.
+	if got := extractID("cases", map[string]any{"case_id": "C-1"}); got != "C-1" {
+		t.Fatalf("soft-e plural cases: extractID = %q, want C-1", got)
+	}
+	if got := extractID("databases", map[string]any{"database_id": "DB-1"}); got != "DB-1" {
+		t.Fatalf("soft-e plural databases: extractID = %q, want DB-1", got)
 	}
 }
 

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -1,0 +1,285 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedSyncStoreBatch4TemplateFixes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "batch4syncstore",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/batch4syncstore-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"currencies": {
+				Description: "Currencies",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/currencies",
+						Description: "List currencies",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"things": {
+				Description: "Things",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/things",
+						Description: "List things",
+						Response:    spec.ResponseDef{Type: "array"},
+						Pagination:  &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+					},
+				},
+			},
+			"parents": {
+				Description: "Parents",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/parents",
+						Description: "List parents",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"children": {
+				Description: "Children",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/parents/{parentId}/children",
+						Description: "List children",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "currencies", Path: "/currencies", Method: "GET"},
+			{Name: "things", Path: "/things", Method: "GET"},
+			{Name: "parents", Path: "/parents", Method: "GET"},
+		},
+		DependentSyncResources: []profiler.DependentResource{
+			{Name: "children", ParentResource: "parents", ParentIDParam: "parentId", Path: "/parents/{parentId}/children", Method: "GET"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	storeTest := `package store
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
+	obj := map[string]any{"currency_code": "USD", "name": "US Dollar"}
+	if got := ExtractResourceID("currencies", obj); got != "US Dollar" {
+		t.Fatalf("exact fallback should still prefer name before suffix scan, got %q", got)
+	}
+
+	obj = map[string]any{"currency_code": "USD", "symbol": "$"}
+	if got := ExtractResourceID("currencies", obj); got != "USD" {
+		t.Fatalf("suffix fallback id = %q, want USD", got)
+	}
+	if got := ExtractResourceID("get-currencies", map[string]any{"currency_code": "USD"}); got != "USD" {
+		t.Fatalf("verb-prefixed suffix fallback id = %q, want USD", got)
+	}
+	if got := ExtractResourceID("things", map[string]any{"account_id": "acct-1"}); got != "" {
+		t.Fatalf("foreign-key suffix fallback id = %q, want empty", got)
+	}
+	for i := 0; i < 50; i++ {
+		got := ExtractResourceID("currencies", map[string]any{"currency_code": "USD", "region_id": "NA", "account_id": "x"})
+		if got != "USD" {
+			t.Fatalf("deterministic suffix fallback id on iteration %d = %q, want USD", i, got)
+		}
+	}
+
+	db, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	items := []json.RawMessage{json.RawMessage(` + "`" + `{"currency_code":"EUR","symbol":"EUR"}` + "`" + `)}
+	stored, failures, err := db.UpsertBatch("currencies", items)
+	if err != nil {
+		t.Fatalf("upsert batch: %v", err)
+	}
+	if stored != 1 || failures != 0 {
+		t.Fatalf("stored/failures = %d/%d, want 1/0", stored, failures)
+	}
+	rows, err := db.List("currencies", 10)
+	if err != nil {
+		t.Fatalf("list currencies: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("stored rows = %d, want 1", len(rows))
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "store", "suffix_id_test.go"), []byte(storeTest), 0o644))
+
+	cliTest := `package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type fixedBodyClient struct {
+	body json.RawMessage
+}
+
+func (c fixedBodyClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return c.body, nil
+}
+
+func (c fixedBodyClient) RateLimit() float64 {
+	return 0
+}
+
+func TestSyncExtractIDSuffixFallbackIsGuarded(t *testing.T) {
+	if got := extractID("currencies", map[string]any{"id": "id-wins", "currency_code": "USD"}); got != "id-wins" {
+		t.Fatalf("exact id fallback should win, got %q", got)
+	}
+	if got := extractID("currencies", map[string]any{"currency_code": "USD"}); got != "USD" {
+		t.Fatalf("suffix fallback id = %q, want USD", got)
+	}
+	if got := extractID("get-currencies", map[string]any{"currency_code": "USD"}); got != "USD" {
+		t.Fatalf("verb-prefixed suffix fallback id = %q, want USD", got)
+	}
+	if got := extractID("things", map[string]any{"account_id": "acct-1"}); got != "" {
+		t.Fatalf("foreign-key suffix fallback id = %q, want empty", got)
+	}
+	if got := extractID("get-expenses", map[string]any{"user_id": "u1"}); got != "" {
+		t.Fatalf("verb-prefixed foreign-key suffix fallback id = %q, want empty", got)
+	}
+	for i := 0; i < 50; i++ {
+		got := extractID("currencies", map[string]any{"currency_code": "USD", "region_id": "NA", "account_id": "x"})
+		if got != "USD" {
+			t.Fatalf("deterministic suffix fallback id on iteration %d = %q, want USD", i, got)
+		}
+	}
+	if got := extractID("currencies", map[string]any{"currency_code": map[string]any{"nested": "USD"}}); got != "" {
+		t.Fatalf("non-scalar suffix fallback id = %q, want empty", got)
+	}
+}
+
+func TestExtractPageItemsDRFTopLevelNextURL(t *testing.T) {
+	body := json.RawMessage(` + "`" + `{"count":2,"next":"http://h.example/api/things?cursor=abc","results":[{"id":"one"}]}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(body, "cursor")
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if cursor != "abc" {
+		t.Fatalf("cursor = %q, want abc", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("hasMore = false, want true")
+	}
+}
+
+func TestExtractPageItemsBareTokenCursorUnaffected(t *testing.T) {
+	body := json.RawMessage(` + "`" + `{"next_cursor":"bare-token","next":"http://h.example/api/things?cursor=url-token","results":[{"id":"one"}]}` + "`" + `)
+	_, cursor, _ := extractPageItems(body, "cursor")
+	if cursor != "bare-token" {
+		t.Fatalf("cursor = %q, want bare-token", cursor)
+	}
+}
+
+func TestSyncResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `<html><body>wrong app</body></html>` + "`" + `)}, db, "things", "", false, 1, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if !strings.Contains(events.String(), "\"reason\":\"non_json_200_body\"") {
+		t.Fatalf("events did not contain non_json_200_body anomaly: %s", events.String())
+	}
+}
+
+func TestSyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	var events bytes.Buffer
+	res := syncResource(context.Background(), fixedBodyClient{body: json.RawMessage(` + "`" + `[]` + "`" + `)}, db, "things", "", false, 1, false, nil, &events)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if strings.Contains(events.String(), "\"reason\":\"non_json_200_body\"") {
+		t.Fatalf("valid empty JSON emitted non_json_200_body anomaly: %s", events.String())
+	}
+}
+
+func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Upsert("parents", "p1", []byte(` + "`" + `{"id":"p1"}` + "`" + `)); err != nil {
+		t.Fatalf("insert parent: %v", err)
+	}
+
+	var events bytes.Buffer
+	res := syncDependentResource(
+		context.Background(),
+		fixedBodyClient{body: json.RawMessage(` + "`" + `<html><body>wrong app</body></html>` + "`" + `)},
+		db,
+		dependentResourceDef{Name: "children", ParentTable: "parents", ParentIDParam: "parentId", PathTemplate: "/parents/{parentId}/children"},
+		"", false, 1, false, nil, &events,
+	)
+	if res.Err != nil {
+		t.Fatalf("syncDependentResource error: %v", res.Err)
+	}
+	if !strings.Contains(events.String(), "\"reason\":\"non_json_200_body\"") {
+		t.Fatalf("events did not contain dependent non_json_200_body anomaly: %s", events.String())
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "batch4_sync_test.go"), []byte(cliTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestCurrencyCodeSuffixExtractsResourceID", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
+}

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -105,6 +105,10 @@ func TestCurrencyCodeSuffixExtractsResourceID(t *testing.T) {
 	if got := ExtractResourceID("currencies", obj); got != "USD" {
 		t.Fatalf("suffix fallback id = %q, want USD", got)
 	}
+	obj = map[string]any{"currency_code": nil, "symbol": "$"}
+	if got := ExtractResourceID("currencies", obj); got != "" {
+		t.Fatalf("nil suffix fallback id = %q, want empty", got)
+	}
 	if got := ExtractResourceID("get-currencies", map[string]any{"currency_code": "USD"}); got != "USD" {
 		t.Fatalf("verb-prefixed suffix fallback id = %q, want USD", got)
 	}
@@ -209,6 +213,20 @@ func TestExtractPageItemsDRFTopLevelNextURL(t *testing.T) {
 	}
 }
 
+func TestExtractPageItemsDRFTopLevelRelativeNextURL(t *testing.T) {
+	body := json.RawMessage(` + "`" + `{"count":2,"next":"/api/things?cursor=rel-abc","results":[{"id":"one"}]}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(body, "cursor")
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if cursor != "rel-abc" {
+		t.Fatalf("cursor = %q, want rel-abc", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("hasMore = false, want true")
+	}
+}
+
 func TestExtractPageItemsBareTokenCursorUnaffected(t *testing.T) {
 	body := json.RawMessage(` + "`" + `{"next_cursor":"bare-token","next":"http://h.example/api/things?cursor=url-token","results":[{"id":"one"}]}` + "`" + `)
 	_, cursor, _ := extractPageItems(body, "cursor")
@@ -281,5 +299,5 @@ func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "batch4_sync_test.go"), []byte(cliTest), 0o644))
 
 	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "TestCurrencyCodeSuffixExtractsResourceID", "-count=1")
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "Test(SyncExtractIDSuffixFallbackIsGuarded|ExtractPageItemsDRFTopLevelNextURL|ExtractPageItemsDRFTopLevelRelativeNextURL|ExtractPageItemsBareTokenCursorUnaffected|SyncResourceNonJSONBodyEmitsAnomaly|SyncResourceValidEmptyJSONDoesNotEmitNonJSONAnomaly|SyncDependentResourceNonJSONBodyEmitsAnomaly)", "-count=1")
 }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1221,7 +1221,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return ResourceIDString(value)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1209,12 +1209,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1138,7 +1138,96 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return ResourceIDString(value)
+	default:
+		return ""
+	}
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1808,6 +1808,7 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 	return cursorFromNextURL(nextURL, cursorParam)
 }
 
+// nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.
 func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
 	for _, key := range []string{"next", "next_url"} {
 		rawNext, ok := envelope[key]
@@ -1818,11 +1819,22 @@ func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam 
 		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+		if isFollowableNextURL(nextURL) {
 			return cursorFromNextURL(nextURL, cursorParam)
 		}
 	}
 	return ""
+}
+
+// isFollowableNextURL reports whether a top-level "next" string is a URL we can
+// pull a cursor query param from: an absolute http(s) URL, a root-relative path,
+// or any value carrying a query string. Bare opaque cursor tokens (no query)
+// are rejected so they aren't mis-parsed.
+func isFollowableNextURL(nextURL string) bool {
+	lower := strings.ToLower(nextURL)
+	return strings.HasPrefix(lower, "http") ||
+		strings.HasPrefix(nextURL, "/") ||
+		strings.Contains(nextURL, "?")
 }
 
 func cursorFromNextURL(nextURL string, cursorParam string) string {
@@ -2770,7 +2782,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return store.ResourceIDString(value)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2770,12 +2770,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -739,6 +739,15 @@ func syncResource(ctx context.Context, c interface {
 		}
 {{- end}}
 
+		if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body; no rows were stored.\n", resource)
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","reason":"non_json_200_body"}`+"\n", resource)
+			}
+			break
+		}
+
 		if len(items) == 0 {
 			if isEmptyPageResponse(data) {
 				break
@@ -1668,6 +1677,11 @@ func isJSONNull(raw json.RawMessage) bool {
 	return strings.TrimSpace(string(raw)) == "null"
 }
 
+func isJSONResponse(data json.RawMessage) bool {
+	var probe any
+	return json.Unmarshal(data, &probe) == nil
+}
+
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
 func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
 	var hasMore bool
@@ -1705,6 +1719,10 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 				break
 			}
 		}
+	}
+
+	if nextCursor == "" {
+		nextCursor = nextCursorFromTopLevelURL(envelope, cursorParam)
 	}
 
 	// Try common has_more field names
@@ -1787,6 +1805,27 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 		return ""
 	}
 
+	return cursorFromNextURL(nextURL, cursorParam)
+}
+
+func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
+	for _, key := range []string{"next", "next_url"} {
+		rawNext, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var nextURL string
+		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
+	}
+	return ""
+}
+
+func cursorFromNextURL(nextURL string, cursorParam string) string {
 	cursorKeys := []string{cursorParam}
 	if cursorParam != "page[cursor]" {
 		cursorKeys = append(cursorKeys, "page[cursor]")
@@ -2348,6 +2387,15 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 {{- end}}
 
+			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				if humanFriendly {
+					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","parent":"%s","reason":"non_json_200_body"}`+"\n", dep.Name, parentID)
+				}
+				break
+			}
+
 			if len(items) == 0 {
 				break
 			}
@@ -2639,5 +2687,94 @@ func extractID(resource string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resource, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return store.ResourceIDString(value)
+	default:
+		return ""
+	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1957,12 +1957,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -539,6 +539,15 @@ func syncResource(ctx context.Context, c interface {
 			hasMore = true
 		}
 
+		if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body; no rows were stored.\n", resource)
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","reason":"non_json_200_body"}`+"\n", resource)
+			}
+			break
+		}
+
 		if len(items) == 0 {
 			if isEmptyPageResponse(data) {
 				break
@@ -1051,6 +1060,11 @@ func isJSONNull(raw json.RawMessage) bool {
 	return strings.TrimSpace(string(raw)) == "null"
 }
 
+func isJSONResponse(data json.RawMessage) bool {
+	var probe any
+	return json.Unmarshal(data, &probe) == nil
+}
+
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
 func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
 	var hasMore bool
@@ -1088,6 +1102,10 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 				break
 			}
 		}
+	}
+
+	if nextCursor == "" {
+		nextCursor = nextCursorFromTopLevelURL(envelope, cursorParam)
 	}
 
 	// Try common has_more field names
@@ -1170,6 +1188,27 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 		return ""
 	}
 
+	return cursorFromNextURL(nextURL, cursorParam)
+}
+
+func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
+	for _, key := range []string{"next", "next_url"} {
+		rawNext, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var nextURL string
+		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
+	}
+	return ""
+}
+
+func cursorFromNextURL(nextURL string, cursorParam string) string {
 	cursorKeys := []string{cursorParam}
 	if cursorParam != "page[cursor]" {
 		cursorKeys = append(cursorKeys, "page[cursor]")
@@ -1543,6 +1582,15 @@ func syncDependentResource(ctx context.Context, c interface {
 				hasMore = true
 			}
 
+			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				if humanFriendly {
+					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","parent":"%s","reason":"non_json_200_body"}`+"\n", dep.Name, parentID)
+				}
+				break
+			}
+
 			if len(items) == 0 {
 				break
 			}
@@ -1826,5 +1874,94 @@ func extractID(resource string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resource, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return store.ResourceIDString(value)
+	default:
+		return ""
+	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1191,6 +1191,7 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 	return cursorFromNextURL(nextURL, cursorParam)
 }
 
+// nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.
 func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
 	for _, key := range []string{"next", "next_url"} {
 		rawNext, ok := envelope[key]
@@ -1201,11 +1202,22 @@ func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam 
 		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+		if isFollowableNextURL(nextURL) {
 			return cursorFromNextURL(nextURL, cursorParam)
 		}
 	}
 	return ""
+}
+
+// isFollowableNextURL reports whether a top-level "next" string is a URL we can
+// pull a cursor query param from: an absolute http(s) URL, a root-relative path,
+// or any value carrying a query string. Bare opaque cursor tokens (no query)
+// are rejected so they aren't mis-parsed.
+func isFollowableNextURL(nextURL string) bool {
+	lower := strings.ToLower(nextURL)
+	return strings.HasPrefix(lower, "http") ||
+		strings.HasPrefix(nextURL, "/") ||
+		strings.Contains(nextURL, "?")
 }
 
 func cursorFromNextURL(nextURL string, cursorParam string) string {
@@ -1957,7 +1969,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return store.ResourceIDString(value)

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1107,12 +1107,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1036,7 +1036,96 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return ResourceIDString(value)
+	default:
+		return ""
+	}
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1119,7 +1119,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return ResourceIDString(value)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -538,6 +538,15 @@ func syncResource(ctx context.Context, c interface {
 			hasMore = true
 		}
 
+		if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body; no rows were stored.\n", resource)
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","reason":"non_json_200_body"}`+"\n", resource)
+			}
+			break
+		}
+
 		if len(items) == 0 {
 			if isEmptyPageResponse(data) {
 				break
@@ -1046,6 +1055,11 @@ func isJSONNull(raw json.RawMessage) bool {
 	return strings.TrimSpace(string(raw)) == "null"
 }
 
+func isJSONResponse(data json.RawMessage) bool {
+	var probe any
+	return json.Unmarshal(data, &probe) == nil
+}
+
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
 func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
 	var hasMore bool
@@ -1083,6 +1097,10 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 				break
 			}
 		}
+	}
+
+	if nextCursor == "" {
+		nextCursor = nextCursorFromTopLevelURL(envelope, cursorParam)
 	}
 
 	// Try common has_more field names
@@ -1165,6 +1183,27 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 		return ""
 	}
 
+	return cursorFromNextURL(nextURL, cursorParam)
+}
+
+func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
+	for _, key := range []string{"next", "next_url"} {
+		rawNext, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var nextURL string
+		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
+	}
+	return ""
+}
+
+func cursorFromNextURL(nextURL string, cursorParam string) string {
 	cursorKeys := []string{cursorParam}
 	if cursorParam != "page[cursor]" {
 		cursorKeys = append(cursorKeys, "page[cursor]")
@@ -1527,6 +1566,15 @@ func syncDependentResource(ctx context.Context, c interface {
 				hasMore = true
 			}
 
+			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				if humanFriendly {
+					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
+				} else {
+					fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","parent":"%s","reason":"non_json_200_body"}`+"\n", dep.Name, parentID)
+				}
+				break
+			}
+
 			if len(items) == 0 {
 				break
 			}
@@ -1807,5 +1855,94 @@ func extractID(resource string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resource, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return store.ResourceIDString(value)
+	default:
+		return ""
+	}
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1938,12 +1938,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1186,6 +1186,7 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 	return cursorFromNextURL(nextURL, cursorParam)
 }
 
+// nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.
 func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
 	for _, key := range []string{"next", "next_url"} {
 		rawNext, ok := envelope[key]
@@ -1196,11 +1197,22 @@ func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam 
 		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+		if isFollowableNextURL(nextURL) {
 			return cursorFromNextURL(nextURL, cursorParam)
 		}
 	}
 	return ""
+}
+
+// isFollowableNextURL reports whether a top-level "next" string is a URL we can
+// pull a cursor query param from: an absolute http(s) URL, a root-relative path,
+// or any value carrying a query string. Bare opaque cursor tokens (no query)
+// are rejected so they aren't mis-parsed.
+func isFollowableNextURL(nextURL string) bool {
+	lower := strings.ToLower(nextURL)
+	return strings.HasPrefix(lower, "http") ||
+		strings.HasPrefix(nextURL, "/") ||
+		strings.Contains(nextURL, "?")
 }
 
 func cursorFromNextURL(nextURL string, cursorParam string) string {
@@ -1938,7 +1950,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return store.ResourceIDString(value)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1008,7 +1008,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return ResourceIDString(value)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -925,7 +925,96 @@ func ExtractResourceID(resourceType string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resourceType, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return ResourceIDString(value)
+	default:
+		return ""
+	}
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -996,12 +996,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -505,6 +505,15 @@ func syncResource(ctx context.Context, c interface {
 			hasMore = true
 		}
 
+		if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+			if humanFriendly {
+				fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body; no rows were stored.\n", resource)
+			} else {
+				fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","reason":"non_json_200_body"}`+"\n", resource)
+			}
+			break
+		}
+
 		if len(items) == 0 {
 			if isEmptyPageResponse(data) {
 				break
@@ -1015,6 +1024,11 @@ func isJSONNull(raw json.RawMessage) bool {
 	return strings.TrimSpace(string(raw)) == "null"
 }
 
+func isJSONResponse(data json.RawMessage) bool {
+	var probe any
+	return json.Unmarshal(data, &probe) == nil
+}
+
 // extractPaginationFromEnvelope extracts cursor and has_more from a response envelope.
 func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorParam string) (string, bool) {
 	var hasMore bool
@@ -1052,6 +1066,10 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 				break
 			}
 		}
+	}
+
+	if nextCursor == "" {
+		nextCursor = nextCursorFromTopLevelURL(envelope, cursorParam)
 	}
 
 	// Try common has_more field names
@@ -1134,6 +1152,27 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 		return ""
 	}
 
+	return cursorFromNextURL(nextURL, cursorParam)
+}
+
+func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
+	for _, key := range []string{"next", "next_url"} {
+		rawNext, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var nextURL string
+		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
+	}
+	return ""
+}
+
+func cursorFromNextURL(nextURL string, cursorParam string) string {
 	cursorKeys := []string{cursorParam}
 	if cursorParam != "page[cursor]" {
 		cursorKeys = append(cursorKeys, "page[cursor]")
@@ -1423,5 +1462,94 @@ func extractID(resource string, obj map[string]any) string {
 			}
 		}
 	}
+	if s := suffixIDFieldFallback(resource, obj); s != "" {
+		return s
+	}
 	return ""
+}
+
+// suffixIDFieldFallback resolves an id-less resource that keys on its own
+// "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the
+// "currencies" resource keying on "currency_code" — see #2327). It is scoped to
+// the resource's OWN name so a foreign key like account_id/parent_id is never
+// promoted to the primary key, and it uses direct map lookups in a fixed suffix
+// order so the chosen id is deterministic.
+func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
+	for _, base := range resourceIDBaseNames(resourceType) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resourceIDBaseNames returns lowercase candidate singular/plural stems of a
+// resource name to build "<base>_id"-style key probes from (e.g. "currencies"
+// -> ["currencies","currency"]). OpenAPI-/path-derived names can carry a
+// leading verb token ("get-currencies"), so the same probes are also attempted
+// on the de-verbed stem. Minimal English depluralization; the raw name is
+// always included so already-singular names work too.
+func resourceIDBaseNames(resourceType string) []string {
+	r := strings.ToLower(strings.TrimSpace(resourceType))
+	if r == "" {
+		return nil
+	}
+	stems := []string{r}
+	if d := stripLeadingResourceVerb(r); d != "" && d != r {
+		stems = append(stems, d)
+	}
+	var bases []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			bases = append(bases, s)
+		}
+	}
+	for _, stem := range stems {
+		add(stem)
+		add(depluralizeResourceStem(stem))
+	}
+	return bases
+}
+
+func stripLeadingResourceVerb(r string) string {
+	for _, verb := range []string{"get", "list", "fetch", "find", "retrieve", "read", "show", "all"} {
+		for _, sep := range []string{"-", "_"} {
+			prefix := verb + sep
+			if strings.HasPrefix(r, prefix) && len(r) > len(prefix) {
+				return r[len(prefix):]
+			}
+		}
+	}
+	return ""
+}
+
+func depluralizeResourceStem(r string) string {
+	switch {
+	case strings.HasSuffix(r, "ies") && len(r) > 3:
+		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
+	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
+		strings.HasSuffix(r, "shes"):
+		return strings.TrimSuffix(r, "es") // boxes -> box
+	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
+		return strings.TrimSuffix(r, "s") // languages -> language
+	}
+	return r
+}
+
+func scalarIDString(value any) string {
+	switch value.(type) {
+	case nil, string, bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number, []byte:
+		return store.ResourceIDString(value)
+	default:
+		return ""
+	}
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1155,6 +1155,7 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 	return cursorFromNextURL(nextURL, cursorParam)
 }
 
+// nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.
 func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam string) string {
 	for _, key := range []string{"next", "next_url"} {
 		rawNext, ok := envelope[key]
@@ -1165,11 +1166,22 @@ func nextCursorFromTopLevelURL(envelope map[string]json.RawMessage, cursorParam 
 		if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(nextURL), "http") {
+		if isFollowableNextURL(nextURL) {
 			return cursorFromNextURL(nextURL, cursorParam)
 		}
 	}
 	return ""
+}
+
+// isFollowableNextURL reports whether a top-level "next" string is a URL we can
+// pull a cursor query param from: an absolute http(s) URL, a root-relative path,
+// or any value carrying a query string. Bare opaque cursor tokens (no query)
+// are rejected so they aren't mis-parsed.
+func isFollowableNextURL(nextURL string) bool {
+	lower := strings.ToLower(nextURL)
+	return strings.HasPrefix(lower, "http") ||
+		strings.HasPrefix(nextURL, "/") ||
+		strings.Contains(nextURL, "?")
 }
 
 func cursorFromNextURL(nextURL string, cursorParam string) string {
@@ -1545,7 +1557,7 @@ func depluralizeResourceStem(r string) string {
 
 func scalarIDString(value any) string {
 	switch value.(type) {
-	case nil, string, bool, int, int8, int16, int32, int64,
+	case string, bool, int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, json.Number, []byte:
 		return store.ResourceIDString(value)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1545,12 +1545,19 @@ func depluralizeResourceStem(r string) string {
 	switch {
 	case strings.HasSuffix(r, "ies") && len(r) > 3:
 		return strings.TrimSuffix(r, "ies") + "y" // currencies -> currency
-	case strings.HasSuffix(r, "ses") || strings.HasSuffix(r, "xes") ||
+	// Plurals formed by adding "es" to a base ending in s/x/z/ch/sh. The
+	// double-s "sses" guard (not bare "ses") keeps soft-e plurals — where the
+	// singular already ends in a silent "e" (cases, databases, licenses,
+	// purchases) — out of this branch; they fall through to the "-s" case below
+	// (cases -> case, not cas). Trade-off: a genuine "-es" plural of an s-ending
+	// singular (buses, statuses) depluralizes imperfectly, but those are rare as
+	// resource names and this stem only feeds best-effort id-field probing.
+	case strings.HasSuffix(r, "sses") || strings.HasSuffix(r, "xes") ||
 		strings.HasSuffix(r, "zes") || strings.HasSuffix(r, "ches") ||
 		strings.HasSuffix(r, "shes"):
-		return strings.TrimSuffix(r, "es") // boxes -> box
+		return strings.TrimSuffix(r, "es") // classes -> class, boxes -> box, dishes -> dish
 	case strings.HasSuffix(r, "s") && !strings.HasSuffix(r, "ss") && len(r) > 1:
-		return strings.TrimSuffix(r, "s") // languages -> language
+		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
 }


### PR DESCRIPTION
Three independent generator-template fixes for `sync`/`store` paths that silently drop or cap data while reporting success. Each is **guarded to run only after the existing path returns empty**, so default behavior is unchanged.

### #2327 — id-less reference resources keyed on a code/slug field are silently dropped
A resource whose objects key on e.g. `currency_code` (no `id`) failed generic id-extraction, so every row was dropped (`all_items_failed_id_extraction`) while `sync_summary` still reported `success`. `ExtractResourceID`/`extractID` now fall back — **only after** the override and exact `genericIDFieldFallbacks` loops both miss — to the resource's **own-name** id field via direct lookups in a fixed `_id`/`_code`/`_key`/`_slug` order. The base-name probe strips a leading path verb (`get-`/`list-`/`fetch-`/…) and depluralizes, so the OpenAPI-derived resource `get-currencies` resolves `currency_code`.

Scoping to the resource's own name keeps it **deterministic** (direct lookups, no map iteration) and **FK-safe** — a foreign key like `user_id`/`account_id` is never promoted to the primary key (which would silently collapse distinct entities into one row, reintroducing the same class of silent loss).

### #2569 — DRF-style top-level `next` URL ignored, so `--all` capped at page 1
`extractPaginationFromEnvelope` now — only after the links + top-level + wrapper cursor scans return empty — parses a top-level `"next"`/`"next_url"` http URL and extracts the cursor query param (logic shared with the JSON:API `links.next` path). `has_more` is derived from the resolved cursor; bare-token cursor fields still win, and DRF's last-page `next: null` stops cleanly.

### #2621 — non-JSON 200 body breaks silently as if the page were empty
A 200 with an HTML body (error/login page) hit `len(items)==0` and broke as a clean empty page. `syncResource` and `syncDependentResource` now emit a `non_json_200_body` sync_anomaly when items are empty, the body is non-empty, and it does not parse as JSON. Valid empty JSON (`[]`/`{}`) still breaks cleanly without an anomaly.

### Tests
`internal/generator/sync_store_template_fixes_test.go` generates a CLI and runs the assertions against the **real generated `store` and `cli` packages**: verb-prefixed resolution (`get-currencies` → `currency_code`), FK-not-promoted (`get-expenses`+`user_id` → empty), 50-iteration determinism, DRF top-level next-URL, bare-token precedence, and the non-JSON-vs-valid-empty-JSON anomaly boundary on both flat and dependent sync. Full local gate green: `go test ./...`, `golden.sh verify` (31 cases), `verify-generator-output.sh` (9 cases), golangci-lint clean.

Closes #2327
Closes #2569
Closes #2621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
