### PR TITLE
fix(catalog): add health category

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -14,7 +14,7 @@ Add entries when they broaden or sharpen the blueprint set: official OpenAPI, do
 
 The catalog is embedded into the printing-press binary via `catalog.FS`, so a bad entry is not a local typo; it becomes part of every rebuilt binary. The inline `AGENTS.md` rule keeps the write-time fence close to the edit, while this doc carries the longer rationale and the wrapper-only shape.
 
-`category` and `tier` are deliberately finite enums because they drive catalog browsing, risk expectations, and downstream copy. `category` must be one of `ai`, `auth`, `cloud`, `commerce`, `developer-tools`, `devices`, `food-and-dining`, `maps`, `marketing`, `media-and-entertainment`, `monitoring`, `payments`, `productivity`, `project-management`, `sales-and-crm`, `social-and-messaging`, `travel`, or `other` (the public catch-all). `tier` must be `official` or `community`. `example` is accepted only as a test-only bucket for fixtures such as `catalog/petstore.yaml`; do not use it for real catalog entries.
+`category` and `tier` are deliberately finite enums because they drive catalog browsing, risk expectations, and downstream copy. `category` must be one of `ai`, `auth`, `cloud`, `commerce`, `developer-tools`, `devices`, `food-and-dining`, `health`, `maps`, `marketing`, `media-and-entertainment`, `monitoring`, `payments`, `productivity`, `project-management`, `sales-and-crm`, `social-and-messaging`, `travel`, or `other` (the public catch-all). `tier` must be `official` or `community`. `example` is accepted only as a test-only bucket for fixtures such as `catalog/petstore.yaml`; do not use it for real catalog entries.
 
 ## Inclusion rubric
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -36,6 +36,7 @@ var validCategories = map[string]struct{}{
 	"developer-tools":         {},
 	"devices":                 {},
 	"food-and-dining":         {},
+	"health":                  {},
 	"maps":                    {},
 	"marketing":               {},
 	"media-and-entertainment": {},

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -296,8 +296,8 @@ func TestValidateEntry(t *testing.T) {
 func TestAllPublicCategoriesAreValid(t *testing.T) {
 	publicCategories := []string{
 		"ai", "auth", "cloud", "commerce", "developer-tools", "devices",
-		"food-and-dining", "maps", "marketing", "media-and-entertainment", "monitoring",
-		"payments", "productivity", "project-management", "sales-and-crm",
+		"food-and-dining", "health", "maps", "marketing", "media-and-entertainment",
+		"monitoring", "payments", "productivity", "project-management", "sales-and-crm",
 		"social-and-messaging", "travel", "other",
 	}
 	base := Entry{
@@ -565,11 +565,13 @@ func TestPublicCategoriesExcludeExample(t *testing.T) {
 	categories := PublicCategories()
 	assert.NotContains(t, categories, "example")
 	assert.Contains(t, categories, "developer-tools")
+	assert.Contains(t, categories, "health")
 	assert.Contains(t, categories, "other")
 }
 
 func TestIsPublicCategory(t *testing.T) {
 	assert.True(t, IsPublicCategory("developer-tools"))
+	assert.True(t, IsPublicCategory("health"))
 	assert.True(t, IsPublicCategory("other"))
 	assert.False(t, IsPublicCategory("example"))
 	assert.False(t, IsPublicCategory("banana"))

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -330,7 +330,7 @@ Read `.printing-press.json` from the resolved CLI directory.
 3. If neither provides a category, present the full list via AskUserQuestion:
    - developer-tools, monitoring, cloud, project-management
    - productivity, social-and-messaging, sales-and-crm, marketing
-   - payments, auth, commerce, ai, media-and-entertainment, devices, other
+   - payments, auth, commerce, ai, media-and-entertainment, devices, health, other
 
 ## Step 4: Validate
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -330,7 +330,8 @@ Read `.printing-press.json` from the resolved CLI directory.
 3. If neither provides a category, present the full list via AskUserQuestion:
    - developer-tools, monitoring, cloud, project-management
    - productivity, social-and-messaging, sales-and-crm, marketing
-   - payments, auth, commerce, ai, media-and-entertainment, devices, health, other
+   - payments, auth, commerce, ai, food-and-dining, health, maps, media-and-entertainment, devices, other
+   - travel
 
 ## Step 4: Validate
 


### PR DESCRIPTION
## Summary

Health, wellness, biometrics, fitness, and similar APIs can now use `health` as a first-class public-library category instead of falling back to `other`. The catalog validator, publish skill prompt, and catalog docs now agree on the new category.

Closes #2610

## Verification

- `go test ./internal/catalog`
- `go test ./internal/cli -run 'Category|PublishPackage|Generate.*Category|catalog' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./...`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
