### PR TITLE
fix(cli): preserve authored generated descriptions

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -321,6 +321,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"copyrightHolder": func() string {
 			return copyrightHolderString(g.Spec.Creator, g.Spec.OwnerName, g.Spec.Owner)
 		},
+		"endsSentence": endsSentence,
 		"modulePath": func() string {
 			if g.ModulePath != "" {
 				return g.ModulePath
@@ -908,15 +909,16 @@ func (g *Generator) readmeData() *readmeTemplateData {
 }
 
 func (g *Generator) compactDescription() string {
-	candidates := []string{}
 	if g.Narrative != nil {
-		candidates = append(candidates, g.Narrative.Headline)
+		if desc := naming.AuthoredDescription(g.Narrative.Headline); desc != "" {
+			return desc
+		}
 	}
 	if g.Spec != nil {
-		candidates = append(candidates, g.Spec.CLIDescription, g.Spec.Description)
-	}
-	for _, candidate := range candidates {
-		if desc := naming.CompactDescription(candidate); desc != "" {
+		if desc := naming.AuthoredDescription(g.Spec.CLIDescription); desc != "" {
+			return desc
+		}
+		if desc := naming.CompactDescription(g.Spec.Description); desc != "" {
 			return desc
 		}
 	}
@@ -966,9 +968,9 @@ func (g *Generator) CatalogDisplayName() string {
 func (g *Generator) skillDescription() string {
 	switch {
 	case g.Narrative != nil && strings.TrimSpace(g.Narrative.Headline) != "":
-		return naming.CompactDescription(g.Narrative.Headline)
+		return naming.AuthoredDescription(g.Narrative.Headline)
 	case g.Spec != nil && strings.TrimSpace(g.Spec.CLIDescription) != "":
-		return naming.CompactDescription(g.Spec.CLIDescription)
+		return naming.AuthoredDescription(g.Spec.CLIDescription)
 	case g.Spec != nil && strings.TrimSpace(g.Spec.Description) != "":
 		return fmt.Sprintf("Printing Press CLI for %s. %s", g.proseName(), naming.CompactDescription(g.Spec.Description))
 	default:

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10927,6 +10927,58 @@ func TestGenerateMCPContextEscapesDomainStrings(t *testing.T) {
 	assert.Contains(t, src, `filter=\"active\"`)
 }
 
+func TestGeneratePreservesDescriptionHeadlinesAcrossAgentSurfaces(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("headlinecopy")
+	headline := "The first CLI for Scrape.do: requests, browsers, proxies, retries, webhook replay, license seats, churn analytics, and local SQLite workflows no other tool ships"
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet.MCP = true
+	gen.Narrative = &ReadmeNarrative{
+		Headline:       headline,
+		TriggerPhrases: []string{"check Scrape.do usage"},
+	}
+	require.NoError(t, gen.Generate())
+
+	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(skill), headline+". Trigger phrases: `check Scrape.do usage`.")
+	assert.NotContains(t, string(skill), "Scrape. Trigger phrases")
+	assert.NotContains(t, string(skill), "ships.. Trigger phrases")
+
+	goreleaser, err := os.ReadFile(filepath.Join(outputDir, ".goreleaser.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(goreleaser), `description: "`+headline+`"`)
+
+	agentContext, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "agent_context.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(agentContext), `Description: "`+headline+`"`)
+
+	mcpTools, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(mcpTools), `"description": "`+headline+`"`)
+}
+
+func TestGenerateSkillTriggerPhraseTailDoesNotDoublePunctuate(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("punctuatedheadline")
+	headline := "Search routes, compare prices, and track reliability."
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.Narrative = &ReadmeNarrative{
+		Headline:       headline,
+		TriggerPhrases: []string{"track route reliability"},
+	}
+	require.NoError(t, gen.Generate())
+
+	skill, err := os.ReadFile(filepath.Join(outputDir, "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(skill), headline+" Trigger phrases: `track route reliability`.")
+	assert.NotContains(t, string(skill), "reliability.. Trigger phrases")
+}
+
 func TestGenerateMCPCompactsRepeatedParamDescriptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -620,6 +620,19 @@ func yamlDoubleQuoted(s string) string {
 	return s
 }
 
+func endsSentence(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	switch s[len(s)-1] {
+	case '.', '!', '?':
+		return true
+	default:
+		return false
+	}
+}
+
 func copyrightHolderString(creator spec.Person, ownerName, ownerSlug string) string {
 	holder := creator.Name
 	if holder == "" {

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: pp-{{.Name}}
-description: "{{yamlDoubleQuoted .SkillDescription}}{{if and .Narrative .Narrative.TriggerPhrases}} Trigger phrases: {{range $i, $p := .Narrative.TriggerPhrases}}{{if $i}}, {{end}}`{{yamlDoubleQuoted $p}}`{{end}}.{{end}}"
+description: "{{yamlDoubleQuoted .SkillDescription}}{{if and .Narrative .Narrative.TriggerPhrases}}{{if not (endsSentence .SkillDescription)}}.{{end}} Trigger phrases: {{range $i, $p := .Narrative.TriggerPhrases}}{{if $i}}, {{end}}`{{yamlDoubleQuoted $p}}`{{end}}.{{end}}"
 author: "{{yamlDoubleQuoted .OwnerName}}"
 license: "Apache-2.0"
 argument-hint: "<command> [args] | install cli|mcp"

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -297,6 +297,15 @@ func CompactDescription(s string) string {
 	return truncateOneLine(s)
 }
 
+// AuthoredDescription produces one-line human-facing copy for agent-authored
+// narrative and cli_description fields. It preserves the authored sentence
+// instead of truncating at punctuation, since brand dots, commas, and colons
+// are common in product headlines.
+func AuthoredDescription(s string) string {
+	s = stripDescriptionMarkup(stripLeadingMarkdownHeading(s))
+	return collapseWhitespace(s)
+}
+
 // CatalogDescription produces single-line prose for durable catalog metadata.
 // It normalizes markdown and whitespace without applying compact-surface
 // truncation, since this value becomes the canonical description in generated

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -302,8 +302,7 @@ func CompactDescription(s string) string {
 // instead of truncating at punctuation, since brand dots, commas, and colons
 // are common in product headlines.
 func AuthoredDescription(s string) string {
-	s = stripDescriptionMarkup(stripLeadingMarkdownHeading(s))
-	return collapseWhitespace(s)
+	return CatalogDescription(s)
 }
 
 // CatalogDescription produces single-line prose for durable catalog metadata.

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -87,6 +87,16 @@ func TestIsThinCommandShort(t *testing.T) {
 	}
 }
 
+func TestAuthoredDescriptionPreservesAuthoredOneLiner(t *testing.T) {
+	in := "The first CLI for Scrape.do: requests, browsers, proxies, retries, and local SQLite analytics that keep agent workflows grounded without losing the brand dot or clause richness."
+
+	got := AuthoredDescription(in)
+
+	if got != in {
+		t.Fatalf("AuthoredDescription() = %q, want full authored one-liner %q", got, in)
+	}
+}
+
 func TestEnvPrefix(t *testing.T) {
 	tests := map[string]string{
 		"pokeapi":       "POKEAPI",


### PR DESCRIPTION
## Summary
Generated agent metadata now preserves authored narrative headlines and `cli_description` copy across the SKILL frontmatter, Homebrew metadata, `agent-context`, and MCP context surfaces instead of cutting at brand dots, commas, colons, or the old compact cap.

SKILL trigger phrases now get a sentence separator only when the generated description does not already end with `.`, `!`, or `?`, preventing both run-on text like `license seats Trigger phrases` and double-period output.

Closes #2474

## Testing
- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
