### PR TITLE
fix(cli): make graphql latest-only choose newest page

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -394,7 +394,9 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"publicFlagAliases":            publicFlagAliases,
 		"flagChangedExpr":              flagChangedExpr,
 		"graphqlListParams":            graphqlListParams,
+		"graphqlLatestParams":          graphqlLatestParams,
 		"graphqlVariableType":          graphqlVariableType,
+		"hasGraphQLParam":              hasGraphQLParam,
 		"mcpInputName":                 mcpInputName,
 		"mcpToolInputParams":           mcpToolInputParams,
 		"mcpParamBindings":             mcpParamBindings,
@@ -6734,6 +6736,31 @@ func graphqlListParams(endpoint spec.Endpoint) []spec.Param {
 	return params
 }
 
+func graphqlLatestParams(endpoint spec.Endpoint) []spec.Param {
+	params := make([]spec.Param, 0, len(endpoint.Params))
+	for _, p := range endpoint.Params {
+		if p.Positional || p.PathParam {
+			continue
+		}
+		switch p.Name {
+		case "last", "query":
+		default:
+			continue
+		}
+		params = append(params, p)
+	}
+	return params
+}
+
+func hasGraphQLParam(endpoint spec.Endpoint, name string) bool {
+	for _, p := range endpoint.Params {
+		if p.Name == name && !p.Positional && !p.PathParam {
+			return true
+		}
+	}
+	return false
+}
+
 func graphqlVariableType(p spec.Param) string {
 	var typ string
 	switch primitiveKind(p.Type) {
@@ -6748,7 +6775,7 @@ func graphqlVariableType(p spec.Param) string {
 	default:
 		typ = "String"
 	}
-	if p.Required || strings.EqualFold(p.Name, "first") {
+	if p.Required || strings.EqualFold(p.Name, "first") || strings.EqualFold(p.Name, "last") {
 		typ += "!"
 	}
 	return typ

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6742,9 +6742,7 @@ func graphqlLatestParams(endpoint spec.Endpoint) []spec.Param {
 		if p.Positional || p.PathParam {
 			continue
 		}
-		switch p.Name {
-		case "last", "query":
-		default:
+		if p.Name != "last" {
 			continue
 		}
 		params = append(params, p)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12182,10 +12182,11 @@ import (
 )
 
 type gqlLatestChoiceHandler struct {
-	forward  []map[string]any
-	backward []map[string]any
-	after    []map[string]any
-	calls    []string
+	forward              []map[string]any
+	backward             []map[string]any
+	after                []map[string]any
+	omitBackwardPageInfo bool
+	calls                []string
 }
 
 func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -12200,10 +12201,12 @@ func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	nodes := h.forward
 	hasNextPage := true
 	endCursor := "forward-end"
+	includePageInfo := true
 	if _, ok := req.Variables["last"]; ok {
 		h.calls = append(h.calls, "last")
 		nodes = h.backward
 		endCursor = "latest-end"
+		includePageInfo = !h.omitBackwardPageInfo
 	} else if _, ok := req.Variables["after"]; ok {
 		h.calls = append(h.calls, "after")
 		nodes = h.after
@@ -12213,15 +12216,18 @@ func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		h.calls = append(h.calls, "first")
 	}
 
+	conn := map[string]any{
+		"nodes": nodes,
+	}
+	if includePageInfo {
+		conn["pageInfo"] = map[string]any{
+			"hasNextPage": hasNextPage,
+			"endCursor":   endCursor,
+		}
+	}
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"data": map[string]any{
-			"issues": map[string]any{
-				"nodes": nodes,
-				"pageInfo": map[string]any{
-					"hasNextPage": hasNextPage,
-					"endCursor":   endCursor,
-				},
-			},
+			"issues": conn,
 		},
 	})
 }
@@ -12234,6 +12240,11 @@ func runGraphQLLatestOnlyChoice(t *testing.T, forward, backward []map[string]any
 func runGraphQLLatestOnlyChoiceWithMaxPages(t *testing.T, forward, backward, after []map[string]any, maxPages int, wantCalls []string) (*gqlLatestChoiceHandler, *store.Store) {
 	t.Helper()
 	handler := &gqlLatestChoiceHandler{forward: forward, backward: backward, after: after}
+	return runGraphQLLatestOnlyChoiceWithHandler(t, handler, maxPages, wantCalls)
+}
+
+func runGraphQLLatestOnlyChoiceWithHandler(t *testing.T, handler *gqlLatestChoiceHandler, maxPages int, wantCalls []string) (*gqlLatestChoiceHandler, *store.Store) {
+	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
@@ -12333,19 +12344,19 @@ func TestGraphQLLatestOnlyReadsNestedTimestampFields(t *testing.T) {
 }
 
 func TestGraphQLLatestOnlyCanContinueAfterBackwardPageWins(t *testing.T) {
-	_, db := runGraphQLLatestOnlyChoiceWithMaxPages(t,
-		[]map[string]any{
+	handler := &gqlLatestChoiceHandler{
+		forward: []map[string]any{
 			{"id": "old-1", "title": "oldest first", "createdAt": "2021-08-02T00:00:00Z"},
 		},
-		[]map[string]any{
+		backward: []map[string]any{
 			{"id": "new-1", "title": "newest page", "createdAt": "2026-06-02T00:00:00Z"},
 		},
-		[]map[string]any{
+		after: []map[string]any{
 			{"id": "after-1", "title": "after latest", "createdAt": "2026-06-03T00:00:00Z"},
 		},
-		2,
-		[]string{"first", "last", "after"},
-	)
+		omitBackwardPageInfo: true,
+	}
+	_, db := runGraphQLLatestOnlyChoiceWithHandler(t, handler, 2, []string{"first", "last", "after"})
 	assertGraphQLLatestOnlyStored(t, db, "new-1", "old-1")
 	if _, err := db.Get("issues", "after-1"); err != nil {
 		t.Fatalf("wanted issue after-1 to be stored after latest page pagination: %v", err)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12126,6 +12126,173 @@ func TestGraphQLSyncResourceClearsSelfReferentialCursorOnMaxPagesCap(t *testing.
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGeneratedGraphQLLatestOnlyChoosesNewestPage(t *testing.T) {
+	t.Parallel()
+
+	const sdl = `
+type Query {
+  issues(first: Int, after: String, last: Int, before: String): IssueConnection
+}
+
+type IssueConnection {
+  nodes: [Issue]
+  pageInfo: PageInfo
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+
+type Issue {
+  id: ID!
+  title: String!
+  createdAt: String
+}
+`
+
+	gqlSpec, err := graphql.ParseSDLBytes("latest-choice.graphql", []byte(sdl))
+	require.NoError(t, err)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(gqlSpec.Name))
+	gen := New(gqlSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	behaviorTest := `package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"` + naming.CLI(gqlSpec.Name) + `/internal/client"
+	"` + naming.CLI(gqlSpec.Name) + `/internal/config"
+	"` + naming.CLI(gqlSpec.Name) + `/internal/store"
+)
+
+type gqlLatestChoiceHandler struct {
+	forward  []map[string]string
+	backward []map[string]string
+	calls    []string
+}
+
+func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Variables map[string]any ` + "`json:\"variables\"`" + `
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	nodes := h.forward
+	if _, ok := req.Variables["last"]; ok {
+		h.calls = append(h.calls, "last")
+		nodes = h.backward
+	} else {
+		h.calls = append(h.calls, "first")
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{
+			"issues": map[string]any{
+				"nodes": nodes,
+				"pageInfo": map[string]any{
+					"hasNextPage": true,
+					"endCursor":   "forward-end",
+				},
+			},
+		},
+	})
+}
+
+func runGraphQLLatestOnlyChoice(t *testing.T, forward, backward []map[string]string) (*gqlLatestChoiceHandler, *store.Store) {
+	t.Helper()
+	handler := &gqlLatestChoiceHandler{forward: forward, backward: backward}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	c := client.New(&config.Config{BaseURL: server.URL}, time.Second, 0)
+	res := syncResource(context.Background(), c, db, "issues", "", false, 1, true)
+	if res.Err != nil {
+		t.Fatalf("syncResource error: %v", res.Err)
+	}
+	if !reflect.DeepEqual(handler.calls, []string{"first", "last"}) {
+		t.Fatalf("query calls = %#v, want forward then backward latest probe", handler.calls)
+	}
+	return handler, db
+}
+
+func assertGraphQLLatestOnlyStored(t *testing.T, db *store.Store, wantID, rejectID string) {
+	t.Helper()
+	if _, err := db.Get("issues", wantID); err != nil {
+		t.Fatalf("wanted issue %s to be stored: %v", wantID, err)
+	}
+	if _, err := db.Get("issues", rejectID); err == nil {
+		t.Fatalf("issue %s should not have been stored", rejectID)
+	} else if err != sql.ErrNoRows {
+		t.Fatalf("checking rejected issue %s: %v", rejectID, err)
+	}
+}
+
+func TestGraphQLLatestOnlyChoosesBackwardPageForOldestFirst(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoice(t,
+		[]map[string]string{
+			{"id": "old-1", "title": "oldest first", "createdAt": "2021-08-02T00:00:00Z"},
+			{"id": "old-2", "title": "oldest second", "createdAt": "2021-08-03T00:00:00Z"},
+		},
+		[]map[string]string{
+			{"id": "new-1", "title": "newest page", "createdAt": "2026-06-01T00:00:00Z"},
+			{"id": "new-2", "title": "newer page", "createdAt": "2026-06-02T00:00:00Z"},
+		},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "new-1", "old-1")
+}
+
+func TestGraphQLLatestOnlyKeepsForwardPageForNewestFirst(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoice(t,
+		[]map[string]string{
+			{"id": "new-1", "title": "newest first", "createdAt": "2026-06-02T00:00:00Z"},
+			{"id": "new-2", "title": "newest second", "createdAt": "2026-06-01T00:00:00Z"},
+		},
+		[]map[string]string{
+			{"id": "old-1", "title": "oldest tail", "createdAt": "2021-08-02T00:00:00Z"},
+			{"id": "old-2", "title": "oldest tail second", "createdAt": "2021-08-03T00:00:00Z"},
+		},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "new-1", "old-1")
+}
+
+func TestGraphQLLatestOnlyKeepsForwardPageWithoutTimestampEvidence(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoice(t,
+		[]map[string]string{
+			{"id": "forward-1", "title": "forward page"},
+			{"id": "forward-2", "title": "forward second"},
+		},
+		[]map[string]string{
+			{"id": "backward-1", "title": "backward page"},
+			{"id": "backward-2", "title": "backward second"},
+		},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "forward-1", "backward-1")
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "graphql_sync_latest_only_test.go"), []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestGraphQLLatestOnly(ChoosesBackwardPageForOldestFirst|KeepsForwardPageForNewestFirst|KeepsForwardPageWithoutTimestampEvidence)$")
+}
+
 func TestGeneratedGraphQLSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {
 	t.Parallel()
 
@@ -13810,6 +13977,7 @@ func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 						Params: []spec.Param{
 							{Name: "first", Type: "integer", Default: 100},
 							{Name: "after", Type: "string"},
+							{Name: "last", Type: "integer"},
 							{Name: "before", Type: "string"},
 						},
 						Pagination: &spec.Pagination{
@@ -13860,6 +14028,7 @@ func TestGenerateGraphQLListWiresOptionalQueryVariable(t *testing.T) {
 	assert.Contains(t, queriesContent, "query($first: Int!, $after: String, $query: String)")
 	assert.Contains(t, queriesContent, "orders(first: $first, after: $after, query: $query)")
 	assert.Contains(t, queriesContent, "query($first: Int!, $after: String) {\n  fulfillmentOrders(first: $first, after: $after)")
+	assert.Contains(t, queriesContent, "query($last: Int!) {\n  fulfillmentOrders(last: $last)")
 	assert.NotContains(t, queriesContent, "before: $before")
 	assert.NotContains(t, queriesContent, "fulfillmentOrders(first: $first, after: $after, query: $query)")
 	assert.Contains(t, queriesContent, "query {\n  customers {\n")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12325,7 +12325,14 @@ func TestGraphQLLatestOnlyIgnoresDateLikeNonTimestampFields(t *testing.T) {
 			{"id": "forward-1", "title": "newest first", "createdAt": "2026-06-02T00:00:00Z"},
 		},
 		[]map[string]any{
-			{"id": "backward-1", "title": "2027-01-01"},
+			{
+				"id":         "backward-1",
+				"title":      "2027-01-01",
+				"lastUpdate": "2027-01-01T00:00:00Z",
+				"candidate":  "2027-01-02",
+				"uptime":     "2027-01-03T00:00:00Z",
+				"runtime":    "2027-01-04T00:00:00Z",
+			},
 		},
 	)
 	assertGraphQLLatestOnlyStored(t, db, "forward-1", "backward-1")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12131,7 +12131,7 @@ func TestGeneratedGraphQLLatestOnlyChoosesNewestPage(t *testing.T) {
 
 	const sdl = `
 type Query {
-  issues(first: Int, after: String, last: Int, before: String): IssueConnection
+  issues(first: Int, after: String, last: Int, before: String, query: String): IssueConnection
 }
 
 type IssueConnection {
@@ -12158,6 +12158,11 @@ type Issue {
 	gen := New(gqlSpec, outputDir)
 	require.NoError(t, gen.Generate())
 
+	queriesGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "queries.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(queriesGo), "pageInfo { hasNextPage endCursor }")
+	require.NotContains(t, string(queriesGo), "ListLatestQuery = `query($last: Int!, $query")
+
 	behaviorTest := `package cli
 
 import (
@@ -12177,8 +12182,9 @@ import (
 )
 
 type gqlLatestChoiceHandler struct {
-	forward  []map[string]string
-	backward []map[string]string
+	forward  []map[string]any
+	backward []map[string]any
+	after    []map[string]any
 	calls    []string
 }
 
@@ -12192,9 +12198,17 @@ func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	nodes := h.forward
+	hasNextPage := true
+	endCursor := "forward-end"
 	if _, ok := req.Variables["last"]; ok {
 		h.calls = append(h.calls, "last")
 		nodes = h.backward
+		endCursor = "latest-end"
+	} else if _, ok := req.Variables["after"]; ok {
+		h.calls = append(h.calls, "after")
+		nodes = h.after
+		hasNextPage = false
+		endCursor = ""
 	} else {
 		h.calls = append(h.calls, "first")
 	}
@@ -12204,17 +12218,22 @@ func (h *gqlLatestChoiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			"issues": map[string]any{
 				"nodes": nodes,
 				"pageInfo": map[string]any{
-					"hasNextPage": true,
-					"endCursor":   "forward-end",
+					"hasNextPage": hasNextPage,
+					"endCursor":   endCursor,
 				},
 			},
 		},
 	})
 }
 
-func runGraphQLLatestOnlyChoice(t *testing.T, forward, backward []map[string]string) (*gqlLatestChoiceHandler, *store.Store) {
+func runGraphQLLatestOnlyChoice(t *testing.T, forward, backward []map[string]any) (*gqlLatestChoiceHandler, *store.Store) {
 	t.Helper()
-	handler := &gqlLatestChoiceHandler{forward: forward, backward: backward}
+	return runGraphQLLatestOnlyChoiceWithMaxPages(t, forward, backward, nil, 1, []string{"first", "last"})
+}
+
+func runGraphQLLatestOnlyChoiceWithMaxPages(t *testing.T, forward, backward, after []map[string]any, maxPages int, wantCalls []string) (*gqlLatestChoiceHandler, *store.Store) {
+	t.Helper()
+	handler := &gqlLatestChoiceHandler{forward: forward, backward: backward, after: after}
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
@@ -12225,12 +12244,12 @@ func runGraphQLLatestOnlyChoice(t *testing.T, forward, backward []map[string]str
 	t.Cleanup(func() { db.Close() })
 
 	c := client.New(&config.Config{BaseURL: server.URL}, time.Second, 0)
-	res := syncResource(context.Background(), c, db, "issues", "", false, 1, true)
+	res := syncResource(context.Background(), c, db, "issues", "", false, maxPages, true)
 	if res.Err != nil {
 		t.Fatalf("syncResource error: %v", res.Err)
 	}
-	if !reflect.DeepEqual(handler.calls, []string{"first", "last"}) {
-		t.Fatalf("query calls = %#v, want forward then backward latest probe", handler.calls)
+	if !reflect.DeepEqual(handler.calls, wantCalls) {
+		t.Fatalf("query calls = %#v, want %#v", handler.calls, wantCalls)
 	}
 	return handler, db
 }
@@ -12249,11 +12268,11 @@ func assertGraphQLLatestOnlyStored(t *testing.T, db *store.Store, wantID, reject
 
 func TestGraphQLLatestOnlyChoosesBackwardPageForOldestFirst(t *testing.T) {
 	_, db := runGraphQLLatestOnlyChoice(t,
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "old-1", "title": "oldest first", "createdAt": "2021-08-02T00:00:00Z"},
 			{"id": "old-2", "title": "oldest second", "createdAt": "2021-08-03T00:00:00Z"},
 		},
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "new-1", "title": "newest page", "createdAt": "2026-06-01T00:00:00Z"},
 			{"id": "new-2", "title": "newer page", "createdAt": "2026-06-02T00:00:00Z"},
 		},
@@ -12263,11 +12282,11 @@ func TestGraphQLLatestOnlyChoosesBackwardPageForOldestFirst(t *testing.T) {
 
 func TestGraphQLLatestOnlyKeepsForwardPageForNewestFirst(t *testing.T) {
 	_, db := runGraphQLLatestOnlyChoice(t,
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "new-1", "title": "newest first", "createdAt": "2026-06-02T00:00:00Z"},
 			{"id": "new-2", "title": "newest second", "createdAt": "2026-06-01T00:00:00Z"},
 		},
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "old-1", "title": "oldest tail", "createdAt": "2021-08-02T00:00:00Z"},
 			{"id": "old-2", "title": "oldest tail second", "createdAt": "2021-08-03T00:00:00Z"},
 		},
@@ -12277,20 +12296,83 @@ func TestGraphQLLatestOnlyKeepsForwardPageForNewestFirst(t *testing.T) {
 
 func TestGraphQLLatestOnlyKeepsForwardPageWithoutTimestampEvidence(t *testing.T) {
 	_, db := runGraphQLLatestOnlyChoice(t,
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "forward-1", "title": "forward page"},
 			{"id": "forward-2", "title": "forward second"},
 		},
-		[]map[string]string{
+		[]map[string]any{
 			{"id": "backward-1", "title": "backward page"},
 			{"id": "backward-2", "title": "backward second"},
 		},
 	)
 	assertGraphQLLatestOnlyStored(t, db, "forward-1", "backward-1")
 }
+
+func TestGraphQLLatestOnlyIgnoresDateLikeNonTimestampFields(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoice(t,
+		[]map[string]any{
+			{"id": "forward-1", "title": "newest first", "createdAt": "2026-06-02T00:00:00Z"},
+		},
+		[]map[string]any{
+			{"id": "backward-1", "title": "2027-01-01"},
+		},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "forward-1", "backward-1")
+}
+
+func TestGraphQLLatestOnlyReadsNestedTimestampFields(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoice(t,
+		[]map[string]any{
+			{"id": "old-1", "title": "oldest first", "createdAt": "2021-08-02T00:00:00Z"},
+		},
+		[]map[string]any{
+			{"id": "new-1", "title": "newest nested", "meta": map[string]any{"updatedAt": "2026-06-02T00:00:00Z"}},
+		},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "new-1", "old-1")
+}
+
+func TestGraphQLLatestOnlyCanContinueAfterBackwardPageWins(t *testing.T) {
+	_, db := runGraphQLLatestOnlyChoiceWithMaxPages(t,
+		[]map[string]any{
+			{"id": "old-1", "title": "oldest first", "createdAt": "2021-08-02T00:00:00Z"},
+		},
+		[]map[string]any{
+			{"id": "new-1", "title": "newest page", "createdAt": "2026-06-02T00:00:00Z"},
+		},
+		[]map[string]any{
+			{"id": "after-1", "title": "after latest", "createdAt": "2026-06-03T00:00:00Z"},
+		},
+		2,
+		[]string{"first", "last", "after"},
+	)
+	assertGraphQLLatestOnlyStored(t, db, "new-1", "old-1")
+	if _, err := db.Get("issues", "after-1"); err != nil {
+		t.Fatalf("wanted issue after-1 to be stored after latest page pagination: %v", err)
+	}
+}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "graphql_sync_latest_only_test.go"), []byte(behaviorTest), 0o644))
-	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestGraphQLLatestOnly(ChoosesBackwardPageForOldestFirst|KeepsForwardPageForNewestFirst|KeepsForwardPageWithoutTimestampEvidence)$")
+	selector := "^TestGraphQLLatestOnly(ChoosesBackwardPageForOldestFirst|KeepsForwardPageForNewestFirst|KeepsForwardPageWithoutTimestampEvidence|IgnoresDateLikeNonTimestampFields|ReadsNestedTimestampFields|CanContinueAfterBackwardPageWins)$"
+	listCmd := exec.Command("go", "test", "-mod=mod", "./internal/cli", "-list", selector)
+	listCmd.Dir = outputDir
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	listCmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	listOut, err := listCmd.CombinedOutput()
+	require.NoError(t, err, string(listOut))
+	for _, name := range []string{
+		"TestGraphQLLatestOnlyChoosesBackwardPageForOldestFirst",
+		"TestGraphQLLatestOnlyKeepsForwardPageForNewestFirst",
+		"TestGraphQLLatestOnlyKeepsForwardPageWithoutTimestampEvidence",
+		"TestGraphQLLatestOnlyIgnoresDateLikeNonTimestampFields",
+		"TestGraphQLLatestOnlyReadsNestedTimestampFields",
+		"TestGraphQLLatestOnlyCanContinueAfterBackwardPageWins",
+	} {
+		require.Contains(t, string(listOut), name)
+	}
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", selector)
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratedGraphQLSyncConcurrencyDefaultHonorsRateClass(t *testing.T) {

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -30,6 +30,7 @@ const {{pascal $rName}}ListLatestQuery = {{backtick}}query{{if $latestParams}}({
       {{.}}
 {{- end}}
     }
+    pageInfo { hasNextPage endCursor }
   }
 }{{backtick}}
 {{- end}}

--- a/internal/generator/templates/graphql_queries.go.tmpl
+++ b/internal/generator/templates/graphql_queries.go.tmpl
@@ -20,6 +20,19 @@ const {{pascal $rName}}ListQuery = {{backtick}}query{{if $params}}({{- range $i,
     pageInfo { hasNextPage endCursor }
   }
 }{{backtick}}
+{{- if hasGraphQLParam $endpoint "last"}}
+{{- $latestParams := graphqlLatestParams $endpoint}}
+
+const {{pascal $rName}}ListLatestQuery = {{backtick}}query{{if $latestParams}}({{- range $i, $p := $latestParams}}{{if $i}}, {{end}}${{$p.Name}}: {{graphqlVariableType $p}}{{- end}}){{end}} {
+  {{$queryField}}{{if $latestParams}}({{- range $i, $p := $latestParams}}{{if $i}}, {{end}}{{$p.Name}}: ${{$p.Name}}{{- end}}){{end}} {
+    nodes {
+{{- range graphqlFieldSelection $endpoint.Response.Item $.Types}}
+      {{.}}
+{{- end}}
+    }
+  }
+}{{backtick}}
+{{- end}}
 {{- end}}
 {{- if eq $eName "get"}}
 {{- $queryField := graphqlQueryField $endpoint.ResponsePath}}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -627,8 +627,12 @@ func isSyncTimestampField(name string) bool {
 		strings.HasSuffix(lower, "_at") ||
 		strings.HasSuffix(lower, "-at") ||
 		strings.Contains(normalized, "timestamp") ||
-		strings.HasSuffix(normalized, "time") ||
-		strings.HasSuffix(normalized, "date")
+		strings.HasSuffix(name, "Time") ||
+		strings.HasSuffix(lower, "_time") ||
+		strings.HasSuffix(lower, "-time") ||
+		strings.HasSuffix(name, "Date") ||
+		strings.HasSuffix(lower, "_date") ||
+		strings.HasSuffix(lower, "-date")
 }
 
 func parseSyncTimestamp(value string) (time.Time, bool) {

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -252,9 +252,10 @@ Exit codes & warnings:
 
 // graphqlSyncDef describes how to sync a resource via GraphQL.
 type graphqlSyncDef struct {
-	Query     string // GraphQL query constant
-	FieldPath string // top-level field in the response data (e.g., "issues")
-	PageSize  int    // default page size for this resource
+	Query       string // GraphQL forward-page query constant
+	LatestQuery string // GraphQL backward-page query constant, when the schema supports last
+	FieldPath   string // top-level field in the response data (e.g., "issues")
+	PageSize    int    // default page size for this resource
 }
 
 // graphqlSyncDefs returns the sync definitions for all syncable resources.
@@ -262,9 +263,14 @@ func graphqlSyncDefs() map[string]graphqlSyncDef {
 	return map[string]graphqlSyncDef{
 {{- range .SyncableResources}}
 		"{{.Name}}": {
-			Query:     client.{{pascal .Name}}ListQuery,
-			FieldPath: "{{index $.GraphQLFieldPaths .Name}}",
-			PageSize:  50,
+			Query:       client.{{pascal .Name}}ListQuery,
+{{- $resource := index $.Resources .Name}}
+{{- $endpoint := index $resource.Endpoints "list"}}
+{{- if hasGraphQLParam $endpoint "last"}}
+			LatestQuery: client.{{pascal .Name}}ListLatestQuery,
+{{- end}}
+			FieldPath:   "{{index $.GraphQLFieldPaths .Name}}",
+			PageSize:    50,
 		},
 {{- end}}
 	}
@@ -324,6 +330,13 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 				fmt.Fprintln(os.Stderr, syncErrorJSON(resource, "", err))
 			}
 			return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching %s: %w", resource, err), Duration: time.Since(started)}
+		}
+		if latestOnly && cursor == "" && def.LatestQuery != "" {
+			latestData, err := c.Query(ctx, def.LatestQuery, map[string]any{"last": pageSize})
+			if err != nil {
+				return syncResult{Resource: resource, Count: totalCount, Err: fmt.Errorf("fetching latest page for %s: %w", resource, err), Duration: time.Since(started)}
+			}
+			data = chooseGraphQLLatestPage(def.FieldPath, data, latestData)
 		}
 
 		// Navigate to the connection field in the response
@@ -455,6 +468,91 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
+}
+
+func chooseGraphQLLatestPage(fieldPath string, forwardData, backwardData json.RawMessage) json.RawMessage {
+	forwardTime, forwardOK := newestGraphQLConnectionTimestamp(fieldPath, forwardData)
+	backwardTime, backwardOK := newestGraphQLConnectionTimestamp(fieldPath, backwardData)
+	if forwardOK && backwardOK && backwardTime.After(forwardTime) {
+		return backwardData
+	}
+	return forwardData
+}
+
+func newestGraphQLConnectionTimestamp(fieldPath string, data json.RawMessage) (time.Time, bool) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return time.Time{}, false
+	}
+	connRaw, ok := root[fieldPath]
+	if !ok {
+		for _, v := range root {
+			connRaw = v
+			break
+		}
+	}
+	if connRaw == nil {
+		return time.Time{}, false
+	}
+
+	var conn struct {
+		Nodes []json.RawMessage `json:"nodes"`
+	}
+	if err := json.Unmarshal(connRaw, &conn); err != nil {
+		return time.Time{}, false
+	}
+
+	var newest time.Time
+	var found bool
+	for _, node := range conn.Nodes {
+		nodeNewest, ok := newestJSONTimestamp(node)
+		if !ok {
+			continue
+		}
+		if !found || nodeNewest.After(newest) {
+			newest = nodeNewest
+			found = true
+		}
+	}
+	return newest, found
+}
+
+func newestJSONTimestamp(data json.RawMessage) (time.Time, bool) {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return time.Time{}, false
+	}
+	var newest time.Time
+	var found bool
+	for _, value := range obj {
+		s, ok := value.(string)
+		if !ok {
+			continue
+		}
+		ts, ok := parseSyncTimestamp(s)
+		if !ok {
+			continue
+		}
+		if !found || ts.After(newest) {
+			newest = ts
+			found = true
+		}
+	}
+	return newest, found
+}
+
+func parseSyncTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		ts, err := time.Parse(layout, value)
+		if err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
 }
 
 func defaultSyncResources() []string {

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -474,9 +474,65 @@ func chooseGraphQLLatestPage(fieldPath string, forwardData, backwardData json.Ra
 	forwardTime, forwardOK := newestGraphQLConnectionTimestamp(fieldPath, forwardData)
 	backwardTime, backwardOK := newestGraphQLConnectionTimestamp(fieldPath, backwardData)
 	if forwardOK && backwardOK && backwardTime.After(forwardTime) {
+		if mergedData, ok := graphQLConnectionWithForwardPageInfo(fieldPath, forwardData, backwardData); ok {
+			return mergedData
+		}
 		return backwardData
 	}
 	return forwardData
+}
+
+func graphQLConnectionWithForwardPageInfo(fieldPath string, forwardData, chosenData json.RawMessage) (json.RawMessage, bool) {
+	var forwardRoot map[string]json.RawMessage
+	if err := json.Unmarshal(forwardData, &forwardRoot); err != nil {
+		return nil, false
+	}
+	forwardKey, forwardConnRaw := graphQLConnectionRaw(fieldPath, forwardRoot)
+	if forwardKey == "" || forwardConnRaw == nil {
+		return nil, false
+	}
+	var forwardConn map[string]json.RawMessage
+	if err := json.Unmarshal(forwardConnRaw, &forwardConn); err != nil {
+		return nil, false
+	}
+	pageInfo, ok := forwardConn["pageInfo"]
+	if !ok {
+		return nil, false
+	}
+
+	var chosenRoot map[string]json.RawMessage
+	if err := json.Unmarshal(chosenData, &chosenRoot); err != nil {
+		return nil, false
+	}
+	chosenKey, chosenConnRaw := graphQLConnectionRaw(fieldPath, chosenRoot)
+	if chosenKey == "" || chosenConnRaw == nil {
+		return nil, false
+	}
+	var chosenConn map[string]json.RawMessage
+	if err := json.Unmarshal(chosenConnRaw, &chosenConn); err != nil {
+		return nil, false
+	}
+	chosenConn["pageInfo"] = pageInfo
+	connData, err := json.Marshal(chosenConn)
+	if err != nil {
+		return nil, false
+	}
+	chosenRoot[chosenKey] = connData
+	mergedData, err := json.Marshal(chosenRoot)
+	if err != nil {
+		return nil, false
+	}
+	return mergedData, true
+}
+
+func graphQLConnectionRaw(fieldPath string, root map[string]json.RawMessage) (string, json.RawMessage) {
+	if connRaw, ok := root[fieldPath]; ok {
+		return fieldPath, connRaw
+	}
+	for key, connRaw := range root {
+		return key, connRaw
+	}
+	return "", nil
 }
 
 func newestGraphQLConnectionTimestamp(fieldPath string, data json.RawMessage) (time.Time, bool) {
@@ -484,13 +540,7 @@ func newestGraphQLConnectionTimestamp(fieldPath string, data json.RawMessage) (t
 	if err := json.Unmarshal(data, &root); err != nil {
 		return time.Time{}, false
 	}
-	connRaw, ok := root[fieldPath]
-	if !ok {
-		for _, v := range root {
-			connRaw = v
-			break
-		}
-	}
+	_, connRaw := graphQLConnectionRaw(fieldPath, root)
 	if connRaw == nil {
 		return time.Time{}, false
 	}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -518,27 +518,67 @@ func newestGraphQLConnectionTimestamp(fieldPath string, data json.RawMessage) (t
 }
 
 func newestJSONTimestamp(data json.RawMessage) (time.Time, bool) {
-	var obj map[string]any
-	if err := json.Unmarshal(data, &obj); err != nil {
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
 		return time.Time{}, false
 	}
+	return newestJSONValueTimestamp("", value)
+}
+
+func newestJSONValueTimestamp(fieldName string, value any) (time.Time, bool) {
 	var newest time.Time
 	var found bool
-	for _, value := range obj {
-		s, ok := value.(string)
-		if !ok {
-			continue
+	switch v := value.(type) {
+	case map[string]any:
+		for k, child := range v {
+			ts, ok := newestJSONValueTimestamp(k, child)
+			if !ok {
+				continue
+			}
+			if !found || ts.After(newest) {
+				newest = ts
+				found = true
+			}
 		}
-		ts, ok := parseSyncTimestamp(s)
-		if !ok {
-			continue
+	case []any:
+		for _, child := range v {
+			ts, ok := newestJSONValueTimestamp("", child)
+			if !ok {
+				continue
+			}
+			if !found || ts.After(newest) {
+				newest = ts
+				found = true
+			}
 		}
-		if !found || ts.After(newest) {
-			newest = ts
-			found = true
+	case string:
+		if isSyncTimestampField(fieldName) {
+			ts, ok := parseSyncTimestamp(v)
+			if ok {
+				newest = ts
+				found = true
+			}
 		}
 	}
 	return newest, found
+}
+
+func isSyncTimestampField(name string) bool {
+	if name == "" {
+		return false
+	}
+	normalized := strings.ToLower(strings.NewReplacer("_", "", "-", "").Replace(name))
+	switch normalized {
+	case "createdat", "updatedat", "publishedat", "modifiedat", "completedat", "closedat", "openedat", "startedat", "endedat", "expiresat", "timestamp", "datetime", "date", "time":
+		return true
+	}
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(name, "At") ||
+		strings.HasSuffix(lower, "_at") ||
+		strings.HasSuffix(lower, "-at") ||
+		strings.Contains(normalized, "timestamp") ||
+		strings.HasSuffix(normalized, "time") ||
+		strings.HasSuffix(normalized, "date")
 }
 
 func parseSyncTimestamp(value string) (time.Time, bool) {


### PR DESCRIPTION
## Summary
Generated GraphQL CLIs no longer assume the first Relay page is the latest page for `sync --latest-only`. When a list field exposes `last`, sync now probes the backward page and uses timestamp evidence to choose the genuinely newest page, while timestamp-less or already-newest-first connections keep the existing forward-page behavior.

Closes #2354

## Tests
- `go test ./internal/generator -run '^TestGeneratedGraphQLLatestOnlyChoosesNewestPage$' -count=1`
- `go test ./internal/generator -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
