### PR TITLE
fix(cli): apply api key auth prefixes

### DIFF
--- a/internal/generator/auth_header_prefix_test.go
+++ b/internal/generator/auth_header_prefix_test.go
@@ -41,6 +41,46 @@ func TestAPIKeyAuthHeaderPrefix(t *testing.T) {
 	runGoCommandRequired(t, outputDir, "test", "./internal/config")
 }
 
+func TestGeneratedAPIKeyAuthHeaderORCaseAppliesPrefix(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("api-key-prefix-or")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:   "api_key",
+		In:     "header",
+		Header: "Authorization",
+		Prefix: "Token",
+		EnvVarSpecs: []spec.AuthEnvVar{
+			{Name: "OR_PREFIX_PRIMARY_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true, Description: "Set this OR OR_PREFIX_FALLBACK_TOKEN."},
+			{Name: "OR_PREFIX_FALLBACK_TOKEN", Kind: spec.AuthEnvVarKindPerCall, Required: false, Sensitive: true, Description: "Set this OR OR_PREFIX_PRIMARY_TOKEN."},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "api-key-prefix-or-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const inlineTest = `package config
+
+import "testing"
+
+func TestAPIKeyAuthHeaderORCasePrefix(t *testing.T) {
+	cfg := &Config{OrPrefixPrimaryToken: "primary"}
+	if got := cfg.AuthHeader(); got != "Token primary" {
+		t.Fatalf("AuthHeader() with primary token = %q", got)
+	}
+
+	cfg = &Config{OrPrefixFallbackToken: "fallback"}
+	if got := cfg.AuthHeader(); got != "Token fallback" {
+		t.Fatalf("AuthHeader() with fallback token = %q", got)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "config", "auth_header_prefix_or_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/config")
+}
+
 func TestGeneratedAPIKeyAuthHeaderWithoutPrefixKeepsRawToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/auth_header_prefix_test.go
+++ b/internal/generator/auth_header_prefix_test.go
@@ -1,0 +1,73 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedAPIKeyAuthHeaderAppliesPrefix(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("api-key-prefix")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		In:      "header",
+		Header:  "Authorization",
+		Prefix:  "Token",
+		EnvVars: []string{"MAKE_API_TOKEN"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "api-key-prefix-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const inlineTest = `package config
+
+import "testing"
+
+func TestAPIKeyAuthHeaderPrefix(t *testing.T) {
+	cfg := &Config{MakeApiToken: "secret"}
+	if got := cfg.AuthHeader(); got != "Token secret" {
+		t.Fatalf("AuthHeader() = %q", got)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "config", "auth_header_prefix_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/config")
+}
+
+func TestGeneratedAPIKeyAuthHeaderWithoutPrefixKeepsRawToken(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("api-key-no-prefix")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "api_key",
+		In:      "header",
+		Header:  "X-API-Key",
+		EnvVars: []string{"PLAIN_API_KEY"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "api-key-no-prefix-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const inlineTest = `package config
+
+import "testing"
+
+func TestAPIKeyAuthHeaderNoPrefix(t *testing.T) {
+	cfg := &Config{PlainApiKey: "secret"}
+	if got := cfg.AuthHeader(); got != "secret" {
+		t.Fatalf("AuthHeader() = %q", got)
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "config", "auth_header_no_prefix_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/config")
+}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -348,7 +348,11 @@ func (c *Config) AuthHeader() string {
 			{{- end}}
 		})
 		{{- else}}
+		{{- if $.Auth.Prefix}}
+		return {{printf "%q" (printf "%s " $.Auth.Prefix)}} + c.{{resolveEnvVarField .Name}}
+		{{- else}}
 		return c.{{resolveEnvVarField .Name}}
+		{{- end}}
 		{{- end}}
 	}
 {{- end}}
@@ -404,7 +408,11 @@ func (c *Config) AuthHeader() string {
 	}
 	return applyAuthFormat("{{.Auth.Format}}", replacements)
 	{{- else if $canonicalEnvVar}}
+	{{- if .Auth.Prefix}}
+	return {{printf "%q" (printf "%s " .Auth.Prefix)}} + token
+	{{- else}}
 	return token
+	{{- end}}
 	{{- else}}
 	return ""
 	{{- end}}


### PR DESCRIPTION
## Summary

Generated CLIs now honor spec-declared API-key auth prefixes such as `Authorization: Token <token>`. APIs that require a non-Bearer scheme word no longer ship with raw-token Authorization headers that 401 even though credentials are configured.

The fix stays in the Printing Press generator template, so future printed CLIs get the corrected `Config.AuthHeader()` behavior. Prefixless API-key headers continue returning the raw token, and formatted auth templates still take precedence over `auth.prefix`.

Closes #2494

## Verification

- `go test ./internal/generator -run 'TestGeneratedAPIKeyAuthHeader(AppliesPrefix|WithoutPrefixKeepsRawToken)'`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push hook: `fmt`, `lint`
