### PR TITLE
fix(cli): fail dogfood on missing data-source strategy

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -2351,6 +2351,9 @@ var dogfoodVerdictRules = []dogfoodVerdictRule{
 	{"WARN", func(r *DogfoodReport, _ bool) bool {
 		return mcpSurfaceCheckActive(r.MCPSurfaceParityCheck) && r.MCPSurfaceParityCheck.HandEdited
 	}},
+	{"FAIL", func(r *DogfoodReport, _ bool) bool {
+		return len(r.ReimplementationCheck.MissingDataSourceStrategy) > 0
+	}},
 	// Surface hand-rolled responses without hard-blocking early iteration.
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return len(r.ReimplementationCheck.Suspicious) > 0 }},
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return len(r.SyncParamDropCheck.Findings) > 0 }},
@@ -2454,6 +2457,16 @@ func collectDogfoodIssues(report *DogfoodReport, hasSpec bool) []string {
 		}
 		issues = append(issues, fmt.Sprintf("%d/%d novel features look reimplemented: %s",
 			len(report.ReimplementationCheck.Suspicious),
+			report.ReimplementationCheck.Checked,
+			strings.Join(parts, "; ")))
+	}
+	if len(report.ReimplementationCheck.MissingDataSourceStrategy) > 0 {
+		parts := make([]string, 0, len(report.ReimplementationCheck.MissingDataSourceStrategy))
+		for _, f := range report.ReimplementationCheck.MissingDataSourceStrategy {
+			parts = append(parts, fmt.Sprintf("%s (%s) — %s", f.Command, f.File, f.Reason))
+		}
+		issues = append(issues, fmt.Sprintf("%d/%d novel features missing data-source strategy: %s",
+			len(report.ReimplementationCheck.MissingDataSourceStrategy),
 			report.ReimplementationCheck.Checked,
 			strings.Join(parts, "; ")))
 	}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -2320,6 +2320,9 @@ var dogfoodVerdictRules = []dogfoodVerdictRule{
 	{"FAIL", func(r *DogfoodReport, _ bool) bool {
 		return r.ExampleCheck.Tested > 0 && (r.ExampleCheck.WithExamples*100/r.ExampleCheck.Tested) < 50
 	}},
+	{"FAIL", func(r *DogfoodReport, _ bool) bool {
+		return len(r.ReimplementationCheck.MissingDataSourceStrategy) > 0
+	}},
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return r.DeadFlags.Dead >= 1 && r.DeadFlags.Dead <= 2 }},
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return r.DeadFuncs.Dead >= 1 }},
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return !r.IsDeviceCLI && !r.PipelineCheck.SyncCallsDomain }},
@@ -2350,9 +2353,6 @@ var dogfoodVerdictRules = []dogfoodVerdictRule{
 	}},
 	{"WARN", func(r *DogfoodReport, _ bool) bool {
 		return mcpSurfaceCheckActive(r.MCPSurfaceParityCheck) && r.MCPSurfaceParityCheck.HandEdited
-	}},
-	{"FAIL", func(r *DogfoodReport, _ bool) bool {
-		return len(r.ReimplementationCheck.MissingDataSourceStrategy) > 0
 	}},
 	// Surface hand-rolled responses without hard-blocking early iteration.
 	{"WARN", func(r *DogfoodReport, _ bool) bool { return len(r.ReimplementationCheck.Suspicious) > 0 }},

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -785,6 +785,7 @@ func TestDeriveDogfoodVerdict(t *testing.T) {
 
 func TestDeriveDogfoodVerdict_FailsOnMissingDataSourceStrategy(t *testing.T) {
 	report := passingDogfoodReport()
+	report.NovelFeaturesCheck = NovelFeaturesCheckResult{Planned: 1, Found: 1, Stubbed: []string{"id-hunt"}}
 	report.ReimplementationCheck = ReimplementationCheckResult{
 		Checked: 1,
 		MissingDataSourceStrategy: []ReimplementationFinding{{

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -783,6 +783,20 @@ func TestDeriveDogfoodVerdict(t *testing.T) {
 	assert.Equal(t, "PASS", deriveDogfoodVerdict(report, true))
 }
 
+func TestDeriveDogfoodVerdict_FailsOnMissingDataSourceStrategy(t *testing.T) {
+	report := passingDogfoodReport()
+	report.ReimplementationCheck = ReimplementationCheckResult{
+		Checked: 1,
+		MissingDataSourceStrategy: []ReimplementationFinding{{
+			Command: "id-hunt",
+			File:    "id_hunt.go",
+			Reason:  "missing // pp:data-source <auto|local|live> annotation",
+		}},
+	}
+
+	assert.Equal(t, "FAIL", deriveDogfoodVerdict(report, false))
+}
+
 func TestExtractExamplesSection(t *testing.T) {
 	tests := []struct {
 		name string
@@ -3372,6 +3386,22 @@ func TestCollectDogfoodIssues_IncludesNovelFeatureStubs(t *testing.T) {
 
 	issues := collectDogfoodIssues(report, false)
 	assert.Contains(t, issues, "1/2 novel features are TODO stubs: call")
+}
+
+func TestCollectDogfoodIssues_IncludesMissingDataSourceStrategy(t *testing.T) {
+	report := &DogfoodReport{
+		ReimplementationCheck: ReimplementationCheckResult{
+			Checked: 2,
+			MissingDataSourceStrategy: []ReimplementationFinding{{
+				Command: "id-hunt",
+				File:    "id_hunt.go",
+				Reason:  "missing // pp:data-source <auto|local|live> annotation",
+			}},
+		},
+	}
+
+	issues := collectDogfoodIssues(report, false)
+	assert.Contains(t, issues, "1/2 novel features missing data-source strategy: id-hunt (id_hunt.go) — missing // pp:data-source <auto|local|live> annotation")
 }
 
 func TestDeriveDogfoodVerdict_FailsOnMissingTests(t *testing.T) {


### PR DESCRIPTION
## Summary
Dogfood now hard-fails when a hand-written novel command omits or misspells its `// pp:data-source <auto|local|live>` strategy annotation. That turns the capture-to-analytics local-store contract from passive JSON metadata into an executable authoring-time gate, while leaving the existing hand-rolled-response warning behavior unchanged.

Closes #2449

## Verification
- `go test ./internal/pipeline -run 'Test(CheckReimplementation|DeriveDogfoodVerdict|CollectDogfoodIssues)'`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- pre-push `golangci-lint` hook passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
