### PR TITLE
fix(generator): make store list zero limit unlimited

### DIFF
--- a/internal/generator/store_list_limit_test.go
+++ b/internal/generator/store_list_limit_test.go
@@ -1,0 +1,68 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedStoreListLimitSemantics(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("store-list-limit")
+	outputDir := filepath.Join(t.TempDir(), "store-list-limit-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "store", "store_list_limit_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestListLimitSemantics(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	for i := 0; i < 250; i++ {
+		id := fmt.Sprintf("item-%03d", i)
+		if err := db.Upsert("items", id, []byte(fmt.Sprintf(`+"`"+`{"id":%q}`+"`"+`, id))); err != nil {
+			t.Fatalf("upsert %s: %v", id, err)
+		}
+	}
+
+	allRows, err := db.List("items", 0)
+	if err != nil {
+		t.Fatalf("list all rows: %v", err)
+	}
+	if len(allRows) != 250 {
+		t.Fatalf("List(items, 0) returned %d rows, want all 250", len(allRows))
+	}
+
+	negativeRows, err := db.List("items", -1)
+	if err != nil {
+		t.Fatalf("list all rows with negative limit: %v", err)
+	}
+	if len(negativeRows) != 250 {
+		t.Fatalf("List(items, -1) returned %d rows, want all 250", len(negativeRows))
+	}
+
+	cappedRows, err := db.List("items", 50)
+	if err != nil {
+		t.Fatalf("list capped rows: %v", err)
+	}
+	if len(cappedRows) != 50 {
+		t.Fatalf("List(items, 50) returned %d rows, want 50", len(cappedRows))
+	}
+}
+`), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/store", "-run", "^TestListLimitSemantics$", "-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -853,13 +853,13 @@ func (s *Store) Get(resourceType, id string) (json.RawMessage, error) {
 }
 
 func (s *Store) List(resourceType string, limit int) ([]json.RawMessage, error) {
-	if limit <= 0 {
-		limit = 200
+	query := `SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC`
+	args := []any{resourceType}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
 	}
-	rows, err := s.db.Query(
-		`SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC LIMIT ?`,
-		resourceType, limit,
-	)
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -781,13 +781,13 @@ func (s *Store) Get(resourceType, id string) (json.RawMessage, error) {
 }
 
 func (s *Store) List(resourceType string, limit int) ([]json.RawMessage, error) {
-	if limit <= 0 {
-		limit = 200
+	query := `SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC`
+	args := []any{resourceType}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
 	}
-	rows, err := s.db.Query(
-		`SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC LIMIT ?`,
-		resourceType, limit,
-	)
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -670,13 +670,13 @@ func (s *Store) Get(resourceType, id string) (json.RawMessage, error) {
 }
 
 func (s *Store) List(resourceType string, limit int) ([]json.RawMessage, error) {
-	if limit <= 0 {
-		limit = 200
+	query := `SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC`
+	args := []any{resourceType}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
 	}
-	rows, err := s.db.Query(
-		`SELECT data FROM resources WHERE resource_type = ? ORDER BY updated_at DESC LIMIT ?`,
-		resourceType, limit,
-	)
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Generated stores now treat `List(resource, 0)` and other non-positive limits as an unlimited read, matching the callers that use `0` to aggregate all synced rows. Positive limits still apply a parameterized SQL cap, so commands that intentionally request a bounded sample keep their existing behavior.

This prevents generated analytics, BI, and data-source commands from silently undercounting resources after 200 cached rows.

## Tests
- `go test ./internal/generator -run '^TestGeneratedStoreListLimitSemantics$' -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `go test -p 1 ./...`

Closes #2468
