### PR TITLE
feat(cli): add Apify actor reachability audit

### DIFF
--- a/internal/cli/apify_actor_audit.go
+++ b/internal/cli/apify_actor_audit.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+func newApifyActorAuditCmd() *cobra.Command {
+	var dir string
+	var researchDir string
+	var asJSON bool
+	var baseURL string
+
+	cmd := &cobra.Command{
+		Use:   "apify-audit",
+		Short: "Verify referenced Apify actors are reachable",
+		Long: `Scan a generated CLI and optional research directory for Apify actor IDs
+used with actor run endpoints, then probe GET /v2/acts/{actor}. The audit checks
+actor reachability only and never starts paid actor runs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := pipeline.RunApifyActorAudit(context.Background(), pipeline.ApifyActorAuditOptions{
+				Dir:         dir,
+				ResearchDir: researchDir,
+				BaseURL:     baseURL,
+			})
+			if err != nil {
+				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("apify actor audit: %w", err)}
+			}
+			if err := pipeline.WriteApifyActorAuditReport(dir, report); err != nil {
+				return &ExitError{Code: ExitGenerationError, Err: err}
+			}
+
+			if asJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(report); err != nil {
+					return fmt.Errorf("rendering Apify actor audit JSON: %w", err)
+				}
+			} else {
+				printApifyActorAuditReport(report)
+			}
+
+			if report.Verdict == pipeline.ApifyActorAuditFail {
+				return &ExitError{Code: ExitGenerationError, Err: fmt.Errorf("apify actor audit failed: %d issue(s)", len(report.Issues))}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", "", "Path to the generated CLI directory (required)")
+	cmd.Flags().StringVar(&researchDir, "research-dir", "", "Pipeline directory containing research.json")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+	cmd.Flags().StringVar(&baseURL, "base-url", "", "Override Apify API base URL (for tests)")
+	_ = cmd.Flags().MarkHidden("base-url")
+	_ = cmd.MarkFlagRequired("dir")
+	return cmd
+}
+
+func printApifyActorAuditReport(report *pipeline.ApifyActorAuditReport) {
+	fmt.Println("Apify Actor Audit")
+	fmt.Println("=================")
+	fmt.Println()
+	for _, actor := range report.Actors {
+		fmt.Printf("%s: %s\n", actor.ID, actor.Status)
+		if actor.Detail != "" {
+			fmt.Printf("  %s\n", actor.Detail)
+		}
+		for _, source := range actor.Sources {
+			fmt.Printf("  - %s\n", source)
+		}
+	}
+	if len(report.Actors) == 0 {
+		fmt.Println("No Apify actor references found.")
+	}
+	fmt.Println()
+	fmt.Printf("Verdict: %s\n", report.Verdict)
+	for _, issue := range report.Issues {
+		fmt.Printf("  - %s\n", issue)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -96,6 +96,7 @@ func NewRootCommand(commandName string) *cobra.Command {
 	rootCmd.AddCommand(newPublishCmd())
 	rootCmd.AddCommand(newPolishCmd())
 	rootCmd.AddCommand(newWorkflowVerifyCmd())
+	rootCmd.AddCommand(newApifyActorAuditCmd())
 	rootCmd.AddCommand(newShipcheckCmd())
 	rootCmd.AddCommand(newLockCmd())
 	rootCmd.AddCommand(newMCPAuditCmd())

--- a/internal/cli/shipcheck.go
+++ b/internal/cli/shipcheck.go
@@ -17,7 +17,7 @@ import (
 )
 
 // shipcheck is the canonical Phase 4 verification umbrella. It runs each
-// of the six legs as a subprocess of the same printing-press binary,
+// leg as a subprocess of the same printing-press binary,
 // aggregates exit codes, and prints a per-leg summary. Legs remain
 // callable standalone — this command is purely additive orchestration.
 //
@@ -67,7 +67,7 @@ type shipcheckLeg struct {
 	args func(*shipcheckOpts) []string
 }
 
-// shipcheckLegs enumerates the six legs in canonical execution order.
+// shipcheckLegs enumerates the legs in canonical execution order.
 // Order matters: verify builds the binary; validate-narrative checks
 // research.json command paths against the binary BEFORE dogfood synthesizes
 // README/SKILL from those commands.
@@ -122,6 +122,16 @@ var shipcheckLegs = []shipcheckLeg{
 		name: "workflow-verify",
 		args: func(o *shipcheckOpts) []string {
 			return []string{"workflow-verify", "--dir", o.dir}
+		},
+	},
+	{
+		name: "apify-audit",
+		args: func(o *shipcheckOpts) []string {
+			a := []string{"apify-audit", "--dir", o.dir}
+			if o.researchDir != "" {
+				a = append(a, "--research-dir", o.researchDir)
+			}
+			return a
 		},
 	},
 	{
@@ -410,7 +420,7 @@ func newShipcheckCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "shipcheck",
-		Short: "Run all six verification legs (verify, validate-narrative, dogfood, workflow-verify, verify-skill, scorecard) as one canonical Phase 4 sweep",
+		Short: "Run all verification legs as one canonical Phase 4 sweep",
 		Long: `shipcheck runs every Phase 4 verification leg in sequence and aggregates their
 exit codes into a single verdict. It is the canonical local invocation that
 matches what the public-library CI runs.
@@ -420,6 +430,7 @@ Legs (in canonical order):
   validate-narrative — README/SKILL narrative commands against the built CLI
   dogfood          — structural validation against the source spec
   workflow-verify  — primary workflow end-to-end against the verification manifest
+  apify-audit      — Apify actor reachability checks for actor-backed CLIs
   verify-skill     — SKILL.md flag/positional/command consistency with the shipped CLI
   scorecard        — Steinberger quality bar (with --live-check sampled output probes)
 

--- a/internal/cli/shipcheck_test.go
+++ b/internal/cli/shipcheck_test.go
@@ -216,8 +216,8 @@ func TestShipcheck_AllLegsPass(t *testing.T) {
 		t.Fatalf("expected %d leg invocations; got %d: %v", len(shipcheckLegs), len(invocations), invocations)
 	}
 
-	// Confirm canonical order: verify, validate-narrative, dogfood, workflow-verify, verify-skill, scorecard.
-	wantOrder := []string{"verify", "validate-narrative", "dogfood", "workflow-verify", "verify-skill", "scorecard"}
+	// Confirm canonical order: verify, validate-narrative, dogfood, workflow-verify, apify-audit, verify-skill, scorecard.
+	wantOrder := []string{"verify", "validate-narrative", "dogfood", "workflow-verify", "apify-audit", "verify-skill", "scorecard"}
 	for i, want := range wantOrder {
 		// argv[0] is the stub binary path; argv[1] is the leg name.
 		if len(invocations[i]) < 2 {
@@ -230,7 +230,7 @@ func TestShipcheck_AllLegsPass(t *testing.T) {
 }
 
 // TestShipcheck_OneLegFails: verify-skill exits 1, umbrella returns
-// ExitError with code 1; all six legs still ran (no fail-fast).
+// ExitError with code 1; all legs still ran (no fail-fast).
 func TestShipcheck_OneLegFails(t *testing.T) {
 	h := newShipcheckHarness(t)
 	t.Setenv("STUB_EXIT_VERIFY_SKILL", "1")
@@ -352,6 +352,11 @@ func TestShipcheck_PassesSpecAndResearchDir(t *testing.T) {
 	}
 	if !argvHas(scorecardArgs, "--research-dir") || !argvHas(scorecardArgs, researchDir) {
 		t.Errorf("scorecard argv missing --research-dir: %v", scorecardArgs)
+	}
+
+	apifyArgs := findInvocation(invocations, "apify-audit")
+	if !argvHas(apifyArgs, "--research-dir") || !argvHas(apifyArgs, researchDir) {
+		t.Errorf("apify-audit argv missing --research-dir: %v", apifyArgs)
 	}
 
 	// workflow-verify, verify-skill, and validate-narrative don't take --spec or --research-dir;
@@ -556,7 +561,7 @@ func TestShipcheck_PassesAuthFlagsToVerify(t *testing.T) {
 	}
 
 	// Other legs must NOT receive these flags — they don't accept them.
-	for _, leg := range []string{"dogfood", "workflow-verify", "verify-skill", "scorecard"} {
+	for _, leg := range []string{"dogfood", "workflow-verify", "apify-audit", "verify-skill", "scorecard"} {
 		args := findInvocation(invocations, leg)
 		if argvHas(args, "--api-key") {
 			t.Errorf("%s argv should not include --api-key; got %v", leg, args)
@@ -581,7 +586,7 @@ func TestShipcheck_StrictPassesToVerifySkill(t *testing.T) {
 	if !argvHas(vsArgs, "--strict") {
 		t.Errorf("verify-skill argv missing --strict: %v", vsArgs)
 	}
-	for _, leg := range []string{"dogfood", "verify", "workflow-verify", "scorecard"} {
+	for _, leg := range []string{"dogfood", "verify", "workflow-verify", "apify-audit", "scorecard"} {
 		args := findInvocation(invocations, leg)
 		if argvHas(args, "--strict") {
 			t.Errorf("%s argv should not include --strict; got %v", leg, args)

--- a/internal/pipeline/apify_actor_audit.go
+++ b/internal/pipeline/apify_actor_audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"net/url"
@@ -57,8 +58,7 @@ type ApifyActorAuditReport struct {
 	Issues      []string               `json:"issues,omitempty"`
 }
 
-var apifyActorIDRe = regexp.MustCompile(`\b[A-Za-z0-9][A-Za-z0-9_-]*~[A-Za-z0-9][A-Za-z0-9_-]*\b`)
-var apifyActPathRe = regexp.MustCompile(`/acts/([A-Za-z0-9][A-Za-z0-9_-]*~[A-Za-z0-9][A-Za-z0-9_-]*)(?:/|%2[Ff])`)
+var apifyActPathRe = regexp.MustCompile(`/acts/([A-Za-z0-9][A-Za-z0-9_-]*~[A-Za-z0-9][A-Za-z0-9_-]*)(?:/|%2[Ff]|[?#"'\s),;\]}]|$)`)
 
 func RunApifyActorAudit(ctx context.Context, opts ApifyActorAuditOptions) (*ApifyActorAuditReport, error) {
 	if strings.TrimSpace(opts.Dir) == "" {
@@ -218,9 +218,6 @@ func apifyActorIDsInContent(content string) []string {
 	for _, m := range apifyActPathRe.FindAllStringSubmatch(content, -1) {
 		seen[m[1]] = struct{}{}
 	}
-	for _, id := range apifyActorIDRe.FindAllString(content, -1) {
-		seen[id] = struct{}{}
-	}
 	out := make([]string, 0, len(seen))
 	for id := range seen {
 		out = append(out, id)
@@ -242,7 +239,10 @@ func probeApifyActor(ctx context.Context, client *http.Client, baseURL, token, a
 	if err != nil {
 		return ApifyActorStatusUnverified, err.Error()
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/pipeline/apify_actor_audit.go
+++ b/internal/pipeline/apify_actor_audit.go
@@ -1,0 +1,267 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/artifacts"
+)
+
+type ApifyActorAuditVerdict string
+
+const (
+	ApifyActorAuditPass       ApifyActorAuditVerdict = "pass"
+	ApifyActorAuditFail       ApifyActorAuditVerdict = "fail"
+	ApifyActorAuditUnverified ApifyActorAuditVerdict = "unverified"
+)
+
+type ApifyActorAuditStatus string
+
+const (
+	ApifyActorStatusReachable  ApifyActorAuditStatus = "reachable"
+	ApifyActorStatusMissing    ApifyActorAuditStatus = "missing"
+	ApifyActorStatusAuth       ApifyActorAuditStatus = "auth-required"
+	ApifyActorStatusUnverified ApifyActorAuditStatus = "unverified"
+)
+
+type ApifyActorAuditOptions struct {
+	Dir         string
+	ResearchDir string
+	BaseURL     string
+	Token       string
+	HTTPClient  *http.Client
+}
+
+type ApifyActorAuditActor struct {
+	ID      string                `json:"id"`
+	Status  ApifyActorAuditStatus `json:"status"`
+	Sources []string              `json:"sources"`
+	Detail  string                `json:"detail,omitempty"`
+}
+
+type ApifyActorAuditReport struct {
+	Dir         string                 `json:"dir"`
+	ResearchDir string                 `json:"research_dir,omitempty"`
+	Verdict     ApifyActorAuditVerdict `json:"verdict"`
+	Actors      []ApifyActorAuditActor `json:"actors"`
+	Issues      []string               `json:"issues,omitempty"`
+}
+
+var apifyActorIDRe = regexp.MustCompile(`\b[A-Za-z0-9][A-Za-z0-9_-]*~[A-Za-z0-9][A-Za-z0-9_-]*\b`)
+var apifyActPathRe = regexp.MustCompile(`/acts/([A-Za-z0-9][A-Za-z0-9_-]*~[A-Za-z0-9][A-Za-z0-9_-]*)(?:/|%2[Ff])`)
+
+func RunApifyActorAudit(ctx context.Context, opts ApifyActorAuditOptions) (*ApifyActorAuditReport, error) {
+	if strings.TrimSpace(opts.Dir) == "" {
+		return nil, fmt.Errorf("--dir is required")
+	}
+	baseURL := strings.TrimRight(opts.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.apify.com"
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	token := strings.TrimSpace(opts.Token)
+	if token == "" {
+		token = apifyTokenFromEnv()
+	}
+
+	sources, err := scanApifyActorReferences(opts.Dir, opts.ResearchDir)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &ApifyActorAuditReport{
+		Dir:         opts.Dir,
+		ResearchDir: opts.ResearchDir,
+		Verdict:     ApifyActorAuditPass,
+	}
+	if len(sources) == 0 {
+		report.Issues = []string{"no Apify actor references found, skipping"}
+		return report, nil
+	}
+
+	ids := make([]string, 0, len(sources))
+	for id := range sources {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		actor := ApifyActorAuditActor{
+			ID:      id,
+			Sources: sources[id],
+		}
+		status, detail := probeApifyActor(ctx, client, baseURL, token, id)
+		actor.Status = status
+		actor.Detail = detail
+		report.Actors = append(report.Actors, actor)
+
+		switch status {
+		case ApifyActorStatusMissing:
+			report.Verdict = ApifyActorAuditFail
+			report.Issues = append(report.Issues, fmt.Sprintf("Apify actor %q is missing (GET /v2/acts/%s returned 404); referenced by %s", id, id, strings.Join(actor.Sources, ", ")))
+		case ApifyActorStatusAuth, ApifyActorStatusUnverified:
+			if report.Verdict != ApifyActorAuditFail {
+				report.Verdict = ApifyActorAuditUnverified
+			}
+			report.Issues = append(report.Issues, fmt.Sprintf("Apify actor %q could not be verified: %s; referenced by %s", id, detail, strings.Join(actor.Sources, ", ")))
+		}
+	}
+
+	return report, nil
+}
+
+func WriteApifyActorAuditReport(dir string, report *ApifyActorAuditReport) error {
+	emitted := *report
+	emitted.Dir = artifacts.RedactCLIDirRoot(report.Dir)
+	if report.ResearchDir != "" {
+		emitted.ResearchDir = artifacts.RedactCLIDirRoot(report.ResearchDir)
+	}
+	data, err := json.MarshalIndent(&emitted, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling Apify actor audit report: %w", err)
+	}
+	path := filepath.Join(dir, "apify-actor-audit-report.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing Apify actor audit report: %w", err)
+	}
+	return nil
+}
+
+func scanApifyActorReferences(dir, researchDir string) (map[string][]string, error) {
+	roots := []string{dir}
+	if researchDir != "" && researchDir != dir {
+		roots = append(roots, researchDir)
+	}
+	found := make(map[string]map[string]struct{})
+	for _, root := range roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if shouldSkipApifyAuditDir(d.Name()) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !shouldScanApifyAuditFile(path) {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for _, id := range apifyActorIDsInContent(string(data)) {
+				if found[id] == nil {
+					found[id] = make(map[string]struct{})
+				}
+				found[id][path] = struct{}{}
+			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("scanning Apify actor references under %s: %w", root, err)
+		}
+	}
+
+	out := make(map[string][]string, len(found))
+	for id, sourceSet := range found {
+		for source := range sourceSet {
+			out[id] = append(out[id], source)
+		}
+		sort.Strings(out[id])
+	}
+	return out, nil
+}
+
+func shouldSkipApifyAuditDir(name string) bool {
+	switch name {
+	case ".git", ".gotmp", "node_modules", "vendor", "dist", "build":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldScanApifyAuditFile(path string) bool {
+	if filepath.Base(path) == "apify-actor-audit-report.json" {
+		return false
+	}
+	switch filepath.Ext(path) {
+	case ".go", ".json", ".md", ".yaml", ".yml", ".txt":
+		return true
+	default:
+		return false
+	}
+}
+
+func apifyActorIDsInContent(content string) []string {
+	if !strings.Contains(content, "/acts/") {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, m := range apifyActPathRe.FindAllStringSubmatch(content, -1) {
+		seen[m[1]] = struct{}{}
+	}
+	for _, id := range apifyActorIDRe.FindAllString(content, -1) {
+		seen[id] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func probeApifyActor(ctx context.Context, client *http.Client, baseURL, token, actorID string) (ApifyActorAuditStatus, string) {
+	endpoint := fmt.Sprintf("%s/v2/acts/%s", baseURL, url.PathEscape(actorID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return ApifyActorStatusUnverified, err.Error()
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ApifyActorStatusUnverified, err.Error()
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return ApifyActorStatusReachable, "reachable"
+	case http.StatusNotFound:
+		return ApifyActorStatusMissing, "not found"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		if token == "" {
+			return ApifyActorStatusAuth, fmt.Sprintf("GET /v2/acts/%s returned %d; set APIFY_TOKEN to verify private actors", actorID, resp.StatusCode)
+		}
+		return ApifyActorStatusAuth, fmt.Sprintf("GET /v2/acts/%s returned %d with configured Apify token", actorID, resp.StatusCode)
+	default:
+		return ApifyActorStatusUnverified, fmt.Sprintf("GET /v2/acts/%s returned %d", actorID, resp.StatusCode)
+	}
+}
+
+func apifyTokenFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("APIFY_TOKEN")); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv("APIFY_API_TOKEN"))
+}

--- a/internal/pipeline/apify_actor_audit_test.go
+++ b/internal/pipeline/apify_actor_audit_test.go
@@ -101,6 +101,42 @@ const ownerRepo = "someone~not-an-apify-actor"
 	assert.Contains(t, report.Issues[0], "no Apify actor references found")
 }
 
+func TestRunApifyActorAuditOnlyExtractsActorIDsFromActPaths(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "research"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "research", "research.json"), `{
+  "timeRange": "2022~2024",
+  "notes": "Fetched https://api.apify.com/v2/acts/apify~instagram-scraper and https://api.apify.com/v2/acts/apify~tiktok-scraper/runs"
+}`)
+
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/v2/acts/apify~instagram-scraper", "/v2/acts/apify~tiktok-scraper":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	report, err := RunApifyActorAudit(context.Background(), ApifyActorAuditOptions{
+		Dir:     cliDir,
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ApifyActorAuditPass, report.Verdict)
+	assert.Equal(t, []string{
+		"/v2/acts/apify~instagram-scraper",
+		"/v2/acts/apify~tiktok-scraper",
+	}, requested)
+	require.Len(t, report.Actors, 2)
+	assert.Equal(t, "apify~instagram-scraper", report.Actors[0].ID)
+	assert.Equal(t, "apify~tiktok-scraper", report.Actors[1].ID)
+}
+
 func TestRunApifyActorAuditReportsAuthBlockedAsUnverified(t *testing.T) {
 	cliDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))

--- a/internal/pipeline/apify_actor_audit_test.go
+++ b/internal/pipeline/apify_actor_audit_test.go
@@ -1,0 +1,128 @@
+package pipeline
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunApifyActorAuditDetectsGeneratedSourceAndResearchActors(t *testing.T) {
+	cliDir := t.TempDir()
+	researchDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "internal", "cli", "scrape.go"), `package cli
+
+const tiktokRunsPath = "/v2/acts/apify~tiktok-scraper/runs"
+`)
+	writeTestFile(t, filepath.Join(researchDir, "research.json"), `{
+  "notes": "Apify actors verified with GET /v2/acts/clockworks~tiktok-scraper/runs and GET /v2/acts/apify~instagram-scraper/runs"
+}`)
+
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/v2/acts/clockworks~tiktok-scraper", "/v2/acts/apify~instagram-scraper":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/acts/apify~tiktok-scraper":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	report, err := RunApifyActorAudit(context.Background(), ApifyActorAuditOptions{
+		Dir:         cliDir,
+		ResearchDir: researchDir,
+		BaseURL:     server.URL,
+		Token:       "test-token",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ApifyActorAuditFail, report.Verdict)
+	require.Len(t, report.Actors, 3)
+	assert.Equal(t, []string{
+		"/v2/acts/apify~instagram-scraper",
+		"/v2/acts/apify~tiktok-scraper",
+		"/v2/acts/clockworks~tiktok-scraper",
+	}, requested)
+	assert.Contains(t, report.Issues[0], `Apify actor "apify~tiktok-scraper" is missing`)
+	assert.Contains(t, report.Issues[0], "GET /v2/acts/apify~tiktok-scraper returned 404")
+}
+
+func TestRunApifyActorAuditPassesReachableActors(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "internal", "cli", "scrape.go"), `package cli
+
+const instagramRunsPath = "https://api.apify.com/v2/acts/apify~instagram-scraper/runs"
+`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/acts/apify~instagram-scraper", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	report, err := RunApifyActorAudit(context.Background(), ApifyActorAuditOptions{
+		Dir:     cliDir,
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ApifyActorAuditPass, report.Verdict)
+	require.Len(t, report.Actors, 1)
+	assert.Equal(t, ApifyActorStatusReachable, report.Actors[0].Status)
+	assert.Empty(t, report.Issues)
+}
+
+func TestRunApifyActorAuditSkipsWhenNoActorReferences(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "internal", "cli", "regular.go"), `package cli
+
+const ownerRepo = "someone~not-an-apify-actor"
+`)
+
+	report, err := RunApifyActorAudit(context.Background(), ApifyActorAuditOptions{Dir: cliDir})
+	require.NoError(t, err)
+
+	assert.Equal(t, ApifyActorAuditPass, report.Verdict)
+	assert.Empty(t, report.Actors)
+	require.Len(t, report.Issues, 1)
+	assert.Contains(t, report.Issues[0], "no Apify actor references found")
+}
+
+func TestRunApifyActorAuditReportsAuthBlockedAsUnverified(t *testing.T) {
+	cliDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "cli"), 0o755))
+	writeTestFile(t, filepath.Join(cliDir, "internal", "cli", "scrape.go"), `package cli
+
+const privateRunsPath = "https://api.apify.com/v2/acts/example~private-actor/runs"
+`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	report, err := RunApifyActorAudit(context.Background(), ApifyActorAuditOptions{
+		Dir:     cliDir,
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ApifyActorAuditUnverified, report.Verdict)
+	require.Len(t, report.Actors, 1)
+	assert.Equal(t, ApifyActorStatusAuth, report.Actors[0].Status)
+	require.Len(t, report.Issues, 1)
+	assert.Contains(t, report.Issues[0], "set APIFY_TOKEN")
+}


### PR DESCRIPTION
## Summary

Shipcheck now catches Apify actor wrappers that reference nonexistent actor IDs before the first real scrape fails at runtime. The new audit scans generated source and optional research manifests for actor-run endpoint references, probes `GET /v2/acts/{actor}`, and fails only on confirmed missing actors while leaving private or transiently unreachable actors as unverified warnings.

Closes #2403

## Verification

- `go test ./internal/pipeline -run 'TestRunApifyActorAudit'`
- `go test ./internal/cli -run 'TestShipcheck'`
- `go test ./...`
- `scripts/golden.sh verify`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
