### PR TITLE
fix(generator): quote local FTS search terms

### DIFF
--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -886,7 +886,7 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		 WHERE resources_fts MATCH ?
 		 ORDER BY rank
 		 LIMIT ?`,
-		query, limit,
+		ftsMatchQuery(query), limit,
 	)
 	if err != nil {
 		return nil, err
@@ -902,6 +902,19 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		results = append(results, json.RawMessage(data))
 	}
 	return results, rows.Err()
+}
+
+func ftsMatchQuery(query string) string {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		return `""`
+	}
+
+	quoted := make([]string, 0, len(terms))
+	for _, term := range terms {
+		quoted = append(quoted, `"`+strings.ReplaceAll(term, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " AND ")
 }
 
 func extractObjectID(obj map[string]any) string {
@@ -1264,7 +1277,7 @@ func (s *Store) Search{{pascal .Name}}(query string, limit int) ([]json.RawMessa
 		 JOIN {{safeNameSuffix .Name "_fts"}} ON {{safeNameSuffix .Name "_fts"}}.rowid = t.rowid
 		 WHERE {{safeNameSuffix .Name "_fts"}} MATCH ?
 		 ORDER BY rank LIMIT ?`,
-		query, limit,
+		ftsMatchQuery(query), limit,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -317,6 +317,48 @@ func TestUpsertBatch_ExtractFailuresReturnedForPerItemMisses(t *testing.T) {
 	}
 }
 
+func TestSearchQuotesFTSQuerySyntax(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "ip", "value": "10.0.0.1"}`),
+		json.RawMessage(`{"id": "cidr", "value": "172.16.192.0/18"}`),
+		json.RawMessage(`{"id": "host", "value": "host.example.com"}`),
+		json.RawMessage(`{"id": "email", "value": "user@example.com"}`),
+		json.RawMessage(`{"id": "mac", "value": "aa:bb:cc:dd:ee:ff"}`),
+		json.RawMessage(`{"id": "hyphen", "value": "some-name"}`),
+		json.RawMessage(`{"id": "multi", "value": "error with extra words before timeout"}`),
+	}
+	if stored, failed, err := s.UpsertBatch("search-regression", items); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	} else if failed != 0 || stored != len(items) {
+		t.Fatalf("UpsertBatch stored=%d failed=%d, want stored=%d failed=0", stored, failed, len(items))
+	}
+
+	for _, query := range []string{
+		"10.0.0.1",
+		"172.16.192.0/18",
+		"host.example.com",
+		"user@example.com",
+		"aa:bb:cc:dd:ee:ff",
+		"some-name",
+		"error timeout",
+	} {
+		results, err := s.Search(query, 10)
+		if err != nil {
+			t.Fatalf("Search(%q): %v", query, err)
+		}
+		if len(results) == 0 {
+			t.Fatalf("Search(%q) returned no results", query)
+		}
+	}
+}
+
 {{- $hasDomainTable := false }}
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
@@ -509,6 +551,43 @@ func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
 	}
 	if len(results) == 0 {
 		t.Fatalf("dependent resource %q stored but not searchable via generic resources_fts (issue #2629)", "{{.Resource}}")
+	}
+}
+{{- end}}
+{{- if .FTS5}}
+{{- $ftsField := index .FTS5Fields 0 }}
+
+func TestSearch{{pascal .Name}}QuotesFTSQuerySyntax(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "typed-ip", "{{$ftsField}}": "10.0.0.1"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}}`),
+		json.RawMessage(`{"id": "typed-host", "{{$ftsField}}": "host.example.com"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}}`),
+		json.RawMessage(`{"id": "typed-multi", "{{$ftsField}}": "error with extra words before timeout"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}}`),
+	}
+	if stored, failed, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	} else if failed != 0 || stored != len(items) {
+		t.Fatalf("UpsertBatch stored=%d failed=%d, want stored=%d failed=0", stored, failed, len(items))
+	}
+
+	for _, query := range []string{
+		"10.0.0.1",
+		"host.example.com",
+		"error timeout",
+	} {
+		results, err := s.Search{{pascal .Name}}(query, 10)
+		if err != nil {
+			t.Fatalf("Search{{pascal .Name}}(%q): %v", query, err)
+		}
+		if len(results) == 0 {
+			t.Fatalf("Search{{pascal .Name}}(%q) returned no results", query)
+		}
 	}
 }
 {{- end}}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -814,7 +814,7 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		 WHERE resources_fts MATCH ?
 		 ORDER BY rank
 		 LIMIT ?`,
-		query, limit,
+		ftsMatchQuery(query), limit,
 	)
 	if err != nil {
 		return nil, err
@@ -830,6 +830,19 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		results = append(results, json.RawMessage(data))
 	}
 	return results, rows.Err()
+}
+
+func ftsMatchQuery(query string) string {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		return `""`
+	}
+
+	quoted := make([]string, 0, len(terms))
+	for _, term := range terms {
+		quoted = append(quoted, `"`+strings.ReplaceAll(term, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " AND ")
 }
 
 func extractObjectID(obj map[string]any) string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -703,7 +703,7 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		 WHERE resources_fts MATCH ?
 		 ORDER BY rank
 		 LIMIT ?`,
-		query, limit,
+		ftsMatchQuery(query), limit,
 	)
 	if err != nil {
 		return nil, err
@@ -719,6 +719,19 @@ func (s *Store) Search(query string, limit int) ([]json.RawMessage, error) {
 		results = append(results, json.RawMessage(data))
 	}
 	return results, rows.Err()
+}
+
+func ftsMatchQuery(query string) string {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		return `""`
+	}
+
+	quoted := make([]string, 0, len(terms))
+	for _, term := range terms {
+		quoted = append(quoted, `"`+strings.ReplaceAll(term, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " AND ")
 }
 
 func extractObjectID(obj map[string]any) string {


### PR DESCRIPTION
## Summary

Local `search` now treats user input as free text before handing it to SQLite FTS5, so pasted identifiers like IPs, CIDRs, hostnames, emails, MAC addresses, and hyphenated names no longer fail with FTS syntax errors. The generated store quotes each whitespace-separated term and joins terms with `AND`, preserving broad multi-word search while neutralizing FTS query punctuation by default.

The fix is applied at the generated store helpers, so both the CLI search command and MCP search tool share the corrected behavior. Generated store tests now exercise the punctuation-heavy queries through real SQLite FTS for both generic and typed FTS search helpers.

Closes #2464

## Tests

- `go test ./internal/generator -run 'TestGenerateStoreSubResourceNamesUseRuntimeResourceKeys|TestSearchTemplateEmptyTypeQueriesGenericFTS' -count=1`
- `go test ./internal/store -run 'TestSearch.*QuotesFTSQuerySyntax|TestUpsertBatch_.*SearchableViaGenericFTS' -count=1` from `.gotmp/generator-output-compile/generate-golden-api/printing-press-golden`
- `go test $(go list ./... | rg -v '/internal/generator$')`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-learn-loop-api generate-sync-walker-api`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push `golangci-lint` hook: 0 issues
