### PR TITLE
fix(cli): derive live dogfood fixtures from store

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -580,10 +580,18 @@ func runLiveDogfoodPreSync(commands []liveDogfoodCommand, ctx resolveCtx) {
 	}
 	for _, command := range commands {
 		if len(command.Path) == 1 && command.Path[0] == "sync" {
-			_ = runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, []string{"sync"}, ctx.timeout)
+			_ = runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, []string{"sync"}, liveDogfoodPreSyncTimeout(ctx.timeout))
 			return
 		}
 	}
+}
+
+func liveDogfoodPreSyncTimeout(timeout time.Duration) time.Duration {
+	const maxPreSyncTimeout = 5 * time.Second
+	if timeout <= 0 || timeout > maxPreSyncTimeout {
+		return maxPreSyncTimeout
+	}
+	return timeout
 }
 
 // buildSiblingMap groups commands by their joined parent path so the chain
@@ -649,7 +657,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 	}
 
 	resolved := make([]string, 0, nPlaceholders)
-	fixtureSource := ""
+	storeResolved := 0
 	for i, name := range placeholders {
 		nameLower := strings.ToLower(name)
 		// id-shape covers: bare "id", snake_case "*_id", or camelCase "*id"
@@ -668,7 +676,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		listCmd := findListCompanion(ctx.siblings[siblingKey])
 		if listCmd == nil {
 			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
-				fixtureSource = "store"
+				storeResolved++
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
@@ -691,7 +699,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 				// run. Skip immediately so sibling get-shape commands sharing
 				// the same companion don't each block on the same 30s timeout.
 				if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
-					fixtureSource = "store"
+					storeResolved++
 					resolved = append(resolved, id)
 					continue
 				} else if storeAvailable {
@@ -708,7 +716,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		if run.exitCode != 0 {
 			ctx.cache.results[cacheKey] = "" // negative-cache sentinel
 			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
-				fixtureSource = "store"
+				storeResolved++
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
@@ -722,7 +730,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		if !ok {
 			ctx.cache.results[cacheKey] = "" // negative-cache sentinel
 			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
-				fixtureSource = "store"
+				storeResolved++
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
@@ -736,6 +744,10 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		resolved = append(resolved, id)
 	}
 
+	fixtureSource := ""
+	if storeResolved == nPlaceholders {
+		fixtureSource = "store"
+	}
 	return substitutePositionals(happyArgs, command.Path, resolved), false, "", fixtureSource
 }
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -85,13 +85,14 @@ type LiveDogfoodReport struct {
 }
 
 type LiveDogfoodTestResult struct {
-	Command      string              `json:"command"`
-	Kind         LiveDogfoodTestKind `json:"kind"`
-	Args         []string            `json:"args"`
-	Status       LiveDogfoodStatus   `json:"status"`
-	ExitCode     int                 `json:"exit_code,omitempty"`
-	Reason       string              `json:"reason,omitempty"`
-	OutputSample string              `json:"output_sample,omitempty"`
+	Command       string              `json:"command"`
+	Kind          LiveDogfoodTestKind `json:"kind"`
+	Args          []string            `json:"args"`
+	Status        LiveDogfoodStatus   `json:"status"`
+	ExitCode      int                 `json:"exit_code,omitempty"`
+	Reason        string              `json:"reason,omitempty"`
+	FixtureSource string              `json:"fixture_source,omitempty"`
+	OutputSample  string              `json:"output_sample,omitempty"`
 }
 
 type liveDogfoodCommand struct {
@@ -180,7 +181,9 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		timeout:          timeout,
 		authTier:         resolveLiveDogfoodAuthTier(opts.AuthTier),
 		allowDestructive: opts.AllowDestructive,
+		storeDBPath:      liveDogfoodDefaultDBPath(liveDogfoodCLINameForStore(binaryPath, opts.BinaryName)),
 	}
+	runLiveDogfoodPreSync(commands, ctx)
 
 	for _, command := range commands {
 		commandName := strings.Join(command.Path, " ")
@@ -536,12 +539,50 @@ type resolveCtx struct {
 	timeout          time.Duration
 	authTier         string
 	allowDestructive bool
+	storeDBPath      string
 }
 
 func newCompanionCache() *companionCache {
 	return &companionCache{
 		results: map[string]string{},
 		helps:   map[string]string{},
+	}
+}
+
+func liveDogfoodCLINameForStore(binaryPath, requestedName string) string {
+	name := strings.TrimSpace(requestedName)
+	if name == "" {
+		name = filepath.Base(binaryPath)
+	}
+	name = strings.TrimSuffix(name, ".exe")
+	name = strings.TrimSuffix(name, "-dogfood")
+	return name
+}
+
+func liveDogfoodDefaultDBPath(cliName string) string {
+	if cliName == "" {
+		return ""
+	}
+	home := currentSubprocessHome()
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+	}
+	return filepath.Join(home, ".local", "share", cliName, "data.db")
+}
+
+func runLiveDogfoodPreSync(commands []liveDogfoodCommand, ctx resolveCtx) {
+	if ctx.binaryPath == "" {
+		return
+	}
+	for _, command := range commands {
+		if len(command.Path) == 1 && command.Path[0] == "sync" {
+			_ = runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, []string{"sync"}, ctx.timeout)
+			return
+		}
 	}
 }
 
@@ -581,20 +622,21 @@ func findListCompanion(candidates []liveDogfoodCommand) *liveDogfoodCommand {
 // nested resources (projects/tasks/update <pid> <tid>) work end-to-end.
 //
 // Returns:
-//   - (newArgs, false, "")   — placeholders substituted; run happy_path with newArgs
-//   - (nil, true, reason)    — chain broke; caller must skip happy_path + json_fidelity
-//   - (happyArgs, false, "") — no positionals at all; pass-through unchanged
-func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string) {
+//   - (newArgs, false, "", source)   - placeholders substituted; run happy_path with newArgs
+//   - (happyArgs, false, "", source) - store was empty; run the synthetic example unchanged
+//   - (nil, true, reason, "")        - chain broke before an ID fixture source was available
+//   - (happyArgs, false, "", "")     - no positionals at all; pass-through unchanged
+func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string, string) {
 	// pp:happy-args already supplies real positional values, so the args are
 	// authoritative — skip placeholder re-resolution, which would otherwise
 	// overwrite them via the list companion or skip the command when no
 	// companion is reachable.
 	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) != "" {
-		return happyArgs, false, ""
+		return happyArgs, false, "", ""
 	}
 	placeholders := extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))
 	if len(placeholders) == 0 {
-		return happyArgs, false, ""
+		return happyArgs, false, "", ""
 	}
 
 	pathLen := len(command.Path)
@@ -603,10 +645,11 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		// More placeholders than path segments before the verb. Unusual
 		// shape (top-level command with multiple positionals); skip.
 		return nil, true, fmt.Sprintf(
-			"command path %v has fewer segments than placeholders (%d)", command.Path, nPlaceholders)
+			"command path %v has fewer segments than placeholders (%d)", command.Path, nPlaceholders), ""
 	}
 
 	resolved := make([]string, 0, nPlaceholders)
+	fixtureSource := ""
 	for i, name := range placeholders {
 		nameLower := strings.ToLower(name)
 		// id-shape covers: bare "id", snake_case "*_id", or camelCase "*id"
@@ -616,14 +659,22 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		isIDShape := nameLower == "id" ||
 			(strings.HasSuffix(nameLower, "id") && len(nameLower) > 2)
 		if !isIDShape {
-			return nil, true, fmt.Sprintf("non-id positional %q at depth %d", name, i)
+			return nil, true, fmt.Sprintf("non-id positional %q at depth %d", name, i), ""
 		}
 
 		// parent path of the verb that expects this placeholder.
-		siblingKey := strings.Join(command.Path[:pathLen-nPlaceholders+i], " ")
+		parentPath := command.Path[:pathLen-nPlaceholders+i]
+		siblingKey := strings.Join(parentPath, " ")
 		listCmd := findListCompanion(ctx.siblings[siblingKey])
 		if listCmd == nil {
-			return nil, true, fmt.Sprintf("no list companion at depth %d for %q", i, name)
+			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
+				fixtureSource = "store"
+				resolved = append(resolved, id)
+				continue
+			} else if storeAvailable {
+				return happyArgs, false, "", "synthetic"
+			}
+			return nil, true, fmt.Sprintf("no list companion at depth %d for %q", i, name), ""
 		}
 
 		listArgs := append([]string{}, listCmd.Path...)
@@ -639,8 +690,15 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 				// Negative-cache sentinel: this companion already failed in this
 				// run. Skip immediately so sibling get-shape commands sharing
 				// the same companion don't each block on the same 30s timeout.
+				if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
+					fixtureSource = "store"
+					resolved = append(resolved, id)
+					continue
+				} else if storeAvailable {
+					return happyArgs, false, "", "synthetic"
+				}
 				return nil, true, fmt.Sprintf(
-					"list companion previously failed at depth %d for %q", i, name)
+					"list companion previously failed at depth %d for %q", i, name), ""
 			}
 			resolved = append(resolved, id)
 			continue
@@ -649,22 +707,136 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		run := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, listArgs, ctx.timeout)
 		if run.exitCode != 0 {
 			ctx.cache.results[cacheKey] = "" // negative-cache sentinel
+			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
+				fixtureSource = "store"
+				resolved = append(resolved, id)
+				continue
+			} else if storeAvailable {
+				return happyArgs, false, "", "synthetic"
+			}
 			return nil, true, fmt.Sprintf(
-				"list companion failed at depth %d: exit %d", i, run.exitCode)
+				"list companion failed at depth %d: exit %d", i, run.exitCode), ""
 		}
 
 		id, ok := extractFirstIDFromJSON(run.stdout)
 		if !ok {
 			ctx.cache.results[cacheKey] = "" // negative-cache sentinel
+			if id, ok, storeAvailable := resolveStoreFixtureID(name, parentPath, ctx); ok {
+				fixtureSource = "store"
+				resolved = append(resolved, id)
+				continue
+			} else if storeAvailable {
+				return happyArgs, false, "", "synthetic"
+			}
 			return nil, true, fmt.Sprintf(
-				"no id parseable from companion at depth %d", i)
+				"no id parseable from companion at depth %d", i), ""
 		}
 
 		ctx.cache.results[cacheKey] = id
 		resolved = append(resolved, id)
 	}
 
-	return substitutePositionals(happyArgs, command.Path, resolved), false, ""
+	return substitutePositionals(happyArgs, command.Path, resolved), false, "", fixtureSource
+}
+
+func resolveStoreFixtureID(placeholder string, parentPath []string, ctx resolveCtx) (string, bool, bool) {
+	return liveDogfoodStoreFixtureID(ctx.storeDBPath, storeResourceCandidates(placeholder, parentPath), ctx.timeout)
+}
+
+func liveDogfoodStoreFixtureID(dbPath string, candidates []string, timeout time.Duration) (string, bool, bool) {
+	if dbPath == "" || len(candidates) == 0 {
+		return "", false, false
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return "", false, false
+	}
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		return "", false, false
+	}
+	table, err := runSQLiteScalar(sqlite, dbPath, `SELECT name FROM sqlite_master WHERE type='table' AND name='resources'`, timeout)
+	if err != nil {
+		return "", false, false
+	}
+	if strings.TrimSpace(table) == "" {
+		return "", false, true
+	}
+	query := fmt.Sprintf(
+		"SELECT id FROM resources WHERE resource_type IN (%s) ORDER BY updated_at DESC LIMIT 1",
+		sqlLiteralList(candidates),
+	)
+	id, err := runSQLiteScalar(sqlite, dbPath, query, timeout)
+	if err != nil {
+		return "", false, true
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", false, true
+	}
+	if line, _, ok := strings.Cut(id, "\n"); ok {
+		id = strings.TrimSpace(line)
+	}
+	return id, true, true
+}
+
+func runSQLiteScalar(sqlite, dbPath, query string, timeout time.Duration) (string, error) {
+	if timeout <= 0 || timeout > 2*time.Second {
+		timeout = 2 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, sqlite, "-batch", "-noheader", dbPath, query)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", ctx.Err()
+	}
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func storeResourceCandidates(placeholder string, parentPath []string) []string {
+	var out []string
+	add := func(v string) {
+		v = strings.Trim(strings.ToLower(v), " <>{}[]()")
+		v = strings.TrimSuffix(v, "_id")
+		v = strings.TrimSuffix(v, "-id")
+		if strings.HasSuffix(v, "id") && len(v) > 2 {
+			v = strings.TrimSuffix(v, "id")
+			v = strings.TrimRight(v, "-_")
+		}
+		v = strings.Trim(v, "-_ ")
+		if v == "" {
+			return
+		}
+		variants := []string{v, strings.ReplaceAll(v, "_", "-"), strings.ReplaceAll(v, "-", "_")}
+		for _, variant := range variants {
+			if variant == "" || slices.Contains(out, variant) {
+				continue
+			}
+			out = append(out, variant)
+			if !strings.HasSuffix(variant, "s") {
+				plural := variant + "s"
+				if !slices.Contains(out, plural) {
+					out = append(out, plural)
+				}
+			}
+		}
+	}
+	if len(parentPath) > 0 {
+		add(parentPath[len(parentPath)-1])
+	}
+	add(placeholder)
+	return out
+}
+
+func sqlLiteralList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, "'"+strings.ReplaceAll(value, "'", "''")+"'")
+	}
+	return strings.Join(quoted, ", ")
 }
 
 // substitutePositionals replaces the first len(resolved) non-flag args in
@@ -960,7 +1132,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
-	resolvedArgs, resolveSkipped, resolveReason := resolveCommandPositionals(command, happyArgs, ctx)
+	resolvedArgs, resolveSkipped, resolveReason, fixtureSource := resolveCommandPositionals(command, happyArgs, ctx)
 	switch {
 	case fixtureSkip != "":
 		results = append(results,
@@ -982,6 +1154,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 		happyRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, runArgs, ctx.timeout)
 		happyResult := liveDogfoodResult(commandName, LiveDogfoodTestHappy, runArgs, happyRun)
+		happyResult.FixtureSource = fixtureSource
 		if happyRun.exitCode == 0 {
 			happyResult.Status = LiveDogfoodStatusPass
 			happyResult.Reason = ""
@@ -996,11 +1169,14 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 		if happyResult.Status == LiveDogfoodStatusSkip &&
 			(happyResult.Reason == reasonUnavailableRunnerCredentials || happyResult.Reason == reasonRequiredParamFixture) {
-			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, happyResult.Reason))
+			jsonResult := skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, happyResult.Reason)
+			jsonResult.FixtureSource = fixtureSource
+			results = append(results, jsonResult)
 		} else if commandSupportsJSON(command.Help) {
 			jsonArgs := appendJSONArg(runArgs)
 			jsonRun := runLiveDogfoodProcess(ctx.binaryPath, ctx.cliDir, jsonArgs, ctx.timeout)
 			jsonResult := liveDogfoodResult(commandName, LiveDogfoodTestJSON, jsonArgs, jsonRun)
+			jsonResult.FixtureSource = fixtureSource
 			if jsonRun.exitCode == 0 {
 				if jsonRun.stdoutTruncated || !validLiveDogfoodJSONOutput(jsonRun.stdout) {
 					jsonResult.Status = LiveDogfoodStatusFail

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -2311,7 +2312,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "list"},
 		Help: "Usage:\n  cli widgets list [flags]\n",
 	}
-	args, skipped, _ := resolveCommandPositionals(cmd, []string{"widgets", "list"}, ctx)
+	args, skipped, _, _ := resolveCommandPositionals(cmd, []string{"widgets", "list"}, ctx)
 	assert.False(t, skipped)
 	assert.Equal(t, []string{"widgets", "list"}, args)
 
@@ -2320,7 +2321,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "search"},
 		Help: "Usage:\n  cli widgets search <query> [flags]\n",
 	}
-	_, skipped, reason := resolveCommandPositionals(cmd, []string{"widgets", "search", "x"}, ctx)
+	_, skipped, reason, _ := resolveCommandPositionals(cmd, []string{"widgets", "search", "x"}, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "non-id positional")
 
@@ -2329,7 +2330,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "get"},
 		Help: "Usage:\n  cli widgets get <id> [flags]\n",
 	}
-	_, skipped, reason = resolveCommandPositionals(cmd, []string{"widgets", "get", "x"}, ctx)
+	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"widgets", "get", "x"}, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "no list companion")
 
@@ -2338,7 +2339,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"movies", "get"},
 		Help: "Usage:\n  cli movies get <movieId> [flags]\n",
 	}
-	_, skipped, reason = resolveCommandPositionals(cmd, []string{"movies", "get", "x"}, ctx)
+	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"movies", "get", "x"}, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "no list companion")
 
@@ -2347,7 +2348,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"get"},
 		Help: "Usage:\n  cli get <id> <name> [flags]\n",
 	}
-	_, skipped, _ = resolveCommandPositionals(cmd, []string{"get", "x", "y"}, ctx)
+	_, skipped, _, _ = resolveCommandPositionals(cmd, []string{"get", "x", "y"}, ctx)
 	assert.True(t, skipped)
 }
 
@@ -3737,6 +3738,135 @@ func runRichFixtureMatrix(t *testing.T, dir, binaryName string) *LiveDogfoodRepo
 	return report
 }
 
+func requireSQLite3(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 is required for live dogfood store fixture tests")
+	}
+}
+
+func writeLiveDogfoodStoreFixture(t *testing.T, seedTask bool) (dir string, binaryName string) {
+	t.Helper()
+	requireSQLite3(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	seedLine := ":"
+	if seedTask {
+		seedLine = `sqlite3 "$db" "INSERT OR REPLACE INTO resources(resource_type, id, data) VALUES('tasks', 'real-task-1', '{}')"`
+	}
+	binPath := filepath.Join(dir, binaryName)
+	script := fmt.Sprintf(`#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"sync"},
+    {"name":"tasks","subcommands":[
+      {"name":"get-task"}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
+  cat <<'HELP'
+Sync records.
+
+Usage:
+  fixture-pp-cli sync [flags]
+
+Examples:
+  fixture-pp-cli sync
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "sync" ]; then
+  db="$HOME/.local/share/fixture-pp-cli/data.db"
+  mkdir -p "$(dirname "$db")"
+  sqlite3 "$db" "CREATE TABLE IF NOT EXISTS resources (id TEXT NOT NULL, resource_type TEXT NOT NULL, data JSON NOT NULL, synced_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (resource_type, id))"
+  %s
+  echo '{"synced":true}'
+  exit 0
+fi
+
+if [ "$1" = "tasks" ] && [ "$2" = "get-task" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Get a task.
+
+Usage:
+  fixture-pp-cli tasks get-task <task-id> [flags]
+
+Examples:
+  fixture-pp-cli tasks get-task example-id
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "tasks" ] && [ "$2" = "get-task" ]; then
+  if [ "${3:-}" = "real-task-1" ]; then
+    if [ "${4:-}" = "--json" ]; then
+      echo '{"id":"real-task-1"}'
+    else
+      echo 'real-task-1'
+    fi
+    exit 0
+  fi
+  echo 'HTTP 400: Invalid argument value' >&2
+  exit 1
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`, seedLine)
+	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
+	return dir, binaryName
+}
+
+func TestRunLiveDogfoodStoreFixtureSourceUsesSyncedResourceID(t *testing.T) {
+	dir, binaryName := writeLiveDogfoodStoreFixture(t, true)
+	report := runRichFixtureMatrix(t, dir, binaryName)
+
+	happy := findResultByCommandKind(report, "tasks get-task", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected tasks get-task happy_path result")
+	assert.Equal(t, LiveDogfoodStatusPass, happy.Status, happy.Reason)
+	assert.Equal(t, []string{"tasks", "get-task", "real-task-1"}, happy.Args)
+	assert.Equal(t, "store", happy.FixtureSource)
+
+	jsonResult := findResultByCommandKind(report, "tasks get-task", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult, "expected tasks get-task json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusPass, jsonResult.Status, jsonResult.Reason)
+	assert.Equal(t, []string{"tasks", "get-task", "real-task-1", "--json"}, jsonResult.Args)
+	assert.Equal(t, "store", jsonResult.FixtureSource)
+}
+
+func TestRunLiveDogfoodStoreFixtureSourceMarksSyntheticWhenStoreEmpty(t *testing.T) {
+	dir, binaryName := writeLiveDogfoodStoreFixture(t, false)
+	report := runRichFixtureMatrix(t, dir, binaryName)
+
+	happy := findResultByCommandKind(report, "tasks get-task", LiveDogfoodTestHappy)
+	require.NotNil(t, happy, "expected tasks get-task happy_path result")
+	assert.Equal(t, LiveDogfoodStatusFail, happy.Status)
+	assert.Equal(t, []string{"tasks", "get-task", "example-id"}, happy.Args)
+	assert.Equal(t, "synthetic", happy.FixtureSource)
+}
+
 func TestRunLiveDogfoodResolveSuccessSinglePositional(t *testing.T) {
 	dir, binaryName, argvLog := setupRichFixture(t)
 	report := runRichFixtureMatrix(t, dir, binaryName)
@@ -4451,7 +4581,7 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 	args, ok = liveDogfoodHappyArgs(posCmd)
 	require.True(t, ok)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, args)
-	resolved, skipped, reason := resolveCommandPositionals(posCmd, args, resolveCtx{})
+	resolved, skipped, reason, _ := resolveCommandPositionals(posCmd, args, resolveCtx{})
 	assert.False(t, skipped, "pp:happy-args positional must not be skipped: %s", reason)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, resolved,
 		"resolveCommandPositionals must preserve the pp:happy-args positional value")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2352,6 +2352,55 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 	assert.True(t, skipped)
 }
 
+func TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged(t *testing.T) {
+	requireSQLite3(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fixture-pp-cli")
+	script := `#!/bin/sh
+set -u
+if [ "$1" = "projects" ] && [ "$2" = "tasks" ] && [ "$3" = "list" ] && [ "$4" = "real-project-1" ] && [ "$5" = "--json" ]; then
+  echo '{"results":[{"id":"real-task-1"}]}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 99
+`
+	require.NoError(t, os.WriteFile(binaryPath, []byte(script), 0o755))
+
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	createResources := "CREATE TABLE resources (id TEXT NOT NULL, resource_type TEXT NOT NULL, data JSON NOT NULL, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (resource_type, id)); INSERT INTO resources(resource_type, id, data) VALUES('projects', 'real-project-1', '{}')"
+	require.NoError(t, exec.Command("sqlite3", dbPath, createResources).Run())
+
+	cmd := liveDogfoodCommand{
+		Path: []string{"projects", "tasks", "get"},
+		Help: "Usage:\n  fixture-pp-cli projects tasks get <project-id> <task-id> [flags]\n",
+	}
+	listCmd := liveDogfoodCommand{Path: []string{"projects", "tasks", "list"}}
+	ctx := resolveCtx{
+		binaryPath:  binaryPath,
+		cliDir:      dir,
+		siblings:    map[string][]liveDogfoodCommand{"projects tasks": {listCmd}},
+		cache:       newCompanionCache(),
+		timeout:     time.Second,
+		storeDBPath: dbPath,
+	}
+
+	args, skipped, reason, source := resolveCommandPositionals(cmd, []string{"projects", "tasks", "get", "example-project", "example-task"}, ctx)
+	require.False(t, skipped, reason)
+	assert.Equal(t, []string{"projects", "tasks", "get", "real-project-1", "real-task-1"}, args)
+	assert.Empty(t, source, "mixed store and companion resolution should not be counted as store-backed")
+}
+
+func TestLiveDogfoodPreSyncTimeoutCapsLongTimeout(t *testing.T) {
+	assert.Equal(t, 5*time.Second, liveDogfoodPreSyncTimeout(30*time.Second))
+	assert.Equal(t, 2*time.Second, liveDogfoodPreSyncTimeout(2*time.Second))
+	assert.Equal(t, 5*time.Second, liveDogfoodPreSyncTimeout(0))
+}
+
 func TestCommandSupportsSearch(t *testing.T) {
 	tests := []struct {
 		name string
@@ -3115,10 +3164,15 @@ exit 99
 
 func writeTestManifestForLiveDogfood(t *testing.T, dir string) {
 	t.Helper()
+	writeTestManifestForLiveDogfoodCLIName(t, dir, "fixture-pp-cli")
+}
+
+func writeTestManifestForLiveDogfoodCLIName(t *testing.T, dir, cliName string) {
+	t.Helper()
 	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
 		SchemaVersion: 1,
 		APIName:       "fixture",
-		CLIName:       "fixture-pp-cli",
+		CLIName:       cliName,
 		RunID:         "run-live-dogfood",
 		AuthType:      "none",
 	}))
@@ -3753,8 +3807,8 @@ func writeLiveDogfoodStoreFixture(t *testing.T, seedTask bool) (dir string, bina
 	}
 
 	dir = t.TempDir()
-	binaryName = "fixture-pp-cli"
-	writeTestManifestForLiveDogfood(t, dir)
+	binaryName = liveDogfoodStoreFixtureBinaryName(t.Name())
+	writeTestManifestForLiveDogfoodCLIName(t, dir, binaryName)
 
 	seedLine := ":"
 	if seedTask {
@@ -3783,10 +3837,10 @@ if [ "$1" = "sync" ] && [ "${2:-}" = "--help" ]; then
 Sync records.
 
 Usage:
-  fixture-pp-cli sync [flags]
+  %[1]s sync [flags]
 
 Examples:
-  fixture-pp-cli sync
+  %[1]s sync
 
 Flags:
       --json    Output JSON
@@ -3795,10 +3849,10 @@ HELP
 fi
 
 if [ "$1" = "sync" ]; then
-  db="$HOME/.local/share/fixture-pp-cli/data.db"
+  db="$HOME/.local/share/%[1]s/data.db"
   mkdir -p "$(dirname "$db")"
   sqlite3 "$db" "CREATE TABLE IF NOT EXISTS resources (id TEXT NOT NULL, resource_type TEXT NOT NULL, data JSON NOT NULL, synced_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (resource_type, id))"
-  %s
+  %[2]s
   echo '{"synced":true}'
   exit 0
 fi
@@ -3808,10 +3862,10 @@ if [ "$1" = "tasks" ] && [ "$2" = "get-task" ] && [ "${3:-}" = "--help" ]; then
 Get a task.
 
 Usage:
-  fixture-pp-cli tasks get-task <task-id> [flags]
+  %[1]s tasks get-task <task-id> [flags]
 
 Examples:
-  fixture-pp-cli tasks get-task example-id
+  %[1]s tasks get-task example-id
 
 Flags:
       --json    Output JSON
@@ -3834,9 +3888,15 @@ fi
 
 echo "unexpected args: $*" >&2
 exit 99
-`, seedLine)
+`, binaryName, seedLine)
 	require.NoError(t, os.WriteFile(binPath, []byte(script), 0o755))
 	return dir, binaryName
+}
+
+func liveDogfoodStoreFixtureBinaryName(testName string) string {
+	name := strings.ToLower(testName)
+	name = strings.NewReplacer("/", "-", "_", "-").Replace(name)
+	return "fixture-" + name + "-pp-cli"
 }
 
 func TestRunLiveDogfoodStoreFixtureSourceUsesSyncedResourceID(t *testing.T) {


### PR DESCRIPTION
## Summary

Live dogfood now primes the printed CLI store with a quiet `sync` pass when the CLI exposes one, then uses the scoped local SQLite cache to replace ID-shaped example placeholders when companion list calls cannot provide a real ID.

If the store exists but has no matching row, the matrix keeps the synthetic example and marks the row with `fixture_source: synthetic`, giving retros a reliable way to classify fixture-driven failures.

Closes #2431

## Tests

- `go test ./internal/pipeline -run 'TestRunLiveDogfood(StoreFixture|ResolveSuccess|ResolveCommandPositionalsSkipPaths)'`
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodStoreFixture'`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
