### PR TITLE
fix(skills): rebuild stale repo preflight binary

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -73,3 +73,25 @@ func TestPrintingPressSkillReachabilityGateAllowsLANOnlyCarveout(t *testing.T) {
 	require.Contains(t, content, "do not use this carve-out for normal public/cloud origins such as `https://api.example.com`")
 	require.Contains(t, content, "those still run the reachability probe and decision matrix below")
 }
+
+func TestPrintingPressSkillRebuildsStaleRepoLocalBinary(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+	setupChecks, err := os.ReadFile("../../skills/printing-press/references/setup-checks.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "_source_press_version()")
+	require.Contains(t, content, "_rebuild_local_press_bin_if_stale()")
+	require.Contains(t, content, "[local-binary-stale] local build v$_local_v is older than source v$_source_v")
+	require.Contains(t, content, "go build -o ./cli-printing-press ./cmd/cli-printing-press")
+	require.Contains(t, content, "[local-binary-rebuilt] rebuilt $_scope_dir/cli-printing-press")
+	require.Contains(t, content, "hooks can be absent or")
+	require.NotContains(t, content, "always newer than the go-install version")
+
+	setupContent := string(setupChecks)
+	require.Contains(t, setupContent, "[local-binary-stale]` / `[local-binary-rebuilt]")
+	require.Contains(t, setupContent, "The repo-mode local binary was older than the checked-out source version")
+}

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -845,6 +845,7 @@ var Version = "`+sourceVersion+`" // x-release-please-version
 	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript(localVersion))
 
 	goLogPath := filepath.Join(root, "go.log")
+	require.NoError(t, os.WriteFile(goLogPath, nil, 0o644))
 	writeExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
 echo "$@" >> "$GO_LOG"
 if [ "$1" = "run" ]; then

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -74,9 +74,16 @@ func TestSkillSetupBlocksMatchWorkspaceContract(t *testing.T) {
 			assert.Contains(t, block, `PRESS_RUNSTATE="$PRESS_HOME/.runstate/$PRESS_SCOPE"`)
 			assert.Contains(t, block, `PRESS_LIBRARY="$PRESS_HOME/library"`)
 
-			// May reference local build for repo-internal development,
-			// but must not hardcode go build or use ./cli-printing-press as default
-			assert.NotContains(t, block, `go build`)
+			// May reference local build for repo-internal development.
+			// Only /printing-press may rebuild it, and only after a stale local
+			// binary is detected against the checked-out source version.
+			if filepath.Base(filepath.Dir(tt.path)) == "printing-press" {
+				assert.Contains(t, block, `_rebuild_local_press_bin_if_stale`)
+				assert.Contains(t, block, `[local-binary-stale]`)
+				assert.Contains(t, block, `go build -o ./cli-printing-press ./cmd/cli-printing-press`)
+			} else {
+				assert.NotContains(t, block, `go build`)
+			}
 			// Must NOT contain REPO_ROOT or cd to repo
 			assert.NotContains(t, block, `REPO_ROOT`)
 			assert.NotContains(t, block, `cd "$REPO_ROOT"`)
@@ -88,6 +95,28 @@ func TestSkillSetupBlocksMatchWorkspaceContract(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrintingPressSetupContractRebuildsStaleRepoLocalBinary(t *testing.T) {
+	t.Parallel()
+
+	output, goLog := runPrintingPressSetupContract(t, "4.12.0", "4.23.0")
+
+	assert.Contains(t, output, "[local-binary-stale] local build v4.12.0 is older than source v4.23.0")
+	assert.Contains(t, output, "[local-binary-rebuilt] rebuilt")
+	assert.Contains(t, output, "PRINTING_PRESS_BIN=")
+	assert.Contains(t, goLog, "build -o ./cli-printing-press ./cmd/cli-printing-press")
+}
+
+func TestPrintingPressSetupContractLeavesFreshRepoLocalBinaryAlone(t *testing.T) {
+	t.Parallel()
+
+	output, goLog := runPrintingPressSetupContract(t, "4.23.0", "4.23.0")
+
+	assert.NotContains(t, output, "[local-binary-stale]")
+	assert.NotContains(t, output, "[local-binary-rebuilt]")
+	assert.Contains(t, output, "PRINTING_PRESS_BIN=")
+	assert.NotContains(t, goLog, "build -o ./cli-printing-press ./cmd/cli-printing-press")
 }
 
 func TestSkillsEnforceCurrencyFloor(t *testing.T) {
@@ -795,6 +824,96 @@ func extractContractBlock(t *testing.T, content string) string {
 	require.NotEqual(t, -1, endIdx, "missing contract end marker")
 
 	return content[startIdx : startIdx+endIdx]
+}
+
+func runPrintingPressSetupContract(t *testing.T, localVersion, sourceVersion string) (output string, goLog string) {
+	t.Helper()
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	fakeBin := filepath.Join(root, "bin")
+	home := filepath.Join(root, "home")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "cmd", "cli-printing-press"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "internal", "version"), 0o755))
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/press\n\ngo 1.20\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "internal", "version", "version.go"), []byte(`package version
+
+var Version = "`+sourceVersion+`" // x-release-please-version
+`), 0o644))
+	writeExecutable(t, filepath.Join(repo, "cli-printing-press"), versionScript(localVersion))
+
+	goLogPath := filepath.Join(root, "go.log")
+	writeExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+echo "$@" >> "$GO_LOG"
+if [ "$1" = "run" ]; then
+  exit 0
+fi
+if [ "$1" = "build" ]; then
+  out=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      shift
+      out="$1"
+      break
+    fi
+    shift
+  done
+  if [ -z "$out" ]; then
+    echo "missing -o" >&2
+    exit 1
+  fi
+  cat > "$out" <<'__PP_FAKE_BINARY__'
+`+versionScript(sourceVersion)+`__PP_FAKE_BINARY__
+  chmod +x "$out"
+  exit 0
+fi
+exit 0
+`)
+
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = repo
+	gitInitOutput, err := gitInit.CombinedOutput()
+	require.NoError(t, err, string(gitInitOutput))
+
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
+	contract := extractContractBlock(t, skill)
+	contract = strings.ReplaceAll(contract, "```bash\n", "")
+	contract = strings.ReplaceAll(contract, "\n```", "")
+	scriptPath := filepath.Join(root, "setup-contract.sh")
+	writeExecutable(t, scriptPath, "#!/bin/sh\n"+contract)
+
+	cmd := exec.Command(scriptPath)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(),
+		"ARGUMENTS=",
+		"GO_LOG="+goLogPath,
+		"HOME="+home,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"PRINTING_PRESS_HOME="+filepath.Join(home, "printing-press"),
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	logBytes, err := os.ReadFile(goLogPath)
+	require.NoError(t, err)
+	return string(out), string(logBytes)
+}
+
+func versionScript(version string) string {
+	return `#!/bin/sh
+if [ "$1" = "version" ] && [ "$2" = "--json" ]; then
+  echo '{"version":"` + version + `"}'
+  exit 0
+fi
+echo "cli-printing-press ` + version + `"
+`
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
 }
 
 func substringBetween(t *testing.T, content, start, end string) string {

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -141,9 +141,57 @@ _resolve_press_bin() {
   return 1
 }
 
+# Strict-older semver compare on the first three components. Pre-release
+# suffixes collapse to their GA counterpart (acceptable: we ship no pre-release
+# tags).
+_semver_lt() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, x, ".")
+    split(b, y, ".")
+    for (i = 1; i <= 3; i++) {
+      if ((x[i] + 0) < (y[i] + 0)) exit 0
+      if ((x[i] + 0) > (y[i] + 0)) exit 1
+    }
+    exit 1
+  }'
+}
+
+_source_press_version() {
+  sed -nE 's/^var[[:space:]]+Version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+    "$_scope_dir/internal/version/version.go" 2>/dev/null | head -n 1
+}
+
+_rebuild_local_press_bin_if_stale() {
+  if [ "$_press_repo" != "true" ] || [ ! -x "$_scope_dir/cli-printing-press" ]; then
+    return 0
+  fi
+
+  _local_v="$("$_scope_dir/cli-printing-press" version --json 2>/dev/null | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
+  _source_v="$(_source_press_version)"
+  if [ -z "$_local_v" ] || [ -z "$_source_v" ] || ! _semver_lt "$_local_v" "$_source_v"; then
+    return 0
+  fi
+
+  echo ""
+  echo "[local-binary-stale] local build v$_local_v is older than source v$_source_v"
+  if ! command -v go >/dev/null 2>&1; then
+    echo "[setup-error] local cli-printing-press binary is stale and Go is not on PATH, so it cannot be rebuilt."
+    return 1 2>/dev/null || exit 1
+  fi
+
+  if (cd "$_scope_dir" && go build -o ./cli-printing-press ./cmd/cli-printing-press); then
+    echo "[local-binary-rebuilt] rebuilt $_scope_dir/cli-printing-press"
+    echo ""
+  else
+    echo "[setup-error] local cli-printing-press binary is stale and rebuild failed."
+    return 1 2>/dev/null || exit 1
+  fi
+}
+
 # Prefer local build when running from inside the printing-press repo.
-# The lefthook build hook keeps ./cli-printing-press current after every commit/pull,
-# so it's always newer than the go-install version.
+# Lefthook may keep ./cli-printing-press current, but hooks can be absent or
+# disabled. Compare against the checked-out source version before trusting it.
+_rebuild_local_press_bin_if_stale || { return 1 2>/dev/null || exit 1; }
 if [ "$_press_repo" = "true" ] && [ -x "$_scope_dir/cli-printing-press" ]; then
   export PATH="$_scope_dir:$PATH"
   echo "Using local build: $_scope_dir/cli-printing-press"
@@ -323,20 +371,6 @@ PRESS_VERCHECK_FILE="$PRESS_HOME/.version-check"
 PRESS_VERCHECK_TTL=86400
 _now_ts=$(date +%s)
 
-# Strict-older semver compare on the first three components. Pre-release
-# suffixes collapse to their GA counterpart (acceptable: we ship no pre-release
-# tags).
-_semver_lt() {
-  awk -v a="$1" -v b="$2" 'BEGIN {
-    split(a, x, ".")
-    split(b, y, ".")
-    for (i = 1; i <= 3; i++) {
-      if ((x[i] + 0) < (y[i] + 0)) exit 0
-      if ((x[i] + 0) > (y[i] + 0)) exit 1
-    }
-    exit 1
-  }'
-}
 _should_check=true
 if [ -f "$PRESS_VERCHECK_FILE" ] && [ -z "$PRESS_VERCHECK_FORCE" ]; then
   _last_ts=$(awk -F= '/^last_check=/{print $2}' "$PRESS_VERCHECK_FILE" 2>/dev/null)
@@ -501,7 +535,7 @@ CODEX_CONSECUTIVE_FAILURES=0
 ```
 <!-- PRESS_SETUP_CONTRACT_END -->
 
-**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
+**MANDATORY: Read and apply [references/setup-checks.md](references/setup-checks.md) immediately after the setup contract bash block runs, before any other action.** It handles the contract output signals: `[setup-error]` (refuse to run, surface the install instructions), optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]` (interactive `AskUserQuestion` prompt + optional repo pull), `PRESS_REPO_MODE=<true|false>` plus the targeted global open-agent-skills freshness check, the min-binary-version compatibility check (hard stop if binary is too old), `[upgrade-required]` (hard gate below the published currency floor — interactive upgrade-or-abort, no skip), `[upgrade-available]` (interactive `AskUserQuestion` prompt + optional standalone binary upgrade), `[browser-tools-missing]` (interactive `AskUserQuestion` prompt + optional install of browser-use and/or agent-browser), and the `PRINTING_PRESS_BIN=<abs-path>` marker plus optional `[binary-shadow]` warning (capture the path; use it for every subsequent generator invocation). Skipping the reference will cause the skill to proceed with a missing or out-of-date binary, run with stale global skill text when the session is managed by open-agent-skills, hit a mid-flight install prompt if browser-sniff is later needed, or invoke the wrong binary because a stale global or the public catalog installer on `PATH` shadowed the local build. Do not skip.
 
 **Absolute-path rule.** The preflight contract always emits `PRINTING_PRESS_BIN=<absolute path>` to stdout. Capture this value and substitute it (the resolved absolute path, not the literal `$PRINTING_PRESS_BIN` token) for every subsequent `cli-printing-press ...` invocation in this skill, references, and any sub-skill you delegate to. The `export PATH=...` line inside the contract only affects the single Bash tool call it runs in; later Bash tool calls open fresh shells and resolve bare `cli-printing-press` against the user's default `PATH`, where a stale globally-installed binary (`$HOME/go/bin/cli-printing-press`, Homebrew copy, etc.) will silently shadow the local build the preflight just chose. Bash code examples below are written `cli-printing-press generate ...` for readability — replace `cli-printing-press` with the captured absolute path each time you actually run one.
 

--- a/skills/printing-press/references/setup-checks.md
+++ b/skills/printing-press/references/setup-checks.md
@@ -1,6 +1,6 @@
 # Setup Checks
 
-Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
+Post-contract checks the skill must run after executing the bash setup contract block in `SKILL.md`. These handle the contract output signals: `[setup-error]`, optional `[local-binary-stale]` / `[local-binary-rebuilt]` repo-mode rebuild markers, `[repo-upgrade-available]`, the always-emitted `PRINTING_PRESS_BIN=<abs-path>` and `PRESS_REPO_MODE=<true|false>` markers, the global open-agent-skills freshness check, the `min-binary-version` compatibility check, `[upgrade-required]`, `[upgrade-available]`, `[browser-tools-missing]`, and optional `[binary-shadow]` advisory.
 
 Apply these in order. The preamble below runs unconditionally; each numbered section after it is conditional — do nothing if its trigger isn't present.
 
@@ -21,6 +21,8 @@ If the setup contract output contains a line starting with `[setup-error]`, a re
 **Stop the skill immediately.** Do not proceed to research, generation, or any other work. Surface the message the contract printed (it includes the exact install command or download URL) verbatim to the user.
 
 The user must install the missing prerequisite in their terminal before re-running. Do not offer to auto-install — the README's install flow is the source of truth for the binary, and silent auto-install hides failure modes (network, wrong GOPATH, no Go toolchain) inside an opaque skill invocation.
+
+If the contract output contains `[local-binary-stale]` followed by `[local-binary-rebuilt]`, continue setup. The repo-mode local binary was older than the checked-out source version and the contract rebuilt it before emitting `PRINTING_PRESS_BIN`. If `[local-binary-stale]` is followed by `[setup-error]`, this section's refusal rule applies.
 
 ## 2. Interactive repo upgrade prompt
 


### PR DESCRIPTION
## Summary

Repo-mode `/printing-press` setup no longer trusts an existing `./cli-printing-press` blindly. If the local repo binary is older than the checked-out source version, the preflight rebuilds it before emitting `PRINTING_PRESS_BIN`; if that rebuild cannot happen, setup stops instead of continuing with a known-stale binary.

Closes #2497

## Approach

The setup contract now parses the checked-out source version from `internal/version/version.go`, compares it with the repo-local binary's `version --json`, and rebuilds `./cli-printing-press` only when the local binary is strictly older. The setup-checks reference documents the new stale/rebuilt markers, and contract tests cover both stale rebuild and fresh no-op paths with an isolated fake repo.

## Risk

The changed behavior is limited to repo-mode setup for the main `/printing-press` skill. Standalone installs and the other setup contracts keep the existing no-rebuild behavior.

## Verification

- `go test ./internal/cli -run '^TestPrintingPressSkill'`
- `awk '/<!-- PRESS_SETUP_CONTRACT_START -->/{in_contract=1; next} /<!-- PRESS_SETUP_CONTRACT_END -->/{in_contract=0} in_contract && $0 !~ /^```/{print}' skills/printing-press/SKILL.md | bash -n`
- `go test ./internal/pipeline -run '^Test(PrintingPressSetupContract|SkillSetupBlocksMatchWorkspaceContract)'`
- `go test ./...`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `git diff --check`
