### PR TITLE
fix(skills): add sqlite missing-mirror guard guidance

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,25 @@ func TestPrintingPressSkillTranscendenceCollectorSliceInit(t *testing.T) {
 	require.Contains(t, content, "successfulItems := make([]yourEntryType, 0)")
 	require.NotContains(t, content, "var failures []fetchFailure")
 	require.NotContains(t, content, "var successfulItems []yourEntryType")
+}
+
+func TestPrintingPressSkillSQLiteNovelCommandsGuardMissingMirror(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../skills/printing-press/SKILL.md")
+	require.NoError(t, err)
+
+	content := string(data)
+	require.Contains(t, content, "For SQLite-backed novel commands only")
+	require.Contains(t, content, "live execution without `--dry-run`, before the user has run `sync`")
+	require.Contains(t, content, "os.Stat(dbPath); os.IsNotExist(statErr)")
+	require.Contains(t, content, "flags.asJSON || flags.agent")
+	require.Contains(t, content, "store.OpenWithContext")
+
+	guard := strings.Index(content, "os.Stat(dbPath); os.IsNotExist(statErr)")
+	openStore := strings.Index(content, "store.OpenWithContext(ctx, dbPath)")
+	require.NotEqual(t, -1, openStore, "full store.OpenWithContext(ctx, dbPath) call not found in SKILL.md")
+	require.Less(t, guard, openStore, "missing-mirror guard should be shown before opening SQLite")
 }
 
 func TestPrintingPressSkillReachabilityGateAllowsLANOnlyCarveout(t *testing.T) {

--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -68,6 +68,7 @@ func TestPrintingPressSkillSQLiteNovelCommandsGuardMissingMirror(t *testing.T) {
 	require.Contains(t, content, "live execution without `--dry-run`, before the user has run `sync`")
 	require.Contains(t, content, "os.Stat(dbPath); os.IsNotExist(statErr)")
 	require.Contains(t, content, "flags.asJSON || flags.agent")
+	require.Contains(t, content, "The unconditional `return nil` is intentional")
 	require.Contains(t, content, "store.OpenWithContext")
 
 	guard := strings.Index(content, "os.Stat(dbPath); os.IsNotExist(statErr)")

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3248,6 +3248,20 @@ RunE: func(cmd *cobra.Command, args []string) error {
 
 Why each branch exists: the `len(args) == 0 && cmd.Flags().NFlag() == 0` branch handles an interactive `<cli> mycommand` help-only invocation without treating help as an error. The `dryRunOK` branch handles verify's `<cli> mycommand <fixture> --dry-run` probes before network or filesystem IO. The required-input branch handles non-help invocations where a mode or output flag is present (`--no-input`, `--agent`, `--json`) but the required ID, query, path, or other command input is still missing. Missing required input must print usage and return `usageErr(...)` so callers get exit code 2 instead of a silent rc=0 skip.
 
+For SQLite-backed novel commands only, add this missing-mirror guard after `dryRunOK(flags)`, after any required-input `usageErr(...)` check, and after `dbPath` is resolved, but before `store.OpenWithContext`, `store.OpenReadOnly`, `sql.Open`, or other SQLite access:
+
+```go
+if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
+	if flags.asJSON || flags.agent {
+		fmt.Fprintln(cmd.OutOrStdout(), "[]")
+	}
+	return nil
+}
+```
+
+The missing-mirror branch covers a different probe layer from `dryRunOK`: live execution without `--dry-run`, before the user has run `sync`. Return empty JSON (`[]`) for `--json` / `--agent` so agents receive a valid empty result instead of a SQLite open failure; print a human hint to stderr that names the sync command needed to populate the mirror. Do not add this branch to novel commands that call live API endpoints directly or do not use the local store.
+
 Multi-positional commands (N >= 2 required args) must use a two-check shape so only the bare help probe returns exit 0:
 
 ```go
@@ -3377,7 +3391,7 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-	// add: "encoding/json", "fmt", "<module>/internal/store", etc. as needed
+	// add: "encoding/json", "fmt", "os", "<module>/internal/store", etc. as needed
 )
 
 func newNovelXxxCmd(flags *rootFlags) *cobra.Command {
@@ -3583,7 +3597,14 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	if dbPath == "" {
 		dbPath = defaultDBPath("<cli>-pp-cli") // replace <cli> with the API slug
 	}
-	db, err := store.OpenWithContext(ctx, dbPath)
+		if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
+			if flags.asJSON || flags.agent {
+				fmt.Fprintln(cmd.OutOrStdout(), "[]")
+			}
+			return nil
+		}
+		db, err := store.OpenWithContext(ctx, dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3260,7 +3260,7 @@ if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
 }
 ```
 
-The missing-mirror branch covers a different probe layer from `dryRunOK`: live execution without `--dry-run`, before the user has run `sync`. Return empty JSON (`[]`) for `--json` / `--agent` so agents receive a valid empty result instead of a SQLite open failure; print a human hint to stderr that names the sync command needed to populate the mirror. Do not add this branch to novel commands that call live API endpoints directly or do not use the local store.
+The missing-mirror branch covers a different probe layer from `dryRunOK`: live execution without `--dry-run`, before the user has run `sync`. Return empty JSON (`[]`) for `--json` / `--agent` so agents receive a valid empty result instead of a SQLite open failure; print a human hint to stderr that names the sync command needed to populate the mirror. The unconditional `return nil` is intentional for both machine and human paths: a missing local mirror is an empty local-cache state, not a usage or API failure. Do not add this branch to novel commands that call live API endpoints directly or do not use the local store.
 
 Multi-positional commands (N >= 2 required args) must use a two-check shape so only the bare help probe returns exit 0:
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3597,14 +3597,14 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	if dbPath == "" {
 		dbPath = defaultDBPath("<cli>-pp-cli") // replace <cli> with the API slug
 	}
-		if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
-			fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
-			if flags.asJSON || flags.agent {
-				fmt.Fprintln(cmd.OutOrStdout(), "[]")
-			}
-			return nil
+	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "no local mirror at %s\nrun: <cli> sync --resources <resource> --db %s\n", dbPath, dbPath)
+		if flags.asJSON || flags.agent {
+			fmt.Fprintln(cmd.OutOrStdout(), "[]")
 		}
-		db, err := store.OpenWithContext(ctx, dbPath)
+		return nil
+	}
+	db, err := store.OpenWithContext(ctx, dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}


### PR DESCRIPTION
## Summary

SQLite-backed novel-command guidance now gives agents a copyable missing-mirror guard for first-run live executions, scoped to commands that read the local store. The store-query skeleton now checks `dbPath` before opening SQLite and returns `[]` for `--json` / `--agent` while giving humans a sync hint.

Closes #2393

## Tests

- `go test ./internal/cli -run 'TestPrintingPressSkill|TestInternalSkillMinimumBinaryVersionsTrackMajor' -count=1`
- `go test ./internal/pipeline -run 'TestLiveCheck_(PassOnQueryOnlyJSONOutput|FailOnIrrelevantOutput)$' -count=1`
- `go test ./...` failed in `internal/pipeline`: `TestLiveCheck_PassOnQueryOnlyJSONOutput` and `TestLiveCheck_FailOnIrrelevantOutput` timed out after 5s during the full-suite run; both passed on targeted rerun.
