### PR TITLE
fix(cli): filter telemetry hosts in browser sniff

### DIFF
--- a/internal/browsersniff/classifier.go
+++ b/internal/browsersniff/classifier.go
@@ -65,6 +65,9 @@ var (
 		"amplitude.com",
 		"pendo.io",
 		"hotjar.com",
+		"vortex.data.microsoft.com",
+		"dc.services.visualstudio.com",
+		"analytics.google.com",
 	}
 	telemetryPathMarkers = []string{"/sentry/envelope/", "/intake/v1/", "/intercom/"}
 	telemetryQueryKeys   = []string{"sentry_key", "dd-api-key", "dd-client-token", "ddsource", "intercom-device-id"}

--- a/internal/browsersniff/classifier_test.go
+++ b/internal/browsersniff/classifier_test.go
@@ -148,6 +148,50 @@ func TestClassifyEntries(t *testing.T) {
 			},
 		},
 		{
+			name: "known telemetry hosts with json post bodies are noise",
+			entries: []EnrichedEntry{
+				{
+					Method:              "POST",
+					URL:                 "https://vortex.data.microsoft.com/collect/v1",
+					RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+					RequestBody:         `{"name":"Microsoft.ApplicationInsights.PageView"}`,
+					ResponseContentType: "application/json",
+					ResponseBody:        `{"itemsReceived":1,"itemsAccepted":1}`,
+				},
+				{
+					Method:              "POST",
+					URL:                 "https://dc.services.visualstudio.com/v2/track",
+					RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+					RequestBody:         `[{"name":"Microsoft.ApplicationInsights.Event"}]`,
+					ResponseContentType: "application/json",
+					ResponseBody:        `{"itemsReceived":1,"itemsAccepted":1}`,
+				},
+				{
+					Method:              "POST",
+					URL:                 "https://analytics.google.com/g/collect",
+					RequestHeaders:      map[string]string{"Content-Type": "application/json"},
+					RequestBody:         `{"client_id":"abc"}`,
+					ResponseContentType: "application/json",
+					ResponseBody:        `{}`,
+				},
+			},
+			wantNoiseURLs: []string{
+				"https://vortex.data.microsoft.com/collect/v1",
+				"https://dc.services.visualstudio.com/v2/track",
+				"https://analytics.google.com/g/collect",
+			},
+			wantClassByURL: map[string]string{
+				"https://vortex.data.microsoft.com/collect/v1":  "noise",
+				"https://dc.services.visualstudio.com/v2/track": "noise",
+				"https://analytics.google.com/g/collect":        "noise",
+			},
+			wantIsNoiseByURL: map[string]bool{
+				"https://vortex.data.microsoft.com/collect/v1":  true,
+				"https://dc.services.visualstudio.com/v2/track": true,
+				"https://analytics.google.com/g/collect":        true,
+			},
+		},
+		{
 			name: "first-party intake path without telemetry query remains api",
 			entries: []EnrichedEntry{
 				{


### PR DESCRIPTION
## Summary

Browser-sniff now treats the known Application Insights and analytics collection hosts from the RUAF retro as telemetry noise before normal API scoring runs. High-scoring JSON POST beacons such as `https://vortex.data.microsoft.com/collect/v1` no longer become spurious `collect` endpoints in sniffed specs.

Closes #2711

## Verification

- `go test ./internal/browsersniff -run 'TestClassifyEntries'`
- `git diff --check`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
