### PR TITLE
fix(scorer): strip shipcheck report JSON on publish package (#2658)

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -402,6 +402,12 @@ func newPublishPackageCmd() *cobra.Command {
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged test binary %s: %w", filepath.Base(path), err)}
 				}
 			}
+			for _, name := range stagedShipcheckReportNames() {
+				if err := os.Remove(filepath.Join(outCLIDir, name)); err != nil && !os.IsNotExist(err) {
+					cleanupOnFailure()
+					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("stripping staged shipcheck report %s: %w", name, err)}
+				}
+			}
 
 			// Rewrite go.mod module path if --module-path is set
 			if modulePath != "" {
@@ -1350,6 +1356,10 @@ func stagedBinaryNames(cliName, apiSlug string) []string {
 		add(apiSlug + "-pp-mcp")
 	}
 	return names
+}
+
+func stagedShipcheckReportNames() []string {
+	return []string{"dogfood-results.json", "workflow-verify-report.json"}
 }
 
 type fileSnapshot struct {

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -921,6 +921,35 @@ func TestPublishPackageStripsRootBinaries(t *testing.T) {
 	require.FileExists(t, filepath.Join(result.StagedDir, "root_test.go"), "staged dir should keep Go test source files")
 }
 
+func TestPublishPackageStripsRootShipcheckReports(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	for _, name := range stagedShipcheckReportNames() {
+		require.NoError(t, os.WriteFile(filepath.Join(cliDir, name), []byte(`{"passed":true}`+"\n"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "config.json"), []byte(`{"name":"test"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "internal", "cli", "extra.go"), []byte("package cli\n"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+
+	for _, name := range stagedShipcheckReportNames() {
+		assert.FileExists(t, filepath.Join(cliDir, name), "package must not delete source-tree shipcheck report %s", name)
+		assert.NoFileExists(t, filepath.Join(result.StagedDir, name), "staged dir must not include root-level shipcheck report %s", name)
+	}
+	assert.FileExists(t, filepath.Join(result.StagedDir, "config.json"), "legitimate root JSON source should remain staged")
+	assert.FileExists(t, filepath.Join(result.StagedDir, "internal", "cli", "extra.go"), "legitimate Go source should remain staged")
+}
+
 func TestStagedBinaryNamesDeduplicates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`publish package` stripped staged binaries but not the shipcheck report artifacts (`dogfood-results.json`, `workflow-verify-report.json`) that the dogfood and workflow-verify legs write to the CLI directory, so they were published into the library.

Strips them from the staged output by exact filename (alongside the binary strip), with an `os.IsNotExist` guard so a CLI that never ran shipcheck is unaffected.

Closes #2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)
