### PR TITLE
fix(cli): preserve dependent child-parent store rows

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3037,6 +3037,9 @@ func (g *Generator) schemaWithDependentParents() []TableDef {
 				if table.JSONOnlyFallback {
 					continue
 				}
+				if schema[i].ParentKeyColumn == "" {
+					schema[i].ParentKeyColumn = "parent_id"
+				}
 				hasParentID := false
 				for _, col := range table.Columns {
 					if col.Name == "parent_id" {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5226,11 +5226,11 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 		t.Fatalf("iterate contacts: %v", err)
 	}
 
-	if got["contact-injected_list-A"] != "list-A" {
-		t.Fatalf("injected contact lists_id = %q, want list-A", got["contact-injected_list-A"])
+	if got["contact-injected\x00list-A"] != "list-A" {
+		t.Fatalf("injected contact lists_id = %q, want list-A", got["contact-injected\x00list-A"])
 	}
-	if got["contact-preserved_api-list"] != "api-list" {
-		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved_api-list"])
+	if got["contact-preserved\x00api-list"] != "api-list" {
+		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved\x00api-list"])
 	}
 }
 `

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -5226,11 +5226,11 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 		t.Fatalf("iterate contacts: %v", err)
 	}
 
-	if got["contact-injected"] != "list-A" {
-		t.Fatalf("injected contact lists_id = %q, want list-A", got["contact-injected"])
+	if got["contact-injected_list-A"] != "list-A" {
+		t.Fatalf("injected contact lists_id = %q, want list-A", got["contact-injected_list-A"])
 	}
-	if got["contact-preserved"] != "api-list" {
-		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved"])
+	if got["contact-preserved_api-list"] != "api-list" {
+		t.Fatalf("preserved contact lists_id = %q, want api-list", got["contact-preserved_api-list"])
 	}
 }
 `

--- a/internal/generator/schema_builder.go
+++ b/internal/generator/schema_builder.go
@@ -19,6 +19,11 @@ type TableDef struct {
 	FTS5Fields   []string
 	FTS5Triggers bool
 
+	// ParentKeyColumn is set for dependent resource tables whose rows carry
+	// parent context. Store upserts use it to keep one row per child-parent
+	// pair instead of collapsing many-to-many relations onto the child id.
+	ParentKeyColumn string
+
 	JSONOnlyFallback    bool
 	OriginalColumnCount int
 }
@@ -397,9 +402,10 @@ func buildSubResourceTable(name string, r spec.Resource, parentTable string) Tab
 	columns = append(columns, baseTableColumns[1:]...) // data, synced_at
 
 	return TableDef{
-		Name:     tableName,
-		Resource: tableName,
-		Columns:  columns,
+		Name:            tableName,
+		Resource:        tableName,
+		Columns:         columns,
+		ParentKeyColumn: parentCol,
 		Indexes: []IndexDef{
 			{
 				Name:      "idx_" + tableName + "_" + parentCol,

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1131,9 +1131,12 @@ var resourceParentKeyColumns = map[string]string{
 {{- end}}
 }
 
-// ExtractResourceID resolves the primary key UpsertBatch would use for a
-// resource item. Callers that need to gate best-effort writes can use this to
-// avoid passing non-entity envelopes into the batch path.
+// ExtractResourceID resolves the bare resource id field that UpsertBatch
+// extracts from a resource item. For dependent resource types, UpsertBatch
+// derives the actual storage key by combining this id with the parent value;
+// use resourceStorageID if you need the key as it appears in the database.
+// Callers that need to gate best-effort writes can use this to avoid passing
+// non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if v := lookupFieldValue(obj, override); v != nil {
@@ -1259,7 +1262,7 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	if parentValue == "" || parentValue == "<nil>" {
 		return id
 	}
-	return id + "_" + parentValue
+	return id + string([]byte{0}) + parentValue
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1073,6 +1073,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	if id == "" {
 		return fmt.Errorf("missing id for {{.Name}}")
 	}
+	storageID := resourceStorageID("{{.Resource}}", id, obj)
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -1082,10 +1083,10 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, "{{.Resource}}", id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, "{{.Resource}}", storageID, data); err != nil {
 		return err
 	}
-	if err := s.upsert{{pascal .Name}}Tx(tx, id, obj, data); err != nil {
+	if err := s.upsert{{pascal .Name}}Tx(tx, storageID, obj, data); err != nil {
 		return err
 	}
 
@@ -1117,6 +1118,18 @@ var resourceIDFieldOverrides = map[string]string{
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
 var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+
+// resourceParentKeyColumns identifies generated dependent resources whose
+// local mirror rows need the parent context in the storage key. Without this,
+// many-to-many sub-collections collapse every parent association onto the
+// child's bare id and silently keep only the last synced parent.
+var resourceParentKeyColumns = map[string]string{
+{{- range .Tables}}
+{{- if and (emitsDomainTable .) .ParentKeyColumn}}
+	{{printf "%q" .Resource}}: {{printf "%q" .ParentKeyColumn}},
+{{- end}}
+{{- end}}
+}
 
 // ExtractResourceID resolves the primary key UpsertBatch would use for a
 // resource item. Callers that need to gate best-effort writes can use this to
@@ -1237,6 +1250,18 @@ func scalarIDString(value any) string {
 	}
 }
 
+func resourceStorageID(resourceType, id string, obj map[string]any) string {
+	parentKey := resourceParentKeyColumns[resourceType]
+	if parentKey == "" {
+		return id
+	}
+	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+	if parentValue == "" || parentValue == "<nil>" {
+		return id
+	}
+	return id + "_" + parentValue
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1288,19 +1313,20 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			extractFailures++
 			continue
 		}
+		storageID := resourceStorageID(resourceType, id, obj)
 
-		if err := s.upsertGenericResourceTx(tx, resourceType, id, item); err != nil {
+		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 {{- if $hasDomainTable}}
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
@@ -1308,23 +1334,23 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
 		case "{{.Resource}}":
-			typedErr = s.upsert{{pascal .Name}}Tx(tx, id, obj, item)
+			typedErr = s.upsert{{pascal .Name}}Tx(tx, storageID, obj, item)
 {{- end}}
 {{- end}}
 		}
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, id, typedErr, rbErr)
+				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, id, relErr)
+				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 {{- end}}
 	}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -450,9 +450,10 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 	defer s.Close()
 
 	items := []json.RawMessage{
-		json.RawMessage(`{"id": "shared-child", "{{$parentFKCol}}": "parent-A"}`),
-		json.RawMessage(`{"id": "shared-child", "{{$parentFKCol}}": "parent-B"}`),
-		json.RawMessage(`{"id": "other-child", "{{$parentFKCol}}": "parent-A"}`),
+		json.RawMessage(`{"id": "shared_child", "{{$parentFKCol}}": "parent_A"}`),
+		json.RawMessage(`{"id": "shared", "{{$parentFKCol}}": "child_parent_A"}`),
+		json.RawMessage(`{"id": "shared_child", "{{$parentFKCol}}": "parent_B"}`),
+		json.RawMessage(`{"id": "other_child", "{{$parentFKCol}}": "parent_A"}`),
 	}
 	stored, extractFailures, err := s.UpsertBatch("{{.Resource}}", items)
 	if err != nil {
@@ -486,11 +487,11 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 
 	var parentMatches int
 	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE "{{$parentFKCol}}" = ?`, "{{.Name}}")
-	if err := db.QueryRow(parentQuery, "parent-A").Scan(&parentMatches); err != nil {
+	if err := db.QueryRow(parentQuery, "parent_A").Scan(&parentMatches); err != nil {
 		t.Fatalf("count by {{$parentFKCol}}: %v", err)
 	}
 	if parentMatches != 2 {
-		t.Fatalf("{{$parentFKCol}}=parent-A count = %d, want 2", parentMatches)
+		t.Fatalf("{{$parentFKCol}}=parent_A count = %d, want 2", parentMatches)
 	}
 }
 {{- end}}

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -435,6 +435,65 @@ func TestUpsertBatch_TypedFailureDoesNotStrand{{pascal .Name}}Generic(t *testing
 	}
 }
 {{- end}}
+{{- if $parentFKCol }}
+
+// TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent verifies dependent
+// sub-collection rows with the same child id but different parent ids do not
+// overwrite one another in either the generic resources table or the typed
+// table. Regression for issue #2471.
+func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id": "shared-child", "{{$parentFKCol}}": "parent-A"}`),
+		json.RawMessage(`{"id": "shared-child", "{{$parentFKCol}}": "parent-B"}`),
+		json.RawMessage(`{"id": "other-child", "{{$parentFKCol}}": "parent-A"}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("{{.Resource}}", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != len(items) {
+		t.Fatalf("stored = %d, want %d", stored, len(items))
+	}
+	if extractFailures != 0 {
+		t.Fatalf("extractFailures = %d, want 0", extractFailures)
+	}
+
+	db := s.DB()
+
+	var generic int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Resource}}").Scan(&generic); err != nil {
+		t.Fatalf("count resources: %v", err)
+	}
+	if generic != len(items) {
+		t.Fatalf("resources count = %d, want %d (dependent rows collapsed on child id)", generic, len(items))
+	}
+
+	var typed int
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "{{.Name}}")
+	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
+		t.Fatalf("count {{.Name}}: %v", err)
+	}
+	if typed != len(items) {
+		t.Fatalf("{{.Name}} count = %d, want %d (typed rows collapsed on child id)", typed, len(items))
+	}
+
+	var parentMatches int
+	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE "{{$parentFKCol}}" = ?`, "{{.Name}}")
+	if err := db.QueryRow(parentQuery, "parent-A").Scan(&parentMatches); err != nil {
+		t.Fatalf("count by {{$parentFKCol}}: %v", err)
+	}
+	if parentMatches != 2 {
+		t.Fatalf("{{$parentFKCol}}=parent-A count = %d, want 2", parentMatches)
+	}
+}
+{{- end}}
 {{- if $hasParentID }}
 
 // TestUpsertBatch_Sets{{pascal .Name}}ParentID verifies that dependent-resource

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1025,9 +1025,12 @@ var resourceParentKeyColumns = map[string]string{
 	"leagues": "parent_id",
 }
 
-// ExtractResourceID resolves the primary key UpsertBatch would use for a
-// resource item. Callers that need to gate best-effort writes can use this to
-// avoid passing non-entity envelopes into the batch path.
+// ExtractResourceID resolves the bare resource id field that UpsertBatch
+// extracts from a resource item. For dependent resource types, UpsertBatch
+// derives the actual storage key by combining this id with the parent value;
+// use resourceStorageID if you need the key as it appears in the database.
+// Callers that need to gate best-effort writes can use this to avoid passing
+// non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if v := lookupFieldValue(obj, override); v != nil {
@@ -1153,7 +1156,7 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	if parentValue == "" || parentValue == "<nil>" {
 		return id
 	}
-	return id + "_" + parentValue
+	return id + string([]byte{0}) + parentValue
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -976,6 +976,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
+	storageID := resourceStorageID("leagues", id, obj)
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -985,10 +986,10 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, "leagues", id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, "leagues", storageID, data); err != nil {
 		return err
 	}
-	if err := s.upsertLeaguesTx(tx, id, obj, data); err != nil {
+	if err := s.upsertLeaguesTx(tx, storageID, obj, data); err != nil {
 		return err
 	}
 
@@ -1015,6 +1016,14 @@ var resourceIDFieldOverrides = map[string]string{
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
 var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+
+// resourceParentKeyColumns identifies generated dependent resources whose
+// local mirror rows need the parent context in the storage key. Without this,
+// many-to-many sub-collections collapse every parent association onto the
+// child's bare id and silently keep only the last synced parent.
+var resourceParentKeyColumns = map[string]string{
+	"leagues": "parent_id",
+}
 
 // ExtractResourceID resolves the primary key UpsertBatch would use for a
 // resource item. Callers that need to gate best-effort writes can use this to
@@ -1135,6 +1144,18 @@ func scalarIDString(value any) string {
 	}
 }
 
+func resourceStorageID(resourceType, id string, obj map[string]any) string {
+	parentKey := resourceParentKeyColumns[resourceType]
+	if parentKey == "" {
+		return id
+	}
+	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+	if parentValue == "" || parentValue == "<nil>" {
+		return id
+	}
+	return id + "_" + parentValue
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1182,38 +1203,39 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			extractFailures++
 			continue
 		}
+		storageID := resourceStorageID(resourceType, id, obj)
 
-		if err := s.upsertGenericResourceTx(tx, resourceType, id, item); err != nil {
+		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
 		switch resourceType {
 		case "leagues":
-			typedErr = s.upsertLeaguesTx(tx, id, obj, item)
+			typedErr = s.upsertLeaguesTx(tx, storageID, obj, item)
 		}
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, id, typedErr, rbErr)
+				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, id, relErr)
+				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 	}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -865,6 +865,7 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	if id == "" {
 		return fmt.Errorf("missing id for leagues")
 	}
+	storageID := resourceStorageID("leagues", id, obj)
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -874,10 +875,10 @@ func (s *Store) UpsertLeagues(data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, "leagues", id, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, "leagues", storageID, data); err != nil {
 		return err
 	}
-	if err := s.upsertLeaguesTx(tx, id, obj, data); err != nil {
+	if err := s.upsertLeaguesTx(tx, storageID, obj, data); err != nil {
 		return err
 	}
 
@@ -904,6 +905,14 @@ var resourceIDFieldOverrides = map[string]string{
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
 var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+
+// resourceParentKeyColumns identifies generated dependent resources whose
+// local mirror rows need the parent context in the storage key. Without this,
+// many-to-many sub-collections collapse every parent association onto the
+// child's bare id and silently keep only the last synced parent.
+var resourceParentKeyColumns = map[string]string{
+	"leagues": "parent_id",
+}
 
 // ExtractResourceID resolves the primary key UpsertBatch would use for a
 // resource item. Callers that need to gate best-effort writes can use this to
@@ -1024,6 +1033,18 @@ func scalarIDString(value any) string {
 	}
 }
 
+func resourceStorageID(resourceType, id string, obj map[string]any) string {
+	parentKey := resourceParentKeyColumns[resourceType]
+	if parentKey == "" {
+		return id
+	}
+	parentValue := ResourceIDString(lookupFieldValue(obj, parentKey))
+	if parentValue == "" || parentValue == "<nil>" {
+		return id
+	}
+	return id + "_" + parentValue
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1071,38 +1092,39 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 			extractFailures++
 			continue
 		}
+		storageID := resourceStorageID(resourceType, id, obj)
 
-		if err := s.upsertGenericResourceTx(tx, resourceType, id, item); err != nil {
+		if err := s.upsertGenericResourceTx(tx, resourceType, storageID, item); err != nil {
 			// Return the running stored count rather than zero so callers
 			// inspecting partial progress on failure see what already
 			// landed in earlier loop iterations.
-			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("upserting %s/%s: %w", resourceType, storageID, err)
 		}
 		stored++
 
 		savepoint := fmt.Sprintf("pp_typed_%d", i)
 		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("savepoint begin for %s/%s: %w", resourceType, storageID, err)
 		}
 
 		var typedErr error
 		switch resourceType {
 		case "leagues":
-			typedErr = s.upsertLeaguesTx(tx, id, obj, item)
+			typedErr = s.upsertLeaguesTx(tx, storageID, obj, item)
 		}
 
 		if typedErr != nil {
 			if _, rbErr := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); rbErr != nil {
-				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, id, typedErr, rbErr)
+				return stored, extractFailures, fmt.Errorf("rollback to savepoint for %s/%s (typed err: %v): %w", resourceType, storageID, typedErr, rbErr)
 			}
 			if _, relErr := tx.Exec("RELEASE SAVEPOINT " + savepoint); relErr != nil {
-				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, id, relErr)
+				return stored, extractFailures, fmt.Errorf("release savepoint after rollback for %s/%s: %w", resourceType, storageID, relErr)
 			}
 			typedFailures++
 			continue
 		}
 		if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
-			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, id, err)
+			return stored, extractFailures, fmt.Errorf("release savepoint for %s/%s: %w", resourceType, storageID, err)
 		}
 	}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -914,9 +914,12 @@ var resourceParentKeyColumns = map[string]string{
 	"leagues": "parent_id",
 }
 
-// ExtractResourceID resolves the primary key UpsertBatch would use for a
-// resource item. Callers that need to gate best-effort writes can use this to
-// avoid passing non-entity envelopes into the batch path.
+// ExtractResourceID resolves the bare resource id field that UpsertBatch
+// extracts from a resource item. For dependent resource types, UpsertBatch
+// derives the actual storage key by combining this id with the parent value;
+// use resourceStorageID if you need the key as it appears in the database.
+// Callers that need to gate best-effort writes can use this to avoid passing
+// non-entity envelopes into the batch path.
 func ExtractResourceID(resourceType string, obj map[string]any) string {
 	if override, ok := resourceIDFieldOverrides[resourceType]; ok && override != "" {
 		if v := lookupFieldValue(obj, override); v != nil {
@@ -1042,7 +1045,7 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	if parentValue == "" || parentValue == "<nil>" {
 		return id
 	}
-	return id + "_" + parentValue
+	return id + string([]byte{0}) + parentValue
 }
 
 // UpsertBatch inserts or replaces multiple records in a single transaction


### PR DESCRIPTION
## Summary

Generated stores now keep one cached row per dependent child-parent pair when parent context is present. Before this, many-to-many sub-collections that returned the same child under multiple parents upserted every association onto the child id alone, so the last synced parent silently won.

The generator now marks dependent tables with their parent key column and uses that parent value to derive the local storage id for both generic `resources` rows and typed table rows. Rows without parent context continue to use the bare resource id.

Closes #2471

## Verification

- `go test ./internal/generator -run 'TestGenerate(DependentSyncInjectsSubResourceParentFK|StoreSubResourceUpsertBatchTestSatisfiesNotNullFK|DependentSyncCompiles)'`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `scripts/golden.sh verify`
- pre-push hook: `golangci-lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
