### PR TITLE
fix(cli): allow adaptive limiter backoff to floor

### DIFF
--- a/internal/generator/ratelimit_toctou_test.go
+++ b/internal/generator/ratelimit_toctou_test.go
@@ -1,7 +1,10 @@
 package generator
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -58,16 +61,47 @@ func TestAdaptiveLimiterFloor_AllowsBackoffToHalfRPS(t *testing.T) {
 	require.NoError(t, err)
 	src := string(srcBytes)
 
-	require.Contains(t, src, "floor:     0.5,")
+	require.Contains(t, src, "floor := 0.5")
+	require.Contains(t, src, "if ratePerSec < floor {")
+	require.Contains(t, src, "floor:     floor,")
 	require.Contains(t, src, "if l.rate < l.floor {")
 	require.NotContains(t, src, "floor:     ratePerSec,")
 
-	runGoCommandRequired(
+	requireGeneratedTestsPass(
 		t,
 		outputDir,
-		"test",
-		"./internal/cliutil",
-		"-run",
-		"TestAdaptiveLimiter_(HalvesOnRateLimit|FloorsAtHalfRPS)$",
+		"TestAdaptiveLimiter_(HalvesOnRateLimit|FloorsAtHalfRPS|DoesNotRaiseSubFloorRateOnRateLimit)$",
+		[]string{
+			"TestAdaptiveLimiter_HalvesOnRateLimit",
+			"TestAdaptiveLimiter_FloorsAtHalfRPS",
+			"TestAdaptiveLimiter_DoesNotRaiseSubFloorRateOnRateLimit",
+		},
 	)
+}
+
+func requireGeneratedTestsPass(t *testing.T, dir, pattern string, want []string) {
+	t.Helper()
+
+	cmd := exec.Command("go", "test", "-mod=mod", "-json", "./internal/cliutil", "-run", pattern)
+	cmd.Dir = dir
+	cacheDir, err := goBuildCacheDir(dir)
+	require.NoError(t, err)
+	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var event struct {
+		Action string `json:"Action"`
+		Test   string `json:"Test"`
+	}
+	seen := map[string]bool{}
+	dec := json.NewDecoder(bytes.NewReader(output))
+	for dec.Decode(&event) == nil {
+		if event.Action == "pass" && event.Test != "" {
+			seen[event.Test] = true
+		}
+	}
+	for _, name := range want {
+		require.Truef(t, seen[name], "generated test selector %q did not run %s", pattern, name)
+	}
 }

--- a/internal/generator/ratelimit_toctou_test.go
+++ b/internal/generator/ratelimit_toctou_test.go
@@ -87,15 +87,18 @@ func requireGeneratedTestsPass(t *testing.T, dir, pattern string, want []string)
 	cacheDir, err := goBuildCacheDir(dir)
 	require.NoError(t, err)
 	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	require.NoError(t, err, stderr.String())
 
 	var event struct {
 		Action string `json:"Action"`
 		Test   string `json:"Test"`
 	}
 	seen := map[string]bool{}
-	dec := json.NewDecoder(bytes.NewReader(output))
+	dec := json.NewDecoder(&stdout)
 	for dec.Decode(&event) == nil {
 		if event.Action == "pass" && event.Test != "" {
 			seen[event.Test] = true

--- a/internal/generator/ratelimit_toctou_test.go
+++ b/internal/generator/ratelimit_toctou_test.go
@@ -65,16 +65,18 @@ func TestAdaptiveLimiterFloor_AllowsBackoffToHalfRPS(t *testing.T) {
 	require.Contains(t, src, "if ratePerSec < floor {")
 	require.Contains(t, src, "floor:     floor,")
 	require.Contains(t, src, "if l.rate < l.floor {")
+	require.Contains(t, src, "if newRate < l.floor {")
 	require.NotContains(t, src, "floor:     ratePerSec,")
 
 	requireGeneratedTestsPass(
 		t,
 		outputDir,
-		"TestAdaptiveLimiter_(HalvesOnRateLimit|FloorsAtHalfRPS|DoesNotRaiseSubFloorRateOnRateLimit)$",
+		"TestAdaptiveLimiter_(HalvesOnRateLimit|FloorsAtHalfRPS|DoesNotRaiseSubFloorRateOnRateLimit|DoesNotRampBelowFloorAfterRateLimit)$",
 		[]string{
 			"TestAdaptiveLimiter_HalvesOnRateLimit",
 			"TestAdaptiveLimiter_FloorsAtHalfRPS",
 			"TestAdaptiveLimiter_DoesNotRaiseSubFloorRateOnRateLimit",
+			"TestAdaptiveLimiter_DoesNotRampBelowFloorAfterRateLimit",
 		},
 	)
 }

--- a/internal/generator/ratelimit_toctou_test.go
+++ b/internal/generator/ratelimit_toctou_test.go
@@ -46,3 +46,28 @@ func TestAdaptiveLimiterWait_ReservesUnderSingleLock(t *testing.T) {
 	require.Less(t, lockIdx, writeIdx, "Wait must hold lock before reservation write")
 	require.Less(t, writeIdx, unlockIdx, "Wait must not unlock before reservation write")
 }
+
+func TestAdaptiveLimiterFloor_AllowsBackoffToHalfRPS(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("ratelimit-floor")
+	outputDir := filepath.Join(t.TempDir(), "ratelimit-floor-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	srcBytes, err := os.ReadFile(filepath.Join(outputDir, "internal", "cliutil", "ratelimit.go"))
+	require.NoError(t, err)
+	src := string(srcBytes)
+
+	require.Contains(t, src, "floor:     0.5,")
+	require.Contains(t, src, "if l.rate < l.floor {")
+	require.NotContains(t, src, "floor:     ratePerSec,")
+
+	runGoCommandRequired(
+		t,
+		outputDir,
+		"test",
+		"./internal/cliutil",
+		"-run",
+		"TestAdaptiveLimiter_(HalvesOnRateLimit|FloorsAtHalfRPS)$",
+	)
+}

--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -35,7 +35,7 @@ func NewAdaptiveLimiter(ratePerSec float64) *AdaptiveLimiter {
 	}
 	return &AdaptiveLimiter{
 		rate:      ratePerSec,
-		floor:     ratePerSec,
+		floor:     0.5,
 		rampAfter: 10,
 	}
 }
@@ -83,8 +83,8 @@ func (l *AdaptiveLimiter) OnRateLimit() {
 	defer l.mu.Unlock()
 	l.ceiling = l.rate
 	l.rate = l.rate / 2
-	if l.rate < 0.5 {
-		l.rate = 0.5
+	if l.rate < l.floor {
+		l.rate = l.floor
 	}
 	l.successes = 0
 }

--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -33,9 +33,13 @@ func NewAdaptiveLimiter(ratePerSec float64) *AdaptiveLimiter {
 	if ratePerSec <= 0 {
 		return nil
 	}
+	floor := 0.5
+	if ratePerSec < floor {
+		floor = ratePerSec
+	}
 	return &AdaptiveLimiter{
 		rate:      ratePerSec,
-		floor:     0.5,
+		floor:     floor,
 		rampAfter: 10,
 	}
 }

--- a/internal/generator/templates/cliutil_ratelimit.go.tmpl
+++ b/internal/generator/templates/cliutil_ratelimit.go.tmpl
@@ -74,6 +74,9 @@ func (l *AdaptiveLimiter) OnSuccess() {
 		if l.ceiling > 0 && newRate > l.ceiling*0.9 {
 			newRate = l.ceiling * 0.9
 		}
+		if newRate < l.floor {
+			newRate = l.floor
+		}
 		l.rate = newRate
 		l.successes = 0
 	}

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -679,6 +679,15 @@ func TestAdaptiveLimiter_FloorsAtHalfRPS(t *testing.T) {
 	}
 }
 
+func TestAdaptiveLimiter_DoesNotRaiseSubFloorRateOnRateLimit(t *testing.T) {
+	l := NewAdaptiveLimiter(0.3)
+	startRate := l.Rate()
+	l.OnRateLimit()
+	if got := l.Rate(); got > startRate {
+		t.Errorf("Rate() after OnRateLimit = %v, want <= %v", got, startRate)
+	}
+}
+
 func TestAdaptiveLimiter_WaitEnforcesPacing(t *testing.T) {
 	l := NewAdaptiveLimiter(10.0)
 	l.Wait()

--- a/internal/generator/templates/cliutil_test.go.tmpl
+++ b/internal/generator/templates/cliutil_test.go.tmpl
@@ -688,6 +688,18 @@ func TestAdaptiveLimiter_DoesNotRaiseSubFloorRateOnRateLimit(t *testing.T) {
 	}
 }
 
+func TestAdaptiveLimiter_DoesNotRampBelowFloorAfterRateLimit(t *testing.T) {
+	l := NewAdaptiveLimiter(0.3)
+	floor := l.Rate()
+	l.OnRateLimit()
+	for i := 0; i < l.rampAfter; i++ {
+		l.OnSuccess()
+	}
+	if got := l.Rate(); got < floor {
+		t.Errorf("Rate() after ramping from rate-limit ceiling = %v, want >= %v", got, floor)
+	}
+}
+
 func TestAdaptiveLimiter_WaitEnforcesPacing(t *testing.T) {
 	l := NewAdaptiveLimiter(10.0)
 	l.Wait()

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -35,7 +35,7 @@ func NewAdaptiveLimiter(ratePerSec float64) *AdaptiveLimiter {
 	}
 	return &AdaptiveLimiter{
 		rate:      ratePerSec,
-		floor:     ratePerSec,
+		floor:     0.5,
 		rampAfter: 10,
 	}
 }
@@ -83,8 +83,8 @@ func (l *AdaptiveLimiter) OnRateLimit() {
 	defer l.mu.Unlock()
 	l.ceiling = l.rate
 	l.rate = l.rate / 2
-	if l.rate < 0.5 {
-		l.rate = 0.5
+	if l.rate < l.floor {
+		l.rate = l.floor
 	}
 	l.successes = 0
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -33,9 +33,13 @@ func NewAdaptiveLimiter(ratePerSec float64) *AdaptiveLimiter {
 	if ratePerSec <= 0 {
 		return nil
 	}
+	floor := 0.5
+	if ratePerSec < floor {
+		floor = ratePerSec
+	}
 	return &AdaptiveLimiter{
 		rate:      ratePerSec,
-		floor:     0.5,
+		floor:     floor,
 		rampAfter: 10,
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cliutil/ratelimit.go
@@ -74,6 +74,9 @@ func (l *AdaptiveLimiter) OnSuccess() {
 		if l.ceiling > 0 && newRate > l.ceiling*0.9 {
 			newRate = l.ceiling * 0.9
 		}
+		if newRate < l.floor {
+			newRate = l.floor
+		}
 		l.rate = newRate
 		l.successes = 0
 	}


### PR DESCRIPTION
## Summary

Generated AdaptiveLimiter instances now keep the stored backoff floor at 0.5 RPS instead of the starting rate. A 429 can now halve the current rate and clamp through the same floor field the limiter carries, so future generated CLIs match the existing runtime tests for halving and minimum backoff.

Closes #2374

## Tests

- `go test ./internal/generator -run 'TestAdaptiveLimiter(Wait_ReservesUnderSingleLock|Floor_AllowsBackoffToHalfRPS)$' -count=1`
- `scripts/verify-generator-output.sh generate-golden-api`
- `scripts/golden.sh verify`
- `go fmt ./...`
- `go test ./...`
