### PR TITLE
fix(scorer): SKIP data-pipeline gate for no-sync and local-datastore CLIs (#2622, #2672)

### DIFF
--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -319,7 +319,7 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 		report.DataPipeline = true
 		report.DataPipelineDetail = "SKIP (device CLI: no sync data pipeline)"
 	} else {
-		report.DataPipeline, report.DataPipelineDetail = runDataPipelineTest(binaryPath, report.Mode, buildEnv, expectedMockRows)
+		report.DataPipeline, report.DataPipelineDetail = runDataPipelineTest(binaryPath, cfg.Dir, report.Mode, buildEnv, expectedMockRows)
 	}
 	report.Freshness = runFreshnessContractTest(cfg.Dir)
 	report.PathParamProbes = runPathParamProbes(binaryPath, buildEnv(), paramDefaults)
@@ -610,7 +610,16 @@ func runBrowserSessionProofTest(binary string, auth apispec.AuthConfig) CommandR
 
 // runDataPipelineTest tests the sync -> sql -> search -> health chain.
 // Returns (pass bool, detail string) where detail gives PASS/WARN/SKIP/FAIL context.
-func runDataPipelineTest(binary, mode string, envFn func() []string, expectedRows int) (bool, string) {
+func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, expectedRows int) (bool, string) {
+	if strings.TrimSpace(cliDir) != "" {
+		if manifest, err := ReadCLIManifest(cliDir); err == nil && manifest.IsLocalDatastore() {
+			return true, "SKIP (local-datastore CLI: no network sync to verify)"
+		}
+		if !cliHasSyncCommand(cliDir) {
+			return true, "SKIP (CLI has no sync command)"
+		}
+	}
+
 	env := envFn()
 
 	// Create a temp dir for the test database
@@ -720,6 +729,10 @@ func allSyncAttemptsWereUnknownCommand(errs []error) bool {
 func isUnknownSyncCommandError(err error) bool {
 	text := strings.ToLower(err.Error())
 	return strings.Contains(text, "unknown command \"sync\"")
+}
+
+func cliHasSyncCommand(cliDir string) bool {
+	return hasRegisteredCommandFileWithPrefix(filepath.Join(cliDir, "internal", "cli"), "sync")
 }
 
 func isAuxiliaryPipelineTable(table string, totalTables int) bool {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -207,7 +207,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("fails when sync creates tables but stores no rows", func(t *testing.T) {
 		binary := buildDataPipelineProbeBinary(t, 0)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.False(t, pass)
 		assert.Contains(t, detail, "1 domain tables created but 0 rows after sync")
@@ -216,7 +216,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("fails when nested mock sync stores fewer rows than served", func(t *testing.T) {
 		binary := buildDataPipelineProbeBinary(t, 1)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.False(t, pass)
 		assert.Contains(t, detail, "items has 1 rows after sync, expected at least 2")
@@ -225,7 +225,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("passes when sync stores rows", func(t *testing.T) {
 		binary := buildDataPipelineProbeBinary(t, 2)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Contains(t, detail, "items has 2 rows")
@@ -234,7 +234,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
 		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0, 2)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Contains(t, detail, "items has 2 rows")
@@ -243,7 +243,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("passes when an auxiliary table has fewer rows before populated data table", func(t *testing.T) {
 		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 1, 2)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Contains(t, detail, "items has 2 rows")
@@ -252,7 +252,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("fails when only an auxiliary table satisfies expected rows", func(t *testing.T) {
 		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 3, 0)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.False(t, pass)
 		assert.Contains(t, detail, "items has 0 rows")
@@ -274,6 +274,41 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 
 		assert.False(t, pass)
 		assert.Equal(t, "FAIL: sync crashed", detail)
+	})
+}
+
+func TestRunDataPipelineTestSkipsUnsyncableCLIs(t *testing.T) {
+	t.Run("skips local-datastore manifests before sync", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "sqlite"}))
+		binary := buildNoSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "SKIP (local-datastore CLI: no network sync to verify)", detail)
+	})
+
+	t.Run("skips CLIs without sync command", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, false)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))
+		binary := buildNoSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "SKIP (CLI has no sync command)", detail)
+	})
+
+	t.Run("runs normal sync CLIs", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))
+		binary := buildDataPipelineProbeBinary(t, 2)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Contains(t, detail, "items has 2 rows")
 	})
 }
 
@@ -688,6 +723,50 @@ func dbArg(args []string) string {
 	out, err := buildCmd.CombinedOutput()
 	require.NoError(t, err, "building test binary: %s", string(out))
 	return binaryPath
+}
+
+func buildNoSyncDataPipelineProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import "os"
+
+func main() {
+	os.Exit(1)
+}
+`)
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func seedDataPipelineCLIDir(t *testing.T, includeSync bool) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cliDir := filepath.Join(dir, "internal", "cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	if includeSync {
+		writeTestFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() { rootCmd.AddCommand(newSyncCmd(nil)) }
+`)
+		writeTestFile(t, filepath.Join(cliDir, "sync_bluray.go"), `package cli
+func newSyncCmd(flags any) {}
+`)
+		return dir
+	}
+	writeTestFile(t, filepath.Join(cliDir, "root.go"), `package cli
+func newRootCmd() {}
+`)
+	writeTestFile(t, filepath.Join(cliDir, "items.go"), `package cli
+func newItemsCmd(flags any) {}
+`)
+	return dir
 }
 
 func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T, settingsRows, itemRows int) string {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -261,7 +261,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("warns when sync command is absent", func(t *testing.T) {
 		binary := buildNoSyncDataPipelineProbeBinary(t)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Equal(t, "WARN: no sync command — data-pipeline check skipped", detail)
@@ -270,7 +270,7 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 	t.Run("fails when sync command exists but crashes", func(t *testing.T) {
 		binary := buildFailingSyncDataPipelineProbeBinary(t)
 
-		pass, detail := runDataPipelineTest(binary, "mock", os.Environ, 2)
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
 
 		assert.False(t, pass)
 		assert.Equal(t, "FAIL: sync crashed", detail)
@@ -718,26 +718,6 @@ func dbArg(args []string) string {
 	return ""
 }
 `, rowCount))
-	binaryPath := filepath.Join(dir, "test-cli")
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
-	out, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, "building test binary: %s", string(out))
-	return binaryPath
-}
-
-func buildNoSyncDataPipelineProbeBinary(t *testing.T) string {
-	t.Helper()
-
-	dir := t.TempDir()
-	mainFile := filepath.Join(dir, "main.go")
-	writeTestFile(t, mainFile, `package main
-
-import "os"
-
-func main() {
-	os.Exit(1)
-}
-`)
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()

--- a/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
+++ b/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
@@ -3,7 +3,7 @@
     "binary": "<ARTIFACT_DIR>/verify-runtime-matrix/fixtures/mock-pass-pp-cli/mock-pass-pp-cli",
     "critical": 0,
     "data_pipeline": true,
-    "data_pipeline_detail": "SKIP (CLI has no sync command)",
+    "data_pipeline_detail": "PASS: 1 domain tables, items has 1 rows",
     "failed": 0,
     "freshness": {
       "detail": "cache freshness helper not emitted",

--- a/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
+++ b/testdata/golden/expected/verify-runtime-matrix/mock-pass.json
@@ -3,7 +3,7 @@
     "binary": "<ARTIFACT_DIR>/verify-runtime-matrix/fixtures/mock-pass-pp-cli/mock-pass-pp-cli",
     "critical": 0,
     "data_pipeline": true,
-    "data_pipeline_detail": "PASS: 1 domain tables, items has 1 rows",
+    "data_pipeline_detail": "SKIP (CLI has no sync command)",
     "failed": 0,
     "freshness": {
       "detail": "cache freshness helper not emitted",

--- a/testdata/golden/fixtures/verify-runtime-matrix/mock-pass-pp-cli/internal/cli/sync.go
+++ b/testdata/golden/fixtures/verify-runtime-matrix/mock-pass-pp-cli/internal/cli/sync.go
@@ -1,0 +1,10 @@
+// Package cli models a generated CLI's command layout for the verify
+// data-pipeline gate. The mock-pass-pp-cli fixture implements its actual
+// command handling in cmd/mock-pass-pp-cli/main.go, but the verify gate's
+// sync-capability detection (hasRegisteredCommandFileWithPrefix, via
+// runDataPipelineTest's cliHasSyncCommand) probes internal/cli for a
+// sync-prefixed command file the way a real generated CLI is structured.
+// This stub makes the fixture representative so the data-pipeline gate runs
+// the binary's real sync handler and exercises the sync->sql->rows PASS path
+// end-to-end, rather than being skipped as "no sync command".
+package cli


### PR DESCRIPTION
`runDataPipelineTest` only carved out device CLIs; every other CLI was driven through `sync --full`, and a non-zero / "unknown command" exit was reported as **FAIL: sync crashed**. A POST-only CLI with no sync command (#2622) and a local-datastore CLI that reads a local DB rather than syncing over the network (#2672) both failed the gate for having nothing to sync.

Adds two SKIP carve-outs (returning the same pass + `SKIP (...)` verdict shape as the existing device carve-out) before running sync:
- `manifest.IsLocalDatastore()` → local-datastore CLI
- absent sync command, detected via the existing `hasRegisteredCommandFileWithPrefix`

Real sync CLIs still run the gate and FAIL on a genuine crash; the `sync.go` file ⟺ `VisionSet.Sync` invariant means a network-sync CLI is never false-skipped.

Closes #2622
Closes #2672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
