### PR TITLE
fix(cli): scope global params from env

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -410,6 +410,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		// Surfaced by hackernews retro #350 finding F6.
 		"endpointNeedsClientLimit":  endpointNeedsClientLimit,
 		"endpointClientSideFilters": endpointClientSideFilters,
+		"globalScopeParams":         globalScopeParams,
 		"envName":                   naming.EnvPrefix,
 		// endpointTemplateEnvName resolves the env-var name for a
 		// {placeholder} in EndpointTemplateVars. Returns the spec-declared
@@ -420,6 +421,11 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"endpointTemplateEnvName": func(placeholder string) string {
 			return s.EndpointTemplateEnvName(placeholder)
 		},
+		"globalScopeEnvName": func(param spec.Param) string {
+			return globalScopeEnvName(s.Name, param)
+		},
+		"globalScopeFallbackValue": globalScopeFallbackValue,
+		"paramHasEnvDefault":       paramHasEnvDefault,
 		// endpointTemplateDefault returns the spec-declared default value for
 		// a placeholder (e.g. server-URL variables' `default:` value), or ""
 		// when none. Templates branch on the empty case to skip the runtime
@@ -4540,6 +4546,66 @@ func paramHasDefault(p spec.Param) bool {
 	return p.Default != nil
 }
 
+func paramHasEnvDefault(p spec.Param) bool {
+	return p.GlobalScope && primitiveKind(p.Type) == "string"
+}
+
+func globalScopeFallbackValue(p spec.Param) string {
+	if p.Default == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", p.Default)
+}
+
+func globalScopeEnvName(apiName string, p spec.Param) string {
+	name := p.PublicInputName()
+	if name == "" {
+		name = p.Name
+	}
+	placeholder := strings.ToUpper(strings.ReplaceAll(naming.FlagName(name), "-", "_"))
+	if placeholder == "" {
+		placeholder = "SCOPE"
+	}
+	return naming.EnvPrefix(apiName) + "_" + placeholder
+}
+
+func globalScopeParams(resources map[string]spec.Resource) []spec.Param {
+	resourceNames := make([]string, 0, len(resources))
+	for name := range resources {
+		resourceNames = append(resourceNames, name)
+	}
+	sort.Strings(resourceNames)
+
+	seen := map[string]struct{}{}
+	var out []spec.Param
+	for _, resourceName := range resourceNames {
+		resource := resources[resourceName]
+		endpointNames := make([]string, 0, len(resource.Endpoints))
+		for endpointName := range resource.Endpoints {
+			endpointNames = append(endpointNames, endpointName)
+		}
+		sort.Strings(endpointNames)
+		for _, endpointName := range endpointNames {
+			endpoint := resource.Endpoints[endpointName]
+			for _, param := range endpoint.Params {
+				if !paramHasEnvDefault(param) {
+					continue
+				}
+				key := param.WireName()
+				if key == "" {
+					key = param.Name
+				}
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				out = append(out, param)
+			}
+		}
+	}
+	return out
+}
+
 // paramIsConstDefault holds for single-value-enum params whose default
 // equals the only enum value. Templates emit MarkHidden for these so
 // --help does not list a flag whose only valid value is the default,
@@ -5490,6 +5556,9 @@ func endpointHasQueryFlags(endpoint spec.Endpoint) bool {
 // param does not falsely trip the guard.
 func endpointHasRequiredInput(endpoint spec.Endpoint) bool {
 	for _, p := range endpoint.Params {
+		if paramHasEnvDefault(p) {
+			continue
+		}
 		if p.Required && !p.Positional {
 			if truth, _ := template.IsTrue(p.Default); !truth {
 				return true

--- a/internal/generator/global_scope_param_test.go
+++ b/internal/generator/global_scope_param_test.go
@@ -1,10 +1,14 @@
 package generator
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -12,10 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateGlobalScopeParamRequiresExplicitFlag(t *testing.T) {
+func TestGenerateGlobalScopeParamDefaultsFromEnv(t *testing.T) {
 	t.Parallel()
 
+	var mu sync.Mutex
+	var seenQueries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/users", r.URL.Path)
+		mu.Lock()
+		seenQueries = append(seenQueries, r.URL.Query().Encode())
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id":"user-1","name":"Ada"}]`)
+	}))
+	t.Cleanup(server.Close)
+
 	apiSpec := minimalSpec("cipp")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"User": {
+			Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "name", Type: "string"}},
+		},
+	}
 	apiSpec.Resources = map[string]spec.Resource{
 		"users": {
 			Description: "Manage users",
@@ -24,6 +47,8 @@ func TestGenerateGlobalScopeParamRequiresExplicitFlag(t *testing.T) {
 					Method:      "GET",
 					Path:        "/users",
 					Description: "List users",
+					Response:    spec.ResponseDef{Type: "array", Item: "User"},
+					Pagination:  &spec.Pagination{Type: "cursor", LimitParam: "limit", CursorParam: "cursor"},
 					Params: []spec.Param{{
 						Name:        "TenantFilter",
 						Type:        "string",
@@ -60,19 +85,39 @@ func TestGenerateGlobalScopeParamRequiresExplicitFlag(t *testing.T) {
 	content := string(contentBytes)
 
 	assert.Contains(t, content, `func newUsersListCmd`)
-	assert.Contains(t, content, `StringVar(&flagTenantFilter, "tenant-filter", "", "Tenant scope")`)
-	assert.Contains(t, content, `return fmt.Errorf("required flag \"%s\" not set", "tenant-filter")`)
-	assert.Contains(t, content, `params["TenantFilter"] = formatCLIParamValue(flagTenantFilter)`)
-	assert.NotContains(t, content, `CIPP_TENANT_FILTER`)
-	assert.NotContains(t, content, `defaults from`)
+	assert.Contains(t, content, `StringVar(&flagTenantFilter, "tenant-filter", globalScopeParamDefault("CIPP_TENANT_FILTER", ""), "Tenant scope (env: CIPP_TENANT_FILTER)")`)
+	assert.Contains(t, content, `!cmd.Flags().Changed("tenant-filter") && flagTenantFilter == ""`)
+	assert.Contains(t, content, `"TenantFilter": formatCLIParamValue(flagTenantFilter)`)
 	assert.NotContains(t, strings.ToLower(content), `markflagrequired`)
+
+	syncContent := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncContent, `func applySyncGlobalScopeEnvDefaults(userParams *syncUserParams)`)
+	assert.Contains(t, syncContent, `globalScopeParamDefault("CIPP_TENANT_FILTER", "")`)
+	assert.Contains(t, syncContent, `userParams.setGlobalDefault("TenantFilter", v)`)
+	assert.Contains(t, syncContent, `"users": "/users"`)
 
 	binaryPath := filepath.Join(outputDir, "cipp-pp-cli")
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/cipp-pp-cli")
 
 	cmd := exec.Command(binaryPath, "users", "list", "--json", "--limit", "10")
-	cmd.Env = append(os.Environ(), "CIPP_TENANT_FILTER=tenant-a")
 	out, err := cmd.CombinedOutput()
 	require.Error(t, err)
 	assert.Contains(t, string(out), `required flag "tenant-filter" not set`)
+
+	cmd = exec.Command(binaryPath, "users", "list", "--json", "--limit", "10")
+	cmd.Env = append(os.Environ(), "CIPP_TENANT_FILTER=tenant-a")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	dbPath := filepath.Join(t.TempDir(), "sync.db")
+	cmd = exec.Command(binaryPath, "--json", "sync", "--resources", "users", "--max-pages", "1", "--db", dbPath)
+	cmd.Env = append(os.Environ(), "CIPP_TENANT_FILTER=tenant-b")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seenQueries, 2)
+	assert.Contains(t, seenQueries[0], "TenantFilter=tenant-a")
+	assert.Contains(t, seenQueries[1], "TenantFilter=tenant-b")
 }

--- a/internal/generator/global_scope_param_test.go
+++ b/internal/generator/global_scope_param_test.go
@@ -96,6 +96,51 @@ func TestGenerateGlobalScopeParamDefaultsFromEnv(t *testing.T) {
 	assert.Contains(t, syncContent, `userParams.setGlobalDefault("TenantFilter", v)`)
 	assert.Contains(t, syncContent, `"users": "/users"`)
 
+	helperTest := `package cli
+
+import "testing"
+
+func TestSyncGlobalScopeEnvDefaultsUseFlatGlobal(t *testing.T) {
+	params := &syncUserParams{
+		flatGlobal:  map[string]string{},
+		trueGlobal:  map[string]string{},
+		perResource: map[string]map[string]string{},
+	}
+	params.setGlobalDefault("TenantFilter", "tenant-a")
+
+	flatParams := map[string]string{}
+	params.applyTo("users", flatParams, false)
+	if got := flatParams["TenantFilter"]; got != "tenant-a" {
+		t.Fatalf("flat request TenantFilter = %q, want tenant-a", got)
+	}
+
+	dependentParams := map[string]string{}
+	params.applyTo("tasks", dependentParams, true)
+	if _, ok := dependentParams["TenantFilter"]; ok {
+		t.Fatalf("dependent request unexpectedly received TenantFilter from env default: %#v", dependentParams)
+	}
+
+	params.trueGlobal["TenantFilter"] = "tenant-global"
+	dependentParams = map[string]string{}
+	params.applyTo("tasks", dependentParams, true)
+	if got := dependentParams["TenantFilter"]; got != "tenant-global" {
+		t.Fatalf("explicit trueGlobal TenantFilter = %q, want tenant-global", got)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_global_scope_env_test.go"), []byte(helperTest), 0o644))
+
+	listCmd := exec.Command("go", "test", "-mod=mod", "-list", "^TestSyncGlobalScopeEnvDefaultsUseFlatGlobal$", "./internal/cli")
+	listCmd.Dir = outputDir
+	cacheDir, err := goBuildCacheDir(outputDir)
+	require.NoError(t, err)
+	listCmd.Env = append(os.Environ(), "GOCACHE="+cacheDir)
+	listOut, err := listCmd.CombinedOutput()
+	require.NoError(t, err, string(listOut))
+	assert.Contains(t, string(listOut), "TestSyncGlobalScopeEnvDefaultsUseFlatGlobal")
+
+	runGoCommandRequired(t, outputDir, "test", "-v", "-run", "^TestSyncGlobalScopeEnvDefaultsUseFlatGlobal$", "./internal/cli")
+
 	binaryPath := filepath.Join(outputDir, "cipp-pp-cli")
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/cipp-pp-cli")
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -84,9 +84,15 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .Required (not .Positional) (not .Default)}}
+{{- if paramHasEnvDefault .}}
+			if !{{flagChangedExpr .}} && flag{{camel (paramIdent .)}} == "" && !flags.dryRun {
+				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
+			}
+{{- else}}
 			if !{{flagChangedExpr .}} && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "{{publicFlagName .}}")
 			}
+{{- end}}
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
@@ -857,12 +863,20 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- range .Endpoint.Params}}
 {{- if not .Positional}}
 {{- $param := .}}
+{{- if paramHasEnvDefault .}}
+	cmd.Flags().StringVar(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", globalScopeParamDefault("{{globalScopeEnvName .}}", {{printf "%q" (globalScopeFallbackValue .)}}), "{{oneline .Description}}{{enumDescriptionHint .Enum}} (env: {{globalScopeEnvName .}})")
+{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired .Name .Type .Required (hasDefault .)}}(&flag{{camel (paramIdent .)}}, "{{publicFlagName .}}", {{defaultValForParamRequired . .Required (hasDefault .)}}, "{{oneline .Description}}{{enumDescriptionHint .Enum}}")
+{{- end}}
 {{- if isConstDefault .}}
 	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
 {{- end}}
 {{- range publicFlagAliases $param}}
+{{- if paramHasEnvDefault $param}}
+	cmd.Flags().StringVar(&flag{{camel (paramIdent $param)}}, "{{.}}", globalScopeParamDefault("{{globalScopeEnvName $param}}", {{printf "%q" (globalScopeFallbackValue $param)}}), "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}} (env: {{globalScopeEnvName $param}})")
+{{- else}}
 	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
+{{- end}}
 	_ = cmd.Flags().MarkHidden("{{.}}")
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -383,6 +383,15 @@ func syncWarningJSON(resource, parent string, status int, reason, message string
 	return string(out)
 }
 
+{{- if globalScopeParams .Resources}}
+func globalScopeParamDefault(envName, fallback string) string {
+	if v := os.Getenv(envName); v != "" {
+		return v
+	}
+	return fallback
+}
+{{- end}}
+
 // syncUserParams carries user-supplied query parameters injected into sync
 // HTTP requests. flatGlobal entries come from --param and inject into
 // flat-list requests only; trueGlobal entries come from --global-param and
@@ -472,6 +481,24 @@ func (p *syncUserParams) applyTo(resource string, params map[string]string, isDe
 		params[k] = v
 	}
 }
+
+{{- if globalScopeParams .Resources}}
+func (p *syncUserParams) setGlobalDefault(key, value string) {
+	if p == nil || key == "" || value == "" {
+		return
+	}
+	if _, ok := p.flatGlobal[key]; ok {
+		return
+	}
+	if _, ok := p.trueGlobal[key]; ok {
+		return
+	}
+	if p.trueGlobal == nil {
+		p.trueGlobal = map[string]string{}
+	}
+	p.trueGlobal[key] = value
+}
+{{- end}}
 
 // validateResourceNames returns a usage-shaped error when any --resource-param
 // key targets a resource not in known. Without this check a typo

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -493,10 +493,10 @@ func (p *syncUserParams) setGlobalDefault(key, value string) {
 	if _, ok := p.trueGlobal[key]; ok {
 		return
 	}
-	if p.trueGlobal == nil {
-		p.trueGlobal = map[string]string{}
+	if p.flatGlobal == nil {
+		p.flatGlobal = map[string]string{}
 	}
-	p.trueGlobal[key] = value
+	p.flatGlobal[key] = value
 }
 {{- end}}
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -71,6 +71,16 @@ type syncResult struct {
 	Duration time.Duration
 }
 
+{{- if globalScopeParams .Resources}}
+func applySyncGlobalScopeEnvDefaults(userParams *syncUserParams) {
+{{- range globalScopeParams .Resources}}
+	if v := globalScopeParamDefault("{{globalScopeEnvName .}}", {{printf "%q" (globalScopeFallbackValue .)}}); v != "" {
+		userParams.setGlobalDefault("{{paramWireName .}}", v)
+	}
+{{- end}}
+}
+{{- end}}
+
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
@@ -148,6 +158,9 @@ Resource scoping:
 			if err != nil {
 				return usageErr(err)
 			}
+{{- if globalScopeParams .Resources}}
+			applySyncGlobalScopeEnvDefaults(userParams)
+{{- end}}
 {{- if .EndpointTemplateVars}}
 			pathContext, err := parseSyncKVFlags(pathContextFlags, "--path-context")
 			if err != nil {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -3778,7 +3778,7 @@ func classifyGlobalParams(resources map[string]spec.Resource) {
 
 		seen := map[string]struct{}{}
 		for _, param := range endpoint.Params {
-			if !isGlobalFilterCandidate(param) {
+			if isPathSubstitutionParam(param) {
 				continue
 			}
 			key := strings.ToLower(param.Name)
@@ -3858,11 +3858,11 @@ func classifyGlobalParams(resources map[string]spec.Resource) {
 		filtered := endpoint.Params[:0]
 		for _, param := range endpoint.Params {
 			key := strings.ToLower(param.Name)
-			if isGlobalFilterCandidate(param) {
-				if _, ok := scopeParams[key]; ok {
-					param.Required = true
-					param.GlobalScope = true
-				} else if _, ok := filteredParams[key]; ok {
+			if _, ok := scopeParams[key]; ok {
+				param.Required = true
+				param.GlobalScope = true
+			} else if isGlobalFilterCandidate(param) {
+				if _, ok := filteredParams[key]; ok {
 					droppedCounts[key]++
 					continue
 				}

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3763,6 +3763,10 @@ paths:
           name: TenantFilter
           schema: {type: string}
         - in: query
+          name: workspaceId
+          required: true
+          schema: {type: string}
+        - in: query
           name: limit
           schema: {type: integer}
       responses: {"200": {description: ok}}
@@ -3774,6 +3778,10 @@ paths:
           name: TenantFilter
           schema: {type: string}
         - in: query
+          name: workspaceId
+          required: true
+          schema: {type: string}
+        - in: query
           name: limit
           schema: {type: integer}
       responses: {"200": {description: ok}}
@@ -3783,6 +3791,10 @@ paths:
       parameters:
         - in: query
           name: TenantFilter
+          schema: {type: string}
+        - in: query
+          name: workspaceId
+          required: true
           schema: {type: string}
         - in: query
           name: limit
@@ -3812,16 +3824,21 @@ paths:
 
 	for _, resourceName := range []string{"users", "mailboxes", "devices"} {
 		endpoint := parsed.Resources[resourceName].Endpoints["list"]
-		var tenant spec.Param
+		var tenant, workspace spec.Param
 		for _, param := range endpoint.Params {
 			if param.Name == "TenantFilter" {
 				tenant = param
-				break
+			}
+			if param.Name == "workspaceId" {
+				workspace = param
 			}
 		}
 		require.Equal(t, "TenantFilter", tenant.Name, "%s should keep TenantFilter", resourceName)
 		assert.True(t, tenant.Required)
 		assert.True(t, tenant.GlobalScope)
+		require.Equal(t, "workspaceId", workspace.Name, "%s should keep required workspaceId", resourceName)
+		assert.True(t, workspace.Required)
+		assert.True(t, workspace.GlobalScope)
 		for _, param := range endpoint.Params {
 			assert.NotEqual(t, "limit", param.Name, "%s should still filter non-scope global params", resourceName)
 		}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -846,6 +846,9 @@ func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
 	}
 	for _, param := range endpoint.Params {
 		if param.Required && !param.Positional && !param.PathParam {
+			if param.GlobalScope && strings.EqualFold(param.Type, "string") {
+				continue
+			}
 			lower := strings.ToLower(param.Name)
 			if pageSizeParamCandidates[lower] || cursorParamCandidates[lower] || temporalOrFormatParams[lower] {
 				continue


### PR DESCRIPTION
## Summary
- classify API-wide string scope parameters as env-backed global scope, including parameters that were already required in the source spec
- generate endpoint commands that default required global scope flags from canonical env vars while preserving explicit flag precedence
- inject the same env/default global scope values into generated sync user params so sync can populate scoped resources

Closes #2389

## Verification
- go test ./...
- go test ./internal/generator -run TestGenerateGlobalScopeParamDefaultsFromEnv -count=1
- go test ./internal/openapi ./internal/profiler -run 'TestPromoteGlobalScopeQueryParams|TestParsePreservesRequiredQueryParamsDuringGlobalFilter|TestProfile' -count=1\n- scripts/verify-generator-output.sh\n- scripts/golden.sh verify\n- go build -o ./cli-printing-press ./cmd/cli-printing-press\n- golangci-lint run ./...