### PR TITLE
chore(ci): add Greptile review state helper

### DIFF
--- a/.github/scripts/pr-review-state/greptile_feedback.py
+++ b/.github/scripts/pr-review-state/greptile_feedback.py
@@ -42,15 +42,34 @@ def split_repo(repo: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
-def fetch_pr(repo: str, pr_number: int) -> dict[str, Any]:
+def parse_graphql_response(stdout: str) -> dict[str, Any]:
+    data = json.loads(stdout)
+    errors = data.get("errors") or []
+    if errors:
+        messages = "; ".join(error.get("message", str(error)) for error in errors)
+        raise SystemExit(f"GitHub GraphQL error: {messages}")
+    return data
+
+
+def pull_request_from_response(data: dict[str, Any], repo: str, pr_number: int) -> dict[str, Any]:
+    repository = (data.get("data") or {}).get("repository")
+    if repository is None:
+        raise SystemExit(f"Repository {repo} not found or inaccessible")
+    pr = repository.get("pullRequest")
+    if pr is None:
+        raise SystemExit(f"PR #{pr_number} not found in {repo}")
+    return pr
+
+
+def fetch_review_threads(repo: str, pr_number: int) -> tuple[str, str, list[dict[str, Any]]]:
     owner, name = split_repo(repo)
     query = """
-query($owner: String!, $repo: String!, $number: Int!) {
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       url
       headRefOid
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
         nodes {
           id
           isResolved
@@ -66,23 +85,21 @@ query($owner: String!, $repo: String!, $number: Int!) {
             }
           }
         }
-      }
-      comments(first: 100) {
-        nodes {
-          id
-          body
-          createdAt
-          updatedAt
-          author { login }
-          url
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }
   }
 }
 """
-    proc = run(
-        [
+    cursor: str | None = None
+    threads: list[dict[str, Any]] = []
+    pr_url = ""
+    head_sha = ""
+    while True:
+        cmd = [
             "gh",
             "api",
             "graphql",
@@ -95,12 +112,81 @@ query($owner: String!, $repo: String!, $number: Int!) {
             "-F",
             f"number={pr_number}",
         ]
-    )
-    data = json.loads(proc.stdout)
-    pr = data["data"]["repository"]["pullRequest"]
-    if pr is None:
-        raise SystemExit(f"PR #{pr_number} not found in {repo}")
-    return pr
+        if cursor:
+            cmd.extend(["-f", f"cursor={cursor}"])
+        proc = run(cmd)
+        pr = pull_request_from_response(parse_graphql_response(proc.stdout), repo, pr_number)
+        pr_url = pr["url"]
+        head_sha = pr["headRefOid"]
+        page = pr["reviewThreads"]
+        threads.extend(page["nodes"])
+        page_info = page["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return pr_url, head_sha, threads
+        cursor = page_info["endCursor"]
+
+
+def fetch_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    owner, name = split_repo(repo)
+    query = """
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      comments(first: 100, after: $cursor) {
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          author { login }
+          url
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"""
+    cursor: str | None = None
+    comments: list[dict[str, Any]] = []
+    while True:
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"repo={name}",
+            "-F",
+            f"number={pr_number}",
+        ]
+        if cursor:
+            cmd.extend(["-f", f"cursor={cursor}"])
+        proc = run(cmd)
+        pr = pull_request_from_response(parse_graphql_response(proc.stdout), repo, pr_number)
+        page = pr["comments"]
+        comments.extend(page["nodes"])
+        page_info = page["pageInfo"]
+        if not page_info["hasNextPage"]:
+            return comments
+        cursor = page_info["endCursor"]
+
+
+def fetch_pr(repo: str, pr_number: int) -> dict[str, Any]:
+    pr_url, head_sha, threads = fetch_review_threads(repo, pr_number)
+    comments = fetch_comments(repo, pr_number)
+    return {
+        "url": pr_url,
+        "headRefOid": head_sha,
+        "reviewThreads": {"nodes": threads},
+        "comments": {"nodes": comments},
+    }
 
 
 def fetch_checks(repo: str, pr_number: int) -> list[dict[str, Any]]:

--- a/.github/scripts/pr-review-state/greptile_feedback.py
+++ b/.github/scripts/pr-review-state/greptile_feedback.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Summarize Greptile PR review state.
+
+This helper intentionally uses only `gh` and the Python standard library so it
+can be run by contributor agents without local Codex plugin scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_REPO = "mvanhorn/cli-printing-press"
+ACTIONABLE_MARKERS = (
+    "Issue 1 of",
+    "Fix the following",
+    "Comments Outside Diff",
+    "remaining open item",
+    "Safe to merge after fixing",
+    "Safe to merge after reviewing",
+    "needs attention",
+)
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    return proc
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise SystemExit(f"--repo must be OWNER/REPO, got {repo!r}")
+    return parts[0], parts[1]
+
+
+def fetch_pr(repo: str, pr_number: int) -> dict[str, Any]:
+    owner, name = split_repo(repo)
+    query = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      url
+      headRefOid
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            nodes {
+              body
+              createdAt
+              author { login }
+              url
+            }
+          }
+        }
+      }
+      comments(first: 100) {
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          author { login }
+          url
+        }
+      }
+    }
+  }
+}
+"""
+    proc = run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"repo={name}",
+            "-F",
+            f"number={pr_number}",
+        ]
+    )
+    data = json.loads(proc.stdout)
+    pr = data["data"]["repository"]["pullRequest"]
+    if pr is None:
+        raise SystemExit(f"PR #{pr_number} not found in {repo}")
+    return pr
+
+
+def fetch_checks(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    proc = run(
+        [
+            "gh",
+            "pr",
+            "checks",
+            str(pr_number),
+            "-R",
+            repo,
+            "--json",
+            "name,bucket,state,link,description,workflow",
+        ],
+        check=False,
+    )
+    if not proc.stdout.strip():
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stderr)
+            raise SystemExit(proc.returncode)
+        return []
+    return json.loads(proc.stdout)
+
+
+def latest_greptile_comment(comments: list[dict[str, Any]]) -> dict[str, Any] | None:
+    greptile_comments = [
+        c for c in comments if (c.get("author") or {}).get("login") == "greptile-apps"
+    ]
+    if not greptile_comments:
+        return None
+    return max(greptile_comments, key=lambda c: c.get("updatedAt") or c.get("createdAt") or "")
+
+
+def reviewed_commit(body: str) -> str | None:
+    match = re.search(r"Last reviewed commit: \[\"[^\"]+\"\]\([^)]+/commit/([0-9a-f]{7,40})\)", body)
+    if match:
+        return match.group(1)
+    return None
+
+
+def check_bucket(checks: list[dict[str, Any]], name: str) -> str:
+    for check in checks:
+        if check.get("name") == name:
+            return check.get("bucket") or check.get("state") or "unknown"
+    return "missing"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pr_number", type=int, help="GitHub pull request number, e.g. 2492")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help=f"GitHub repo, default: {DEFAULT_REPO}")
+    args = parser.parse_args()
+
+    pr = fetch_pr(args.repo, args.pr_number)
+    checks = fetch_checks(args.repo, args.pr_number)
+    active_threads = [
+        t
+        for t in pr["reviewThreads"]["nodes"]
+        if not t.get("isResolved") and not t.get("isOutdated")
+    ]
+    latest = latest_greptile_comment(pr["comments"]["nodes"])
+    latest_body = latest.get("body", "") if latest else ""
+    latest_reviewed = reviewed_commit(latest_body) if latest else None
+    markers = [marker for marker in ACTIONABLE_MARKERS if marker in latest_body]
+    greptile_review = check_bucket(checks, "Greptile Review")
+    conversations_resolved = check_bucket(checks, "All conversations resolved")
+    head = pr["headRefOid"]
+
+    print(f"PR: {pr['url']}")
+    print(f"Head SHA: {head}")
+    print(f"Greptile reviewed SHA: {latest_reviewed or 'none'}")
+    print(f"Greptile Review check: {greptile_review}")
+    print(f"All conversations resolved check: {conversations_resolved}")
+    print(f"Active unresolved review threads: {len(active_threads)}")
+    print(f"Latest Greptile actionable markers: {', '.join(markers) if markers else 'none'}")
+
+    ready = True
+    if latest_reviewed != head:
+        ready = False
+        print("NOT READY: latest Greptile comment does not match PR head")
+    if greptile_review != "pass":
+        ready = False
+        print("NOT READY: Greptile Review check is not passing")
+    if conversations_resolved != "pass":
+        ready = False
+        print("NOT READY: All conversations resolved check is not passing")
+    if active_threads:
+        ready = False
+        print("NOT READY: unresolved non-outdated review threads remain")
+        for thread in active_threads:
+            print(f"  - {thread.get('path')}:{thread.get('line')} {thread.get('id')}")
+    if markers:
+        ready = False
+        print("NOT READY: latest Greptile top-level comment contains actionable markers")
+
+    if ready:
+        print("READY: Greptile feedback is resolved for the current PR head")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pr-review-state/greptile_feedback.py
+++ b/.github/scripts/pr-review-state/greptile_feedback.py
@@ -23,7 +23,6 @@ ACTIONABLE_MARKERS = (
     "remaining open item",
     "Safe to merge after fixing",
     "Safe to merge after reviewing",
-    "needs attention",
 )
 
 
@@ -250,10 +249,13 @@ def main() -> int:
     latest = latest_greptile_comment(pr["comments"]["nodes"])
     latest_body = latest.get("body", "") if latest else ""
     latest_reviewed = reviewed_commit(latest_body) if latest else None
+    head = pr["headRefOid"]
+    latest_reviewed_matches_head = (
+        latest_reviewed is not None and head.startswith(latest_reviewed)
+    )
     markers = [marker for marker in ACTIONABLE_MARKERS if marker in latest_body]
     greptile_review = check_bucket(checks, "Greptile Review")
     conversations_resolved = check_bucket(checks, "All conversations resolved")
-    head = pr["headRefOid"]
 
     print(f"PR: {pr['url']}")
     print(f"Head SHA: {head}")
@@ -264,7 +266,7 @@ def main() -> int:
     print(f"Latest Greptile actionable markers: {', '.join(markers) if markers else 'none'}")
 
     ready = True
-    if latest_reviewed != head:
+    if not latest_reviewed_matches_head:
         ready = False
         print("NOT READY: latest Greptile comment does not match PR head")
     if greptile_review != "pass":

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,18 @@ Every commit and PR title must include one of the allowed scopes. GitHub squash-
 - If unsure whether a PR is exempt, keep the template.
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing contributor guide and AI / automation disclosure definitions.
 
+## Automated code review with Greptile
+
+Every PR gets automated Greptile review alongside CI. Resolve every Greptile finding before calling a PR ready: P0 and P1 comments block merge, and P2 comments need either a fix or a concrete reply explaining why the deferral is intentional. Do not use the score alone as the gate.
+
+Greptile feedback is not limited to GitHub review threads. It also edits top-level PR summary comments, and those summaries can contain actionable issue blocks, including `Comments Outside Diff`, even when the thread list has zero unresolved comments. Before saying a PR is ready, run the repo-owned review-state helper:
+
+```bash
+python3 .github/scripts/pr-review-state/greptile_feedback.py <PR_NUMBER>
+```
+
+`PR_NUMBER` is the GitHub pull request number, for example `2492` - not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/cli-printing-press` and exits non-zero until all of these are true: Greptile Review passes, the `All conversations resolved` check passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, or `Safe to merge after fixing/reviewing`.
+
 ## Versioning
 Releases are automated by release-please. Never manually edit version numbers.
 - Normal feature/fix PRs land through the Mergify queue: add the `ready-to-merge` label when the PR is ready to merge, and let Mergify rebase/test/merge it. Do not use the GitHub merge button for normal PRs once `Mergify Merge Protections` is required on `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ Greptile feedback is not limited to GitHub review threads. It also edits top-lev
 python3 .github/scripts/pr-review-state/greptile_feedback.py <PR_NUMBER>
 ```
 
-`PR_NUMBER` is the GitHub pull request number, for example `2492` - not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/cli-printing-press` and exits non-zero until all of these are true: Greptile Review passes, the `All conversations resolved` check passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, or `Safe to merge after fixing/reviewing`.
+`PR_NUMBER` is the GitHub pull request number, for example `2492` - not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/cli-printing-press` and exits non-zero until all of these are true: Greptile Review passes, the `All conversations resolved` check passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, `needs attention`, or `Safe to merge after fixing/reviewing`.
 
 ## Versioning
 Releases are automated by release-please. Never manually edit version numbers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ Greptile feedback is not limited to GitHub review threads. It also edits top-lev
 python3 .github/scripts/pr-review-state/greptile_feedback.py <PR_NUMBER>
 ```
 
-`PR_NUMBER` is the GitHub pull request number, for example `2492` - not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/cli-printing-press` and exits non-zero until all of these are true: Greptile Review passes, the `All conversations resolved` check passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, `needs attention`, or `Safe to merge after fixing/reviewing`.
+`PR_NUMBER` is the GitHub pull request number, for example `2492` - not a branch name, URL, issue number, or commit SHA. The helper defaults to `mvanhorn/cli-printing-press` and exits non-zero until all of these are true: Greptile Review passes, the `All conversations resolved` check passes, there are no unresolved non-outdated review threads, the latest `greptile-apps` top-level comment reviewed the current PR head SHA, and that latest comment has no actionable markers such as `Issue 1 of`, `Fix the following`, `Comments Outside Diff`, `remaining open item`, or `Safe to merge after fixing/reviewing`.
 
 ## Versioning
 Releases are automated by release-please. Never manually edit version numbers.


### PR DESCRIPTION
## Summary
- add a repo-owned helper for checking Greptile PR readiness, including top-level summary comments and Comments Outside Diff markers
- document the helper in AGENTS.md with a concrete PR number definition and the cli repo default
- align readiness checks with cli-printing-press CI by requiring Greptile Review and All conversations resolved

## Validation
- python3 -m py_compile .github/scripts/pr-review-state/greptile_feedback.py
- git diff --check -- AGENTS.md .github/scripts/pr-review-state/greptile_feedback.py
- python3 .github/scripts/pr-review-state/greptile_feedback.py --help
- python3 .github/scripts/pr-review-state/greptile_feedback.py 2835