### PR TITLE
fix(cli): reject missing analytics group-by fields

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15873,6 +15873,15 @@ func runPMHintCommand(t *testing.T, dbPath string, args ...string) (string, stri
 
 func runPMCommand(t *testing.T, dbPath string, asJSON bool, args ...string) (string, string) {
 	t.Helper()
+	stdout, stderr, err := runPMCommandErr(t, dbPath, asJSON, args...)
+	if err != nil {
+		t.Fatalf("execute %v: %v; stderr=%s", args, err, stderr)
+	}
+	return stdout, stderr
+}
+
+func runPMCommandErr(t *testing.T, dbPath string, asJSON bool, args ...string) (string, string, error) {
+	t.Helper()
 	root := RootCmd()
 	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
@@ -15882,10 +15891,8 @@ func runPMCommand(t *testing.T, dbPath string, asJSON bool, args ...string) (str
 		fullArgs = append(fullArgs, "--json")
 	}
 	root.SetArgs(fullArgs)
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute %v: %v; stderr=%s", args, err, stderr.String())
-	}
-	return stdout.String(), stderr.String()
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func TestPMWorkflowCommandEmitsSyncHints(t *testing.T) {
@@ -15935,8 +15942,8 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 		t.Fatalf("open store: %v", err)
 	}
 	for _, raw := range []string{
-		` + "`" + `{"id":"issue-1","status":"open"}` + "`" + `,
-		` + "`" + `{"id":"issue-2","status":"open"}` + "`" + `,
+		` + "`" + `{"id":"issue-1","status":"open","stage_id":"qualified"}` + "`" + `,
+		` + "`" + `{"id":"issue-2","status":"open","stage_id":"qualified"}` + "`" + `,
 	} {
 		var payload json.RawMessage = []byte(raw)
 		var obj map[string]any
@@ -15968,6 +15975,26 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	for _, want := range []string{"status\tCount", "open\t2"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("analytics text group-by stdout = %q, want %q in configured output", stdout, want)
+		}
+	}
+
+	stdout, _ = runPMCommand(t, dbPath, false, "analytics", "--type", "issues", "--group-by", "stage")
+	for _, want := range []string{"stage\tCount", "qualified\t2"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("analytics friendly group-by stdout = %q, want %q in configured output", stdout, want)
+		}
+	}
+
+	stdout, stderr, err := runPMCommandErr(t, dbPath, false, "analytics", "--type", "issues", "--group-by", "bogus")
+	if err == nil {
+		t.Fatalf("analytics bogus group-by stdout = %q, stderr = %q, want error", stdout, stderr)
+	}
+	if strings.Contains(stdout, "<nil>") {
+		t.Fatalf("analytics bogus group-by stdout = %q, want no nil bucket", stdout)
+	}
+	for _, want := range []string{` + "`" + `group-by field "bogus" was not found` + "`" + `, "valid group-by fields:", "stage_id", "status"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("analytics bogus group-by error = %q, want %q", err.Error(), want)
 		}
 	}
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15992,9 +15992,9 @@ func TestAnalyticsCommandWritesToConfiguredOutput(t *testing.T) {
 	if strings.Contains(stdout, "<nil>") {
 		t.Fatalf("analytics bogus group-by stdout = %q, want no nil bucket", stdout)
 	}
-	for _, want := range []string{` + "`" + `group-by field "bogus" was not found` + "`" + `, "valid group-by fields:", "stage_id", "status"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("analytics bogus group-by error = %q, want %q", err.Error(), want)
+	for _, want := range []string{` + "`" + `group-by field "bogus" was not found` + "`" + `, "valid group-by fields:", "stage_id", "status", "aliases:", "stage"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("analytics bogus group-by stderr = %q, want %q", stderr, want)
 		}
 	}
 

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"{{modulePath}}/internal/store"
 	"github.com/spf13/cobra"
@@ -102,13 +103,27 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 	}
 
 	counts := make(map[string]int)
+	validFields := make(map[string]struct{})
+	matchedAny := false
+	decodedRows := 0
 	for _, item := range items {
 		var obj map[string]any
 		if err := json.Unmarshal(item, &obj); err != nil {
 			continue
 		}
-		val := fmt.Sprintf("%v", obj[field])
+		decodedRows++
+		for key := range obj {
+			validFields[key] = struct{}{}
+		}
+		raw, ok := resolvedGroupValue(obj, field)
+		if ok {
+			matchedAny = true
+		}
+		val := fmt.Sprintf("%v", raw)
 		counts[val]++
+	}
+	if decodedRows > 0 && !matchedAny {
+		return fmt.Errorf("group-by field %q was not found in any %s record; valid group-by fields: %s", field, resourceType, formatGroupByFields(validFields))
 	}
 
 	type kv struct {
@@ -136,4 +151,28 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 		fmt.Fprintf(out, "%s\t%d\n", kv.Key, kv.Count)
 	}
 	return nil
+}
+
+func resolvedGroupValue(obj map[string]any, field string) (any, bool) {
+	if val, ok := obj[field]; ok {
+		return val, true
+	}
+	if !strings.HasSuffix(field, "_id") {
+		if val, ok := obj[field+"_id"]; ok {
+			return val, true
+		}
+	}
+	return nil, false
+}
+
+func formatGroupByFields(fields map[string]struct{}) string {
+	if len(fields) == 0 {
+		return "none"
+	}
+	var names []string
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -105,6 +105,7 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 	counts := make(map[string]int)
 	validFields := make(map[string]struct{})
 	matchedAny := false
+	missingFieldCount := 0
 	decodedRows := 0
 	for _, item := range items {
 		var obj map[string]any
@@ -118,12 +119,17 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 		raw, ok := resolvedGroupValue(obj, field)
 		if ok {
 			matchedAny = true
+			val := fmt.Sprintf("%v", raw)
+			counts[val]++
+		} else {
+			missingFieldCount++
 		}
-		val := fmt.Sprintf("%v", raw)
-		counts[val]++
 	}
 	if decodedRows > 0 && !matchedAny {
 		return fmt.Errorf("group-by field %q was not found in any %s record; valid group-by fields: %s", field, resourceType, formatGroupByFields(validFields))
+	}
+	if missingFieldCount > 0 {
+		counts["<nil>"] += missingFieldCount
 	}
 
 	type kv struct {
@@ -170,9 +176,22 @@ func formatGroupByFields(fields map[string]struct{}) string {
 		return "none"
 	}
 	var names []string
+	var aliases []string
 	for name := range fields {
 		names = append(names, name)
+		if strings.HasSuffix(name, "_id") {
+			alias := strings.TrimSuffix(name, "_id")
+			if alias != "" {
+				if _, exists := fields[alias]; !exists {
+					aliases = append(aliases, alias)
+				}
+			}
+		}
 	}
 	sort.Strings(names)
-	return strings.Join(names, ", ")
+	sort.Strings(aliases)
+	if len(aliases) == 0 {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s (aliases: %s)", strings.Join(names, ", "), strings.Join(aliases, ", "))
 }


### PR DESCRIPTION
## Intent

Issue: Closes #2466

Generated analytics commands no longer turn a mistyped or absent `--group-by` field into a plausible-looking single `<nil>` bucket. Users can also group by a friendly field name when the synced records expose the corresponding `<field>_id` key.

## Approach

The generated group-by path now resolves the requested key first, then falls back to `<field>_id` for friendly-name aliases. While scanning decoded rows it records the available JSON keys, and if no row contains either the exact key or alias it returns an error with the valid group-by fields instead of rendering a bucket of nil values.

## Scope

Primary area: generated analytics command template.

Why this belongs in this repo: the symptom was found in a printed CLI, but the behavior comes from the Printing Press analytics template and affects future generated CLIs across APIs.

## Catalog Justification

Embedded catalog fit: N/A

Distinct blueprint pattern: N/A

Closest existing entries checked: N/A

Source provenance: N/A

Auth and tenant assumptions: N/A

Safe default surface: N/A

Generation path: N/A

Stale-body check: N/A

## Risk

Invalid group-by fields now fail fast instead of returning misleading output. Exact-key grouping is unchanged, and sparse mixed data still preserves the existing behavior of counting missing rows as `<nil>` once at least one row has the requested field.

## Output Contract

The emitted analytics command now includes the generic group-by resolver and valid-field error path. The generated-output test executes the emitted CLI against a local store and covers exact grouping, friendly alias grouping through `stage_id`, and bogus-field rejection without a nil bucket.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:

- `go test ./internal/generator -run TestProjectManagementWorkflowsEmitSyncHints -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...` failed in `internal/cli` after the package 10 minute timeout while `TestVerifySkill_DetectsWrongFlagOnCommand` and `TestVerifySkill_NoFalsePositiveOnSharedLeafName` were waiting in `buildPrintingPressBinary`; all other listed packages passed
- `go test ./internal/cli -run 'TestVerifySkill_(DetectsWrongFlagOnCommand|NoFalsePositiveOnSharedLeafName)$' -count=1`
- `go fmt ./...`
- `golangci-lint run ./...`
