### PR TITLE
fix(skills): make run ids collision-proof

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -217,7 +217,7 @@ func newGenerateCmd() *cobra.Command {
 					}
 				}
 
-				runID := pipeline.DeriveRunIDFromResearchDir(researchDir)
+				runID := pipeline.ResolveRunIDFromResearchDir(researchDir)
 				if runID == "" {
 					fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
 				}
@@ -517,7 +517,7 @@ func newGenerateCmd() *cobra.Command {
 				}
 			}
 
-			runID := pipeline.DeriveRunIDFromResearchDir(researchDir)
+			runID := pipeline.ResolveRunIDFromResearchDir(researchDir)
 			if runID == "" {
 				fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
 			}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -736,25 +736,23 @@ type GenerateManifestParams struct {
 	Owner         string                 // legacy, derived from Creator.Handle (dual-write)
 	Printer       string                 // legacy, derived from Creator.Handle (dual-write)
 	PrinterName   string                 // legacy, derived from Creator.Name (dual-write)
-	RunID         string                 // YYYYMMDD-HHMMSS, derived from --research-dir basename when empty
+	RunID         string                 // from --research-dir/state.json when available, legacy basename fallback otherwise
 	Spec          *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
 	NovelFeatures []NovelFeatureManifest // transcendence features from research (nil if unavailable)
 }
 
-// runIDPattern matches the canonical pipeline run_id shape: YYYYMMDD-HHMMSS.
-// When an arbitrary path basename happens to match this pattern, treat it as
-// a real run_id; otherwise fall back to empty (and warn at the call site).
-var runIDPattern = regexp.MustCompile(`^\d{8}-\d{6}$`)
+// runIDPattern matches legacy and skill-allocated pipeline run_id basenames.
+// State files are the source of truth for current runs; this is only a legacy
+// fallback for older run directories that predate state-backed generate.
+var runIDPattern = regexp.MustCompile(`^\d{8}-\d{6}(?:-[A-Za-z0-9._-]+)?$`)
 
-// runIDTimeFormat is the canonical YYYYMMDD-HHMMSS layout matched by
-// runIDPattern. Kept as a const so the format and pattern can't drift.
+// runIDTimeFormat is the legacy timestamp-only layout used when generate has
+// no state-backed run_id. Kept as a const so fallback formatting stays stable.
 const runIDTimeFormat = "20060102-150405"
 
 // DeriveRunIDFromResearchDir extracts a canonical run_id from a research-dir
-// path, or returns "" when no valid run_id can be derived. The standalone
-// generate command does not load a PipelineState, so it cannot reach
-// state.RunID directly; the basename of --research-dir is the only structured
-// signal available without a state-loading refactor.
+// path, or returns "" when no valid run_id can be derived. Prefer
+// ResolveRunIDFromResearchDir for current generate flows so state.json wins.
 func DeriveRunIDFromResearchDir(researchDir string) string {
 	if researchDir == "" {
 		return ""
@@ -766,6 +764,39 @@ func DeriveRunIDFromResearchDir(researchDir string) string {
 	return ""
 }
 
+type generateResearchState struct {
+	APIName string `json:"api_name"`
+	RunID   string `json:"run_id"`
+}
+
+func loadGenerateResearchState(researchDir string) (generateResearchState, bool) {
+	if researchDir == "" {
+		return generateResearchState{}, false
+	}
+	statePath := filepath.Join(researchDir, "state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return generateResearchState{}, false
+	}
+	var state generateResearchState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return generateResearchState{}, false
+	}
+	state.APIName = strings.TrimSpace(state.APIName)
+	state.RunID = strings.TrimSpace(state.RunID)
+	return state, state.APIName != "" || state.RunID != ""
+}
+
+// ResolveRunIDFromResearchDir reads the run_id recorded by Run Initialization
+// in `<researchDir>/state.json`, falling back to the path basename only for
+// legacy runs that predate state-backed generate.
+func ResolveRunIDFromResearchDir(researchDir string) string {
+	if state, ok := loadGenerateResearchState(researchDir); ok && state.RunID != "" {
+		return state.RunID
+	}
+	return DeriveRunIDFromResearchDir(researchDir)
+}
+
 // LoadAPINameFromResearchDir reads `<researchDir>/state.json` and returns the
 // recorded api_name slug, or "" when the file is absent, unreadable, malformed,
 // or has no api_name. The generate command uses this as an implicit --name
@@ -775,21 +806,11 @@ func DeriveRunIDFromResearchDir(researchDir string) string {
 // --name wins over this; an absent or unreadable state.json silently yields
 // to the title-derived default.
 func LoadAPINameFromResearchDir(researchDir string) string {
-	if researchDir == "" {
+	state, ok := loadGenerateResearchState(researchDir)
+	if !ok {
 		return ""
 	}
-	statePath := filepath.Join(researchDir, "state.json")
-	data, err := os.ReadFile(statePath)
-	if err != nil {
-		return ""
-	}
-	var probe struct {
-		APIName string `json:"api_name"`
-	}
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(probe.APIName)
+	return state.APIName
 }
 
 // WriteManifestForGenerate writes a .printing-press.json manifest into the
@@ -798,8 +819,9 @@ func LoadAPINameFromResearchDir(researchDir string) string {
 //
 // An empty p.RunID is auto-filled with a fresh timestamp so the emitted
 // manifest satisfies publish-validate's required-run_id contract. Phase 5
-// dogfood acceptance still needs the original research-dir-derived run_id,
-// and the root.go --research-dir warning informs phase5 callers of that gap.
+// dogfood acceptance still needs the original run_id from state.json or the
+// legacy research-dir basename, and the root.go --research-dir warning
+// informs phase5 callers of that gap.
 func WriteManifestForGenerate(p GenerateManifestParams) error {
 	now := time.Now().UTC()
 	runID := p.RunID

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -832,12 +832,13 @@ func TestDeriveRunIDFromResearchDir(t *testing.T) {
 		expected string
 	}{
 		{"canonical run_id basename", "/tmp/runs/20260504-190931", "20260504-190931"},
+		{"skill-allocated suffixed basename", "/tmp/runs/20260504-190931-a1b2c3d4", "20260504-190931-a1b2c3d4"},
 		{"trailing slash", "/tmp/runs/20260504-190931/", "20260504-190931"},
 		{"basename only", "20260101-000000", "20260101-000000"},
 		{"empty input", "", ""},
 		{"non-matching basename", "/tmp/runs/research", ""},
 		{"partial match (date only)", "/tmp/runs/20260504", ""},
-		{"longer suffix", "/tmp/runs/20260504-190931-x", ""},
+		{"legacy basename with suffix", "/tmp/runs/20260504-190931-x", "20260504-190931-x"},
 		{"wrong shape (T separator)", "/tmp/runs/20260504T190931", ""},
 	}
 	for _, tc := range cases {
@@ -845,6 +846,32 @@ func TestDeriveRunIDFromResearchDir(t *testing.T) {
 			assert.Equal(t, tc.expected, DeriveRunIDFromResearchDir(tc.input))
 		})
 	}
+}
+
+func TestResolveRunIDFromResearchDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("state json wins over basename", func(t *testing.T) {
+		t.Parallel()
+		dir := filepath.Join(t.TempDir(), "20260504-190931")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "state.json"),
+			[]byte(`{"api_name":"canvas","run_id":"20260606-102750-a1b2c3d4"}`),
+			0o644,
+		))
+		assert.Equal(t, "20260606-102750-a1b2c3d4", ResolveRunIDFromResearchDir(dir))
+	})
+
+	t.Run("falls back to legacy basename", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "20260504-190931", ResolveRunIDFromResearchDir("/tmp/runs/20260504-190931"))
+	})
+
+	t.Run("empty string when state and basename are not usable", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", ResolveRunIDFromResearchDir(t.TempDir()))
+	})
 }
 
 func TestLoadAPINameFromResearchDir(t *testing.T) {

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -235,6 +235,9 @@ func TestPrintingPressSkillUsesRunRootStateFile(t *testing.T) {
 	assert.Contains(t, skill, `STATE_FILE="$API_RUN_DIR/state.json"`)
 	assert.NotContains(t, skill, `STATE_FILE="$PIPELINE_DIR/state.json"`)
 	assert.Contains(t, skill, `"working_dir": "$CLI_WORK_DIR"`)
+	assert.Contains(t, skill, `CANDIDATE_RUN_ID="$(date +%Y%m%d-%H%M%S)-$RUN_SUFFIX"`)
+	assert.Contains(t, skill, `if mkdir "$CANDIDATE_RUN_DIR" 2>/dev/null; then`)
+	assert.Contains(t, skill, "state file the source of truth for generate, dogfood acceptance, promote")
 }
 
 func TestPrintingPressSkillWarnsOnMultiSpecDirectories(t *testing.T) {

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -652,7 +652,7 @@ mkdir -p "$PRESS_RUNSTATE/runs"
 RUN_ID=""
 API_RUN_DIR=""
 for attempt in 1 2 3 4 5; do
-  RUN_SUFFIX="$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 8 2>/dev/null || true)"
+  RUN_SUFFIX="$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 8 || true)"
   if [ -z "$RUN_SUFFIX" ]; then
     RUN_SUFFIX="pid$$-$attempt"
   fi

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -648,8 +648,26 @@ Default to option 1 unless the user overrides. Record the decision in `source-pr
 After you know `<api>` (from the Orientation & Briefing flow above; preflight already ran at the top), initialize the run-scoped artifact paths:
 
 ```bash
-RUN_ID="$(date +%Y%m%d-%H%M%S)"
-API_RUN_DIR="$PRESS_RUNSTATE/runs/$RUN_ID"
+mkdir -p "$PRESS_RUNSTATE/runs"
+RUN_ID=""
+API_RUN_DIR=""
+for attempt in 1 2 3 4 5; do
+  RUN_SUFFIX="$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 8 2>/dev/null || true)"
+  if [ -z "$RUN_SUFFIX" ]; then
+    RUN_SUFFIX="pid$$-$attempt"
+  fi
+  CANDIDATE_RUN_ID="$(date +%Y%m%d-%H%M%S)-$RUN_SUFFIX"
+  CANDIDATE_RUN_DIR="$PRESS_RUNSTATE/runs/$CANDIDATE_RUN_ID"
+  if mkdir "$CANDIDATE_RUN_DIR" 2>/dev/null; then
+    RUN_ID="$CANDIDATE_RUN_ID"
+    API_RUN_DIR="$CANDIDATE_RUN_DIR"
+    break
+  fi
+done
+if [ -z "$RUN_ID" ]; then
+  echo "could not allocate a unique run directory under $PRESS_RUNSTATE/runs" >&2
+  exit 1
+fi
 RESEARCH_DIR="$API_RUN_DIR/research"
 PROOFS_DIR="$API_RUN_DIR/proofs"
 PIPELINE_DIR="$API_RUN_DIR/pipeline"
@@ -694,7 +712,7 @@ Maintain a lightweight state file at `$STATE_FILE` so `/printing-press-score` ca
 }
 ```
 
-`run_id` is the same `YYYYMMDD-HHMMSS` value computed earlier as `RUN_ID="$(date +%Y%m%d-%H%M%S)"`. The generator's manifest writer derives the same value from the `--research-dir` basename when generate is invoked through the canonical `$API_RUN_DIR` (whose basename equals `$RUN_ID`); persisting it in `state.json` here keeps `/printing-press-score` and any future state-loading consumer in sync. Without `run_id` in either path, `cli-printing-press dogfood --live --write-acceptance` refuses to write the gate marker.
+`run_id` is the unique value allocated above from the wall-clock stamp plus a short random suffix. `mkdir "$CANDIDATE_RUN_DIR"` is the collision guard: if another run already owns a candidate directory, allocate another ID instead of reusing the directory. Persisting this value in `state.json` makes the state file the source of truth for generate, dogfood acceptance, promote, `/printing-press-score`, and future state-loading consumers. Without `run_id` in either state or legacy path fallback, `cli-printing-press dogfood --live --write-acceptance` refuses to write the gate marker.
 
 Do not create a `go.work` file in `$CLI_WORK_DIR`. Generated modules must build and test as standalone modules; a mismatched workspace `go` directive can break Go 1.25+ toolchains and lefthook checks. Editor/gopls workspace noise is cosmetic and must not be traded for broken `go build` or `go test`.
 


### PR DESCRIPTION
## Summary

Concurrent `/printing-press` runs now allocate distinct run directories before writing any artifacts, so two sessions that start in the same second no longer share `runs/<id>/` or overwrite each other's gate markers.

Generate now reads `run_id` from the run's `state.json` first, with basename derivation kept only as a legacy fallback. That keeps the manifest, dogfood acceptance marker, and promote gate on the same run identity even when the directory name carries a collision-avoidance suffix.

Closes #2723

## Verification

- `go test ./internal/pipeline -run 'Test(DeriveRunIDFromResearchDir|ResolveRunIDFromResearchDir|LoadAPINameFromResearchDir|PrintingPressSkillUsesRunRootStateFile)$'`
- `go test ./internal/cli -run '^TestPublishPackageNormalizesManifestCategoryToPublishCategory$' -count=1`
- `scripts/golden.sh verify`
- `git push -u origin HEAD` pre-push hook: `fmt`, `lint`

Full `go test ./...` was attempted twice in the batch environment. The default-timeout run timed out in `internal/cli`; the 15-minute run hit unrelated 5s live-check timeouts plus one publish package validation failure. The timed-out package and the exact failing tests passed when rerun in isolation.
