### PR TITLE
fix(cli): format generated numeric params without exponents

### DIFF
--- a/internal/generator/delete_body_test.go
+++ b/internal/generator/delete_body_test.go
@@ -168,7 +168,7 @@ func TestGenerateDeleteEndpointWithoutBodyKeepsQueryParams(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "assets_delete.go")
-	assert.Contains(t, endpointSrc, `params["force"] = fmt.Sprintf("%v", flagForce)`)
+	assert.Contains(t, endpointSrc, `params["force"] = formatCLIParamValue(flagForce)`)
 	assert.Contains(t, endpointSrc, `c.DeleteWithParams(cmd.Context(), path, params)`)
 	assert.NotContains(t, endpointSrc, `DeleteWithBody`)
 
@@ -236,7 +236,7 @@ func TestGeneratePromotedDeleteEndpointWithJSONBodyAndParamsUsesRequestBodyAndQu
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_assets.go")
-	assert.Contains(t, endpointSrc, `params["mode"] = fmt.Sprintf("%v", flagMode)`)
+	assert.Contains(t, endpointSrc, `params["mode"] = formatCLIParamValue(flagMode)`)
 	assert.Contains(t, endpointSrc, `body := map[string]any{}`)
 	assert.Contains(t, endpointSrc, `body["ids"] = parsed`)
 	assert.Contains(t, endpointSrc, `c.DeleteWithParamsAndBody(cmd.Context(), path, params, body)`)

--- a/internal/generator/endpoint_is_write_test.go
+++ b/internal/generator/endpoint_is_write_test.go
@@ -382,13 +382,13 @@ func TestPromotedCommandSubstitutesFlagPathParams(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	src := readPromotedCommandFile(t, outputDir)
-	assert.Contains(t, src, `path = replacePathParam(path, "userId", fmt.Sprintf("%v", flagUserId))`,
+	assert.Contains(t, src, `path = replacePathParam(path, "userId", formatCLIParamValue(flagUserId))`,
 		"promoted command must substitute flag-backed path params before making the request")
-	assert.Contains(t, src, `params["limit"] = fmt.Sprintf("%v", flagLimit)`,
+	assert.Contains(t, src, `params["limit"] = formatCLIParamValue(flagLimit)`,
 		"ordinary non-positional flags still belong in query params")
 	assert.NotContains(t, src, `params["userId"]`,
 		"path params must not also be sent as query params")
-	assert.NotContains(t, src, `"userId": fmt.Sprintf("%v", flagUserID)`,
+	assert.NotContains(t, src, `"userId": formatCLIParamValue(flagUserID)`,
 		"path params must not be passed to paginated query maps")
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13229,7 +13229,7 @@ func TestGenerateOperationRoutingPathParamDefault(t *testing.T) {
 		cliContent,
 		"defaulted operation-routing path param should be user-overridable")
 	assert.Contains(t, cliContent,
-		`path = replacePathParam(path, "pathQueryId", fmt.Sprintf("%v", flagPathQueryId))`,
+		`path = replacePathParam(path, "pathQueryId", formatCLIParamValue(flagPathQueryId))`,
 		"generated command must substitute the path template before calling the API")
 
 	helpersGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "helpers.go"))
@@ -14896,7 +14896,7 @@ func TestGenerateMCPCodeOrchestrationGlobalPathTemplateVars(t *testing.T) {
 	src := string(data)
 	assert.Contains(t, src, `TemplateParams []codeOrchParamBinding`)
 	assert.Contains(t, src, `TemplateParams: []codeOrchParamBinding{{PublicName: "tenant_id", WireName: "tenant_id"}}`)
-	assert.Contains(t, src, `c.Config.TemplateVars[binding.WireName] = fmt.Sprintf("%v", v)`)
+	assert.Contains(t, src, `c.Config.TemplateVars[binding.WireName] = formatMCPParamValue(v)`)
 	assert.Contains(t, src, `delete(params, binding.PublicName)`,
 		"code-orchestration execute must not also route promoted template params as query/body inputs")
 
@@ -15268,7 +15268,7 @@ func TestGeneratePublicParamNamesAcrossCLISurfaces(t *testing.T) {
 	assert.Contains(t, findSource, `StringVar(&flagS, "s", "", "Street address")`)
 	assert.Contains(t, findSource, `_ = cmd.Flags().MarkHidden("s")`)
 	assert.Contains(t, findSource, `if !(cmd.Flags().Changed("address") || cmd.Flags().Changed("s")) && !flags.dryRun`)
-	assert.Contains(t, findSource, `params["s"] = fmt.Sprintf("%v", flagS)`)
+	assert.Contains(t, findSource, `params["s"] = formatCLIParamValue(flagS)`)
 	assert.NotContains(t, findSource, `required flag "s" not set`)
 
 	createSource := readGeneratedFile(t, outputDir, "internal", "cli", "stores_create.go")
@@ -15279,7 +15279,7 @@ func TestGeneratePublicParamNamesAcrossCLISurfaces(t *testing.T) {
 	mcpSource := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	assert.Contains(t, mcpSource, `mcplib.WithString("address", mcplib.Required(), mcplib.Description("Street address"))`)
 	assert.Contains(t, mcpSource, `PublicName: "address", WireName: "s", Location: "query"`)
-	assert.Contains(t, mcpSource, `params[binding.WireName] = fmt.Sprintf("%v", v)`)
+	assert.Contains(t, mcpSource, `params[binding.WireName] = formatMCPParamValue(v)`)
 	assert.Contains(t, mcpSource, `mcplib.WithString("store-code", mcplib.Required(), mcplib.Description("Store code"))`)
 	assert.Contains(t, mcpSource, `PublicName: "store-code", WireName: "store_code", Location: "body"`)
 	assert.Contains(t, mcpSource, `bodyArgs[binding.WireName] = v`)
@@ -17048,7 +17048,7 @@ func TestGenerateGlobalPathTemplateVarRootFlag(t *testing.T) {
 		"MCP endpoint tools must expose a per-call override matching the CLI root flag")
 	assert.Contains(t, mcpSrc, `Location: "template"`,
 		"MCP handler binding must route tenant_id into Config.TemplateVars instead of query params")
-	assert.Contains(t, mcpSrc, `c.Config.TemplateVars[binding.WireName] = fmt.Sprintf("%v", v)`,
+	assert.Contains(t, mcpSrc, `c.Config.TemplateVars[binding.WireName] = formatMCPParamValue(v)`,
 		"MCP handler must merge global template inputs into Config.TemplateVars before the request")
 	contactsGetTool := generatedMCPToolBlock(t, mcpSrc, "contacts_get")
 	assert.NotContains(t, contactsGetTool, `"tenant_id"`,

--- a/internal/generator/global_param_flag_test.go
+++ b/internal/generator/global_param_flag_test.go
@@ -65,7 +65,7 @@ paths:
 
 		assert.Contains(t, cmdSrc, `cmd.Flags().StringVar(&flagInput, "input", "", "Input")`,
 			"%s: the sole global query param must be registered as a --input flag", file)
-		assert.Contains(t, cmdSrc, `params["input"] = fmt.Sprintf("%v", flagInput)`,
+		assert.Contains(t, cmdSrc, `params["input"] = formatCLIParamValue(flagInput)`,
 			"%s: the --input flag value must propagate into the request params map", file)
 	}
 

--- a/internal/generator/global_scope_param_test.go
+++ b/internal/generator/global_scope_param_test.go
@@ -62,7 +62,7 @@ func TestGenerateGlobalScopeParamRequiresExplicitFlag(t *testing.T) {
 	assert.Contains(t, content, `func newUsersListCmd`)
 	assert.Contains(t, content, `StringVar(&flagTenantFilter, "tenant-filter", "", "Tenant scope")`)
 	assert.Contains(t, content, `return fmt.Errorf("required flag \"%s\" not set", "tenant-filter")`)
-	assert.Contains(t, content, `params["TenantFilter"] = fmt.Sprintf("%v", flagTenantFilter)`)
+	assert.Contains(t, content, `params["TenantFilter"] = formatCLIParamValue(flagTenantFilter)`)
 	assert.NotContains(t, content, `CIPP_TENANT_FILTER`)
 	assert.NotContains(t, content, `defaults from`)
 	assert.NotContains(t, strings.ToLower(content), `markflagrequired`)

--- a/internal/generator/mutating_query_params_test.go
+++ b/internal/generator/mutating_query_params_test.go
@@ -43,7 +43,7 @@ func TestGenerateMutatingEndpointPassesQueryParams(t *testing.T) {
 
 	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_text-to-speech.go")
 	assert.Contains(t, endpointSrc, `params := map[string]string{}`)
-	assert.Contains(t, endpointSrc, `params["output_format"] = fmt.Sprintf("%v", flagOutputFormat)`)
+	assert.Contains(t, endpointSrc, `params["output_format"] = formatCLIParamValue(flagOutputFormat)`)
 	assert.Contains(t, endpointSrc, `c.PostWithParamsAndHeaders(cmd.Context(), path, params, body, headerOverrides)`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")

--- a/internal/generator/numeric_param_format_test.go
+++ b/internal/generator/numeric_param_format_test.go
@@ -1,0 +1,60 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedNumericPathAndQueryParamsUsePlainDecimalFormatting(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("numeric-param-format")
+	apiSpec.Resources = map[string]spec.Resource{
+		"tasks": {
+			Description: "Tasks",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:      "GET",
+					Path:        "/task/{task_id}",
+					Description: "Get a task",
+					Params: []spec.Param{
+						{Name: "task_id", Type: "string", Required: true, Positional: true},
+						{Name: "team_id", Type: "number", Required: true, Description: "Workspace ID"},
+					},
+					Response: spec.ResponseDef{Type: "object", Item: "Task"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Task": {Fields: []spec.TypeField{{Name: "id", Type: "string"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "numeric-param-format-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	require.Contains(t, helpersSrc, "func formatCLIParamValue(v any) string")
+	require.Contains(t, helpersSrc, "strconv.FormatFloat(f, 'f', -1, 64)")
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	require.Contains(t, mcpSrc, "func formatMCPParamValue(v any) string")
+	require.Contains(t, mcpSrc, `path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)`)
+	require.Contains(t, mcpSrc, `params[binding.WireName] = formatMCPParamValue(v)`)
+	require.NotContains(t, mcpSrc, `params[binding.WireName] = fmt.Sprintf("%v", v)`)
+
+	requireGeneratedCompiles(t, outputDir)
+
+	binaryPath := filepath.Join(outputDir, "numeric-param-format-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/numeric-param-format-pp-cli")
+
+	stdout, stderr := runGeneratedBinary(t, binaryPath, "tasks", "get", "CS-27102", "--team-id", "4653482", "--dry-run")
+	output := stdout + stderr
+	require.Contains(t, output, "team_id=4653482")
+	require.NotContains(t, output, "4.653482e")
+	require.False(t, strings.Contains(output, "e+06"), "dry-run output used scientific notation:\n%s", output)
+}

--- a/internal/generator/path_param_positional_index_test.go
+++ b/internal/generator/path_param_positional_index_test.go
@@ -291,7 +291,7 @@ func TestPathParamArgsIndexFlagExposedPathParam(t *testing.T) {
 		`path = replacePathParam(path, "reportId", args[0])`,
 		"positional path param must resolve to args[0] when a flag-exposed path param precedes it in Params")
 	assert.Contains(t, body,
-		`path = replacePathParam(path, "groupId", fmt.Sprintf("%v", flagGroupId))`,
+		`path = replacePathParam(path, "groupId", formatCLIParamValue(flagGroupId))`,
 		"flag-exposed path param must continue to substitute from its flag, not args[]")
 	assert.NotContains(t, body,
 		`args[1]`,
@@ -351,7 +351,7 @@ func TestPromotedCommandPathParamArgsIndexFlagExposedPathParam(t *testing.T) {
 		`path = replacePathParam(path, "reportId", args[0])`,
 		"promoted command: positional path param must resolve to args[0] when a flag-exposed path param precedes it")
 	assert.Contains(t, src,
-		`path = replacePathParam(path, "groupId", fmt.Sprintf("%v", flagGroupId))`,
+		`path = replacePathParam(path, "groupId", formatCLIParamValue(flagGroupId))`,
 		"promoted command: flag-exposed path param must continue to substitute from its flag")
 	assert.Contains(t, src,
 		`if len(args) < 1`,

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -166,7 +166,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .PathParam (not .Positional)}}
-			path = replacePathParam(path, "{{.Name}}", fmt.Sprintf("%v", flag{{camel (paramIdent .)}}))
+			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
 {{- if $isGraphQLEndpoint}}
@@ -181,7 +181,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				htmlRequestParams["{{.Name}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -306,7 +306,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
@@ -324,7 +324,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -337,7 +337,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -366,7 +366,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -425,7 +425,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -473,7 +473,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -523,7 +523,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -595,7 +595,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- else}}
 {{- range endpointClientSideFilters .APISpec .Endpoint}}
 			if flag{{camel (paramIdent .Param)}} != {{zeroValForParamRequired .Param.Name .Param.Type .Param.Required (hasDefault .Param)}} {
-				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, fmt.Sprintf("%v", flag{{camel (paramIdent .Param)}}))
+				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, formatCLIParamValue(flag{{camel (paramIdent .Param)}}))
 			}
 {{- end}}
 {{- if endpointNeedsClientLimit .Endpoint}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -148,7 +148,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .PathParam (not .Positional)}}
-			path = replacePathParam(path, "{{.Name}}", fmt.Sprintf("%v", flag{{camel (paramIdent .)}}))
+			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
 
@@ -160,7 +160,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				htmlRequestParams["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -185,7 +185,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
@@ -203,7 +203,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": fmt.Sprintf("%v", flag{{camel (paramIdent .)}}),
+				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
 			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
@@ -217,7 +217,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = fmt.Sprintf("%v", flag{{camel (paramIdent .)}})
+				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -325,7 +325,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- else}}
 {{- range endpointClientSideFilters .APISpec .Endpoint}}
 			if flag{{camel (paramIdent .Param)}} != {{zeroValForParamRequired .Param.Name .Param.Type .Param.Required (hasDefault .Param)}} {
-				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, fmt.Sprintf("%v", flag{{camel (paramIdent .Param)}}))
+				data = filterJSONByFieldValues(data, {{printf "%q" .Field}}, formatCLIParamValue(flag{{camel (paramIdent .Param)}}))
 			}
 {{- end}}
 {{- if endpointNeedsClientLimit .Endpoint}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -49,6 +49,13 @@ var As = errors.As
 
 const paginatedGetMaxPages = 100
 
+func formatCLIParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // noColor is set by the --no-color flag
 var noColor bool
 

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -295,7 +295,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 			if c.Config.TemplateVars == nil {
 				c.Config.TemplateVars = map[string]string{}
 			}
-			c.Config.TemplateVars[binding.WireName] = fmt.Sprintf("%v", v)
+			c.Config.TemplateVars[binding.WireName] = formatMCPParamValue(v)
 			delete(params, binding.PublicName)
 		}
 	}
@@ -304,7 +304,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	path := ep.Path
 	for _, p := range ep.Positional {
 		if v, ok := params[p]; ok {
-			path = strings.ReplaceAll(path, "{"+p+"}", fmt.Sprintf("%v", v))
+			path = strings.ReplaceAll(path, "{"+p+"}", formatMCPParamValue(v))
 			delete(params, p)
 		}
 	}
@@ -315,7 +315,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
 		for k, v := range params {
-			query[codeOrchWireQueryName(ep.QueryParams, k)] = fmt.Sprintf("%v", v)
+			query[codeOrchWireQueryName(ep.QueryParams, k)] = formatMCPParamValue(v)
 		}
 	} else {
 		// Route spec-declared in:query params to the query string for write
@@ -427,7 +427,7 @@ func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]an
 				continue
 			}
 			if v, ok := params[key]; ok {
-				uv.Set(q.WireName, fmt.Sprintf("%v", v))
+				uv.Set(q.WireName, formatMCPParamValue(v))
 				delete(params, key)
 				break
 			}

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -229,10 +229,10 @@ func callIntentEndpoint(ctx context.Context, c *client.Client, {{if .HasRequired
 	for k, v := range params {
 		placeholder := "{" + k + "}"
 		if strings.Contains(path, placeholder) {
-			path = strings.ReplaceAll(path, placeholder, fmt.Sprintf("%v", v))
+			path = strings.ReplaceAll(path, placeholder, formatMCPParamValue(v))
 			continue
 		}
-		query[k] = fmt.Sprintf("%v", v)
+		query[k] = formatMCPParamValue(v)
 	}
 
 	var data json.RawMessage
@@ -371,7 +371,7 @@ func recipeValueString(value any) string {
 	case string:
 		return strings.TrimSpace(v)
 	case float64:
-		return fmt.Sprintf("%v", v)
+		return formatMCPParamValue(v)
 	case bool:
 		if v {
 			return "true"

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -19,6 +19,7 @@ import (
 {{- end}}
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -207,6 +208,13 @@ func mcpFormFieldValue(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 {{- end}}
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 {{- if $hasNestedBodyPath}}
 func setNestedBodyArg(body map[string]any, path []string, value any) {
 	if len(path) == 0 {
@@ -324,13 +332,13 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 {{- if .GlobalPathTemplateVars}}
 			case "template":
 				if c.Config.TemplateVars == nil {
 					c.Config.TemplateVars = map[string]string{}
 				}
-				c.Config.TemplateVars[binding.WireName] = fmt.Sprintf("%v", v)
+				c.Config.TemplateVars[binding.WireName] = formatMCPParamValue(v)
 {{- end}}
 			case "body":
 {{- if $hasNestedBodyPath}}
@@ -370,7 +378,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				}
 {{- end}}
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -380,7 +388,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -402,7 +410,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 				}
 {{- end}}
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/internal/generator/url_name_test.go
+++ b/internal/generator/url_name_test.go
@@ -301,6 +301,6 @@ func TestCodeOrchQueryParamsUseParamWireName(t *testing.T) {
 		"GET and POST code-orch endpoints must preserve both public and wire query names")
 	require.Contains(t, content, `query[codeOrchWireQueryName(ep.QueryParams, k)]`,
 		"GET/DELETE code-orch routing must translate public names to wire names")
-	require.Contains(t, content, `uv.Set(q.WireName, fmt.Sprintf("%v", v))`,
+	require.Contains(t, content, `uv.Set(q.WireName, formatMCPParamValue(v))`,
 		"write-method code-orch routing must append wire query names")
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -30,6 +30,13 @@ var As = errors.As
 
 const paginatedGetMaxPages = 100
 
+func formatCLIParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // noColor is set by the --no-color flag
 var noColor bool
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -117,6 +118,13 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -161,11 +169,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -175,7 +183,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -187,7 +195,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -29,6 +29,13 @@ var As = errors.As
 
 const paginatedGetMaxPages = 100
 
+func formatCLIParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // noColor is set by the --no-color flag
 var noColor bool
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +68,13 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -111,11 +119,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -125,7 +133,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -137,7 +145,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 68
+    "total": 69
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -30,6 +30,13 @@ var As = errors.As
 
 const paginatedGetMaxPages = 100
 
+func formatCLIParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // noColor is set by the --no-color flag
 var noColor bool
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -35,7 +35,7 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 			path = replacePathParam(path, "projectId", args[0])
 			params := map[string]string{}
 			if flagOverwrite != false {
-				params["overwrite"] = fmt.Sprintf("%v", flagOverwrite)
+				params["overwrite"] = formatCLIParamValue(flagOverwrite)
 			}
 			fields := map[string]string{}
 			fileFields := map[string]string{}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -43,9 +43,9 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/projects"
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "projects", path, map[string]string{
-				"status": fmt.Sprintf("%v", flagStatus),
-				"limit":  fmt.Sprintf("%v", flagLimit),
-				"cursor": fmt.Sprintf("%v", flagCursor),
+				"status": formatCLIParamValue(flagStatus),
+				"limit":  formatCLIParamValue(flagLimit),
+				"cursor": formatCLIParamValue(flagCursor),
 			}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -48,9 +48,9 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			path := "/projects/{projectId}/tasks"
 			path = replacePathParam(path, "projectId", args[0])
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "tasks", path, map[string]string{
-				"priority": fmt.Sprintf("%v", flagPriority),
-				"limit":    fmt.Sprintf("%v", flagLimit),
-				"cursor":   fmt.Sprintf("%v", flagCursor),
+				"priority": formatCLIParamValue(flagPriority),
+				"limit":    formatCLIParamValue(flagLimit),
+				"cursor":   formatCLIParamValue(flagCursor),
 			}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -44,7 +44,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			path = replacePathParam(path, "taskId", args[1])
 			params := map[string]string{}
 			if flagNotify != false {
-				params["notify"] = fmt.Sprintf("%v", flagNotify)
+				params["notify"] = formatCLIParamValue(flagNotify)
 			}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -36,7 +36,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/reports/{year}/export"
-			path = replacePathParam(path, "year", fmt.Sprintf("%v", flagYear))
+			path = replacePathParam(path, "year", formatCLIParamValue(flagYear))
 			headerOverrides := map[string]string{
 				"Accept":                           "application/octet-stream",
 				"X-Printing-Press-Binary-Response": "true",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -189,6 +190,12 @@ func mcpMultipartFieldValue(v any) string {
 	}
 	return fmt.Sprintf("%v", v)
 }
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
@@ -244,7 +251,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 				if multipart {
@@ -255,7 +262,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 					}
 				}
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -265,7 +272,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -280,7 +287,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 					multipartFields[k] = mcpMultipartFieldValue(v)
 				}
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/code_orch.go
@@ -225,7 +225,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	path := ep.Path
 	for _, p := range ep.Positional {
 		if v, ok := params[p]; ok {
-			path = strings.ReplaceAll(path, "{"+p+"}", fmt.Sprintf("%v", v))
+			path = strings.ReplaceAll(path, "{"+p+"}", formatMCPParamValue(v))
 			delete(params, p)
 		}
 	}
@@ -236,7 +236,7 @@ func handleCodeOrchExecute(ctx context.Context, req mcplib.CallToolRequest) (*mc
 	query := map[string]string{}
 	if ep.Method == "GET" || ep.Method == "DELETE" {
 		for k, v := range params {
-			query[codeOrchWireQueryName(ep.QueryParams, k)] = fmt.Sprintf("%v", v)
+			query[codeOrchWireQueryName(ep.QueryParams, k)] = formatMCPParamValue(v)
 		}
 	} else {
 		// Route spec-declared in:query params to the query string for write
@@ -348,7 +348,7 @@ func codeOrchSplitQuery(queryParams []codeOrchParamBinding, params map[string]an
 				continue
 			}
 			if v, ok := params[key]; ok {
-				uv.Set(q.WireName, fmt.Sprintf("%v", v))
+				uv.Set(q.WireName, formatMCPParamValue(v))
 				delete(params, key)
 				break
 			}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,6 +62,13 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -105,11 +113,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -119,7 +127,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -131,7 +139,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -42,7 +42,7 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 			path := "/stores"
 			params := map[string]string{}
 			if flagDryRun != false {
-				params["$dry_run"] = fmt.Sprintf("%v", flagDryRun)
+				params["$dry_run"] = formatCLIParamValue(flagDryRun)
 			}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -45,13 +45,13 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			path := "/power/store-locator"
 			params := map[string]string{}
 			if flagS != "" {
-				params["s"] = fmt.Sprintf("%v", flagS)
+				params["s"] = formatCLIParamValue(flagS)
 			}
 			if flagC != "" {
-				params["c"] = fmt.Sprintf("%v", flagC)
+				params["c"] = formatCLIParamValue(flagC)
 			}
 			if flagLocationId != "" {
-				params["location_id"] = fmt.Sprintf("%v", flagLocationId)
+				params["location_id"] = formatCLIParamValue(flagLocationId)
 			}
 			data, err := c.Get(cmd.Context(), path, params)
 			if err != nil {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +69,13 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -112,11 +120,11 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -126,7 +134,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -138,7 +146,7 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -85,6 +86,13 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+func formatMCPParamValue(v any) string {
+	if f, ok := v.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -130,11 +138,11 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 			case "path":
 				placeholder := "{" + binding.WireName + "}"
 				pathParams[binding.PublicName] = true
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			case "body":
 				bodyArgs[binding.WireName] = v
 			default:
-				params[binding.WireName] = fmt.Sprintf("%v", v)
+				params[binding.WireName] = formatMCPParamValue(v)
 			}
 		}
 		for _, p := range positionalParams {
@@ -144,7 +152,7 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 			}
 			pathParams[p] = true
 			if v, ok := args[p]; ok {
-				path = strings.Replace(path, placeholder, fmt.Sprintf("%v", v), 1)
+				path = strings.Replace(path, placeholder, formatMCPParamValue(v), 1)
 			}
 		}
 
@@ -156,7 +164,7 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 			case "POST", "PUT", "PATCH":
 				bodyArgs[k] = v
 			default:
-				params[k] = fmt.Sprintf("%v", v)
+				params[k] = formatMCPParamValue(v)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Generated CLIs now serialize numeric path and query values as plain decimals before sending them through CLI and MCP request paths. Large JSON-number or `float64` values such as `4653482` no longer become `4.653482e+06`, which avoids malformed IDs and misleading upstream 4xx responses.

This covers generated CLI endpoint commands, promoted commands, MCP endpoint tools, MCP intents, and code-orchestration execute paths. The golden fixtures now pin the emitted helper and call-site shape across representative generated CLIs.

## Testing

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator -run TestGeneratedNumericPathAndQueryParamsUsePlainDecimalFormatting -count=1`
- `go test ./internal/generator -count=1`
- `go test ./...`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Closes #2513

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
