### PR TITLE
fix(cli): support next_token sync pagination

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17702,6 +17702,8 @@ components:
 	assert.Contains(t, defaultResources[1], `"usercollection",`)
 	assert.Contains(t, defaultResources[1], `"usercollection-daily-sleep",`)
 	assert.Contains(t, defaultResources[1], `"usercollection-personal-info",`)
+	assert.NotContains(t, defaultResources[1], `"usercollection-heartrate",`,
+		"heartrate should stay absorbed by the canonical usercollection resource")
 	assert.NotContains(t, defaultResources[1], `"webhook",`,
 		"auth-tagged webhook resources must stay out of the default sync set")
 
@@ -17722,11 +17724,18 @@ func TestSyncSinceParamFormatForDateOnlyResources(t *testing.T) {
 	if got := syncResourceSinceParamFormat("usercollection-daily-sleep"); got != "date" {
 		t.Fatalf("daily sleep since format = %q, want date", got)
 	}
+	// The canonical usercollection endpoint is heartrate because it has the shortest shared-prefix path.
 	if got := syncResourceSinceParamFormat("usercollection"); got != "date-time" {
 		t.Fatalf("heartrate since format = %q, want date-time", got)
 	}
 	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date"); got != "2026-06-07" {
 		t.Fatalf("date-formatted since value = %q, want YYYY-MM-DD", got)
+	}
+	if got := formatSyncSinceValue("2026-06-07T12:34:56.789Z", "date"); got != "2026-06-07" {
+		t.Fatalf("date-formatted fractional since value = %q, want YYYY-MM-DD", got)
+	}
+	if got := formatSyncSinceValue("not-a-date-value", "date"); got != "not-a-date-value" {
+		t.Fatalf("invalid date-formatted since value = %q, want original value", got)
 	}
 	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date-time"); got != "2026-06-07T12:34:56Z" {
 		t.Fatalf("date-time since value = %q, want original RFC3339", got)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17555,6 +17555,189 @@ func TestGenerateEndpointTemplateEnvOverridesWireThrough(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGenerateSyncIncludesMultiLeafCollectionResources(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := openapi.Parse([]byte(`
+openapi: 3.0.3
+info:
+  title: Wearable Metrics
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /v2/usercollection/daily_sleep:
+    get:
+      operationId: get_daily_sleep
+      parameters:
+        - name: start_date
+          in: query
+          schema: {type: string, format: date}
+        - name: next_token
+          in: query
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DailySleepEnvelope"
+  /v2/usercollection/heartrate:
+    get:
+      operationId: get_heartrate
+      parameters:
+        - name: start_datetime
+          in: query
+          schema: {type: string, format: date-time}
+        - name: next_token
+          in: query
+          schema: {type: string}
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeartrateEnvelope"
+  /v2/usercollection/personal_info:
+    get:
+      operationId: get_personal_info
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonalInfoEnvelope"
+  /v2/webhook/subscription:
+    get:
+      operationId: list_webhook_subscriptions
+      tags: [oauth]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookEnvelope"
+components:
+  schemas:
+    DailySleepEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/DailySleep"
+        next_token:
+          type: string
+          nullable: true
+    HeartrateEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Heartrate"
+        next_token:
+          type: string
+          nullable: true
+    PersonalInfoEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/PersonalInfo"
+    WebhookEnvelope:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Webhook"
+    DailySleep:
+      type: object
+      properties:
+        id: {type: string}
+        day: {type: string, format: date}
+    Heartrate:
+      type: object
+      properties:
+        id: {type: string}
+        timestamp: {type: string, format: date-time}
+    PersonalInfo:
+      type: object
+      properties:
+        id: {type: string}
+        age: {type: integer}
+    Webhook:
+      type: object
+      properties:
+        id: {type: string}
+`))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	src := string(syncSrc)
+
+	assert.Contains(t, src, `"/v2/usercollection/daily_sleep"`,
+		"syncResourcePath must include every data list resource under a shared collection prefix")
+	assert.Contains(t, src, `"/v2/usercollection/heartrate"`,
+		"syncResourcePath must include sibling list resources instead of collapsing to one resource")
+	assert.Contains(t, src, `"/v2/usercollection/personal_info"`,
+		"single-page data resources under the shared prefix must stay syncable")
+	assert.Contains(t, src, `"/v2/webhook/subscription"`,
+		"auth-tagged resources remain accepted when explicitly requested")
+
+	defaultResources := regexp.MustCompile(`(?s)func defaultSyncResources\(\) \[\]string \{(.*?)\n\}`).FindStringSubmatch(src)
+	require.Len(t, defaultResources, 2)
+	assert.Contains(t, defaultResources[1], `"usercollection",`)
+	assert.Contains(t, defaultResources[1], `"usercollection-daily-sleep",`)
+	assert.Contains(t, defaultResources[1], `"usercollection-personal-info",`)
+	assert.NotContains(t, defaultResources[1], `"webhook",`,
+		"auth-tagged webhook resources must stay out of the default sync set")
+
+	paginationSwitch := regexp.MustCompile(`(?s)func resourceSupportsPagination\(resource string\) bool \{(.*?)\n\}`).FindStringSubmatch(src)
+	require.Len(t, paginationSwitch, 2)
+	assert.Contains(t, paginationSwitch[1], `case "usercollection":`)
+	assert.Contains(t, paginationSwitch[1], `case "usercollection-daily-sleep":`)
+	assert.NotContains(t, paginationSwitch[1], `case "usercollection-personal-info":`,
+		"single-object resources without cursor params must not be marked paginated")
+	assert.Contains(t, src, `cursorParam: "next_token"`,
+		"the generated sync layer must derive the API cursor param instead of hardcoding after")
+
+	sinceFormatTest := `package cli
+
+import "testing"
+
+func TestSyncSinceParamFormatForDateOnlyResources(t *testing.T) {
+	if got := syncResourceSinceParamFormat("usercollection-daily-sleep"); got != "date" {
+		t.Fatalf("daily sleep since format = %q, want date", got)
+	}
+	if got := syncResourceSinceParamFormat("usercollection"); got != "date-time" {
+		t.Fatalf("heartrate since format = %q, want date-time", got)
+	}
+	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date"); got != "2026-06-07" {
+		t.Fatalf("date-formatted since value = %q, want YYYY-MM-DD", got)
+	}
+	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date-time"); got != "2026-06-07T12:34:56Z" {
+		t.Fatalf("date-time since value = %q, want original RFC3339", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_since_format_test.go"), []byte(sinceFormatTest), 0o644))
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "^TestSyncSinceParamFormatForDateOnlyResources$")
+}
+
 func TestGenerateGlobalPathTemplateVarRootFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1288,8 +1288,11 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")
 		}
-		if len(value) >= len("2006-01-02") {
-			return value[:len("2006-01-02")]
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if _, err := time.Parse("2006-01-02", value); err == nil {
+			return value
 		}
 	}
 	return value

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -596,6 +596,9 @@ func syncResource(ctx context.Context, c interface {
 		}
 		effectiveSince = ""
 	}
+	if effectiveSince != "" {
+		effectiveSince = formatSyncSinceValue(effectiveSince, syncResourceSinceParamFormat(resource))
+	}
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
@@ -1261,6 +1264,36 @@ func syncResourceSinceParam(resource string) string {
 	}
 	return ""
 }
+
+func syncResourceSinceParamFormat(resource string) string {
+	switch resource {
+{{- range .SyncableResources}}
+{{- if .SinceParamFormat}}
+	case "{{.Name}}":
+		return "{{.SinceParamFormat}}"
+{{- end}}
+{{- end}}
+{{- range .DependentSyncResources}}
+{{- if .SinceParamFormat}}
+	case "{{.Name}}":
+		return "{{.SinceParamFormat}}"
+{{- end}}
+{{- end}}
+	}
+	return ""
+}
+
+func formatSyncSinceValue(value string, paramFormat string) string {
+	if strings.EqualFold(paramFormat, "date") {
+		if ts, err := time.Parse(time.RFC3339, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if len(value) >= len("2006-01-02") {
+			return value[:len("2006-01-02")]
+		}
+	}
+	return value
+}
 {{- if .Pagination.DateRangeParam}}
 
 // determineDateRangeParam returns the query parameter name for date-range sync filtering.
@@ -1677,8 +1710,8 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 
 	// Try common cursor field names
 	cursorKeys := []string{
-		"next_cursor", "nextCursor", "cursor", "next_page_token",
-		"nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -2271,6 +2304,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		}
 		depSinceTS = ""
 	}
+	if depSinceTS != "" {
+		depSinceTS = formatSyncSinceValue(depSinceTS, syncResourceSinceParamFormat(dep.Name))
+	}
 	// Per-resource extract-failure tracking for the F4b symptom probe and
 	// per-item primary_key_unresolved warning. See syncResource for the
 	// concurrency rationale (one goroutine per resource → no race).
@@ -2647,6 +2683,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"Data": true, "Results": true, "Items": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
 	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
 	"page_token": true, "pageToken": true, "PageToken": true,
 	"end_cursor": true, "endCursor": true, "EndCursor": true,

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -7403,7 +7403,7 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 		}
 	}
 	if pag.Type == "" {
-		for _, name := range []string{"after", "cursor", "page[cursor]"} {
+		for _, name := range []string{"after", "cursor", "page[cursor]", "nexttoken", "next_token"} {
 			if orig, ok := originalCase[name]; ok {
 				pag.CursorParam = orig
 				pag.Type = "cursor"
@@ -7640,7 +7640,7 @@ var nextFieldPageTokenNames = []string{"next_page_token", "nextpagetoken"}
 // strings that cannot advance pagination without a known query parameter.
 // The runtime treats their presence as a truncation signal when no cursor
 // param is configured.
-var nextFieldCursorNames = []string{"next_cursor", "nextcursor", "cursor"}
+var nextFieldCursorNames = []string{"next_cursor", "nextcursor", "next_token", "nexttoken", "cursor"}
 
 // nextFieldBoolNames lists boolean-typed "more pages" flags.
 var nextFieldBoolNames = []string{"has_more", "hasmore"}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -10595,6 +10595,7 @@ func TestDetectPaginationPreservesCursorParamCase(t *testing.T) {
 		{"google camelCase pageToken", "pageToken", "pageToken", "page_token"},
 		{"snake_case page_token", "page_token", "page_token", "page_token"},
 		{"plain after", "after", "after", "cursor"},
+		{"snake_case next_token", "next_token", "next_token", "cursor"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -123,6 +123,10 @@ type SyncableResource struct {
 	// those resources and emits one resource_not_incremental warning per
 	// run when --since/incremental sync was requested.
 	SinceParam string
+	// SinceParamFormat mirrors the OpenAPI format hint for SinceParam. The
+	// sync template uses "date" to send YYYY-MM-DD values instead of RFC3339
+	// timestamps to date-only endpoints.
+	SinceParamFormat string
 
 	// SupportsPagination is true when the chosen list endpoint declares a
 	// cursor or page-size parameter. The sync template uses this to avoid
@@ -183,7 +187,8 @@ type DependentResource struct {
 	// SinceParam mirrors SyncableResource.SinceParam for child paths so
 	// the same per-resource temporal-filter gating applies to dependent
 	// syncs.
-	SinceParam string
+	SinceParam       string
+	SinceParamFormat string
 
 	// SupportsPagination mirrors SyncableResource.SupportsPagination for child
 	// paths so dependent syncs skip synthetic limit/offset params on endpoints
@@ -525,7 +530,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 			}
 			for _, param := range endpoint.Params {
 				name := strings.ToLower(param.Name)
-				if strings.Contains(name, "since") || strings.Contains(name, "updated_after") || strings.Contains(name, "modified_since") || strings.Contains(name, "updated_at") {
+				if isEndpointSinceParamName(name) {
 					sinceParams[param.Name]++
 				}
 				if name == "dates" || name == "date_range" || name == "daterange" {
@@ -1359,6 +1364,7 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 		IDField:            entry.meta.IDField,
 		Critical:           entry.meta.Critical,
 		SinceParam:         entry.meta.SinceParam,
+		SinceParamFormat:   entry.meta.SinceParamFormat,
 		SupportsPagination: entry.meta.SupportsPagination,
 		UsesHTMLResponse:   entry.meta.UsesHTMLResponse,
 		HTMLExtract:        entry.meta.HTMLExtract,
@@ -1573,6 +1579,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				IDField:            meta.IDField,
 				Critical:           meta.Critical,
 				SinceParam:         meta.SinceParam,
+				SinceParamFormat:   meta.SinceParamFormat,
 				SupportsPagination: meta.SupportsPagination,
 				UsesHTMLResponse:   meta.UsesHTMLResponse,
 				HTMLExtract:        meta.HTMLExtract,
@@ -1824,6 +1831,7 @@ type syncableMeta struct {
 	IDField            string
 	Critical           bool
 	SinceParam         string
+	SinceParamFormat   string
 	SupportsPagination bool
 	UsesHTMLResponse   bool
 	HTMLExtract        *spec.HTMLExtract
@@ -1864,6 +1872,7 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		IDField:            e.IDField,
 		Critical:           e.Critical,
 		SinceParam:         detectEndpointSinceParam(e.Params),
+		SinceParamFormat:   detectEndpointSinceParamFormat(e.Params),
 		SupportsPagination: endpointSupportsPagination(e),
 		UsesHTMLResponse:   e.UsesHTMLResponse(),
 		HTMLExtract:        e.HTMLExtract,
@@ -1983,13 +1992,36 @@ func paginationLimitDefault(endpoint spec.Endpoint) (int, bool) {
 // Profile() so per-endpoint detection stays consistent with the
 // PaginationProfile.SinceParam summary.
 func detectEndpointSinceParam(params []spec.Param) string {
+	name, _ := detectEndpointSinceParamAndFormat(params)
+	return name
+}
+
+func detectEndpointSinceParamFormat(params []spec.Param) string {
+	_, format := detectEndpointSinceParamAndFormat(params)
+	return format
+}
+
+func detectEndpointSinceParamAndFormat(params []spec.Param) (string, string) {
 	for _, p := range params {
 		name := strings.ToLower(p.Name)
-		if strings.Contains(name, "since") || strings.Contains(name, "updated_after") || strings.Contains(name, "modified_since") || strings.Contains(name, "updated_at") {
-			return p.Name
+		if isEndpointSinceParamName(name) {
+			return p.Name, strings.ToLower(strings.TrimSpace(p.Format))
 		}
 	}
-	return ""
+	return "", ""
+}
+
+func isEndpointSinceParamName(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	return strings.Contains(name, "since") ||
+		strings.Contains(name, "updated_after") ||
+		strings.Contains(name, "modified_since") ||
+		strings.Contains(name, "updated_at") ||
+		name == "start_date" ||
+		name == "start_datetime" ||
+		name == "start_time" ||
+		name == "from_date" ||
+		name == "from_datetime"
 }
 
 func detectEndpointFieldSelector(endpoint spec.Endpoint) FieldSelector {
@@ -2276,6 +2308,7 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 			IDField:            meta.IDField,
 			Critical:           meta.Critical,
 			SinceParam:         meta.SinceParam,
+			SinceParamFormat:   meta.SinceParamFormat,
 			SupportsPagination: meta.SupportsPagination,
 			UsesHTMLResponse:   meta.UsesHTMLResponse,
 			HTMLExtract:        meta.HTMLExtract,

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1962,7 +1962,7 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 						Path:     "/v1/events",
 						Response: spec.ResponseDef{Type: "array"},
 						Params: []spec.Param{
-							{Name: "since", Type: "string"},
+							{Name: "since", Type: "string", Format: "date-time"},
 						},
 					},
 				},
@@ -1974,7 +1974,7 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 						Path:     "/v1/audit",
 						Response: spec.ResponseDef{Type: "array"},
 						Params: []spec.Param{
-							{Name: "updated_after", Type: "string"},
+							{Name: "updated_after", Type: "string", Format: "date"},
 						},
 					},
 				},
@@ -2024,9 +2024,11 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 
 	require.Contains(t, byName, "events")
 	assert.Equal(t, "since", byName["events"].SinceParam, "literal since param should propagate verbatim")
+	assert.Equal(t, "date-time", byName["events"].SinceParamFormat, "date-time format should propagate for RFC3339 temporal filters")
 
 	require.Contains(t, byName, "audit")
 	assert.Equal(t, "updated_after", byName["audit"].SinceParam, "spec-declared name (not the profile-wide guess) wins")
+	assert.Equal(t, "date", byName["audit"].SinceParamFormat, "date format should propagate so sync can send YYYY-MM-DD")
 
 	require.Contains(t, byName, "posts")
 	assert.Equal(t, "modified_since", byName["posts"].SinceParam, "modified_since heuristic branch")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -803,8 +803,11 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")
 		}
-		if len(value) >= len("2006-01-02") {
-			return value[:len("2006-01-02")]
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if _, err := time.Parse("2006-01-02", value); err == nil {
+			return value
 		}
 	}
 	return value

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -458,6 +458,9 @@ func syncResource(ctx context.Context, c interface {
 		}
 		effectiveSince = ""
 	}
+	if effectiveSince != "" {
+		effectiveSince = formatSyncSinceValue(effectiveSince, syncResourceSinceParamFormat(resource))
+	}
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
@@ -789,6 +792,24 @@ func syncResourceSinceParam(resource string) string {
 	return ""
 }
 
+func syncResourceSinceParamFormat(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func formatSyncSinceValue(value string, paramFormat string) string {
+	if strings.EqualFold(paramFormat, "date") {
+		if ts, err := time.Parse(time.RFC3339, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if len(value) >= len("2006-01-02") {
+			return value[:len("2006-01-02")]
+		}
+	}
+	return value
+}
+
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
 // 1. Direct JSON array
@@ -1085,8 +1106,8 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 
 	// Try common cursor field names
 	cursorKeys := []string{
-		"next_cursor", "nextCursor", "cursor", "next_page_token",
-		"nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1543,6 +1564,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		}
 		depSinceTS = ""
 	}
+	if depSinceTS != "" {
+		depSinceTS = formatSyncSinceValue(depSinceTS, syncResourceSinceParamFormat(dep.Name))
+	}
 	// Per-resource extract-failure tracking for the F4b symptom probe and
 	// per-item primary_key_unresolved warning. See syncResource for the
 	// concurrency rationale (one goroutine per resource → no race).
@@ -1863,6 +1887,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"Data": true, "Results": true, "Items": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
 	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
 	"page_token": true, "pageToken": true, "PageToken": true,
 	"end_cursor": true, "endCursor": true, "EndCursor": true,

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -457,6 +457,9 @@ func syncResource(ctx context.Context, c interface {
 		}
 		effectiveSince = ""
 	}
+	if effectiveSince != "" {
+		effectiveSince = formatSyncSinceValue(effectiveSince, syncResourceSinceParamFormat(resource))
+	}
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
@@ -784,6 +787,24 @@ func syncResourceSinceParam(resource string) string {
 	return ""
 }
 
+func syncResourceSinceParamFormat(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func formatSyncSinceValue(value string, paramFormat string) string {
+	if strings.EqualFold(paramFormat, "date") {
+		if ts, err := time.Parse(time.RFC3339, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if len(value) >= len("2006-01-02") {
+			return value[:len("2006-01-02")]
+		}
+	}
+	return value
+}
+
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
 // 1. Direct JSON array
@@ -1080,8 +1101,8 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 
 	// Try common cursor field names
 	cursorKeys := []string{
-		"next_cursor", "nextCursor", "cursor", "next_page_token",
-		"nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1527,6 +1548,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		}
 		depSinceTS = ""
 	}
+	if depSinceTS != "" {
+		depSinceTS = formatSyncSinceValue(depSinceTS, syncResourceSinceParamFormat(dep.Name))
+	}
 	// Per-resource extract-failure tracking for the F4b symptom probe and
 	// per-item primary_key_unresolved warning. See syncResource for the
 	// concurrency rationale (one goroutine per resource → no race).
@@ -1846,6 +1870,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"Data": true, "Results": true, "Items": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
 	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
 	"page_token": true, "pageToken": true, "PageToken": true,
 	"end_cursor": true, "endCursor": true, "EndCursor": true,

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -798,8 +798,11 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")
 		}
-		if len(value) >= len("2006-01-02") {
-			return value[:len("2006-01-02")]
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if _, err := time.Parse("2006-01-02", value); err == nil {
+			return value
 		}
 	}
 	return value

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -424,6 +424,9 @@ func syncResource(ctx context.Context, c interface {
 		}
 		effectiveSince = ""
 	}
+	if effectiveSince != "" {
+		effectiveSince = formatSyncSinceValue(effectiveSince, syncResourceSinceParamFormat(resource))
+	}
 
 	cursor := existingCursor
 	pageSize := determinePaginationDefaults()
@@ -753,6 +756,24 @@ func syncResourceSinceParam(resource string) string {
 	return ""
 }
 
+func syncResourceSinceParamFormat(resource string) string {
+	switch resource {
+	}
+	return ""
+}
+
+func formatSyncSinceValue(value string, paramFormat string) string {
+	if strings.EqualFold(paramFormat, "date") {
+		if ts, err := time.Parse(time.RFC3339, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if len(value) >= len("2006-01-02") {
+			return value[:len("2006-01-02")]
+		}
+	}
+	return value
+}
+
 // extractPageItems attempts to extract an array of items and pagination cursor from a response.
 // It tries multiple strategies:
 // 1. Direct JSON array
@@ -1049,8 +1070,8 @@ func extractPaginationFromEnvelope(envelope map[string]json.RawMessage, cursorPa
 
 	// Try common cursor field names
 	cursorKeys := []string{
-		"next_cursor", "nextCursor", "cursor", "next_page_token",
-		"nextPageToken", "page_token", "after", "end_cursor", "endCursor",
+		"next_cursor", "nextCursor", "next_token", "nextToken", "cursor",
+		"next_page_token", "nextPageToken", "page_token", "after", "end_cursor", "endCursor",
 	}
 	if nextCursor == "" {
 		nextCursor = findCursorInMap(envelope, cursorKeys)
@@ -1446,6 +1467,7 @@ var pageEnvelopeMetadataKeys = map[string]bool{
 	"Data": true, "Results": true, "Items": true,
 	// pagination cursors / tokens
 	"next_cursor": true, "nextCursor": true, "NextCursor": true,
+	"next_token": true, "nextToken": true, "NextToken": true,
 	"next_page_token": true, "nextPageToken": true, "NextPageToken": true,
 	"page_token": true, "pageToken": true, "PageToken": true,
 	"end_cursor": true, "endCursor": true, "EndCursor": true,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -767,8 +767,11 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")
 		}
-		if len(value) >= len("2006-01-02") {
-			return value[:len("2006-01-02")]
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts.Format("2006-01-02")
+		}
+		if _, err := time.Parse("2006-01-02", value); err == nil {
+			return value
 		}
 	}
 	return value


### PR DESCRIPTION
## Summary

Generated REST sync now recognizes `next_token` as a cursor request parameter and response cursor field, so multi-page APIs using that token shape no longer fall back to the hardcoded `after` cursor.

The sync profiler also carries temporal parameter formats into generated CLIs. Date-only lower-bound params such as `start_date` now receive `YYYY-MM-DD`, while datetime params keep RFC3339 values.

A generated-output test covers the multi-leaf collection shape from the issue: shared `/usercollection/...` list paths stay syncable, auth-tagged webhook resources stay out of the default sync set, cursor-backed resources are marked paginated, and the generated runtime helper formats date-only sync params correctly.

Closes #2804

## Verification

- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `golangci-lint run ./...`
