### PR TITLE
fix(skills): add blocked API journal flow

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -548,7 +548,9 @@ func TestPublishSkillDocumentsBlockedAPIJournalMode(t *testing.T) {
 	assert.Contains(t, skill, "printed-CLI package, live-test, registry, or skill-mirror steps")
 	assert.Contains(t, skill, "Journal-only PRs may edit `blocked-apis.json`")
 	assert.Contains(t, skill, "/printing-press publish notion --blocked-api-journal notion")
-	assert.Contains(t, skill, "jq empty blocked-apis.json.tmp && mv blocked-apis.json.tmp blocked-apis.json")
+	assert.Contains(t, skill, "' blocked-apis.json > blocked-apis.json.tmp || {")
+	assert.Contains(t, skill, "Error: jq failed to update blocked-apis.json")
+	assert.Contains(t, skill, "Error: blocked-apis.json update produced invalid JSON")
 	assert.NotContains(t, skill, "git add library/ blocked-apis.json")
 }
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -527,6 +527,28 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	require.NotEqual(t, -1, copyIntoLibrary)
 }
 
+func TestPrintingPressSkillChecksBlockedAPIJournal(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+
+	assert.Contains(t, skill, "blocked-apis.json")
+	assert.Contains(t, skill, "Blocked-API journal check skipped")
+	assert.Contains(t, skill, "Read the blocked journal before reasoning about registry matches")
+	assert.Contains(t, skill, "Add to blocked-API journal")
+	assert.Contains(t, skill, "/printing-press-publish --blocked-api-journal <api>")
+	assert.Contains(t, skill, "Offer journaling only when the one-line hold reason is a reachability or buildability blocker")
+}
+
+func TestPublishSkillDocumentsBlockedAPIJournalMode(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+
+	assert.Contains(t, skill, "Blocked API Journal Mode")
+	assert.Contains(t, skill, "git add blocked-apis.json")
+	assert.Contains(t, skill, "Do not continue into normal")
+	assert.Contains(t, skill, "printed-CLI package, live-test, registry, or skill-mirror steps")
+	assert.Contains(t, skill, "Journal-only PRs may edit `blocked-apis.json`")
+	assert.NotContains(t, skill, "git add library/ blocked-apis.json")
+}
+
 func TestPublishSkillDocumentsPatchesIndexContract(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -536,6 +536,7 @@ func TestPrintingPressSkillChecksBlockedAPIJournal(t *testing.T) {
 	assert.Contains(t, skill, "Add to blocked-API journal")
 	assert.Contains(t, skill, "/printing-press-publish --blocked-api-journal <api>")
 	assert.Contains(t, skill, "Offer journaling only when the one-line hold reason is a reachability or buildability blocker")
+	assert.Contains(t, skill, " (tracking #<entry.blocking_issue>; marked permanent)")
 }
 
 func TestPublishSkillDocumentsBlockedAPIJournalMode(t *testing.T) {
@@ -546,6 +547,8 @@ func TestPublishSkillDocumentsBlockedAPIJournalMode(t *testing.T) {
 	assert.Contains(t, skill, "Do not continue into normal")
 	assert.Contains(t, skill, "printed-CLI package, live-test, registry, or skill-mirror steps")
 	assert.Contains(t, skill, "Journal-only PRs may edit `blocked-apis.json`")
+	assert.Contains(t, skill, "/printing-press publish notion --blocked-api-journal notion")
+	assert.Contains(t, skill, "jq empty blocked-apis.json.tmp\nmv blocked-apis.json.tmp blocked-apis.json")
 	assert.NotContains(t, skill, "git add library/ blocked-apis.json")
 }
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -548,7 +548,7 @@ func TestPublishSkillDocumentsBlockedAPIJournalMode(t *testing.T) {
 	assert.Contains(t, skill, "printed-CLI package, live-test, registry, or skill-mirror steps")
 	assert.Contains(t, skill, "Journal-only PRs may edit `blocked-apis.json`")
 	assert.Contains(t, skill, "/printing-press publish notion --blocked-api-journal notion")
-	assert.Contains(t, skill, "jq empty blocked-apis.json.tmp\nmv blocked-apis.json.tmp blocked-apis.json")
+	assert.Contains(t, skill, "jq empty blocked-apis.json.tmp && mv blocked-apis.json.tmp blocked-apis.json")
 	assert.NotContains(t, skill, "git add library/ blocked-apis.json")
 }
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -22,6 +22,7 @@ Publish a generated CLI from your local library to the [printing-press-library](
 /printing-press publish notion
 /printing-press publish notion --from-polish
 /printing-press publish notion --skip-live-test=auth-unavailable
+/printing-press publish notion --blocked-api-journal notion
 /printing-press publish
 ```
 
@@ -122,8 +123,8 @@ jq --arg slug "<api-slug>" \
     }]
   | sort_by(.slug)
 ' blocked-apis.json > blocked-apis.json.tmp
+jq empty blocked-apis.json.tmp
 mv blocked-apis.json.tmp blocked-apis.json
-jq empty blocked-apis.json
 ```
 
 Create a journal branch and PR:

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -123,8 +123,7 @@ jq --arg slug "<api-slug>" \
     }]
   | sort_by(.slug)
 ' blocked-apis.json > blocked-apis.json.tmp
-jq empty blocked-apis.json.tmp
-mv blocked-apis.json.tmp blocked-apis.json
+jq empty blocked-apis.json.tmp && mv blocked-apis.json.tmp blocked-apis.json
 ```
 
 Create a journal branch and PR:

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -42,6 +42,13 @@ resolving the CLI name. The marker is not a second confirmation and is not
 passed to `cli-printing-press`; it only preserves standalone polish's old
 post-publish retro offer after the fresh-turn publish completes.
 
+If the request includes `--blocked-api-journal`, enter **Blocked API Journal
+Mode** below instead of the normal printed-CLI publish flow. This mode may be
+invoked from `/printing-press`'s hold-path menu after the user explicitly chose
+"Add to blocked-API journal"; that parent menu choice is sufficient user
+authorization for the public-library journal write. Do not require a second
+fresh-turn invocation for this journal-only mode.
+
 If the fresh user-authored request includes `--skip-live-test=<reason>`, record
 the exact non-empty reason as `SKIP_LIVE_TEST_REASON` and remove the flag before
 resolving the CLI name. This is the only supported escape valve for the
@@ -58,6 +65,85 @@ workflows. The library's `Fail on changes to generated artifacts` check in
 `verify-library-conventions.yml` hard-fails any PR — fork or same-repo — whose
 diff against base touches `registry.json` or `cli-skills/pp-*/SKILL.md`, so a
 publish that includes either is pre-rejected before review.
+
+`blocked-apis.json` is different: it is a hand-maintained public-library journal,
+not a generated registry surface. Journal-only PRs may edit `blocked-apis.json`
+and must not stage `library/`, `registry.json`, README catalog cells, or
+`cli-skills/`.
+
+## Blocked API Journal Mode
+
+Use this mode only when the invocation includes `--blocked-api-journal`. It
+records a held `/printing-press` attempt whose blocker is likely to repeat for
+other users until a machine or upstream issue changes.
+
+Required fields from the caller:
+
+- `slug`: canonical API slug, not the CLI binary name.
+- `attempted_at`: `YYYY-MM-DD`.
+- `verdict`: `hold`.
+- `reason`: concise blocker reason, with no secrets, local paths, cookies,
+  tokens, or account-specific details.
+- `blocking_issue`: Printing Press issue number if known, otherwise `null`.
+- `permanent`: boolean.
+
+If the caller did not provide one of these fields, infer only safe values from
+the current run context. If `reason` is missing or vague, stop and ask for one
+specific blocker sentence; do not write an unhelpful journal entry.
+
+Run the normal Setup, Configuration, scoped clone cleanup, and GitHub auth
+checks, then prepare the public-library clone exactly as the normal publish
+flow does: fork if needed, ensure `upstream` points to
+`mvanhorn/printing-press-library`, fetch `upstream`, and reset the clone to
+`upstream/main` before editing.
+
+Then update only `$PUBLISH_REPO_DIR/blocked-apis.json`:
+
+```bash
+cd "$PUBLISH_REPO_DIR"
+if [ ! -f blocked-apis.json ]; then
+  printf '[]\n' > blocked-apis.json
+fi
+jq --arg slug "<api-slug>" \
+   --arg attempted_at "<YYYY-MM-DD>" \
+   --arg verdict "hold" \
+   --arg reason "<reason>" \
+   --argjson blocking_issue '<number-or-null>' \
+   --argjson permanent '<true-or-false>' '
+  (if type == "array" then . else [] end)
+  | map(select(.slug != $slug))
+  + [{
+      slug: $slug,
+      attempted_at: $attempted_at,
+      verdict: $verdict,
+      reason: $reason,
+      blocking_issue: $blocking_issue,
+      permanent: $permanent
+    }]
+  | sort_by(.slug)
+' blocked-apis.json > blocked-apis.json.tmp
+mv blocked-apis.json.tmp blocked-apis.json
+jq empty blocked-apis.json
+```
+
+Create a journal branch and PR:
+
+```bash
+git checkout -B chore/blocked-api-<api-slug>
+git add blocked-apis.json
+git commit -m "chore(<api-slug>): journal blocked API"
+git push --force-with-lease -u origin chore/blocked-api-<api-slug>
+```
+
+Open the PR against `mvanhorn/printing-press-library` with a body that includes:
+
+- the held API slug and reason
+- whether the block is permanent or tied to `blocking_issue`
+- the expected Phase 0 behavior: future `/printing-press <api-slug>` runs warn
+  before repeating the attempt
+
+After the PR is open, report the URL and stop. Do not continue into normal
+printed-CLI package, live-test, registry, or skill-mirror steps.
 
 ## Setup
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -122,8 +122,17 @@ jq --arg slug "<api-slug>" \
       permanent: $permanent
     }]
   | sort_by(.slug)
-' blocked-apis.json > blocked-apis.json.tmp
-jq empty blocked-apis.json.tmp && mv blocked-apis.json.tmp blocked-apis.json
+' blocked-apis.json > blocked-apis.json.tmp || {
+  rm -f blocked-apis.json.tmp
+  echo "Error: jq failed to update blocked-apis.json"
+  exit 1
+}
+if ! jq empty blocked-apis.json.tmp; then
+  rm -f blocked-apis.json.tmp
+  echo "Error: blocked-apis.json update produced invalid JSON"
+  exit 1
+fi
+mv blocked-apis.json.tmp blocked-apis.json
 ```
 
 Create a journal branch and PR:

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -931,16 +931,18 @@ Before new research:
 
    If no CLI exists in the local library and no lock is active, run the **Public-library check** below before proceeding to Phase 1.
 
-   #### Public-library check (registry.json)
+   #### Public-library check (registry.json + blocked-apis.json)
 
    The local library check above only sees CLIs this machine has already printed. A user on a fresh checkout — or one who typed a slightly different name than the published slug (`Slack` vs `slack-bot`, `Cal` vs `cal-com`), or who described what they wanted in their own words (`Hacker News reader`, `Notion clone`, `prediction market`) — will miss CLIs that already exist in the public library. Scan `mvanhorn/printing-press-library/registry.json` to catch those cases before Phase 1 research begins (the expensive 30-60-minute portion of the pipeline).
+
+   The public library also carries `blocked-apis.json`, a shared journal of APIs that were attempted and put on hold for reachability or buildability reasons. Scan it in the same Phase 0 window so a user does not repeat an already-known dead-end run before the blocking issue is fixed.
 
    **Skip this check entirely when:**
    - The local-library check above already prompted (mutual exclusion — do not double-ask).
    - `BROWSER_SNIFF_TARGET_URL` is set (the user is building a from-website CLI; the registry indexes API CLIs and naming collisions are unlikely and intentional).
    - The user passed `--har <path>` with an explicit `--name <api>` for a private capture.
 
-   **Fetch the registry.** Match the pattern `/printing-press-import` and `/printing-press-reprint` already use:
+   **Fetch the registry and blocked journal.** Match the pattern `/printing-press-import` and `/printing-press-reprint` already use:
 
    ```bash
    REGISTRY=$(mktemp)
@@ -951,9 +953,50 @@ Before new research:
      rm -f "$REGISTRY"
      REGISTRY=""
    fi
+
+   BLOCKED_APIS=$(mktemp)
+   if ! gh api -H "Accept: application/vnd.github.v3.raw" \
+        repos/mvanhorn/printing-press-library/contents/blocked-apis.json \
+        > "$BLOCKED_APIS" 2>/dev/null; then
+     echo "Blocked-API journal check skipped: blocked-apis.json unreachable or absent. Proceeding with the registry check."
+     rm -f "$BLOCKED_APIS"
+     BLOCKED_APIS=""
+   fi
    ```
 
-   Do not block on a network failure. After step 4 finishes, clean up the tempfile only if the fetch succeeded: `[ -n "$REGISTRY" ] && rm -f "$REGISTRY"`. The failure branch above already removed it and set `REGISTRY=""`, so an unconditional `rm -f "$REGISTRY"` would run `rm -f ""`.
+   Do not block on a network failure or on a missing `blocked-apis.json` file. After step 4 finishes, clean up tempfiles only if the fetch succeeded: `[ -n "$REGISTRY" ] && rm -f "$REGISTRY"` and `[ -n "$BLOCKED_APIS" ] && rm -f "$BLOCKED_APIS"`. The failure branches above already removed each file and set its variable to empty, so an unconditional `rm -f "$REGISTRY"` or `rm -f "$BLOCKED_APIS"` would run `rm -f ""`.
+
+   **Read the blocked journal before reasoning about registry matches.** If `BLOCKED_APIS` is non-empty, read it directly. Expected shape:
+
+   ```json
+   [
+     {
+       "slug": "1001tracklists",
+       "attempted_at": "2026-05-25",
+       "verdict": "hold",
+       "reason": "Cloudflare Turnstile clearance gate; pure-HTTP cannot mint fsuid",
+       "blocking_issue": 2140,
+       "permanent": false
+     }
+   ]
+   ```
+
+   Entries are API-slug records, not printed-CLI registry entries. Match the user's requested API against `slug` using the same slug-normalization judgment as the registry check (`<api>`, `<api>-cli`, `<api>-pp-cli`, punctuation and case variants). Do not use vague category or description matching for the blocked journal. A false positive here stops a potentially valid run; only prompt when the entry appears to be the same API under a slug or brand spelling variant.
+
+   If a blocked entry matches, prompt before reading registry matches:
+
+   > "`<entry.slug>` was attempted on `<entry.attempted_at>` and held — `<entry.reason>`<tracking suffix>. The shared blocked-API journal exists so users do not repeat known unreachable or unbuildable runs before the blocker changes. Proceed anyway?"
+
+   Where `<tracking suffix>` is:
+   - ` (tracking #<entry.blocking_issue>)` when `blocking_issue` is non-null.
+   - ` (marked permanent)` when `permanent` is `true` and no blocking issue is present.
+   - empty when neither applies.
+
+   Options:
+   1. **Stop here (recommended)** — end this run. If a tracking issue is present, tell the user to re-attempt only after that issue closes or the journal entry is updated.
+   2. **Proceed anyway** — continue to the registry check and then Phase 1. Use this only when the user has new evidence that the blocker no longer applies or wants a deliberate fresh attempt.
+
+   If multiple blocked entries somehow match, pick the most recent `attempted_at` value and mention that additional older journal entries exist. If `blocked-apis.json` is malformed, print "Blocked-API journal check skipped: blocked-apis.json is malformed. Proceeding with the registry check." and continue; do not let a bad journal file block fresh prints.
 
    **Read the registry and reason about matches** — do not gate on string equality alone. The file is small (~88 KB, ~135 entries today); read it directly and use judgment. Each entry has fields `name` (slug), `category`, `api` (brand display), `description`, `path`, `printer`.
 
@@ -4520,13 +4563,16 @@ End normally. The CLI is in `$PRESS_LIBRARY/<api>` and the user can run `/printi
 
 The CLI did not promote to library. The working copy is at `$CLI_WORK_DIR`; manuscripts and proofs are archived. Hold runs are the highest-value retro signal — something blocked the machine from reaching ship, and that signal is most valuable while session context is fresh.
 
+Before rendering the menu, decide whether this hold should offer a blocked-API journal entry. Offer journaling only when the one-line hold reason is a reachability or buildability blocker that would likely repeat for another user before a machine or upstream change, for example browser-clearance barriers, Cloudflare Turnstile, login/session surfaces that a pure-HTTP printed CLI cannot replay, unreachable official specs, or an upstream API that cannot be called from generated code. Do not offer journaling for ordinary fix-loop failures, local setup problems, missing credentials, temporary network outages, test flakes, or quality issues that polish can plausibly fix.
+
 Present via `AskUserQuestion`:
 
 > "<api> couldn't pass shipcheck — <one-line reason from the shipcheck report or polish result>. The working copy is at <expanded $CLI_WORK_DIR path> and was not added to the library. What do you want to do?"
 >
 > 1. **Run retro** (recommended) — capture what blocked ship so the Printing Press maintainers can fix it for the next CLI you generate
 > 2. **Polish to retry** — run another polish pass and try again to reach ship
-> 3. **Done for now**
+> 3. **Add to blocked-API journal** — open a public-library PR that appends or updates `blocked-apis.json` so future `/printing-press <api>` runs warn before repeating this held attempt. Include this option only for repeatable reachability/buildability holds as described above.
+> 4. **Done for now**
 
 Default the recommendation to **Run retro**. Override to **Polish to retry** when the polish result block specifically says another pass is likely to close the gap (`further_polish_recommended: yes`) — that signal means the CLI is on hold not because the machine is structurally short, but because the last polish pass ran out of time on issues it can plausibly close.
 
@@ -4552,6 +4598,21 @@ Three reasons for this exact form, all mirroring Phase 5.5:
 2. **Use the Skill tool (forked context), not the `/printing-press-polish` slash command.** This matches Phase 5.5's invocation pattern — same shape, same expectations. Slash-command invocations auto-enable polish's standalone mode (Publish Offer fires); the Skill tool form defers to the parent unless `--standalone` is passed explicitly. Main SKILL owns the menu on this path.
 3. **Do not include `--standalone` in `args`.** The flag is what polish gates its Publish Offer on (see polish SKILL.md "Publish Offer"). On the hold path the CLI has not been promoted; firing the offer would open a public PR for an un-promoted, un-shipped working copy.
 4. **Pass `printing_press_bin`.** Use the absolute path captured by the parent setup preflight so this forked polish pass cannot downgrade the CLI by resolving an older global binary.
+
+#### If "Add to blocked-API journal"
+
+Invoke `/printing-press-publish --blocked-api-journal <api>`. The publish skill owns public-library writes and will append or update only `blocked-apis.json`, not `registry.json`, README catalog cells, generated skill mirrors, or a printed CLI package.
+
+Pass the journal fields from the current run context:
+
+- `slug`: the canonical API slug (`<api>`), not the CLI binary name.
+- `attempted_at`: today's date in `YYYY-MM-DD` form.
+- `verdict`: always `hold`.
+- `reason`: one concise sentence from the hold reason. Do not include secrets, local paths, cookies, tokens, or user-specific account details.
+- `blocking_issue`: the Printing Press issue number that would unblock this API if known, otherwise `null`.
+- `permanent`: `true` only when the API is fundamentally incompatible with a replayable printed CLI, such as a resident-browser-only product surface with no API or stable replayable HTTP path. Use `false` for machine gaps that could be fixed.
+
+If the current hold also warrants a retro, tell the user after the journal PR opens that a retro is still useful for the machine-level fix. Do not run retro automatically from this branch; the user chose the journal action.
 
 After polish returns, parse the result block and act on the new `ship_recommendation`:
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -988,8 +988,9 @@ Before new research:
    > "`<entry.slug>` was attempted on `<entry.attempted_at>` and held — `<entry.reason>`<tracking suffix>. The shared blocked-API journal exists so users do not repeat known unreachable or unbuildable runs before the blocker changes. Proceed anyway?"
 
    Where `<tracking suffix>` is:
-   - ` (tracking #<entry.blocking_issue>)` when `blocking_issue` is non-null.
-   - ` (marked permanent)` when `permanent` is `true` and no blocking issue is present.
+   - ` (tracking #<entry.blocking_issue>; marked permanent)` when `blocking_issue` is non-null and `permanent` is `true`.
+   - ` (tracking #<entry.blocking_issue>)` when `blocking_issue` is non-null and `permanent` is `false`.
+   - ` (marked permanent)` when `permanent` is `true` and `blocking_issue` is `null`.
    - empty when neither applies.
 
    Options:


### PR DESCRIPTION
## Intent

Closes #2143.

Held API attempts now have a shared path to prevent repeated wasted `/printing-press` runs. A future run can warn before rebuilding an API that the public library already records as held for a repeatable reachability or buildability blocker.

## Approach

- Extend the Phase 0 public-library check to fetch `blocked-apis.json` alongside `registry.json`, match only same-API slug or brand variants, and prompt before continuing when a held entry matches.
- Add a hold-path menu option for repeatable reachability and buildability holds so the run can hand off a durable journal entry instead of only archiving local manuscripts.
- Add a journal-only mode to `/printing-press-publish` that updates only `blocked-apis.json` in the public library and stops before normal printed-CLI package or registry flows.
- Add pipeline contract tests that pin the new skill instructions and publish-mode boundaries.

## Scope

Primary area: `skills/printing-press` and `skills/printing-press-publish`.

This belongs in the Printing Press because the bug is in the orchestration skills: fresh users had no shared preflight warning for known held APIs, and only the publish skill should touch public-library state.

## Risk

The main risk is over-warning on a blocked journal entry. The Phase 0 instructions constrain matching to same-API slug or brand variants and explicitly avoid vague category or description matching.

## Verification

- `go test ./internal/pipeline -run 'Test(PrintingPressSkillChecksBlockedAPIJournal|PublishSkillDocumentsBlockedAPIJournalMode|PublishSkillSkipsCliSkillsMirrorRegen)'`
- `gofmt -w internal/pipeline/contracts_test.go`
- `git diff --check`
- `go test ./...`
- push hook: `fmt`, `lint`
