### PR TITLE
fix(cli): skip required-query dependent sync

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13543,6 +13543,87 @@ paths:
 	assert.Contains(t, string(storeGo), `"identity_providers": "idpId",`)
 }
 
+func TestGeneratedSyncSkipsRequiredQueryDependentResources(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("required-query-dependent")
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:     "GET",
+					Path:       "/widgets",
+					Response:   spec.ResponseDef{Type: "array", Item: "Widget"},
+					Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+				},
+			},
+			SubResources: map[string]spec.Resource{
+				"comments": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:     "GET",
+							Path:       "/widgets/{widget_id}/comments",
+							Response:   spec.ResponseDef{Type: "array", Item: "Comment"},
+							Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						},
+					},
+				},
+				"availableSlots": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:   "GET",
+							Path:     "/widgets/{widget_id}/availableSlots",
+							Response: spec.ResponseDef{Type: "array", Item: "AvailableSlot"},
+							Params: []spec.Param{{
+								Name:     "size",
+								Type:     "string",
+								Required: true,
+							}},
+							Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						},
+					},
+				},
+				"typedViews": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:   "GET",
+							Path:     "/widgets/{widget_id}/typedViews",
+							Response: spec.ResponseDef{Type: "array", Item: "TypedView"},
+							Params: []spec.Param{{
+								Name:     "viewType",
+								Type:     "string",
+								Required: true,
+								Enum:     []string{"compact", "full"},
+							}},
+							Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := profiler.Profile(apiSpec)
+	require.Len(t, profile.SyncableResources, 1)
+	assert.Equal(t, "widgets", profile.SyncableResources[0].Name)
+	require.Len(t, profile.DependentSyncResources, 1)
+	assert.Equal(t, "comments", profile.DependentSyncResources[0].Name)
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+	require.Len(t, gen.profile.DependentSyncResources, 1)
+	assert.Equal(t, "comments", gen.profile.DependentSyncResources[0].Name)
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(syncGo), `case "comments":`)
+	assert.NotContains(t, string(syncGo), "/widgets/{widget_id}/availableSlots")
+	assert.NotContains(t, string(syncGo), "/widgets/{widget_id}/typedViews")
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGenerateOperationRoutingPathParamDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -449,7 +449,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 					// entity type that should sync independently. Example:
 					// GET /v1/api/networkentity?entityType=collection|workspace|api|flow
 					// → sync resources: collection, workspace, api, flow
-					if enumParam := findEntityTypeEnum(endpoint); enumParam != nil && len(enumParam.Enum) >= 2 {
+					if enumParam := findEntityTypeEnum(endpoint); standaloneList && enumParam != nil && len(enumParam.Enum) >= 2 {
 						addSyncCandidate(resourceName, metaFromEndpoint(s, r, endpoint, s.Types, resourceNameIndex))
 						for _, val := range enumParam.Enum {
 							expandedName := strings.ToLower(val)
@@ -461,7 +461,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 							meta.Path = expandedPath
 							syncable[expandedName] = meta
 						}
-					} else if strings.Contains(endpoint.Path, "{") && !resolvable {
+					} else if strings.Contains(endpoint.Path, "{") && !resolvable && !hasRequiredDependentScopeParams(endpoint) {
 						// Parameterized paginated paths can't sync standalone — track
 						// them for dependent-resource detection below. Carry the
 						// endpoint's metadata so x-resource-id and x-critical
@@ -840,6 +840,14 @@ func pathParamsAllTemplateVars(path string, s *spec.APISpec) bool {
 // hasRequiredScopeParams flags "scoped list" endpoints (e.g., GetFriendList
 // requires steamid) that can't be synced without runtime context.
 func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
+	return hasRequiredScopeParamsForSync(endpoint, true)
+}
+
+func hasRequiredDependentScopeParams(endpoint spec.Endpoint) bool {
+	return hasRequiredScopeParamsForSync(endpoint, false)
+}
+
+func hasRequiredScopeParamsForSync(endpoint spec.Endpoint, allowEnumExpansion bool) bool {
 	temporalOrFormatParams := map[string]bool{
 		"since": true, "updated_after": true, "modified_since": true, "since_id": true,
 		"key": true, "format": true,
@@ -851,7 +859,9 @@ func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
 				continue
 			}
 			// Enum params with 2+ values are handled by enum expansion, not scope
-			if len(param.Enum) >= 2 {
+			// for flat resources. Dependent sync has no per-parent enum expansion
+			// path, so required enum filters are still unsatisfied there.
+			if allowEnumExpansion && len(param.Enum) >= 2 {
 				continue
 			}
 			return true

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -843,6 +843,10 @@ func hasRequiredScopeParams(endpoint spec.Endpoint) bool {
 	return hasRequiredScopeParamsForSync(endpoint, true)
 }
 
+// hasRequiredDependentScopeParams flags parameterized child endpoints that
+// require a caller-supplied query filter that dependent sync cannot satisfy.
+// Unlike hasRequiredScopeParams, enum params are not exempt here because
+// dependent sync has no per-parent enum-expansion path.
 func hasRequiredDependentScopeParams(endpoint spec.Endpoint) bool {
 	return hasRequiredScopeParamsForSync(endpoint, false)
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1688,6 +1688,101 @@ func TestProfileDependentResources_NoParentNoDependent(t *testing.T) {
 	assert.Empty(t, profile.DependentSyncResources, "no parent resource means no dependent detection")
 }
 
+func TestProfileDependentResources_SkipsRequiredQueryParamDependents(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "widgets",
+		Resources: map[string]spec.Resource{
+			"widgets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/widgets",
+						Response:   spec.ResponseDef{Type: "array", Item: "Widget"},
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+				SubResources: map[string]spec.Resource{
+					"comments": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:     "GET",
+								Path:       "/widgets/{widget_id}/comments",
+								Response:   spec.ResponseDef{Type: "array", Item: "Comment"},
+								Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							},
+						},
+					},
+					"availableSlots": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:   "GET",
+								Path:     "/widgets/{widget_id}/availableSlots",
+								Response: spec.ResponseDef{Type: "array", Item: "AvailableSlot"},
+								Params: []spec.Param{{
+									Name:     "size",
+									Type:     "string",
+									Required: true,
+								}},
+								Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							},
+						},
+					},
+					"typedViews": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:   "GET",
+								Path:     "/widgets/{widget_id}/typedViews",
+								Response: spec.ResponseDef{Type: "array", Item: "TypedView"},
+								Params: []spec.Param{{
+									Name:     "viewType",
+									Type:     "string",
+									Required: true,
+									Enum:     []string{"compact", "full"},
+								}},
+								Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							},
+						},
+					},
+					"pagedLogs": {
+						Endpoints: map[string]spec.Endpoint{
+							"list": {
+								Method:   "GET",
+								Path:     "/widgets/{widget_id}/pagedLogs",
+								Response: spec.ResponseDef{Type: "array", Item: "PagedLog"},
+								Params: []spec.Param{{
+									Name:     "limit",
+									Type:     "integer",
+									Required: true,
+								}},
+								Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	syncNames := make(map[string]bool)
+	for _, resource := range profile.SyncableResources {
+		syncNames[resource.Name] = true
+	}
+	names := make(map[string]bool)
+	for _, dep := range profile.DependentSyncResources {
+		names[dep.Name] = true
+	}
+	assert.False(t, syncNames["available_slots"], "filter-required child collection must not flatten into SyncableResources")
+	assert.False(t, syncNames["typedviews"], "required enum child collection must not flatten into SyncableResources")
+	assert.False(t, syncNames["compact"], "dependent sync has no per-parent enum expansion")
+	assert.False(t, syncNames["full"], "dependent sync has no per-parent enum expansion")
+	assert.True(t, names["comments"], "ordinary parent-scoped collections stay syncable")
+	assert.True(t, names["paged_logs"], "required pagination params are supplied by sync and stay syncable")
+	assert.False(t, names["available_slots"], "filter-required child collection must not auto-sync without that filter")
+	assert.False(t, names["typed_views"], "dependent sync cannot enum-expand required filters per parent")
+}
+
 // TestProfileSyncableResourcePropagatesIDFieldAndCritical asserts that the new
 // per-endpoint metadata flows into SyncableResource. The OpenAPI parser is
 // responsible for resolving IDField (x-resource-id → id → name → required


### PR DESCRIPTION
## Summary

Generated sync no longer auto-registers parent-scoped child collections that require non-pagination query input. This prevents sync from iterating every parent into endpoints that cannot be listed without caller-specific filters, while preserving ordinary child collections and required pagination parameters.

Standalone enum-expanded list behavior is preserved, but parameterized child endpoints no longer enum-expand into invalid flat sync resources when they still contain an unresolved parent path parameter.

Closes #2463

## Verification

- `go test ./internal/profiler -run 'TestProfileDependentResources_SkipsRequiredQueryParamDependents' -count=1`
- `go test ./internal/generator -run 'TestGeneratedSyncSkipsRequiredQueryDependentResources' -count=1`
- `go test ./...`
- `scripts/golden.sh verify`
- pre-push hook: `golangci-lint`
