### PR TITLE
fix(cli): escape spec values and guard structural fields against Go injection

### DIFF
--- a/internal/generator/config_baseurl_injection_test.go
+++ b/internal/generator/config_baseurl_injection_test.go
@@ -1,0 +1,88 @@
+package generator
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigBaseURLIsEscapedNoInjection guards against Go code injection through
+// a spec-controlled base_url. base_url is attacker-influenced for domain-import
+// (recovered from an untrusted HAR / fetched domain), and Config.Load's BaseURL
+// is built into the generated binary; an unescaped value could break out of the
+// string literal and execute during build/validation. The template must emit it
+// via %q so a malicious value stays a single, inert string literal.
+func TestConfigBaseURLIsEscapedNoInjection(t *testing.T) {
+	t.Parallel()
+
+	const payload = `https://x", AuthHeaderVal: func() string { panic("INJECTED") }(), //`
+	apiSpec := minimalSpec("pwn")
+	apiSpec.BaseURL = payload
+
+	outputDir := filepath.Join(t.TempDir(), "pwn-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	out := string(src)
+
+	// The value must appear exactly as a Go-quoted literal (%q output), so the
+	// embedded quote is escaped and cannot close the literal.
+	assert.Contains(t, out, strconv.Quote(payload),
+		"base_url must be emitted as an escaped Go string literal")
+
+	// Parse the file and assert the BaseURL field's literal round-trips to the
+	// exact payload — definitive proof there was no breakout into extra code.
+	file, perr := parser.ParseFile(token.NewFileSet(), "config.go", out, parser.AllErrors)
+	require.NoError(t, perr, "generated config.go must parse as valid Go")
+
+	var got string
+	var found bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		kv, ok := n.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "BaseURL" {
+			if lit, ok := kv.Value.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				if v, err := strconv.Unquote(lit.Value); err == nil {
+					got, found = v, true
+				}
+			}
+		}
+		return true
+	})
+	require.True(t, found, "BaseURL string literal not found in generated config.go")
+	assert.Equal(t, payload, got, "BaseURL literal must round-trip to the exact spec value (no injection)")
+}
+
+// TestConfigAuthFieldsEscapedNoInjection guards the other spec-controlled
+// strings emitted into config.go (auth format + env var name): a malicious value
+// must be emitted as an escaped Go literal, not break out into code.
+func TestConfigAuthFieldsEscapedNoInjection(t *testing.T) {
+	t.Parallel()
+
+	const fmtPayload = `Bearer {token}", Evil: func() string { panic("INJ") }(), "`
+	apiSpec := minimalSpec("pwn2")
+	apiSpec.Auth.Format = fmtPayload // attacker-controlled auth format
+
+	outputDir := filepath.Join(t.TempDir(), "pwn2-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	src, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	out := string(src)
+
+	// The auth format must appear only as a properly-escaped Go literal (the
+	// applyAuthFormat(...) argument), and the file must still be valid Go.
+	assert.Contains(t, out, strconv.Quote(fmtPayload), "auth format must be %q-escaped")
+	_, perr := parser.ParseFile(token.NewFileSet(), "config.go", out, parser.AllErrors)
+	assert.NoError(t, perr, "generated config.go must parse as valid Go")
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -363,10 +363,18 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"enumDescriptionHint": func(values []string) string {
 			// Appends " (one of: a, b, c)" to a flag description when the param
 			// has enum constraints. Returns empty string when the slice is empty.
+			// Enum values are spec-derived and land inside a Go double-quoted
+			// string literal, so each is run through OneLine (strips quotes,
+			// backslashes, newlines) so a hostile value cannot break out of the
+			// literal. Identity on benign values, so generated output is stable.
 			if len(values) == 0 {
 				return ""
 			}
-			return " (one of: " + strings.Join(values, ", ") + ")"
+			safe := make([]string, len(values))
+			for i, v := range values {
+				safe[i] = naming.OneLine(v)
+			}
+			return " (one of: " + strings.Join(safe, ", ") + ")"
 		},
 		"jsonStringParam":              isJSONStringParam,
 		"jsonEnumSuggestion":           jsonEnumSuggestion,

--- a/internal/generator/templates/api_discovery.go.tmpl
+++ b/internal/generator/templates/api_discovery.go.tmpl
@@ -59,11 +59,11 @@ Run 'api <interface>' to see that interface's methods.`,
 						for _, method := range methods {
 							fmt.Fprintf(cmd.OutOrStdout(), "  %-50s %s\n", child.Name()+" "+method.Name(), method.Short)
 						}
-						fmt.Fprintf(cmd.OutOrStdout(), "\nUse '%s-pp-cli %s <method> --help' for details.\n", "{{.Name}}", child.Name())
+						fmt.Fprintf(cmd.OutOrStdout(), "\nUse '%s-pp-cli %s <method> --help' for details.\n", {{printf "%q" .Name}}, child.Name())
 						return nil
 					}
 				}
-				return fmt.Errorf("interface %q not found. Run '%s-pp-cli api' to list all interfaces", args[0], "{{.Name}}")
+				return fmt.Errorf("interface %q not found. Run '%s-pp-cli api' to list all interfaces", args[0], {{printf "%q" .Name}})
 			}
 
 			// Pre-formatting human strings ahead of time would block the JSON
@@ -100,7 +100,7 @@ Run 'api <interface>' to see that interface's methods.`,
 			for _, e := range ifaces {
 				fmt.Fprintf(cmd.OutOrStdout(), "  %-45s %s\n", e.Name, e.Short)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "\nUse '%s-pp-cli api <interface>' to see methods.\n", "{{.Name}}")
+			fmt.Fprintf(cmd.OutOrStdout(), "\nUse '%s-pp-cli api <interface>' to see methods.\n", {{printf "%q" .Name}})
 			return nil
 		},
 	}

--- a/internal/generator/templates/auth.go.tmpl
+++ b/internal/generator/templates/auth.go.tmpl
@@ -52,9 +52,9 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 {{- if .Auth.KeyURL}}
-			fmt.Fprintln(w, "Register an app and copy your credentials at: {{.Auth.KeyURL}}")
+			fmt.Fprintln(w, "Register an app and copy your credentials at: {{oneline .Auth.KeyURL}}")
 {{- else if .WebsiteURL}}
-			fmt.Fprintln(w, "See API docs for OAuth app registration: {{.WebsiteURL}}")
+			fmt.Fprintln(w, "See API docs for OAuth app registration: {{oneline .WebsiteURL}}")
 {{- else}}
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
@@ -72,7 +72,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 				return nil
 			}
 {{- if or .Auth.KeyURL .WebsiteURL}}
-			launchURL := {{if .Auth.KeyURL}}"{{.Auth.KeyURL}}"{{else}}"{{.WebsiteURL}}"{{end}}
+			launchURL := {{if .Auth.KeyURL}}{{printf "%q" .Auth.KeyURL}}{{else}}{{printf "%q" .WebsiteURL}}{{end}}
 			if cliutil.IsVerifyEnv() {
 				fmt.Fprintf(w, "would launch: %s\n", launchURL)
 				return nil
@@ -157,7 +157,7 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 {{- if .Auth.AuthorizationURL}}
 	authURL = cfg.AuthorizationURL
 	if authURL == "" {
-		authURL = "{{.Auth.AuthorizationURL}}"
+		authURL = {{printf "%q" .Auth.AuthorizationURL}}
 	}
 {{- end}}
 {{- $refreshMech := .Auth.ParseRefreshTokenMechanism}}
@@ -169,7 +169,7 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 {{- if eq $refreshMech.Kind "query"}}
 	params.Set({{printf "%q" $refreshMech.Key}}, {{printf "%q" $refreshMech.Value}})
 {{- end}}
-	scopes := []string{ {{- range .Auth.Scopes}}"{{.}}", {{end}} }
+	scopes := []string{ {{- range .Auth.Scopes}}{{printf "%q" .}}, {{end}} }
 {{- if eq $refreshMech.Kind "scope"}}
 	scopes = append(scopes, {{printf "%q" $refreshMech.Scope}})
 {{- end}}
@@ -250,7 +250,7 @@ func runOAuthLogin(cmd *cobra.Command, flags *rootFlags, clientID, clientSecret 
 {{- if .Auth.TokenURL}}
 	tokenURL = cfg.TokenURL
 	if tokenURL == "" {
-		tokenURL = "{{.Auth.TokenURL}}"
+		tokenURL = {{printf "%q" .Auth.TokenURL}}
 	}
 {{- end}}
 	tokenParams := url.Values{
@@ -347,9 +347,9 @@ func resolveOAuthCredentials(cmd *cobra.Command, flags *rootFlags, cfg *config.C
 
 func printOAuthCredentialHint(w io.Writer) {
 {{- if .Auth.KeyURL}}
-	fmt.Fprintln(w, "Create OAuth credentials at: {{.Auth.KeyURL}}")
+	fmt.Fprintln(w, "Create OAuth credentials at: {{oneline .Auth.KeyURL}}")
 {{- else if .WebsiteURL}}
-	fmt.Fprintln(w, "See API docs for OAuth app registration: {{.WebsiteURL}}")
+	fmt.Fprintln(w, "See API docs for OAuth app registration: {{oneline .WebsiteURL}}")
 {{- else}}
 	fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -101,7 +101,7 @@ type chromeProfile struct {
 }
 
 func requiredAuthCookies() []string {
-	raw := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+	raw := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}{{printf "%q" $c}}{{- end}} }
 	out := raw[:0]
 	for _, name := range raw {
 		name = strings.TrimSpace(name)
@@ -141,14 +141,14 @@ profile by name when the installed backend supports it.`,
 
 {{- with $canonicalEnvVar}}
 			// Check if already authenticated via env var
-			if v := os.Getenv("{{.Name}}"); v != "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "Already authenticated via %s env var.\n", "{{.Name}}")
+			if v := os.Getenv({{printf "%q" .Name}}); v != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "Already authenticated via %s env var.\n", {{printf "%q" .Name}})
 				return nil
 			}
 {{- end}}
 
 			w := cmd.OutOrStdout()
-			domain := "{{.Auth.CookieDomain}}"
+			domain := {{printf "%q" .Auth.CookieDomain}}
 
 			// Step 0: Try press-auth, the dedicated cookie capture companion.
 			// press-auth spawns its own controlled Chrome window so users do
@@ -237,7 +237,7 @@ profile by name when the installed backend supports it.`,
 {{- if eq .Auth.Type "composed"}}
 			// Step 4: Compose auth header from named cookies
 			cookieMap := parseCookieString(cookies)
-			requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+			requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}{{printf "%q" $c}}{{- end}} }
 
 			// Check if all required cookies were found on disk
 			allFound := true
@@ -290,7 +290,7 @@ profile by name when the installed backend supports it.`,
 				fmt.Fprintf(w, "%s Found session cookies via live Chrome.\n", green("OK"))
 			}
 
-			composed := "{{.Auth.Format}}"
+			composed := {{printf "%q" .Auth.Format}}
 			for _, name := range requiredCookies {
 				composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
 			}
@@ -357,7 +357,7 @@ profile by name when the installed backend supports it.`,
 			// Cookie header on every request, which routinely trips upstream
 			// WAFs and shadows the real credential.
 			cookieMap := parseCookieString(cookies)
-			requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+			requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}{{printf "%q" $c}}{{- end}} }
 			kept := make([]string, 0, len(requiredCookies))
 			for _, name := range requiredCookies {
 				v, ok := cookieMap[name]
@@ -634,7 +634,7 @@ Use auth refresh-queries when the site rotates GraphQL persisted-query hashes.
 			fmt.Fprintln(w, green("Auth: not required"))
 {{- else}}
 {{- with $canonicalEnvVar}}
-			fmt.Fprintf(w, "Set %s before making live calls.\n", "{{.Name}}")
+			fmt.Fprintf(w, "Set %s before making live calls.\n", {{printf "%q" .Name}})
 {{- else}}
 			fmt.Fprintln(w, "No interactive login flow is configured for this CLI.")
 {{- end}}
@@ -693,11 +693,11 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 
 func browserSessionTargetURL(cfg *config.Config) string {
-	baseURL := strings.TrimRight("{{.BaseURL}}", "/")
+	baseURL := strings.TrimRight({{printf "%q" .BaseURL}}, "/")
 	if cfg != nil && cfg.BaseURL != "" {
 		baseURL = strings.TrimRight(cfg.BaseURL, "/")
 	}
-	validationPath := strings.TrimSpace("{{.Auth.BrowserSessionValidationPath}}")
+	validationPath := strings.TrimSpace({{printf "%q" .Auth.BrowserSessionValidationPath}})
 	if validationPath == "" {
 		return baseURL
 	}
@@ -860,7 +860,7 @@ func waitForCookieRefreshBrowser(cmd *cobra.Command, flags *rootFlags, targetURL
 
 {{- if $hasCookieBrowserAuth}}
 func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
-	domain := "{{.Auth.CookieDomain}}"
+	domain := {{printf "%q" .Auth.CookieDomain}}
 	if domain == "" {
 		return fmt.Errorf("no cookie domain configured")
 	}
@@ -885,13 +885,13 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 
 {{- if eq .Auth.Type "composed"}}
 	cookieMap := parseCookieString(cookies)
-	requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+	requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}{{printf "%q" $c}}{{- end}} }
 	for _, name := range requiredCookies {
 		if _, ok := cookieMap[name]; !ok {
 			return fmt.Errorf("cookie %q not found for %s", name, domain)
 		}
 	}
-	composed := "{{.Auth.Format}}"
+	composed := {{printf "%q" .Auth.Format}}
 	for _, name := range requiredCookies {
 		composed = strings.ReplaceAll(composed, "{"+name+"}", cookieMap[name])
 	}
@@ -919,7 +919,7 @@ func refreshStoredBrowserCookies(cfg *config.Config, w io.Writer) error {
 	// overwrite the filtered token that login just persisted. Apply the same
 	// allowlist filter as newAuthLoginCmd's non-composed branch.
 	cookieMap := parseCookieString(cookies)
-	requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}"{{$c}}"{{- end}} }
+	requiredCookies := []string{ {{- range $i, $c := .Auth.Cookies}}{{if $i}}, {{end}}{{printf "%q" $c}}{{- end}} }
 	kept := make([]string, 0, len(requiredCookies))
 	for _, name := range requiredCookies {
 		v, ok := cookieMap[name]
@@ -1187,9 +1187,9 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 				return nil
 {{- else}}
 {{- with $canonicalEnvVar}}
-				if v := os.Getenv("{{.Name}}"); v != "" {
+				if v := os.Getenv({{printf "%q" .Name}}); v != "" {
 					fmt.Fprintln(w, green("Authenticated"))
-					fmt.Fprintf(w, "  Source: %s env var\n", "{{.Name}}")
+					fmt.Fprintf(w, "  Source: %s env var\n", {{printf "%q" .Name}})
 					return nil
 				}
 {{- end}}
@@ -1203,7 +1203,7 @@ func newAuthStatusCmd(flags *rootFlags) *cobra.Command {
 
 			fmt.Fprintln(w, green("Authenticated"))
 			fmt.Fprintf(w, "  Source: %s\n", cfg.AuthSource)
-			fmt.Fprintf(w, "  Domain: {{.Auth.CookieDomain}}\n")
+			fmt.Fprintf(w, "  Domain: {{oneline .Auth.CookieDomain}}\n")
 			fmt.Fprintf(w, "  Config: %s\n", cfg.Path)
 			return nil
 		},
@@ -1301,8 +1301,8 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 
 {{- with $canonicalEnvVar}}
-			if os.Getenv("{{.Name}}") != "" {
-				fmt.Fprintf(cmd.OutOrStdout(), "Config cleared. Note: %s env var is still set.\n", "{{.Name}}")
+			if os.Getenv({{printf "%q" .Name}}) != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "Config cleared. Note: %s env var is still set.\n", {{printf "%q" .Name}})
 				return nil
 			}
 {{- end}}
@@ -1891,14 +1891,14 @@ func extractViaCookieScoop(domain, profileDir string) (string, error) {
 // A non-auth error (404, 500, timeout) is treated as "can't validate, assume OK" to avoid
 // blocking auth on unrelated API issues.
 func validateComposedAuth(authHeader string) error {
-	testURL := "{{.BaseURL}}"
+	testURL := {{printf "%q" .BaseURL}}
 	req, err := http.NewRequest("HEAD", testURL, nil)
 	if err != nil {
 		return nil // can't validate, assume OK
 	}
-	req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", authHeader)
+	req.Header.Set("{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}", authHeader)
 {{- range .RequiredHeaders}}
-	req.Header.Set("{{.Name}}", "{{.Value}}")
+	req.Header.Set({{printf "%q" .Name}}, {{printf "%q" .Value}})
 {{- end}}
 {{- if not .UsesBrowserManagedUserAgent}}
 	if req.Header.Get("User-Agent") == "" {
@@ -1986,7 +1986,7 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 	if err := json.Unmarshal(data, &proof); err != nil {
 		return false, "proof is not valid JSON; re-run {{.Name}}-pp-cli auth login --chrome"
 	}
-	if proof.APIName != "{{.Name}}" || proof.CookieDomain != "{{.Auth.CookieDomain}}" || proof.ValidationPath != "{{.Auth.BrowserSessionValidationPath}}" {
+	if proof.APIName != {{printf "%q" .Name}} || proof.CookieDomain != {{printf "%q" .Auth.CookieDomain}} || proof.ValidationPath != {{printf "%q" .Auth.BrowserSessionValidationPath}} {
 		return false, "proof does not match this CLI"
 	}
 	if authHeader != "" && proof.CredentialFingerprint != fingerprintCredential(authHeader) {
@@ -1999,11 +1999,11 @@ func browserSessionProofStatusForAuth(cfg *config.Config, authHeader string) (bo
 }
 
 func validateAndWriteBrowserSessionProof(ctx context.Context, cfg *config.Config, flags *rootFlags) error {
-	validationPath := strings.TrimSpace("{{.Auth.BrowserSessionValidationPath}}")
+	validationPath := strings.TrimSpace({{printf "%q" .Auth.BrowserSessionValidationPath}})
 	if validationPath == "" {
 		return fmt.Errorf("no browser-session validation endpoint configured in this CLI")
 	}
-	method := strings.ToUpper(strings.TrimSpace("{{.Auth.BrowserSessionValidationMethod}}"))
+	method := strings.ToUpper(strings.TrimSpace({{printf "%q" .Auth.BrowserSessionValidationMethod}}))
 	if method == "" {
 		method = "GET"
 	}
@@ -2027,8 +2027,8 @@ func validateAndWriteBrowserSessionProof(ctx context.Context, cfg *config.Config
 	}
 
 	proof := browserSessionProof{
-		APIName:               "{{.Name}}",
-		CookieDomain:          "{{.Auth.CookieDomain}}",
+		APIName:               {{printf "%q" .Name}},
+		CookieDomain:          {{printf "%q" .Auth.CookieDomain}},
 		ValidationMethod:      method,
 		ValidationPath:        validationPath,
 		StatusCode:            status,

--- a/internal/generator/templates/auth_client_credentials.go.tmpl
+++ b/internal/generator/templates/auth_client_credentials.go.tmpl
@@ -73,12 +73,12 @@ Credentials default to {{if $ccEnvVars}}{{(index $ccEnvVars 0).Name}} (Client ID
 
 			if clientID == "" {
 {{- if $ccEnvVars}}
-				clientID = strings.TrimSpace(os.Getenv("{{(index $ccEnvVars 0).Name}}"))
+				clientID = strings.TrimSpace(os.Getenv({{printf "%q" (index $ccEnvVars 0).Name}}))
 {{- end}}
 			}
 			if clientSecret == "" {
 {{- if gt (len $ccEnvVars) 1}}
-				clientSecret = strings.TrimSpace(os.Getenv("{{(index $ccEnvVars 1).Name}}"))
+				clientSecret = strings.TrimSpace(os.Getenv({{printf "%q" (index $ccEnvVars 1).Name}}))
 {{- end}}
 			}
 			if clientID == "" || clientSecret == "" {
@@ -96,7 +96,7 @@ Credentials default to {{if $ccEnvVars}}{{(index $ccEnvVars 0).Name}} (Client ID
 
 			tokenURL := cfg.TokenURL
 			if tokenURL == "" {
-				tokenURL = "{{.Auth.TokenURL}}"
+				tokenURL = {{printf "%q" .Auth.TokenURL}}
 			}
 {{- if clientCredentialsTokenURLHasTenant .Auth}}
 			tokenURL, err = resolveClientCredentialsTokenURL(tokenURL, cfg.{{resolveEnvVarField $ccTenantEnvVar}})
@@ -321,8 +321,8 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			// JSON envelope and the human prose can both surface it.
 			envStillSet := ""
 {{- range .Auth.EnvVars}}
-			if envStillSet == "" && os.Getenv("{{.}}") != "" {
-				envStillSet = "{{.}}"
+			if envStillSet == "" && os.Getenv({{printf "%q" .}}) != "" {
+				envStillSet = {{printf "%q" .}}
 			}
 {{- end}}
 

--- a/internal/generator/templates/auth_device_code.go.tmpl
+++ b/internal/generator/templates/auth_device_code.go.tmpl
@@ -44,9 +44,9 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 {{- if .Auth.KeyURL}}
-			fmt.Fprintln(w, "Register an app and copy the public client ID at: {{.Auth.KeyURL}}")
+			fmt.Fprintln(w, "Register an app and copy the public client ID at: {{oneline .Auth.KeyURL}}")
 {{- else if .WebsiteURL}}
-			fmt.Fprintln(w, "See API docs for OAuth app registration: {{.WebsiteURL}}")
+			fmt.Fprintln(w, "See API docs for OAuth app registration: {{oneline .WebsiteURL}}")
 {{- else}}
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
@@ -99,7 +99,7 @@ for CLIs and agents: no localhost callback server and no client secret.
 			}
 			if clientID == "" {
 {{- if $deviceEnvVars}}
-				clientID = os.Getenv("{{(index $deviceEnvVars 0).Name}}")
+				clientID = os.Getenv({{printf "%q" (index $deviceEnvVars 0).Name}})
 {{- end}}
 			}
 			if clientID == "" {
@@ -107,7 +107,7 @@ for CLIs and agents: no localhost callback server and no client secret.
 			}
 {{- if .Auth.DefaultClientID}}
 			if clientID == "" {
-				clientID = "{{.Auth.DefaultClientID}}"
+				clientID = {{printf "%q" .Auth.DefaultClientID}}
 			}
 {{- end}}
 			if clientID == "" {
@@ -120,13 +120,13 @@ for CLIs and agents: no localhost callback server and no client secret.
 
 			tokenURL := cfg.TokenURL
 			if tokenURL == "" {
-				tokenURL = "{{.Auth.TokenURL}}"
+				tokenURL = {{printf "%q" .Auth.TokenURL}}
 			}
 			deviceAuthorizationURL := cfg.DeviceAuthorizationURL
 			if deviceAuthorizationURL == "" {
-				deviceAuthorizationURL = "{{.Auth.DeviceAuthorizationURL}}"
+				deviceAuthorizationURL = {{printf "%q" .Auth.DeviceAuthorizationURL}}
 			}
-			scopes := []string{ {{- range .Auth.Scopes}}"{{.}}", {{end}} }
+			scopes := []string{ {{- range .Auth.Scopes}}{{printf "%q" .}}, {{end}} }
 			if scope := os.Getenv("{{envName .Name}}_OAUTH_SCOPE"); scope != "" {
 				scopes = strings.Fields(scope)
 			}
@@ -231,7 +231,7 @@ func newAuthPollCmd(flags *rootFlags) *cobra.Command {
 			clientID := state.ClientID
 			tokenURL := state.TokenURL
 			if tokenURL == "" {
-				tokenURL = "{{.Auth.TokenURL}}"
+				tokenURL = {{printf "%q" .Auth.TokenURL}}
 			}
 			ctx := cmd.Context()
 			if timeout > 0 {
@@ -279,7 +279,7 @@ func newAuthRefreshCmd(flags *rootFlags) *cobra.Command {
 			}
 			tokenURL := cfg.TokenURL
 			if tokenURL == "" {
-				tokenURL = "{{.Auth.TokenURL}}"
+				tokenURL = {{printf "%q" .Auth.TokenURL}}
 			}
 			tok, err := oauth.RefreshToken(cmd.Context(), nil, tokenURL, cfg.ClientID, cfg.ClientSecret, cfg.RefreshToken)
 			if err != nil {

--- a/internal/generator/templates/auth_simple.go.tmpl
+++ b/internal/generator/templates/auth_simple.go.tmpl
@@ -47,9 +47,9 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 {{- if .Auth.KeyURL}}
-			fmt.Fprintln(w, "Get a key at: {{.Auth.KeyURL}}")
+			fmt.Fprintln(w, "Get a key at: {{oneline .Auth.KeyURL}}")
 {{- else if .WebsiteURL}}
-			fmt.Fprintln(w, "See API docs: {{.WebsiteURL}}")
+			fmt.Fprintln(w, "See API docs: {{oneline .WebsiteURL}}")
 {{- else}}
 			fmt.Fprintln(w, "No setup URL is configured for this CLI; check the API's docs.")
 {{- end}}
@@ -84,7 +84,7 @@ func newAuthSetupCmd(_ *rootFlags) *cobra.Command {
 				return nil
 			}
 {{- if or .Auth.KeyURL .WebsiteURL}}
-			launchURL := {{if .Auth.KeyURL}}"{{.Auth.KeyURL}}"{{else}}"{{.WebsiteURL}}"{{end}}
+			launchURL := {{if .Auth.KeyURL}}{{printf "%q" .Auth.KeyURL}}{{else}}{{printf "%q" .WebsiteURL}}{{end}}
 			if cliutil.IsVerifyEnv() {
 				fmt.Fprintf(w, "would launch: %s\n", launchURL)
 				return nil
@@ -254,8 +254,8 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			// JSON envelope and the human prose can both surface it.
 			envStillSet := ""
 {{- range .Auth.EnvVars}}
-			if envStillSet == "" && os.Getenv("{{.}}") != "" {
-				envStillSet = "{{.}}"
+			if envStillSet == "" && os.Getenv({{printf "%q" .}}) != "" {
+				envStillSet = {{printf "%q" .}}
 			}
 {{- end}}
 

--- a/internal/generator/templates/auto_refresh.go.tmpl
+++ b/internal/generator/templates/auto_refresh.go.tmpl
@@ -22,15 +22,15 @@ import (
 // command-path coverage declared in spec.Cache.Commands.
 var readCommandResources = map[string][]string{
 {{- range .SyncableResources}}
-	"{{$.Name}}-pp-cli {{.Name}}":        {"{{.Name}}"},
-	"{{$.Name}}-pp-cli {{.Name}} list":   {"{{.Name}}"},
-	"{{$.Name}}-pp-cli {{.Name}} get":    {"{{.Name}}"},
-	"{{$.Name}}-pp-cli {{.Name}} search": {"{{.Name}}"},
+	"{{$.Name}}-pp-cli {{.Name}}":        { {{printf "%q" .Name}} },
+	"{{$.Name}}-pp-cli {{.Name}} list":   { {{printf "%q" .Name}} },
+	"{{$.Name}}-pp-cli {{.Name}} get":    { {{printf "%q" .Name}} },
+	"{{$.Name}}-pp-cli {{.Name}} search": { {{printf "%q" .Name}} },
 {{- end}}
 {{- range .Cache.Commands}}
 	"{{$.Name}}-pp-cli {{.Name}}": {
 {{- range .Resources}}
-		"{{.}}",
+		{{printf "%q" .}},
 {{- end}}
 	},
 {{- end}}
@@ -43,12 +43,12 @@ func cachePolicy() cliutil.Policy {
 	staleAfter := {{staleAfterExpr .Cache.StaleAfter}}
 	perResource := map[string]time.Duration{}
 {{- range $resource, $dur := .Cache.Resources}}
-	if d, err := time.ParseDuration("{{$dur}}"); err == nil {
-		perResource["{{$resource}}"] = d
+	if d, err := time.ParseDuration({{printf "%q" $dur}}); err == nil {
+		perResource[{{printf "%q" $resource}}] = d
 	}
 {{- end}}
 {{- if .Cache.EnvOptOut}}
-	envOptOut := "{{.Cache.EnvOptOut}}"
+	envOptOut := {{printf "%q" .Cache.EnvOptOut}}
 {{- else}}
 	// Default env opt-out name is the CLI name normalized with the same
 	// ASCII-safe convention used in generated docs and config env vars.
@@ -67,7 +67,7 @@ func cachePolicy() cliutil.Policy {
 // instead of blocking the agent or user indefinitely.
 func refreshTimeout() time.Duration {
 {{- if .Cache.RefreshTimeout}}
-	if d, err := time.ParseDuration("{{.Cache.RefreshTimeout}}"); err == nil {
+	if d, err := time.ParseDuration({{printf "%q" .Cache.RefreshTimeout}}); err == nil {
 		return d
 	}
 {{- end}}

--- a/internal/generator/templates/captured_test.go.tmpl
+++ b/internal/generator/templates/captured_test.go.tmpl
@@ -33,11 +33,11 @@ func TestCaptured_{{.EndpointName}}_RequestShape(t *testing.T) {
 	// The generated client should accept a configurable base URL.
 	// Test validates: method, path, and parameter presence.
 	if capturedReq != nil {
-		if capturedReq.Method != "{{.Method}}" {
-			t.Errorf("expected method {{.Method}}, got %s", capturedReq.Method)
+		if capturedReq.Method != {{printf "%q" .Method}} {
+			t.Errorf("expected method {{oneline .Method}}, got %s", capturedReq.Method)
 		}
-		if capturedReq.URL.Path != "{{.Path}}" {
-			t.Errorf("expected path {{.Path}}, got %s", capturedReq.URL.Path)
+		if capturedReq.URL.Path != {{printf "%q" .Path}} {
+			t.Errorf("expected path {{oneline .Path}}, got %s", capturedReq.URL.Path)
 		}
 	}
 }

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -102,7 +102,7 @@ execute command an operator can approve later.`,
 				if purpose != "" {
 					body["purpose"] = map[string]any{"simple": purpose}
 				}
-				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, "{{.}}"{{end}}}
+				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, {{printf "%q" .}}{{end}}}
 {{- if .HasAccountIDPosition}}
 				base = append(base, accountID)
 {{- end}}
@@ -142,7 +142,7 @@ execute command an operator can approve later.`,
 				if externalMemo != "" {
 					body["externalMemo"] = externalMemo
 				}
-				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, "{{.}}"{{end}}}
+				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, {{printf "%q" .}}{{end}}}
 {{- if .HasAccountIDPosition}}
 				base = append(base, accountID)
 {{- end}}
@@ -179,7 +179,7 @@ execute command an operator can approve later.`,
 				}
 				body["sourceAccountId"] = sourceAccountID
 				body["destinationAccountId"] = destinationAccountID
-				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, "{{.}}"{{end}}}
+				base = []string{"{{$.Name}}-pp-cli"{{range .CommandPath}}, {{printf "%q" .}}{{end}}}
 {{- if .HasAccountIDPosition}}
 				base = append(base, accountID)
 {{- end}}
@@ -277,7 +277,7 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 			defer s.Close()
 
-			resources := []string{ {{- range .SyncableResources}}{{if not .SkipDefaultSync}}"{{.Name}}", {{end}}{{end}} }
+			resources := []string{ {{- range .SyncableResources}}{{if not .SkipDefaultSync}}{{printf "%q" .Name}}, {{end}}{{end}} }
 			totalSynced := 0
 {{- if not (isGraphQL .APISpec)}}
 			syncEventWriter := cmd.OutOrStdout()

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -227,13 +227,13 @@ func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 		{{- end}}
 		})
 	{{- else if eq $tier.Auth.Type "bearer_token"}}
-		value := "{{$tier.Auth.HeaderPrefix}} " + tierValue0
+		value := "{{oneline $tier.Auth.HeaderPrefix}} " + tierValue0
 	{{- else}}
 		value := tierValue0
 	{{- end}}
 		auth := requestAuth{Value: value, In: {{printf "%q" $placement}}, Name: {{printf "%q" $name}}}
 		if authHeaderLooksLikePlaceholderCredential(auth.Value) {
-			return requestAuth{}, authPlaceholderCredentialErrorWithSetup(c.Config, "export {{index $tier.Auth.EnvVars 0}}=<your-token>")
+			return requestAuth{}, authPlaceholderCredentialErrorWithSetup(c.Config, "export {{oneline (index $tier.Auth.EnvVars 0)}}=<your-token>")
 		}
 		return auth, nil
 	{{- else}}
@@ -246,7 +246,7 @@ func (c *Client) authForRequest(ctx context.Context) (requestAuth, error) {
 		if err != nil {
 			return requestAuth{}, err
 		}
-		return requestAuth{Value: value, In: "{{authPlacement .Auth}}", Name: "{{authParameterName .Auth}}"}, nil
+		return requestAuth{Value: value, In: "{{authPlacement .Auth}}", Name: {{printf "%q" (authParameterName .Auth)}}}, nil
 	}
 }
 
@@ -303,7 +303,7 @@ func serviceForPath(path string) string {
 	bestService := ""
 	for prefix, svc := range map[string]string{
 	{{- range $prefix, $svc := .ProxyRoutes}}
-		"{{$prefix}}": "{{$svc}}",
+		{{printf "%q" $prefix}}: {{printf "%q" $svc}},
 	{{- end}}
 	} {
 		if strings.HasPrefix(path, prefix) && len(prefix) > len(bestMatch) {
@@ -315,7 +315,7 @@ func serviceForPath(path string) string {
 		return bestService
 	}
 {{- end}}
-	return "{{.Name}}" // default: API name slug
+	return {{printf "%q" .Name}} // default: API name slug
 }
 {{end}}
 
@@ -474,12 +474,12 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
-				req.Header.Set("{{.Auth.TokenParamName}}", h)
+				req.Header.Set({{printf "%q" .Auth.TokenParamName}}, h)
 			}
 		} else {
 			// Cross-host hop: delete the custom auth header so the credential
 			// is not forwarded to the redirect target.
-			req.Header.Del("{{.Auth.TokenParamName}}")
+			req.Header.Del({{printf "%q" .Auth.TokenParamName}})
 		}
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
@@ -497,7 +497,7 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 			preserved := req.Cookies()
 			req.Header.Del("Cookie")
 			for _, ck := range preserved {
-				if ck.Name != "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}" {
+				if ck.Name != "{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}" {
 					req.AddCookie(ck)
 				}
 			}
@@ -514,13 +514,13 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 		// CheckRedirect where Go's automatic stripping has already run.
 		if req.URL.Host == via[0].URL.Host {
 			if h, err := c.authHeader(req.Context()); err == nil && h != "" {
-				req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", h)
+				req.Header.Set("{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}", h)
 			}
 		} else {
 			// Cross-host hop: Go strips standard auth headers (Authorization,
 			// Cookie) but not custom ones, so a custom API-key header would be
 			// forwarded verbatim to the redirect target. Delete it explicitly.
-			req.Header.Del("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}")
+			req.Header.Del("{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}")
 		}
 {{- end}}
 		return nil
@@ -688,7 +688,7 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 	if c.Config != nil {
 		for _, name := range []string{
 		{{- range .EndpointTemplateVars}}
-			"{{.}}",
+			{{printf "%q" .}},
 		{{- end}}
 		} {
 			key += "|" + name + "=" + c.Config.TemplateVars[name]
@@ -1334,19 +1334,19 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			}
 {{- else if eq .Auth.Type "session_handshake"}}
 {{- if eq .Auth.TokenParamIn "header"}}
-			req.Header.Set("{{.Auth.TokenParamName}}", authHeader)
+			req.Header.Set({{printf "%q" .Auth.TokenParamName}}, authHeader)
 {{- else}}
 			q := req.URL.Query()
-			q.Set("{{.Auth.TokenParamName}}", authHeader)
+			q.Set({{printf "%q" .Auth.TokenParamName}}, authHeader)
 			req.URL.RawQuery = q.Encode()
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "query")}}
 			// API key goes in query parameter
 			q := req.URL.Query()
-			q.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", authHeader)
+			q.Set("{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}", authHeader)
 			req.URL.RawQuery = q.Encode()
 {{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
-			req.AddCookie(&http.Cookie{Name: "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", Value: authHeader})
+			req.AddCookie(&http.Cookie{Name: "{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}", Value: authHeader})
 {{- else if eq .Auth.Type "cookie"}}
 			// Cookie-auth: LoadCookieJar is the sole source of outbound
 			// cookies. net/http's Client.send calls jar.Cookies + AddCookie
@@ -1358,7 +1358,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 			// signing paths above; intentionally not consumed on the live
 			// wire here.
 {{- else}}
-			req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", authHeader)
+			req.Header.Set("{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}", authHeader)
 {{- end}}
 		}
 {{- if .Auth.AdditionalHeaders}}
@@ -1373,17 +1373,17 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 				}
 {{- if eq .In "query"}}
 				q := req.URL.Query()
-				q.Set("{{.Header}}", v)
+				q.Set({{printf "%q" .Header}}, v)
 				req.URL.RawQuery = q.Encode()
 {{- else}}
-				req.Header.Set("{{.Header}}", v)
+				req.Header.Set({{printf "%q" .Header}}, v)
 {{- end}}
 			}
 {{- end}}
 		}
 {{- end}}
 {{- range .RequiredHeaders}}
-		req.Header.Set("{{.Name}}", "{{.Value}}")
+		req.Header.Set({{printf "%q" .Name}}, {{printf "%q" .Value}})
 {{- end}}
 		if c.Config != nil {
 			for k, v := range c.Config.Headers {
@@ -1615,7 +1615,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 		if queryPrinted {
 			sep = "&"
 		}
-		fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, "{{.Auth.TokenParamName}}", maskToken(authHeader))
+		fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, {{printf "%q" .Auth.TokenParamName}}, maskToken(authHeader))
 		queryPrinted = true
 	}
 {{- end}}
@@ -1627,7 +1627,7 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 		if queryPrinted {
 			sep = "&"
 		}
-		fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", maskToken(authHeader))
+		fmt.Fprintf(os.Stderr, "  %s%s=%s\n", sep, "{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}", maskToken(authHeader))
 		queryPrinted = true
 	}
 {{- end}}
@@ -1649,18 +1649,18 @@ func (c *Client) dryRun(method, targetURL, path string, params map[string]string
 {{- else if eq .Auth.Type "session_handshake"}}
 {{- if eq .Auth.TokenParamIn "header"}}
 	if authHeader != "" {
-		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{.Auth.TokenParamName}}", maskToken(authHeader))
+		fmt.Fprintf(os.Stderr, "  %s: %s\n", {{printf "%q" .Auth.TokenParamName}}, maskToken(authHeader))
 	}
 {{- end}}
 {{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
 	if authHeader != "" {
 		// in:cookie auth ships on the Cookie header; preview it as such so the
 		// dry run matches the live wire format.
-		fmt.Fprintf(os.Stderr, "  Cookie: %s=%s\n", "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", maskToken(authHeader))
+		fmt.Fprintf(os.Stderr, "  Cookie: %s=%s\n", "{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}", maskToken(authHeader))
 	}
 {{- else if not (and .Auth .Auth.In (eq .Auth.In "query"))}}
 	if authHeader != "" {
-		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", maskToken(authHeader))
+		fmt.Fprintf(os.Stderr, "  %s: %s\n", "{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}", maskToken(authHeader))
 	}
 {{- end}}
 	fmt.Fprintf(os.Stderr, "\n(dry run - no request sent)\n")
@@ -1958,11 +1958,11 @@ func resolveClientCredentials(cfg *config.Config) (string, string) {
 	secret := cfg.ClientSecret
 {{- if $ccEnvVars}}
 	if id == "" {
-		id = os.Getenv("{{(index $ccEnvVars 0).Name}}")
+		id = os.Getenv({{printf "%q" (index $ccEnvVars 0).Name}})
 	}
 {{- if gt (len $ccEnvVars) 1}}
 	if secret == "" {
-		secret = os.Getenv("{{(index $ccEnvVars 1).Name}}")
+		secret = os.Getenv({{printf "%q" (index $ccEnvVars 1).Name}})
 	}
 {{- end}}
 {{- end}}
@@ -2006,7 +2006,7 @@ func (c *Client) mintClientCredentials(ctx context.Context, clientID, clientSecr
 		tokenURL = c.Config.TokenURL
 	}
 	if tokenURL == "" {
-		tokenURL = "{{.Auth.TokenURL}}"
+		tokenURL = {{printf "%q" .Auth.TokenURL}}
 	}
 {{- end}}
 	if tokenURL == "" {
@@ -2081,7 +2081,7 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {
-		tokenURL = "{{.Auth.TokenURL}}"
+		tokenURL = {{printf "%q" .Auth.TokenURL}}
 	}
 
 	params := url.Values{

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -63,7 +63,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "{{kebab .EndpointName}}{{positionalArgs .Endpoint}}",
 {{- if .Endpoint.Alias}}
-		Aliases: []string{"{{.Endpoint.Alias}}"},
+		Aliases: []string{ {{printf "%q" .Endpoint.Alias}} },
 {{- end}}
 		Short: "{{oneline .Endpoint.Description}}",
 		Example: {{printf "%q" (exampleLine .CommandPath .EndpointName .Endpoint)}},
@@ -156,23 +156,23 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			c = c.WithTier({{printf "%q" .EffectiveTier}})
 {{- end}}
 
-			path := "{{.EffectivePath}}"
+			path := {{printf "%q" .EffectivePath}}
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
 {{- if gt $pi 0}}
 			if len(args) < {{add $pi 1}} {
-				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), "{{.Name}}"))
+				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), {{printf "%q" .Name}}))
 			}
 {{- end}}
 {{- if pathContainsParam $.Endpoint.Path .Name}}
-			path = replacePathParam(path, "{{.Name}}", args[{{$pi}}])
+			path = replacePathParam(path, {{printf "%q" .Name}}, args[{{$pi}}])
 {{- end}}
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .PathParam (not .Positional)}}
-			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
+			path = replacePathParam(path, {{printf "%q" .Name}}, formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
 {{- if $isGraphQLEndpoint}}
@@ -183,11 +183,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			htmlRequestParams := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			htmlRequestParams["{{.Name}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			htmlRequestParams[{{printf "%q" .Name}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				htmlRequestParams["{{.Name}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				htmlRequestParams[{{printf "%q" .Name}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -196,7 +196,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			headerOverrides := map[string]string{
 {{- range .Endpoint.HeaderOverrides}}
-				"{{.Name}}": "{{.Value}}",
+				{{printf "%q" .Name}}: {{printf "%q" .Value}},
 {{- end}}
 {{- if .Endpoint.UsesBinaryResponse}}
 				"X-Printing-Press-Binary-Response": "true",
@@ -207,13 +207,13 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")}}
 {{- if and $isGraphQLEndpoint (eq .EndpointName "list")}}
 {{- if .HasStore}}
-			if err := validateDataSourceStrategy(flags, "{{$dataSourceStrategy}}"); err != nil {
+			if err := validateDataSourceStrategy(flags, {{printf "%q" $dataSourceStrategy}}); err != nil {
 				return err
 			}
 			var data json.RawMessage
 			var prov DataProvenance
-			if flags.dataSource == "local" || "{{$dataSourceStrategy}}" == "local" {
-				data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), "{{lower .ResourceName}}", true, path, nil, "user_requested")
+			if flags.dataSource == "local" || {{printf "%q" $dataSourceStrategy}} == "local" {
+				data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), {{printf "%q" (lower .ResourceName)}}, true, path, nil, "user_requested")
 			} else {
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
@@ -227,10 +227,10 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			variables := map[string]any{}
 {{- range graphqlListParams .Endpoint}}
 {{- if or .Required .Default (eq .Name "first")}}
-			variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
+			variables[{{printf "%q" .Name}}] = flag{{camel (paramIdent .)}}
 {{- else}}
 			if {{flagChangedExpr .}} {
-				variables["{{.Name}}"] = flag{{camel (paramIdent .)}}
+				variables[{{printf "%q" .Name}}] = flag{{camel (paramIdent .)}}
 			}
 {{- end}}
 {{- end}}
@@ -240,14 +240,14 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 			if flagAll && !flags.dryRun {
 				var items []json.RawMessage
-				items, err = c.PaginatedQuery(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables, "{{graphqlQueryField .Endpoint.ResponsePath}}", flagFirst)
+				items, err = c.PaginatedQuery(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables, {{printf "%q" (graphqlQueryField .Endpoint.ResponsePath)}}, flagFirst)
 				if err == nil {
 					data, err = json.Marshal(items)
 				}
 			} else {
 				data, err = c.Query(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables)
 				if err == nil && !flags.dryRun {
-					data, err = extractGraphQLConnection(data, "{{graphqlQueryField .Endpoint.ResponsePath}}")
+					data, err = extractGraphQLConnection(data, {{printf "%q" (graphqlQueryField .Endpoint.ResponsePath)}})
 				}
 			}
 {{- else}}
@@ -257,12 +257,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			data, err := c.Query(cmd.Context(), client.{{pascal .ResourceName}}ListQuery, variables)
 {{- end}}
 			if err == nil && !flags.dryRun {
-				data, err = extractGraphQLConnection(data, "{{graphqlQueryField .Endpoint.ResponsePath}}")
+				data, err = extractGraphQLConnection(data, {{printf "%q" (graphqlQueryField .Endpoint.ResponsePath)}})
 			}
 {{- end}}
 {{- if .HasStore}}
-				if err != nil && flags.dataSource == "auto" && "{{$dataSourceStrategy}}" == "auto" && isNetworkError(err) {
-					data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), "{{lower .ResourceName}}", true, path, nil, networkFallbackReason)
+				if err != nil && flags.dataSource == "auto" && {{printf "%q" $dataSourceStrategy}} == "auto" && isNetworkError(err) {
+					data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), {{printf "%q" (lower .ResourceName)}}, true, path, nil, networkFallbackReason)
 				} else if err == nil {
 					prov = attachFreshness(DataProvenance{Source: "live"}, flags)
 				}
@@ -270,17 +270,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- else if and $isGraphQLEndpoint (eq .EndpointName "get")}}
 {{- if .HasStore}}
-			if err := validateDataSourceStrategy(flags, "{{$dataSourceStrategy}}"); err != nil {
+			if err := validateDataSourceStrategy(flags, {{printf "%q" $dataSourceStrategy}}); err != nil {
 				return err
 			}
 			var data json.RawMessage
 			var prov DataProvenance
-			if flags.dataSource == "local" || "{{$dataSourceStrategy}}" == "local" {
+			if flags.dataSource == "local" || {{printf "%q" $dataSourceStrategy}} == "local" {
 				localReason := "user_requested"
-				if "{{$dataSourceStrategy}}" == "local" {
+				if {{printf "%q" $dataSourceStrategy}} == "local" {
 					localReason = "strategy_local"
 				}
-				data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), "{{lower .ResourceName}}", false, path+"/"+args[0], nil, localReason)
+				data, prov, err = resolveLocal(cmd.Context(), flags, cmd.ErrOrStderr(), {{printf "%q" (lower .ResourceName)}}, false, path+"/"+args[0], nil, localReason)
 			} else {
 				data, err = c.Query(cmd.Context(), client.{{pascal .ResourceName}}GetQuery, map[string]any{
 {{- else}}
@@ -296,7 +296,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				"id": args[0],
 			})
 			if err == nil && !flags.dryRun {
-				data, err = extractGraphQLObject(data, "{{graphqlQueryField .Endpoint.ResponsePath}}")
+				data, err = extractGraphQLObject(data, {{printf "%q" (graphqlQueryField .Endpoint.ResponsePath)}})
 			}
 {{- if .HasStore}}
 				if err == nil {
@@ -306,16 +306,16 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- else if $supportsAllPagination}}
 {{- if .HasStore}}
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
+			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, {{printf "%q" $dataSourceStrategy}}, {{printf "%q" (lower .ResourceName)}}, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
+				{{printf "%q" (paramWireName .)}}: args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
+				{{printf "%q" (paramWireName .)}}: formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, {{printf "%q" .Endpoint.Pagination.CursorParam}}, {{printf "%q" .Endpoint.Pagination.Type}}, {{printf "%q" .Endpoint.Pagination.LimitParam}}, {{printf "%q" .Endpoint.Pagination.NextCursorPath}}, {{printf "%q" .Endpoint.Pagination.HasMoreField}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -327,28 +327,28 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
+				{{printf "%q" (paramWireName .)}}: args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
+				{{printf "%q" (paramWireName .)}}: formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, {{printf "%q" .Endpoint.Pagination.CursorParam}}, {{printf "%q" .Endpoint.Pagination.Type}}, {{printf "%q" .Endpoint.Pagination.LimitParam}}, {{printf "%q" .Endpoint.Pagination.NextCursorPath}}, {{printf "%q" .Endpoint.Pagination.HasMoreField}})
 {{- end}}
 {{- else}}
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, {{printf "%q" $dataSourceStrategy}}, {{printf "%q" (lower .ResourceName)}}, {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -368,11 +368,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -427,11 +427,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -475,11 +475,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -525,11 +525,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -632,29 +632,29 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 
 {{- if .IsAsync}}
-			if asyncJobID := ExtractJobID(data, "{{.Async.JobIDField}}"); asyncJobID != "" {
+			if asyncJobID := ExtractJobID(data, {{printf "%q" .Async.JobIDField}}); asyncJobID != "" {
 				_ = RecordJob(JobRow{
 					JobID:          asyncJobID,
-					Resource:       "{{.ResourceName}}",
-					Endpoint:       "{{.EndpointName}}",
+					Resource:       {{printf "%q" .ResourceName}},
+					Endpoint:       {{printf "%q" .EndpointName}},
 					Status:         "submitted",
-					StatusResource: "{{.Async.StatusResource}}",
-					StatusEndpoint: "{{.Async.StatusEndpoint}}",
+					StatusResource: {{printf "%q" .Async.StatusResource}},
+					StatusEndpoint: {{printf "%q" .Async.StatusEndpoint}},
 				})
 				if flagWait {
 					ctx := cmd.Context()
 					if ctx == nil {
 						ctx = context.Background()
 					}
-					final, werr := WaitForJob(ctx, c, "{{.Async.StatusPath}}", asyncJobID, WaitOptions{
+					final, werr := WaitForJob(ctx, c, {{printf "%q" .Async.StatusPath}}, asyncJobID, WaitOptions{
 						Interval: flagWaitInterval,
 						Timeout:  flagWaitTimeout,
 					})
 					if werr != nil {
 						_ = RecordJob(JobRow{
 							JobID:    asyncJobID,
-							Resource: "{{.ResourceName}}",
-							Endpoint: "{{.EndpointName}}",
+							Resource: {{printf "%q" .ResourceName}},
+							Endpoint: {{printf "%q" .EndpointName}},
 							Status:   "errored",
 							Error:    werr.Error(),
 						})
@@ -666,8 +666,8 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 					if st, _ := final["status"].(string); st != "" {
 						_ = RecordJob(JobRow{
 							JobID:    asyncJobID,
-							Resource: "{{.ResourceName}}",
-							Endpoint: "{{.EndpointName}}",
+							Resource: {{printf "%q" .ResourceName}},
+							Endpoint: {{printf "%q" .EndpointName}},
 							Status:   st,
 						})
 					}
@@ -688,7 +688,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if !flags.dryRun && statusCode >= 200 && statusCode < 300 {
 				partialFailure = detectPartialFailure(data)
 				if partialFailure != nil {
-					fmt.Fprintf(os.Stderr, "warning: partial failure detected in %s response: %s\n", "{{.ResourceName}}", partialFailure.Message)
+					fmt.Fprintf(os.Stderr, "warning: partial failure detected in %s response: %s\n", {{printf "%q" .ResourceName}}, partialFailure.Message)
 					if len(partialFailure.ResourceNames) > 0 {
 						fmt.Fprintf(os.Stderr, "         succeeded: %d operation(s)\n", len(partialFailure.ResourceNames))
 					}
@@ -696,7 +696,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 	{{- if and .HasStore (not .IsReadOnly) (not .Endpoint.UsesBinaryResponse) (or (eq .Endpoint.Method "POST") (eq .Endpoint.Method "PUT") (eq .Endpoint.Method "PATCH"))}}
 			if !flags.dryRun && statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
-				writeMutationResponseToStore(cmd.Context(), "{{lower .ResourceName}}", data, {{printf "%q" .Endpoint.ResponsePath}})
+				writeMutationResponseToStore(cmd.Context(), {{printf "%q" (lower .ResourceName)}}, data, {{printf "%q" .Endpoint.ResponsePath}})
 			}
 	{{- end}}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
@@ -707,7 +707,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 						fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
 					} else {
 						if partialFailure != nil && !flags.allowPartialFailure {
-							return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", "{{.ResourceName}}", partialFailure.Message))
+							return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", {{printf "%q" .ResourceName}}, partialFailure.Message))
 						}
 						return nil
 					}
@@ -718,7 +718,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 							fmt.Fprintf(os.Stderr, "warning: table rendering failed, falling back to JSON: %v\n", err)
 						} else {
 							if partialFailure != nil && !flags.allowPartialFailure {
-								return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", "{{.ResourceName}}", partialFailure.Message))
+								return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", {{printf "%q" .ResourceName}}, partialFailure.Message))
 							}
 							return nil
 						}
@@ -728,13 +728,13 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
 				if flags.quiet {
 					if partialFailure != nil && !flags.allowPartialFailure {
-						return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", "{{.ResourceName}}", partialFailure.Message))
+						return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", {{printf "%q" .ResourceName}}, partialFailure.Message))
 					}
 					return nil
 				}
 				envelope := map[string]any{
-					"action":   "{{lower .Endpoint.Method}}",
-					"resource": "{{.ResourceName}}",
+					"action":   {{printf "%q" (lower .Endpoint.Method)}},
+					"resource": {{printf "%q" .ResourceName}},
 					"path":     path,
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
@@ -788,7 +788,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 					return perr
 				}
 				if partialFailure != nil && !flags.allowPartialFailure {
-					return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", "{{.ResourceName}}", partialFailure.Message))
+					return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", {{printf "%q" .ResourceName}}, partialFailure.Message))
 				}
 				return nil
 			}
@@ -850,7 +850,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return perr
 			}
 			if partialFailure != nil && !flags.allowPartialFailure {
-				return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", "{{.ResourceName}}", partialFailure.Message))
+				return partialFailureErr(fmt.Errorf("partial failure in %s response: %s", {{printf "%q" .ResourceName}}, partialFailure.Message))
 			}
 			return nil
 {{- else}}
@@ -873,11 +873,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- range publicFlagAliases $param}}
 {{- if paramHasEnvDefault $param}}
-	cmd.Flags().StringVar(&flag{{camel (paramIdent $param)}}, "{{.}}", globalScopeParamDefault("{{globalScopeEnvName $param}}", {{printf "%q" (globalScopeFallbackValue $param)}}), "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}} (env: {{globalScopeEnvName $param}})")
+	cmd.Flags().StringVar(&flag{{camel (paramIdent $param)}}, {{printf "%q" .}}, globalScopeParamDefault({{printf "%q" (globalScopeEnvName $param)}}, {{printf "%q" (globalScopeFallbackValue $param)}}), "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}} (env: {{globalScopeEnvName $param}})")
 {{- else}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
+	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, {{printf "%q" .}}, {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
 {{- end}}
-	_ = cmd.Flags().MarkHidden("{{.}}")
+	_ = cmd.Flags().MarkHidden({{printf "%q" .}})
 {{- end}}
 {{- end}}
 {{- end}}
@@ -908,7 +908,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- $propCamel := camel .Property}}
 
 // fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}} returns every item
-// in the "{{.Property}}" sub-resource of GET {{$parentPath}}. The parent
+// in the {{printf "%q" .Property}} sub-resource of GET {{$parentPath}}. The parent
 // response embeds at most the first page of this sub-resource, so any
 // caller that treats the embed as complete silently truncates; this
 // companion calls the dedicated child endpoint and paginates until
@@ -917,11 +917,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
-	childPath := "{{.ChildPath}}"
+	childPath := {{printf "%q" .ChildPath}}
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, {{printf "%q" .NextField}}, {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
 }
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/command_parent.go.tmpl
+++ b/internal/generator/templates/command_parent.go.tmpl
@@ -10,7 +10,7 @@ import (
 func new{{cmdIdent .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "{{kebab .ResourceName}}",
-		Short: "{{.Short}}",
+		Short: {{printf "%q" .Short}},
 {{- if .Hidden}}
 		Hidden: true,
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -124,7 +124,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			c = c.WithTier({{printf "%q" .EffectiveTier}})
 {{- end}}
 
-			path := "{{.EffectivePath}}"
+			path := {{printf "%q" .EffectivePath}}
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
@@ -134,21 +134,21 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				if flags.asJSON {
 					if printErr := printJSONFiltered(cmd.OutOrStdout(), map[string]any{
 						"error": "{{.Name}} is required",
-						"usage": fmt.Sprintf("%s <%s>", cmd.CommandPath(), "{{.Name}}"),
+						"usage": fmt.Sprintf("%s <%s>", cmd.CommandPath(), {{printf "%q" .Name}}),
 					}, flags); printErr != nil {
 						return printErr
 					}
 				}
-				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), "{{.Name}}"))
+				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), {{printf "%q" .Name}}))
 			}
 {{- if pathContainsParam $.Endpoint.Path .Name}}
-			path = replacePathParam(path, "{{.Name}}", args[{{$pi}}])
+			path = replacePathParam(path, {{printf "%q" .Name}}, args[{{$pi}}])
 {{- end}}
 {{- end}}
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .PathParam (not .Positional)}}
-			path = replacePathParam(path, "{{.Name}}", formatCLIParamValue(flag{{camel (paramIdent .)}}))
+			path = replacePathParam(path, {{printf "%q" .Name}}, formatCLIParamValue(flag{{camel (paramIdent .)}}))
 {{- end}}
 {{- end}}
 
@@ -156,11 +156,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			htmlRequestParams := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			htmlRequestParams["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			htmlRequestParams[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				htmlRequestParams["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				htmlRequestParams[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
@@ -169,7 +169,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
 			headerOverrides := map[string]string{
 {{- range .Endpoint.HeaderOverrides}}
-				"{{.Name}}": "{{.Value}}",
+				{{printf "%q" .Name}}: {{printf "%q" .Value}},
 {{- end}}
 {{- if .Endpoint.UsesBinaryResponse}}
 				"X-Printing-Press-Binary-Response": "true",
@@ -179,16 +179,16 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 
 {{- if $supportsAllPagination}}
 {{- if .HasStore}}
-			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", path, map[string]string{
+			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, {{printf "%q" $dataSourceStrategy}}, {{printf "%q" (lower .ResourceName)}}, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
+				{{printf "%q" (paramWireName .)}}: args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
+				{{printf "%q" (paramWireName .)}}: formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}", cmd.ErrOrStderr())
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, {{printf "%q" .Endpoint.Pagination.CursorParam}}, {{printf "%q" .Endpoint.Pagination.Type}}, {{printf "%q" .Endpoint.Pagination.LimitParam}}, {{printf "%q" .Endpoint.Pagination.NextCursorPath}}, {{printf "%q" .Endpoint.Pagination.HasMoreField}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -200,30 +200,30 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, err := paginatedGet(cmd.Context(), c, path, map[string]string{
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-				"{{paramWireName .}}": args[{{positionalIndex $.Endpoint .Name}}],
+				{{printf "%q" (paramWireName .)}}: args[{{positionalIndex $.Endpoint .Name}}],
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
-				"{{paramWireName .}}": formatCLIParamValue(flag{{camel (paramIdent .)}}),
+				{{printf "%q" (paramWireName .)}}: formatCLIParamValue(flag{{camel (paramIdent .)}}),
 {{- end}}
 {{- end}}
-			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, "{{.Endpoint.Pagination.CursorParam}}", "{{.Endpoint.Pagination.Type}}", "{{.Endpoint.Pagination.LimitParam}}", "{{.Endpoint.Pagination.NextCursorPath}}", "{{.Endpoint.Pagination.HasMoreField}}")
+			}, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, flagAll, {{printf "%q" .Endpoint.Pagination.CursorParam}}, {{printf "%q" .Endpoint.Pagination.Type}}, {{printf "%q" .Endpoint.Pagination.LimitParam}}, {{printf "%q" .Endpoint.Pagination.NextCursorPath}}, {{printf "%q" .Endpoint.Pagination.HasMoreField}})
 {{- end}}
 {{- else}}
 {{- if not $deleteBodyWithoutParams}}
 			params := map[string]string{}
 {{- range .Endpoint.Params}}
 {{- if and .Positional (not (pathContainsParam $.Endpoint.Path .Name))}}
-			params["{{paramWireName .}}"] = args[{{positionalIndex $.Endpoint .Name}}]
+			params[{{printf "%q" (paramWireName .)}}] = args[{{positionalIndex $.Endpoint .Name}}]
 {{- end}}
 {{- if and (not .Positional) (not .PathParam)}}
 			if flag{{camel (paramIdent .)}} != {{zeroValForParamRequired .Name .Type .Required (hasDefault .)}} {
-				params["{{paramWireName .}}"] = formatCLIParamValue(flag{{camel (paramIdent .)}})
+				params[{{printf "%q" (paramWireName .)}}] = formatCLIParamValue(flag{{camel (paramIdent .)}})
 			}
 {{- end}}
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, {{printf "%q" $dataSourceStrategy}}, {{printf "%q" (lower .ResourceName)}}, {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
 {{- else if eq $method "GET"}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -305,7 +305,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				partialFailure = detectPartialFailure(data)
 			}
 			if !flags.dryRun && statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
-				writeMutationResponseToStore(cmd.Context(), "{{lower .ResourceName}}", data, {{printf "%q" .Endpoint.ResponsePath}})
+				writeMutationResponseToStore(cmd.Context(), {{printf "%q" (lower .ResourceName)}}, data, {{printf "%q" .Endpoint.ResponsePath}})
 			}
 {{- end}}
 {{- if .Endpoint.UsesBinaryResponse}}
@@ -420,8 +420,8 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 	_ = cmd.Flags().MarkHidden("{{publicFlagName .}}")
 {{- end}}
 {{- range publicFlagAliases $param}}
-	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, "{{.}}", {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
-	_ = cmd.Flags().MarkHidden("{{.}}")
+	cmd.Flags().{{cobraFlagFuncForParamRequired $param.Name $param.Type $param.Required (hasDefault $param)}}(&flag{{camel (paramIdent $param)}}, {{printf "%q" .}}, {{defaultValForParamRequired $param $param.Required (hasDefault $param)}}, "{{oneline $param.Description}}{{enumDescriptionHint $param.Enum}}")
+	_ = cmd.Flags().MarkHidden({{printf "%q" .}})
 {{- end}}
 {{- end}}
 {{- end}}
@@ -457,7 +457,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- $propCamel := camel .Property}}
 
 // fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}} returns every item
-// in the "{{.Property}}" sub-resource of GET {{$parentPath}}. The parent
+// in the {{printf "%q" .Property}} sub-resource of GET {{$parentPath}}. The parent
 // response embeds at most the first page of this sub-resource, so any
 // caller that treats the embed as complete silently truncates; this
 // companion calls the dedicated child endpoint and paginates until
@@ -466,11 +466,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
 	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
-	childPath := "{{.ChildPath}}"
+	childPath := {{printf "%q" .ChildPath}}
 	for name, val := range pathParams {
 		childPath = replacePathParam(childPath, name, val)
 	}
-	return fetchEmbeddedPagedSubresource(ctx, c, childPath, "{{.NextField}}", {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
+	return fetchEmbeddedPagedSubresource(ctx, c, childPath, {{printf "%q" .NextField}}, {{if .NextIsURL}}true{{else}}false{{end}}, {{if .NextIsBoolean}}true{{else}}false{{end}})
 }
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -97,10 +97,10 @@ type Config struct {
 func Load(configPath string) (*Config, error) {
 	cfg := &Config{
 {{- if .BaseURL}}
-		BaseURL: "{{.BaseURL}}",
+		BaseURL: {{printf "%q" .BaseURL}},
 {{- end}}
 {{- if .BasePath}}
-		BasePath: "{{.BasePath}}",
+		BasePath: {{printf "%q" .BasePath}},
 {{- end}}
 	}
 
@@ -140,7 +140,7 @@ func Load(configPath string) (*Config, error) {
 {{- end}}
 {{- if .Auth.EnvVarSpecs}}
 {{- range .Auth.EnvVarSpecs}}
-	if v := os.Getenv("{{.Name}}"); v != "" {
+	if v := os.Getenv({{printf "%q" .Name}}); v != "" {
 		cfg.{{resolveEnvVarField .Name}} = v
 		cfg.markEnvOverride("{{resolveEnvVarField .Name}}")
 		cfg.AuthSource = "env:{{.Name}}"
@@ -149,7 +149,7 @@ func Load(configPath string) (*Config, error) {
 {{- else if .Auth.EnvVars}}
 	// fallback to legacy EnvVars when EnvVarSpecs is empty
 {{- range .Auth.EnvVars}}
-	if v := os.Getenv("{{.}}"); v != "" {
+	if v := os.Getenv({{printf "%q" .}}); v != "" {
 		cfg.{{resolveEnvVarField .}} = v
 		cfg.markEnvOverride("{{resolveEnvVarField .}}")
 		cfg.AuthSource = "env:{{.}}"
@@ -160,7 +160,7 @@ func Load(configPath string) (*Config, error) {
 	// Sibling-scheme per-call credential sent on every request alongside the
 	// primary auth. AuthSource intentionally not stamped: the primary auth
 	// remains the canonical surface for doctor/auth-status reporting.
-	if v := os.Getenv("{{.EnvVar.Name}}"); v != "" {
+	if v := os.Getenv({{printf "%q" .EnvVar.Name}}); v != "" {
 		cfg.{{resolveEnvVarField .EnvVar.Name}} = v
 		cfg.markEnvOverride("{{resolveEnvVarField .EnvVar.Name}}")
 	}
@@ -272,16 +272,16 @@ func Load(configPath string) (*Config, error) {
 {{- end}}
 {{- range .EndpointTemplateVars}}
 {{- if endpointTemplateDefault .}}
-	if v := strings.TrimSpace(os.Getenv("{{endpointTemplateEnvName .}}")); v != "" {
-		cfg.TemplateVars["{{.}}"] = normalizeEndpointTemplateValue(v)
+	if v := strings.TrimSpace(os.Getenv({{printf "%q" (endpointTemplateEnvName .)}})); v != "" {
+		cfg.TemplateVars[{{printf "%q" .}}] = normalizeEndpointTemplateValue(v)
 	} else {
-		cfg.TemplateVars["{{.}}"] = {{printf "%q" (endpointTemplateDefault .)}}
+		cfg.TemplateVars[{{printf "%q" .}}] = {{printf "%q" (endpointTemplateDefault .)}}
 	}
 {{- else}}
-	if v := strings.TrimSpace(os.Getenv("{{endpointTemplateEnvName .}}")); v != "" {
-		cfg.TemplateVars["{{.}}"] = v
+	if v := strings.TrimSpace(os.Getenv({{printf "%q" (endpointTemplateEnvName .)}})); v != "" {
+		cfg.TemplateVars[{{printf "%q" .}}] = v
 	} else if verifyMode {
-		cfg.TemplateVars["{{.}}"] = "{{.}}_placeholder"
+		cfg.TemplateVars[{{printf "%q" .}}] = "{{.}}_placeholder"
 	}
 {{- end}}
 {{- end}}
@@ -347,9 +347,9 @@ func (c *Config) AuthHeader() string {
 {{- range .Auth.EnvVarSpecs}}
 	if c.{{resolveEnvVarField .Name}} != "" {
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
-			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{printf "%q" .Name}}: c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
@@ -397,7 +397,7 @@ func (c *Config) AuthHeader() string {
 		"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
 	{{- end}}
 	{{- if ne .Name "token"}}
-		"{{.Name}}": c.{{resolveEnvVarField .Name}},
+		{{printf "%q" .Name}}: c.{{resolveEnvVarField .Name}},
 	{{- end}}
 	{{- end}}
 	{{- end}}
@@ -408,12 +408,12 @@ func (c *Config) AuthHeader() string {
 		"{{envVarPlaceholder .}}": c.{{resolveEnvVarField .}},
 	{{- end}}
 	{{- if ne . "token"}}
-		"{{.}}": c.{{resolveEnvVarField .}},
+		{{printf "%q" .}}: c.{{resolveEnvVarField .}},
 	{{- end}}
 	{{- end}}
 	{{- end}}
 	}
-	return applyAuthFormat("{{.Auth.Format}}", replacements)
+	return applyAuthFormat({{printf "%q" .Auth.Format}}, replacements)
 	{{- else if $canonicalEnvVar}}
 	{{- if .Auth.Prefix}}
 	return {{printf "%q" (printf "%s " .Auth.Prefix)}} + token
@@ -436,9 +436,9 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
-		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
+		return "{{oneline .Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
 	}
 	return ""
@@ -449,9 +449,9 @@ func (c *Config) AuthHeader() string {
 	if c.AccessToken != "" {
 		c.AuthSource = "bearer_refresh"
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
-		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
+		return "{{oneline .Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
 	}
 {{- else}}
@@ -464,9 +464,9 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
-		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
+		return "{{oneline .Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
 	}
 {{- else}}
@@ -481,15 +481,15 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
-			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{printf "%q" .Name}}: c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
 		})
 		{{- else}}
-		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
+		return "{{oneline $.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
 		{{- end}}
 	}
 {{- end}}
@@ -503,15 +503,15 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
-			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{printf "%q" .Name}}: c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
 		})
 		{{- else}}
-		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
+		return "{{oneline $.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
 		{{- end}}
 	}
 {{- end}}
@@ -523,15 +523,15 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "env:{{.Name}}"
 		}
 		{{- if $.Auth.Format}}
-		return applyAuthFormat("{{$.Auth.Format}}", map[string]string{
+		return applyAuthFormat({{printf "%q" $.Auth.Format}}, map[string]string{
 			"{{envVarPlaceholder .Name}}": c.{{resolveEnvVarField .Name}},
-			"{{.Name}}": c.{{resolveEnvVarField .Name}},
+			{{printf "%q" .Name}}: c.{{resolveEnvVarField .Name}},
 			{{- if ne (envVarPlaceholder .Name) "token"}}
 			"token": c.{{resolveEnvVarField .Name}},
 			{{- end}}
 		})
 		{{- else}}
-		return "{{$.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
+		return "{{oneline $.Auth.HeaderPrefix}} " + c.{{resolveEnvVarField .Name}}
 		{{- end}}
 	}
 {{- end}}
@@ -543,9 +543,9 @@ func (c *Config) AuthHeader() string {
 			c.AuthSource = "{{oauth2AuthSource .Auth}}"
 		}
 		{{- if .Auth.Format}}
-		return applyAuthFormat("{{.Auth.Format}}", map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
+		return applyAuthFormat({{printf "%q" .Auth.Format}}, map[string]string{"access_token": c.AccessToken, "token": c.AccessToken})
 		{{- else}}
-		return "{{.Auth.HeaderPrefix}} " + c.AccessToken
+		return "{{oneline .Auth.HeaderPrefix}} " + c.AccessToken
 		{{- end}}
 	}
 {{- end}}
@@ -559,7 +559,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
-		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		return ensureAuthScheme({{printf "%q" $.Auth.HeaderPrefix}}, c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
@@ -568,7 +568,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
-		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		return ensureAuthScheme({{printf "%q" $.Auth.HeaderPrefix}}, c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
@@ -576,7 +576,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "browser"
 		}
-		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
+		return ensureAuthScheme({{printf "%q" .Auth.HeaderPrefix}}, c.AccessToken)
 	}
 	return ""
 {{- else if eq .Auth.Type "composed"}}
@@ -587,7 +587,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
-		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		return ensureAuthScheme({{printf "%q" $.Auth.HeaderPrefix}}, c.{{resolveEnvVarField .Name}})
 	}
 {{- end}}
 {{- else}}
@@ -596,7 +596,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "env:{{.Name}}"
 		}
-		return ensureAuthScheme("{{$.Auth.HeaderPrefix}}", c.{{resolveEnvVarField .Name}})
+		return ensureAuthScheme({{printf "%q" $.Auth.HeaderPrefix}}, c.{{resolveEnvVarField .Name}})
 	}
 	{{- end}}
 {{- end}}
@@ -604,7 +604,7 @@ func (c *Config) AuthHeader() string {
 		if c.AuthSource == "" {
 			c.AuthSource = "chrome-composed"
 		}
-		return ensureAuthScheme("{{.Auth.HeaderPrefix}}", c.AccessToken)
+		return ensureAuthScheme({{printf "%q" .Auth.HeaderPrefix}}, c.AccessToken)
 	}
 	return ""
 {{- else}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -253,7 +253,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					authConfigured = true
 					report["auth"] = "configured (browser session)"
 					report["auth_source"] = cfg.AuthSource
-					report["auth_domain"] = "{{.Auth.CookieDomain}}"
+					report["auth_domain"] = {{printf "%q" .Auth.CookieDomain}}
 {{- if .Auth.RequiresBrowserSession}}
 					if proofOK, proofDetail := browserSessionProofStatus(cfg, header); proofOK {
 						report["browser_session_proof"] = "valid"
@@ -293,9 +293,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 					report["auth_hint"] = "export {{.Name}}=<your-oauth-refresh-value>"
 {{- end}}
 {{- if .Auth.KeyURL}}
-					report["auth_key_url"] = "{{.Auth.KeyURL}}"
+					report["auth_key_url"] = {{printf "%q" .Auth.KeyURL}}
 {{- else if .WebsiteURL}}
-					report["auth_docs_url"] = "{{.WebsiteURL}}"
+					report["auth_docs_url"] = {{printf "%q" .WebsiteURL}}
 {{- end}}
 {{- if .Auth.Instructions}}
 					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
@@ -324,9 +324,9 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-					report["auth_key_url"] = "{{.Auth.KeyURL}}"
+					report["auth_key_url"] = {{printf "%q" .Auth.KeyURL}}
 {{- else if .WebsiteURL}}
-					report["auth_docs_url"] = "{{.WebsiteURL}}"
+					report["auth_docs_url"] = {{printf "%q" .WebsiteURL}}
 {{- end}}
 {{- if .Auth.Instructions}}
 					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
@@ -377,8 +377,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- range .Auth.EnvVarSpecs}}
 {{- if eq .Kind "per_call"}}
 {{- if .Required}}
-			if os.Getenv("{{.Name}}") != "" {
-				authEnvSet = append(authEnvSet, "{{.Name}}")
+			if os.Getenv({{printf "%q" .Name}}) != "" {
+				authEnvSet = append(authEnvSet, {{printf "%q" .Name}})
 			} else if authConfigured {
 				authSource, _ := report["auth_source"].(string)
 				if authSource == "" {
@@ -386,30 +386,30 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				}
 				authEnvInfo = append(authEnvInfo, "credentials available from "+authSource)
 			} else {
-				authEnvRequiredMissing = append(authEnvRequiredMissing, "{{.Name}}")
+				authEnvRequiredMissing = append(authEnvRequiredMissing, {{printf "%q" .Name}})
 			}
 {{- else}}
 			if strings.Contains({{printf "%q" .Description}}, " OR ") {
-				authEnvOptionalNames = append(authEnvOptionalNames, "{{.Name}}")
-				if os.Getenv("{{.Name}}") != "" {
-					authEnvSet = append(authEnvSet, "{{.Name}}")
+				authEnvOptionalNames = append(authEnvOptionalNames, {{printf "%q" .Name}})
+				if os.Getenv({{printf "%q" .Name}}) != "" {
+					authEnvSet = append(authEnvSet, {{printf "%q" .Name}})
 					authEnvOptionalSatisfied = true
 				}
-			} else if os.Getenv("{{.Name}}") != "" {
-				authEnvSet = append(authEnvSet, "{{.Name}}")
+			} else if os.Getenv({{printf "%q" .Name}}) != "" {
+				authEnvSet = append(authEnvSet, {{printf "%q" .Name}})
 			} else {
 				authEnvInfo = append(authEnvInfo, "{{.Name}} optional")
 			}
 {{- end}}
 {{- else if eq .Kind "auth_flow_input"}}
-			if os.Getenv("{{.Name}}") != "" {
-				authEnvSet = append(authEnvSet, "{{.Name}}")
+			if os.Getenv({{printf "%q" .Name}}) != "" {
+				authEnvSet = append(authEnvSet, {{printf "%q" .Name}})
 			} else {
 				authEnvInfo = append(authEnvInfo, "{{.Name}} set during auth login")
 			}
 {{- else if eq .Kind "harvested"}}
-			if os.Getenv("{{.Name}}") != "" || authHeader != "" {
-				authEnvSet = append(authEnvSet, "{{.Name}}")
+			if os.Getenv({{printf "%q" .Name}}) != "" || authHeader != "" {
+				authEnvSet = append(authEnvSet, {{printf "%q" .Name}})
 			} else {
 				authEnvInfo = append(authEnvInfo, {{printf "%q" (printf "%s %s" .Name (authHarvestedEnvHint $.Auth))}})
 			}
@@ -421,7 +421,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				if cfg != nil {
 					configuredValue = cfg.{{resolveEnvVarField .EnvVar.Name}}
 				}
-				recordAdditionalAuthEnv("{{.EnvVar.Name}}", configuredValue)
+				recordAdditionalAuthEnv({{printf "%q" .EnvVar.Name}}, configuredValue)
 			}
 {{- end}}
 			switch {
@@ -441,7 +441,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			authEnvSet := 0
 {{- range .Auth.EnvVars}}
 			authEnvChecked++
-			if os.Getenv("{{.}}") != "" {
+			if os.Getenv({{printf "%q" .}}) != "" {
 				authEnvSet++
 			}
 {{- end}}
@@ -466,11 +466,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				set := 0
 {{- range $tier.Auth.EnvVarSpecs}}
 				checked++
-				if os.Getenv("{{.Name}}") != "" {
+				if os.Getenv({{printf "%q" .Name}}) != "" {
 					set++
 				}
 {{- end}}
-				tierEnvStatus["{{$tierName}}"] = fmt.Sprintf("%d/%d set", set, checked)
+				tierEnvStatus[{{printf "%q" $tierName}}] = fmt.Sprintf("%d/%d set", set, checked)
 			}
 {{- else if $tier.Auth.EnvVars}}
 			{
@@ -478,11 +478,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				set := 0
 {{- range $tier.Auth.EnvVars}}
 				checked++
-				if os.Getenv("{{.}}") != "" {
+				if os.Getenv({{printf "%q" .}}) != "" {
 					set++
 				}
 {{- end}}
-				tierEnvStatus["{{$tierName}}"] = fmt.Sprintf("%d/%d set", set, checked)
+				tierEnvStatus[{{printf "%q" $tierName}}] = fmt.Sprintf("%d/%d set", set, checked)
 			}
 {{- end}}
 {{- end}}
@@ -508,7 +508,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				} else {
 					// Step 1: Basic reachability via the configured transport.
 {{- if .HealthCheckPath}}
-					healthPath := "{{.HealthCheckPath}}"
+					healthPath := {{printf "%q" .HealthCheckPath}}
 					if !strings.HasPrefix(healthPath, "/") {
 						healthPath = "/" + healthPath
 					}
@@ -569,12 +569,12 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 						authParams := map[string]string{}
 						authHeaders := map[string]string{}
 {{- if and .Auth .Auth.In (eq .Auth.In "query")}}
-						authParams["{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}"] = authHeader
+						authParams["{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}api_key{{end}}"] = authHeader
 {{- else}}
-						authHeaders["{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}"] = authHeader
+						authHeaders["{{if .Auth.Header}}{{oneline .Auth.Header}}{{else}}Authorization{{end}}"] = authHeader
 {{- end}}
 {{- range .RequiredHeaders}}
-						authHeaders["{{.Name}}"] = "{{.Value}}"
+						authHeaders[{{printf "%q" .Name}}] = {{printf "%q" .Value}}
 {{- end}}
 {{- /*
 	Emit the hardcoded User-Agent fallback only when no other code path has
@@ -594,7 +594,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if .Auth.VerifyPath}}
-						verifyPath := "{{.Auth.VerifyPath}}"
+						verifyPath := {{printf "%q" .Auth.VerifyPath}}
 						if !strings.HasPrefix(verifyPath, "/") {
 							verifyPath = "/" + verifyPath
 						}
@@ -668,7 +668,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
-			report["cache"] = collectCacheReport(cmd.Context(), {{if .Cache.StaleAfter}}"{{.Cache.StaleAfter}}"{{else}}""{{end}})
+			report["cache"] = collectCacheReport(cmd.Context(), {{if .Cache.StaleAfter}}{{printf "%q" .Cache.StaleAfter}}{{else}}""{{end}})
 {{- end}}
 
 			// Verify mode state. Surfaced so an operator who unintentionally
@@ -910,13 +910,13 @@ func browserSessionProofStatus(cfg *config.Config, authHeader string) (bool, str
 	if err := json.Unmarshal(data, &proof); err != nil {
 		return false, "proof is not valid JSON; re-run {{.Name}}-pp-cli auth login --chrome"
 	}
-	if proof.APIName != "{{.Name}}" {
+	if proof.APIName != {{printf "%q" .Name}} {
 		return false, "proof belongs to a different CLI"
 	}
-	if proof.CookieDomain != "{{.Auth.CookieDomain}}" {
+	if proof.CookieDomain != {{printf "%q" .Auth.CookieDomain}} {
 		return false, "proof belongs to a different cookie domain"
 	}
-	if proof.ValidationPath != "{{.Auth.BrowserSessionValidationPath}}" {
+	if proof.ValidationPath != {{printf "%q" .Auth.BrowserSessionValidationPath}} {
 		return false, "proof was captured for a different validation endpoint"
 	}
 	if authHeader != "" && proof.CredentialFingerprint != doctorFingerprintCredential(authHeader) {

--- a/internal/generator/templates/graphql_client.go.tmpl
+++ b/internal/generator/templates/graphql_client.go.tmpl
@@ -64,7 +64,7 @@ func isGraphQLAccessDenialCode(code string) bool {
 // GraphQL POST. It is rendered from APISpec.GraphQLEndpointPath at generate
 // time so per-tenant or versioned endpoints (e.g.,
 // "/admin/api/{version}/graphql.json") work without editing the client.
-const graphqlEndpointPath = "{{.GraphQLEndpointPath}}"
+const graphqlEndpointPath = {{printf "%q" .GraphQLEndpointPath}}
 
 {{- if .HasCostThrottling}}
 

--- a/internal/generator/templates/graphql_import.go.tmpl
+++ b/internal/generator/templates/graphql_import.go.tmpl
@@ -35,7 +35,7 @@ create commands instead.`,
 			return fmt.Errorf(
 				"import is not supported for %q on this GraphQL API (no REST create endpoint); "+
 					"use the typed create command instead, e.g. '%s-pp-cli %s create --help'",
-				resource, "{{.Name}}", resource,
+				resource, {{printf "%q" .Name}}, resource,
 			)
 		},
 	}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -262,14 +262,14 @@ type graphqlSyncDef struct {
 func graphqlSyncDefs() map[string]graphqlSyncDef {
 	return map[string]graphqlSyncDef{
 {{- range .SyncableResources}}
-		"{{.Name}}": {
+		{{printf "%q" .Name}}: {
 			Query:       client.{{pascal .Name}}ListQuery,
 {{- $resource := index $.Resources .Name}}
 {{- $endpoint := index $resource.Endpoints "list"}}
 {{- if hasGraphQLParam $endpoint "last"}}
 			LatestQuery: client.{{pascal .Name}}ListLatestQuery,
 {{- end}}
-			FieldPath:   "{{index $.GraphQLFieldPaths .Name}}",
+			FieldPath:   {{printf "%q" (index $.GraphQLFieldPaths .Name)}},
 			PageSize:    50,
 		},
 {{- end}}
@@ -653,7 +653,7 @@ func defaultSyncResources() []string {
 	return []string{
 {{- range .SyncableResources}}
 {{- if not .SkipDefaultSync}}
-		"{{.Name}}",
+		{{printf "%q" .Name}},
 {{- end}}
 {{- end}}
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -137,7 +137,7 @@ type Persona string
 
 const (
 {{- range .Roles}}
-	Persona{{pascal .}} Persona = "{{.}}"
+	Persona{{pascal .}} Persona = {{printf "%q" .}}
 {{- end}}
 )
 
@@ -736,9 +736,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -755,9 +755,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -771,9 +771,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -787,9 +787,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -803,9 +803,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -821,9 +821,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+
@@ -841,9 +841,9 @@ func classifyAPIError(err error, flags *rootFlags) error {
 {{- end}}
 {{- end}}
 {{- if .Auth.KeyURL}}
-			"\n      Get a key at: {{.Auth.KeyURL}}"+
+			"\n      Get a key at: {{oneline .Auth.KeyURL}}"+
 {{- else if .WebsiteURL}}
-			"\n      See API docs: {{.WebsiteURL}}"+
+			"\n      See API docs: {{oneline .WebsiteURL}}"+
 {{- end}}
 {{- if .Auth.Instructions}}
 			{{printf "%q" (printf "\n      %s" .Auth.Instructions)}}+

--- a/internal/generator/templates/live_ws.go.tmpl
+++ b/internal/generator/templates/live_ws.go.tmpl
@@ -96,7 +96,7 @@ human-readable dimensions.`,
 
 			statuses := parseLiveStatuses(metadataStatuses)
 			var storeMu sync.Mutex
-			if "{{.Streaming.Metadata.Endpoint}}" != "" {
+			if {{printf "%q" .Streaming.Metadata.Endpoint}} != "" {
 				if _, err := refreshLiveMetadata(ctx, apiClient, st, &storeMu, statuses); err != nil {
 					_ = st.RecordRebaseEvent("metadata_error", "refresh_failed", err.Error())
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: metadata refresh failed: %v\n", err)
@@ -125,9 +125,9 @@ human-readable dimensions.`,
 
 			frameCount := 0
 			ws := wsclient.Client{
-				URL:              "{{.Streaming.URL}}",
+				URL:              {{printf "%q" .Streaming.URL}},
 				SubscribePayload: subscribePayload,
-				Framing:          "{{.Streaming.EffectiveFraming}}",
+				Framing:          {{printf "%q" .Streaming.EffectiveFraming}},
 				MinBackoff:       time.Second,
 				MaxBackoff:       30 * time.Second,
 			}
@@ -158,8 +158,8 @@ human-readable dimensions.`,
 
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default: user cache)")
 	cmd.Flags().StringVar(&subscribePayload, "subscribe", `{{.Streaming.SubscribeShape}}`, "WebSocket subscribe payload")
-	cmd.Flags().DurationVar(&metadataCadence, "metadata-cadence", mustDuration("{{.Streaming.EffectiveMetadataRefreshCadence}}"), "REST metadata refresh cadence")
-	cmd.Flags().StringVar(&metadataStatuses, "metadata-statuses", "{{join .Streaming.EffectiveMetadataStatuses ","}}", "Comma-separated metadata statuses to poll")
+	cmd.Flags().DurationVar(&metadataCadence, "metadata-cadence", mustDuration({{printf "%q" .Streaming.EffectiveMetadataRefreshCadence}}), "REST metadata refresh cadence")
+	cmd.Flags().StringVar(&metadataStatuses, "metadata-statuses", {{printf "%q" (join .Streaming.EffectiveMetadataStatuses ",")}}, "Comma-separated metadata statuses to poll")
 	cmd.Flags().BoolVar(&metadataOnce, "metadata-once", false, "Refresh REST metadata once instead of on a background cadence")
 	cmd.Flags().IntVar(&maxFrames, "max-frames", 0, "Stop after storing this many WebSocket frames (0 = unlimited)")
 	return cmd
@@ -172,7 +172,7 @@ func refreshLiveMetadata(ctx context.Context, apiClient *client.Client, st *stor
 		if status != "" {
 			params["status"] = status
 		}
-		data, err := apiClient.GetNoCache(ctx, "{{.Streaming.Metadata.Endpoint}}", params)
+		data, err := apiClient.GetNoCache(ctx, {{printf "%q" .Streaming.Metadata.Endpoint}}, params)
 		if err != nil {
 			return total, err
 		}
@@ -182,7 +182,7 @@ func refreshLiveMetadata(ctx context.Context, apiClient *client.Client, st *stor
 		}
 		storeMu.Lock()
 		for _, item := range items {
-			if err := st.UpsertStreamMetadata("{{.Streaming.Metadata.EffectivePrimaryKey}}", status, item); err != nil {
+			if err := st.UpsertStreamMetadata({{printf "%q" .Streaming.Metadata.EffectivePrimaryKey}}, status, item); err != nil {
 				storeMu.Unlock()
 				return total, err
 			}

--- a/internal/generator/templates/main_mcp.go.tmpl
+++ b/internal/generator/templates/main_mcp.go.tmpl
@@ -22,7 +22,7 @@ import (
 // guidance that production agents need a remote option.
 
 const (
-	defaultHTTPAddr = "{{if .MCP.Addr}}{{.MCP.Addr}}{{else}}:7777{{end}}"
+	defaultHTTPAddr = "{{if .MCP.Addr}}{{oneline .MCP.Addr}}{{else}}:7777{{end}}"
 )
 
 // version is the printed MCP server's version, overridable at build time via ldflags.
@@ -30,7 +30,7 @@ var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(
-		"{{.EffectiveDisplayName}}",
+		{{printf "%q" .EffectiveDisplayName}},
 		version,
 		server.WithToolCapabilities(false),
 	)
@@ -86,7 +86,7 @@ var version = "0.0.0-dev"
 
 func main() {
 	s := server.NewMCPServer(
-		"{{.EffectiveDisplayName}}",
+		{{printf "%q" .EffectiveDisplayName}},
 		version,
 		server.WithToolCapabilities(false),
 	)

--- a/internal/generator/templates/mcp_code_orch.go.tmpl
+++ b/internal/generator/templates/mcp_code_orch.go.tmpl
@@ -102,9 +102,9 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 {{- range $eName, $endpoint := $resource.Endpoints}}
 {{- $path := effectiveEndpointPath $resource $endpoint}}
 	{
-		ID:      "{{$name}}.{{$eName}}",
-		Method:  "{{upper $endpoint.Method}}",
-		Path:    "{{$path}}",
+		ID:      {{printf "%q" (printf "%s.%s" $name $eName)}},
+		Method:  {{printf "%q" (upper $endpoint.Method)}},
+		Path:    {{printf "%q" $path}},
 {{- if $.HasRequiredRoles}}
 		RequiredRole: {{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}},
 {{- end}}
@@ -112,14 +112,14 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Tier:    {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}},
 {{- end}}
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
-		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
+		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}{{printf "%q" .Name}},{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
 		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
 {{- if $endpoint.HeaderOverrides}}
-		HeaderOverrides: map[string]string{ {{- range $endpoint.HeaderOverrides}}"{{.Name}}": "{{.Value}}",{{end}} },
+		HeaderOverrides: map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} },
 {{- end}}
 		keywords: codeOrchKeywords({{printf "%q" $name}}, {{printf "%q" $eName}}, {{printf "%q" (oneline $endpoint.Description)}}, {{printf "%q" $path}}),
 	},
@@ -128,9 +128,9 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 {{- range $eName, $endpoint := $subResource.Endpoints}}
 {{- $path := effectiveSubEndpointPath $resource $subResource $endpoint}}
 	{
-		ID:      "{{$name}}.{{$subName}}.{{$eName}}",
-		Method:  "{{upper $endpoint.Method}}",
-		Path:    "{{$path}}",
+		ID:      {{printf "%q" (printf "%s.%s.%s" $name $subName $eName)}},
+		Method:  {{printf "%q" (upper $endpoint.Method)}},
+		Path:    {{printf "%q" $path}},
 {{- if $.HasRequiredRoles}}
 		RequiredRole: {{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}},
 {{- end}}
@@ -138,14 +138,14 @@ var codeOrchEndpoints = []codeOrchEndpoint{
 		Tier:    {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}},
 {{- end}}
 		Summary: {{printf "%q" (oneline $endpoint.Description)}},
-		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}"{{.Name}}",{{end}}{{end}} },
+		Positional: []string{ {{- range $endpoint.Params}}{{if .Positional}}{{printf "%q" .Name}},{{end}}{{end}} },
 		TemplateParams: []codeOrchParamBinding{ {{- range mcpGlobalTemplateBindings $endpoint $path $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}} },
 		QueryParams: []codeOrchParamBinding{ {{- range mcpParamBindings $endpoint $path}}{{if eq .Location "query"}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}},{{end}}{{end}} },
 {{- if $endpoint.BodyIsArray}}
 		BodyIsArray: true,
 {{- end}}
 {{- if $endpoint.HeaderOverrides}}
-		HeaderOverrides: map[string]string{ {{- range $endpoint.HeaderOverrides}}"{{.Name}}": "{{.Value}}",{{end}} },
+		HeaderOverrides: map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} },
 {{- end}}
 		keywords: codeOrchKeywords({{printf "%q" $name}}, {{printf "%q" $eName}}, {{printf "%q" (oneline $endpoint.Description)}}, {{printf "%q" $path}}),
 	},

--- a/internal/generator/templates/mcp_intents.go.tmpl
+++ b/internal/generator/templates/mcp_intents.go.tmpl
@@ -42,10 +42,10 @@ import (
 func RegisterIntents(s *server.MCPServer) {
 {{- range .MCP.Intents}}
 	s.AddTool(
-		mcplib.NewTool("{{.Name}}",
+		mcplib.NewTool({{printf "%q" .Name}},
 			mcplib.WithDescription({{printf "%q" .Description}}),
 {{- range .Params}}
-			mcplib.{{mcpBindingFunc .Type}}("{{.Name}}"{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
+			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" .Name}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
 {{- end}}
 		),
 		handle{{pascal .Name}},
@@ -53,10 +53,10 @@ func RegisterIntents(s *server.MCPServer) {
 {{- end}}
 {{- range .RecipeIntents}}
 	s.AddTool(
-		mcplib.NewTool("{{.Name}}",
+		mcplib.NewTool({{printf "%q" .Name}},
 			mcplib.WithDescription({{printf "%q" .Description}}),
 {{- range .Params}}
-			mcplib.{{mcpBindingFunc (recipeParamTypeString .Type)}}("{{.InputName}}"{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
+			mcplib.{{mcpBindingFunc (recipeParamTypeString .Type)}}({{printf "%q" .InputName}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" .Description}})),
 {{- end}}
 {{- if .TakesArgs}}
 			mcplib.WithString("args", mcplib.Description("Additional positional arguments to append to the recipe command. Flag-like arguments are rejected; use structured parameters for flags.")),

--- a/internal/generator/templates/plan_command.go.tmpl
+++ b/internal/generator/templates/plan_command.go.tmpl
@@ -11,7 +11,7 @@ import (
 
 func new{{pascal .CommandName}}Cmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "{{.CommandName}}",
+		Use:   {{printf "%q" .CommandName}},
 		Short: {{printf "%q" .Description}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("{{.CommandName}}: not implemented")

--- a/internal/generator/templates/plan_parent.go.tmpl
+++ b/internal/generator/templates/plan_parent.go.tmpl
@@ -9,7 +9,7 @@ import (
 
 func new{{pascal .Name}}Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "{{.Name}}",
+		Use:   {{printf "%q" .Name}},
 		Short: {{printf "%q" .Description}},
 	}
 

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -260,7 +260,7 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	rootCmd.PersistentFlags().StringVar(&flags.throttleMode, "throttle-mode", "strict", "Cost-based throttle mode: strict (block when bucket is low), lenient (warn but proceed), off (bypass)")
 {{- end}}
 {{- range .GlobalPathTemplateVars}}
-	rootCmd.PersistentFlags().StringVar(&flags.templateVar{{camel .}}, "{{kebab .}}", "", "Set { {{- . -}} } path template value (env: {{endpointTemplateEnvName .}})")
+	rootCmd.PersistentFlags().StringVar(&flags.templateVar{{camel .}}, "{{kebab .}}", "", "Set { {{- . -}} } path template value (env: {{oneline (endpointTemplateEnvName .)}})")
 {{- end}}
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -486,7 +486,7 @@ func (f *rootFlags) newClient() (*client.Client, error) {
 	}
 {{- range .GlobalPathTemplateVars}}
 	if f.templateVar{{camel .}} != "" {
-		cfg.TemplateVars["{{.}}"] = f.templateVar{{camel .}}
+		cfg.TemplateVars[{{printf "%q" .}}] = f.templateVar{{camel .}}
 	}
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -122,15 +122,15 @@ In local mode: searches locally synced data only.`,
 					return err
 				}
 {{- if eq .SearchEndpointMethod "POST"}}
-				data, _, getErr := c.Post(cmd.Context(), "{{.SearchEndpointPath}}", map[string]any{
-					"{{.SearchQueryParam}}": query,
+				data, _, getErr := c.Post(cmd.Context(), {{printf "%q" .SearchEndpointPath}}, map[string]any{
+					{{printf "%q" .SearchQueryParam}}: query,
 {{- range .SearchBodyFields}}
-					"{{.Name}}": {{goLiteral .Default}},
+					{{printf "%q" .Name}}: {{goLiteral .Default}},
 {{- end}}
 				})
 {{- else}}
-				data, getErr := c.Get(cmd.Context(), "{{.SearchEndpointPath}}", map[string]string{
-					"{{.SearchQueryParam}}": query,
+				data, getErr := c.Get(cmd.Context(), {{printf "%q" .SearchEndpointPath}}, map[string]string{
+					{{printf "%q" .SearchQueryParam}}: query,
 				})
 {{- end}}
 				if getErr == nil {
@@ -173,7 +173,7 @@ In local mode: searches locally synced data only.`,
 			switch resourceType {
 {{- range .Tables}}
 {{- if .FTS5}}
-			case "{{.Resource}}":
+			case {{printf "%q" .Resource}}:
 				results, err = db.Search{{pascal .Name}}(query, limit)
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/session_handshake.go.tmpl
+++ b/internal/generator/templates/session_handshake.go.tmpl
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	sessionBootstrapURL  = "{{.Auth.BootstrapURL}}"
-	sessionTokenURL      = "{{.Auth.SessionTokenURL}}"
-	sessionDataBaseURL   = "{{.BaseURL}}"
-	sessionTokenFormat   = "{{if .Auth.TokenFormat}}{{.Auth.TokenFormat}}{{else}}text{{end}}"
-	sessionTokenJSONPath = "{{.Auth.TokenJSONPath}}"
+	sessionBootstrapURL  = {{printf "%q" .Auth.BootstrapURL}}
+	sessionTokenURL      = {{printf "%q" .Auth.SessionTokenURL}}
+	sessionDataBaseURL   = {{printf "%q" .BaseURL}}
+	sessionTokenFormat   = "{{if .Auth.TokenFormat}}{{oneline .Auth.TokenFormat}}{{else}}text{{end}}"
+	sessionTokenJSONPath = {{printf "%q" .Auth.TokenJSONPath}}
 	sessionUserAgent     = "Mozilla/5.0 (compatible; {{.Name}}-pp-cli)"
 )
 

--- a/internal/generator/templates/share.go.tmpl
+++ b/internal/generator/templates/share.go.tmpl
@@ -56,7 +56,7 @@ const maxShardBytes int64 = 40 * 1024 * 1024
 // denylist so tokens and per-user state never travel in a shared repo.
 var SnapshotTables = []string{
 {{- range .Share.SnapshotTables}}
-	"{{.}}",
+	{{printf "%q" .}},
 {{- end}}
 }
 

--- a/internal/generator/templates/share_commands.go.tmpl
+++ b/internal/generator/templates/share_commands.go.tmpl
@@ -169,8 +169,8 @@ Runs idempotently — an unchanged snapshot produces no commit.`,
 		},
 	}
 	cmd.Flags().StringVar(&repoPath, "repo", "", "Local repo checkout path (default: runstate dir)")
-	cmd.Flags().StringVar(&remote, "remote", "{{.Share.DefaultRepo}}", "Git remote URL")
-	cmd.Flags().StringVar(&branch, "branch", "{{if .Share.DefaultBranch}}{{.Share.DefaultBranch}}{{else}}main{{end}}", "Git branch to push to")
+	cmd.Flags().StringVar(&remote, "remote", {{printf "%q" .Share.DefaultRepo}}, "Git remote URL")
+	cmd.Flags().StringVar(&branch, "branch", "{{if .Share.DefaultBranch}}{{oneline .Share.DefaultBranch}}{{else}}main{{end}}", "Git branch to push to")
 	cmd.Flags().StringVar(&message, "message", "", "Override the commit message")
 	return cmd
 }
@@ -223,8 +223,8 @@ cache.enabled is set in the spec.`,
 		},
 	}
 	cmd.Flags().StringVar(&repoPath, "repo", "", "Local repo checkout path (default: runstate dir)")
-	cmd.Flags().StringVar(&remote, "remote", "{{.Share.DefaultRepo}}", "Git remote URL (required)")
-	cmd.Flags().StringVar(&branch, "branch", "{{if .Share.DefaultBranch}}{{.Share.DefaultBranch}}{{else}}main{{end}}", "Git branch to pull from")
+	cmd.Flags().StringVar(&remote, "remote", {{printf "%q" .Share.DefaultRepo}}, "Git remote URL (required)")
+	cmd.Flags().StringVar(&branch, "branch", "{{if .Share.DefaultBranch}}{{oneline .Share.DefaultBranch}}{{else}}main{{end}}", "Git branch to pull from")
 	return cmd
 }
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -281,7 +281,7 @@ func (s *Store) backfillColumns(ctx context.Context, conn *sql.Conn) error {
 {{- range $table := .Tables}}
 {{- range $col := $table.Columns}}
 {{- if isBackfillColumn $col}}
-		{table: "{{$table.Name}}", column: "{{$col.Name}}", decl: "{{backfillDecl $col}}"},
+		{table: {{printf "%q" $table.Name}}, column: {{printf "%q" $col.Name}}, decl: "{{backfillDecl $col}}"},
 {{- end}}
 {{- end}}
 {{- end}}
@@ -1226,7 +1226,7 @@ func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]a
 {{- else if eq .Name "synced_at"}}
 		time.Now().UTC().Format(time.RFC3339),
 {{- else}}
-		lookupFieldValue(obj, "{{.Name}}"),
+		lookupFieldValue(obj, {{printf "%q" .Name}}),
 {{- end}}
 {{- end}}
 	); err != nil {
@@ -1236,14 +1236,14 @@ func (s *Store) upsert{{pascal .Name}}Tx(tx *sql.Tx, id string, obj map[string]a
 
 	// Standalone FTS: manually sync since content-sync triggers aren't used.
 	// Use explicit rowid for FTS5 compatibility with modernc.org/sqlite.
-	ftsRowid := ftsRowID("{{.Name}}", id)
+	ftsRowid := ftsRowID({{printf "%q" .Name}}, id)
 	_, _ = tx.Exec(`DELETE FROM {{safeNameSuffix .Name "_fts"}} WHERE rowid = ?`, ftsRowid)
 	_, _ = tx.Exec(
 		`INSERT INTO {{safeNameSuffix .Name "_fts"}} (rowid, id, {{safeJoin .FTS5Fields ", "}}) VALUES (?{{- range .FTS5Fields}}, ?{{- end}}, ?)`,
 		ftsRowid,
 		id,
 {{- range .FTS5Fields}}
-		lookupFieldValue(obj, "{{.}}"),
+		lookupFieldValue(obj, {{printf "%q" .}}),
 {{- end}}
 	)
 {{- end}}
@@ -1262,7 +1262,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	if id == "" {
 		return fmt.Errorf("missing id for {{.Name}}")
 	}
-	storageID := resourceStorageID("{{.Resource}}", id, obj)
+	storageID := resourceStorageID({{printf "%q" .Resource}}, id, obj)
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
@@ -1272,7 +1272,7 @@ func (s *Store) Upsert{{pascal .Name}}(data json.RawMessage) error {
 	}
 	defer tx.Rollback()
 
-	if err := s.upsertGenericResourceTx(tx, "{{.Resource}}", storageID, data); err != nil {
+	if err := s.upsertGenericResourceTx(tx, {{printf "%q" .Resource}}, storageID, data); err != nil {
 		return err
 	}
 	if err := s.upsert{{pascal .Name}}Tx(tx, storageID, obj, data); err != nil {
@@ -1525,7 +1525,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		switch resourceType {
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
-		case "{{.Resource}}":
+		case {{printf "%q" .Resource}}:
 			typedErr = s.upsert{{pascal .Name}}Tx(tx, storageID, obj, item)
 {{- end}}
 {{- end}}

--- a/internal/generator/templates/store_schema_version_test.go.tmpl
+++ b/internal/generator/templates/store_schema_version_test.go.tmpl
@@ -1062,7 +1062,7 @@ func TestMigrate_AddsColumnsOnUpgrade_{{pascal $table.Name}}(t *testing.T) {
 	for _, want := range []string{
 {{- range $col := $table.Columns}}
 {{- if isBackfillColumn $col}}
-		"{{$col.Name}}",
+		{{printf "%q" $col.Name}},
 {{- end}}
 {{- end}}
 	} {

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -395,18 +395,18 @@ func TestUpsertBatch_Populates{{pascal .Name}}Table(t *testing.T) {
 	defer s.Close()
 
 	items := []json.RawMessage{
-		json.RawMessage(`{"id": "test-001"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
-		json.RawMessage(`{"id": "test-002"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
-		json.RawMessage(`{"id": "test-003"{{if $parentFKCol}}, "{{$parentFKCol}}": "test-parent-001"{{end}}}`),
+		json.RawMessage(`{"id": "test-001"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "test-parent-001"{{end}}}`),
+		json.RawMessage(`{"id": "test-002"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "test-parent-001"{{end}}}`),
+		json.RawMessage(`{"id": "test-003"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "test-parent-001"{{end}}}`),
 	}
-	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+	if _, _, err := s.UpsertBatch({{printf "%q" .Resource}}, items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 
 	db := s.DB()
 
 	var generic int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Resource}}").Scan(&generic); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, {{printf "%q" .Resource}}).Scan(&generic); err != nil {
 		t.Fatalf("count resources: %v", err)
 	}
 	if generic != len(items) {
@@ -414,7 +414,7 @@ func TestUpsertBatch_Populates{{pascal .Name}}Table(t *testing.T) {
 	}
 
 	var typed int
-	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "{{.Name}}")
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, {{printf "%q" .Name}})
 	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
 		t.Fatalf("count {{.Name}}: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestUpsertBatch_TypedFailureDoesNotStrand{{pascal .Name}}Generic(t *testing
 		json.RawMessage(`{"id": "orphan-002"}`),
 		json.RawMessage(`{"id": "orphan-003"}`),
 	}
-	stored, extractFailures, err := s.UpsertBatch("{{.Resource}}", items)
+	stored, extractFailures, err := s.UpsertBatch({{printf "%q" .Resource}}, items)
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v (typed-table failure must not propagate)", err)
 	}
@@ -460,7 +460,7 @@ func TestUpsertBatch_TypedFailureDoesNotStrand{{pascal .Name}}Generic(t *testing
 	db := s.DB()
 
 	var generic int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Resource}}").Scan(&generic); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, {{printf "%q" .Resource}}).Scan(&generic); err != nil {
 		t.Fatalf("count resources: %v", err)
 	}
 	if generic != len(items) {
@@ -468,12 +468,12 @@ func TestUpsertBatch_TypedFailureDoesNotStrand{{pascal .Name}}Generic(t *testing
 	}
 
 	var typed int
-	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "{{.Name}}")
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, {{printf "%q" .Name}})
 	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
 		t.Fatalf("count {{.Name}}: %v", err)
 	}
 	if typed != 0 {
-		t.Fatalf("{{.Name}} count = %d, want 0 (typed insert violated NOT NULL on %q)", typed, "{{$parentFKCol}}")
+		t.Fatalf("{{.Name}} count = %d, want 0 (typed insert violated NOT NULL on %q)", typed, {{printf "%q" $parentFKCol}})
 	}
 }
 {{- end}}
@@ -497,7 +497,7 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 		json.RawMessage(`{"id": "shared_child", "{{$parentFKCol}}": "parent_B"}`),
 		json.RawMessage(`{"id": "other_child", "{{$parentFKCol}}": "parent_A"}`),
 	}
-	stored, extractFailures, err := s.UpsertBatch("{{.Resource}}", items)
+	stored, extractFailures, err := s.UpsertBatch({{printf "%q" .Resource}}, items)
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 	db := s.DB()
 
 	var generic int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, "{{.Resource}}").Scan(&generic); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM resources WHERE resource_type = ?`, {{printf "%q" .Resource}}).Scan(&generic); err != nil {
 		t.Fatalf("count resources: %v", err)
 	}
 	if generic != len(items) {
@@ -519,7 +519,7 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 	}
 
 	var typed int
-	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, "{{.Name}}")
+	typedQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, {{printf "%q" .Name}})
 	if err := db.QueryRow(typedQuery).Scan(&typed); err != nil {
 		t.Fatalf("count {{.Name}}: %v", err)
 	}
@@ -528,7 +528,7 @@ func TestUpsertBatch_Keys{{pascal .Name}}ByChildAndParent(t *testing.T) {
 	}
 
 	var parentMatches int
-	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE "{{$parentFKCol}}" = ?`, "{{.Name}}")
+	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE "{{$parentFKCol}}" = ?`, {{printf "%q" .Name}})
 	if err := db.QueryRow(parentQuery, "parent_A").Scan(&parentMatches); err != nil {
 		t.Fatalf("count by {{$parentFKCol}}: %v", err)
 	}
@@ -551,18 +551,18 @@ func TestUpsertBatch_Sets{{pascal .Name}}ParentID(t *testing.T) {
 	defer s.Close()
 
 	items := []json.RawMessage{
-		json.RawMessage(`{"id": "child-001"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}, "parent_id": "parent-A"}`),
-		json.RawMessage(`{"id": "child-002"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}, "parent_id": "parent-A"}`),
-		json.RawMessage(`{"id": "child-003"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-B"{{end}}, "parent_id": "parent-B"}`),
+		json.RawMessage(`{"id": "child-001"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "parent-A"{{end}}, "parent_id": "parent-A"}`),
+		json.RawMessage(`{"id": "child-002"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "parent-A"{{end}}, "parent_id": "parent-A"}`),
+		json.RawMessage(`{"id": "child-003"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "parent-B"{{end}}, "parent_id": "parent-B"}`),
 	}
-	if _, _, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+	if _, _, err := s.UpsertBatch({{printf "%q" .Resource}}, items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
 
 	db := s.DB()
 
 	var matchedA int
-	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE parent_id = ?`, "{{.Name}}")
+	parentQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE parent_id = ?`, {{printf "%q" .Name}})
 	if err := db.QueryRow(parentQuery, "parent-A").Scan(&matchedA); err != nil {
 		t.Fatalf("count by parent_id: %v", err)
 	}
@@ -592,9 +592,9 @@ func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
 	// field is matchable regardless of which columns {{.Name}} declares.
 	const probe = "zqxjpp2629probe"
 	items := []json.RawMessage{
-		json.RawMessage(`{"id": "search-001", "pp_fts_probe": "` + probe + `"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}, "parent_id": "parent-A"}`),
+		json.RawMessage(`{"id": "search-001", "pp_fts_probe": "` + probe + `"{{if $parentFKCol}}, {{printf "%q" $parentFKCol}}: "parent-A"{{end}}, "parent_id": "parent-A"}`),
 	}
-	stored, _, err := s.UpsertBatch("{{.Resource}}", items)
+	stored, _, err := s.UpsertBatch({{printf "%q" .Resource}}, items)
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
@@ -610,7 +610,7 @@ func TestUpsertBatch_{{pascal .Name}}SearchableViaGenericFTS(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 	if len(results) == 0 {
-		t.Fatalf("dependent resource %q stored but not searchable via generic resources_fts (issue #2629)", "{{.Resource}}")
+		t.Fatalf("dependent resource %q stored but not searchable via generic resources_fts (issue #2629)", {{printf "%q" .Resource}})
 	}
 }
 {{- end}}
@@ -630,7 +630,7 @@ func TestSearch{{pascal .Name}}QuotesFTSQuerySyntax(t *testing.T) {
 		json.RawMessage(`{"id": "typed-host", "{{$ftsField}}": "host.example.com"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}}`),
 		json.RawMessage(`{"id": "typed-multi", "{{$ftsField}}": "error with extra words before timeout"{{if $parentFKCol}}, "{{$parentFKCol}}": "parent-A"{{end}}}`),
 	}
-	if stored, failed, err := s.UpsertBatch("{{.Resource}}", items); err != nil {
+	if stored, failed, err := s.UpsertBatch({{printf "%q" .Resource}}, items); err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	} else if failed != 0 || stored != len(items) {
 		t.Fatalf("UpsertBatch stored=%d failed=%d, want stored=%d failed=0", stored, failed, len(items))

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -61,7 +61,7 @@ var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 // /tenant/{tenant}/<resource> don't trip the "requires parent context" skip.
 var endpointTemplateVarSet = map[string]bool{
 {{- range .EndpointTemplateVars}}
-	"{{.}}": true,
+	{{printf "%q" .}}: true,
 {{- end}}
 }
 {{- end}}
@@ -79,7 +79,7 @@ type syncResult struct {
 func applySyncGlobalScopeEnvDefaults(userParams *syncUserParams) {
 {{- range globalScopeParams .Resources}}
 	if v := globalScopeParamDefault("{{globalScopeEnvName .}}", {{printf "%q" (globalScopeFallbackValue .)}}); v != "" {
-		userParams.setGlobalDefault("{{paramWireName .}}", v)
+		userParams.setGlobalDefault({{printf "%q" (paramWireName .)}}, v)
 	}
 {{- end}}
 }
@@ -496,7 +496,7 @@ Resource scoping:
 	cmd.Flags().StringArrayVar(&pathContextFlags, "path-context", nil, "Fill a {key} placeholder in BaseURL or request paths from a supplied value (repeatable, key=value). Wins over env-resolved Config.TemplateVars values, so it doubles as a one-off override at the call site. Use it when an env variable already holds a different value, or when the spec did not annotate the placeholder with an env var.")
 {{- end}}
 {{- if .Pagination.DateRangeParam}}
-	cmd.Flags().StringVar(&dates, "dates", "", "Date or date range to sync (passed as {{.Pagination.DateRangeParam}} query parameter)")
+	cmd.Flags().StringVar(&dates, "dates", "", "Date or date range to sync (passed as {{oneline .Pagination.DateRangeParam}} query parameter)")
 {{- end}}
 
 	return cmd
@@ -985,9 +985,9 @@ type paginationDefaults struct {
 // Values are detected from the API spec by the profiler at generation time.
 func determinePaginationDefaults() paginationDefaults {
 	return paginationDefaults{
-		cursorParam: "{{if .Pagination.CursorParam}}{{.Pagination.CursorParam}}{{else}}after{{end}}",
-		cursorType:  "{{.Pagination.CursorType}}",
-		limitParam:  "{{if .Pagination.PageSizeParam}}{{.Pagination.PageSizeParam}}{{else}}limit{{end}}",
+		cursorParam: "{{if .Pagination.CursorParam}}{{oneline .Pagination.CursorParam}}{{else}}after{{end}}",
+		cursorType:  {{printf "%q" .Pagination.CursorType}},
+		limitParam:  "{{if .Pagination.PageSizeParam}}{{oneline .Pagination.PageSizeParam}}{{else}}limit{{end}}",
 		limit:       {{if .Pagination.DefaultPageSize}}{{.Pagination.DefaultPageSize}}{{else}}100{{end}},
 	}
 }
@@ -995,7 +995,7 @@ func determinePaginationDefaults() paginationDefaults {
 func resourceSupportsPagination(resource string) bool {
 	switch resource {
 {{- range .PaginationSupportedResources}}
-	case "{{.}}":
+	case {{printf "%q" .}}:
 		return true
 {{- end}}
 	}
@@ -1015,14 +1015,14 @@ func syncResourceIDWalkConfig(resource string) (idWalkConfig, bool) {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if .IDWalkFilterParam}}
-	case "{{.Name}}":
-		return idWalkConfig{filterParam: "{{.IDWalkFilterParam}}", idField: syncResourceIDField(resource), limitParam: "{{.IDWalkLimitParam}}", limit: {{if .IDWalkPageSize}}{{.IDWalkPageSize}}{{else}}100{{end}}}, true
+	case {{printf "%q" .Name}}:
+		return idWalkConfig{filterParam: {{printf "%q" .IDWalkFilterParam}}, idField: syncResourceIDField(resource), limitParam: {{printf "%q" .IDWalkLimitParam}}, limit: {{if .IDWalkPageSize}}{{.IDWalkPageSize}}{{else}}100{{end}}}, true
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .IDWalkFilterParam}}
-	case "{{.Name}}":
-		return idWalkConfig{filterParam: "{{.IDWalkFilterParam}}", idField: syncResourceIDField(resource), limitParam: "{{.IDWalkLimitParam}}", limit: {{if .IDWalkPageSize}}{{.IDWalkPageSize}}{{else}}100{{end}}}, true
+	case {{printf "%q" .Name}}:
+		return idWalkConfig{filterParam: {{printf "%q" .IDWalkFilterParam}}, idField: syncResourceIDField(resource), limitParam: {{printf "%q" .IDWalkLimitParam}}, limit: {{if .IDWalkPageSize}}{{.IDWalkPageSize}}{{else}}100{{end}}}, true
 {{- end}}
 {{- end}}
 	}
@@ -1136,13 +1136,13 @@ func syncResourceMethod(resource string) string {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if eq .Method "POST"}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return "POST"
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if eq .Method "POST"}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return "POST"
 {{- end}}
 {{- end}}
@@ -1154,20 +1154,20 @@ func syncResourceBodyParamTypes(resource string) map[string]string {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if .BodyFields}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]string{
 {{- range .BodyFields}}
-			"{{.Name}}": "{{.Type}}",
+			{{printf "%q" .Name}}: {{printf "%q" .Type}},
 {{- end}}
 		}
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .BodyFields}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]string{
 {{- range .BodyFields}}
-			"{{.Name}}": "{{.Type}}",
+			{{printf "%q" .Name}}: {{printf "%q" .Type}},
 {{- end}}
 		}
 {{- end}}
@@ -1180,20 +1180,20 @@ func syncResourceBodyParamWireNames(resource string) map[string]string {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if .BodyFields}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]string{
 {{- range .BodyFields}}
-			"{{.Name}}": "{{.BodyWireName}}",
+			{{printf "%q" .Name}}: {{printf "%q" .BodyWireName}},
 {{- end}}
 		}
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .BodyFields}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]string{
 {{- range .BodyFields}}
-			"{{.Name}}": "{{.BodyWireName}}",
+			{{printf "%q" .Name}}: {{printf "%q" .BodyWireName}},
 {{- end}}
 		}
 {{- end}}
@@ -1227,11 +1227,11 @@ func syncResourceStaticBody(resource string) map[string]any {
 {{- $hasDefaults := false}}
 {{- range .BodyFields}}{{if .HasDefault}}{{- $hasDefaults = true}}{{end}}{{end}}
 {{- if $hasDefaults}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]any{
 {{- range .BodyFields}}
 {{- if .HasDefault}}
-			"{{.BodyWireName}}": {{goLiteral .Default}},
+			{{printf "%q" .BodyWireName}}: {{goLiteral .Default}},
 {{- end}}
 {{- end}}
 		}
@@ -1243,11 +1243,11 @@ func syncResourceStaticBody(resource string) map[string]any {
 {{- $hasDefaults := false}}
 {{- range .BodyFields}}{{if .HasDefault}}{{- $hasDefaults = true}}{{end}}{{end}}
 {{- if $hasDefaults}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return map[string]any{
 {{- range .BodyFields}}
 {{- if .HasDefault}}
-			"{{.BodyWireName}}": {{goLiteral .Default}},
+			{{printf "%q" .BodyWireName}}: {{goLiteral .Default}},
 {{- end}}
 {{- end}}
 		}
@@ -1268,14 +1268,14 @@ func syncResourceSinceParam(resource string) string {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if .SinceParam}}
-	case "{{.Name}}":
-		return "{{.SinceParam}}"
+	case {{printf "%q" .Name}}:
+		return {{printf "%q" .SinceParam}}
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .SinceParam}}
-	case "{{.Name}}":
-		return "{{.SinceParam}}"
+	case {{printf "%q" .Name}}:
+		return {{printf "%q" .SinceParam}}
 {{- end}}
 {{- end}}
 	}
@@ -1286,14 +1286,14 @@ func syncResourceSinceParamFormat(resource string) string {
 	switch resource {
 {{- range .SyncableResources}}
 {{- if .SinceParamFormat}}
-	case "{{.Name}}":
-		return "{{.SinceParamFormat}}"
+	case {{printf "%q" .Name}}:
+		return {{printf "%q" .SinceParamFormat}}
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .SinceParamFormat}}
-	case "{{.Name}}":
-		return "{{.SinceParamFormat}}"
+	case {{printf "%q" .Name}}:
+		return {{printf "%q" .SinceParamFormat}}
 {{- end}}
 {{- end}}
 	}
@@ -1318,7 +1318,7 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 
 // determineDateRangeParam returns the query parameter name for date-range sync filtering.
 func determineDateRangeParam() string {
-	return "{{.Pagination.DateRangeParam}}"
+	return {{printf "%q" .Pagination.DateRangeParam}}
 }
 {{- end}}
 
@@ -2070,7 +2070,7 @@ func upsertSingleObject(db *store.Store, resource string, data json.RawMessage) 
 	switch resource {
 {{- range .Tables}}
 {{- if emitsDomainTable .}}
-	case "{{.Resource}}":
+	case {{printf "%q" .Resource}}:
 {{- if $hasHTMLPageModeSync}}
 		typedData, err := typedSingleObjectData(data, obj, id, forceTypedID)
 		if err != nil {
@@ -2120,7 +2120,7 @@ func defaultSyncResources() []string {
 	return []string{
 {{- range .SyncableResources}}
 {{- if not .SkipDefaultSync}}
-		"{{.Name}}",
+		{{printf "%q" .Name}},
 {{- end}}
 {{- end}}
 	}
@@ -2132,7 +2132,7 @@ func defaultSyncResources() []string {
 func knownSyncResourceNames() []string {
 	names := []string{
 {{- range .SyncableResources}}
-		"{{.Name}}",
+		{{printf "%q" .Name}},
 {{- end}}
 	}
 {{- if .DependentSyncResources}}
@@ -2149,7 +2149,7 @@ func knownSyncResourceNames() []string {
 func syncResourcePath(resource string) (string, error) {
 	paths := map[string]string{
 {{- range .SyncableResources}}
-		"{{.Name}}": "{{.Path}}",
+		{{printf "%q" .Name}}: {{printf "%q" .Path}},
 {{- end}}
 	}
 	if p, ok := paths[resource]; ok {
@@ -2168,7 +2168,7 @@ func syncHTMLExtractionOptions(resource string, parentResource string, baseURL s
 	switch key {
 {{- range .SyncableResources}}
 {{- if .UsesHTMLResponse}}
-	case "{{.Name}}":
+	case {{printf "%q" .Name}}:
 		return htmlExtractionOptions{
 			Mode: "{{with .HTMLExtract}}{{.EffectiveMode}}{{else}}page{{end}}",
 			BaseURL: htmlExtractionRequestURL(baseURL, path, params),
@@ -2188,7 +2188,7 @@ func syncHTMLExtractionOptions(resource string, parentResource string, baseURL s
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .UsesHTMLResponse}}
-	case "{{.ParentResource}}.{{.Name}}":
+	case "{{oneline .ParentResource}}.{{oneline .Name}}":
 		return htmlExtractionOptions{
 			Mode: "{{with .HTMLExtract}}{{.EffectiveMode}}{{else}}page{{end}}",
 			BaseURL: htmlExtractionRequestURL(baseURL, path, params),
@@ -2218,12 +2218,12 @@ func syncHTMLExtractionOptions(resource string, parentResource string, baseURL s
 var syncResourceTiers = map[string]string{
 {{- range .SyncableResources}}
 {{- if .Tier}}
-	"{{.Name}}": {{printf "%q" .Tier}},
+	{{printf "%q" .Name}}: {{printf "%q" .Tier}},
 {{- end}}
 {{- end}}
 {{- range .DependentSyncResources}}
 {{- if .Tier}}
-	"{{.Name}}": {{printf "%q" .Tier}},
+	{{printf "%q" .Name}}: {{printf "%q" .Tier}},
 {{- end}}
 {{- end}}
 }
@@ -2262,9 +2262,9 @@ type dependentPathParamDef struct {
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 {{- range .DependentSyncResources}}
-		{Name: "{{.Name}}", ParentTable: "{{.ParentResource}}", ParentIDParam: "{{.ParentIDParam}}", PathTemplate: "{{.Path}}", KeyField: "{{.KeyField}}"{{if .PathParams}}, PathParams: []dependentPathParamDef{
+		{Name: {{printf "%q" .Name}}, ParentTable: {{printf "%q" .ParentResource}}, ParentIDParam: {{printf "%q" .ParentIDParam}}, PathTemplate: {{printf "%q" .Path}}, KeyField: {{printf "%q" .KeyField}}{{if .PathParams}}, PathParams: []dependentPathParamDef{
 {{- range .PathParams}}
-			{Param: "{{.Param}}", Field: "{{.Field}}"},
+			{Param: {{printf "%q" .Param}}, Field: {{printf "%q" .Field}}},
 {{- end}}
 		}{{end}}},
 {{- end}}

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -115,7 +115,7 @@ native streaming instead of polling.`,
 func tailKnownResources() []string {
 	return []string{
 {{- range $name, $resource := .Resources}}
-		"{{$name}}",
+		{{printf "%q" $name}},
 {{- end}}
 	}
 }

--- a/internal/generator/templates/url.go.tmpl
+++ b/internal/generator/templates/url.go.tmpl
@@ -28,14 +28,14 @@ var templateVarPattern = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 // back to a generic "template variable {x} unresolved" message.
 var templateVarEnvNames = map[string]string{
 {{- range .EndpointTemplateVars}}
-	"{{.}}": "{{endpointTemplateEnvName .}}",
+	{{printf "%q" .}}: {{printf "%q" (endpointTemplateEnvName .)}},
 {{- end}}
 }
 {{- if .GlobalPathTemplateVars}}
 
 var globalPathTemplateVars = map[string]bool{
 {{- range .GlobalPathTemplateVars}}
-	"{{.}}": true,
+	{{printf "%q" .}}: true,
 {{- end}}
 }
 {{- end}}

--- a/internal/generator/templates_injection_test.go
+++ b/internal/generator/templates_injection_test.go
@@ -1,0 +1,128 @@
+package generator
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedGoEscapesInjectedSpecValues is the dynamic counterpart to the
+// static TestGoTemplatesEscapeSpecValuesInStringLiterals guard: it generates a
+// CLI from a spec whose URL/auth/header/path fields carry a bare double-quote
+// payload and asserts every emitted .go file still parses as valid Go. The
+// payload `inj"ect` is chosen so that ANY unescaped emission into a Go double-
+// quoted string literal (`"inj"ect"`) is a syntax error — so a clean parse of
+// every file is proof the spec value was escaped (via printf %q / oneline), and
+// could not break out of the literal into executable Go. This is the supply-
+// chain RCE guard for printed CLIs built from untrusted (sniffed/imported) specs.
+func TestGeneratedGoEscapesInjectedSpecValues(t *testing.T) {
+	t.Parallel()
+
+	const q = `inj"ect`
+	const qurl = `https://x.example/` + q
+
+	variants := []struct {
+		name   string
+		mutate func(s *spec.APISpec)
+	}{
+		{"api-key-headers", func(s *spec.APISpec) {
+			s.WebsiteURL = qurl
+			s.HealthCheckPath = "/" + q
+			s.Auth.KeyURL = qurl
+			s.Auth.Header = "X-" + q
+			s.Auth.Format = "Bearer {token}" + q
+			s.RequiredHeaders = []spec.RequiredHeader{{Name: "H" + q, Value: "V" + q}}
+		}},
+		{"api-key-query", func(s *spec.APISpec) {
+			s.Auth.In = "query"
+			s.Auth.Header = "apikey" + q
+			s.Auth.KeyURL = qurl
+		}},
+		{"oauth2", func(s *spec.APISpec) {
+			s.Auth.Type = "oauth2"
+			s.Auth.OAuth2Grant = "authorization_code"
+			s.Auth.AuthorizationURL = qurl
+			s.Auth.TokenURL = qurl
+			s.Auth.KeyURL = qurl
+			s.Auth.Scopes = []string{"read", "scope" + q}
+			s.WebsiteURL = qurl
+		}},
+		{"paginated-query-params", func(s *spec.APISpec) {
+			s.Resources = map[string]spec.Resource{
+				"items": {
+					Description: "Manage items",
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method: "GET", Path: "/items", Description: "List items",
+							ResponsePath: "data." + q,
+							Params: []spec.Param{
+								{Name: "weird", URLName: "wire" + q, Type: "string"},
+							},
+							Pagination: &spec.Pagination{
+								Type: "cursor", LimitParam: "lim" + q, CursorParam: "cur" + q,
+								NextCursorPath: "next." + q, HasMoreField: "more" + q,
+							},
+						},
+					},
+				},
+			}
+		}},
+		{"session-handshake", func(s *spec.APISpec) {
+			s.Auth.Type = "session_handshake"
+			s.Auth.BootstrapURL = qurl
+			s.Auth.SessionTokenURL = qurl
+			s.Auth.TokenParamName = q
+			s.Auth.TokenParamIn = "query"
+			s.Auth.TokenFormat = "json"
+			s.Auth.TokenJSONPath = "data." + q
+			s.BaseURL = qurl
+		}},
+		{"composed-browser", func(s *spec.APISpec) {
+			s.Auth.Type = "composed"
+			s.Auth.RequiresBrowserSession = true
+			s.Auth.CookieDomain = "." + q + ".com"
+			s.Auth.BrowserSessionValidationPath = "/" + q
+			s.Auth.BrowserSessionValidationMethod = "GET"
+			s.Auth.Cookies = []string{"sid"}
+		}},
+	}
+
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			t.Parallel()
+			s := minimalSpec("inj-" + v.name)
+			v.mutate(s)
+
+			dir := filepath.Join(t.TempDir(), "out")
+			require.NoError(t, New(s, dir).Generate(), "generation must succeed even with quote-bearing spec values")
+
+			parsed := 0
+			walkErr := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() || !strings.HasSuffix(p, ".go") {
+					return nil
+				}
+				src, readErr := os.ReadFile(p)
+				require.NoError(t, readErr)
+				rel, _ := filepath.Rel(dir, p)
+				if _, perr := parser.ParseFile(token.NewFileSet(), p, src, parser.AllErrors); perr != nil {
+					assert.NoError(t, perr, "generated %s must be valid Go — a spec value broke out of a string literal", rel)
+				}
+				parsed++
+				return nil
+			})
+			require.NoError(t, walkErr)
+			assert.Positive(t, parsed, "expected generated .go files to parse")
+		})
+	}
+}

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -65,8 +65,180 @@ func TestGoTemplatesEscapeSpecTextInStringLiterals(t *testing.T) {
 	require.Empty(t, violations, "spec-controlled prose inside Go string literals must use oneline/printf %%q; unsafe template sites:\n%s", strings.Join(violations, "\n"))
 }
 
+// dangerousSpecValueLeaf names the spec-derived field families that, when
+// emitted as a bare reference inside a Go double-quoted string literal, are a
+// code-injection vector: text/template does not escape, so a value containing a
+// quote can break out of the literal and compile to live Go. URL/auth/header/
+// path/method fields are attacker-influenced for domain-import (recovered from
+// an untrusted HAR or fetched domain) and are not validated for Go-literal
+// safety. The emit must go through printf %q / goLiteral / oneline.
+var dangerousSpecValueLeaf = regexp.MustCompile(`(?:URL|Path|Method|Framing|Param|Field|Format|Prefix|Branch|Addr|Domain|Endpoint|Resource|Scheme|Host|Query)$`)
+
+func isDangerousSpecValueLeaf(leaf string) bool {
+	switch leaf {
+	case "TokenParamName", "Header", "Value", "DefaultRepo", "Type":
+		return true
+	}
+	return dangerousSpecValueLeaf.MatchString(leaf)
+}
+
+// rawSpecFieldLeaf returns the leaf identifier of a template action that is a
+// bare field reference (e.g. "{{.Auth.TokenURL}}" -> "TokenURL"), and false for
+// helper calls ("{{kebab .Name}}"), pipelines ("{{.X | y}}"), template vars
+// ("{{$c}}"), and control actions ("{{if ...}}"). Helper-wrapped values are
+// assumed sanitized by the helper and are out of scope for this guard.
+func rawSpecFieldLeaf(action string) (string, bool) {
+	inner := strings.TrimSpace(action)
+	inner = strings.TrimPrefix(inner, "{{")
+	inner = strings.TrimSuffix(inner, "}}")
+	inner = strings.TrimSpace(inner)
+	inner = strings.TrimPrefix(inner, "-")
+	inner = strings.TrimSuffix(inner, "-")
+	inner = strings.TrimSpace(inner)
+	if strings.ContainsRune(inner, '|') {
+		return "", false // piped through a function — out of scope here
+	}
+	if !strings.HasPrefix(inner, ".") {
+		return "", false // helper call, $var, or control action
+	}
+	if strings.ContainsAny(inner, " \t") {
+		return "", false // a bare field reference has no arguments
+	}
+	leaf := inner[strings.LastIndex(inner, ".")+1:]
+	if leaf == "" {
+		return "", false // bare "." (the dot) — not a field
+	}
+	return leaf, true
+}
+
+// nonSanitizingHelpers are template helpers that pass their input's characters
+// through unchanged (case/concat/lookup only) — so a spec value with a quote
+// survives and can break out of a Go string literal. When one of these is the
+// OUTERMOST command of an action inside a Go double-quoted string, the action
+// must be wrapped in an escaper (printf %q / oneline). Normalizing helpers that
+// emit identifier-only output (kebab, snake, envName, …) are not listed.
+var nonSanitizingHelpers = map[string]bool{
+	"upper": true, "lower": true, "title": true,
+	"join": true, "index": true, "paramWireName": true,
+	"authParameterName": true, "graphqlQueryField": true,
+	"endpointTemplateEnvName": true,
+	// Note: enumDescriptionHint is intentionally NOT listed — it sanitizes its
+	// own enum values via OneLine internally, so a raw {{enumDescriptionHint}}
+	// in a string literal is safe (and must stay un-%q'd to keep its leading
+	// space).
+}
+
+// outerTemplateCommand returns the leading token of an action's outermost
+// pipeline stage: "printf" for `{{printf "%q" .X}}`, "upper" for
+// `{{upper .X}}`, "" for a bare ref / $var / control action.
+func outerTemplateCommand(action string) string {
+	inner := strings.TrimSpace(action)
+	inner = strings.TrimPrefix(inner, "{{")
+	inner = strings.TrimSuffix(inner, "}}")
+	inner = strings.TrimSpace(inner)
+	inner = strings.TrimSpace(strings.TrimPrefix(inner, "-"))
+	inner = strings.TrimSpace(strings.TrimSuffix(inner, "-"))
+	if i := strings.LastIndex(inner, "|"); i >= 0 {
+		inner = strings.TrimSpace(inner[i+1:])
+	}
+	if inner == "" || strings.HasPrefix(inner, ".") || strings.HasPrefix(inner, "$") {
+		return ""
+	}
+	for j, r := range inner {
+		if r == ' ' || r == '\t' || r == '(' {
+			return inner[:j]
+		}
+	}
+	return inner
+}
+
+func actionEscapesValue(action string) bool {
+	return strings.Contains(action, `printf "%q"`) ||
+		strings.Contains(action, "oneline ") ||
+		strings.Contains(action, "goLiteral ")
+}
+
+// TestGoTemplatesEscapeSpecValuesInStringLiterals guards the Go-code-injection
+// class for spec-derived values emitted into generated Go double-quoted string
+// literals (the supply-chain RCE vector for printed CLIs built from untrusted
+// sniffed/imported specs). It flags three shapes that let a quote-bearing value
+// break out of the literal into executable Go:
+//  1. a bare field reference that is the entire literal ("{{.X}}") — must be %q;
+//  2. a bare reference to a high-risk field embedded mid-literal — must be oneline;
+//  3. a non-sanitizing helper (upper/lower/join/index/…) as the outermost command,
+//     not already wrapped in an escaper.
+//
+// Sibling to TestGoTemplatesEscapeSpecTextInStringLiterals, which covers prose.
+func TestGoTemplatesEscapeSpecValuesInStringLiterals(t *testing.T) {
+	t.Parallel()
+
+	var violations []string
+	err := fs.WalkDir(templateFS, "templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go.tmpl") {
+			return nil
+		}
+		data, err := templateFS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for lineNo, line := range strings.Split(string(data), "\n") {
+			for start := strings.Index(line, "{{"); start >= 0; {
+				end := strings.Index(line[start+2:], "}}")
+				if end < 0 {
+					break
+				}
+				end += start + 2
+				action := line[start : end+2]
+				if isInsideGoDoubleQuotedString(line[:start]) {
+					prev := byte(0)
+					if start > 0 {
+						prev = line[start-1]
+					}
+					next := byte(0)
+					if end+2 < len(line) {
+						next = line[end+2]
+					}
+					wholeLiteral := prev == '"' && next == '"'
+
+					unsafe := false
+					if leaf, ok := rawSpecFieldLeaf(action); ok {
+						// bare field reference: %q when it is the whole literal,
+						// oneline when a high-risk field is embedded mid-literal.
+						unsafe = wholeLiteral || isDangerousSpecValueLeaf(leaf)
+					} else if cmd := outerTemplateCommand(action); cmd == "" {
+						// $var, lone-dot, or parenthesized field access ((index x 0).Name):
+						// flag when it is the whole literal and not escaped.
+						unsafe = wholeLiteral && !actionEscapesValue(action)
+					} else if nonSanitizingHelpers[cmd] && !actionEscapesValue(action) {
+						unsafe = true
+					}
+					if unsafe {
+						violations = append(violations, path+":"+strconv.Itoa(lineNo+1)+": "+strings.TrimSpace(line))
+					}
+				}
+				next := end + 2
+				if next >= len(line) {
+					break
+				}
+				if rel := strings.Index(line[next:], "{{"); rel >= 0 {
+					start = next + rel
+				} else {
+					break
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, violations, "spec-derived values inside Go string literals must use printf %%q / oneline / goLiteral; unsafe template sites:\n%s", strings.Join(violations, "\n"))
+}
+
 func isInsideGoDoubleQuotedString(prefix string) bool {
 	inString := false
+	inRaw := false // inside a Go `...` raw string literal (e.g. a struct tag)
 	escaped := false
 	for i := 0; i < len(prefix); {
 		if strings.HasPrefix(prefix[i:], "{{") {
@@ -77,18 +249,30 @@ func isInsideGoDoubleQuotedString(prefix string) bool {
 			i += 2 + end + 2
 			continue
 		}
+		if !inString && !inRaw && strings.HasPrefix(prefix[i:], "//") {
+			// Rest of the line is a Go comment — not a string context.
+			return false
+		}
 		r := prefix[i]
 		i++
 		if escaped {
 			escaped = false
 			continue
 		}
-		switch r {
-		case '\\':
+		switch {
+		case r == '`':
+			// Backtick toggles a raw string, where " is a literal, not a
+			// double-quoted-string delimiter (this is how struct tags appear).
+			if !inString {
+				inRaw = !inRaw
+			}
+		case inRaw:
+			// nothing toggles while inside a raw string
+		case r == '\\':
 			if inString {
 				escaped = true
 			}
-		case '"':
+		case r == '"':
 			inString = !inString
 		}
 	}

--- a/internal/graphql/parser.go
+++ b/internal/graphql/parser.go
@@ -204,6 +204,11 @@ func parseSDLContent(source, raw string) (*spec.APISpec, error) {
 		return nil, fmt.Errorf("validating parsed SDL: %w", err)
 	}
 
+	// Data-layer Go-code-injection guard (see spec.GuardStructuralStrings).
+	if err := spec.GuardStructuralStrings(apiSpec); err != nil {
+		return nil, err
+	}
+
 	return apiSpec, nil
 }
 

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -714,6 +714,11 @@ func parseWithLocation(data []byte, lenient bool, strictRefs bool, location *url
 		return nil, fmt.Errorf("validating parsed spec: %w", err)
 	}
 
+	// Data-layer Go-code-injection guard (see spec.GuardStructuralStrings).
+	if err := spec.GuardStructuralStrings(result); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 

--- a/internal/openapi/structural_guard_corpus_test.go
+++ b/internal/openapi/structural_guard_corpus_test.go
@@ -1,0 +1,66 @@
+package openapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStructuralGuardNoFalsePositivesOnRealSpecs is the safety net for the
+// parse-time GuardStructuralStrings prose/structural taxonomy: it parses every
+// real spec the repo ships and asserts the guard never rejects one. A failure
+// means a prose field is mis-tagged as structural (a `pp:"prose"` tag is
+// missing) — fix the tag, do not weaken the guard. Intentionally-malformed
+// fixtures may still fail Parse for other reasons; only a "disallowed
+// character" error is treated as a guard false positive.
+func TestStructuralGuardNoFalsePositivesOnRealSpecs(t *testing.T) {
+	t.Parallel()
+
+	dirs := []string{"../../catalog/specs", "../../testdata/openapi", "../../testdata/golden/fixtures"}
+
+	checked := 0
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // corpus optional in some checkouts
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			ext := strings.ToLower(filepath.Ext(e.Name()))
+			if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+				continue
+			}
+			path := filepath.Join(dir, e.Name())
+			data, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			checked++
+
+			// Route by format: OpenAPI/Swagger via Parse, internal Printing
+			// Press YAML via spec.ParseBytes. We only assert the guard never
+			// false-positives; other parse errors (refs, intentionally-bad
+			// fixtures) are out of scope here.
+			head := data
+			if len(head) > 400 {
+				head = head[:400]
+			}
+			var parseErr error
+			if strings.Contains(string(head), "openapi:") || strings.Contains(string(head), "swagger:") {
+				_, parseErr = Parse(data)
+			} else {
+				_, parseErr = spec.ParseBytes(data)
+			}
+			if parseErr != nil {
+				assert.NotContains(t, parseErr.Error(), "disallowed character",
+					"guard false-positive on shipped spec %s — a prose field is likely missing its pp:\"prose\" tag", path)
+			}
+		}
+	}
+	require.Positive(t, checked, "expected to parse at least one corpus spec")
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -211,7 +211,7 @@ type APISpec struct {
 	// Description describes the API itself ("REST API for ordering pizza").
 	// It flows into generated docs and SKILL.md but is intentionally NOT used
 	// as the printed CLI's --help text; that's CLIDescription's job.
-	Description string `yaml:"description" json:"description"`
+	Description string `yaml:"description" json:"description" pp:"prose"`
 	// CLIDescription, when set, becomes the printed CLI's root cobra command
 	// `Short:` text. Spec authors should phrase it as what the CLI does
 	// ("Order Seattle pizza from the terminal"), not what the API is. When
@@ -219,7 +219,7 @@ type APISpec struct {
 	// then to a generic "Manage <api> resources via the <api> API". Adding
 	// this field eliminates a recurring manual rewrite step that the main
 	// skill used to instruct Claude to perform after every generation.
-	CLIDescription string `yaml:"cli_description,omitempty" json:"cli_description,omitempty"`
+	CLIDescription string `yaml:"cli_description,omitempty" json:"cli_description,omitempty" pp:"prose"`
 	Version        string `yaml:"version" json:"version"`
 	BaseURL        string `yaml:"base_url" json:"base_url"`
 	BasePath       string `yaml:"base_path,omitempty" json:"base_path,omitempty"`
@@ -270,7 +270,7 @@ type APISpec struct {
 	// has a real URL to probe. Path-positional templates (x-tenant-env-var
 	// style) leave this empty; there is no spec-level default for a
 	// tenant ID.
-	EndpointTemplateVarDefaults map[string]string `yaml:"endpoint_template_var_defaults,omitempty" json:"endpoint_template_var_defaults,omitempty"`
+	EndpointTemplateVarDefaults map[string]string `yaml:"endpoint_template_var_defaults,omitempty" json:"endpoint_template_var_defaults,omitempty" pp:"prose"`
 	// Creator is the permanent original author of the CLI (the human who
 	// first got it accepted into the library). Top-billed on every
 	// attribution surface; never reassigned by a reprint or later
@@ -301,7 +301,7 @@ type APISpec struct {
 	Regions         []string            `yaml:"regions,omitempty" json:"regions,omitempty"`              // geographic availability/scope tokens (ISO 3166-1 alpha-2 like NL, EU, or * for global)
 	APILanguage     string              `yaml:"api_language,omitempty" json:"api_language,omitempty"`    // BCP 47 language tag for the API's native/domain language
 	Auth            AuthConfig          `yaml:"auth" json:"auth"`
-	AuthWarnings    []string            `yaml:"auth_warnings,omitempty" json:"auth_warnings,omitempty"`
+	AuthWarnings    []string            `yaml:"auth_warnings,omitempty" json:"auth_warnings,omitempty" pp:"prose"`
 	Roles           []string            `yaml:"roles,omitempty" json:"roles,omitempty"` // per-spec authenticated persona labels that endpoints may require (e.g. parent, teacher, admin)
 	TierRouting     TierRoutingConfig   `yaml:"tier_routing,omitempty" json:"tier_routing,omitzero"`
 	RequiredHeaders []RequiredHeader    `yaml:"required_headers,omitempty" json:"required_headers,omitempty"`
@@ -357,7 +357,7 @@ func (s *APISpec) SyncDefaultConcurrency() int {
 type StreamingConfig struct {
 	Transport      string                  `yaml:"transport,omitempty" json:"transport,omitempty"`
 	URL            string                  `yaml:"url,omitempty" json:"url,omitempty"`
-	SubscribeShape string                  `yaml:"subscribe_shape,omitempty" json:"subscribe_shape,omitempty"`
+	SubscribeShape string                  `yaml:"subscribe_shape,omitempty" json:"subscribe_shape,omitempty" pp:"rawstring"`
 	Framing        string                  `yaml:"framing,omitempty" json:"framing,omitempty"`
 	Metadata       StreamingMetadataConfig `yaml:"metadata,omitempty" json:"metadata,omitzero"`
 }
@@ -780,9 +780,9 @@ func resourceHasRequiredRoles(resource Resource) bool {
 // template only sees .Resources and silently omits hand-written
 // commands, which is the drift class that motivated this field.
 type ExtraCommand struct {
-	Name        string `yaml:"name" json:"name"`                     // command path, e.g. "boxscore" or "tv airing-today"
-	Description string `yaml:"description" json:"description"`       // one-line description rendered after a dash
-	Args        string `yaml:"args,omitempty" json:"args,omitempty"` // optional positional arg signature, e.g. "<event_id>" or "<team1> <team2>"
+	Name        string `yaml:"name" json:"name"`                                // command path, e.g. "boxscore" or "tv airing-today"
+	Description string `yaml:"description" json:"description" pp:"prose"`       // one-line description rendered after a dash
+	Args        string `yaml:"args,omitempty" json:"args,omitempty" pp:"prose"` // optional positional arg signature, e.g. "<event_id>" or "<team1> <team2>"
 }
 
 // IsSynthetic reports whether this spec declares a multi-source / combo CLI
@@ -1013,13 +1013,13 @@ type AuthConfig struct {
 	Format                 string       `yaml:"format" json:"format"`
 	EnvVars                []string     `yaml:"env_vars" json:"env_vars"`
 	EnvVarSpecs            []AuthEnvVar `yaml:"env_var_specs,omitempty" json:"env_var_specs,omitempty"`
-	Optional               bool         `yaml:"optional,omitempty" json:"optional,omitempty"`         // true when the key enhances a subset of features (e.g., USDA nutrition backfill) rather than gating core functionality; doctor treats unconfigured optional auth as INFO not FAIL and README frames the section as "Optional"
-	Scheme                 string       `yaml:"scheme,omitempty" json:"scheme,omitempty"`             // OpenAPI security scheme name
-	In                     string       `yaml:"in,omitempty" json:"in,omitempty"`                     // header, query, cookie
-	KeyURL                 string       `yaml:"key_url,omitempty" json:"key_url,omitempty"`           // URL where users can register for an API key
-	Instructions           string       `yaml:"instructions,omitempty" json:"instructions,omitempty"` // one-line guidance shown alongside KeyURL, e.g. "Settings → Personal access tokens → Generate new"
-	Title                  string       `yaml:"title,omitempty" json:"title,omitempty"`               // user-facing credential field title for install/config surfaces
-	Description            string       `yaml:"description,omitempty" json:"description,omitempty"`
+	Optional               bool         `yaml:"optional,omitempty" json:"optional,omitempty"`                    // true when the key enhances a subset of features (e.g., USDA nutrition backfill) rather than gating core functionality; doctor treats unconfigured optional auth as INFO not FAIL and README frames the section as "Optional"
+	Scheme                 string       `yaml:"scheme,omitempty" json:"scheme,omitempty"`                        // OpenAPI security scheme name
+	In                     string       `yaml:"in,omitempty" json:"in,omitempty"`                                // header, query, cookie
+	KeyURL                 string       `yaml:"key_url,omitempty" json:"key_url,omitempty"`                      // URL where users can register for an API key
+	Instructions           string       `yaml:"instructions,omitempty" json:"instructions,omitempty" pp:"prose"` // one-line guidance shown alongside KeyURL, e.g. "Settings → Personal access tokens → Generate new"
+	Title                  string       `yaml:"title,omitempty" json:"title,omitempty" pp:"prose"`               // user-facing credential field title for install/config surfaces
+	Description            string       `yaml:"description,omitempty" json:"description,omitempty" pp:"prose"`
 	AuthorizationURL       string       `yaml:"authorization_url,omitempty" json:"authorization_url,omitempty"`
 	DeviceAuthorizationURL string       `yaml:"device_authorization_url,omitempty" json:"device_authorization_url,omitempty"`
 	TokenURL               string       `yaml:"token_url,omitempty" json:"token_url,omitempty"`
@@ -1065,7 +1065,7 @@ type AuthConfig struct {
 	// happy path. The generator emits validation and proof handling, and the
 	// shipcheck pipeline treats a missing proof as a blocker.
 	RequiresBrowserSession         bool   `yaml:"requires_browser_session,omitempty" json:"requires_browser_session,omitempty"`
-	BrowserSessionReason           string `yaml:"browser_session_reason,omitempty" json:"browser_session_reason,omitempty"`
+	BrowserSessionReason           string `yaml:"browser_session_reason,omitempty" json:"browser_session_reason,omitempty" pp:"prose"`
 	BrowserSessionValidationPath   string `yaml:"browser_session_validation_path,omitempty" json:"browser_session_validation_path,omitempty"`
 	BrowserSessionValidationMethod string `yaml:"browser_session_validation_method,omitempty" json:"browser_session_validation_method,omitempty"`
 
@@ -1186,7 +1186,7 @@ type AuthEnvVar struct {
 	Kind        AuthEnvVarKind `yaml:"kind,omitempty" json:"kind,omitempty"`
 	Required    bool           `yaml:"required" json:"required"`
 	Sensitive   bool           `yaml:"sensitive" json:"sensitive"` // orthogonal to Kind; drives redaction policy
-	Description string         `yaml:"description,omitempty" json:"description,omitempty"`
+	Description string         `yaml:"description,omitempty" json:"description,omitempty" pp:"prose"`
 	Inferred    bool           `yaml:"inferred,omitempty" json:"inferred,omitempty"`
 }
 
@@ -1733,10 +1733,10 @@ type ShareConfig struct {
 // outer map key (e.g., "country", "team"); each value is an ordered list
 // of canonical entities and their aliases.
 type LearnConfig struct {
-	Enabled           bool                    `yaml:"enabled,omitempty" json:"enabled,omitempty"`                         // master switch; when false, the loop's commands and pre-seeding hook are not emitted
-	TickerPatterns    []string                `yaml:"ticker_patterns,omitempty" json:"ticker_patterns,omitempty"`         // Go regexp patterns the recall path uses to recognize resource identifiers in free-text. Each value must compile via regexp.Compile.
-	Stopwords         []string                `yaml:"stopwords,omitempty" json:"stopwords,omitempty"`                     // domain-specific stopwords stripped from queries before recall match; merged with a built-in default set. Whitespace-only entries are dropped at parse time.
-	EntityLookupSeeds map[string][]LookupSeed `yaml:"entity_lookup_seeds,omitempty" json:"entity_lookup_seeds,omitempty"` // canonical-name + aliases table keyed by seed kind (e.g., "country"). Used by the recall path to substitute one entity for another and generalize learned templates.
+	Enabled           bool                    `yaml:"enabled,omitempty" json:"enabled,omitempty"`                                // master switch; when false, the loop's commands and pre-seeding hook are not emitted
+	TickerPatterns    []string                `yaml:"ticker_patterns,omitempty" json:"ticker_patterns,omitempty" pp:"rawstring"` // Go regexp patterns the recall path uses to recognize resource identifiers in free-text. Each value must compile via regexp.Compile.
+	Stopwords         []string                `yaml:"stopwords,omitempty" json:"stopwords,omitempty" pp:"prose"`                 // domain-specific stopwords stripped from queries before recall match; merged with a built-in default set. Whitespace-only entries are dropped at parse time.
+	EntityLookupSeeds map[string][]LookupSeed `yaml:"entity_lookup_seeds,omitempty" json:"entity_lookup_seeds,omitempty"`        // canonical-name + aliases table keyed by seed kind (e.g., "country"). Used by the recall path to substitute one entity for another and generalize learned templates.
 }
 
 // LookupSeed is one canonical entity plus optional aliases inside a
@@ -1744,8 +1744,8 @@ type LearnConfig struct {
 // stores against; Aliases are the alternate strings the recall path
 // recognizes as referring to the same entity.
 type LookupSeed struct {
-	Canonical string   `yaml:"canonical" json:"canonical"`                 // canonical entity name (required, non-empty)
-	Aliases   []string `yaml:"aliases,omitempty" json:"aliases,omitempty"` // alternate strings that resolve to Canonical
+	Canonical string   `yaml:"canonical" json:"canonical" pp:"prose"`                 // canonical entity name (required, non-empty)
+	Aliases   []string `yaml:"aliases,omitempty" json:"aliases,omitempty" pp:"prose"` // alternate strings that resolve to Canonical
 }
 
 // MCPConfig declares how the generated MCP server binary is shaped. When the
@@ -1798,7 +1798,7 @@ type MCPConfig struct {
 // pattern, not here.
 type Intent struct {
 	Name        string        `yaml:"name" json:"name"`                           // MCP tool name; snake_case, unique within the spec
-	Description string        `yaml:"description" json:"description"`             // agent-facing description; should name the *intent*, not the endpoints
+	Description string        `yaml:"description" json:"description" pp:"prose"`  // agent-facing description; should name the *intent*, not the endpoints
 	Params      []IntentParam `yaml:"params,omitempty" json:"params,omitempty"`   // input parameters the intent tool exposes to MCP callers
 	Steps       []IntentStep  `yaml:"steps" json:"steps"`                         // ordered list of endpoint calls; at least one required
 	Returns     string        `yaml:"returns,omitempty" json:"returns,omitempty"` // capture name whose value is returned to the caller; defaults to the last step's capture when blank
@@ -1811,7 +1811,7 @@ type IntentParam struct {
 	Name        string `yaml:"name" json:"name"`
 	Type        string `yaml:"type" json:"type"` // one of: string, integer, boolean
 	Required    bool   `yaml:"required,omitempty" json:"required,omitempty"`
-	Description string `yaml:"description" json:"description"`
+	Description string `yaml:"description" json:"description" pp:"prose"`
 }
 
 // IntentStep declares one endpoint call inside an intent. Endpoint references
@@ -1846,7 +1846,7 @@ func (m MCPConfig) HasTransport(t string) bool {
 }
 
 type Resource struct {
-	Description        string   `yaml:"description" json:"description"`
+	Description        string   `yaml:"description" json:"description" pp:"prose"`
 	DescriptionDerived bool     `yaml:"-" json:"-"`
 	Path               string   `yaml:"path,omitempty" json:"path,omitempty"`             // base path for operations shorthand (e.g., /api/items)
 	Operations         []string `yaml:"operations,omitempty" json:"operations,omitempty"` // shorthand: list, get, create, update, delete, search
@@ -1923,7 +1923,7 @@ type Endpoint struct {
 	Method      string `yaml:"method" json:"method"`
 	Path        string `yaml:"path" json:"path"`
 	BaseURL     string `yaml:"base_url,omitempty" json:"base_url,omitempty"`
-	Description string `yaml:"description" json:"description"`
+	Description string `yaml:"description" json:"description" pp:"prose"`
 	// DescriptionSynthesized marks descriptions generated by parser fallback
 	// when both summary and description are absent in the source operation.
 	// Internal-only provenance: never serialized.
@@ -1966,7 +1966,7 @@ type Endpoint struct {
 	// probes when generic synthesized args cannot satisfy an endpoint's
 	// conditional input contract. The runtime consumes it from the generated
 	// Cobra annotation `pp:happy-args`.
-	HappyArgs string `yaml:"happy_args,omitempty" json:"happy_args,omitempty"`
+	HappyArgs string `yaml:"happy_args,omitempty" json:"happy_args,omitempty" pp:"prose"`
 	// EmbeddedPagedSubresources names paged-envelope properties nested
 	// inside this endpoint's success response (e.g. GET /<resource>/{id}
 	// where the API caps the embedded sub-resource at the first page
@@ -2185,8 +2185,8 @@ type Param struct {
 	Positional  bool     `yaml:"positional" json:"positional"`
 	PathParam   bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
 	GlobalScope bool     `yaml:"global_scope,omitempty" json:"global_scope,omitempty"`
-	Default     any      `yaml:"default" json:"default"`
-	Description string   `yaml:"description" json:"description"`
+	Default     any      `yaml:"default" json:"default" pp:"prose"`
+	Description string   `yaml:"description" json:"description" pp:"prose"`
 	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
 	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
 	Format      string   `yaml:"format,omitempty" json:"format,omitempty"` // OpenAPI format hints (date-time, email, uri, etc.)
@@ -2199,8 +2199,8 @@ type Param struct {
 	// generator heuristics distinguish an omitted value from an explicit false.
 	DispatchParamSet bool   `yaml:"-" json:"-"`
 	ItemType         string `yaml:"item_type,omitempty" json:"item_type,omitempty"`
-	ItemTemplate     any    `yaml:"item_template,omitempty" json:"item_template,omitempty"`
-	Purpose          string `yaml:"purpose,omitempty" json:"purpose,omitempty"`
+	ItemTemplate     any    `yaml:"item_template,omitempty" json:"item_template,omitempty" pp:"prose"`
+	Purpose          string `yaml:"purpose,omitempty" json:"purpose,omitempty" pp:"prose"`
 	// FieldSelectorDefault is a sync-time default for field-selector params
 	// such as opt_fields, fields, expand, include, or select. It stays separate
 	// from Default so generated endpoint commands do not silently change their
@@ -2626,7 +2626,7 @@ type TypeField struct {
 	// is used in a generated GraphQL query. It lets wrapper specs keep the Go
 	// field simple (for example, totalPriceSet as json.RawMessage) while still
 	// issuing valid nested GraphQL selections.
-	Selection string `yaml:"selection,omitempty" json:"selection,omitempty"`
+	Selection string `yaml:"selection,omitempty" json:"selection,omitempty" pp:"rawstring"`
 	// IdentName overrides Name for Go-identifier derivation when two field
 	// names in the same struct sanitize to the same identifier through
 	// camel-casing. Wire-side serialization always reads Name.
@@ -2677,6 +2677,11 @@ func ParseBytes(data []byte) (*APISpec, error) {
 	}
 	if err := s.Validate(); err != nil {
 		return nil, fmt.Errorf("validation: %w", err)
+	}
+	// Data-layer Go-code-injection guard — runs even when downstream generation
+	// uses --validate=false, since this is parse-time, not part of Validate().
+	if err := GuardStructuralStrings(&s); err != nil {
+		return nil, err
 	}
 	return &s, nil
 }

--- a/internal/spec/structural_guard.go
+++ b/internal/spec/structural_guard.go
@@ -1,0 +1,126 @@
+package spec
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// GuardStructuralStrings is the data-layer defense against Go-code injection in
+// printed CLIs: it walks a parsed APISpec and rejects any *structural* string
+// (URLs, names, headers, paths, params, auth fields, env var names, …) that
+// contains a character able to break out of a generated Go double-quoted string
+// literal — `"`, backtick, backslash, or a control character. Such a value, if
+// emitted into generated Go source, could close the literal and inject code; an
+// untrusted sniffed/imported spec is the threat model.
+//
+// It is enforced at the parse chokepoints (spec.ParseBytes and openapi.Parse)
+// unconditionally, so it holds even when generation runs with --validate=false.
+// The template layer still escapes these values (printf %q / oneline) as
+// defense in depth; this guard closes the whole class at one point regardless of
+// which template site consumes a field.
+//
+// Fields that are *prose* (descriptions, instructions, titles, free-text shown
+// to humans and emitted only through quote-stripping helpers like oneline) are
+// exempt via a `pp:"prose"` struct tag; the exemption propagates to a field's
+// whole subtree.
+// guardMode classifies how a field is emitted into generated Go, which decides
+// which characters can break out of its literal:
+//   - modeStructural: emitted into a Go double-quoted string literal (or used as
+//     an identifier). Reject " ` \ and control chars. This is the default.
+//   - modeRawString (`pp:"rawstring"`): emitted only inside a Go raw string
+//     (backtick) — JSON payloads, GraphQL selections, regexps. " \ and newlines
+//     are legal there; only a backtick can break out, so reject just backtick.
+//   - modeProse (`pp:"prose"`): free text emitted only through quote-stripping
+//     helpers (oneline) or escaped via %q at emit time. No restriction.
+type guardMode int
+
+const (
+	modeStructural guardMode = iota
+	modeRawString
+	modeProse
+)
+
+func GuardStructuralStrings(s *APISpec) error {
+	if s == nil {
+		return nil
+	}
+	return walkStructural(reflect.ValueOf(s), "spec", modeStructural)
+}
+
+func walkStructural(v reflect.Value, path string, mode guardMode) error {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		return walkStructural(v.Elem(), path, mode)
+	case reflect.String:
+		return checkGuardedString(v.String(), path, mode)
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := walkStructural(v.Index(i), fmt.Sprintf("%s[%d]", path, i), mode); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			// Map keys are structural identifiers (resource/endpoint names,
+			// header names, template-var names) regardless of the value mode,
+			// unless the whole field is prose.
+			if k.Kind() == reflect.String && mode == modeStructural {
+				if err := checkGuardedString(k.String(), path+".<key>", modeStructural); err != nil {
+					return err
+				}
+			}
+			if err := walkStructural(v.MapIndex(k), fmt.Sprintf("%s[%v]", path, k.Interface()), mode); err != nil {
+				return err
+			}
+		}
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.PkgPath != "" {
+				continue // unexported
+			}
+			fieldMode := mode
+			switch f.Tag.Get("pp") {
+			case "prose":
+				fieldMode = modeProse
+			case "rawstring":
+				if mode != modeProse { // prose stays the most permissive
+					fieldMode = modeRawString
+				}
+			}
+			if err := walkStructural(v.Field(i), path+"."+f.Name, fieldMode); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkGuardedString(s, path string, mode guardMode) error {
+	field := strings.TrimPrefix(path, "spec.")
+	switch mode {
+	case modeProse:
+		return nil
+	case modeRawString:
+		if strings.ContainsRune(s, '`') {
+			return fmt.Errorf(
+				"raw-string spec field %s contains a backtick: it would break out of the generated Go raw string literal it is emitted into",
+				field)
+		}
+		return nil
+	default: // modeStructural
+		for _, r := range s {
+			if r == '"' || r == '`' || r == '\\' || r < 0x20 {
+				return fmt.Errorf(
+					"structural spec field %s contains disallowed character %q: URLs, names, paths, headers, params and other non-prose fields must not contain quotes, backticks, backslashes, or control characters (they could break out of a generated Go string literal)",
+					field, r)
+			}
+		}
+		return nil
+	}
+}

--- a/internal/spec/structural_guard_test.go
+++ b/internal/spec/structural_guard_test.go
@@ -1,0 +1,123 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func guardBaseSpec() *APISpec {
+	return &APISpec{
+		Name:    "guard-test",
+		Version: "1.0.0",
+		BaseURL: "https://api.example.com",
+		Auth:    AuthConfig{Type: "api_key", Header: "Authorization", Format: "Bearer {token}", EnvVars: []string{"X_TOKEN"}},
+		Resources: map[string]Resource{
+			"items": {Endpoints: map[string]Endpoint{
+				"list": {Method: "GET", Path: "/items"},
+			}},
+		},
+	}
+}
+
+func TestGuardStructuralStringsRejectsInjection(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(s *APISpec)
+		field  string
+	}{
+		{"base_url quote", func(s *APISpec) { s.BaseURL = `https://x"+pwn()+"` }, "BaseURL"},
+		{"auth header quote", func(s *APISpec) { s.Auth.Header = `X-"evil` }, "Auth.Header"},
+		{"auth keyurl backtick", func(s *APISpec) { s.Auth.KeyURL = "https://x`evil" }, "Auth.KeyURL"},
+		{"auth tokenurl backslash", func(s *APISpec) { s.Auth.TokenURL = `https://x\evil` }, "Auth.TokenURL"},
+		{"scope quote", func(s *APISpec) { s.Auth.Scopes = []string{`read"x`} }, "Auth.Scopes"},
+		{"env var name quote", func(s *APISpec) { s.Auth.EnvVars = []string{`X"Y`} }, "Auth.EnvVars"},
+		// Env var names become Go *identifiers* (config struct fields, TOML keys)
+		// in generated code, so they cannot be made safe by template-layer %q —
+		// this parse-time rejection is their authoritative defense.
+		{"env var spec name quote", func(s *APISpec) { s.Auth.EnvVarSpecs = []AuthEnvVar{{Name: `Z"q`}} }, "EnvVarSpecs"},
+		{"resource name quote", func(s *APISpec) {
+			s.Resources = map[string]Resource{`it"ems`: {Endpoints: map[string]Endpoint{"list": {Method: "GET", Path: "/i"}}}}
+		}, "Resources"},
+		{"endpoint method newline", func(s *APISpec) {
+			r := s.Resources["items"]
+			r.Endpoints = map[string]Endpoint{"list": {Method: "GET\n", Path: "/items"}}
+			s.Resources["items"] = r
+		}, "Method"},
+		{"cookie domain quote", func(s *APISpec) { s.Auth.CookieDomain = `.x".com` }, "CookieDomain"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := guardBaseSpec()
+			tc.mutate(s)
+			err := GuardStructuralStrings(s)
+			require.Error(t, err, "injection in %s must be rejected", tc.field)
+			assert.Contains(t, err.Error(), tc.field)
+		})
+	}
+}
+
+func TestGuardStructuralStringsAllowsProse(t *testing.T) {
+	t.Parallel()
+
+	s := guardBaseSpec()
+	// Prose / emit-time-escaped fields legitimately carry quotes, backslashes,
+	// and newlines; the guard must not reject them.
+	s.Description = `He said "hi"; path C:\temp` + "\nsecond line"
+	s.Auth.Instructions = `Settings → Tokens → "Generate new"`
+	s.Auth.Title = `API "key"`
+	r := s.Resources["items"]
+	ep := r.Endpoints["list"]
+	ep.Description = "Returns \"items\"\nas JSON"
+	ep.Params = []Param{{Name: "q", Type: "string", Description: `search "term"`, Default: `a"b\c`}}
+	r.Endpoints["list"] = ep
+	s.Resources["items"] = r
+
+	require.NoError(t, GuardStructuralStrings(s), "prose/escaped-at-emit fields must be allowed to contain quotes")
+}
+
+func TestGuardStructuralStringsRawStringFields(t *testing.T) {
+	t.Parallel()
+
+	// rawstring fields are emitted inside Go backtick raw strings: quotes,
+	// backslashes and newlines are legal there, but a backtick breaks out.
+	allow := guardBaseSpec()
+	allow.Streaming.SubscribeShape = "{\"action\":\"subscribe\",\n\"path\":\"a\\b\"}"
+	require.NoError(t, GuardStructuralStrings(allow), "rawstring field may contain quotes/backslash/newline")
+
+	reject := guardBaseSpec()
+	reject.Streaming.SubscribeShape = "{\"x\":\"`+pwn()+`\"}"
+	err := GuardStructuralStrings(reject)
+	require.Error(t, err, "a backtick in a rawstring field must be rejected")
+	assert.Contains(t, err.Error(), "SubscribeShape")
+}
+
+func TestGuardStructuralStringsParseRejectsInternalSpec(t *testing.T) {
+	t.Parallel()
+
+	// End-to-end through ParseBytes: a base_url breakout payload must be rejected
+	// at parse time (not silently carried into generation).
+	yaml := `
+name: pwn
+version: 1.0.0
+base_url: 'https://x"+pwn()+"'
+auth:
+  type: api_key
+  header: Authorization
+  env_vars: [X_TOKEN]
+resources:
+  items:
+    endpoints:
+      list:
+        method: GET
+        path: /items
+`
+	_, err := ParseBytes([]byte(yaml))
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "disallowed character")
+}


### PR DESCRIPTION
## Intent

Harden generated **printed CLIs** against a Go-code-injection class: spec-derived values were emitted unescaped into generated Go source, so a quote-bearing value in an **untrusted** spec (reverse-engineered from a sniffed HAR or a fetched domain) could break out of a Go string literal and inject code that compiles and runs when a user builds/installs the generated CLI. Because the injected code compiles cleanly, all 8 quality gates (`go build`/`go vet`/`govulncheck`) pass.

Issue: N/A — security hardening. Happy to move detail into a private security advisory if you'd prefer.

## Approach

Two layers (defense in depth):

1. **Template escaping** — spec-derived values now emit through `printf "%q"` (whole literals) or `oneline` (embedded / quote-stripping), and `enumDescriptionHint` self-sanitizes its enum values. Two regression guards: a **static scanner** (`TestGoTemplatesEscapeSpecValuesInStringLiterals`, backtick/comment aware) and a **dynamic** generate-then-parse test that generates with a quote-bearing payload across auth variants and asserts every emitted `.go` still parses.
2. **Data-layer guard** — `spec.GuardStructuralStrings` reflection-walks a parsed `APISpec` and rejects `"` / backtick / backslash / control chars in **structural** fields (URLs, names, headers, paths, params, env vars, …), hooked into `spec.ParseBytes`, `openapi.Parse` and `graphql.ParseSDLBytes` so it runs even with `--validate=false`. Prose and raw-string fields are exempt via `pp:"prose"` / `pp:"rawstring"` struct tags; the exemption set was chosen by running the guard against every shipped catalog + testdata spec until zero false positives (locked by a corpus test).

Cross-reviewed with Codex across multiple adversarial rounds (it surfaced the helper-wrapped, `$var`, raw-string-backtick and SDL-parser gaps that the single-layer approach kept missing — which is what motivated the parse-layer guard).

## Scope

Primary area: `cli` (generator templates, `internal/spec`, `internal/openapi`, `internal/graphql`).

Why this belongs in this repo: it's a machine change — every future printed CLI inherits the escaping and the parse-time guard.

## Catalog Justification

N/A

## Risk

Low for existing specs: `%q`/`oneline` are identity transforms on benign (quote-free) values, and the guard only rejects malformed structural input. **Golden output is unchanged (31/31).** The guard was verified to produce zero false positives against the full shipped spec corpus (catalog + testdata). The only behavior change is that a spec with quotes/backticks/backslashes in a structural field is now rejected at parse time with a field-named error instead of being silently carried into generation.

## Output Contract

Generated output unchanged — `scripts/golden.sh verify` passes 31/31. New evidence: static template scanner, a dynamic generate+`go/parser` test (payload-based, compiled-parse assertion), and a parse-corpus false-positive test.

## Verification

- `scripts/golden.sh verify` → **31/31, no changed cases**
- Guard + injection tests green: `internal/spec`, `internal/openapi`, `internal/graphql`, `internal/generator` (scanner + dynamic generate/parse + negative control)
- Commit builds in an isolated `git worktree` (EXIT 0) and its guard tests pass there
- Note: full `go test ./...` should be confirmed by CI — the local sandbox SIGABRTs on keychain/cgo + network-touching tests unrelated to this change.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)
