### PR TITLE
fix(generator): rewrite bare-root self-imports on publish --module-path (#2578)

### DIFF
--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -53,7 +53,7 @@ func RewriteModulePathReferences(dir, oldPath, newPath string) error {
 		return nil
 	}
 
-	// Only replace subpath references: oldPath/internal/... and oldPath/cmd/...
+	// Replace known non-Go subpath references, plus Go import declarations.
 	// This avoids corrupting command Use strings, User-Agent headers,
 	// config paths, and other runtime literals that contain the CLI name.
 	replacements := []struct{ old, new string }{
@@ -78,8 +78,11 @@ func RewriteModulePathReferences(dir, oldPath, newPath string) error {
 		}
 
 		result := string(content)
+		if strings.HasSuffix(path, ".go") {
+			result = rewriteGoImportModulePaths(result, oldPath, newPath)
+		}
 		for _, r := range replacements {
-			result = strings.ReplaceAll(result, r.old, r.new)
+			result = replaceModulePathToken(result, r.old, r.new)
 		}
 		result = rewriteModuleInstallPaths(result, oldPath, newPath)
 		result = rewriteGitHubRepoURLs(result, oldPath, newPath)
@@ -103,6 +106,96 @@ func RewriteModulePathReferences(dir, oldPath, newPath string) error {
 
 		return os.WriteFile(path, []byte(result), 0o644)
 	})
+}
+
+func rewriteGoImportModulePaths(content, oldPath, newPath string) string {
+	lines := strings.SplitAfter(content, "\n")
+	inImportBlock := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "import ("):
+			inImportBlock = true
+			continue
+		case inImportBlock && trimmed == ")":
+			inImportBlock = false
+			continue
+		case inImportBlock || strings.HasPrefix(trimmed, "import "):
+			lines[i] = rewriteGoImportLine(line, oldPath, newPath)
+		}
+	}
+
+	return strings.Join(lines, "")
+}
+
+func rewriteGoImportLine(line, oldPath, newPath string) string {
+	for _, quote := range []string{`"`, "`"} {
+		start := strings.Index(line, quote)
+		if start == -1 {
+			continue
+		}
+		end := strings.Index(line[start+len(quote):], quote)
+		if end == -1 {
+			continue
+		}
+		end += start + len(quote)
+
+		importPath := line[start+len(quote) : end]
+		rewritten, ok := rewriteModuleImportPath(importPath, oldPath, newPath)
+		if !ok {
+			return line
+		}
+		return line[:start+len(quote)] + rewritten + line[end:]
+	}
+
+	return line
+}
+
+func rewriteModuleImportPath(importPath, oldPath, newPath string) (string, bool) {
+	if importPath == oldPath {
+		return newPath, true
+	}
+	if strings.HasPrefix(importPath, oldPath+"/") {
+		return newPath + strings.TrimPrefix(importPath, oldPath), true
+	}
+	return importPath, false
+}
+
+func replaceModulePathToken(content, oldToken, newToken string) string {
+	var b strings.Builder
+	for {
+		idx := strings.Index(content, oldToken)
+		if idx == -1 {
+			b.WriteString(content)
+			return b.String()
+		}
+
+		beforeOK := modulePathTokenBoundaryBefore(b.String(), content, idx)
+		if beforeOK {
+			b.WriteString(content[:idx])
+			b.WriteString(newToken)
+			content = content[idx+len(oldToken):]
+			continue
+		}
+
+		b.WriteString(content[:idx+len(oldToken)])
+		content = content[idx+len(oldToken):]
+	}
+}
+
+func modulePathTokenBoundaryBefore(prefix, content string, idx int) bool {
+	if idx == 0 && prefix == "" {
+		return true
+	}
+	if idx > 0 {
+		return isModulePathDelimiter(content[idx-1])
+	}
+	return isModulePathDelimiter(prefix[len(prefix)-1])
+}
+
+func isModulePathDelimiter(ch byte) bool {
+	return ch == '"' || ch == '\'' || ch == '`' || ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '=' || ch == ':'
 }
 
 func hasRewriteExtension(path string) bool {

--- a/internal/pipeline/modulepath.go
+++ b/internal/pipeline/modulepath.go
@@ -115,11 +115,20 @@ func rewriteGoImportModulePaths(content, oldPath, newPath string) string {
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		switch {
-		case strings.HasPrefix(trimmed, "import ("):
+		case strings.HasPrefix(trimmed, "import (") || strings.HasPrefix(trimmed, "import("):
 			inImportBlock = true
-			continue
+			// A grouped import may carry a path on the same line
+			// (e.g. import("oldmod")); rewrite it and, if the group also
+			// closes on this line, leave the block.
+			lines[i] = rewriteGoImportLine(line, oldPath, newPath)
+			if strings.Contains(trimmed, ")") {
+				inImportBlock = false
+			}
 		case inImportBlock && trimmed == ")":
 			inImportBlock = false
+		case strings.HasPrefix(trimmed, "//"):
+			// Comment line (incl. inside an import block): never rewrite, so a
+			// comment that happens to quote the old module path is untouched.
 			continue
 		case inImportBlock || strings.HasPrefix(trimmed, "import "):
 			lines[i] = rewriteGoImportLine(line, oldPath, newPath)

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -286,3 +286,41 @@ var _ = other.X
 	assert.Equal(t, content, string(again), "module path rewrite must be idempotent")
 	assert.NotContains(t, string(again), "newmod/newmod")
 }
+
+func TestRewriteModulePathReferences_SkipsImportBlockCommentsAndSingleLineGroup(t *testing.T) {
+	t.Parallel()
+
+	// A comment inside an import block that quotes the old module path must
+	// NOT be rewritten, while a real import on the next line is.
+	dir := t.TempDir()
+	src := `package cli
+
+import (
+	// "oldmod" is the self-reference package; this comment must stay verbatim
+	root "oldmod"
+)
+
+var _ = root.X
+`
+	goPath := filepath.Join(dir, "imports.go")
+	require.NoError(t, os.WriteFile(goPath, []byte(src), 0o644))
+	require.NoError(t, RewriteModulePathReferences(dir, "oldmod", "newmod"))
+	out, err := os.ReadFile(goPath)
+	require.NoError(t, err)
+	content := string(out)
+	assert.Contains(t, content, `root "newmod"`, "real import must be rewritten")
+	assert.Contains(t, content, `// "oldmod" is the self-reference package`, "import-block comment text must be left untouched")
+
+	// A single-line grouped import carries the path on the import( line.
+	dir2 := t.TempDir()
+	src2 := "package cli\n\nimport(\"oldmod\")\n\nvar _ = X\n"
+	goPath2 := filepath.Join(dir2, "single.go")
+	require.NoError(t, os.WriteFile(goPath2, []byte(src2), 0o644))
+	require.NoError(t, RewriteModulePathReferences(dir2, "oldmod", "newmod"))
+	out2, err := os.ReadFile(goPath2)
+	require.NoError(t, err)
+	// The rewrite chain gofmts the file, so the single-line group is
+	// reformatted; assert on the path token rather than the exact form.
+	assert.Contains(t, string(out2), `"newmod"`, "single-line grouped import path must be rewritten")
+	assert.NotContains(t, string(out2), `"oldmod"`, "old module path must not survive the rewrite")
+}

--- a/internal/pipeline/modulepath_test.go
+++ b/internal/pipeline/modulepath_test.go
@@ -246,3 +246,43 @@ var _ = config.Y
 	assert.Equal(t, string(formatted), string(out), "rewritten .go file must be gofmt-clean")
 	assert.Contains(t, string(out), newPath+"/internal/cliutil")
 }
+
+func TestRewriteModulePathReferences_RewritesBareRootSelfImports(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	src := `package cli
+
+import (
+	root "oldmod"
+	store "oldmod/internal/store"
+	extra "oldmod-extra/x"
+	other "oldmodother"
+)
+
+var _ = root.X
+var _ = store.X
+var _ = extra.X
+var _ = other.X
+`
+	goPath := filepath.Join(dir, "imports.go")
+	require.NoError(t, os.WriteFile(goPath, []byte(src), 0o644))
+
+	require.NoError(t, RewriteModulePathReferences(dir, "oldmod", "newmod"))
+	out, err := os.ReadFile(goPath)
+	require.NoError(t, err)
+	content := string(out)
+
+	assert.Contains(t, content, `root "newmod"`)
+	assert.Contains(t, content, `store "newmod/internal/store"`)
+	assert.Contains(t, content, `extra "oldmod-extra/x"`)
+	assert.Contains(t, content, `other "oldmodother"`)
+	assert.NotContains(t, content, `"oldmod"`)
+	assert.NotContains(t, content, `"oldmod/internal/store"`)
+
+	require.NoError(t, RewriteModulePathReferences(dir, "oldmod", "newmod"))
+	again, err := os.ReadFile(goPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(again), "module path rewrite must be idempotent")
+	assert.NotContains(t, string(again), "newmod/newmod")
+}


### PR DESCRIPTION
`publish package --module-path <new>` rewrites a generated CLI's internal import paths, but `RewriteModulePathReferences` only rewrote `oldPath + "/internal/"` subpath imports. A generated file importing the **bare root module path** (`import "everbee-pp-cli"`) kept a dangling reference to the old module name and failed to build under the new path.

Adds Go-import-aware rewriting (`rewriteGoImportModulePaths` parses `import` declarations and rewrites the bare root path plus subpaths) and makes the existing generic replacements **boundary-aware** so `oldPath` is only rewritten as a complete path token — never as a prefix of a different module whose name merely starts with `oldPath` (e.g. `oldmod-extra/x` / `oldmodother` are left alone).

Tests cover bare-root rewrite, subpath rewrite (no regression), prefix/suffix-collision non-rewrite, and idempotence.

Closes #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
