### PR TITLE
fix(cli): stamp printed MCP versions in bundles

### DIFF
--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -23,6 +23,7 @@ func newBundleCmd() *cobra.Command {
 	var binaryPath string
 	var cliSkipBuild bool
 	var cliBinaryPath string
+	var bundleVersion string
 
 	cmd := &cobra.Command{
 		Use:   "bundle <cli-dir>",
@@ -104,6 +105,7 @@ from another build pipeline.`,
 				CLIBinaryName: cliArchiveName,
 				CLIBinaryPath: cliBinaryPath,
 				OutputPath:    output,
+				Version:       bundleVersion,
 			}); err != nil {
 				return fmt.Errorf("packaging bundle: %w", err)
 			}
@@ -119,6 +121,7 @@ from another build pipeline.`,
 	cmd.Flags().StringVar(&binaryPath, "binary", "", "Pre-built MCP binary path (only meaningful with --skip-build)")
 	cmd.Flags().BoolVar(&cliSkipBuild, "cli-skip-build", false, "Skip go build for the companion CLI binary; use the binary at --cli-binary")
 	cmd.Flags().StringVar(&cliBinaryPath, "cli-binary", "", "Pre-built CLI binary path (only meaningful with --cli-skip-build)")
+	cmd.Flags().StringVar(&bundleVersion, "version", "", "Printed CLI release version to stamp into the bundled manifest")
 	return cmd
 }
 

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -136,8 +136,8 @@ func validateBundleVersion(version string) error {
 	if version == "" {
 		return nil
 	}
-	if strings.HasPrefix(version, "v") {
-		return fmt.Errorf("--version must not have a v prefix (got %q); use %q", version, strings.TrimPrefix(version, "v"))
+	if trimmed, ok := strings.CutPrefix(version, "v"); ok {
+		return fmt.Errorf("--version must not have a v prefix (got %q); use %q", version, trimmed)
 	}
 	if !bundleVersionPattern.MatchString(version) || !semver.IsValid("v"+version) {
 		return fmt.Errorf("--version must be a semantic version without a v prefix, e.g. %q (got %q)", "1.2.3", version)

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -136,8 +136,11 @@ func validateBundleVersion(version string) error {
 	if version == "" {
 		return nil
 	}
-	if strings.HasPrefix(version, "v") || !bundleVersionPattern.MatchString(version) || !semver.IsValid("v"+version) {
-		return fmt.Errorf("--version must be a semantic version without a v prefix (got %q)", version)
+	if strings.HasPrefix(version, "v") {
+		return fmt.Errorf("--version must not have a v prefix (got %q); use %q", version, strings.TrimPrefix(version, "v"))
+	}
+	if !bundleVersionPattern.MatchString(version) || !semver.IsValid("v"+version) {
+		return fmt.Errorf("--version must be a semantic version without a v prefix, e.g. %q (got %q)", "1.2.3", version)
 	}
 	return nil
 }

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/platform"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -75,6 +77,9 @@ from another build pipeline.`,
 			if manifest.Name == "" {
 				return fmt.Errorf("manifest.name is empty; cannot determine binary name")
 			}
+			if err := validateBundleVersion(bundleVersion); err != nil {
+				return &ExitError{Code: ExitInputError, Err: err}
+			}
 
 			goos, goarch, err := resolvePlatform(platform)
 			if err != nil {
@@ -123,6 +128,18 @@ from another build pipeline.`,
 	cmd.Flags().StringVar(&cliBinaryPath, "cli-binary", "", "Pre-built CLI binary path (only meaningful with --cli-skip-build)")
 	cmd.Flags().StringVar(&bundleVersion, "version", "", "Printed CLI release version to stamp into the bundled manifest")
 	return cmd
+}
+
+var bundleVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+
+func validateBundleVersion(version string) error {
+	if version == "" {
+		return nil
+	}
+	if strings.HasPrefix(version, "v") || !bundleVersionPattern.MatchString(version) || !semver.IsValid("v"+version) {
+		return fmt.Errorf("--version must be a semantic version without a v prefix (got %q)", version)
+	}
+	return nil
 }
 
 // autoBundleForHost packages a host-platform .mcpb after generate.

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -197,8 +197,15 @@ func TestNewBundleCmdVersionStampsBundledManifest(t *testing.T) {
 }
 
 func TestNewBundleCmdRejectsInvalidBundleVersion(t *testing.T) {
-	for _, version := range []string{"v0.1.4", "latest", "0.1"} {
-		t.Run(version, func(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		wantErr string
+	}{
+		{version: "v0.1.4", wantErr: "--version must not have a v prefix"},
+		{version: "latest", wantErr: "--version must be a semantic version"},
+		{version: "0.1", wantErr: "--version must be a semantic version"},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
 			dir := t.TempDir()
 			writeBundleManifest(t, dir, pipeline.MCPBManifest{
 				ManifestVersion: pipeline.MCPBManifestVersion,
@@ -213,11 +220,11 @@ func TestNewBundleCmdRejectsInvalidBundleVersion(t *testing.T) {
 
 			cmd := newBundleCmd()
 			cmd.SilenceUsage = true
-			cmd.SetArgs([]string{dir, "--version", version})
+			cmd.SetArgs([]string{dir, "--version", tc.version})
 
 			err := cmd.Execute()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "--version must be a semantic version")
+			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
 }

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -196,6 +196,32 @@ func TestNewBundleCmdVersionStampsBundledManifest(t *testing.T) {
 	assert.Contains(t, string(diskData), `"version":"0.0.0"`)
 }
 
+func TestNewBundleCmdRejectsInvalidBundleVersion(t *testing.T) {
+	for _, version := range []string{"v0.1.4", "latest", "0.1"} {
+		t.Run(version, func(t *testing.T) {
+			dir := t.TempDir()
+			writeBundleManifest(t, dir, pipeline.MCPBManifest{
+				ManifestVersion: pipeline.MCPBManifestVersion,
+				Name:            "demo-pp-mcp",
+				Version:         "0.0.0",
+				Server: pipeline.MCPBServer{
+					Type:       "binary",
+					EntryPoint: "bin/demo-pp-mcp",
+					MCPConfig:  pipeline.MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+				},
+			})
+
+			cmd := newBundleCmd()
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{dir, "--version", version})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--version must be a semantic version")
+		})
+	}
+}
+
 func TestNewBundleCmdWindowsPlatformBuildsToExeStagingPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake go shim uses POSIX shell")

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -156,6 +156,46 @@ func TestNewBundleCmdWindowsPlatformUsesExeNamesInMCPB(t *testing.T) {
 	assert.Equal(t, "${__dirname}/bin/demo-pp-mcp.exe", manifest.Server.MCPConfig.Command)
 }
 
+func TestNewBundleCmdVersionStampsBundledManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeBundleManifest(t, dir, pipeline.MCPBManifest{
+		ManifestVersion: pipeline.MCPBManifestVersion,
+		Name:            "demo-pp-mcp",
+		Version:         "0.0.0",
+		Server: pipeline.MCPBServer{
+			Type:       "binary",
+			EntryPoint: "bin/demo-pp-mcp",
+			MCPConfig:  pipeline.MCPBLaunchSpec{Command: "${__dirname}/bin/demo-pp-mcp"},
+		},
+	})
+
+	mcpBinary := filepath.Join(dir, "mcp")
+	outPath := filepath.Join(dir, "out.mcpb")
+	require.NoError(t, os.WriteFile(mcpBinary, []byte("mcp"), 0o755))
+
+	cmd := newBundleCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{
+		dir,
+		"--skip-build",
+		"--binary", mcpBinary,
+		"--output", outPath,
+		"--version", "0.1.4",
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	manifest := readBundleZipManifest(t, outPath)
+	assert.Equal(t, "0.1.4", manifest.Version)
+
+	diskData, err := os.ReadFile(filepath.Join(dir, pipeline.MCPBManifestFilename))
+	require.NoError(t, err)
+	assert.Contains(t, string(diskData), `"version":"0.0.0"`)
+}
+
 func TestNewBundleCmdWindowsPlatformBuildsToExeStagingPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake go shim uses POSIX shell")

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -2533,7 +2533,7 @@ import (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -169,7 +169,7 @@ func TestGeneratedBLEDeviceEmitsMCPSurface(t *testing.T) {
 	// The MCP server version must be an ldflag-overridable var, not a hardcoded
 	// literal — the device .goreleaser injects -X main.version at release time, so
 	// a bare "1.0.0" in NewMCPServer would make that injection a silent no-op.
-	assert.Contains(t, mcpMain, `var version = "1.0.0"`)
+	assert.Contains(t, mcpMain, `var version = "0.0.0-dev"`)
 	assert.NotContains(t, mcpMain, "\n\t\t\"1.0.0\",\n\t\tserver.WithToolCapabilities(false),")
 
 	toolsSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -15157,7 +15157,7 @@ func TestGenerateMCPMainRemoteOptIn(t *testing.T) {
 func assertMCPMainUsesVersionVar(t *testing.T, body string) {
 	t.Helper()
 
-	assert.Contains(t, body, `var version = "1.0.0"`)
+	assert.Contains(t, body, `var version = "0.0.0-dev"`)
 	assert.Contains(t, body, "server.NewMCPServer(")
 	assert.Contains(t, body, "\n\t\tversion,\n\t\tserver.WithToolCapabilities(false),")
 	assert.NotContains(t, body, "\n\t\t\"1.0.0\",\n\t\tserver.WithToolCapabilities(false),")

--- a/internal/generator/templates/main_mcp.go.tmpl
+++ b/internal/generator/templates/main_mcp.go.tmpl
@@ -26,7 +26,7 @@ const (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(
@@ -82,7 +82,7 @@ import (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1067,6 +1067,21 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr))
 	})
 
+	t.Run("uses generate-time placeholder instead of printing press version", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifest(t, dir, CLIManifest{
+			APIName:              "demo",
+			MCPBinary:            "demo-pp-mcp",
+			MCPReady:             "full",
+			PrintingPressVersion: "4.11.0",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Equal(t, "0.0.0", got.Version)
+	})
+
 	t.Run("api_key auth emits required user_config fields", func(t *testing.T) {
 		dir := t.TempDir()
 		writeManifest(t, dir, CLIManifest{

--- a/internal/pipeline/mcpb_bundle.go
+++ b/internal/pipeline/mcpb_bundle.go
@@ -28,6 +28,10 @@ import (
 // the binary inside the zip; we deliberately do NOT serialize this name
 // into manifest.json because Claude Desktop's MCPB v0.3 schema
 // strictly rejects unknown top-level keys.
+//
+// Version optionally stamps the printed CLI release version into the
+// bundled manifest bytes. It does not mutate manifest.json on disk because
+// that file is generated before release tags exist.
 type BundleParams struct {
 	CLIDir        string
 	BinaryPath    string
@@ -35,6 +39,7 @@ type BundleParams struct {
 	CLIBinaryName string
 	CLIBinaryPath string
 	OutputPath    string
+	Version       string
 }
 
 // BuildMCPBBundle assembles an MCPB ZIP at OutputPath. The bundle layout is:
@@ -72,6 +77,13 @@ func BuildMCPBBundle(params BundleParams) error {
 			}
 		}
 	}
+	if params.Version != "" {
+		manifest.Version = params.Version
+		manifestData, err = rewriteMCPBManifestVersion(manifestData, params.Version)
+		if err != nil {
+			return err
+		}
+	}
 
 	if err := os.MkdirAll(filepath.Dir(params.OutputPath), 0o755); err != nil {
 		return fmt.Errorf("creating bundle output dir: %w", err)
@@ -105,6 +117,23 @@ func BuildMCPBBundle(params BundleParams) error {
 		return fmt.Errorf("finalizing bundle archive: %w", err)
 	}
 	return nil
+}
+
+func rewriteMCPBManifestVersion(data []byte, version string) ([]byte, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing manifest document: %w", err)
+	}
+	doc["version"] = version
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("marshaling manifest document: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func rewriteMCPBManifestLaunch(data []byte, entryPoint string) ([]byte, error) {

--- a/internal/pipeline/mcpb_bundle_test.go
+++ b/internal/pipeline/mcpb_bundle_test.go
@@ -157,6 +157,46 @@ func TestBuildMCPBBundle(t *testing.T) {
 		assert.Equal(t, mData, readZipEntryBytes(t, out, MCPBManifestFilename))
 	})
 
+	t.Run("stamps release version only in bundled manifest", func(t *testing.T) {
+		dir := t.TempDir()
+
+		mData := []byte(`{
+  "manifest_version": "0.3",
+  "name": "demo-pp-mcp",
+  "version": "0.0.0",
+  "server": {
+    "type": "binary",
+    "entry_point": "bin/demo-pp-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/bin/demo-pp-mcp",
+      "custom_launch_field": "preserve-me"
+    }
+  },
+  "custom_top_level_field": ["preserve-me"]
+}`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, MCPBManifestFilename), mData, 0o644))
+
+		mcpPath := filepath.Join(dir, "fake-mcp")
+		require.NoError(t, os.WriteFile(mcpPath, []byte("mcp"), 0o755))
+
+		out := filepath.Join(dir, "demo.mcpb")
+		err := BuildMCPBBundle(BundleParams{
+			CLIDir:     dir,
+			BinaryPath: mcpPath,
+			OutputPath: out,
+			Version:    "0.1.4",
+		})
+		require.NoError(t, err)
+
+		bundledDoc := readZipJSONMap(t, out, MCPBManifestFilename)
+		assert.Equal(t, "0.1.4", bundledDoc["version"])
+		assert.Equal(t, []any{"preserve-me"}, bundledDoc["custom_top_level_field"])
+		server := bundledDoc["server"].(map[string]any)
+		mcpConfig := server["mcp_config"].(map[string]any)
+		assert.Equal(t, "preserve-me", mcpConfig["custom_launch_field"])
+		assert.Equal(t, mData, readManifestFileBytes(t, filepath.Join(dir, MCPBManifestFilename)))
+	})
+
 	t.Run("missing manifest skips silently", func(t *testing.T) {
 		dir := t.TempDir()
 		// No manifest.json written; bundle call should no-op.
@@ -280,6 +320,13 @@ func readManifestFile(t *testing.T, path string) MCPBManifest {
 	var manifest MCPBManifest
 	require.NoError(t, json.Unmarshal(data, &manifest))
 	return manifest
+}
+
+func readManifestFileBytes(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
 }
 
 func readZipJSONMap(t *testing.T, path, entry string) map[string]any {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -203,7 +203,7 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 		// The generated on-disk manifest does not know the printed CLI's
 		// release tag yet. Release packaging can stamp the bundle version
 		// into the ZIP without mutating this generate-time manifest.
-		Version:     bundleVersion(m),
+		Version:     bundleVersion(),
 		Description: manifestDescription(existing, m, displayName),
 		Author:      MCPBAuthor{Name: "CLI Printing Press"},
 		License:     "Apache-2.0",
@@ -227,7 +227,7 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 // bundleVersion returns a semver-shaped generate-time placeholder. The MCPB
 // manifest's version is the printed CLI bundle version, which is not known
 // until release packaging passes it to BuildMCPBBundle.
-func bundleVersion(m CLIManifest) string {
+func bundleVersion() string {
 	return "0.0.0"
 }
 

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
-	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
 )
 
 // MCPB-bundle constants. Promoted from string literals so a typo here can't
@@ -201,10 +200,9 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 		ManifestVersion: MCPBManifestVersion,
 		Name:            m.MCPBinary,
 		DisplayName:     displayName,
-		// Bundle version tracks the printing-press release that produced
-		// it so Claude Desktop's update detection sees a fresh value on
-		// regeneration. A hardcoded "1.0.0" would defeat the host's
-		// "newer bundle available" prompt.
+		// The generated on-disk manifest does not know the printed CLI's
+		// release tag yet. Release packaging can stamp the bundle version
+		// into the ZIP without mutating this generate-time manifest.
 		Version:     bundleVersion(m),
 		Description: manifestDescription(existing, m, displayName),
 		Author:      MCPBAuthor{Name: "CLI Printing Press"},
@@ -226,17 +224,10 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 	}
 }
 
-// bundleVersion returns a semver-shaped version for the manifest. Prefers
-// the manifest's recorded printing-press version (so two bundles built
-// from different generator releases differ), falls back to the linker-
-// stamped version when the manifest field is empty (older runs).
+// bundleVersion returns a semver-shaped generate-time placeholder. The MCPB
+// manifest's version is the printed CLI bundle version, which is not known
+// until release packaging passes it to BuildMCPBBundle.
 func bundleVersion(m CLIManifest) string {
-	if m.PrintingPressVersion != "" {
-		return m.PrintingPressVersion
-	}
-	if version.Version != "" {
-		return version.Version
-	}
 	return "0.0.0"
 }
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/cmd/ble-temperature-sensor-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/cmd/ble-temperature-sensor-pp-mcp/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/cmd/cafe-bistro-pp-mcp/main.go
@@ -24,7 +24,7 @@ const (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/cmd/printing-press-golden-pp-mcp/main.go
@@ -24,7 +24,7 @@ const (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/cmd/mcp-cloudflare-pp-mcp/main.go
@@ -24,7 +24,7 @@ const (
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
-var version = "1.0.0"
+var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(


### PR DESCRIPTION
## Intent

Issue: Closes #2387

Printed CLI MCPB bundles no longer present the Printing Press generator release as the bundle's own version, and generated MCP servers no longer default to a release-looking `1.0.0` serverInfo version before release stamping.

## Approach

Generate-time `manifest.json` now uses a neutral `0.0.0` placeholder because the printed CLI release tag is not known during generation. The bundle path accepts `--version` and stamps that printed CLI release version into the manifest bytes inside the `.mcpb` archive without mutating the on-disk manifest.

Generated HTTP and device MCP server mains now default their ldflag-overridable `version` variable to `0.0.0-dev`; the existing goreleaser `-X main.version={{ .Version }}` injection remains the release-time source of truth.

## Scope

Primary area: MCPB packaging and generated MCP server version metadata.

Why this belongs in this repo: the bug appears in every future printed CLI generated or bundled by the Printing Press, so the fix belongs in the generator and bundle command rather than in one published CLI.

## Catalog Justification

Embedded catalog fit: N/A

Distinct blueprint pattern: N/A

Closest existing entries checked: N/A

Source provenance: N/A

Auth and tenant assumptions: N/A

Safe default surface: N/A

Generation path: N/A

Stale-body check: N/A

## Risk

The main risk is release workflow adoption: published CLI workflows must pass `cli-printing-press bundle --version <release>` to stamp non-placeholder MCPB versions. Generated MCP server releases still receive the tag via existing goreleaser ldflags, and generate-time artifacts intentionally remain placeholders.

## Output Contract

Generated MCP server `main.go` files now emit `var version = "0.0.0-dev"` and still pass that variable to `server.NewMCPServer`. Golden fixtures cover HTTP, stdio, and device generated MCP mains. `scripts/verify-generator-output.sh` compiled representative generated modules for HTTP, device, and MCP-first cases.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- `go test ./internal/pipeline ./internal/cli ./internal/generator -run 'Test(BuildMCPBBundle|WriteMCPBManifest|NewBundleCmd|GenerateMCPMainRemoteOptIn|GeneratedBLEDeviceEmitsMCPSurface)'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-device-ble generate-mcp-api`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- Headless read-only review: no findings

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change
