### PR TITLE
fix(cli): make BLE backend opt-in for default builds

### DIFF
--- a/docs/BLE-PROBE.md
+++ b/docs/BLE-PROBE.md
@@ -12,6 +12,10 @@ Build a live BLE probe for the current machine:
 scripts/build-ble-probe.sh live
 ```
 
+Live builds use the `ble_live` build tag and link the host BLE stack. The
+default `cli-printing-press` and `ble-probe` builds are replay-only so ordinary
+generation and verification paths do not load Bluetooth frameworks.
+
 Build a copyable Windows artifact from macOS:
 
 ```bash

--- a/internal/cli/device_sniff_test.go
+++ b/internal/cli/device_sniff_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/devicesniff/ble"
@@ -250,4 +252,17 @@ func TestDeviceSniffBLECmdRequiresCapturedEvidenceInput(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required flag(s) \"input\" not set")
+}
+
+func TestDefaultCLIBuildDoesNotLinkTinyGoBluetooth(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("go", "list", "-deps", "-f", "{{.ImportPath}}", "./cmd/cli-printing-press")
+	cmd.Dir = filepath.Join("..", "..")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	for dep := range strings.FieldsSeq(string(output)) {
+		assert.NotEqual(t, "tinygo.org/x/bluetooth", dep, "default cli-printing-press builds must not link the live BLE backend")
+	}
 }

--- a/internal/cli/device_sniff_test.go
+++ b/internal/cli/device_sniff_test.go
@@ -263,6 +263,6 @@ func TestDefaultCLIBuildDoesNotLinkTinyGoBluetooth(t *testing.T) {
 	require.NoError(t, err, string(output))
 
 	for dep := range strings.FieldsSeq(string(output)) {
-		assert.NotEqual(t, "tinygo.org/x/bluetooth", dep, "default cli-printing-press builds must not link the live BLE backend")
+		assert.False(t, strings.HasPrefix(dep, "tinygo.org/x/bluetooth"), "default cli-printing-press builds must not link the live BLE backend (got %s)", dep)
 	}
 }

--- a/internal/devicesniff/ble/adapter_live_unavailable.go
+++ b/internal/devicesniff/ble/adapter_live_unavailable.go
@@ -1,4 +1,4 @@
-//go:build ble_replay_only || !(darwin || linux || windows)
+//go:build !ble_live || ble_replay_only || !(darwin || linux || windows)
 
 package ble
 

--- a/internal/devicesniff/ble/driver_tinygo.go
+++ b/internal/devicesniff/ble/driver_tinygo.go
@@ -1,4 +1,4 @@
-//go:build !ble_replay_only && (darwin || linux || windows)
+//go:build ble_live && !ble_replay_only && (darwin || linux || windows)
 
 package ble
 

--- a/scripts/build-ble-probe.sh
+++ b/scripts/build-ble-probe.sh
@@ -90,11 +90,11 @@ build_one() {
 }
 
 build_replay_target() {
-  build_one replay "$1" "$2" ble_replay_only
+  build_one replay "$1" "$2" ""
 }
 
 build_live_target() {
-  build_one live "$1" "$2" ""
+  build_one live "$1" "$2" ble_live
 }
 
 if [[ -n "$target" ]]; then


### PR DESCRIPTION
## Summary

Default `cli-printing-press` and `ble-probe` builds no longer compile the TinyGo Bluetooth backend, so subprocess-using commands do not load the host Bluetooth frameworks unless live BLE probing was explicitly requested at build time.

Live BLE remains available with `-tags ble_live`, and the BLE probe helper now uses that tag only for live artifacts. The regression test checks the default CLI dependency graph so the TinyGo Bluetooth package cannot silently return to the standard install path.

Closes #2673

## Tests

- `go list -deps -f '{{.ImportPath}}' ./cmd/cli-printing-press | rg '^tinygo.org/x/bluetooth$' || true` (no output)
- `go list -tags ble_live -deps -f '{{.ImportPath}}' ./cmd/cli-printing-press | rg '^tinygo.org/x/bluetooth$' || true`
- `go test ./internal/devicesniff/ble ./internal/devicesniff/bleprobe ./internal/cli -run 'Test(ProbeReportsLiveUnavailableWhenBuildTagIsAbsent|DoctorReportsReplayOnlyBuildReadiness|DefaultCLIBuildDoesNotLinkTinyGoBluetooth|DeviceSniffBLEDoctorReportsNestedCommands)'`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go build -tags ble_live -o ./cli-printing-press-ble-live ./cmd/cli-printing-press`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
