### PR TITLE
fix(cli): guard regen against stale Printing Press binaries

### DIFF
--- a/internal/cli/mcp_sync.go
+++ b/internal/cli/mcp_sync.go
@@ -29,6 +29,9 @@ a usable brand name.`,
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("resolving cli dir: %w", err)}
 			}
+			if err := ensureNotOlderThanCLIManifest(cliDir, "mcp-sync"); err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
+			}
 			result, err := mcpsync.Sync(cliDir, mcpsync.Options{Force: force})
 			if err != nil {
 				if errors.Is(err, mcpsync.ErrHandEdited) {

--- a/internal/cli/regen_merge.go
+++ b/internal/cli/regen_merge.go
@@ -58,6 +58,9 @@ tree at <cli-dir> by default; --force overrides.`,
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("resolving cli dir: %w", err)}
 			}
+			if err := ensureNotOlderThanCLIManifest(cliDir, "regen-merge"); err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
+			}
 			freshAbs, err := filepath.Abs(freshDir)
 			if err != nil {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("resolving fresh dir: %w", err)}

--- a/internal/cli/version_skew.go
+++ b/internal/cli/version_skew.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
+	"golang.org/x/mod/semver"
+)
+
+func ensureNotOlderThanCLIManifest(cliDir, commandName string) error {
+	return ensureVersionNotOlderThanCLIManifest(cliDir, commandName, version.Get())
+}
+
+func ensureVersionNotOlderThanCLIManifest(cliDir, commandName, currentVersion string) error {
+	manifest, err := pipeline.ReadCLIManifest(cliDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", pipeline.CLIManifestFilename, err)
+	}
+	required := strings.TrimSpace(manifest.PrintingPressVersion)
+	if required == "" {
+		return nil
+	}
+	current := normalizeSemver(currentVersion)
+	required = normalizeSemver(required)
+	if !semver.IsValid(current) || !semver.IsValid(required) {
+		return fmt.Errorf("cannot compare cli-printing-press version %q with %s printing_press_version %q", currentVersion, pipeline.CLIManifestFilename, manifest.PrintingPressVersion)
+	}
+	if semver.Compare(current, required) < 0 {
+		return fmt.Errorf("%s refused: cli-printing-press %s is older than this CLI's generating version %s from %s; upgrade or rebuild the binary before running generator-owned sync paths", commandName, strings.TrimPrefix(current, "v"), strings.TrimPrefix(required, "v"), pipeline.CLIManifestFilename)
+	}
+	return nil
+}
+
+func normalizeSemver(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}

--- a/internal/cli/version_skew_test.go
+++ b/internal/cli/version_skew_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeManifestVersion(t *testing.T, dir, version string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, pipeline.CLIManifestFilename),
+		[]byte(`{"schema_version":1,"printing_press_version":"`+version+`"}`),
+		0o644,
+	))
+}
+
+func TestEnsureVersionNotOlderThanCLIManifest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		current    string
+		generated  string
+		wantErr    bool
+		wantErrSub string
+	}{
+		{name: "same version runs", current: "4.19.0", generated: "4.19.0"},
+		{name: "newer version runs", current: "4.22.1", generated: "4.19.0"},
+		{name: "v-prefixed current version runs", current: "v4.22.1", generated: "4.19.0"},
+		{
+			name:       "older version refuses",
+			current:    "4.2.0",
+			generated:  "4.19.0",
+			wantErr:    true,
+			wantErrSub: "mcp-sync refused: cli-printing-press 4.2.0 is older than this CLI's generating version 4.19.0",
+		},
+		{
+			name:       "invalid version refuses",
+			current:    "not-a-version",
+			generated:  "4.19.0",
+			wantErr:    true,
+			wantErrSub: "cannot compare cli-printing-press version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			writeManifestVersion(t, dir, tt.generated)
+
+			err := ensureVersionNotOlderThanCLIManifest(dir, "mcp-sync", tt.current)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestEnsureVersionNotOlderThanCLIManifestSkipsMissingOrLegacyManifest(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ensureVersionNotOlderThanCLIManifest(t.TempDir(), "mcp-sync", "4.22.1"))
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, pipeline.CLIManifestFilename), []byte(`{"schema_version":1}`), 0o644))
+	require.NoError(t, ensureVersionNotOlderThanCLIManifest(dir, "mcp-sync", "4.22.1"))
+}
+
+func TestRegenMergeCommandRefusesStaleBinaryBeforeClassify(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	freshDir := t.TempDir()
+	writeManifestVersion(t, cliDir, "999.0.0")
+
+	cmd := newRegenMergeCmd()
+	cmd.SetArgs([]string{cliDir, "--fresh", freshDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var exitErr *ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, ExitInputError, exitErr.Code)
+	assert.Contains(t, err.Error(), "regen-merge refused")
+}
+
+func TestMCPSyncCommandRefusesStaleBinaryBeforeSync(t *testing.T) {
+	t.Parallel()
+
+	cliDir := t.TempDir()
+	writeManifestVersion(t, cliDir, "999.0.0")
+
+	cmd := newMCPSyncCmd()
+	cmd.SetArgs([]string{cliDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var exitErr *ExitError
+	require.True(t, errors.As(err, &exitErr))
+	assert.Equal(t, ExitInputError, exitErr.Code)
+	assert.Contains(t, err.Error(), "mcp-sync refused")
+}

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -607,6 +607,15 @@ func TestPolishSkillInheritsPrintingPressBinaryFromParent(t *testing.T) {
 	assert.NotContains(t, polishSkill, "cli-printing-press mcp-sync \"$CLI_DIR\"")
 }
 
+func TestReprintSkillInitializesPrintingPressBinary(t *testing.T) {
+	reprintSkill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-reprint", "SKILL.md"))
+
+	assert.Contains(t, reprintSkill, "printing_press_bin: <abs-path>")
+	assert.Contains(t, reprintSkill, `PRINTING_PRESS_BIN="${PRINTING_PRESS_BIN:-}"`)
+	assert.Contains(t, reprintSkill, `command -v cli-printing-press`)
+	assert.Contains(t, reprintSkill, `"$PRINTING_PRESS_BIN" scorecard --dir "$LIB_TARGET" --json`)
+}
+
 func TestPolishSkillPinsGo126CompatibleGosecFallback(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
 	fallback := "go run github.com/securego/gosec/v2/cmd/gosec@v2.26.1"

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -421,8 +421,8 @@ func TestPrintingPressSkillUsesRunstateForBuilds(t *testing.T) {
 	// Lock acquire should appear before generation.
 	assert.Contains(t, skill, `cli-printing-press lock acquire --cli <api>-pp-cli --scope "$PRESS_SCOPE"`)
 
-	// Lock promote should appear in Phase 5.5.
-	assert.Contains(t, skill, `cli-printing-press lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"`)
+	// Lock promote should use the preflight-selected binary, not PATH.
+	assert.Contains(t, skill, `"$PRINTING_PRESS_BIN" lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"`)
 
 	// Phase 6 should still reference $PRESS_LIBRARY (reads from promoted location, slug-keyed).
 	assert.Contains(t, skill, `$PRESS_LIBRARY/<api>`)
@@ -454,7 +454,7 @@ func TestPrintingPressSkillReprintPromoteRoutingHandlesRebuiltNovels(t *testing.
 	assert.Contains(t, promote, "A false Path A clobbers hand work; a")
 	assert.Contains(t, promote, "false Path B only asks for review")
 
-	assert.Contains(t, reprint, "Phase 5.6 first\ndry-runs `cli-printing-press regen-merge")
+	assert.Contains(t, reprint, "Phase 5.6 first\ndry-runs `\"$PRINTING_PRESS_BIN\" regen-merge")
 	assert.Contains(t, reprint, "fresh tree contains all prior novel work")
 	assert.Contains(t, reprint, "genuine `NOVEL-COLLISION` / missing-referent cases halt")
 	assert.Contains(t, reprint, "preserve the existing\nlibrary manifest's permanent `creator`")
@@ -589,11 +589,22 @@ func TestGeneratedAgentsTemplatePointsToCatalogForPatchMechanics(t *testing.T) {
 func TestPolishSkillHardGatesPublishValidate(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
 
-	assert.Contains(t, skill, `cli-printing-press publish validate --dir "$CLI_DIR" --json`)
+	assert.Contains(t, skill, `"$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json`)
 	assert.Contains(t, skill, "Publish validation failures")
 	assert.Contains(t, skill, "The publish-validate leg is a hard ship-gate")
 	assert.Contains(t, skill, "phase5 acceptance")
 	assert.Contains(t, skill, "ship cannot fire while publish validate fails")
+}
+
+func TestPolishSkillInheritsPrintingPressBinaryFromParent(t *testing.T) {
+	mainSkill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	polishSkill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
+
+	assert.Contains(t, mainSkill, "printing_press_bin: <captured PRINTING_PRESS_BIN>")
+	assert.Contains(t, polishSkill, "printing_press_bin: <abs-path>")
+	assert.Contains(t, polishSkill, `"$PRINTING_PRESS_BIN" mcp-sync "$CLI_DIR"`)
+	assert.Contains(t, polishSkill, `"$PRINTING_PRESS_BIN" verify-skill --dir "$CLI_DIR"`)
+	assert.NotContains(t, polishSkill, "cli-printing-press mcp-sync \"$CLI_DIR\"")
 }
 
 func TestPolishSkillPinsGo126CompatibleGosecFallback(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -602,8 +602,10 @@ func TestPolishSkillInheritsPrintingPressBinaryFromParent(t *testing.T) {
 
 	assert.Contains(t, mainSkill, "printing_press_bin: <captured PRINTING_PRESS_BIN>")
 	assert.Contains(t, polishSkill, "printing_press_bin: <abs-path>")
+	assert.Contains(t, polishSkill, `"$PRINTING_PRESS_BIN" lock update --cli "$CLI_NAME" --phase polish`)
 	assert.Contains(t, polishSkill, `"$PRINTING_PRESS_BIN" mcp-sync "$CLI_DIR"`)
 	assert.Contains(t, polishSkill, `"$PRINTING_PRESS_BIN" verify-skill --dir "$CLI_DIR"`)
+	assert.NotContains(t, polishSkill, "cli-printing-press lock update --cli \"$CLI_NAME\"")
 	assert.NotContains(t, polishSkill, "cli-printing-press mcp-sync \"$CLI_DIR\"")
 }
 

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -50,14 +50,26 @@ Can also be run standalone on any CLI in `$PRESS_LIBRARY/`.
 PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 
-if ! command -v cli-printing-press >/dev/null 2>&1; then
+# Mid-pipeline callers may pass printing_press_bin: <abs-path> in the args
+# bundle. Prefer it so forked polish runs keep using the parent skill's
+# preflight-selected binary instead of re-resolving through PATH.
+PRINTING_PRESS_BIN="${PRINTING_PRESS_BIN:-}"
+if [ -z "$PRINTING_PRESS_BIN" ] && [ -n "${ARGUMENTS:-}" ]; then
+  PRINTING_PRESS_BIN="$(printf '%s\n' "$ARGUMENTS" | sed -nE 's/^[[:space:]]*printing_press_bin:[[:space:]]*(.+)$/\1/p' | head -1)"
+fi
+if [ -z "$PRINTING_PRESS_BIN" ]; then
+  PRINTING_PRESS_BIN="$(command -v cli-printing-press 2>/dev/null || true)"
+fi
+
+if [ -z "$PRINTING_PRESS_BIN" ]; then
   echo "cli-printing-press binary not found."
   echo "Install with:  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
   return 1 2>/dev/null || exit 1
 fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 ```
 
-After setup, check binary version compatibility. Read the `min-binary-version` field from this skill's YAML frontmatter. Run `cli-printing-press version --json` and parse the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
+After setup, capture `PRINTING_PRESS_BIN=<abs-path>` and use that absolute path for every `cli-printing-press ...` invocation in this skill. Check binary version compatibility by reading the `min-binary-version` field from this skill's YAML frontmatter, running `"$PRINTING_PRESS_BIN" version --json`, and parsing the version from the output. Compare it to `min-binary-version` using semver rules. If the installed binary is older than the minimum, stop immediately and tell the user: "cli-printing-press binary vX.Y.Z is older than the minimum required vA.B.C. Run `go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest` to update."
 
 ### Public-library hint
 
@@ -78,10 +90,11 @@ and let the divergence check (below) handle any drift.
 ### Resolve CLI
 
 The argument string can contain a `--standalone` flag plus one positional value
-(a slug, binary name, or path). It can also contain a Phase 3 gate bundle on
-following lines when invoked by the main printing-press skill. The flag may
-appear before or after the positional value; it is the only flag this skill
-consumes from `args`. Strip it before path resolution.
+(a slug, binary name, or path). It can also contain a Phase 3 gate bundle and a
+`printing_press_bin: <abs-path>` line on following lines when invoked by the
+main printing-press skill. The flag may appear before or after the positional
+value; it is the only flag this skill consumes from `args`. Strip it before path
+resolution.
 
 When `args` is multi-line, treat the first non-empty line as the positional
 value and parse the remaining lines as the optional Phase 3 gate bundle. Do not
@@ -141,11 +154,11 @@ STANDALONE_MODE="<true|false>"  # true iff slash-command invocation or --standal
 
 # Check if there's an active build lock — polish edits would be overwritten
 # when the running build promotes to library.
-_lock_json=$(cli-printing-press lock status --cli "$CLI_NAME" --json 2>/dev/null)
+_lock_json=$("$PRINTING_PRESS_BIN" lock status --cli "$CLI_NAME" --json 2>/dev/null)
 if echo "$_lock_json" | grep -q '"held".*true'; then
   if echo "$_lock_json" | grep -q '"stale".*true'; then
     echo "Warning: stale lock exists for $CLI_NAME (build may have crashed)."
-    echo "Proceeding with polish. Run 'cli-printing-press lock release --cli $CLI_NAME' to clear."
+    echo "Proceeding with polish. Run '$PRINTING_PRESS_BIN lock release --cli $CLI_NAME' to clear."
   else
     echo "An active build is in progress for $CLI_NAME."
     echo "Polish edits would be overwritten when the build promotes."
@@ -304,10 +317,10 @@ go build -o "$CLI_NAME" ./cmd/"$CLI_NAME" 2>&1
 # and research dir" step above. RESEARCH_ARGS enables dogfood to
 # verify novel features and sync them into .printing-press.json
 # (required for publish-validate's transcendence gate).
-cli-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
-cli-printing-press verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
-cli-printing-press workflow-verify --dir "$CLI_DIR" --json > /tmp/polish-workflow-verify.json 2>&1 || true
-cli-printing-press verify-skill --dir "$CLI_DIR" --json > /tmp/polish-verify-skill.json 2>&1 || true
+"$PRINTING_PRESS_BIN" dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
+"$PRINTING_PRESS_BIN" verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
+"$PRINTING_PRESS_BIN" workflow-verify --dir "$CLI_DIR" --json > /tmp/polish-workflow-verify.json 2>&1 || true
+"$PRINTING_PRESS_BIN" verify-skill --dir "$CLI_DIR" --json > /tmp/polish-verify-skill.json 2>&1 || true
 # publish-validate is a publish-readiness gate, not a CLI-readiness gate.
 # Mid-pipeline polish runs before the main SKILL's promote step and before
 # the publish skill packages tools-manifest.json, so its prerequisites
@@ -319,7 +332,7 @@ cli-printing-press verify-skill --dir "$CLI_DIR" --json > /tmp/polish-verify-ski
 # CLI-level hold. Only run publish-validate when polish is the publish
 # entry point (slash-command invocation or explicit --standalone).
 if [ "$STANDALONE_MODE" = "true" ]; then
-  cli-printing-press publish validate --dir "$CLI_DIR" --json > /tmp/polish-publish-validate.json 2>&1 || true
+  "$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json > /tmp/polish-publish-validate.json 2>&1 || true
 fi
 # --live-check samples novel-feature outputs and populates
 # live_check.features[].warnings (Wave B entity detection) — required for
@@ -328,10 +341,10 @@ fi
 # CLI lives under $PRESS_RUNSTATE/runs/<id>/working/<cli> (mid-pipeline
 # polish). Without it, scorecard looks adjacent to the binary, doesn't
 # find research.json, and reports `unable: true`.
-cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
-cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
-cli-printing-press tools-audit "$CLI_DIR" --json > /tmp/polish-tools-audit-before.json 2>&1 || true
-cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}" --json > /tmp/polish-pii-audit-before.json 2>&1 || true
+"$PRINTING_PRESS_BIN" scorecard --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" --live-check --json > /tmp/polish-scorecard.json 2>&1 || true
+"$PRINTING_PRESS_BIN" scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
+"$PRINTING_PRESS_BIN" tools-audit "$CLI_DIR" --json > /tmp/polish-tools-audit-before.json 2>&1 || true
+"$PRINTING_PRESS_BIN" pii-audit "$CLI_DIR" "${PII_ARGS[@]}" --json > /tmp/polish-pii-audit-before.json 2>&1 || true
 go vet ./... 2>&1
 if command -v gosec >/dev/null 2>&1; then
   gosec -fmt=json -out=/tmp/polish-gosec-before.json ./... 2>&1 || true
@@ -340,7 +353,7 @@ else
 fi
 ```
 
-verify-skill and workflow-verify run alongside dogfood/verify/scorecard so polish catches the same class of failures the public-library CI catches. `publish-validate` runs only when `STANDALONE_MODE=true` (slash-command or `--standalone` Skill-tool invocation). The publish-validate leg is a hard ship-gate **for standalone polish**: in that mode polish cannot recommend `ship` or `ship-with-gaps` while `cli-printing-press publish validate` reports `passed: false`. Mid-pipeline polish (`STANDALONE_MODE=false`) skips publish-validate entirely — its prerequisites (manifest.printer from `git config github.user`, packaged `tools-manifest.json`, phase5 acceptance proof relocated under `$CLI_DIR/.manuscripts/<run>/proofs/`) are parent-pipeline-owned and not yet satisfied at this point; the main SKILL's Phase 6 publish flow gates on publish-validate at the correct time. See "Ship logic" below for how this affects ship_recommendation.
+verify-skill and workflow-verify run alongside dogfood/verify/scorecard so polish catches the same class of failures the public-library CI catches. `publish-validate` runs only when `STANDALONE_MODE=true` (slash-command or `--standalone` Skill-tool invocation). The publish-validate leg is a hard ship-gate **for standalone polish**: in that mode polish cannot recommend `ship` or `ship-with-gaps` while `"$PRINTING_PRESS_BIN" publish validate` reports `passed: false`. Mid-pipeline polish (`STANDALONE_MODE=false`) skips publish-validate entirely — its prerequisites (manifest.printer from `git config github.user`, packaged `tools-manifest.json`, phase5 acceptance proof relocated under `$CLI_DIR/.manuscripts/<run>/proofs/`) are parent-pipeline-owned and not yet satisfied at this point; the main SKILL's Phase 6 publish flow gates on publish-validate at the correct time. See "Ship logic" below for how this affects ship_recommendation.
 
 `gosec` runs as the off-the-shelf security static-analysis leg for hand-written Go. Prefer an installed `gosec` binary when present; otherwise use the pinned `go run github.com/securego/gosec/v2/cmd/gosec@v2.26.1` fallback so a clean machine still gets a reproducible check without a separate setup step. Read `/tmp/polish-gosec-before.json` for the baseline finding count and issue details. If the command fails before writing JSON, treat the missing scan as a polish failure: add it to `remaining_issues`, set `ship_recommendation: hold`, and include the stderr summary so the next run can distinguish network/tooling failure from CLI defects. Prioritize findings in hand-authored files: whole files under `internal/cli/`, `internal/syncer/`, and `internal/store/` whose first 20 lines lack the `Generated by CLI Printing Press` header are polish-owned novel-feature code. Findings in generator-emitted files are Printing Press retro candidates unless they can be fixed durably by changing the spec and regenerating; do not hand-edit generated files just to silence gosec.
 
@@ -353,7 +366,7 @@ Parse findings into categories:
 | Verify failures | verify --json | Commands with score < 3 |
 | SKILL static-check failures | verify-skill --json | Any `findings[]` with `severity=error` (flag-names, flag-commands, positional-args, unknown-command, canonical-sections). Hard ship-gate: ship cannot fire while these exist. |
 | Workflow gaps | workflow-verify --json | Verdict `workflow-fail`. Soft gate: surface in `remaining_issues` and downgrade to `hold` when the workflow is the CLI's primary value. |
-| Publish validation failures | publish validate --json | `passed: false`. **Standalone polish only** (runs only when `STANDALONE_MODE=true`); skipped in mid-pipeline polish where publish prerequisites aren't yet satisfied. When it runs, it's a hard ship-gate: ship cannot fire while publish validate fails. If the only failing check is missing phase5 acceptance, report `phase5 acceptance required` with the next-step command: authenticate, then run `cli-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG --live --level quick --write-acceptance <proofs-dir>/phase5-acceptance.json`. Use the proofs directory from the validate error when present. |
+| Publish validation failures | publish validate --json | `passed: false`. **Standalone polish only** (runs only when `STANDALONE_MODE=true`); skipped in mid-pipeline polish where publish prerequisites aren't yet satisfied. When it runs, it's a hard ship-gate: ship cannot fire while publish validate fails. If the only failing check is missing phase5 acceptance, report `phase5 acceptance required` with the next-step command: authenticate, then run `"$PRINTING_PRESS_BIN" dogfood --dir "$CLI_DIR" $SPEC_FLAG --live --level quick --write-acceptance <proofs-dir>/phase5-acceptance.json`. Use the proofs directory from the validate error when present. |
 | Security static-analysis failures | gosec JSON | Any `Issues[]` entry, especially G201/G202 SQL construction, G101 credential literals, or unsafe file/command execution. Hard ship-gate when the finding is in hand-authored novel-feature Go. |
 | Dead code | dogfood | Dead functions, dead flags |
 | Stale files | dogfood | Unregistered commands |
@@ -456,7 +469,7 @@ not apply, and still decode nested identifiers to scalars before persistence.
 If Phase 1's `dogfood` reported `MCP Surface: FAIL` with a parity mismatch, the CLI was generated before the runtime cobratree walker existed and is still on the static `internal/mcp/tools.go` surface. The fix is mechanical:
 
 ```bash
-cli-printing-press mcp-sync "$CLI_DIR"
+"$PRINTING_PRESS_BIN" mcp-sync "$CLI_DIR"
 ```
 
 That migrates the MCP surface to the runtime walker, regenerates `tools-manifest.json` and `internal/mcp/tools.go`, and applies any `mcp-descriptions.json` overrides. Re-run `dogfood` after; the parity gate flips to PASS. This is a known migration path for every CLI generated before the cobratree landed; running it on a CLI already on the runtime walker is a no-op refresh.
@@ -625,7 +638,7 @@ Read `/tmp/polish-verify-skill.json` for the full finding list. Each finding has
 
 When editing other parts of SKILL.md, Read the affected section first and Read it again after the Edit. `Edit` replaces a literal string; if the surrounding context has drifted, a single Edit can graft a second copy of a block onto the first instead of replacing it.
 
-After fixing, re-run `cli-printing-press verify-skill --dir "$CLI_DIR"` and confirm exit 0 before moving on.
+After fixing, re-run `"$PRINTING_PRESS_BIN" verify-skill --dir "$CLI_DIR"` and confirm exit 0 before moving on.
 
 ### Priority 6: Remaining dogfood issues
 
@@ -640,7 +653,7 @@ After fixing, re-run `cli-printing-press verify-skill --dir "$CLI_DIR"` and conf
 
 Stop and:
 
-1. Run `cli-printing-press tools-audit "$CLI_DIR" --json` to surface mechanical findings (empty Short, thin Short, missing `mcp:read-only` on read-shaped command names).
+1. Run `"$PRINTING_PRESS_BIN" tools-audit "$CLI_DIR" --json` to surface mechanical findings (empty Short, thin Short, missing `mcp:read-only` on read-shaped command names).
 2. You must read `references/tools-polish.md` and follow its instructions to address the findings AND run a judgment pass over every command — regardless of whether the audit flagged it. The audit catches mechanical issues; description quality and borderline classification (read-only vs. local-write) always require agent reasoning. You must not skip this.
 3. **Accepting MCP-description findings carries a stricter contract.** `thin-mcp-description` and `empty-mcp-description` accepts require three pre-decision fields (`spec_source_material`, `target_description`, `gap_analysis`) populated per finding. The binary rejects bulk accepts (>5 findings sharing one rationale) and runs that "complete" without lifting MCPDescriptionQuality. Fix via override or generator improvement is the expected path; accept is rare. See `references/tools-polish.md` "Marking a finding accepted" for the full contract.
 
@@ -652,7 +665,7 @@ Proceed to "After all fixes" only when the audit's summary line reads `no pendin
 
 Stop and:
 
-1. Run `cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}"` to surface pending findings (or read `/tmp/polish-pii-audit-before.json` from Phase 1's baseline). When `RESEARCH_DIR` exists, this includes that run's `research.json` and `research/*.md` with `.manuscripts/<run-id>/...` paths so accepts carry forward into `publish package`.
+1. Run `"$PRINTING_PRESS_BIN" pii-audit "$CLI_DIR" "${PII_ARGS[@]}"` to surface pending findings (or read `/tmp/polish-pii-audit-before.json` from Phase 1's baseline). When `RESEARCH_DIR` exists, this includes that run's `research.json` and `research/*.md` with `.manuscripts/<run-id>/...` paths so accepts carry forward into `publish package`.
 2. You must read `references/pii-polish.md` and follow its per-finding decision tree — fix real values in source with non-matching placeholders, or accept with the `category` + `evidence_context` pre-decision fields.
 3. **Accepting PII findings carries a strict contract.** Missing fields, 6+ accepts sharing a rationale, or wholesale-accepting ≥10 findings without source fixes all fail the gate. See `references/pii-polish.md` "The accept contract" and "Forbidden accept patterns" for the full rules.
 
@@ -674,16 +687,16 @@ Re-run the diagnostic sweep on the fixed CLI:
 # checkNovelFeatures doesn't re-sync novel_features_built after Phase 2
 # edits, and publish-validate's transcendence gate reads stale state
 # from Phase 1's pass.
-cli-printing-press dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
-cli-printing-press verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
-cli-printing-press workflow-verify --dir "$CLI_DIR" --json 2>&1
-cli-printing-press verify-skill --dir "$CLI_DIR" --json 2>&1
+"$PRINTING_PRESS_BIN" dogfood --dir "$CLI_DIR" $SPEC_FLAG "${RESEARCH_ARGS[@]}" 2>&1
+"$PRINTING_PRESS_BIN" verify --dir "$CLI_DIR" $SPEC_FLAG --json 2>&1
+"$PRINTING_PRESS_BIN" workflow-verify --dir "$CLI_DIR" --json 2>&1
+"$PRINTING_PRESS_BIN" verify-skill --dir "$CLI_DIR" --json 2>&1
 if [ "$STANDALONE_MODE" = "true" ]; then
-  cli-printing-press publish validate --dir "$CLI_DIR" --json 2>&1
+  "$PRINTING_PRESS_BIN" publish validate --dir "$CLI_DIR" --json 2>&1
 fi
-cli-printing-press scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
-cli-printing-press tools-audit "$CLI_DIR" 2>&1
-cli-printing-press pii-audit "$CLI_DIR" "${PII_ARGS[@]}" 2>&1
+"$PRINTING_PRESS_BIN" scorecard --dir "$CLI_DIR" $SPEC_FLAG 2>&1
+"$PRINTING_PRESS_BIN" tools-audit "$CLI_DIR" 2>&1
+"$PRINTING_PRESS_BIN" pii-audit "$CLI_DIR" "${PII_ARGS[@]}" 2>&1
 go vet ./... 2>&1
 if command -v gosec >/dev/null 2>&1; then
   gosec -fmt=json -out=/tmp/polish-gosec-after.json ./... 2>&1 || true

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -408,7 +408,7 @@ Record baseline scores: scorecard total, verify pass rate, dogfood verdict, go v
 Fix in priority order. After each priority level, update the lock heartbeat:
 
 ```bash
-cli-printing-press lock update --cli "$CLI_NAME" --phase polish 2>/dev/null
+"$PRINTING_PRESS_BIN" lock update --cli "$CLI_NAME" --phase polish 2>/dev/null
 ```
 
 ### Runtime variant default checklist

--- a/skills/printing-press-reprint/SKILL.md
+++ b/skills/printing-press-reprint/SKILL.md
@@ -51,6 +51,24 @@ redo research or rebuild the manuscript.
 PRESS_HOME="${PRINTING_PRESS_HOME:-$HOME/printing-press}"
 PRESS_LIBRARY="$PRESS_HOME/library"
 PRESS_MANUSCRIPTS="$PRESS_HOME/manuscripts"
+
+# Mid-pipeline callers may pass printing_press_bin: <abs-path> in the args
+# bundle. Prefer it so reprint keeps using the parent skill's preflight-selected
+# binary instead of re-resolving through PATH.
+PRINTING_PRESS_BIN="${PRINTING_PRESS_BIN:-}"
+if [ -z "$PRINTING_PRESS_BIN" ] && [ -n "${ARGUMENTS:-}" ]; then
+  PRINTING_PRESS_BIN="$(printf '%s\n' "$ARGUMENTS" | sed -nE 's/^[[:space:]]*printing_press_bin:[[:space:]]*(.+)$/\1/p' | head -1)"
+fi
+if [ -z "$PRINTING_PRESS_BIN" ]; then
+  PRINTING_PRESS_BIN="$(command -v cli-printing-press 2>/dev/null || true)"
+fi
+
+if [ -z "$PRINTING_PRESS_BIN" ]; then
+  echo "cli-printing-press binary not found."
+  echo "Install with:  go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest"
+  return 1 2>/dev/null || exit 1
+fi
+echo "PRINTING_PRESS_BIN=$PRINTING_PRESS_BIN"
 ```
 
 ## Phase A — Resolve and reconcile presence

--- a/skills/printing-press-reprint/SKILL.md
+++ b/skills/printing-press-reprint/SKILL.md
@@ -241,7 +241,7 @@ if [[ -n "$SCORECARD_SOURCE" ]]; then
   SCORECARD_JSON=$(cat "$SCORECARD_SOURCE" 2>/dev/null || true)
 elif [[ -d "$LIB_TARGET" ]]; then
   SCORECARD_SOURCE=$(mktemp)
-  if cli-printing-press scorecard --dir "$LIB_TARGET" --json > "$SCORECARD_SOURCE" 2>/dev/null; then
+  if "$PRINTING_PRESS_BIN" scorecard --dir "$LIB_TARGET" --json > "$SCORECARD_SOURCE" 2>/dev/null; then
     SCORECARD_JSON=$(cat "$SCORECARD_SOURCE" 2>/dev/null || true)
   fi
   rm -f "$SCORECARD_SOURCE"
@@ -364,7 +364,7 @@ The library-preservation contract is owned by `/printing-press` Phase 5.6
 ("Promote to Library"), not by this skill. When the existing library has
 `novel_features > 0` in its manifest (or hand-authored files under
 `internal/cli/`, `internal/syncer/`, or `internal/store/`), Phase 5.6 first
-dry-runs `cli-printing-press regen-merge "$LIB_TARGET" --fresh "$CLI_WORK_DIR"
+dry-runs `"$PRINTING_PRESS_BIN" regen-merge "$LIB_TARGET" --fresh "$CLI_WORK_DIR"
 --json` to decide whether the fresh tree rebuilt the prior novels. If the
 fresh tree contains all prior novel work, Phase 5.6 uses the swap path and
 treats generated-file version drift as expected overwrite. Otherwise it routes

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -820,7 +820,7 @@ Before new research:
    First, check lock status to detect active builds:
 
    ```bash
-   LOCK_STATUS=$(cli-printing-press lock status --cli <api>-pp-cli --json 2>/dev/null)
+   LOCK_STATUS=$("$PRINTING_PRESS_BIN" lock status --cli <api>-pp-cli --json 2>/dev/null)
    LOCK_HELD=$(echo "$LOCK_STATUS" | grep -o '"held"[[:space:]]*:[[:space:]]*[a-z]*' | head -1 | sed 's/.*: *//')
    LOCK_STALE=$(echo "$LOCK_STATUS" | grep -o '"stale"[[:space:]]*:[[:space:]]*[a-z]*' | head -1 | sed 's/.*: *//')
    LOCK_PHASE=$(echo "$LOCK_STATUS" | grep -o '"phase"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"phase"[[:space:]]*:[[:space:]]*"//;s/"//')
@@ -2911,7 +2911,7 @@ If generation fails:
 - prefer generator fixes over manual generated-code surgery when the failure is systemic
 - if retries are exhausted, release the lock and stop:
   ```bash
-  cli-printing-press lock release --cli <api>-pp-cli
+  "$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
   ```
 
 ## Phase 3: Build The GOAT
@@ -3670,7 +3670,7 @@ Include:
 
 If the final verdict is `hold`, release the lock without promoting to library:
 ```bash
-cli-printing-press lock release --cli <api>-pp-cli
+"$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
 ```
 The working copy remains in `$CLI_WORK_DIR` for potential future retry. Proceed to Phase 5.6 to archive manuscripts (archiving still happens on hold).
 
@@ -3981,7 +3981,7 @@ keep PII out of the acceptance report from the moment you write it.
 **Gate = FAIL:** fix issues inline (Step 3) and re-run failing tests, up to
 2 fix loops. If the gate still fails after 2 loops, put the CLI on hold:
 ```bash
-cli-printing-press lock release --cli <api>-pp-cli
+"$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
 ```
 The working copy remains in `$CLI_WORK_DIR`. Proceed to Phase 5.6 to archive
 manuscripts (archiving still happens on hold). Tag the failure reason in the
@@ -4080,9 +4080,12 @@ proof or a hold decision.
 **Always runs.** Invoke the `printing-press-polish` skill to run diagnostics, fix quality issues, and return a delta. The polish skill carries `context: fork` in its frontmatter, so its diagnostic-fix-rediagnose loop runs in a forked context — diagnostic spam, fix iterations, and re-audits stay scoped to the polish session and don't pollute this generation flow. The skill is autonomous — no user input needed. The goal is to ship the best CLI possible, not the fastest.
 
 Before invoking polish, collect the Phase 3 transcendence gate state and include
-it in the polish input bundle:
+it in the polish input bundle. Include the captured `PRINTING_PRESS_BIN` value
+so the forked polish skill uses the same preflight-selected binary instead of
+resolving a potentially stale global binary from PATH:
 
 ```yaml
+printing_press_bin: <captured PRINTING_PRESS_BIN>
 phase3_transcendence_rows_planned: <planned>
 phase3_transcendence_rows_built: <built>
 phase3_transcendence_rows_missing:
@@ -4098,6 +4101,7 @@ Pass `$CLI_WORK_DIR` as the first line of `args`, followed by the Phase 3 bundle
 Skill(
   skill: "cli-printing-press:printing-press-polish",
   args: "$CLI_WORK_DIR
+printing_press_bin: <captured PRINTING_PRESS_BIN>
 phase3_transcendence_rows_planned: <planned>
 phase3_transcendence_rows_built: <built>
 phase3_transcendence_rows_missing:
@@ -4205,11 +4209,11 @@ novel list:
 REGEN_DRY_RUN_REPORT="$PROOFS_DIR/regen-merge-dry-run-report.json"
 PATH_A_REBUILT_NOVELS=0
 if [ -d "$LIB_TARGET" ] && [ "$NOVEL_COUNT" -gt 0 ]; then
-  if ! cli-printing-press regen-merge "$LIB_TARGET" \
+  if ! "$PRINTING_PRESS_BIN" regen-merge "$LIB_TARGET" \
       --fresh "$CLI_WORK_DIR" --json > "$REGEN_DRY_RUN_REPORT"; then
     # Real error (input error, missing fresh tree, unreadable library). Release
     # the upstream pipeline lock and surface the dry-run failure.
-    cli-printing-press lock release --cli <api>-pp-cli
+    "$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
     echo "regen-merge dry-run failed; see $REGEN_DRY_RUN_REPORT" >&2
     exit 1
   fi
@@ -4252,7 +4256,7 @@ The override is forbidden unless the fresh tree contains the novels:
 
 ```bash
 # Atomic swap: copies working dir, writes manifest, updates run pointer, releases lock.
-cli-printing-press lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"
+"$PRINTING_PRESS_BIN" lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"
 ```
 
 The `promote` command handles the full sequence: stages the working directory, atomically swaps it into `$PRESS_LIBRARY/<api>` (slug-keyed), writes the `.printing-press.json` manifest, updates the `CurrentRunPointer`, and releases the lock — all in one step. The `--cli` flag accepts the CLI binary name; the Go code translates to the slug-keyed library path internally.
@@ -4263,12 +4267,12 @@ The `promote` command handles the full sequence: stages the working directory, a
 
 ```bash
 REGEN_REPORT="$PROOFS_DIR/regen-merge-report.json"
-if ! cli-printing-press regen-merge "$LIB_TARGET" \
+if ! "$PRINTING_PRESS_BIN" regen-merge "$LIB_TARGET" \
     --fresh "$CLI_WORK_DIR" --apply --json > "$REGEN_REPORT"; then
   # Real error (input error, apply failure). Release the lock — it was
   # acquired upstream by the press pipeline; regen-merge does not own it —
   # and surface the failure to the user.
-  cli-printing-press lock release --cli <api>-pp-cli
+  "$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
   echo "regen-merge --apply failed; see $REGEN_REPORT" >&2
   exit 1
 fi
@@ -4282,7 +4286,7 @@ NEEDS_REVIEW=$(jq '[.files[] | select(.verdict == "TEMPLATED-WITH-ADDITIONS"
 if [ "$NEEDS_REVIEW" -gt 0 ]; then
   # Release the lock so the next reprint of this CLI is not blocked until
   # timeout. lock promote would have released it; the halt path must too.
-  cli-printing-press lock release --cli <api>-pp-cli
+  "$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
   echo "regen-merge flagged $NEEDS_REVIEW file(s) for human review. " \
        "Inspect $REGEN_REPORT, resolve inline hand-edits, then re-run." >&2
   exit 1
@@ -4304,8 +4308,8 @@ else
   # line-shifted generator files and surface false-positive pendings.
   rm -f "$LIB_TARGET/.printing-press-pii-polish.json"
 fi
-cli-printing-press lock promote --cli <api>-pp-cli --dir "$LIB_TARGET" || {
-  cli-printing-press lock release --cli <api>-pp-cli
+"$PRINTING_PRESS_BIN" lock promote --cli <api>-pp-cli --dir "$LIB_TARGET" || {
+  "$PRINTING_PRESS_BIN" lock release --cli <api>-pp-cli
   echo "lock promote failed for $LIB_TARGET; lock released. " \
        "Inspect the PII gate output above and resolve before re-running." >&2
   exit 1
@@ -4519,7 +4523,8 @@ Invoke `/printing-press-retro`. The retro skill analyzes the session for generat
 ```
 Skill(
   skill: "cli-printing-press:printing-press-polish",
-  args: "$CLI_WORK_DIR"
+  args: "$CLI_WORK_DIR
+printing_press_bin: <captured PRINTING_PRESS_BIN>"
 )
 ```
 
@@ -4528,13 +4533,14 @@ Three reasons for this exact form, all mirroring Phase 5.5:
 1. **Pass `$CLI_WORK_DIR` (absolute path), not the slug.** Hold runs leave the CLI in the working directory because Phase 5.6 did not promote — `$PRESS_LIBRARY/<slug>/` either does not exist or holds a stale prior run, and a slug-form invocation would polish that stale copy.
 2. **Use the Skill tool (forked context), not the `/printing-press-polish` slash command.** This matches Phase 5.5's invocation pattern — same shape, same expectations. Slash-command invocations auto-enable polish's standalone mode (Publish Offer fires); the Skill tool form defers to the parent unless `--standalone` is passed explicitly. Main SKILL owns the menu on this path.
 3. **Do not include `--standalone` in `args`.** The flag is what polish gates its Publish Offer on (see polish SKILL.md "Publish Offer"). On the hold path the CLI has not been promoted; firing the offer would open a public PR for an un-promoted, un-shipped working copy.
+4. **Pass `printing_press_bin`.** Use the absolute path captured by the parent setup preflight so this forked polish pass cannot downgrade the CLI by resolving an older global binary.
 
 After polish returns, parse the result block and act on the new `ship_recommendation`:
 
 - **Polish landed on `ship` or `ship-with-gaps`** — the verdict transitioned out of hold. The working copy is still un-promoted; the library is stale. Run promote, then route to the ship-path menu (above):
 
   ```bash
-  cli-printing-press lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"
+  "$PRINTING_PRESS_BIN" lock promote --cli <api>-pp-cli --dir "$CLI_WORK_DIR"
   ```
 
   Then re-enter the ship-path menu using polish's new result block. Skip the Phase 5.6 acceptance-gate JSON check — that gate was already satisfied when this run originally reached Phase 5.6, and polish does not regenerate it.


### PR DESCRIPTION
## Summary

Stale `cli-printing-press` binaries now stop before `mcp-sync` or `regen-merge` can rewrite generator-owned files from an older template set. Both commands compare the running binary version against the target CLI's `.printing-press.json` `printing_press_version`, allow same-or-newer binaries, and refuse older or incomparable versions with a clear error.

Forked polish and reprint paths now carry the parent skill's captured `PRINTING_PRESS_BIN` and use that absolute path for generator commands, so sub-skills do not accidentally resolve a stale global binary from `PATH`.

Closes #2498

## Verification

- `go fmt ./...`
- `go test ./internal/cli -run 'TestEnsureVersionNotOlderThanCLIManifest|TestRegenMergeCommandRefusesStaleBinaryBeforeClassify|TestMCPSyncCommandRefusesStaleBinaryBeforeSync'`
- `go test ./internal/pipeline -run 'TestPrintingPressSkillUsesRunstateForBuilds|TestPrintingPressSkillReprintPromoteRoutingHandlesRebuiltNovels|TestPolishSkillHardGatesPublishValidate|TestPolishSkillInheritsPrintingPressBinaryFromParent'`
- `go test ./internal/pipeline`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`

`go test ./...` was also run. It completed with one load-sensitive timeout in `TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap`; rerunning that exact test and then the full `./internal/pipeline` package passed.
