### PR TITLE
fix(cli): add timeout helper for novel commands

### DIFF
--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -94,6 +94,62 @@ func TestNovelFeatureStubsResolveAtRuntime(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli")
 }
 
+func TestGeneratorEmitsBoundCtxHelperForNovelCommands(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("timeoutnovel")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Sibling client scan",
+			Command:     "scan",
+			Description: "Scan via a sibling client.",
+			Example:     "timeoutnovel-pp-cli scan --json",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	helpers := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	assert.Contains(t, helpers, "func boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc)")
+	assert.Contains(t, helpers, "return context.WithTimeout(parent, flags.timeout)")
+
+	var runtimeTest strings.Builder
+	runtimeTest.WriteString(`package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBoundCtxAppliesRootTimeout(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel := boundCtx(parent, &rootFlags{timeout: 25 * time.Millisecond})
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatalf("boundCtx did not apply a deadline")
+	}
+	if time.Until(deadline) <= 0 {
+		t.Fatalf("deadline already expired")
+	}
+}
+
+func TestBoundCtxNoopsWithoutTimeout(t *testing.T) {
+	parent := context.Background()
+	ctx, cancel := boundCtx(parent, &rootFlags{})
+	defer cancel()
+	if ctx != parent {
+		t.Fatalf("boundCtx should return the parent context when timeout is unset")
+	}
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "bound_ctx_runtime_test.go"), []byte(runtimeTest.String()), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/cli")
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGeneratorSkipsNovelFeatureWiringForAbsorbedEndpointCollisions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -284,6 +284,17 @@ func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
 }
 
+// boundCtx applies the root --timeout flag to hand-written command work that
+// does not go through the generated internal/client.Client. Generated endpoint
+// commands already pass flags.timeout into client.New; sibling typed clients
+// used by novel commands need an explicit command-level context boundary.
+func boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc) {
+	if flags == nil || flags.timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, flags.timeout)
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
 // subcommand. In machine output (--json/--agent) the parent emits a structured
 // error to stdout listing valid subcommands and exits 2; otherwise cobra's

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -337,6 +337,8 @@ func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	assert.Equal(t, 3, strings.Count(starters, "if len(args) == 0 && cmd.Flags().NFlag() == 0 {"))
 	assert.Equal(t, 3, strings.Count(starters, "return cmd.Help()"))
 	assert.Equal(t, 3, strings.Count(starters, "if dryRunOK(flags) {"))
+	assert.Equal(t, 3, strings.Count(starters, "ctx, cancel := boundCtx(cmd.Context(), flags)"))
+	assert.Equal(t, 3, strings.Count(starters, "defer cancel()"))
 	assert.Equal(t, 3, strings.Count(starters, "_ = cmd.Usage()"))
 	assert.Equal(t, 3, strings.Count(starters, `return usageErr(fmt.Errorf("<flag-or-arg> is required"))`))
 	assert.Contains(t, starters, "**RunE skeleton — parallel-fetch aggregation shape**")
@@ -347,9 +349,23 @@ func TestPrintingPressSkillRunERequiredInputContract(t *testing.T) {
 	assert.Contains(t, starters, "partial results: %d of %d fetches failed; average computed over %d items")
 }
 
+func TestPrintingPressSkillRequiresPerCommandTimeoutBoundary(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	checklist := substringBetween(t, skill, "### Agent Build Checklist (per command)", "#### Verify-friendly RunE template")
+	helpers := substringBetween(t, skill, "**Helpers already emitted by the generator.**", "```go")
+	review := substringBetween(t, skill, "## Phase 4.95: Local Code Review", "**Tool selection")
+
+	assert.Contains(t, checklist, "11. **Per-command timeout boundary**")
+	assert.Contains(t, checklist, "boundCtx(cmd.Context(), flags)")
+	assert.Contains(t, checklist, "Generated endpoint commands already pass `flags.timeout` into `client.New`")
+	assert.Contains(t, helpers, "`boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc)`")
+	assert.Contains(t, review, "**Native timeout-boundary check.**")
+	assert.Contains(t, review, "Files that only use `flags.newClient()` / generated `internal/client`")
+}
+
 func TestPrintingPressSkillRequiresScanAndFilterCaps(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
-	block := substringBetween(t, skill, "12. **Scan-and-filter caps**", "#### Verify-friendly RunE template")
+	block := substringBetween(t, skill, "13. **Scan-and-filter caps**", "#### Verify-friendly RunE template")
 
 	assert.Contains(t, block, `"list, filter locally, fan out to detail"`)
 	assert.Contains(t, block, "**`--max-scan-pages int`**")

--- a/internal/pipeline/dead_code_allowlist.go
+++ b/internal/pipeline/dead_code_allowlist.go
@@ -1,0 +1,10 @@
+package pipeline
+
+func isAllowedDeadHelper(name string) bool {
+	switch name {
+	case "boundCtx":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/pipeline/dead_code_allowlist.go
+++ b/internal/pipeline/dead_code_allowlist.go
@@ -1,8 +1,12 @@
 package pipeline
 
+// isAllowedDeadHelper reports whether name is a generated helper intentionally
+// emitted into every printed CLI as an extension point, even when a particular
+// generated tree does not call it yet. Keep this list narrow: entries here are
+// excluded from checkDeadFunctions, scoreDeadCode, and findAllDeadFunctions.
 func isAllowedDeadHelper(name string) bool {
 	switch name {
-	case "boundCtx":
+	case "boundCtx": // used by hand-written novel commands; unused in endpoint-only CLIs
 		return true
 	default:
 		return false

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1890,6 +1890,9 @@ func checkDeadFunctions(dir string) DeadCodeResult {
 
 	names := make(map[string]struct{})
 	for _, match := range matches {
+		if isAllowedDeadHelper(match[1]) {
+			continue
+		}
 		names[match[1]] = struct{}{}
 	}
 

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -44,6 +44,7 @@ func configure(flags *rootFlags) {
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "helpers.go"), `package cli
 func usedHelper() {}
 func deadHelper() {}
+func boundCtx() {}
 `)
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "users_list.go"), `package cli
 func usersList() {

--- a/internal/pipeline/polish.go
+++ b/internal/pipeline/polish.go
@@ -184,7 +184,7 @@ func findAllDeadFunctions(cliDir string, extraSearchDirs ...string) []string {
 	seen := map[string]bool{}
 	var dead []string
 	for _, def := range allDefs {
-		if seen[def.name] || skipNames[def.name] {
+		if seen[def.name] || skipNames[def.name] || isAllowedDeadHelper(def.name) {
 			continue
 		}
 		if strings.HasPrefix(def.name, "Test") || strings.HasPrefix(def.name, "Benchmark") {

--- a/internal/pipeline/polish_test.go
+++ b/internal/pipeline/polish_test.go
@@ -223,6 +223,20 @@ func funcB() { funcA() }
 		assert.Empty(t, dead)
 	})
 
+	t.Run("keeps generated extension point helpers", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_ = os.WriteFile(filepath.Join(dir, "helpers.go"), []byte(`package cli
+
+func boundCtx() {}
+
+func deadHelper() {}
+`), 0o644)
+
+		dead := findAllDeadFunctions(dir)
+		assert.Equal(t, []string{"deadHelper"}, dead)
+	})
+
 	t.Run("empty directory", func(t *testing.T) {
 		dir := t.TempDir()
 		dead := findAllDeadFunctions(dir)

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -3316,6 +3316,9 @@ func scoreDeadCode(dir string) int {
 	// Use Count >= 2 because the definition itself contributes 1 occurrence of name+"(".
 	allContent := helpersContent + "\n" + otherHelpers
 	for _, name := range funcNames {
+		if isAllowedDeadHelper(name) {
+			continue
+		}
 		if strings.Count(allContent, name+"(") < 2 {
 			deadFunctions++
 		}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -274,6 +274,8 @@ package cli
 func filterFields() {}
 
 func outputCSV() {}
+
+func boundCtx() {}
 `)
 
 		// 2 dead flags (csvOutput, stdinInput), 2 dead functions (filterFields, outputCSV)

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2995,7 +2995,7 @@ Priority 3 (polish):
 
 ### Agent Build Checklist (per command)
 
-After building each command in Priority 1 and Priority 2, verify these 12 principles are met. These map 1:1 to what Phase 4.9's agent readiness reviewer will check - apply them now so the review becomes a confirmation, not a catch-all.
+After building each command in Priority 1 and Priority 2, verify these 13 principles are met. These map 1:1 to what Phase 4.9's agent readiness reviewer will check - apply them now so the review becomes a confirmation, not a catch-all.
 
 1. **Non-interactive**: No TTY prompts, no `bufio.Scanner(os.Stdin)`, works in CI without a terminal
 2. **Structured output**: `--json` produces valid JSON, `--select` filters fields correctly. Hand-written novel commands that build a Go-typed slice/struct and emit JSON should use the generated receiver-style helper, `flags.printJSON(cmd, v)`, or call `printJSONFiltered(cmd.OutOrStdout(), v, flags)` directly. Both route through `printOutputWithFlags`, picking up `--select`, `--compact`, `--csv`, and `--quiet` for free. Verify with `<cli> <novel> --json --select <field> | jq 'keys'` returning only the requested fields.
@@ -3025,12 +3025,13 @@ After building each command in Priority 1 and Priority 2, verify these 12 princi
      ```
      Distinct from `IsVerifyEnv`: dogfood is a real-API matrix, so curtail work (paginate once, smaller `--limit`), never substitute mock data for real calls.
 10. **Per-source rate limiting**: any hand-written client in a sibling internal package (`internal/source/<name>/`, `internal/recipes/`, `internal/phgraphql/`, etc. — anything not generator-emitted) that makes outbound HTTP calls MUST use `cliutil.AdaptiveLimiter` and surface `*cliutil.RateLimitError` when 429 retries are exhausted. Empty-on-throttle is indistinguishable from "no data exists" and silently corrupts downstream queries. Read [references/per-source-rate-limiting.md](references/per-source-rate-limiting.md) when authoring a sibling client. Enforced at generation time by dogfood's `source_client_check`.
-11. **Parallel-fetch partial failures**: any command that fans out N API calls and computes an aggregate (averages, rollups, comparisons, cross-source merges, digest summaries) MUST preserve each fetch error through the result channel and exclude error-tagged entries from totals and denominators. Failed fetches may still appear in the response so the caller can see the gap, but they must not become zero-valued phantom rows that dilute averages or counts. Surface the partial failure explicitly with:
+11. **Per-command timeout boundary**: Hand-written novel commands that call a sibling typed HTTP client (`internal/<api>/`, `internal/source/<name>/`, `internal/recipes/`, etc.) MUST wrap `cmd.Context()` with `boundCtx(cmd.Context(), flags)` and `defer cancel()` before the first client call. Generated endpoint commands already pass `flags.timeout` into `client.New`; sibling clients do not. Without this boundary, root `--timeout` is advertised in help but does not bound wide scans, crawlers, or fan-out loops.
+12. **Parallel-fetch partial failures**: any command that fans out N API calls and computes an aggregate (averages, rollups, comparisons, cross-source merges, digest summaries) MUST preserve each fetch error through the result channel and exclude error-tagged entries from totals and denominators. Failed fetches may still appear in the response so the caller can see the gap, but they must not become zero-valued phantom rows that dilute averages or counts. Surface the partial failure explicitly with:
    - a stderr warning that names the failed count and the actual aggregation denominator, for example `warning: 2 of 10 fetches failed; averages computed over the remaining 8 items`
    - a `fetch_failures` field in the JSON response envelope listing the failed entries and error messages
 
 Silently averaging phantom zeros is worse than reporting a partial result.
-12. **Scan-and-filter caps**: any hand-written transcendence command that scans
+13. **Scan-and-filter caps**: any hand-written transcendence command that scans
     a paginated or otherwise unsorted endpoint, filters locally, and then keeps
     matching rows MUST bound scan effort separately from output size. This is the
     "list, filter locally, fan out to detail" shape: the API cannot filter on the
@@ -3285,6 +3286,7 @@ The generator handles Priority 0 (data layer) and most of Priority 1 (absorbed A
 - `printAutoTable(w io.Writer, items []map[string]any) error` - render JSON-like rows as the generated human table format.
 - `defaultDBPath(name string) string` - resolve the local SQLite database path for `<name>`.
 - `dryRunOK(flags *rootFlags) bool` - detect verify-friendly `--dry-run` short-circuits before network, store, or filesystem work.
+- `boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc)` - apply root `--timeout` to hand-written commands that call sibling typed clients instead of the generated `internal/client`.
 - `filterFields(data json.RawMessage, fields string) json.RawMessage` - apply `--select` to a JSON blob.
 - `compactFields(data json.RawMessage) json.RawMessage` - apply `--compact` to a JSON blob.
 - `isTerminal(w io.Writer) bool` - detect terminal output versus pipes.
@@ -3336,7 +3338,7 @@ func newNovelXxxCmd(flags *rootFlags) *cobra.Command {
 // Single-word Commands register directly: rootCmd.AddCommand(newNovelXxxCmd(flags)).
 ```
 
-**RunE skeleton — API-call shape** (live data via the generated client):
+**RunE skeleton — API-call shape** (live data via a sibling typed client):
 
 ```go
 RunE: func(cmd *cobra.Command, args []string) error {
@@ -3347,18 +3349,20 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "would fetch <resource>")
 		return nil
 	}
+	ctx, cancel := boundCtx(cmd.Context(), flags)
+	defer cancel()
 	if <required input missing> {
 		_ = cmd.Usage()
 		return usageErr(fmt.Errorf("<flag-or-arg> is required"))
 	}
-	c, err := flags.newClient()
+	c, err := newSiblingClient(flags) // replace with your internal/<api> or internal/source/<name> constructor
 	if err != nil {
 		return err
 	}
-	// Replace path with the absorbed endpoint or hand-rolled URL. Use
-	// cliutil.FanoutRun for any --site/--source/--region CSV fan-out;
-	// re-implementing fanout inline is the recipe-goat silent-drop bug.
-	data, err := c.Get("/api/v1/path", nil)
+	// Pass ctx to every sibling-client request so root --timeout bounds
+	// crawls, wide scans, and fan-out loops. Generated endpoint commands that
+	// use flags.newClient()/internal/client already consume flags.timeout.
+	data, err := c.FetchResource(ctx, <request params>)
 	if err != nil {
 		return fmt.Errorf("fetching <resource>: %w", err)
 	}
@@ -3391,11 +3395,13 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "would fetch <resource> details")
 		return nil
 	}
+	ctx, cancel := boundCtx(cmd.Context(), flags)
+	defer cancel()
 	if <required input missing> {
 		_ = cmd.Usage()
 		return usageErr(fmt.Errorf("<flag-or-arg> is required"))
 	}
-	c, err := flags.newClient()
+	c, err := newSiblingClient(flags) // replace with your internal/<api> or internal/source/<name> constructor
 	if err != nil {
 		return err
 	}
@@ -3412,7 +3418,7 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			data, err := c.Get("/api/v1/resource/"+url.PathEscape(id), nil)
+			data, err := c.FetchDetail(ctx, id)
 			if err != nil {
 				results <- fetchResult{idx: idx, id: id, err: err}
 				return
@@ -3490,6 +3496,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "would query local store")
 		return nil
 	}
+	ctx, cancel := boundCtx(cmd.Context(), flags)
+	defer cancel()
 	if <required input missing> {
 		_ = cmd.Usage()
 		return usageErr(fmt.Errorf("<flag-or-arg> is required"))
@@ -3497,7 +3505,7 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	if dbPath == "" {
 		dbPath = defaultDBPath("<cli>-pp-cli") // replace <cli> with the API slug
 	}
-	db, err := store.OpenWithContext(cmd.Context(), dbPath)
+	db, err := store.OpenWithContext(ctx, dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
@@ -3508,7 +3516,7 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	// API only exposes the resource flat; add a <resource_singular>
 	// entry for APIs that toggle plural/singular casing. SQL must be
 	// SELECT-only; the search/sql gates reject mutating statements.
-	rows, err := db.DB().QueryContext(cmd.Context(), `
+	rows, err := db.DB().QueryContext(ctx, `
 		SELECT id, data FROM resources
 		WHERE resource_type IN ('<resource>', '<parent>_<resource>')
 		  AND ...`)
@@ -3817,6 +3825,8 @@ The sub-skill carries `context: fork` so the reviewer agent's diagnostic chatter
 **Runs after Phase 4.85, before Phase 5.** Reviews the printed CLI source for security and correctness issues *before* any PR exists. This is the cheapest fix window in the pipeline — session context is hot, no PR feedback round-trip, no CI comments to chase. Catching issues here means they never become PR-time review comments, which is the wrong fix window for the same problems.
 
 **Target.** The generated CLI and MCP source under `$CLI_WORK_DIR`. In scope: `internal/cli/`, `internal/mcp/` (excluding `cobratree/`), `internal/store/`, `internal/client/`, and `cmd/`. **Out of scope:** `internal/cliutil/` and `internal/mcp/cobratree/` — these are generator-reserved packages. Any finding there is a machine bug; route to retro, do not patch in place.
+
+**Native timeout-boundary check.** Before reviewer dispatch, scan every hand-written file under `internal/cli/` that imports a sibling internal package (`internal/<api>/`, `internal/source/<name>/`, `internal/recipes/`, `internal/phgraphql/`, etc.) and makes live requests. Each such command file must call `boundCtx(cmd.Context(), flags)` and pass that context into the sibling client or store query path before the first request. Files that only use `flags.newClient()` / generated `internal/client` are already covered by `client.New(cfg, flags.timeout, ...)` and should not be flagged for missing `boundCtx`.
 
 **Tool selection — pick what's installed, do not name-match.** This phase needs *a* code review, not a specific named command. Survey the review-shaped capabilities the current harness has and pick the best fit. Plausible candidates (names drift across harnesses and plugin sets; treat this as an example list, not a closed set):
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -135,6 +135,17 @@ func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
 }
 
+// boundCtx applies the root --timeout flag to hand-written command work that
+// does not go through the generated internal/client.Client. Generated endpoint
+// commands already pass flags.timeout into client.New; sibling typed clients
+// used by novel commands need an explicit command-level context boundary.
+func boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc) {
+	if flags == nil || flags.timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, flags.timeout)
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
 // subcommand. In machine output (--json/--agent) the parent emits a structured
 // error to stdout listing valid subcommands and exits 2; otherwise cobra's

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -134,6 +134,17 @@ func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
 }
 
+// boundCtx applies the root --timeout flag to hand-written command work that
+// does not go through the generated internal/client.Client. Generated endpoint
+// commands already pass flags.timeout into client.New; sibling typed clients
+// used by novel commands need an explicit command-level context boundary.
+func boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc) {
+	if flags == nil || flags.timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, flags.timeout)
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
 // subcommand. In machine output (--json/--agent) the parent emits a structured
 // error to stdout listing valid subcommands and exits 2; otherwise cobra's

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -210,6 +210,17 @@ func dryRunOK(flags *rootFlags) bool {
 	return flags != nil && flags.dryRun
 }
 
+// boundCtx applies the root --timeout flag to hand-written command work that
+// does not go through the generated internal/client.Client. Generated endpoint
+// commands already pass flags.timeout into client.New; sibling typed clients
+// used by novel commands need an explicit command-level context boundary.
+func boundCtx(parent context.Context, flags *rootFlags) (context.Context, context.CancelFunc) {
+	if flags == nil || flags.timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, flags.timeout)
+}
+
 // parentNoSubcommandRunE returns a RunE that handles parents invoked without a
 // subcommand. In machine output (--json/--agent) the parent emits a structured
 // error to stdout listing valid subcommands and exits 2; otherwise cobra's


### PR DESCRIPTION
## Summary

Hand-written novel commands now have a generated `boundCtx` helper available for propagating the root `--timeout` flag into sibling typed clients and store-query paths. The Printing Press skill now calls out that timeout boundary in the agent build checklist, starter RunE skeletons, and local code-review phase so future novel commands do not bypass the advertised request timeout.

The dead-helper gates now treat `boundCtx` as an intentional generated extension point, so endpoint-only CLIs can still build, dogfood, score, and polish cleanly before any novel sibling-client command uses it.

Closes #2705

## Verification

- `go test ./internal/generator -run 'TestGenerator(EmitsBoundCtxHelperForNovelCommands|EmitsNovelFeatureCommandStubs)'`
- `go test ./internal/pipeline -run 'TestPrintingPressSkillRequires(PerCommandTimeoutBoundary|ScanAndFilterCaps|VerifyFriendlyRunEPattern)|TestRunDogfood|TestScoreDeadCode|TestFindAllDeadFunctions'`
- `scripts/verify-generator-output.sh generate-golden-api generate-embedded-paged-api`
- `scripts/golden.sh verify`
- `go fmt ./...`
- `go test ./...`
