### PR TITLE
fix(cli): allow synthetic phase5 external credential skips

### DIFF
--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -114,6 +114,7 @@ type CLIManifest struct {
 	SpecURL            string            `json:"spec_url,omitempty"`
 	SpecPath           string            `json:"spec_path,omitempty"`
 	SpecFormat         string            `json:"spec_format,omitempty"`
+	SpecKind           string            `json:"spec_kind,omitempty"`
 	SpecSource         string            `json:"spec_source,omitempty"`
 	SpecChecksum       string            `json:"spec_checksum,omitempty"`
 	RunID              string            `json:"run_id,omitempty"`
@@ -188,6 +189,12 @@ func (m CLIManifest) IsLocalDatastore() bool {
 		return true
 	}
 	return strings.Contains(source, "local") && strings.Contains(source, "sqlite")
+}
+
+// IsSyntheticSpec reports whether the manifest came from a spec marked
+// `kind: synthetic`, which relaxes gates that assume HTTP API reachability.
+func (m CLIManifest) IsSyntheticSpec() bool {
+	return strings.EqualFold(strings.TrimSpace(m.SpecKind), spec.KindSynthetic)
 }
 
 // NovelFeatureManifest is a compact representation of a transcendence feature
@@ -669,6 +676,7 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	if parsed == nil {
 		return
 	}
+	m.SpecKind = parsed.Kind
 	total, public := parsed.CountMCPTools()
 	mcpName := m.APIName
 	if mcpName == "" {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -654,6 +654,7 @@ resources:
 	assert.Equal(t, 1, got.MCPPublicToolCount)
 	assert.Equal(t, "full", got.MCPReady)
 	assert.Equal(t, "bearer_token", got.AuthType)
+	assert.Empty(t, got.SpecKind)
 	assert.Equal(t, []string{"INTERNAL_SPEC_TOKEN"}, got.AuthEnvVars)
 }
 
@@ -736,6 +737,32 @@ func TestWriteManifestForGenerateStampsLocalSQLiteSpecFormat(t *testing.T) {
 	assert.Equal(t, spec.SourceLocalSQLite, got.SpecFormat)
 	assert.True(t, got.IsLocalDatastore())
 	assert.Equal(t, "local-data.yaml", got.SpecPath)
+}
+
+func TestWriteManifestForGenerateStampsSyntheticSpecKind(t *testing.T) {
+	dir := t.TempDir()
+	syntheticSpec := &spec.APISpec{
+		Name: "aws-billing",
+		Kind: spec.KindSynthetic,
+		Auth: spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"costs": {Endpoints: map[string]spec.Endpoint{"list": {Method: "GET", Path: "/costs"}}},
+		},
+	}
+
+	require.NoError(t, WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "aws-billing",
+		OutputDir: dir,
+		Spec:      syntheticSpec,
+	}))
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, spec.KindSynthetic, got.SpecKind)
+	assert.True(t, got.IsSyntheticSpec())
 }
 
 func TestWriteManifestForGenerateMCPBManifestUsesResolvedMCPBinarySlug(t *testing.T) {

--- a/internal/pipeline/lock.go
+++ b/internal/pipeline/lock.go
@@ -423,6 +423,7 @@ func validatePhase5GateForPromote(workingDir string, state *PipelineState) error
 			manifest.CLIName = existing.CLIName
 		}
 		manifest.AuthType = existing.AuthType
+		manifest.SpecKind = existing.SpecKind
 	}
 
 	result := ValidatePhase5Gate(state.ProofsDir(), manifest)

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -690,7 +690,7 @@ func TestPromoteWorkingCLI_AllowsSyntheticExternalCredentialPhase5Skip(t *testin
 		CLIName:       "aws-billing-pp-cli",
 		RunID:         "run-synthetic-skip",
 		AuthType:      "none",
-		SpecKind:      "synthetic",
+		SpecKind:      spec.KindSynthetic,
 	}))
 
 	state := NewStateWithRun("aws-billing", workDir, "run-synthetic-skip", "test-scope")

--- a/internal/pipeline/lock_test.go
+++ b/internal/pipeline/lock_test.go
@@ -674,6 +674,47 @@ func TestPromoteWorkingCLI_RejectsManualPhase5Marker(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
+func TestPromoteWorkingCLI_AllowsSyntheticExternalCredentialPhase5Skip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", tmp)
+	t.Setenv("PRINTING_PRESS_SCOPE", "test-scope")
+	t.Setenv("PRINTING_PRESS_REPO_ROOT", tmp)
+
+	workDir := filepath.Join(tmp, "working", "aws-billing-pp-cli")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module aws-billing-pp-cli\n\ngo 1.21\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+	require.NoError(t, WriteCLIManifest(workDir, CLIManifest{
+		SchemaVersion: CurrentCLIManifestSchemaVersion,
+		APIName:       "aws-billing",
+		CLIName:       "aws-billing-pp-cli",
+		RunID:         "run-synthetic-skip",
+		AuthType:      "none",
+		SpecKind:      "synthetic",
+	}))
+
+	state := NewStateWithRun("aws-billing", workDir, "run-synthetic-skip", "test-scope")
+	writePhase5GateMarker(t, state.ProofsDir(), Phase5SkipFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       state.APIName,
+		RunID:         state.RunID,
+		Status:        "skip",
+		Level:         "none",
+		SkipReason:    phase5SkipReasonExternalCredentialsUnavailable,
+		AuthContext:   Phase5AuthContext{Type: "oauth2", APIKeyAvailable: false},
+	})
+
+	err := PromoteWorkingCLI("aws-billing-pp-cli", workDir, state)
+	require.NoError(t, err)
+
+	libDir := filepath.Join(PublishedLibraryRoot(), "aws-billing")
+	data, err := os.ReadFile(filepath.Join(libDir, CLIManifestFilename))
+	require.NoError(t, err)
+	var got CLIManifest
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "synthetic", got.SpecKind)
+}
+
 func TestPromoteWorkingCLI_MinimalStateNoRunstate(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", tmp)

--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -15,9 +15,10 @@ const (
 	phase5AcceptanceLevelQuick = "quick"
 	phase5AcceptanceLevelFull  = "full"
 
-	phase5SkipReasonAuthRequiredNoCredential    = "auth_required_no_credential"
-	phase5SkipReasonLANUnreachableFromHost      = "lan-unreachable-from-generation-host"
-	phase5SkipReasonLocalSourceRequiresDatabase = "local_source_requires_operator_database"
+	phase5SkipReasonAuthRequiredNoCredential       = "auth_required_no_credential"
+	phase5SkipReasonExternalCredentialsUnavailable = "external_credentials_unavailable"
+	phase5SkipReasonLANUnreachableFromHost         = "lan-unreachable-from-generation-host"
+	phase5SkipReasonLocalSourceRequiresDatabase    = "local_source_requires_operator_database"
 )
 
 var phase5AcceptedAcceptanceLevels = []string{
@@ -258,13 +259,13 @@ func validatePhase5SkipMarker(marker Phase5GateMarker) string {
 func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, string) {
 	authType := strings.ToLower(strings.TrimSpace(manifest.AuthType))
 	markerAuthType := strings.ToLower(strings.TrimSpace(marker.AuthContext.Type))
+	skipReason := phase5SkipReason(marker)
 	if authType == "" {
 		authType = markerAuthType
-	} else if markerAuthType != "" && markerAuthType != authType {
+	} else if markerAuthType != "" && markerAuthType != authType && (authType != "none" || !phase5SyntheticExternalCredentialSkip(manifest, skipReason)) {
 		return false, fmt.Sprintf("phase5 skip marker auth type %q does not match manifest auth type %q", marker.AuthContext.Type, manifest.AuthType)
 	}
 	if authType == "" || authType == "none" {
-		skipReason := phase5SkipReason(marker)
 		if manifest.IsLocalDatastore() {
 			if skipReason == phase5SkipReasonLocalSourceRequiresDatabase {
 				return true, ""
@@ -274,6 +275,12 @@ func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, str
 		if skipReason == phase5SkipReasonLANUnreachableFromHost {
 			if !marker.AuthContext.LocalNetworkOnly {
 				return false, "phase5 LAN-unreachable skip requires auth_context.local_network_only=true"
+			}
+			return true, ""
+		}
+		if phase5SyntheticExternalCredentialSkip(manifest, skipReason) {
+			if marker.AuthContext.APIKeyAvailable {
+				return false, "phase5 skip claims an API key was available"
 			}
 			return true, ""
 		}
@@ -298,4 +305,8 @@ func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, str
 
 func phase5SkipReason(marker Phase5GateMarker) string {
 	return strings.ToLower(strings.TrimSpace(marker.SkipReason))
+}
+
+func phase5SyntheticExternalCredentialSkip(manifest CLIManifest, skipReason string) bool {
+	return manifest.IsSyntheticSpec() && skipReason == phase5SkipReasonExternalCredentialsUnavailable
 }

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -347,7 +348,7 @@ func TestValidatePhase5Gate_NoAuthRequiresPassMarker(t *testing.T) {
 
 func TestValidatePhase5Gate_SyntheticNoAuthAllowsExternalCredentialSkip(t *testing.T) {
 	proofsDir := t.TempDir()
-	manifest := CLIManifest{APIName: "aws-billing", CLIName: "aws-billing-pp-cli", RunID: "run-1", AuthType: "none", SpecKind: "synthetic"}
+	manifest := CLIManifest{APIName: "aws-billing", CLIName: "aws-billing-pp-cli", RunID: "run-1", AuthType: "none", SpecKind: spec.KindSynthetic}
 	writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
 		SchemaVersion: 1,
 		APIName:       "aws-billing",

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -345,6 +345,42 @@ func TestValidatePhase5Gate_NoAuthRequiresPassMarker(t *testing.T) {
 	assert.Contains(t, result.Detail, "no-auth")
 }
 
+func TestValidatePhase5Gate_SyntheticNoAuthAllowsExternalCredentialSkip(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "aws-billing", CLIName: "aws-billing-pp-cli", RunID: "run-1", AuthType: "none", SpecKind: "synthetic"}
+	writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "aws-billing",
+		RunID:         "run-1",
+		Status:        "skip",
+		Level:         "none",
+		SkipReason:    phase5SkipReasonExternalCredentialsUnavailable,
+		AuthContext:   Phase5AuthContext{Type: "oauth2", APIKeyAvailable: false},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.True(t, result.Passed, result.Detail)
+	assert.Equal(t, "skip", result.Status)
+}
+
+func TestValidatePhase5Gate_StandardNoAuthRejectsExternalCredentialSkip(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "public-data", CLIName: "public-data-pp-cli", RunID: "run-1", AuthType: "none"}
+	writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "public-data",
+		RunID:         "run-1",
+		Status:        "skip",
+		Level:         "none",
+		SkipReason:    phase5SkipReasonExternalCredentialsUnavailable,
+		AuthContext:   Phase5AuthContext{Type: "none", APIKeyAvailable: false},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.False(t, result.Passed)
+	assert.Contains(t, result.Detail, "no-auth")
+}
+
 func TestValidatePhase5Gate_NoAuthLANUnreachableSkipAllowed(t *testing.T) {
 	proofsDir := t.TempDir()
 	manifest := CLIManifest{APIName: "sonos", CLIName: "sonos-pp-cli", RunID: "run-1", AuthType: "none"}

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -261,6 +261,9 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 			if existing.APIVersion != "" {
 				m.APIVersion = existing.APIVersion
 			}
+			if existing.SpecKind != "" {
+				m.SpecKind = existing.SpecKind
+			}
 			m.MCPBinary = existing.MCPBinary
 			m.MCPToolCount = existing.MCPToolCount
 			m.MCPPublicToolCount = existing.MCPPublicToolCount


### PR DESCRIPTION
## Summary
Synthetic SDK-backed CLIs that rely on out-of-band credential chains can now promote when live credentials are unavailable. A generated CLI manifest records `spec_kind: synthetic`, and the phase5 promote gate accepts `phase5-skip.json` with `skip_reason: external_credentials_unavailable` only for that synthetic no-auth case.

Standard `auth: none` HTTP CLIs still require a real phase5 pass marker, and the promote path now carries manifest spec provenance into the gate before validating skips.

Closes #2479

## Tests
- `go test ./internal/pipeline -run 'TestValidatePhase5Gate_(SyntheticNoAuthAllowsExternalCredentialSkip|StandardNoAuthRejectsExternalCredentialSkip|NoAuthRequiresPassMarker|SkipCannotOverrideManifestAuthType)$'`
- `go test ./internal/pipeline -run 'TestWriteManifestForGenerateStampsSyntheticSpecKind|TestPromoteWorkingCLI_AllowsSyntheticExternalCredentialPhase5Skip'`
- `go test ./internal/pipeline -run 'TestValidatePhase5Gate|TestWriteManifestForGenerateStampsSyntheticSpecKind|TestPromoteWorkingCLI_AllowsSyntheticExternalCredentialPhase5Skip' -count=1`
- `scripts/golden.sh verify`
- pre-push hook: `fmt` and `golangci-lint` passed

`go test ./...` currently fails in `internal/pipeline` at `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged`; rerunning that test alone reproduces the same positional live-dogfood failure, outside the phase5/manifest paths changed here.
