### PR TITLE
fix(cli): warn on unenriched promote manifests

### DIFF
--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -400,12 +400,23 @@ func writeCLIManifestForPublish(state *PipelineState, dir string) error {
 		// succeeds with whatever was carried forward from the existing
 		// manifest; publish validate will surface the
 		// transcendence-check failure separately if relevant.
-		fmt.Fprintf(os.Stderr,
-			"debug: research.json not found at %s or %s; skipping novel_features enrichment "+
-				"(state.RunID=%q)\n",
-			filepath.Join(state.RunRoot(), "research.json"),
-			filepath.Join(state.PipelineDir(), "research.json"),
-			state.RunID)
+		canonicalRunResearch := filepath.Join(state.RunRoot(), "research.json")
+		canonicalPipelineResearch := filepath.Join(state.PipelineDir(), "research.json")
+		if len(m.NovelFeatures) == 0 {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not locate originating run's research.json at %s or %s; "+
+					"manifest will require manual enrichment before publish (state.RunID=%q)\n",
+				canonicalRunResearch,
+				canonicalPipelineResearch,
+				state.RunID)
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"debug: research.json not found at %s or %s; preserving existing novel_features "+
+					"(state.RunID=%q)\n",
+				canonicalRunResearch,
+				canonicalPipelineResearch,
+				state.RunID)
+		}
 	}
 
 	return WriteCLIManifest(dir, m)

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -584,12 +584,18 @@ func TestWriteCLIManifestForPublish_NovelFeaturesPreservedFromCarryForward(t *te
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(state.WorkingDir, CLIManifestFilename), existingData, 0o644))
 
-	// No research.json anywhere. Publish should preserve the carry-forward value.
-	require.NoError(t, writeCLIManifestForPublish(state, state.WorkingDir))
+	// No research.json anywhere. Publish should preserve the carry-forward value
+	// without warning that manual enrichment is required.
+	var stderr string
+	require.NoError(t, captureStderr(t, &stderr, func() error {
+		return writeCLIManifestForPublish(state, state.WorkingDir)
+	}))
 
 	m := readPublishedManifest(t, state.WorkingDir)
 	require.Len(t, m.NovelFeatures, 1, "carry-forward should preserve generate-time novel_features")
 	assert.Equal(t, "today", m.NovelFeatures[0].Command)
+	assert.NotContains(t, stderr, "manifest will require manual enrichment before publish")
+	assert.Contains(t, stderr, "preserving existing novel_features")
 }
 
 func TestWriteCLIManifestForPublish_AuthEnvVarSpecsPreservedFromCarryForward(t *testing.T) {
@@ -701,9 +707,10 @@ func TestWriteCLIManifestForPublish_NoResearchNoExistingManifest(t *testing.T) {
 
 	m := readPublishedManifest(t, state.WorkingDir)
 	assert.Empty(t, m.NovelFeatures, "no novel_features when neither research nor prior manifest has any")
-	assert.Contains(t, stderr, "debug: research.json not found at "+
+	assert.Contains(t, stderr, "warning: could not locate originating run's research.json at "+
 		filepath.Join(state.RunRoot(), "research.json")+" or "+
 		filepath.Join(state.PipelineDir(), "research.json"))
+	assert.Contains(t, stderr, "manifest will require manual enrichment before publish")
 	assert.NotContains(t, stderr, "read failed")
 	assert.NotContains(t, stderr, "failed to parse")
 }


### PR DESCRIPTION
## Summary

`lock promote` now surfaces the missing research context at the point where the manifest is written. If promote cannot locate the originating run's `research.json` and there are no carried-forward `novel_features`, stderr now emits a warning that the manifest will need manual enrichment before publish.

When the staged manifest already has `novel_features`, promote keeps preserving them and only emits the lower-level debug breadcrumb, so valid carry-forward data does not look like a publish blocker.

Closes #2493

## Tests

- `go test ./internal/pipeline -run 'TestWriteCLIManifestForPublish_(NovelFeaturesPreservedFromCarryForward|NoResearchNoExistingManifest|NovelFeaturesFromSkillFlowResearch|NovelFeaturesFromPrintFlowResearch|HydratesFromManifestRunIDAcrossScopes)'`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- pre-push hook: `golangci-lint run ./...`
