### PR TITLE
fix(cli): skip colliding novel command stubs

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -915,7 +915,11 @@ resources:
 	require.NoError(t, json.Unmarshal(data, &manifest))
 	assert.Empty(t, manifest.NovelFeatures)
 
-	parent, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items.go"))
+	root, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(root), "newNovelItemsCmd")
+
+	parent, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "promoted_items.go"))
 	require.NoError(t, err)
 	assert.Contains(t, string(parent), "cmd.AddCommand(newNovelItemsInsightCmd(flags))")
 	stub, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items_insight.go"))

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3796,6 +3796,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 		}
 	}
 
+	novelChildrenByParent := g.novelFeatureChildrenByParent()
 	// Generate promoted top-level commands (user-friendly aliases for nested API commands)
 	// promotedCommands was computed earlier so promoted resources can replace their raw parents.
 	for _, pc := range promotedCommands {
@@ -3813,6 +3814,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			Resource          spec.Resource
 			FuncPrefix        string
 			IsReadOnly        bool
+			NovelChildren     []novelFeatureChildRender
 			*spec.APISpec
 		}{
 			PromotedName:  pc.PromotedName,
@@ -3832,6 +3834,7 @@ func (g *Generator) renderPromotedCommandFiles(promotedCommands []PromotedComman
 			Resource:          resource,
 			FuncPrefix:        pc.ResourceName,
 			IsReadOnly:        endpointIsReadCommand(pc.Endpoint, pc.EndpointName),
+			NovelChildren:     novelChildrenByParent[toKebab(pc.PromotedName)],
 			APISpec:           g.Spec,
 		}
 		promotedPath := filepath.Join("internal", "cli", safeResourceFileStem("promoted_"+pc.PromotedName)+".go")

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -58,9 +58,10 @@ func (g *Generator) renderNovelFeatureStubs() ([]novelFeatureCommandRender, erro
 		return nil, nil
 	}
 
+	generatedPaths := g.generatedCommandPaths()
 	var roots []novelFeatureCommandRender
 	for _, child := range sortedNovelChildren(root) {
-		rendered, err := g.renderNovelFeatureNode(child)
+		rendered, err := g.renderNovelFeatureNode(child, generatedPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -104,6 +105,7 @@ func (g *Generator) buildNovelFeatureStubTree() *novelFeatureStubNode {
 
 func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChildRender {
 	root := g.buildNovelFeatureStubTree()
+	generatedPaths := g.generatedCommandPaths()
 	out := map[string][]novelFeatureChildRender{}
 	var walk func(*novelFeatureStubNode)
 	walk = func(node *novelFeatureStubNode) {
@@ -111,7 +113,7 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 		if len(children) > 0 && len(node.path) > 0 {
 			parentPath := strings.Join(node.path, " ")
 			for _, child := range children {
-				if g.novelFeatureStubCollidesWithGeneratedCommand(child.path) {
+				if novelFeatureStubCollidesWithGeneratedCommand(child.path, generatedPaths) {
 					continue
 				}
 				out[parentPath] = append(out[parentPath], novelFeatureChildRender{Ident: novelFeatureStubIdent(child.path)})
@@ -127,10 +129,10 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 	return out
 }
 
-func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode) (*novelFeatureCommandRender, error) {
+func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generatedPaths map[string]struct{}) (*novelFeatureCommandRender, error) {
 	var renderedChildren []novelFeatureChildRender
 	for _, child := range sortedNovelChildren(node) {
-		rendered, err := g.renderNovelFeatureNode(child)
+		rendered, err := g.renderNovelFeatureNode(child, generatedPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +144,7 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode) (*novelFe
 	data := g.novelFeatureCommandData(node)
 	data.Children = renderedChildren
 	outPath := filepath.Join("internal", "cli", novelFeatureStubFileName(node.path))
-	if g.novelFeatureStubCollidesWithGeneratedCommand(node.path) {
+	if novelFeatureStubCollidesWithGeneratedCommand(node.path, generatedPaths) {
 		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to generated command path; skipping novel stub\n", data.CommandPath)
 		return nil, nil
 	}
@@ -190,11 +192,6 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 	} else if len(node.children) > 0 {
 		short = novelFeatureParentShort(node)
 	}
-	children := sortedNovelChildren(node)
-	childData := make([]novelFeatureChildRender, 0, len(children))
-	for _, child := range children {
-		childData = append(childData, novelFeatureChildRender{Ident: novelFeatureStubIdent(child.path)})
-	}
 	readOnlyString := "true"
 	if !readOnly {
 		readOnlyString = "false"
@@ -209,12 +206,11 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 		HasPositional:  hasPositional,
 		Feature:        node.feature != nil,
 		Flags:          flags,
-		Children:       childData,
 	}
 }
 
-func (g *Generator) novelFeatureStubCollidesWithGeneratedCommand(parts []string) bool {
-	_, ok := g.generatedCommandPaths()[novelFeatureCommandKey(parts)]
+func novelFeatureStubCollidesWithGeneratedCommand(parts []string, generatedPaths map[string]struct{}) bool {
+	_, ok := generatedPaths[novelFeatureCommandKey(parts)]
 	return ok
 }
 

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -60,7 +60,7 @@ func (g *Generator) renderNovelFeatureStubs() ([]novelFeatureCommandRender, erro
 
 	var roots []novelFeatureCommandRender
 	for _, child := range sortedNovelChildren(root) {
-		rendered, err := g.renderNovelFeatureNode(child, true)
+		rendered, err := g.renderNovelFeatureNode(child)
 		if err != nil {
 			return nil, err
 		}
@@ -111,6 +111,9 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 		if len(children) > 0 && len(node.path) > 0 {
 			parentPath := strings.Join(node.path, " ")
 			for _, child := range children {
+				if g.novelFeatureStubCollidesWithGeneratedCommand(child.path) {
+					continue
+				}
 				out[parentPath] = append(out[parentPath], novelFeatureChildRender{Ident: novelFeatureStubIdent(child.path)})
 			}
 		}
@@ -124,18 +127,28 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 	return out
 }
 
-func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, topLevel bool) (*novelFeatureCommandRender, error) {
+func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode) (*novelFeatureCommandRender, error) {
+	var renderedChildren []novelFeatureChildRender
 	for _, child := range sortedNovelChildren(node) {
-		if _, err := g.renderNovelFeatureNode(child, false); err != nil {
+		rendered, err := g.renderNovelFeatureNode(child)
+		if err != nil {
 			return nil, err
+		}
+		if rendered != nil {
+			renderedChildren = append(renderedChildren, novelFeatureChildRender{Ident: rendered.Ident})
 		}
 	}
 
 	data := g.novelFeatureCommandData(node)
+	data.Children = renderedChildren
 	outPath := filepath.Join("internal", "cli", novelFeatureStubFileName(node.path))
+	if g.novelFeatureStubCollidesWithGeneratedCommand(node.path) {
+		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to generated command path; skipping novel stub\n", data.CommandPath)
+		return nil, nil
+	}
 	if _, err := os.Stat(filepath.Join(g.OutputDir, outPath)); err == nil {
 		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to existing %s; leaving existing file unchanged\n", data.CommandPath, outPath)
-		return nil, nil
+		return &data, nil
 	}
 	if err := g.renderTemplate("novel_feature_command.go.tmpl", outPath, data); err != nil {
 		return nil, fmt.Errorf("rendering novel feature command %s: %w", data.CommandPath, err)
@@ -152,10 +165,7 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, topLevel 
 		}
 	}
 
-	if topLevel {
-		return &data, nil
-	}
-	return nil, nil
+	return &data, nil
 }
 
 func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFeatureCommandRender {
@@ -201,6 +211,50 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 		Flags:          flags,
 		Children:       childData,
 	}
+}
+
+func (g *Generator) novelFeatureStubCollidesWithGeneratedCommand(parts []string) bool {
+	_, ok := g.generatedCommandPaths()[novelFeatureCommandKey(parts)]
+	return ok
+}
+
+func (g *Generator) generatedCommandPaths() map[string]struct{} {
+	paths := map[string]struct{}{}
+	add := func(parts ...string) {
+		paths[novelFeatureCommandKey(parts)] = struct{}{}
+	}
+	for _, promoted := range g.PromotedCommands {
+		add(promoted.PromotedName)
+	}
+	for name, resource := range g.Spec.Resources {
+		if !g.PromotedResourceNames[name] {
+			add(name)
+		}
+		for eName := range resource.Endpoints {
+			if g.PromotedEndpointNames[name] == eName {
+				continue
+			}
+			add(name, eName)
+		}
+		for subName, subResource := range resource.SubResources {
+			add(name, subName)
+			for eName := range subResource.Endpoints {
+				add(name, subName, eName)
+			}
+		}
+	}
+	return paths
+}
+
+func novelFeatureCommandKey(parts []string) string {
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		normalized = append(normalized, toKebab(part))
+	}
+	return strings.Join(normalized, " ")
 }
 
 func sortedNovelChildren(node *novelFeatureStubNode) []*novelFeatureStubNode {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,6 +92,111 @@ func TestNovelFeatureStubsResolveAtRuntime(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "novel_stub_runtime_test.go"), []byte(runtimeTest.String()), 0o644))
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func TestGeneratorSkipsNovelFeatureWiringForAbsorbedEndpointCollisions(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("make")
+	apiSpec.Resources = map[string]spec.Resource{
+		"scenarios": {
+			Description: "Manage scenarios",
+			Endpoints: map[string]spec.Endpoint{
+				"get-qrcode": {Method: "GET", Path: "/scenarios/{id}/qrcode", Description: "Get scenario QR code"},
+				"list":       {Method: "GET", Path: "/scenarios", Description: "List scenarios"},
+				"run":        {Method: "POST", Path: "/scenarios/{id}/run", Description: "Run scenario"},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Blocking scenario run",
+			Command:     "scenarios run --wait",
+			Description: "Run a scenario and wait for completion.",
+			Example:     "make-pp-cli scenarios run scenario-123 --wait",
+		},
+		{
+			Name:        "Cross-team scenario list",
+			Command:     "scenarios list --all-teams",
+			Description: "List scenarios across every team.",
+			Example:     "make-pp-cli scenarios list --all-teams",
+		},
+		{
+			Name:        "Scenario QR watcher",
+			Command:     "scenarios get-qrcode --watch",
+			Description: "Watch a scenario QR code until it changes.",
+			Example:     "make-pp-cli scenarios get-qrcode scenario-123 --watch",
+		},
+		{
+			Name:        "Scenario health",
+			Command:     "scenarios health --limit 10",
+			Description: "Summarize scenario health.",
+			Example:     "make-pp-cli scenarios health --limit 10",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	parent := readGeneratedFile(t, outputDir, "internal", "cli", "scenarios.go")
+	assert.Contains(t, parent, "cmd.AddCommand(newScenariosListCmd(flags))")
+	assert.Contains(t, parent, "cmd.AddCommand(newScenariosRunCmd(flags))")
+	assert.Contains(t, parent, "cmd.AddCommand(newNovelScenariosHealthCmd(flags))")
+	assert.NotContains(t, parent, "newNovelScenariosGetQrcodeCmd")
+	assert.NotContains(t, parent, "newNovelScenariosListCmd")
+	assert.NotContains(t, parent, "newNovelScenariosRunCmd")
+
+	health := readGeneratedFile(t, outputDir, "internal", "cli", "scenarios_health.go")
+	assert.Contains(t, health, `TODO: implement novel feature %q", "scenarios health"`)
+	requireGeneratedCompiles(t, outputDir)
+
+	require.NoError(t, gen.Generate())
+	parent = readGeneratedFile(t, outputDir, "internal", "cli", "scenarios.go")
+	assert.Contains(t, parent, "cmd.AddCommand(newNovelScenariosHealthCmd(flags))")
+	assert.NotContains(t, parent, "newNovelScenariosGetQrcodeCmd")
+	assert.NotContains(t, parent, "newNovelScenariosListCmd")
+	assert.NotContains(t, parent, "newNovelScenariosRunCmd")
+}
+
+func TestGeneratorWiresNovelChildrenUnderPromotedResource(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promonovel")
+	apiSpec.Resources = map[string]spec.Resource{
+		"qr": {
+			Description: "Manage QR codes",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {Method: "GET", Path: "/qr/{id}", Description: "Get QR code"},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "QR watcher",
+			Command:     "qr --watch",
+			Description: "Watch the promoted QR command.",
+			Example:     "promonovel-pp-cli qr qr-123 --watch",
+		},
+		{
+			Name:        "QR health",
+			Command:     "qr health --limit 10",
+			Description: "Summarize QR health.",
+			Example:     "promonovel-pp-cli qr health --limit 10",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, root, "rootCmd.AddCommand(newQrPromotedCmd(flags))")
+	assert.NotContains(t, root, "newNovelQrCmd")
+
+	promoted := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_qr.go")
+	assert.Contains(t, promoted, "cmd.AddCommand(newNovelQrHealthCmd(flags))")
+	health := readGeneratedFile(t, outputDir, "internal", "cli", "qr_health.go")
+	assert.Contains(t, health, `TODO: implement novel feature %q", "qr health"`)
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratorSkipsNovelFeatureStubsWhenNoCommandPath(t *testing.T) {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -443,6 +443,9 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		cmd.AddCommand(sub)
 	}
 {{- end}}
+{{- range .NovelChildren}}
+	cmd.AddCommand(newNovel{{.Ident}}Cmd(flags))
+{{- end}}
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Novel features that overlap generated endpoint or promoted command paths no longer emit duplicate TODO stubs or parent wiring that can shadow or reference missing constructors. Non-colliding novel children remain reachable under the generated resource parent or promoted command that owns the path.

Closes #2495

## Verification

- `go test ./internal/generator -run 'TestGenerator(EmitsNovelFeatureCommandStubs|SkipsNovelFeatureWiringForAbsorbedEndpointCollisions|WiresNovelChildrenUnderPromotedResource|SkipsNovelFeatureStubsWhenNoCommandPath|NovelFeatureHelpGuardRequiresPositionalUse|NovelFeatureParentShortHasNoTODO)|TestNovelFeatureStubsResolveAtRuntime'`
- `go test ./internal/cli -count=1 -run '^TestGenerateCmdDoesNotCarryPlannedNovelFeaturesIntoManifest$' -v`
- `go test ./internal/cli -count=1`
- `go test ./...`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
