### PR TITLE
fix(cli): skip idless resources in default sync

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -297,6 +297,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"composeMCPDesc":                     composeMCPDesc,
 		"composeMCPSubDesc":                  composeMCPSubDesc,
 		"mcpParamDesc":                       g.mcpParamDescription,
+		"hasDefaultSyncResources":            hasDefaultSyncResources,
 		"flagName":                           flagName,
 		"paramIdent":                         paramIdent,
 		"paramWireName":                      paramWireName,
@@ -3257,6 +3258,15 @@ func paginationSupportedResources(syncable []profiler.SyncableResource, dependen
 	}
 	sort.Strings(names)
 	return names
+}
+
+func hasDefaultSyncResources(syncable []profiler.SyncableResource) bool {
+	for _, resource := range syncable {
+		if !resource.SkipDefaultSync {
+			return true
+		}
+	}
+	return false
 }
 
 func specDateTimeFieldNames(api *spec.APISpec) []string {

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -215,8 +215,8 @@ func TestGenerateSyncDefaultsSkipTypedIDlessResources(t *testing.T) {
 		"explicit --resources should still accept the idless list endpoint")
 	assert.Contains(t, syncSrc, "no default sync resources",
 		"sync should explain why empty-args sync is a no-op")
-	assert.Contains(t, syncSrc, `"reason":"no_default_sync_resources"`,
-		"JSON sync warnings should classify the empty default set")
+	assert.Contains(t, syncSrc, `"reason":"no_bulk_list_endpoints"`,
+		"JSON sync warnings should preserve the existing structured reason")
 }
 
 // dependentResourceSpec builds a minimal spec with a parent + child
@@ -543,7 +543,7 @@ func TestGenerateSyncEmitsEmptyHintWhenNoBulkList(t *testing.T) {
 	// callers both see the explanation instead of a silent total_records:0.
 	assert.Contains(t, syncSrc, "no default sync resources",
 		"sync should print a stderr hint when defaultSyncResources is empty")
-	assert.Contains(t, syncSrc, `"reason":"no_default_sync_resources"`,
+	assert.Contains(t, syncSrc, `"reason":"no_bulk_list_endpoints"`,
 		"sync should emit a sync_warning JSON event when defaultSyncResources is empty")
 }
 

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -173,6 +173,52 @@ func TestGenerateSyncDefaultsSkipAuthTaggedResources(t *testing.T) {
 	assert.NotContains(t, archiveBlock, `"authorization-grant"`)
 }
 
+func TestGenerateSyncDefaultsSkipTypedIDlessResources(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("sync-idless")
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Technology": {
+			Fields: []spec.TypeField{
+				{Name: "title", Type: "string"},
+				{Name: "url", Type: "string"},
+			},
+		},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"technologies": {
+			Description: "Technologies",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:   "GET",
+					Path:     "/technologies",
+					Response: spec.ResponseDef{Type: "array", Item: "Technology"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	defaultsStart := strings.Index(syncSrc, "func defaultSyncResources() []string")
+	knownStart := strings.Index(syncSrc, "func knownSyncResourceNames() []string")
+	require.NotEqual(t, -1, defaultsStart)
+	require.NotEqual(t, -1, knownStart)
+	defaultsBlock := syncSrc[defaultsStart:knownStart]
+	assert.NotContains(t, defaultsBlock, `"technologies"`,
+		"idless typed resources must not be selected by empty-args sync")
+
+	knownBlock := syncSrc[knownStart:]
+	assert.Contains(t, knownBlock, `"technologies"`,
+		"explicit --resources should still accept the idless list endpoint")
+	assert.Contains(t, syncSrc, "no default sync resources",
+		"sync should explain why empty-args sync is a no-op")
+	assert.Contains(t, syncSrc, `"reason":"no_default_sync_resources"`,
+		"JSON sync warnings should classify the empty default set")
+}
+
 // dependentResourceSpec builds a minimal spec with a parent + child
 // resource so syncDependentResource is actually emitted. The
 // dependent-resource profiler requires paginated list endpoints (not
@@ -495,9 +541,9 @@ func TestGenerateSyncEmitsEmptyHintWhenNoBulkList(t *testing.T) {
 
 	// The runtime hint surfaces in both modes so JSON-driven agents and human
 	// callers both see the explanation instead of a silent total_records:0.
-	assert.Contains(t, syncSrc, "no bulk-list endpoints",
+	assert.Contains(t, syncSrc, "no default sync resources",
 		"sync should print a stderr hint when defaultSyncResources is empty")
-	assert.Contains(t, syncSrc, `"reason":"no_bulk_list_endpoints"`,
+	assert.Contains(t, syncSrc, `"reason":"no_default_sync_resources"`,
 		"sync should emit a sync_warning JSON event when defaultSyncResources is empty")
 }
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -215,19 +215,19 @@ Resource scoping:
 			if len(resources) == 0 {
 				resources = defaultSyncResources()
 			}
-{{- if and (not .SyncableResources) (not .DependentSyncResources)}}
+{{- if and (not (hasDefaultSyncResources .SyncableResources)) (not .DependentSyncResources)}}
 
-			// Empty-sync hint: this spec exposed no bulk-list endpoint and no
-			// dependent resources, so `sync` cannot populate the store on its
-			// own. Emit a one-line note so users and agents understand the
-			// runtime no-op instead of seeing only `total_records: 0`. The
-			// store is still populated by single-fetch commands (recipe, get,
-			// fetch, …) that the spec's other resources define.
+			// Empty-sync hint: this spec exposed no default sync resources, so
+			// `sync` cannot populate the store on its own. Emit a one-line note
+			// so users and agents understand the runtime no-op instead of
+			// seeing only `total_records: 0`. The store can still be populated
+			// by explicit --resources calls or single-fetch commands when the
+			// spec defines them.
 			if len(resources) == 0 {
 				if humanFriendly {
-					fmt.Fprintln(os.Stderr, "{{.Name}}-pp-cli sync: no bulk-list endpoints in spec; populate the store via single-fetch commands instead.")
+					fmt.Fprintln(os.Stderr, "{{.Name}}-pp-cli sync: no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands.")
 				} else {
-					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_bulk_list_endpoints","detail":"no bulk-list endpoints in spec; populate the store via single-fetch commands"}`)
+					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_default_sync_resources","detail":"no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands"}`)
 				}
 			}
 {{- end}}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -227,7 +227,7 @@ Resource scoping:
 				if humanFriendly {
 					fmt.Fprintln(os.Stderr, "{{.Name}}-pp-cli sync: no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands.")
 				} else {
-					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_default_sync_resources","detail":"no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands"}`)
+					fmt.Fprintln(syncEventWriter, `{"event":"sync_warning","reason":"no_bulk_list_endpoints","detail":"no default sync resources in spec; use --resources for explicit sync targets or populate the store via single-fetch commands"}`)
 				}
 			}
 {{- end}}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1916,7 +1916,7 @@ func typeDefHasRuntimeIDField(resourceName string, typeDef spec.TypeDef) bool {
 	for _, field := range typeDef.Fields {
 		fieldNames[normalizeName(spec.ToSnakeCase(field.Name))] = struct{}{}
 	}
-	for _, key := range []string{"id", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"} {
+	for _, key := range []string{"id", "gid", "sid", "uid", "uuid", "guid", "slug", "key", "code"} {
 		if _, ok := fieldNames[key]; ok {
 			return true
 		}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -455,14 +455,14 @@ func Profile(s *spec.APISpec) *APIProfile {
 					// GET /v1/api/networkentity?entityType=collection|workspace|api|flow
 					// → sync resources: collection, workspace, api, flow
 					if enumParam := findEntityTypeEnum(endpoint); standaloneList && enumParam != nil && len(enumParam.Enum) >= 2 {
-						addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
+						addSyncCandidate(resourceName, metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex))
 						for _, val := range enumParam.Enum {
 							expandedName := strings.ToLower(val)
 							expandedPath := endpoint.Path + "?" + enumParam.Name + "=" + val
 							// Enum-expanded paths are more specific than generic resource
 							// paths, so they always win on name collision. This ensures
 							// deterministic output regardless of Go map iteration order.
-							meta := metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex)
+							meta := metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex)
 							meta.Path = expandedPath
 							syncable[expandedName] = meta
 						}
@@ -478,14 +478,14 @@ func Profile(s *spec.APISpec) *APIProfile {
 							parameterized[key] = parameterizedEntry{
 								name:       name,
 								parentName: parentName,
-								meta:       metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex),
+								meta:       metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex),
 							}
 						}
 					} else if standaloneList {
-						addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
+						addSyncCandidate(resourceName, metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex))
 					}
 				} else if standaloneList {
-					addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
+					addSyncCandidate(resourceName, metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex))
 				}
 			} else if method == "GET" && (!strings.Contains(endpoint.Path, "{") || pathParamsAllTemplateVars(endpoint.Path, s)) && !hasRequiredScopeParams(endpoint) && looksLikeCollectionEndpoint(endpointNameLower) && !isSamplerEndpoint(endpoint) && !isScalarItemArray(endpoint.Response) {
 				// Catch-all for simple GET collection endpoints that isListEndpoint
@@ -496,7 +496,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 				// Re-apply the sampler and scalar-array guards here: this branch runs
 				// when isListEndpoint returned false, so without them a collection-named
 				// sampler/scalar-array endpoint would be re-admitted past those gates.
-				addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
+				addSyncCandidate(resourceName, metaFromEndpoint(s, resourceName, r, endpoint, s.Types, resourceNameIndex))
 			}
 
 			if endpoint.Pagination != nil {
@@ -1581,7 +1581,7 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 				deps[idx].PathParams = dependentPathParams(e.Path, parent, deps[idx].ParentIDParam, keyField)
 				continue
 			}
-			meta := metaFromEndpoint(s, r, e, types, resourceNameIndex)
+			meta := metaFromEndpoint(s, resourceName, r, e, types, resourceNameIndex)
 			deps = append(deps, DependentResource{
 				Name:               spec.ToSnakeCase(resourceName),
 				ParentResource:     parent,
@@ -1876,13 +1876,13 @@ type parameterizedEntry struct {
 // from path-item-level extensions (or, for IDField, from response-schema
 // inference). Keeps the per-endpoint plumbing in one place so future profiler
 // fields propagate uniformly.
-func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, types map[string]spec.TypeDef, resourceNameIndex map[string]string) syncableMeta {
+func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resource, e spec.Endpoint, types map[string]spec.TypeDef, resourceNameIndex map[string]string) syncableMeta {
 	idWalkFilterParam, idWalkLimitParam, idWalkPageSize := detectIDWalkParams(e)
 	return syncableMeta{
 		Path:               e.Path,
 		Method:             strings.ToUpper(e.Method),
 		Tier:               s.EffectiveTier(resource, e),
-		SkipDefaultSync:    isAuthTaggedEndpoint(e),
+		SkipDefaultSync:    isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
 		IDField:            e.IDField,
 		Critical:           e.Critical,
 		SinceParam:         detectEndpointSinceParam(e.Params),
@@ -1897,6 +1897,104 @@ func metaFromEndpoint(s *spec.APISpec, resource spec.Resource, e spec.Endpoint, 
 		FieldSelector:      detectEndpointFieldSelector(e),
 		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
 		ResponseItem:       e.Response.Item,
+	}
+}
+
+func hasTypedResponseWithoutRuntimeID(resourceName string, endpoint spec.Endpoint, types map[string]spec.TypeDef) bool {
+	if endpoint.IDField != "" || endpoint.Response.Item == "" {
+		return false
+	}
+	typeDef, ok := lookupTypeDef(endpoint.Response.Item, types)
+	if !ok {
+		return false
+	}
+	return !typeDefHasRuntimeIDField(resourceName, typeDef)
+}
+
+func typeDefHasRuntimeIDField(resourceName string, typeDef spec.TypeDef) bool {
+	fieldNames := make(map[string]struct{}, len(typeDef.Fields))
+	for _, field := range typeDef.Fields {
+		fieldNames[normalizeName(spec.ToSnakeCase(field.Name))] = struct{}{}
+	}
+	for _, key := range []string{"id", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"} {
+		if _, ok := fieldNames[key]; ok {
+			return true
+		}
+	}
+	for _, base := range resourceIDBaseNames(resourceName) {
+		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
+			if _, ok := fieldNames[base+suffix]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func resourceIDBaseNames(resourceName string) []string {
+	normalized := normalizeName(spec.ToSnakeCase(resourceName))
+	if normalized == "" {
+		return nil
+	}
+	bases := []string{normalized}
+	if stripped, ok := strings.CutPrefix(normalized, "get_"); ok && stripped != "" {
+		bases = append(bases, stripped)
+	}
+
+	out := make([]string, 0, len(bases)*2)
+	seen := map[string]struct{}{}
+	add := func(base string) {
+		if base == "" {
+			return
+		}
+		if _, ok := seen[base]; ok {
+			return
+		}
+		seen[base] = struct{}{}
+		out = append(out, base)
+	}
+	for _, base := range bases {
+		add(base)
+		add(singularizeResourceIDBase(base))
+	}
+	return out
+}
+
+func singularizeResourceIDBase(base string) string {
+	if base == "" {
+		return ""
+	}
+	idx := strings.LastIndex(base, "_")
+	prefix, last := "", base
+	if idx >= 0 {
+		prefix, last = base[:idx+1], base[idx+1:]
+	}
+	irregulars := map[string]string{
+		"properties": "property",
+		"companies":  "company",
+		"categories": "category",
+		"entries":    "entry",
+		"statuses":   "status",
+		"addresses":  "address",
+		"analyses":   "analysis",
+		"movies":     "movie",
+		"series":     "series",
+		"matrices":   "matrix",
+		"indices":    "index",
+		"vertices":   "vertex",
+	}
+	if singular, ok := irregulars[last]; ok {
+		return prefix + singular
+	}
+	switch {
+	case strings.HasSuffix(last, "ies") && len(last) > 3:
+		return prefix + last[:len(last)-3] + "y"
+	case strings.HasSuffix(last, "ses"), strings.HasSuffix(last, "xes"), strings.HasSuffix(last, "zes"):
+		return prefix + last[:len(last)-2]
+	case strings.HasSuffix(last, "s") && !strings.HasSuffix(last, "ss") && len(last) > 1:
+		return prefix + last[:len(last)-1]
+	default:
+		return base
 	}
 }
 

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2773,6 +2773,60 @@ func TestProfileExcludesScalarArrayAndSamplerEndpoints(t *testing.T) {
 		"an array-of-scalars endpoint must not be selected as a syncable list (no extractable primary key)")
 }
 
+func TestProfileSkipsTypedIDlessListsFromDefaultSync(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "docs",
+		Types: map[string]spec.TypeDef{
+			"Technology": {
+				Fields: []spec.TypeField{
+					{Name: "title", Type: "string"},
+					{Name: "url", Type: "string"},
+				},
+			},
+			"Sample": {
+				Fields: []spec.TypeField{
+					{Name: "sample_id", Type: "string"},
+					{Name: "title", Type: "string"},
+				},
+			},
+		},
+		Resources: map[string]spec.Resource{
+			"technologies": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/technologies",
+						Response: spec.ResponseDef{Type: "array", Item: "Technology"},
+					},
+				},
+			},
+			"samples": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/samples",
+						Response: spec.ResponseDef{Type: "array", Item: "Sample"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := make(map[string]SyncableResource, len(profile.SyncableResources))
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
+
+	require.Contains(t, byName, "technologies",
+		"idless list endpoints stay explicit sync targets")
+	assert.True(t, byName["technologies"].SkipDefaultSync,
+		"typed list endpoints with no runtime-extractable ID must not run in empty-args sync")
+	require.Contains(t, byName, "samples")
+	assert.False(t, byName["samples"].SkipDefaultSync,
+		"resource-suffixed ID fields are runtime-extractable and remain in the default sync set")
+}
+
 func TestIsScalarItemArray(t *testing.T) {
 	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "string"}))
 	assert.True(t, isScalarItemArray(spec.ResponseDef{Type: "array", Item: "int"}))


### PR DESCRIPTION
## Summary

Empty-args `sync` now skips typed list resources whose response item shape cannot yield a runtime primary key. Those resources remain valid explicit sync targets through `--resources`, so maintainers can still force the current per-resource behavior while generated defaults avoid the known `missing id for <resource>` failure mode.

The empty-default warning now describes the broader condition: no default sync resources are available. This covers both specs with no bulk list endpoints and specs where every known sync target is intentionally excluded from `sync all`.

Closes #2461

## Verification

- `go test ./internal/profiler -run 'TestProfile(SkipsTypedIDlessListsFromDefaultSync|ExcludesScalarArrayAndSamplerEndpoints|WrapperObjectDetection)'`
- `go test ./internal/generator -run 'TestGenerateSync(DefaultsSkipTypedIDlessResources|EmitsEmptyHintWhenNoBulkList|SkipsEmptyHintWhenBulkListExists|DefaultsSkipAuthTaggedResources)'`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./internal/pressauth -run TestCaptureTimeoutCleansTempDir -count=1`
- `go test ./...`

Note: the first `go test ./...` run failed only in `internal/pressauth` on `TestCaptureTimeoutCleansTempDir` reporting a leaked tempdir. The targeted rerun passed, and the second full `go test ./...` run passed.
