### PR TITLE
fix(cli): dedupe multi-spec duplicate endpoint commands

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1370,6 +1370,53 @@ func TestMergeSpecsPrefixesDistinctEndpointResourceCollision(t *testing.T) {
 	assert.Equal(t, "/v1alpha/accounts", merged.Resources["analytics-admin-accounts"].Endpoints["list"].Path)
 }
 
+func TestMergeSpecsDeduplicatesTrailingSlashEndpointResourceCollision(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"reports": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/reports"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "analytics-admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts/"},
+				},
+			},
+			"metadata": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/metadata"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "ga4")
+
+	assert.Contains(t, merged.Resources, "accounts")
+	assert.NotContains(t, merged.Resources, "analytics-admin-accounts")
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["accounts"].Endpoints["list"].Path)
+}
+
 func TestMergeSpecsNamePrefixOptInKeepsNamespacedResourceForm(t *testing.T) {
 	t.Parallel()
 
@@ -1417,6 +1464,44 @@ func TestMergeSpecsNamePrefixOptInKeepsNamespacedResourceForm(t *testing.T) {
 	assert.Contains(t, merged.Resources, "analytics-admin-accounts")
 	assert.Equal(t, "/v1beta/accounts", merged.Resources["admin-accounts"].Endpoints["list"].Path)
 	assert.Equal(t, "/v1beta/accounts", merged.Resources["analytics-admin-accounts"].Endpoints["list"].Path)
+}
+
+func TestMergeSpecsNamePrefixDisambiguatesSameSpecNameCollision(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1alpha/accounts"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecsWithOptions([]*spec.APISpec{specA, specB}, "ga4", mergeSpecOptions{NamePrefix: true})
+
+	assert.Contains(t, merged.Resources, "admin-accounts")
+	assert.Contains(t, merged.Resources, "admin-accounts-2")
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["admin-accounts"].Endpoints["list"].Path)
+	assert.Equal(t, "/v1alpha/accounts", merged.Resources["admin-accounts-2"].Endpoints["list"].Path)
 }
 
 func TestGenerateMultiSpecDeduplicatesSameEndpointResourceCollision(t *testing.T) {

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1275,6 +1275,227 @@ func TestMergeSpecsPreservesPerSpecBaseURLPrefixes(t *testing.T) {
 	)
 }
 
+func TestMergeSpecsDeduplicatesSameEndpointResourceCollision(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"reports": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/reports"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "analytics-admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"metadata": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/metadata"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "ga4")
+
+	assert.Contains(t, merged.Resources, "accounts")
+	assert.NotContains(t, merged.Resources, "analytics-admin-accounts")
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["accounts"].Endpoints["list"].Path)
+}
+
+func TestMergeSpecsPrefixesDistinctEndpointResourceCollision(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"reports": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/reports"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "analytics-admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1alpha/accounts"},
+				},
+			},
+			"metadata": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1alpha/metadata"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecs([]*spec.APISpec{specA, specB}, "ga4")
+
+	assert.Contains(t, merged.Resources, "accounts")
+	assert.Contains(t, merged.Resources, "analytics-admin-accounts")
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["accounts"].Endpoints["list"].Path)
+	assert.Equal(t, "/v1alpha/accounts", merged.Resources["analytics-admin-accounts"].Endpoints["list"].Path)
+}
+
+func TestMergeSpecsNamePrefixOptInKeepsNamespacedResourceForm(t *testing.T) {
+	t.Parallel()
+
+	specA := &spec.APISpec{
+		Name:    "admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"reports": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/reports"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+	specB := &spec.APISpec{
+		Name:    "analytics-admin",
+		Version: "0.1.0",
+		BaseURL: "https://analytics.example.com",
+		Resources: map[string]spec.Resource{
+			"accounts": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/accounts"},
+				},
+			},
+			"metadata": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/v1beta/metadata"},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{},
+	}
+
+	merged := mergeSpecsWithOptions([]*spec.APISpec{specA, specB}, "ga4", mergeSpecOptions{NamePrefix: true})
+
+	assert.NotContains(t, merged.Resources, "accounts")
+	assert.Contains(t, merged.Resources, "admin-accounts")
+	assert.Contains(t, merged.Resources, "analytics-admin-accounts")
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["admin-accounts"].Endpoints["list"].Path)
+	assert.Equal(t, "/v1beta/accounts", merged.Resources["analytics-admin-accounts"].Endpoints["list"].Path)
+}
+
+func TestGenerateMultiSpecDeduplicatesSameEndpointResourceCollision(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specAPath := filepath.Join(dir, "admin.yaml")
+	specBPath := filepath.Join(dir, "analytics-admin.yaml")
+	outputDir := filepath.Join(dir, "ga4")
+	specA := `name: admin
+description: Admin API
+version: 0.1.0
+base_url: https://analytics.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/admin-pp-cli/config.toml
+resources:
+  accounts:
+    description: Accounts
+    endpoints:
+      list:
+        method: GET
+        path: /v1beta/accounts
+        description: List accounts
+  reports:
+    description: Reports
+    endpoints:
+      list:
+        method: GET
+        path: /v1beta/reports
+        description: List reports
+`
+	specB := `name: analytics-admin
+description: Analytics Admin API
+version: 0.1.0
+base_url: https://analytics.example.com
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/analytics-admin-pp-cli/config.toml
+resources:
+  accounts:
+    description: Accounts
+    endpoints:
+      list:
+        method: GET
+        path: /v1beta/accounts
+        description: List accounts
+  metadata:
+    description: Metadata
+    endpoints:
+      list:
+        method: GET
+        path: /v1beta/metadata
+        description: List metadata
+`
+	require.NoError(t, os.WriteFile(specAPath, []byte(specA), 0o644))
+	require.NoError(t, os.WriteFile(specBPath, []byte(specB), 0o644))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specAPath,
+		"--spec", specBPath,
+		"--name", "ga4",
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+	})
+
+	require.NoError(t, cmd.Execute())
+	root, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(root), "newAccountsPromotedCmd(flags)")
+	assert.NotContains(t, string(root), "newAnalyticsAdminAccountsPromotedCmd(flags)")
+}
+
 func TestMergeSpecsUnionsAuthScopesAndAdditionalHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1238,6 +1238,7 @@ func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOpt
 					continue
 				}
 				key = prefixedMultiSpecResourceName(s, resourceName)
+				key = uniqueMultiSpecResourceName(merged.Resources, key)
 			}
 			resource = rewriteDefaultResourceDescription(resource, resourceName, key)
 			if key != resourceName {
@@ -1269,6 +1270,18 @@ func prefixedMultiSpecResourceName(s *spec.APISpec, resourceName string) string 
 		return resourceName
 	}
 	return specName + "-" + resourceName
+}
+
+func uniqueMultiSpecResourceName(resources map[string]spec.Resource, preferred string) string {
+	if _, exists := resources[preferred]; !exists {
+		return preferred
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", preferred, i)
+		if _, exists := resources[candidate]; !exists {
+			return candidate
+		}
+	}
 }
 
 func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
@@ -1535,7 +1548,7 @@ func endpointSignature(resource spec.Resource, endpoint spec.Endpoint) string {
 		baseURL = strings.TrimRight(strings.TrimSpace(resource.BaseURL), "/")
 	}
 	method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
-	path := strings.TrimSpace(endpoint.Path)
+	path := strings.TrimRight(strings.TrimSpace(endpoint.Path), "/")
 	return method + " " + baseURL + " " + path
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -135,6 +135,7 @@ func newGenerateCmd() *cobra.Command {
 	var planFile string
 	var trafficAnalysisPath string
 	var authPreference string
+	var namePrefix bool
 	var mcpOrchestration string
 	var mcpTransport []string
 	var mcpEndpointTools string
@@ -455,7 +456,7 @@ func newGenerateCmd() *cobra.Command {
 				if cliName == "" {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--name is required when using multiple specs")}
 				}
-				apiSpec = mergeSpecs(specs, cliName)
+				apiSpec = mergeSpecsWithOptions(specs, cliName, mergeSpecOptions{NamePrefix: namePrefix})
 			}
 
 			if err := applyGenerateSpecFlags(apiSpec, specSource, "", category, clientPattern, httpTransport, owner, generateMCPFlagOverrides{
@@ -596,6 +597,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&planFile, "plan", "", "Path to a markdown plan document for plan-driven generation (instead of --spec)")
 	cmd.Flags().StringVar(&trafficAnalysisPath, "traffic-analysis", "", "Path to browser-sniff traffic-analysis.json for advisory generation context")
 	cmd.Flags().StringVar(&authPreference, "auth-preference", "", "Preferred securityScheme name from the spec (overrides default selection and any catalog auth_preference; useful when a spec advertises multiple schemes such as OAuth2 + HTTP Basic and you want the simpler one). When omitted, a matching embedded catalog entry's auth_preference applies for OpenAPI parsing.")
+	cmd.Flags().BoolVar(&namePrefix, "name-prefix", false, "Prefix resource command names with their source spec name when merging multiple specs")
 
 	return cmd
 }
@@ -1168,6 +1170,14 @@ func archiveSpecBytes(apiSpec *spec.APISpec, specs []*spec.APISpec, specRawBytes
 }
 
 func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
+	return mergeSpecsWithOptions(specs, name, mergeSpecOptions{})
+}
+
+type mergeSpecOptions struct {
+	NamePrefix bool
+}
+
+func mergeSpecsWithOptions(specs []*spec.APISpec, name string, opts mergeSpecOptions) *spec.APISpec {
 	if len(specs) == 1 {
 		return specs[0]
 	}
@@ -1220,8 +1230,14 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 				resource = resourceWithMergedSpecBaseURL(resource, s.BaseURL, merged.BaseURL)
 			}
 			key := multiSpecResourceName(s, resourceName, sharedPathPrefix)
-			if _, exists := merged.Resources[key]; exists {
-				key = s.Name + "-" + resourceName
+			if opts.NamePrefix {
+				key = prefixedMultiSpecResourceName(s, resourceName)
+			}
+			if existing, exists := merged.Resources[key]; exists {
+				if !opts.NamePrefix && resourceEndpointsCoveredBy(existing, resource) {
+					continue
+				}
+				key = prefixedMultiSpecResourceName(s, resourceName)
 			}
 			resource = rewriteDefaultResourceDescription(resource, resourceName, key)
 			if key != resourceName {
@@ -1244,6 +1260,15 @@ func mergeSpecs(specs []*spec.APISpec, name string) *spec.APISpec {
 	}
 
 	return merged
+}
+
+func prefixedMultiSpecResourceName(s *spec.APISpec, resourceName string) string {
+	specName := strings.Trim(strings.TrimSpace(s.Name), "-")
+	resourceName = strings.Trim(strings.TrimSpace(resourceName), "-")
+	if specName == "" || resourceName == "" || specName == resourceName || strings.HasPrefix(resourceName, specName+"-") {
+		return resourceName
+	}
+	return specName + "-" + resourceName
 }
 
 func mergeMultiSpecAuth(specs []*spec.APISpec) spec.AuthConfig {
@@ -1470,6 +1495,48 @@ func rewriteEndpointResourceRef(ref string, resourceRenames map[string]string) s
 		return renamed + "." + rest
 	}
 	return ref
+}
+
+func resourceEndpointsCoveredBy(existing, incoming spec.Resource) bool {
+	existingSignatures := resourceEndpointSignatures(existing)
+	incomingSignatures := resourceEndpointSignatures(incoming)
+	if len(existingSignatures) == 0 || len(incomingSignatures) == 0 {
+		return false
+	}
+	for signature := range incomingSignatures {
+		if _, ok := existingSignatures[signature]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func resourceEndpointSignatures(resource spec.Resource) map[string]struct{} {
+	signatures := map[string]struct{}{}
+	addResourceEndpointSignatures(signatures, resource)
+	return signatures
+}
+
+func addResourceEndpointSignatures(signatures map[string]struct{}, resource spec.Resource) {
+	for _, endpoint := range resource.Endpoints {
+		signatures[endpointSignature(resource, endpoint)] = struct{}{}
+	}
+	for _, sub := range resource.SubResources {
+		if sub.BaseURL == "" {
+			sub.BaseURL = resource.BaseURL
+		}
+		addResourceEndpointSignatures(signatures, sub)
+	}
+}
+
+func endpointSignature(resource spec.Resource, endpoint spec.Endpoint) string {
+	baseURL := strings.TrimRight(strings.TrimSpace(endpoint.BaseURL), "/")
+	if baseURL == "" {
+		baseURL = strings.TrimRight(strings.TrimSpace(resource.BaseURL), "/")
+	}
+	method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
+	path := strings.TrimSpace(endpoint.Path)
+	return method + " " + baseURL + " " + path
 }
 
 func multiSpecResourceName(s *spec.APISpec, resourceName string, sharedPathPrefix []string) string {


### PR DESCRIPTION
## Summary

Multi-spec generation now drops redundant spec-prefixed resource aliases when another resource already registers the same endpoint signature. A duplicate `accounts list` endpoint now emits one command by default, while genuinely distinct same-name resources still keep the namespaced fallback.

Users who want fully namespaced multi-spec resource commands can pass `--name-prefix` to prefix resource names with the source spec name.

Closes #2455

## Approach

The merge step now compares endpoint signatures during resource-name collisions before creating a `<spec-name>-<resource>` fallback. If the incoming resource is already covered by the existing resource's method, effective base URL, and path signatures, it is skipped. If any endpoint differs, the previous prefixed fallback remains.

## Scope

Primary area: multi-spec generation in the cli-printing-press binary.

Why this belongs in this repo: this is Printing Press generator behavior that affects future printed CLIs, not a one-off printed CLI fix.

Catalog Justification: N/A

## Risk

The main risk is changing command names for multi-spec duplicate endpoint collisions. The tests pin the default dedupe behavior, the distinct-endpoint fallback, the `--name-prefix` opt-in, and generated Cobra output for the duplicate case.

## Output Contract

Generated-output proof is covered by `TestGenerateMultiSpecDeduplicatesSameEndpointResourceCollision`, which runs generation and asserts the emitted root command registers the unprefixed command without the duplicate spec-prefixed command.

## Verification

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/cli -run 'Test(GenerateMultiSpecDeduplicatesSameEndpointResourceCollision|MergeSpecs(DeduplicatesSameEndpointResourceCollision|PrefixesDistinctEndpointResourceCollision|NamePrefixOptInKeepsNamespacedResourceForm|PreservesPerSpecBaseURLPrefixes|CarriesMCPConfigFromFirstDeclaringSpec|RewritesMCPIntentRefsForRenamedResources))$'`
- `go test ./...`
- `scripts/golden.sh verify`
- pre-push hook: `fmt`, `lint`
