### PR TITLE
fix(cli): support local sqlite specs without base urls

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -918,6 +918,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if p.Spec != nil && p.Spec.Version != "" {
 		m.APIVersion = p.Spec.Version
 	}
+	if p.Spec != nil && p.Spec.IsLocalSQLiteSource() {
+		m.SpecFormat = spec.SourceLocalSQLite
+	}
 
 	// Populate MCP metadata from the parsed spec.
 	if p.Spec != nil {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -663,6 +663,36 @@ func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
 	assert.Equal(t, "my-spec.yaml", got.SpecPath)
 }
 
+func TestWriteManifestForGenerateStampsLocalSQLiteSpecFormat(t *testing.T) {
+	dir := t.TempDir()
+	localSpec := &spec.APISpec{
+		Name:   "local-data",
+		Source: spec.SourceLocalSQLite,
+		Auth:   spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"items": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+	}
+
+	for range 2 {
+		require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+			APIName:   "local-data",
+			SpecSrcs:  []string{"/tmp/local-data.yaml"},
+			OutputDir: dir,
+			Spec:      localSpec,
+		}))
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, spec.SourceLocalSQLite, got.SpecFormat)
+	assert.True(t, got.IsLocalDatastore())
+	assert.Equal(t, "local-data.yaml", got.SpecPath)
+}
+
 func TestWriteManifestForGenerateMCPBManifestUsesResolvedMCPBinarySlug(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3609,7 +3609,7 @@ func (s *APISpec) Validate() error {
 	switch strings.ToLower(strings.TrimSpace(s.Source)) {
 	case "", SourceLocalSQLite:
 	default:
-		return fmt.Errorf("source must be one of: local-sqlite")
+		return fmt.Errorf("source %q is not supported; valid values: local-sqlite", s.Source)
 	}
 	// Parser fallback may supply a placeholder base_url when the source spec omits servers.
 	if s.BaseURL == "" && s.BasePath == "" && !s.IsLocalSQLiteSource() {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -57,6 +57,10 @@ const (
 )
 
 const (
+	SourceLocalSQLite = "local-sqlite"
+)
+
+const (
 	StreamingTransportWebSocket = "websocket"
 
 	StreamingFramingSingleObject = "single_object_per_frame"
@@ -284,6 +288,7 @@ type APISpec struct {
 	Printer         string              `yaml:"printer,omitempty" json:"printer,omitempty"`               // legacy: @handle, derived from Creator.Handle
 	PrinterName     string              `yaml:"printer_name,omitempty" json:"printer_name,omitempty"`     // legacy: display, derived from Creator.Name
 	Kind            string              `yaml:"kind,omitempty" json:"kind,omitempty"`                     // "rest" (default) or "synthetic" — synthetic CLIs aggregate multiple sources beyond the spec; dogfood's path-validity check is relaxed accordingly
+	Source          string              `yaml:"source,omitempty" json:"source,omitempty"`                 // source archetype; local-sqlite declares an operator-local SQLite source with no HTTP base URL
 	SpecSource      string              `yaml:"spec_source,omitempty" json:"spec_source,omitempty"`       // official, community, sniffed, docs — affects generated client defaults
 	ClientPattern   string              `yaml:"client_pattern,omitempty" json:"client_pattern,omitempty"` // rest (default), proxy-envelope — affects generated HTTP client
 	HTTPTransport   string              `yaml:"http_transport,omitempty" json:"http_transport,omitempty"` // standard (default for official APIs), browser-http, browser-chrome, browser-chrome-h2, or browser-chrome-h3
@@ -785,6 +790,12 @@ type ExtraCommand struct {
 // strict path-validity and scorecard marks path_validity as unscored.
 func (s *APISpec) IsSynthetic() bool {
 	return s != nil && s.Kind == KindSynthetic
+}
+
+// IsLocalSQLiteSource reports whether the root spec declares an operator-local
+// SQLite data source rather than an HTTP API origin.
+func (s *APISpec) IsLocalSQLiteSource() bool {
+	return s != nil && strings.ToLower(strings.TrimSpace(s.Source)) == SourceLocalSQLite
 }
 
 // EffectiveDisplayName returns the human-readable brand name for this CLI.
@@ -3595,8 +3606,13 @@ func (s *APISpec) Validate() error {
 	// Note: s.Version holds the API version from the spec (for provenance).
 	// The CLI version is always hardcoded to "1.0.0" in the generated root.go
 	// template — it is independent of the API version.
+	switch strings.ToLower(strings.TrimSpace(s.Source)) {
+	case "", SourceLocalSQLite:
+	default:
+		return fmt.Errorf("source must be one of: local-sqlite")
+	}
 	// Parser fallback may supply a placeholder base_url when the source spec omits servers.
-	if s.BaseURL == "" && s.BasePath == "" {
+	if s.BaseURL == "" && s.BasePath == "" && !s.IsLocalSQLiteSource() {
 		return fmt.Errorf("base_url is required")
 	}
 	if err := validateReservedPlaceholderHost("base_url", s.BaseURL); err != nil {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -745,6 +745,31 @@ func TestValidation(t *testing.T) {
 	}
 }
 
+func TestValidationAllowsLocalSQLiteSourceWithoutBaseURL(t *testing.T) {
+	s := APISpec{
+		Name:   "local-data",
+		Source: SourceLocalSQLite,
+		Resources: map[string]Resource{
+			"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+	}
+
+	require.NoError(t, s.Validate())
+}
+
+func TestValidationRejectsUnknownSource(t *testing.T) {
+	s := APISpec{
+		Name:    "local-data",
+		Source:  "local-postgres",
+		BaseURL: "https://api.example.com",
+		Resources: map[string]Resource{
+			"items": {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/items"}}},
+		},
+	}
+
+	require.ErrorContains(t, s.Validate(), "source must be one of: local-sqlite")
+}
+
 // validateAdditionalAuthHeaders covers six distinct error paths; this table
 // hits each one and confirms the happy path still validates.
 func TestValidateAdditionalAuthHeadersErrors(t *testing.T) {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -767,7 +767,7 @@ func TestValidationRejectsUnknownSource(t *testing.T) {
 		},
 	}
 
-	require.ErrorContains(t, s.Validate(), "source must be one of: local-sqlite")
+	require.ErrorContains(t, s.Validate(), `source "local-postgres" is not supported; valid values: local-sqlite`)
 }
 
 // validateAdditionalAuthHeaders covers six distinct error paths; this table

--- a/skills/printing-press/references/spec-format.md
+++ b/skills/printing-press/references/spec-format.md
@@ -9,7 +9,8 @@ Use this format when no OpenAPI spec is available.
 name: my-api                     # string (REQUIRED) CLI binary prefix, e.g. "my-api"
 description: "My API CLI"       # string shown in command help
 version: "0.1.0"                # string baked into generated binary
-base_url: "https://api.example.com/v1" # string (REQUIRED) default base API URL
+source: ""                       # string optional source archetype; local-sqlite means no HTTP API origin
+base_url: "https://api.example.com/v1" # string (REQUIRED unless source: local-sqlite) default base API URL
 http_transport: standard          # string optional: standard | browser-http | browser-chrome | browser-chrome-h3
 health_check_path: "/health"      # string optional doctor reachability path; defaults to /
 required_headers:                 # []RequiredHeader optional headers sent on every request
@@ -372,7 +373,8 @@ pass nested payloads without hand-written Go.
 Validation in `spec.Validate()` enforces:
 
 - `name` is required
-- root `base_url` is required unless `base_path` is supplied
+- `source`, when set, must be `local-sqlite`
+- root `base_url` is required unless `base_path` is supplied or `source: local-sqlite` declares an operator-local SQLite source with no HTTP API origin
 - at least one `resources` entry is required
 - every resource must have at least one endpoint
 - every endpoint must have both `method` and `path`
@@ -385,7 +387,7 @@ Validation in `spec.Validate()` enforces:
 
 These commonly cause generation/build failures or incorrect CLI behavior:
 
-- Missing required fields (`name`, root `base_url`, resource endpoints, endpoint `method`, endpoint `path`)
+- Missing required fields (`name`, root `base_url` for HTTP specs, resource endpoints, endpoint `method`, endpoint `path`)
 - Invalid `method` values (generator templates only handle `GET`, `POST`, `PUT`, `DELETE`)
 - Missing `path` on endpoints
 - Defining `body` params on `GET` endpoints (allowed in YAML, but ignored by GET command generation)


### PR DESCRIPTION
## Summary

Local-datastore specs now have a first-class internal spec front door. A spec can declare `source: local-sqlite`, omit `base_url`, and generation stamps `.printing-press.json` with `spec_format: local-sqlite` so reprints keep the verifier-recognized archetype instead of falling back to `internal`.

HTTP-shaped specs still fail validation when they omit `base_url`, and unknown `source` values are rejected rather than silently falling through.

## Verification

- `go test ./internal/spec -run 'TestValidation(AllowsLocalSQLiteSourceWithoutBaseURL|RejectsUnknownSource|)$'`
- `go test ./internal/pipeline -run 'TestWriteManifestForGenerate(StampsLocalSQLiteSpecFormat|WithLocalSpec)$'`
- Generated a throwaway `source: local-sqlite` spec with no `base_url`; manifest contained `spec_format: local-sqlite`, and the generated module passed `go mod tidy && go test ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- `golangci-lint run ./...`

Closes #2668

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
