### PR TITLE
fix(generator): don't persist env-sourced credentials into config.toml (#2710)

### DIFF
--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -322,6 +322,109 @@ func TestSaveBearerTokenPersistsOverBuiltinEnvOverride(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveBearerTokenPersistsOverBuiltinEnvOverride")
 }
 
+// TestConfigSaveBearerTokenClearsNonBuiltinEnvCollision covers the #2720 review
+// gap: SaveBearerToken zeroed non-builtin custom env-var fields in memory but
+// did not delete their envOverrides entries, so configForSave restored the stale
+// on-disk value and the credential field was never cleared from config.toml on
+// refresh. Also exercises the fileConfig map-isolation (deep-copy) fix.
+func TestConfigSaveBearerTokenClearsNonBuiltinEnvCollision(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-refresh-custom-env")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "bearer_token",
+		Header: "Authorization",
+		Format: "Bearer {access_token}",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "API_TENANT", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+		},
+	}
+	apiSpec.BearerRefresh = spec.BearerRefreshConfig{
+		BundleURL: "https://cdn.example.com/main.js",
+		Pattern:   `"(AAAAAAAA[^"]+)"`,
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-refresh-custom-env-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSaveBearerTokenClearsNonBuiltinEnvOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+
+	// Seed a stale on-disk value for the non-builtin custom credential field,
+	// with no env override in effect.
+	seed, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	seed.ApiTenant = "disk-tenant"
+	if err := seed.save(); err != nil {
+		t.Fatalf("seed save() error = %v", err)
+	}
+
+	// Now the env var overrides the disk value.
+	t.Setenv("API_TENANT", "env-tenant")
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.ApiTenant != "env-tenant" {
+		t.Fatalf("ApiTenant after Load() = %q, want env-tenant", cfg.ApiTenant)
+	}
+
+	refreshedAt := time.Date(2032, 3, 4, 5, 6, 7, 0, time.UTC)
+	if err := cfg.SaveBearerToken("refreshed-access-token", refreshedAt); err != nil {
+		t.Fatalf("SaveBearerToken() error = %v", err)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(after)
+	// On refresh the custom credential field must be cleared: neither the env
+	// value nor the stale on-disk value may survive. (Before the fix the
+	// lingering envOverride entry made configForSave write the stale disk value.)
+	for _, stale := range []string{"disk-tenant", "env-tenant"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("config.toml kept stale custom credential %q:\n%s", stale, text)
+		}
+	}
+}
+
+func TestSnapshotFileConfigIsolatesHeaderMap(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Headers == nil {
+		cfg.Headers = map[string]string{}
+	}
+	cfg.snapshotFileConfig()
+	// Mutating the live Headers map after snapshotting must not leak into the
+	// fileConfig snapshot (reference-type isolation, #2720 P2).
+	cfg.Headers["X-Isolation-Probe"] = "mutated"
+	if cfg.fileConfig != nil {
+		if _, leaked := cfg.fileConfig.Headers["X-Isolation-Probe"]; leaked {
+			t.Fatalf("snapshot fileConfig shares the Headers map with the live config")
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "bearer_custom_collision_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveBearerTokenClearsNonBuiltinEnvOverride|TestSnapshotFileConfigIsolatesHeaderMap")
+}
+
 func TestConfigClearTokensClearsBuiltinEnvCollisionCredentials(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -425,6 +425,78 @@ func TestSnapshotFileConfigIsolatesHeaderMap(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveBearerTokenClearsNonBuiltinEnvOverride|TestSnapshotFileConfigIsolatesHeaderMap")
 }
 
+// TestConfigSaveCredentialClearsBuiltinEnvCollision covers the #2720 follow-up
+// Greptile P1: SaveCredential zeroed AuthHeaderVal/AccessToken but only deleted
+// the canonical env-var's override. A NON-canonical env var that collides with
+// the access_token builtin tag (resolving to the AccessToken field) left its
+// override active, so configForSave restored the stale on-disk value instead of
+// the cleared "". SaveCredential is the one credential-write method in the family
+// that previously had no builtin-collision test.
+func TestConfigSaveCredentialClearsBuiltinEnvCollision(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("apikey-builtin-collision")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "api_key",
+		Header: "X-API-Key",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			// Canonical request credential -> non-builtin custom field.
+			{Name: "SVC_API_KEY", Kind: spec.AuthEnvVarKindPerCall, Required: true, Sensitive: true},
+			// Non-canonical, collides with the access_token builtin tag -> AccessToken.
+			{Name: "SVC_ACCESS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "apikey-builtin-collision-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveCredentialClearsBuiltinEnvOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"disk-access-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// SVC_ACCESS_TOKEN collides with the access_token builtin tag, so it resolves
+	// to the AccessToken field and marks an override on Load.
+	t.Setenv("SVC_ACCESS_TOKEN", "env-access-token")
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AccessToken != "env-access-token" {
+		t.Fatalf("AccessToken after Load() = %q, want env-access-token", cfg.AccessToken)
+	}
+
+	if err := cfg.SaveCredential("new-key"); err != nil {
+		t.Fatalf("SaveCredential() error = %v", err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(after)
+	// SaveCredential clears the alternate AccessToken slot; without deleting its
+	// env-override entry, configForSave would restore the stale on-disk value.
+	for _, stale := range []string{"disk-access-token", "env-access-token"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("config.toml kept stale AccessToken %q after SaveCredential:\n%s", stale, text)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "save_credential_collision_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveCredentialClearsBuiltinEnvOverride")
+}
+
 func TestConfigClearTokensClearsBuiltinEnvCollisionCredentials(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/auth_env_precedence_test.go
+++ b/internal/generator/auth_env_precedence_test.go
@@ -117,6 +117,368 @@ func TestClientCredentialsAccessTokenCorrectsEnvFlowInputSource(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestClientCredentialsAccessToken")
 }
 
+func TestConfigSaveTokensDoesNotPersistEnvSourcedCredentials(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth-env-save")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		Format:           "Bearer {access_token}",
+		OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		AuthorizationURL: "https://example.com/oauth/authorize",
+		TokenURL:         "https://example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "GOOGLE_ADS_ACCESS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth-env-save-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnvSourcedCredentialsStayOutOfConfigSave(t *testing.T) {
+	t.Setenv("GOOGLE_ADS_ACCESS_TOKEN", "env-access-token")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	initial := strings.Join([]string{
+		"client_id = \"disk-client-id\"",
+		"client_secret = \"disk-client-secret\"",
+		"access_token = \"disk-access-token\"",
+		"refresh_token = \"disk-refresh-token\"",
+		"ads_access_token = \"disk-ads-access-token\"",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.GoogleAdsAccessToken != "env-access-token" {
+		t.Fatalf("GoogleAdsAccessToken after Load() = %q, want env-access-token", cfg.GoogleAdsAccessToken)
+	}
+	if err := cfg.save(); err != nil {
+		t.Fatalf("save() error = %v", err)
+	}
+	afterSave, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after save error = %v", err)
+	}
+	afterSaveText := string(afterSave)
+	for _, leaked := range []string{"env-client-id", "env-client-secret", "env-access-token"} {
+		if strings.Contains(afterSaveText, leaked) {
+			t.Fatalf("config.toml leaked env value %q after save:\n%s", leaked, afterSaveText)
+		}
+	}
+	for _, preserved := range []string{"disk-client-id", "disk-client-secret", "disk-access-token", "disk-refresh-token", "disk-ads-access-token"} {
+		if !strings.Contains(afterSaveText, preserved) {
+			t.Fatalf("config.toml did not preserve disk value %q after save:\n%s", preserved, afterSaveText)
+		}
+	}
+
+	expiry := time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := cfg.SaveTokens(cfg.ClientID, cfg.ClientSecret, "refreshed-access-token", "refreshed-refresh-token", expiry); err != nil {
+		t.Fatalf("SaveTokens() error = %v", err)
+	}
+	afterTokens, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after SaveTokens error = %v", err)
+	}
+	afterTokensText := string(afterTokens)
+	for _, leaked := range []string{"env-client-id", "env-client-secret", "env-access-token"} {
+		if strings.Contains(afterTokensText, leaked) {
+			t.Fatalf("config.toml leaked env value %q after SaveTokens:\n%s", leaked, afterTokensText)
+		}
+	}
+	for _, want := range []string{"disk-client-id", "disk-client-secret", "refreshed-access-token", "refreshed-refresh-token", "disk-ads-access-token"} {
+		if !strings.Contains(afterTokensText, want) {
+			t.Fatalf("config.toml missing %q after SaveTokens:\n%s", want, afterTokensText)
+		}
+	}
+}
+
+func TestConfigSaveRoundTripWithoutEnvIsStable(t *testing.T) {
+	t.Setenv("CLIENT_ID", "")
+	t.Setenv("CLIENT_SECRET", "")
+	t.Setenv("GOOGLE_ADS_ACCESS_TOKEN", "")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	expiry := time.Date(2031, 2, 3, 4, 5, 6, 0, time.UTC)
+	original := &Config{
+		Path:         configPath,
+		ClientID:     "disk-client-id",
+		ClientSecret: "disk-client-secret",
+		AccessToken:  "disk-access-token",
+		RefreshToken: "disk-refresh-token",
+		TokenExpiry:  expiry,
+		GoogleAdsAccessToken: "disk-ads-access-token",
+	}
+	if err := original.save(); err != nil {
+		t.Fatalf("initial save() error = %v", err)
+	}
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() before Load error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if err := cfg.save(); err != nil {
+		t.Fatalf("second save() error = %v", err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() after save error = %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("config changed after no-env load+save\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "env_save_tokens_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestEnvSourcedCredentialsStayOutOfConfigSave|TestConfigSaveRoundTripWithoutEnvIsStable")
+}
+
+func TestConfigSaveBearerTokenPersistsBuiltinEnvCollisionWrite(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearer-refresh-collision")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "bearer_token",
+		Header: "Authorization",
+		Format: "Bearer {access_token}",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "REFRESH_ACCESS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+		},
+	}
+	apiSpec.BearerRefresh = spec.BearerRefreshConfig{
+		BundleURL: "https://cdn.example.com/main.js",
+		Pattern:   `"(AAAAAAAA[^"]+)"`,
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "bearer-refresh-collision-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSaveBearerTokenPersistsOverBuiltinEnvOverride(t *testing.T) {
+	t.Setenv("REFRESH_ACCESS_TOKEN", "env-access-token")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("access_token = \"disk-access-token\"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AccessToken != "env-access-token" {
+		t.Fatalf("AccessToken after Load() = %q, want env-access-token", cfg.AccessToken)
+	}
+
+	refreshedAt := time.Date(2032, 3, 4, 5, 6, 7, 0, time.UTC)
+	if err := cfg.SaveBearerToken("refreshed-access-token", refreshedAt); err != nil {
+		t.Fatalf("SaveBearerToken() error = %v", err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(after)
+	if !strings.Contains(text, "refreshed-access-token") {
+		t.Fatalf("config.toml missing refreshed token:\n%s", text)
+	}
+	for _, stale := range []string{"disk-access-token", "env-access-token"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("config.toml kept stale token %q:\n%s", stale, text)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "bearer_builtin_collision_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveBearerTokenPersistsOverBuiltinEnvOverride")
+}
+
+func TestConfigClearTokensClearsBuiltinEnvCollisionCredentials(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("clear-builtin-collision")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		Format:           "Bearer {access_token}",
+		OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		AuthorizationURL: "https://example.com/oauth/authorize",
+		TokenURL:         "https://example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "CLEAR_ACCESS_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true},
+			{Name: "CLEAR_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "clear-builtin-collision-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClearTokensClearsBuiltinEnvOverridesOnDisk(t *testing.T) {
+	t.Setenv("CLEAR_ACCESS_TOKEN", "env-access-token")
+	t.Setenv("CLEAR_CLIENT_ID", "env-client-id")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	initial := strings.Join([]string{
+		"client_id = \"disk-client-id\"",
+		"client_secret = \"disk-client-secret\"",
+		"access_token = \"disk-access-token\"",
+		"refresh_token = \"disk-refresh-token\"",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AccessToken != "env-access-token" {
+		t.Fatalf("AccessToken after Load() = %q, want env-access-token", cfg.AccessToken)
+	}
+	if cfg.ClientID != "env-client-id" {
+		t.Fatalf("ClientID after Load() = %q, want env-client-id", cfg.ClientID)
+	}
+
+	if err := cfg.ClearTokens(); err != nil {
+		t.Fatalf("ClearTokens() error = %v", err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(after)
+	for _, want := range []string{"client_id = ''", "client_secret = ''", "access_token = ''", "refresh_token = ''"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config.toml missing cleared field %q:\n%s", want, text)
+		}
+	}
+	for _, stale := range []string{"disk-client-id", "disk-client-secret", "disk-access-token", "disk-refresh-token", "env-client-id", "env-access-token"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("config.toml kept stale credential %q:\n%s", stale, text)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "clear_builtin_collision_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestClearTokensClearsBuiltinEnvOverridesOnDisk")
+}
+
+func TestConfigSaveTokensPersistsClientIDBuiltinEnvCollisionWrite(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth-client-id-collision")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:             "oauth2",
+		Header:           "Authorization",
+		Format:           "Bearer {access_token}",
+		OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		AuthorizationURL: "https://example.com/oauth/authorize",
+		TokenURL:         "https://example.com/oauth/token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "SAVE_CLIENT_ID", Kind: spec.AuthEnvVarKindAuthFlowInput, Required: false, Sensitive: false},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth-client-id-collision-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSaveTokensPersistsClientIDOverBuiltinEnvOverride(t *testing.T) {
+	t.Setenv("SAVE_CLIENT_ID", "env-client-id")
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	initial := strings.Join([]string{
+		"client_id = \"disk-client-id\"",
+		"client_secret = \"disk-client-secret\"",
+		"access_token = \"disk-access-token\"",
+		"refresh_token = \"disk-refresh-token\"",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.ClientID != "env-client-id" {
+		t.Fatalf("ClientID after Load() = %q, want env-client-id", cfg.ClientID)
+	}
+
+	expiry := time.Date(2033, 4, 5, 6, 7, 8, 0, time.UTC)
+	if err := cfg.SaveTokens("new-client-id", cfg.ClientSecret, "new-access-token", "new-refresh-token", expiry); err != nil {
+		t.Fatalf("SaveTokens() error = %v", err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	text := string(after)
+	for _, want := range []string{"new-client-id", "disk-client-secret", "new-access-token", "new-refresh-token"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config.toml missing %q:\n%s", want, text)
+		}
+	}
+	for _, stale := range []string{"disk-client-id", "env-client-id", "disk-access-token", "disk-refresh-token"} {
+		if strings.Contains(text, stale) {
+			t.Fatalf("config.toml kept stale credential %q:\n%s", stale, text)
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "save_tokens_client_id_collision_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/config", "-run", "TestSaveTokensPersistsClientIDOverBuiltinEnvOverride")
+}
+
 func TestClientCredentialsEnvVarsSkipTenantSetupInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -676,8 +676,18 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
+	// Pair each builtin-field zeroing with an envOverrides delete, like
+	// ClearTokens/SaveBearerToken: if an env var's placeholder collides with the
+	// AuthHeaderVal/AccessToken builtin tag, the override would otherwise survive
+	// and configForSave would restore the stale on-disk value instead of "".
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
 {{- if .HasRequiredRoles}}
 	c.AuthRole = ""
+	delete(c.envOverrides, "AuthRole")
+	c.updateFileConfigField("AuthRole")
 {{- end}}
 {{- with .Auth.CanonicalEnvVar}}
 	c.{{resolveEnvVarField .Name}} = token

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -701,6 +701,7 @@ func (c *Config) SaveBearerToken(accessToken string, refreshedAt time.Time) erro
 {{- range .Auth.EnvVarSpecs}}
 {{- if not (envVarIsBuiltinField .Name)}}
 	c.{{envVarField .Name}} = ""
+	delete(c.envOverrides, "{{resolveEnvVarField .Name}}")
 {{- end}}
 {{- end}}
 {{- else if .Auth.EnvVars}}
@@ -708,6 +709,7 @@ func (c *Config) SaveBearerToken(accessToken string, refreshedAt time.Time) erro
 {{- range .Auth.EnvVars}}
 {{- if not (envVarIsBuiltinField .)}}
 	c.{{envVarField .}} = ""
+	delete(c.envOverrides, "{{resolveEnvVarField .}}")
 {{- end}}
 {{- end}}
 {{- end}}
@@ -795,10 +797,31 @@ func (c *Config) markEnvOverride(field string) {
 	c.envOverrides[field] = true
 }
 
+// cloneStringMap returns an independent copy of m (nil stays nil). The fileConfig
+// snapshot must not share reference-type map fields (such as Headers) with the
+// live config, or a later mutation to one would silently track in the other.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (c *Config) snapshotFileConfig() {
 	snapshot := *c
 	snapshot.envOverrides = nil
 	snapshot.fileConfig = nil
+	// *c is a shallow copy: map fields are reference types, so the snapshot would
+	// share them with c and silently track later mutations, defeating the
+	// isolation this snapshot exists to provide. Clone them.
+	snapshot.Headers = cloneStringMap(c.Headers)
+{{- if or .EndpointTemplateVars .GlobalPathTemplateVars}}
+	snapshot.TemplateVars = cloneStringMap(c.TemplateVars)
+{{- end}}
 	c.fileConfig = &snapshot
 }
 
@@ -907,6 +930,13 @@ func (c *Config) save() error {
 	c.fileConfig = &persisted
 	c.fileConfig.envOverrides = nil
 	c.fileConfig.fileConfig = nil
+	// persisted shares its map fields with c (configForSave shallow-copies *c),
+	// so isolate the stored fileConfig the same way snapshotFileConfig does;
+	// otherwise later mutations to c's maps leak into the on-disk snapshot.
+	c.fileConfig.Headers = cloneStringMap(c.fileConfig.Headers)
+{{- if or .EndpointTemplateVars .GlobalPathTemplateVars}}
+	c.fileConfig.TemplateVars = cloneStringMap(c.fileConfig.TemplateVars)
+{{- end}}
 	return nil
 }
 

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -64,6 +64,8 @@ type Config struct {
 {{- end}}
 {{- end}}
 	Path           string `{{configTag .Config.Format}}:"-"`
+	envOverrides   map[string]bool `{{configTag .Config.Format}}:"-"`
+	fileConfig     *Config `{{configTag .Config.Format}}:"-"`
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 {{- if not (envVarIsBuiltinField .Name)}}
@@ -130,6 +132,8 @@ func Load(configPath string) (*Config, error) {
 	}
 {{- end}}
 
+	cfg.snapshotFileConfig()
+
 	// Env var overrides
 {{- if .Auth.Inferred}}
 	// Auth inferred from API description — verify the env var below is correct
@@ -138,6 +142,7 @@ func Load(configPath string) (*Config, error) {
 {{- range .Auth.EnvVarSpecs}}
 	if v := os.Getenv("{{.Name}}"); v != "" {
 		cfg.{{resolveEnvVarField .Name}} = v
+		cfg.markEnvOverride("{{resolveEnvVarField .Name}}")
 		cfg.AuthSource = "env:{{.Name}}"
 	}
 {{- end}}
@@ -146,6 +151,7 @@ func Load(configPath string) (*Config, error) {
 {{- range .Auth.EnvVars}}
 	if v := os.Getenv("{{.}}"); v != "" {
 		cfg.{{resolveEnvVarField .}} = v
+		cfg.markEnvOverride("{{resolveEnvVarField .}}")
 		cfg.AuthSource = "env:{{.}}"
 	}
 {{- end}}
@@ -156,6 +162,7 @@ func Load(configPath string) (*Config, error) {
 	// remains the canonical surface for doctor/auth-status reporting.
 	if v := os.Getenv("{{.EnvVar.Name}}"); v != "" {
 		cfg.{{resolveEnvVarField .EnvVar.Name}} = v
+		cfg.markEnvOverride("{{resolveEnvVarField .EnvVar.Name}}")
 	}
 {{- end}}
 
@@ -639,8 +646,19 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
 {{- if .HasRequiredRoles}}
 	c.AuthRole = ""
+	c.updateFileConfigField("AuthRole")
 {{- end}}
 	return c.save()
 }
@@ -663,6 +681,8 @@ func (c *Config) SaveCredential(token string) error {
 {{- end}}
 {{- with .Auth.CanonicalEnvVar}}
 	c.{{resolveEnvVarField .Name}} = token
+	delete(c.envOverrides, "{{resolveEnvVarField .Name}}")
+	c.updateFileConfigField("{{resolveEnvVarField .Name}}")
 {{- end}}
 	return c.save()
 }
@@ -692,6 +712,16 @@ func (c *Config) SaveBearerToken(accessToken string, refreshedAt time.Time) erro
 {{- end}}
 {{- end}}
 	c.BearerTokenRefreshedAt = refreshedAt
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "BearerTokenRefreshedAt")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("BearerTokenRefreshedAt")
 	return c.save()
 }
 
@@ -710,16 +740,33 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
 {{- if .HasRequiredRoles}}
 	c.AuthRole = ""
+	delete(c.envOverrides, "AuthRole")
+	c.updateFileConfigField("AuthRole")
 {{- end}}
 {{- if .BearerRefresh.Enabled}}
 	c.BearerTokenRefreshedAt = time.Time{}
+	delete(c.envOverrides, "BearerTokenRefreshedAt")
+	c.updateFileConfigField("BearerTokenRefreshedAt")
 {{- end}}
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
 {{- if not (envVarIsBuiltinField .Name)}}
 	c.{{envVarField .Name}} = ""
+	delete(c.envOverrides, "{{resolveEnvVarField .Name}}")
 {{- end}}
 {{- end}}
 {{- else if .Auth.EnvVars}}
@@ -727,36 +774,140 @@ func (c *Config) ClearTokens() error {
 {{- range .Auth.EnvVars}}
 {{- if not (envVarIsBuiltinField .)}}
 	c.{{envVarField .}} = ""
+	delete(c.envOverrides, "{{resolveEnvVarField .}}")
 {{- end}}
 {{- end}}
 {{- end}}
 {{- range .Auth.AdditionalHeaders}}
 {{- if not (envVarIsBuiltinField .EnvVar.Name)}}
 	c.{{envVarField .EnvVar.Name}} = ""
+	delete(c.envOverrides, "{{resolveEnvVarField .EnvVar.Name}}")
 {{- end}}
 {{- end}}
 	return c.save()
 }
 {{- end}}
 
+func (c *Config) markEnvOverride(field string) {
+	if c.envOverrides == nil {
+		c.envOverrides = map[string]bool{}
+	}
+	c.envOverrides[field] = true
+}
+
+func (c *Config) snapshotFileConfig() {
+	snapshot := *c
+	snapshot.envOverrides = nil
+	snapshot.fileConfig = nil
+	c.fileConfig = &snapshot
+}
+
+func (c *Config) configForSave() Config {
+	out := *c
+	if c.fileConfig != nil {
+{{- if .Auth.EnvVarSpecs}}
+{{- range .Auth.EnvVarSpecs}}
+		if c.envOverrides["{{resolveEnvVarField .Name}}"] {
+			out.{{resolveEnvVarField .Name}} = c.fileConfig.{{resolveEnvVarField .Name}}
+		}
+{{- end}}
+{{- else if .Auth.EnvVars}}
+	// fallback to legacy EnvVars when EnvVarSpecs is empty
+{{- range .Auth.EnvVars}}
+		if c.envOverrides["{{resolveEnvVarField .}}"] {
+			out.{{resolveEnvVarField .}} = c.fileConfig.{{resolveEnvVarField .}}
+		}
+{{- end}}
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+		if c.envOverrides["{{resolveEnvVarField .EnvVar.Name}}"] {
+			out.{{resolveEnvVarField .EnvVar.Name}} = c.fileConfig.{{resolveEnvVarField .EnvVar.Name}}
+		}
+{{- end}}
+	}
+	out.envOverrides = nil
+	out.fileConfig = nil
+	return out
+}
+
+func (c *Config) updateFileConfigField(field string) {
+	if c.fileConfig == nil || c.envOverrides[field] {
+		return
+	}
+	switch field {
+	case "AuthHeaderVal":
+		c.fileConfig.AuthHeaderVal = c.AuthHeaderVal
+{{- if .HasAuthCommand}}
+	case "AccessToken":
+		c.fileConfig.AccessToken = c.AccessToken
+	case "RefreshToken":
+		c.fileConfig.RefreshToken = c.RefreshToken
+	case "TokenExpiry":
+		c.fileConfig.TokenExpiry = c.TokenExpiry
+	case "ClientID":
+		c.fileConfig.ClientID = c.ClientID
+	case "ClientSecret":
+		c.fileConfig.ClientSecret = c.ClientSecret
+{{- if .BearerRefresh.Enabled}}
+	case "BearerTokenRefreshedAt":
+		c.fileConfig.BearerTokenRefreshedAt = c.BearerTokenRefreshedAt
+{{- end}}
+{{- end}}
+{{- if .HasRequiredRoles}}
+	case "AuthRole":
+		c.fileConfig.AuthRole = c.AuthRole
+{{- end}}
+{{- if .Auth.EnvVarSpecs}}
+{{- range .Auth.EnvVarSpecs}}
+{{- if not (envVarIsBuiltinField .Name)}}
+	case "{{resolveEnvVarField .Name}}":
+		c.fileConfig.{{resolveEnvVarField .Name}} = c.{{resolveEnvVarField .Name}}
+{{- end}}
+{{- end}}
+{{- else if .Auth.EnvVars}}
+{{- range .Auth.EnvVars}}
+{{- if not (envVarIsBuiltinField .)}}
+	case "{{resolveEnvVarField .}}":
+		c.fileConfig.{{resolveEnvVarField .}} = c.{{resolveEnvVarField .}}
+{{- end}}
+{{- end}}
+{{- end}}
+{{- range .Auth.AdditionalHeaders}}
+{{- if not (envVarIsBuiltinField .EnvVar.Name)}}
+	case "{{resolveEnvVarField .EnvVar.Name}}":
+		c.fileConfig.{{resolveEnvVarField .EnvVar.Name}} = c.{{resolveEnvVarField .EnvVar.Name}}
+{{- end}}
+{{- end}}
+	}
+}
+
 func (c *Config) save() error {
 	dir := filepath.Dir(c.Path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
+	persisted := c.configForSave()
 {{- if eq .Config.Format "toml"}}
-	data, err := toml.Marshal(c)
+	data, err := toml.Marshal(persisted)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
 {{- else}}
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := json.MarshalIndent(persisted, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
 {{- end}}
+	c.fileConfig = &persisted
+	c.fileConfig.envOverrides = nil
+	c.fileConfig.fileConfig = nil
+	return nil
 }
 
 // Ensure strings import is used

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -203,10 +203,28 @@ func (c *Config) markEnvOverride(field string) {
 	c.envOverrides[field] = true
 }
 
+// cloneStringMap returns an independent copy of m (nil stays nil). The fileConfig
+// snapshot must not share reference-type map fields (such as Headers) with the
+// live config, or a later mutation to one would silently track in the other.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (c *Config) snapshotFileConfig() {
 	snapshot := *c
 	snapshot.envOverrides = nil
 	snapshot.fileConfig = nil
+	// *c is a shallow copy: map fields are reference types, so the snapshot would
+	// share them with c and silently track later mutations, defeating the
+	// isolation this snapshot exists to provide. Clone them.
+	snapshot.Headers = cloneStringMap(c.Headers)
 	c.fileConfig = &snapshot
 }
 
@@ -265,6 +283,10 @@ func (c *Config) save() error {
 	c.fileConfig = &persisted
 	c.fileConfig.envOverrides = nil
 	c.fileConfig.fileConfig = nil
+	// persisted shares its map fields with c (configForSave shallow-copies *c),
+	// so isolate the stored fileConfig the same way snapshotFileConfig does;
+	// otherwise later mutations to c's maps leak into the on-disk snapshot.
+	c.fileConfig.Headers = cloneStringMap(c.fileConfig.Headers)
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/config/config.go
@@ -25,10 +25,12 @@ type Config struct {
 	ClientSecret  string            `toml:"client_secret"`
 	// TokenURL overrides the spec-baked OAuth2 token endpoint. Same fallback
 	// pattern as AuthorizationURL.
-	TokenURL                        string `toml:"token_url,omitempty"`
-	Path                            string `toml:"-"`
-	PrintingPressOauth2ClientId     string `toml:"press_oauth2_client_id"`
-	PrintingPressOauth2ClientSecret string `toml:"press_oauth2_client_secret"`
+	TokenURL                        string          `toml:"token_url,omitempty"`
+	Path                            string          `toml:"-"`
+	envOverrides                    map[string]bool `toml:"-"`
+	fileConfig                      *Config         `toml:"-"`
+	PrintingPressOauth2ClientId     string          `toml:"press_oauth2_client_id"`
+	PrintingPressOauth2ClientSecret string          `toml:"press_oauth2_client_secret"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -55,13 +57,17 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
+	cfg.snapshotFileConfig()
+
 	// Env var overrides
 	if v := os.Getenv("PRINTING_PRESS_OAUTH2_CLIENT_ID"); v != "" {
 		cfg.PrintingPressOauth2ClientId = v
+		cfg.markEnvOverride("PrintingPressOauth2ClientId")
 		cfg.AuthSource = "env:PRINTING_PRESS_OAUTH2_CLIENT_ID"
 	}
 	if v := os.Getenv("PRINTING_PRESS_OAUTH2_CLIENT_SECRET"); v != "" {
 		cfg.PrintingPressOauth2ClientSecret = v
+		cfg.markEnvOverride("PrintingPressOauth2ClientSecret")
 		cfg.AuthSource = "env:PRINTING_PRESS_OAUTH2_CLIENT_SECRET"
 	}
 
@@ -145,6 +151,16 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
 	return c.save()
 }
 
@@ -161,9 +177,76 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
 	c.PrintingPressOauth2ClientId = ""
+	delete(c.envOverrides, "PrintingPressOauth2ClientId")
 	c.PrintingPressOauth2ClientSecret = ""
+	delete(c.envOverrides, "PrintingPressOauth2ClientSecret")
 	return c.save()
+}
+
+func (c *Config) markEnvOverride(field string) {
+	if c.envOverrides == nil {
+		c.envOverrides = map[string]bool{}
+	}
+	c.envOverrides[field] = true
+}
+
+func (c *Config) snapshotFileConfig() {
+	snapshot := *c
+	snapshot.envOverrides = nil
+	snapshot.fileConfig = nil
+	c.fileConfig = &snapshot
+}
+
+func (c *Config) configForSave() Config {
+	out := *c
+	if c.fileConfig != nil {
+		if c.envOverrides["PrintingPressOauth2ClientId"] {
+			out.PrintingPressOauth2ClientId = c.fileConfig.PrintingPressOauth2ClientId
+		}
+		if c.envOverrides["PrintingPressOauth2ClientSecret"] {
+			out.PrintingPressOauth2ClientSecret = c.fileConfig.PrintingPressOauth2ClientSecret
+		}
+	}
+	out.envOverrides = nil
+	out.fileConfig = nil
+	return out
+}
+
+func (c *Config) updateFileConfigField(field string) {
+	if c.fileConfig == nil || c.envOverrides[field] {
+		return
+	}
+	switch field {
+	case "AuthHeaderVal":
+		c.fileConfig.AuthHeaderVal = c.AuthHeaderVal
+	case "AccessToken":
+		c.fileConfig.AccessToken = c.AccessToken
+	case "RefreshToken":
+		c.fileConfig.RefreshToken = c.RefreshToken
+	case "TokenExpiry":
+		c.fileConfig.TokenExpiry = c.TokenExpiry
+	case "ClientID":
+		c.fileConfig.ClientID = c.ClientID
+	case "ClientSecret":
+		c.fileConfig.ClientSecret = c.ClientSecret
+	case "PrintingPressOauth2ClientId":
+		c.fileConfig.PrintingPressOauth2ClientId = c.PrintingPressOauth2ClientId
+	case "PrintingPressOauth2ClientSecret":
+		c.fileConfig.PrintingPressOauth2ClientSecret = c.PrintingPressOauth2ClientSecret
+	}
 }
 
 func (c *Config) save() error {
@@ -171,11 +254,18 @@ func (c *Config) save() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
-	data, err := toml.Marshal(c)
+	persisted := c.configForSave()
+	data, err := toml.Marshal(persisted)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
+	c.fileConfig = &persisted
+	c.fileConfig.envOverrides = nil
+	c.fileConfig.fileConfig = nil
+	return nil
 }
 
 // Ensure strings import is used

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
@@ -200,10 +200,28 @@ func (c *Config) markEnvOverride(field string) {
 	c.envOverrides[field] = true
 }
 
+// cloneStringMap returns an independent copy of m (nil stays nil). The fileConfig
+// snapshot must not share reference-type map fields (such as Headers) with the
+// live config, or a later mutation to one would silently track in the other.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (c *Config) snapshotFileConfig() {
 	snapshot := *c
 	snapshot.envOverrides = nil
 	snapshot.fileConfig = nil
+	// *c is a shallow copy: map fields are reference types, so the snapshot would
+	// share them with c and silently track later mutations, defeating the
+	// isolation this snapshot exists to provide. Clone them.
+	snapshot.Headers = cloneStringMap(c.Headers)
 	c.fileConfig = &snapshot
 }
 
@@ -257,6 +275,10 @@ func (c *Config) save() error {
 	c.fileConfig = &persisted
 	c.fileConfig.envOverrides = nil
 	c.fileConfig.fileConfig = nil
+	// persisted shares its map fields with c (configForSave shallow-copies *c),
+	// so isolate the stored fileConfig the same way snapshotFileConfig does;
+	// otherwise later mutations to c's maps leak into the on-disk snapshot.
+	c.fileConfig.Headers = cloneStringMap(c.fileConfig.Headers)
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/config/config.go
@@ -30,9 +30,11 @@ type Config struct {
 	DeviceAuthorizationURL string `toml:"device_authorization_url,omitempty"`
 	// TokenURL overrides the spec-baked OAuth2 token endpoint. Same fallback
 	// pattern as AuthorizationURL.
-	TokenURL           string `toml:"token_url,omitempty"`
-	Path               string `toml:"-"`
-	DeviceCodeClientId string `toml:"code_client_id"`
+	TokenURL           string          `toml:"token_url,omitempty"`
+	Path               string          `toml:"-"`
+	envOverrides       map[string]bool `toml:"-"`
+	fileConfig         *Config         `toml:"-"`
+	DeviceCodeClientId string          `toml:"code_client_id"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -59,9 +61,12 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
+	cfg.snapshotFileConfig()
+
 	// Env var overrides
 	if v := os.Getenv("DEVICE_CODE_CLIENT_ID"); v != "" {
 		cfg.DeviceCodeClientId = v
+		cfg.markEnvOverride("DeviceCodeClientId")
 		cfg.AuthSource = "env:DEVICE_CODE_CLIENT_ID"
 	}
 
@@ -145,6 +150,16 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
 	return c.save()
 }
 
@@ -161,8 +176,69 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
 	c.DeviceCodeClientId = ""
+	delete(c.envOverrides, "DeviceCodeClientId")
 	return c.save()
+}
+
+func (c *Config) markEnvOverride(field string) {
+	if c.envOverrides == nil {
+		c.envOverrides = map[string]bool{}
+	}
+	c.envOverrides[field] = true
+}
+
+func (c *Config) snapshotFileConfig() {
+	snapshot := *c
+	snapshot.envOverrides = nil
+	snapshot.fileConfig = nil
+	c.fileConfig = &snapshot
+}
+
+func (c *Config) configForSave() Config {
+	out := *c
+	if c.fileConfig != nil {
+		if c.envOverrides["DeviceCodeClientId"] {
+			out.DeviceCodeClientId = c.fileConfig.DeviceCodeClientId
+		}
+	}
+	out.envOverrides = nil
+	out.fileConfig = nil
+	return out
+}
+
+func (c *Config) updateFileConfigField(field string) {
+	if c.fileConfig == nil || c.envOverrides[field] {
+		return
+	}
+	switch field {
+	case "AuthHeaderVal":
+		c.fileConfig.AuthHeaderVal = c.AuthHeaderVal
+	case "AccessToken":
+		c.fileConfig.AccessToken = c.AccessToken
+	case "RefreshToken":
+		c.fileConfig.RefreshToken = c.RefreshToken
+	case "TokenExpiry":
+		c.fileConfig.TokenExpiry = c.TokenExpiry
+	case "ClientID":
+		c.fileConfig.ClientID = c.ClientID
+	case "ClientSecret":
+		c.fileConfig.ClientSecret = c.ClientSecret
+	case "DeviceCodeClientId":
+		c.fileConfig.DeviceCodeClientId = c.DeviceCodeClientId
+	}
 }
 
 func (c *Config) save() error {
@@ -170,11 +246,18 @@ func (c *Config) save() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
-	data, err := toml.Marshal(c)
+	persisted := c.configForSave()
+	data, err := toml.Marshal(persisted)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
+	c.fileConfig = &persisted
+	c.fileConfig.envOverrides = nil
+	c.fileConfig.fileConfig = nil
+	return nil
 }
 
 // Ensure strings import is used

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -210,6 +210,14 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
+	// Pair each builtin-field zeroing with an envOverrides delete, like
+	// ClearTokens/SaveBearerToken: if an env var's placeholder collides with the
+	// AuthHeaderVal/AccessToken builtin tag, the override would otherwise survive
+	// and configForSave would restore the stale on-disk value instead of "".
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
 	c.RichAuthApiKey = token
 	delete(c.envOverrides, "RichAuthApiKey")
 	c.updateFileConfigField("RichAuthApiKey")

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	ClientID              string            `toml:"client_id"`
 	ClientSecret          string            `toml:"client_secret"`
 	Path                  string            `toml:"-"`
+	envOverrides          map[string]bool   `toml:"-"`
+	fileConfig            *Config           `toml:"-"`
 	RichAuthApiKey        string            `toml:"auth_api_key"`
 	RichAuthClientId      string            `toml:"auth_client_id"`
 	RichAuthClientSecret  string            `toml:"auth_client_secret"`
@@ -57,33 +59,42 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
+	cfg.snapshotFileConfig()
+
 	// Env var overrides
 	if v := os.Getenv("RICH_AUTH_API_KEY"); v != "" {
 		cfg.RichAuthApiKey = v
+		cfg.markEnvOverride("RichAuthApiKey")
 		cfg.AuthSource = "env:RICH_AUTH_API_KEY"
 	}
 	if v := os.Getenv("RICH_AUTH_CLIENT_ID"); v != "" {
 		cfg.RichAuthClientId = v
+		cfg.markEnvOverride("RichAuthClientId")
 		cfg.AuthSource = "env:RICH_AUTH_CLIENT_ID"
 	}
 	if v := os.Getenv("RICH_AUTH_CLIENT_SECRET"); v != "" {
 		cfg.RichAuthClientSecret = v
+		cfg.markEnvOverride("RichAuthClientSecret")
 		cfg.AuthSource = "env:RICH_AUTH_CLIENT_SECRET"
 	}
 	if v := os.Getenv("RICH_AUTH_SESSION_COOKIE"); v != "" {
 		cfg.RichAuthSessionCookie = v
+		cfg.markEnvOverride("RichAuthSessionCookie")
 		cfg.AuthSource = "env:RICH_AUTH_SESSION_COOKIE"
 	}
 	if v := os.Getenv("RICH_AUTH_OPTIONAL_TOKEN"); v != "" {
 		cfg.RichAuthOptionalToken = v
+		cfg.markEnvOverride("RichAuthOptionalToken")
 		cfg.AuthSource = "env:RICH_AUTH_OPTIONAL_TOKEN"
 	}
 	if v := os.Getenv("RICH_AUTH_BOT_TOKEN"); v != "" {
 		cfg.RichAuthBotToken = v
+		cfg.markEnvOverride("RichAuthBotToken")
 		cfg.AuthSource = "env:RICH_AUTH_BOT_TOKEN"
 	}
 	if v := os.Getenv("RICH_AUTH_USER_TOKEN"); v != "" {
 		cfg.RichAuthUserToken = v
+		cfg.markEnvOverride("RichAuthUserToken")
 		cfg.AuthSource = "env:RICH_AUTH_USER_TOKEN"
 	}
 
@@ -175,6 +186,16 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
 	return c.save()
 }
 
@@ -190,6 +211,8 @@ func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.RichAuthApiKey = token
+	delete(c.envOverrides, "RichAuthApiKey")
+	c.updateFileConfigField("RichAuthApiKey")
 	return c.save()
 }
 
@@ -206,14 +229,111 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
 	c.RichAuthApiKey = ""
+	delete(c.envOverrides, "RichAuthApiKey")
 	c.RichAuthClientId = ""
+	delete(c.envOverrides, "RichAuthClientId")
 	c.RichAuthClientSecret = ""
+	delete(c.envOverrides, "RichAuthClientSecret")
 	c.RichAuthSessionCookie = ""
+	delete(c.envOverrides, "RichAuthSessionCookie")
 	c.RichAuthOptionalToken = ""
+	delete(c.envOverrides, "RichAuthOptionalToken")
 	c.RichAuthBotToken = ""
+	delete(c.envOverrides, "RichAuthBotToken")
 	c.RichAuthUserToken = ""
+	delete(c.envOverrides, "RichAuthUserToken")
 	return c.save()
+}
+
+func (c *Config) markEnvOverride(field string) {
+	if c.envOverrides == nil {
+		c.envOverrides = map[string]bool{}
+	}
+	c.envOverrides[field] = true
+}
+
+func (c *Config) snapshotFileConfig() {
+	snapshot := *c
+	snapshot.envOverrides = nil
+	snapshot.fileConfig = nil
+	c.fileConfig = &snapshot
+}
+
+func (c *Config) configForSave() Config {
+	out := *c
+	if c.fileConfig != nil {
+		if c.envOverrides["RichAuthApiKey"] {
+			out.RichAuthApiKey = c.fileConfig.RichAuthApiKey
+		}
+		if c.envOverrides["RichAuthClientId"] {
+			out.RichAuthClientId = c.fileConfig.RichAuthClientId
+		}
+		if c.envOverrides["RichAuthClientSecret"] {
+			out.RichAuthClientSecret = c.fileConfig.RichAuthClientSecret
+		}
+		if c.envOverrides["RichAuthSessionCookie"] {
+			out.RichAuthSessionCookie = c.fileConfig.RichAuthSessionCookie
+		}
+		if c.envOverrides["RichAuthOptionalToken"] {
+			out.RichAuthOptionalToken = c.fileConfig.RichAuthOptionalToken
+		}
+		if c.envOverrides["RichAuthBotToken"] {
+			out.RichAuthBotToken = c.fileConfig.RichAuthBotToken
+		}
+		if c.envOverrides["RichAuthUserToken"] {
+			out.RichAuthUserToken = c.fileConfig.RichAuthUserToken
+		}
+	}
+	out.envOverrides = nil
+	out.fileConfig = nil
+	return out
+}
+
+func (c *Config) updateFileConfigField(field string) {
+	if c.fileConfig == nil || c.envOverrides[field] {
+		return
+	}
+	switch field {
+	case "AuthHeaderVal":
+		c.fileConfig.AuthHeaderVal = c.AuthHeaderVal
+	case "AccessToken":
+		c.fileConfig.AccessToken = c.AccessToken
+	case "RefreshToken":
+		c.fileConfig.RefreshToken = c.RefreshToken
+	case "TokenExpiry":
+		c.fileConfig.TokenExpiry = c.TokenExpiry
+	case "ClientID":
+		c.fileConfig.ClientID = c.ClientID
+	case "ClientSecret":
+		c.fileConfig.ClientSecret = c.ClientSecret
+	case "RichAuthApiKey":
+		c.fileConfig.RichAuthApiKey = c.RichAuthApiKey
+	case "RichAuthClientId":
+		c.fileConfig.RichAuthClientId = c.RichAuthClientId
+	case "RichAuthClientSecret":
+		c.fileConfig.RichAuthClientSecret = c.RichAuthClientSecret
+	case "RichAuthSessionCookie":
+		c.fileConfig.RichAuthSessionCookie = c.RichAuthSessionCookie
+	case "RichAuthOptionalToken":
+		c.fileConfig.RichAuthOptionalToken = c.RichAuthOptionalToken
+	case "RichAuthBotToken":
+		c.fileConfig.RichAuthBotToken = c.RichAuthBotToken
+	case "RichAuthUserToken":
+		c.fileConfig.RichAuthUserToken = c.RichAuthUserToken
+	}
 }
 
 func (c *Config) save() error {
@@ -221,11 +341,18 @@ func (c *Config) save() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
-	data, err := toml.Marshal(c)
+	persisted := c.configForSave()
+	data, err := toml.Marshal(persisted)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
+	c.fileConfig = &persisted
+	c.fileConfig.envOverrides = nil
+	c.fileConfig.fileConfig = nil
+	return nil
 }
 
 // Ensure strings import is used

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/config/config.go
@@ -265,10 +265,28 @@ func (c *Config) markEnvOverride(field string) {
 	c.envOverrides[field] = true
 }
 
+// cloneStringMap returns an independent copy of m (nil stays nil). The fileConfig
+// snapshot must not share reference-type map fields (such as Headers) with the
+// live config, or a later mutation to one would silently track in the other.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (c *Config) snapshotFileConfig() {
 	snapshot := *c
 	snapshot.envOverrides = nil
 	snapshot.fileConfig = nil
+	// *c is a shallow copy: map fields are reference types, so the snapshot would
+	// share them with c and silently track later mutations, defeating the
+	// isolation this snapshot exists to provide. Clone them.
+	snapshot.Headers = cloneStringMap(c.Headers)
 	c.fileConfig = &snapshot
 }
 
@@ -352,6 +370,10 @@ func (c *Config) save() error {
 	c.fileConfig = &persisted
 	c.fileConfig.envOverrides = nil
 	c.fileConfig.fileConfig = nil
+	// persisted shares its map fields with c (configForSave shallow-copies *c),
+	// so isolate the stored fileConfig the same way snapshotFileConfig does;
+	// otherwise later mutations to c's maps leak into the on-disk snapshot.
+	c.fileConfig.Headers = cloneStringMap(c.fileConfig.Headers)
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	ClientID                  string            `toml:"client_id"`
 	ClientSecret              string            `toml:"client_secret"`
 	Path                      string            `toml:"-"`
+	envOverrides              map[string]bool   `toml:"-"`
+	fileConfig                *Config           `toml:"-"`
 	PrintingPressGoldenApiKey string            `toml:"press_golden_api_key"`
 }
 
@@ -51,9 +53,12 @@ func Load(configPath string) (*Config, error) {
 		}
 	}
 
+	cfg.snapshotFileConfig()
+
 	// Env var overrides
 	if v := os.Getenv("PRINTING_PRESS_GOLDEN_API_KEY"); v != "" {
 		cfg.PrintingPressGoldenApiKey = v
+		cfg.markEnvOverride("PrintingPressGoldenApiKey")
 		cfg.AuthSource = "env:PRINTING_PRESS_GOLDEN_API_KEY"
 	}
 
@@ -127,6 +132,16 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 	c.AccessToken = accessToken
 	c.RefreshToken = refreshToken
 	c.TokenExpiry = expiry
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
 	return c.save()
 }
 
@@ -142,6 +157,8 @@ func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
 	c.PrintingPressGoldenApiKey = token
+	delete(c.envOverrides, "PrintingPressGoldenApiKey")
+	c.updateFileConfigField("PrintingPressGoldenApiKey")
 	return c.save()
 }
 
@@ -158,8 +175,69 @@ func (c *Config) ClearTokens() error {
 	c.TokenExpiry = time.Time{}
 	c.ClientID = ""
 	c.ClientSecret = ""
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	delete(c.envOverrides, "RefreshToken")
+	delete(c.envOverrides, "TokenExpiry")
+	delete(c.envOverrides, "ClientID")
+	delete(c.envOverrides, "ClientSecret")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
+	c.updateFileConfigField("RefreshToken")
+	c.updateFileConfigField("TokenExpiry")
+	c.updateFileConfigField("ClientID")
+	c.updateFileConfigField("ClientSecret")
 	c.PrintingPressGoldenApiKey = ""
+	delete(c.envOverrides, "PrintingPressGoldenApiKey")
 	return c.save()
+}
+
+func (c *Config) markEnvOverride(field string) {
+	if c.envOverrides == nil {
+		c.envOverrides = map[string]bool{}
+	}
+	c.envOverrides[field] = true
+}
+
+func (c *Config) snapshotFileConfig() {
+	snapshot := *c
+	snapshot.envOverrides = nil
+	snapshot.fileConfig = nil
+	c.fileConfig = &snapshot
+}
+
+func (c *Config) configForSave() Config {
+	out := *c
+	if c.fileConfig != nil {
+		if c.envOverrides["PrintingPressGoldenApiKey"] {
+			out.PrintingPressGoldenApiKey = c.fileConfig.PrintingPressGoldenApiKey
+		}
+	}
+	out.envOverrides = nil
+	out.fileConfig = nil
+	return out
+}
+
+func (c *Config) updateFileConfigField(field string) {
+	if c.fileConfig == nil || c.envOverrides[field] {
+		return
+	}
+	switch field {
+	case "AuthHeaderVal":
+		c.fileConfig.AuthHeaderVal = c.AuthHeaderVal
+	case "AccessToken":
+		c.fileConfig.AccessToken = c.AccessToken
+	case "RefreshToken":
+		c.fileConfig.RefreshToken = c.RefreshToken
+	case "TokenExpiry":
+		c.fileConfig.TokenExpiry = c.TokenExpiry
+	case "ClientID":
+		c.fileConfig.ClientID = c.ClientID
+	case "ClientSecret":
+		c.fileConfig.ClientSecret = c.ClientSecret
+	case "PrintingPressGoldenApiKey":
+		c.fileConfig.PrintingPressGoldenApiKey = c.PrintingPressGoldenApiKey
+	}
 }
 
 func (c *Config) save() error {
@@ -167,11 +245,18 @@ func (c *Config) save() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
-	data, err := toml.Marshal(c)
+	persisted := c.configForSave()
+	data, err := toml.Marshal(persisted)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.Path, data, 0o600)
+	if err := os.WriteFile(c.Path, data, 0o600); err != nil {
+		return err
+	}
+	c.fileConfig = &persisted
+	c.fileConfig.envOverrides = nil
+	c.fileConfig.fileConfig = nil
+	return nil
 }
 
 // Ensure strings import is used

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -199,10 +199,28 @@ func (c *Config) markEnvOverride(field string) {
 	c.envOverrides[field] = true
 }
 
+// cloneStringMap returns an independent copy of m (nil stays nil). The fileConfig
+// snapshot must not share reference-type map fields (such as Headers) with the
+// live config, or a later mutation to one would silently track in the other.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func (c *Config) snapshotFileConfig() {
 	snapshot := *c
 	snapshot.envOverrides = nil
 	snapshot.fileConfig = nil
+	// *c is a shallow copy: map fields are reference types, so the snapshot would
+	// share them with c and silently track later mutations, defeating the
+	// isolation this snapshot exists to provide. Clone them.
+	snapshot.Headers = cloneStringMap(c.Headers)
 	c.fileConfig = &snapshot
 }
 
@@ -256,6 +274,10 @@ func (c *Config) save() error {
 	c.fileConfig = &persisted
 	c.fileConfig.envOverrides = nil
 	c.fileConfig.fileConfig = nil
+	// persisted shares its map fields with c (configForSave shallow-copies *c),
+	// so isolate the stored fileConfig the same way snapshotFileConfig does;
+	// otherwise later mutations to c's maps leak into the on-disk snapshot.
+	c.fileConfig.Headers = cloneStringMap(c.fileConfig.Headers)
 	return nil
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/config/config.go
@@ -156,6 +156,14 @@ func (c *Config) SaveTokens(clientID, clientSecret, accessToken, refreshToken st
 func (c *Config) SaveCredential(token string) error {
 	c.AuthHeaderVal = ""
 	c.AccessToken = ""
+	// Pair each builtin-field zeroing with an envOverrides delete, like
+	// ClearTokens/SaveBearerToken: if an env var's placeholder collides with the
+	// AuthHeaderVal/AccessToken builtin tag, the override would otherwise survive
+	// and configForSave would restore the stale on-disk value instead of "".
+	delete(c.envOverrides, "AuthHeaderVal")
+	delete(c.envOverrides, "AccessToken")
+	c.updateFileConfigField("AuthHeaderVal")
+	c.updateFileConfigField("AccessToken")
 	c.PrintingPressGoldenApiKey = token
 	delete(c.envOverrides, "PrintingPressGoldenApiKey")
 	c.updateFileConfigField("PrintingPressGoldenApiKey")


### PR DESCRIPTION
`config.Load` wrote env-var values (e.g. a CI `<PREFIX>_ACCESS_TOKEN=dummy`) directly onto config fields with no provenance, and `save()` (called by `SaveTokens`/`SaveCredential`/`SaveBearerToken`/`ClearTokens`) serialized the whole struct — so a transient env credential **permanently overwrote the real on-disk credential** in `config.toml`.

The fix tracks env-sourced fields (unexported `envOverrides`) against a snapshot of the on-disk config (`fileConfig`). `configForSave` restores env-overridden fields to their on-disk value before marshaling, so env values never reach disk, while env precedence still wins for the running process. Each `Save*`/`ClearTokens` mutator deletes the env-override for every field it legitimately writes (before updating the snapshot), so refreshed tokens persist and an explicit logout clears the on-disk credentials — including builtin-field collisions like `<PREFIX>_ACCESS_TOKEN` → `AccessToken`.

Tests (`auth_env_precedence_test.go`) run real generated CLIs and assert: a plain save never leaks an env value; a refreshed token persists over a colliding env override; `ClearTokens` empties the on-disk credentials; and a no-env load+save round-trips unchanged. Verified across oauth auth-code, bearer+refresh, client_credentials, api_key, and composed additional-header shapes.

Note: correctness relies on the `Load` markers, `configForSave`, `ClearTokens`, and `updateFileConfigField` keeping the same env-field ranges in sync; a future field added to one but not the others should be caught by extending the collision tests. (A single-rule "authoritative write-set" refactor is a reasonable follow-up.)

Closes #2710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
