### PR TITLE
fix(generator): surface row + query errors in store ResolveByName (#2708)

### DIFF
--- a/internal/generator/store_resolve_by_name_guard_test.go
+++ b/internal/generator/store_resolve_by_name_guard_test.go
@@ -29,6 +29,86 @@ func TestStoreResolveByNameValidatesField(t *testing.T) {
 		"ResolveByName must validate each field name and continue past invalid entries before splicing into the json_extract path; the continue must be inside the validIdentifierRE guard, not the pre-existing query-error continue")
 }
 
+func TestGeneratedStoreResolveByNameSurfacesQueryAndRowErrors(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("resolve-errors")
+	outputDir := filepath.Join(t.TempDir(), "resolve-errors-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "store", "resolve_by_name_error_test.go")
+	testSrc := `package store
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveByNameReturnsQueryAndIterationErrors(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer s.Close()
+
+		if _, err := s.DB().Exec("INSERT INTO resources (resource_type, id, data) VALUES (?, ?, ?)", "users", "user-1", "{\"name\":\"Alice\"}"); err != nil {
+			t.Fatalf("seed resource: %v", err)
+		}
+
+		got, err := s.ResolveByName("users", "Alice", "name")
+		if err != nil {
+			t.Fatalf("ResolveByName happy path: %v", err)
+		}
+		if got != "user-1" {
+			t.Fatalf("ResolveByName = %q, want user-1", got)
+		}
+	})
+
+	t.Run("query error", func(t *testing.T) {
+		s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+
+		_, err = s.ResolveByName("users", "Alice", "name")
+		if err == nil {
+			t.Fatal("ResolveByName returned nil error after db close")
+		}
+		if strings.Contains(err.Error(), "not found in local store") {
+			t.Fatalf("ResolveByName swallowed query error as not-found: %v", err)
+		}
+	})
+
+	t.Run("row error", func(t *testing.T) {
+		s, err := Open(filepath.Join(t.TempDir(), "data.db"))
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		defer s.Close()
+
+		if _, err := s.DB().Exec("INSERT INTO resources (resource_type, id, data) VALUES (?, ?, ?)", "users", "bad-json", "{"); err != nil {
+			t.Fatalf("seed malformed resource: %v", err)
+		}
+
+		_, err = s.ResolveByName("users", "Alice", "name")
+		if err == nil {
+			t.Fatal("ResolveByName returned nil error for malformed JSON row")
+		}
+		if strings.Contains(err.Error(), "not found in local store") {
+			t.Fatalf("ResolveByName swallowed row error as not-found: %v", err)
+		}
+	})
+}
+`
+	require.NoError(t, os.WriteFile(testPath, []byte(testSrc), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestResolveByNameReturnsQueryAndIterationErrors", "-count=1")
+}
+
 func resolveByNameBody(t *testing.T, content string) string {
 	t.Helper()
 	start := strings.Index(content, "func (s *Store) ResolveByName(")

--- a/internal/generator/store_resolve_by_name_guard_test.go
+++ b/internal/generator/store_resolve_by_name_guard_test.go
@@ -91,6 +91,13 @@ func TestResolveByNameReturnsQueryAndIterationErrors(t *testing.T) {
 		}
 		defer s.Close()
 
+		// The "{" value is syntactically broken JSON: json_extract raises a
+		// statement error during row iteration, which ResolveByName must
+		// surface via rows.Err(). This relies on SQLite >= 3.38
+		// (modernc.org/sqlite) erroring on malformed JSON rather than
+		// returning NULL; if that behavior ever changes the query would
+		// return zero rows and this subtest would stop exercising the
+		// rows.Err() path (ResolveByName would report not-found instead).
 		if _, err := s.DB().Exec("INSERT INTO resources (resource_type, id, data) VALUES (?, ?, ?)", "users", "bad-json", "{"); err != nil {
 			t.Fatalf("seed malformed resource: %v", err)
 		}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1645,7 +1645,7 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 		)
 		rows, err := s.db.Query(query, resourceType, input)
 		if err != nil {
-			continue
+			return "", err
 		}
 		for rows.Next() {
 			var id string
@@ -1662,6 +1662,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 					matches = append(matches, id)
 				}
 			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
 		}
 		rows.Close()
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1438,7 +1438,7 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 		)
 		rows, err := s.db.Query(query, resourceType, input)
 		if err != nil {
-			continue
+			return "", err
 		}
 		for rows.Next() {
 			var id string
@@ -1455,6 +1455,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 					matches = append(matches, id)
 				}
 			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
 		}
 		rows.Close()
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1327,7 +1327,7 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 		)
 		rows, err := s.db.Query(query, resourceType, input)
 		if err != nil {
-			continue
+			return "", err
 		}
 		for rows.Next() {
 			var id string
@@ -1344,6 +1344,10 @@ func (s *Store) ResolveByName(resourceType string, input string, matchFields ...
 					matches = append(matches, id)
 				}
 			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
 		}
 		rows.Close()
 	}


### PR DESCRIPTION
`Store.ResolveByName` was the lone row-iteration loop in `store.go` missing a `rows.Err()` check, and it silently `continue`d past a `db.Query` error. A real DB failure (closed/locked store, aborted scan) was swallowed and misreported as `"<name> not found in local store. Run 'sync' first"` — sending the user to re-sync a database that was actually broken.

Adds the `rows.Err()` check (closing the current rows before the early return, matching the in-file `migrateResourcesFTSRowIDs` Close-on-error idiom) and returns the `db.Query` error instead of continuing. Genuine zero-match still falls through to the existing not-found result; query errors here are systemic (SQL is structurally identical across `matchFields`), so early return is correct.

Closes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
