### PR TITLE
fix(cli): synthesize html page sync ids

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3133,6 +3133,7 @@ type visionRenderData struct {
 	GraphQLFieldPaths            map[string]string
 	AgentMoneyWorkflow           AgentMoneyWorkflow
 	HTMLSyncStub                 bool
+	HTMLPageModeResources        []criticalResourceEntry
 }
 
 type resourceIDFieldOverrideEntry struct {
@@ -3166,6 +3167,48 @@ func resourceIDFieldOverrideEntries(syncable []profiler.SyncableResource, depend
 	entries := make([]resourceIDFieldOverrideEntry, len(names))
 	for i, name := range names {
 		entries[i] = resourceIDFieldOverrideEntry{Name: name, Value: overrides[name]}
+	}
+	return entries
+}
+
+func htmlPageModeResourceEntries(api *spec.APISpec, syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []criticalResourceEntry {
+	resources := map[string]bool{}
+	if api != nil {
+		var collect func(resourceMap map[string]spec.Resource)
+		collect = func(resourceMap map[string]spec.Resource) {
+			for resourceName, resource := range resourceMap {
+				name := spec.ToSnakeCase(resourceName)
+				for _, endpoint := range resource.Endpoints {
+					if endpoint.UsesHTMLResponse() && endpoint.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage {
+						resources[name] = true
+						break
+					}
+				}
+				collect(resource.SubResources)
+			}
+		}
+		collect(api.Resources)
+	}
+	for _, resource := range syncable {
+		if syncableResourceUsesHTMLPageMode(resource) {
+			resources[resource.Name] = true
+		}
+	}
+	for _, resource := range dependent {
+		if dependentResourceUsesHTMLPageMode(resource) {
+			resources[resource.Name] = true
+		}
+	}
+
+	names := make([]string, 0, len(resources))
+	for name := range resources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]criticalResourceEntry, len(names))
+	for i, name := range names {
+		entries[i] = criticalResourceEntry{Name: name}
 	}
 	return entries
 }
@@ -3291,6 +3334,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		GraphQLFieldPaths:            gqlFieldPaths,
 		AgentMoneyWorkflow:           detectAgentMoneyWorkflow(g.Spec, g.PromotedEndpointNames),
 		HTMLSyncStub:                 g.shouldEmitHTMLSyncStub(),
+		HTMLPageModeResources:        htmlPageModeResourceEntries(g.Spec, g.profile.SyncableResources, g.profile.DependentSyncResources),
 	}
 }
 

--- a/internal/generator/html_page_sync_id_test.go
+++ b/internal/generator/html_page_sync_id_test.go
@@ -1,0 +1,265 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedHTMLPageModeSingleObjectIDSynthesis(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "html-page-ids",
+		Version: "0.1.0",
+		BaseURL: "https://example.test",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/html-page-ids-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"pages": {
+				Description: "HTML pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/pages",
+						Description:    "Fetch page metadata",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+						Response:       spec.ResponseDef{Type: "object", Item: "Page"},
+					},
+				},
+			},
+			"ships": {
+				Description: "HTML ship pages",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:         "GET",
+						Path:           "/ships",
+						Description:    "Fetch ship metadata",
+						IDField:        "imo",
+						ResponseFormat: spec.ResponseFormatHTML,
+						HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+						Response:       spec.ResponseDef{Type: "object", Item: "Ship"},
+					},
+				},
+			},
+			"articles": {
+				Description: "JSON articles",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/articles",
+						Description: "Fetch article metadata",
+						Response:    spec.ResponseDef{Type: "object", Item: "Article"},
+					},
+				},
+			},
+			"widgets": {
+				Description: "JSON widgets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/widgets",
+						Description: "List widgets",
+						Response:    spec.ResponseDef{Type: "array", Item: "Widget"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Page": {
+				Fields: []spec.TypeField{
+					{Name: "title", Type: "string"},
+					{Name: "canonical_url", Type: "string"},
+					{Name: "image_url", Type: "string"},
+					{Name: "slug", Type: "string"},
+				},
+			},
+			"Ship": {
+				Fields: []spec.TypeField{
+					{Name: "imo", Type: "string"},
+					{Name: "name", Type: "string"},
+					{Name: "canonical_url", Type: "string"},
+				},
+			},
+			"Article": {
+				Fields: []spec.TypeField{
+					{Name: "title", Type: "string"},
+					{Name: "canonical_url", Type: "string"},
+					{Name: "image_url", Type: "string"},
+				},
+			},
+			"Widget": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	inlineTest := `package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"` + naming.CLI(apiSpec.Name) + `/internal/store"
+)
+
+type htmlPageClient struct{}
+
+func (htmlPageClient) Get(ctx context.Context, path string, params map[string]string) (json.RawMessage, error) {
+	return json.RawMessage(` + "`" + `<!doctype html><html><head><title>Docs</title><link rel="canonical" href="https://example.test/docs/page"><meta property="og:image" content="https://example.test/image.png"></head><body>Docs</body></html>` + "`" + `), nil
+}
+
+func (htmlPageClient) RequestBaseURL() string {
+	return "https://example.test"
+}
+
+func (htmlPageClient) LastContentType() string {
+	return "text/html; charset=utf-8"
+}
+
+func (htmlPageClient) RateLimit() float64 {
+	return 0
+}
+
+func assertStoredID(t *testing.T, db *store.Store, table, resource, id string) {
+	t.Helper()
+
+	var genericCount int
+	if err := db.DB().QueryRow("SELECT COUNT(*) FROM resources WHERE resource_type = ? AND id = ?", resource, id).Scan(&genericCount); err != nil {
+		t.Fatalf("query resources %s/%s: %v", resource, id, err)
+	}
+	if genericCount != 1 {
+		t.Fatalf("generic %s rows for %q = %d, want 1", resource, id, genericCount)
+	}
+
+	var typedCount int
+	if err := db.DB().QueryRow("SELECT COUNT(*) FROM "+table+" WHERE id = ?", id).Scan(&typedCount); err != nil {
+		t.Fatalf("query %s %s: %v", table, id, err)
+	}
+	if typedCount != 1 {
+		t.Fatalf("typed %s rows for %q = %d, want 1", table, id, typedCount)
+	}
+}
+
+func TestSyncSingleObjectHTMLPageModeIDFallbacks(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "data.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer db.Close()
+
+	canonicalURL := "https://example.test/docs/page"
+	res := syncResource(context.Background(), htmlPageClient{}, db, "pages", "", false, 1, false, nil, nil)
+	if res.Err != nil {
+		t.Fatalf("syncResource canonical_url fallback: %v", res.Err)
+	}
+	if res.Count != 1 {
+		t.Fatalf("syncResource count = %d, want 1", res.Count)
+	}
+	assertStoredID(t, db, "pages", "pages", canonicalURL)
+
+	pageURL := "https://example.test/docs/url-only"
+	if err := upsertSingleObject(db, "pages", json.RawMessage(` + "`" + `{"title":"URL only","url":"https://example.test/docs/url-only","image_url":"https://example.test/url-only.png"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert url fallback: %v", err)
+	}
+	assertStoredID(t, db, "pages", "pages", pageURL)
+
+	imageURL := "https://example.test/image-only.png"
+	if err := upsertSingleObject(db, "pages", json.RawMessage(` + "`" + `{"title":"Image only","image_url":"https://example.test/image-only.png"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert image_url fallback: %v", err)
+	}
+	assertStoredID(t, db, "pages", "pages", imageURL)
+
+	if err := upsertSingleObject(db, "pages", json.RawMessage(` + "`" + `{"title":"Resource fallback"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert resource-name fallback: %v", err)
+	}
+	assertStoredID(t, db, "pages", "pages", "pages")
+
+	if err := upsertSingleObject(db, "pages", json.RawMessage(` + "`" + `{"title":"Slugged","slug":"explicit-slug","canonical_url":"https://example.test/docs/slugged"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert slug page: %v", err)
+	}
+	assertStoredID(t, db, "pages", "pages", "explicit-slug")
+
+	if err := upsertSingleObject(db, "ships", json.RawMessage(` + "`" + `{"imo":"IMO-123","name":"Mutable Vessel Name","canonical_url":"https://example.test/ships/IMO-123"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert x-resource-id page: %v", err)
+	}
+	assertStoredID(t, db, "ships", "ships", "IMO-123")
+
+	if err := upsertSingleObject(db, "articles", json.RawMessage(` + "`" + `{"title":"JSON article","canonical_url":"https://example.test/articles/a"}` + "`" + `)); err == nil {
+		t.Fatalf("JSON single-object resource without an id-shaped field unexpectedly succeeded")
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "sync_html_page_id_test.go"), []byte(inlineTest), 0o644))
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-run", "^TestSyncSingleObjectHTMLPageModeIDFallbacks$", "-count=1")
+}
+
+func TestGeneratedJSONOnlySyncKeepsSingleObjectIDShape(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "json-only-sync",
+		Version: "0.1.0",
+		BaseURL: "https://example.test",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/json-only-sync-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"articles": {
+				Description: "JSON articles",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/articles",
+						Description: "Fetch article metadata",
+						Response:    spec.ResponseDef{Type: "object", Item: "Article"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Article": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "title", Type: "string"},
+					{Name: "canonical_url", Type: "string"},
+					{Name: "image_url", Type: "string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	require.Contains(t, syncSrc, "id := extractID(resource, obj)")
+	require.Contains(t, syncSrc, "return db.UpsertArticles(data)")
+	require.False(t, strings.Contains(syncSrc, "synthesizeHTMLPageModeID"), "JSON-only sync must not emit HTML page-mode ID fallback")
+	require.False(t, strings.Contains(syncSrc, "htmlPageModeResources"), "JSON-only sync must not emit HTML page-mode resource map")
+	require.False(t, strings.Contains(syncSrc, "typedSingleObjectData"), "JSON-only sync must not emit typed ID injection helper")
+}

--- a/internal/generator/html_page_sync_id_test.go
+++ b/internal/generator/html_page_sync_id_test.go
@@ -81,6 +81,7 @@ func TestGeneratedHTMLPageModeSingleObjectIDSynthesis(t *testing.T) {
 					{Name: "canonical_url", Type: "string"},
 					{Name: "image_url", Type: "string"},
 					{Name: "slug", Type: "string"},
+					{Name: "key", Type: "string"},
 				},
 			},
 			"Ship": {
@@ -198,6 +199,11 @@ func TestSyncSingleObjectHTMLPageModeIDFallbacks(t *testing.T) {
 		t.Fatalf("upsert slug page: %v", err)
 	}
 	assertStoredID(t, db, "pages", "pages", "explicit-slug")
+
+	if err := upsertSingleObject(db, "pages", json.RawMessage(` + "`" + `{"title":"Vendor keyed","key":"vendor-key"}` + "`" + `)); err != nil {
+		t.Fatalf("upsert vendor-key fallback: %v", err)
+	}
+	assertStoredID(t, db, "pages", "pages", "vendor-key")
 
 	if err := upsertSingleObject(db, "ships", json.RawMessage(` + "`" + `{"imo":"IMO-123","name":"Mutable Vessel Name","canonical_url":"https://example.test/ships/IMO-123"}` + "`" + `)); err != nil {
 		t.Fatalf("upsert x-resource-id page: %v", err)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1993,20 +1993,23 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 {{- else}}
 		id, _ = resourceIDFieldOverrideID(resource, obj)
 {{- end}}
+		if id == "" {
+			id = extractIDFallback(resource, obj)
+{{- if $hasDomainTable}}
+			forceTypedID = id != ""
+{{- end}}
+		}
+		if id == "" {
+			id = synthesizeHTMLPageModeID(resource, obj)
+{{- if $hasDomainTable}}
+			forceTypedID = id != ""
+{{- end}}
+		}
 	} else {
 		id = extractID(resource, obj)
-	}
-	if htmlPageModeResources[resource] && id == "" {
-		id = extractIDFallback(resource, obj)
-	}
-	if htmlPageModeResources[resource] && id == "" {
-		id = synthesizeHTMLPageModeID(resource, obj)
-{{- if $hasDomainTable}}
-		forceTypedID = id != ""
-{{- end}}
-	}
-	if id == "" {
-		id = resource
+		if id == "" {
+			id = resource
+		}
 	}
 {{- else}}
 	id := extractID(resource, obj)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -9,6 +9,10 @@
 {{- $hasHTMLSync := false -}}
 {{- range .SyncableResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end -}}
 {{- range .DependentSyncResources}}{{if .UsesHTMLResponse}}{{- $hasHTMLSync = true -}}{{end}}{{end }}
+{{- $hasHTMLPageModeSync := false -}}
+{{- range .HTMLPageModeResources}}{{- $hasHTMLPageModeSync = true -}}{{end }}
+{{- $hasDomainTable := false -}}
+{{- range .Tables}}{{if emitsDomainTable .}}{{- $hasDomainTable = true -}}{{end}}{{end }}
 
 package cli
 
@@ -1978,16 +1982,52 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 
 	resource = resolveDiscriminatedResource(resource, obj)
 
+{{ if $hasHTMLPageModeSync}}
+{{- if $hasDomainTable}}
+	var forceTypedID bool
+{{- end}}
+	var id string
+	if htmlPageModeResources[resource] {
+{{- if $hasDomainTable}}
+		id, forceTypedID = resourceIDFieldOverrideID(resource, obj)
+{{- else}}
+		id, _ = resourceIDFieldOverrideID(resource, obj)
+{{- end}}
+	} else {
+		id = extractID(resource, obj)
+	}
+	if htmlPageModeResources[resource] && id == "" {
+		id = extractIDFallback(resource, obj)
+	}
+	if htmlPageModeResources[resource] && id == "" {
+		id = synthesizeHTMLPageModeID(resource, obj)
+{{- if $hasDomainTable}}
+		forceTypedID = id != ""
+{{- end}}
+	}
+	if id == "" {
+		id = resource
+	}
+{{- else}}
 	id := extractID(resource, obj)
 	if id == "" {
 		id = resource
 	}
+{{- end}}
 
 	switch resource {
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
 	case "{{.Resource}}":
+{{- if $hasHTMLPageModeSync}}
+		typedData, err := typedSingleObjectData(data, obj, id, forceTypedID)
+		if err != nil {
+			return err
+		}
+		return db.Upsert{{pascal .Name}}(typedData)
+{{- else}}
 		return db.Upsert{{pascal .Name}}(data)
+{{- end}}
 {{- end}}
 {{- end}}
 	default:
@@ -2617,6 +2657,17 @@ var resourceIDFieldOverrides = map[string]string{
 {{- end}}
 }
 
+{{- if $hasHTMLPageModeSync}}
+
+// htmlPageModeResources identifies sync resources whose single-object HTML
+// extraction may produce page metadata without an API-native id field.
+var htmlPageModeResources = map[string]bool{
+{{- range .HTMLPageModeResources}}
+	{{printf "%q" .Name}}: true,
+{{- end}}
+}
+{{- end}}
+
 // genericIDFieldFallbacks is the runtime safety net for resources that did
 // NOT receive a templated IDField. API-specific names belong in spec
 // annotations (x-resource-id), not this list. Order matters: vendor
@@ -2696,14 +2747,33 @@ var criticalResources = map[string]bool{
 // way — divergence between the two paths produces silent drops on
 // heterogeneous payloads.
 func extractID(resource string, obj map[string]any) string {
+{{- if $hasHTMLPageModeSync}}
+	if s, ok := resourceIDFieldOverrideID(resource, obj); ok {
+		return s
+	}
+	return extractIDFallback(resource, obj)
+}
+
+func resourceIDFieldOverrideID(resource string, obj map[string]any) (string, bool) {
+{{- end}}
 	if override, ok := resourceIDFieldOverrides[resource]; ok && override != "" {
 		if v := store.LookupFieldValue(obj, override); v != nil {
 			s := store.ResourceIDString(v)
 			if s != "" && s != "<nil>" {
+{{- if $hasHTMLPageModeSync}}
+				return s, true
+{{- else}}
 				return s
+{{- end}}
 			}
 		}
 	}
+{{- if $hasHTMLPageModeSync}}
+	return "", false
+}
+
+func extractIDFallback(resource string, obj map[string]any) string {
+{{- end}}
 	for _, key := range genericIDFieldFallbacks {
 		if v := store.LookupFieldValue(obj, key); v != nil {
 			s := store.ResourceIDString(v)
@@ -2717,6 +2787,40 @@ func extractID(resource string, obj map[string]any) string {
 	}
 	return ""
 }
+
+{{- if $hasHTMLPageModeSync}}
+
+func synthesizeHTMLPageModeID(resource string, obj map[string]any) string {
+	if !htmlPageModeResources[resource] {
+		return ""
+	}
+	for _, key := range []string{"canonical_url", "url", "image_url"} {
+		if v := store.LookupFieldValue(obj, key); v != nil {
+			s := store.ResourceIDString(v)
+			if s != "" && s != "<nil>" {
+				return s
+			}
+		}
+	}
+	return resource
+}
+
+func typedSingleObjectData(data json.RawMessage, obj map[string]any, id string, forceTypedID bool) (json.RawMessage, error) {
+	if !forceTypedID {
+		return data, nil
+	}
+	return objectWithSyntheticID(obj, id)
+}
+
+func objectWithSyntheticID(obj map[string]any, id string) (json.RawMessage, error) {
+	withID := make(map[string]any, len(obj)+1)
+	for key, value := range obj {
+		withID[key] = value
+	}
+	withID["id"] = id
+	return json.Marshal(withID)
+}
+{{- end}}
 
 // suffixIDFieldFallback resolves an id-less resource that keys on its own
 // "<name>_code" / "<name>_id" / "<name>_key" / "<name>_slug" field (e.g. the


### PR DESCRIPTION
## Summary
- add HTML page-mode sync ID synthesis for single-object resources using canonical_url, url, image_url, then the resource name
- inject synthesized IDs into typed upsert payloads while preserving spec/profile ID overrides such as x-resource-id
- add generated-runtime regression coverage for HTML page metadata, URL fallbacks, resource fallback, JSON-only output shape, and spec-declared ID precedence

## Tests
- go test ./internal/generator -run '^(TestGeneratedHTMLPageModeSingleObjectIDSynthesis|TestUpsertDispatchPreservesMultiWordResourceCasing)$' -count=1
- go test ./internal/openapi -run '^TestGenerateDataEnvelopeAllOfBodyFlags$' -count=1
- scripts/golden.sh verify
- scripts/verify-generator-output.sh
- go test ./...
- go build -o ./cli-printing-press ./cmd/cli-printing-press
- golangci-lint run ./...
- git diff --check

Closes #2444
