### PR TITLE
fix(cli): prefer header api keys over oauth alternatives

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2706,6 +2706,7 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 
 	usageCounts := securitySchemeOperationUsageCounts(doc)
 	candidates := candidateSecuritySchemeNames(doc, usageCounts)
+	effectiveRequirements := allEffectiveSecurityRequirements(doc)
 
 	bestScore := math.MaxInt
 	bestUsageCount := 0
@@ -2718,7 +2719,7 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 			continue
 		}
 		usageCount := usageCounts[name]
-		score := schemePriorityScoreForDoc(doc, name, scheme)
+		score := schemePriorityScoreForDoc(doc, effectiveRequirements, name, scheme)
 		if usageCount > bestUsageCount || (usageCount == bestUsageCount && score < bestScore) {
 			bestUsageCount = usageCount
 			bestScore = score
@@ -2828,18 +2829,21 @@ func effectiveSecurityRequirements(op *openapi3.Operation, doc *openapi3.T) open
 // Ordering rationale: Bearer is the simplest already-minted token shape and
 // stays first. OAuth2 Device Code and Password (ROPC) are CLI-friendly flows
 // that stay above apiKey so specs that intentionally offer them do not silently
-// regress. A standalone apiKey-in-header beats OAuth2 browser/client-credential
-// flows because printed CLIs usually want the simplest user-supplied token when
-// the API offers alternatives. apiKey-in-query stays lower because query
-// strings leak to logs. HTTP Basic ranks below standalone apiKey because
-// compound legacy schemes (email + key) surface as basic-ish patterns and
-// shouldn't outrank a modern apiKey alternative when both are offered.
+// regress. Among OAuth2 alternatives, client_credentials keeps its old edge
+// over password for non-interactive runs. A standalone apiKey-in-header beats
+// OAuth2 browser/client-credential flows because printed CLIs usually want the
+// simplest user-supplied token when the API offers alternatives. apiKey-in-query
+// stays lower because query strings leak to logs. HTTP Basic ranks below
+// standalone apiKey because compound legacy schemes (email + key) surface as
+// basic-ish patterns and shouldn't outrank a modern apiKey alternative when
+// both are offered.
 const (
 	schemePriorityBearer          = 0
 	schemePriorityOAuth2Device    = 25
-	schemePriorityOAuth2Password  = 30
+	schemePriorityOAuth2CC        = 30
+	schemePriorityOAuth2Password  = 40
 	schemePriorityAPIKeyHeader    = 50
-	schemePriorityOAuth2CC        = 100
+	schemePriorityOAuth2CCAlt     = 100
 	schemePriorityOAuth2AuthCode  = 200
 	schemePriorityOAuth2Implicit  = 300
 	schemePriorityAPIKeyANDPeer   = 400
@@ -2895,16 +2899,18 @@ func schemePriorityScore(scheme *openapi3.SecurityScheme) int {
 	return schemePriorityUnknown
 }
 
-func schemePriorityScoreForDoc(doc *openapi3.T, name string, scheme *openapi3.SecurityScheme) int {
+func schemePriorityScoreForDoc(doc *openapi3.T, requirements openapi3.SecurityRequirements, name string, scheme *openapi3.SecurityScheme) int {
 	score := schemePriorityScore(scheme)
-	if score == schemePriorityAPIKeyHeader && apiKeyOnlyAppearsWithNonAPIKeySibling(doc, name) {
+	if score == schemePriorityAPIKeyHeader && apiKeyOnlyAppearsWithNonAPIKeySibling(doc, requirements, name) {
 		return schemePriorityAPIKeyANDPeer
+	}
+	if score == schemePriorityOAuth2CC && hasStandaloneHeaderAPIKeyRequirement(doc, requirements) {
+		return schemePriorityOAuth2CCAlt
 	}
 	return score
 }
 
-func apiKeyOnlyAppearsWithNonAPIKeySibling(doc *openapi3.T, schemeName string) bool {
-	requirements := allEffectiveSecurityRequirements(doc)
+func apiKeyOnlyAppearsWithNonAPIKeySibling(doc *openapi3.T, requirements openapi3.SecurityRequirements, schemeName string) bool {
 	seen := false
 	for _, requirement := range requirements {
 		if _, ok := requirement[schemeName]; !ok {
@@ -2929,11 +2935,36 @@ func apiKeyOnlyAppearsWithNonAPIKeySibling(doc *openapi3.T, schemeName string) b
 	return seen
 }
 
+func hasStandaloneHeaderAPIKeyRequirement(doc *openapi3.T, requirements openapi3.SecurityRequirements) bool {
+	for _, requirement := range requirements {
+		hasHeaderAPIKey := false
+		hasNonAPIKeySibling := false
+		for schemeName := range requirement {
+			scheme := securitySchemeValue(doc.Components.SecuritySchemes[schemeName])
+			if scheme == nil {
+				continue
+			}
+			if strings.EqualFold(scheme.Type, "apiKey") && strings.EqualFold(scheme.In, "header") {
+				hasHeaderAPIKey = true
+				continue
+			}
+			if !strings.EqualFold(scheme.Type, "apiKey") {
+				hasNonAPIKeySibling = true
+			}
+		}
+		if hasHeaderAPIKey && !hasNonAPIKeySibling {
+			return true
+		}
+	}
+	return false
+}
+
 func allEffectiveSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirements {
 	if doc == nil {
 		return nil
 	}
 	var requirements openapi3.SecurityRequirements
+	rootIncluded := false
 	if doc.Paths != nil {
 		for _, pathItem := range doc.Paths.Map() {
 			if pathItem == nil {
@@ -2943,7 +2974,14 @@ func allEffectiveSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirem
 				if op == nil {
 					continue
 				}
-				requirements = append(requirements, effectiveSecurityRequirements(op, doc)...)
+				if op.Security != nil {
+					requirements = append(requirements, (*op.Security)...)
+					continue
+				}
+				if !rootIncluded {
+					requirements = append(requirements, doc.Security...)
+					rootIncluded = true
+				}
 			}
 		}
 	}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2718,7 +2718,7 @@ func selectSecurityScheme(doc *openapi3.T, authPreference string) (string, *open
 			continue
 		}
 		usageCount := usageCounts[name]
-		score := schemePriorityScore(scheme)
+		score := schemePriorityScoreForDoc(doc, name, scheme)
 		if usageCount > bestUsageCount || (usageCount == bestUsageCount && score < bestScore) {
 			bestUsageCount = usageCount
 			bestScore = score
@@ -2825,22 +2825,24 @@ func effectiveSecurityRequirements(op *openapi3.Operation, doc *openapi3.T) open
 	return doc.Security
 }
 
-// Ordering rationale: Bearer is the simplest for CLI use; OAuth2 flows rank
-// by viability for non-interactive runs (cc > authorization_code > password >
-// implicit); apiKey-in-header beats apiKey-in-query because query strings leak
-// to logs; HTTP Basic ranks below standalone apiKey because compound legacy
-// schemes (email + key) surface as basic-ish patterns and shouldn't outrank a
-// modern apiKey alternative when both are offered. Password (ROPC) is
-// deprecated but kept above all apiKey shapes so multi-scheme specs that
-// pair ROPC with an apiKey alternative don't regress vs. the prior selector,
-// which returned any well-formed oauth2 before any apiKey.
+// Ordering rationale: Bearer is the simplest already-minted token shape and
+// stays first. OAuth2 Device Code and Password (ROPC) are CLI-friendly flows
+// that stay above apiKey so specs that intentionally offer them do not silently
+// regress. A standalone apiKey-in-header beats OAuth2 browser/client-credential
+// flows because printed CLIs usually want the simplest user-supplied token when
+// the API offers alternatives. apiKey-in-query stays lower because query
+// strings leak to logs. HTTP Basic ranks below standalone apiKey because
+// compound legacy schemes (email + key) surface as basic-ish patterns and
+// shouldn't outrank a modern apiKey alternative when both are offered.
 const (
 	schemePriorityBearer          = 0
+	schemePriorityOAuth2Device    = 25
+	schemePriorityOAuth2Password  = 30
+	schemePriorityAPIKeyHeader    = 50
 	schemePriorityOAuth2CC        = 100
 	schemePriorityOAuth2AuthCode  = 200
-	schemePriorityOAuth2Password  = 250
 	schemePriorityOAuth2Implicit  = 300
-	schemePriorityAPIKeyHeader    = 400
+	schemePriorityAPIKeyANDPeer   = 400
 	schemePriorityAPIKeyQuery     = 450
 	schemePriorityHTTPBasic       = 500
 	schemePriorityAPIKeyCookie    = 600
@@ -2862,7 +2864,7 @@ func schemePriorityScore(scheme *openapi3.SecurityScheme) int {
 		return schemePriorityHTTPOther
 	case "oauth2":
 		if _, ok := scheme.Extensions[extensionOAuthDeviceFlow]; ok {
-			return schemePriorityOAuth2AuthCode
+			return schemePriorityOAuth2Device
 		}
 		if scheme.Flows != nil {
 			if cc := scheme.Flows.ClientCredentials; cc != nil && strings.TrimSpace(cc.TokenURL) != "" {
@@ -2891,6 +2893,64 @@ func schemePriorityScore(scheme *openapi3.SecurityScheme) int {
 		return schemePriorityAPIKeyOther
 	}
 	return schemePriorityUnknown
+}
+
+func schemePriorityScoreForDoc(doc *openapi3.T, name string, scheme *openapi3.SecurityScheme) int {
+	score := schemePriorityScore(scheme)
+	if score == schemePriorityAPIKeyHeader && apiKeyOnlyAppearsWithNonAPIKeySibling(doc, name) {
+		return schemePriorityAPIKeyANDPeer
+	}
+	return score
+}
+
+func apiKeyOnlyAppearsWithNonAPIKeySibling(doc *openapi3.T, schemeName string) bool {
+	requirements := allEffectiveSecurityRequirements(doc)
+	seen := false
+	for _, requirement := range requirements {
+		if _, ok := requirement[schemeName]; !ok {
+			continue
+		}
+		seen = true
+		hasNonAPIKeySibling := false
+		for siblingName := range requirement {
+			if siblingName == schemeName {
+				continue
+			}
+			sibling := securitySchemeValue(doc.Components.SecuritySchemes[siblingName])
+			if sibling != nil && !strings.EqualFold(sibling.Type, "apiKey") {
+				hasNonAPIKeySibling = true
+				break
+			}
+		}
+		if !hasNonAPIKeySibling {
+			return false
+		}
+	}
+	return seen
+}
+
+func allEffectiveSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirements {
+	if doc == nil {
+		return nil
+	}
+	var requirements openapi3.SecurityRequirements
+	if doc.Paths != nil {
+		for _, pathItem := range doc.Paths.Map() {
+			if pathItem == nil {
+				continue
+			}
+			for _, op := range pathItem.Operations() {
+				if op == nil {
+					continue
+				}
+				requirements = append(requirements, effectiveSecurityRequirements(op, doc)...)
+			}
+		}
+	}
+	if len(requirements) > 0 {
+		return requirements
+	}
+	return doc.Security
 }
 
 func securitySchemeValue(ref *openapi3.SecuritySchemeRef) *openapi3.SecurityScheme {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2391,6 +2391,78 @@ paths:
 	assert.Equal(t, "api_token", parsed.Auth.Scheme, "selected scheme name must surface for downstream env-var derivation")
 }
 
+func TestSelectSecuritySchemeAPIKeyHeaderBeatsOAuth2Alternative(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: "3.0.3"
+info:
+  title: Pipedrive
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - oauth: []
+  - api_key: []
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.example.com/oauth/authorize
+          tokenUrl: https://api.example.com/oauth/token
+          scopes:
+            read: read access
+    api_key:
+      type: apiKey
+      in: header
+      name: x-api-token
+paths:
+  /v1/deals:
+    get:
+      operationId: listDeals
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "api_key", parsed.Auth.Type, "standalone header apiKey must be preferred over OAuth2 alternatives")
+	assert.Equal(t, "api_key", parsed.Auth.Scheme)
+	assert.Equal(t, "header", parsed.Auth.In)
+	assert.Equal(t, "x-api-token", parsed.Auth.Header)
+	assert.Equal(t, []string{"PIPEDRIVE_API_KEY"}, parsed.Auth.EnvVars)
+
+	if testing.Short() {
+		t.Skip("generated CLI runtime coverage runs outside short mode")
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+	gen := generator.New(parsed, outputDir)
+	require.NoError(t, gen.Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `req.Header.Set("x-api-token", authHeader)`)
+	require.NotContains(t, clientContent, `req.Header.Set("Authorization", authHeader)`)
+
+	const runtimeTest = `package config
+
+import "testing"
+
+func TestHeaderAPIKeyAuthHeaderIsRaw(t *testing.T) {
+	cfg := &Config{PipedriveApiKey: "raw-token"}
+	if got := cfg.AuthHeader(); got != "raw-token" {
+		t.Fatalf("AuthHeader() = %q, want raw-token", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "config", "header_apikey_test.go"), []byte(runtimeTest), 0o644))
+	runGo(t, outputDir, "mod", "tidy")
+	runGo(t, outputDir, "test", "./internal/config", "-run", "TestHeaderAPIKeyAuthHeaderIsRaw")
+}
+
 func TestSelectSecuritySchemeRespectsRootSecurityFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2408,8 +2408,7 @@ components:
     oauth:
       type: oauth2
       flows:
-        authorizationCode:
-          authorizationUrl: https://api.example.com/oauth/authorize
+        clientCredentials:
           tokenUrl: https://api.example.com/oauth/token
           scopes:
             read: read access
@@ -2638,6 +2637,51 @@ paths:
 
 	assert.Equal(t, "bearer_token", parsed.Auth.Type, "well-formed ROPC oauth2 must outrank co-declared apiKey")
 	assert.Equal(t, "ropcAuth", parsed.Auth.Scheme)
+}
+
+func TestSelectSecuritySchemeOAuth2ClientCredentialsBeatsOAuth2Password(t *testing.T) {
+	t.Parallel()
+
+	// When a spec offers separate OAuth2 machine and user-password schemes, keep
+	// the non-interactive client_credentials scheme ahead of deprecated ROPC.
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: OAuth2FlowPriority
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ccAuth: []
+  - ropcAuth: []
+components:
+  securitySchemes:
+    ccAuth:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://api.example.com/oauth/token
+          scopes:
+            read: read access
+    ropcAuth:
+      type: oauth2
+      flows:
+        password:
+          tokenUrl: https://api.example.com/oauth/token
+          scopes:
+            read: read access
+paths:
+  /v1/items:
+    get:
+      operationId: listItems
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(specBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bearer_token", parsed.Auth.Type)
+	assert.Equal(t, "ccAuth", parsed.Auth.Scheme)
+	assert.Equal(t, spec.OAuth2GrantClientCredentials, parsed.Auth.OAuth2Grant)
 }
 
 func TestSkipUnderscoreFields(t *testing.T) {


### PR DESCRIPTION
## Summary

OpenAPI imports now prefer a standalone `apiKey` header scheme over OAuth2 alternatives, so personal-token specs emit the declared header such as `x-api-token` with the raw token value instead of falling into `Authorization: Bearer` auth.

The selector still preserves the existing CLI-friendly and composed-auth contracts: HTTP bearer remains first, device-code and password OAuth stay above apiKey, and apiKey schemes that only appear as AND siblings with OAuth remain secondary so the OAuth primary can collect the required extra header.

Closes #2470

## Validation

- `go test ./internal/openapi -run 'TestSelectSecurityScheme(APIKeyHeaderBeatsOAuth2Alternative|MultiSchemePrefersBearer|RespectsRootSecurityFilter|OAuth2PasswordBeatsAPIKey)|TestParseOAuth2DeviceCodeSecuritySchemeBeatsAPIKeyAlternative|TestComposedApiKeyPlusOAuthCollectsAdditionalHeader'`
- `go test ./internal/openapi`
- `scripts/golden.sh verify`
- `go test ./internal/pipeline -run '^TestLiveCheck_LocalDataSourceRealFailureStillFails$' -count=1`

`go test ./...` was also run after the final rebase. It reached the changed OpenAPI package cleanly but failed in unrelated `internal/pipeline` test `TestLiveCheck_LocalDataSourceRealFailureStillFails` because the subprocess timed out after 5s under heavy concurrent worker load; the exact test passed immediately when rerun in isolation.
