### PR TITLE
fix(cli): use schema hints in generated examples

### DIFF
--- a/internal/generator/example_value_test.go
+++ b/internal/generator/example_value_test.go
@@ -146,6 +146,7 @@ func TestExampleValuePrefersSchemaHintsBeforeGenericFallback(t *testing.T) {
 		{"enum wins over default", spec.Param{Name: "status", Type: "string", Enum: []string{"active"}, Default: "archived"}, "active"},
 		{"scalar default falls through for non-dispatch params", spec.Param{Name: "query", Type: "string", Default: "recent"}, "example-value"},
 		{"array default picks first item", spec.Param{Name: "part", Type: "array", Default: []any{"snippet"}}, "snippet"},
+		{"object array default falls through to placeholder", spec.Param{Name: "filters", Type: "array", Default: []any{map[string]any{"status": "active"}}}, "example-value"},
 		{"description eg token beats generic fallback", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. INSTANTLY, SMARTLEAD"}, "INSTANTLY"},
 		{"description eg marker ignores word suffix", spec.Param{Name: "data", Type: "string", Description: "Data peg. TOKEN"}, "example-value"},
 		{"description eg marker finds later valid marker", spec.Param{Name: "data", Type: "string", Description: "Data peg. Use e.g. TOKEN"}, "TOKEN"},

--- a/internal/generator/example_value_test.go
+++ b/internal/generator/example_value_test.go
@@ -140,12 +140,14 @@ func TestExampleValuePrefersSchemaHintsBeforeGenericFallback(t *testing.T) {
 		want  string
 	}{
 		{"explicit example wins", spec.Param{Name: "status", Type: "string", Example: "archived", Enum: []string{"active"}}, "archived"},
+		{"dotted explicit example wins", spec.Param{Name: "version", Type: "string", Example: "v1.0"}, "v1.0"},
 		{"array example picks first item", spec.Param{Name: "part", Type: "array", Example: []any{"snippet"}}, "snippet"},
 		{"object example falls through to placeholder", spec.Param{Name: "filter", Type: "object", Example: map[string]any{"status": "active"}}, "example-value"},
 		{"unsafe object example still lets enum win", spec.Param{Name: "status", Type: "object", Example: map[string]any{"status": "archived"}, Enum: []string{"active"}}, "active"},
 		{"enum wins over default", spec.Param{Name: "status", Type: "string", Enum: []string{"active"}, Default: "archived"}, "active"},
 		{"scalar default falls through for non-dispatch params", spec.Param{Name: "query", Type: "string", Default: "recent"}, "example-value"},
 		{"array default picks first item", spec.Param{Name: "part", Type: "array", Default: []any{"snippet"}}, "snippet"},
+		{"dotted array default picks first item", spec.Param{Name: "version", Type: "array", Default: []any{"2.0.1"}}, "2.0.1"},
 		{"object array default falls through to placeholder", spec.Param{Name: "filters", Type: "array", Default: []any{map[string]any{"status": "active"}}}, "example-value"},
 		{"description eg token beats generic fallback", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. INSTANTLY, SMARTLEAD"}, "INSTANTLY"},
 		{"description eg marker ignores word suffix", spec.Param{Name: "data", Type: "string", Description: "Data peg. TOKEN"}, "example-value"},

--- a/internal/generator/example_value_test.go
+++ b/internal/generator/example_value_test.go
@@ -141,10 +141,14 @@ func TestExampleValuePrefersSchemaHintsBeforeGenericFallback(t *testing.T) {
 	}{
 		{"explicit example wins", spec.Param{Name: "status", Type: "string", Example: "archived", Enum: []string{"active"}}, "archived"},
 		{"array example picks first item", spec.Param{Name: "part", Type: "array", Example: []any{"snippet"}}, "snippet"},
+		{"object example falls through to placeholder", spec.Param{Name: "filter", Type: "object", Example: map[string]any{"status": "active"}}, "example-value"},
+		{"unsafe object example still lets enum win", spec.Param{Name: "status", Type: "object", Example: map[string]any{"status": "archived"}, Enum: []string{"active"}}, "active"},
 		{"enum wins over default", spec.Param{Name: "status", Type: "string", Enum: []string{"active"}, Default: "archived"}, "active"},
 		{"scalar default falls through for non-dispatch params", spec.Param{Name: "query", Type: "string", Default: "recent"}, "example-value"},
 		{"array default picks first item", spec.Param{Name: "part", Type: "array", Default: []any{"snippet"}}, "snippet"},
 		{"description eg token beats generic fallback", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. INSTANTLY, SMARTLEAD"}, "INSTANTLY"},
+		{"description eg marker ignores word suffix", spec.Param{Name: "data", Type: "string", Description: "Data peg. TOKEN"}, "example-value"},
+		{"description eg marker finds later valid marker", spec.Param{Name: "data", Type: "string", Description: "Data peg. Use e.g. TOKEN"}, "TOKEN"},
 		{"description hint with spaced prose falls through", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. any active workspace"}, "example-value"},
 	}
 

--- a/internal/generator/example_value_test.go
+++ b/internal/generator/example_value_test.go
@@ -132,3 +132,26 @@ func TestExampleValueEnumWinsOverNameHeuristics(t *testing.T) {
 		})
 	}
 }
+
+func TestExampleValuePrefersSchemaHintsBeforeGenericFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		param spec.Param
+		want  string
+	}{
+		{"explicit example wins", spec.Param{Name: "status", Type: "string", Example: "archived", Enum: []string{"active"}}, "archived"},
+		{"array example picks first item", spec.Param{Name: "part", Type: "array", Example: []any{"snippet"}}, "snippet"},
+		{"enum wins over default", spec.Param{Name: "status", Type: "string", Enum: []string{"active"}, Default: "archived"}, "active"},
+		{"scalar default falls through for non-dispatch params", spec.Param{Name: "query", Type: "string", Default: "recent"}, "example-value"},
+		{"array default picks first item", spec.Param{Name: "part", Type: "array", Default: []any{"snippet"}}, "snippet"},
+		{"description eg token beats generic fallback", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. INSTANTLY, SMARTLEAD"}, "INSTANTLY"},
+		{"description hint with spaced prose falls through", spec.Param{Name: "app", Type: "string", Description: "App name, e.g. any active workspace"}, "example-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exampleValue(tt.param)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -219,6 +219,16 @@ func stringifyDefault(v any) string {
 		return ""
 	case string:
 		return t
+	case []string:
+		if len(t) == 0 {
+			return ""
+		}
+		return stringifyDefault(t[0])
+	case []any:
+		if len(t) == 0 {
+			return ""
+		}
+		return stringifyDefault(t[0])
 	default:
 		return fmt.Sprintf("%v", t)
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6226,7 +6226,7 @@ func exampleValue(p spec.Param) string {
 	}
 
 	if p.Example != nil {
-		if s := stringifyDefault(p.Example); strings.TrimSpace(s) != "" && firstShellSafeDescriptionToken(s) == s {
+		if s := stringifyDefault(p.Example); shellSafeSchemaExampleValue(s) {
 			return s
 		}
 	}
@@ -6242,7 +6242,7 @@ func exampleValue(p spec.Param) string {
 	}
 
 	if p.Default != nil {
-		if s, ok := defaultSliceExampleValue(p.Default); ok && strings.TrimSpace(s) != "" && firstShellSafeDescriptionToken(s) == s {
+		if s, ok := defaultSliceExampleValue(p.Default); ok && shellSafeSchemaExampleValue(s) {
 			return s
 		}
 	}
@@ -6371,6 +6371,20 @@ func firstShellSafeDescriptionToken(s string) string {
 		return ""
 	}
 	return s
+}
+
+func shellSafeSchemaExampleValue(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.ContainsAny(s, " \t\n\r") {
+		return false
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == ':' || r == '/' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func exampleNeedsTODO(line string) bool {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6226,7 +6226,7 @@ func exampleValue(p spec.Param) string {
 	}
 
 	if p.Example != nil {
-		if s := stringifyDefault(p.Example); strings.TrimSpace(s) != "" {
+		if s := stringifyDefault(p.Example); strings.TrimSpace(s) != "" && firstShellSafeDescriptionToken(s) == s {
 			return s
 		}
 	}
@@ -6305,7 +6305,7 @@ func exampleValue(p spec.Param) string {
 func descriptionExampleValue(description string) (string, bool) {
 	lower := strings.ToLower(description)
 	for _, marker := range []string{"e.g.", "eg.", "for example"} {
-		idx := strings.Index(lower, marker)
+		idx := descriptionExampleMarkerIndex(lower, marker)
 		if idx < 0 {
 			continue
 		}
@@ -6316,6 +6316,25 @@ func descriptionExampleValue(description string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func descriptionExampleMarkerIndex(lower, marker string) int {
+	searchFrom := 0
+	for {
+		idx := strings.Index(lower[searchFrom:], marker)
+		if idx < 0 {
+			return -1
+		}
+		idx += searchFrom
+		if idx == 0 {
+			return idx
+		}
+		prev := rune(lower[idx-1])
+		if !unicode.IsLetter(prev) && !unicode.IsDigit(prev) {
+			return idx
+		}
+		searchFrom = idx + len(marker)
+	}
 }
 
 func defaultSliceExampleValue(v any) (string, bool) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -316,6 +316,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		},
 		"exampleLine":         g.exampleLine,
 		"promotedExampleLine": g.promotedExampleLine,
+		"exampleNeedsTODO":    exampleNeedsTODO,
 		"commandExampleArgs":  commandExampleArgs,
 		"currentYear":         func() string { return strconv.Itoa(time.Now().Year()) },
 		"copyrightHolder": func() string {
@@ -6224,6 +6225,12 @@ func exampleValue(p spec.Param) string {
 		return value
 	}
 
+	if p.Example != nil {
+		if s := stringifyDefault(p.Example); strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+
 	// Enum-constrained params: the API rejects anything outside the set,
 	// so prefer the first declared value over name-shape heuristics.
 	// This wins over name-based branches because a hypothetical
@@ -6232,6 +6239,16 @@ func exampleValue(p spec.Param) string {
 		if strings.TrimSpace(v) != "" {
 			return v
 		}
+	}
+
+	if p.Default != nil {
+		if s, ok := defaultSliceExampleValue(p.Default); ok && strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+
+	if value, ok := descriptionExampleValue(p.Description); ok {
+		return value
 	}
 
 	nameLower := strings.ToLower(p.Name)
@@ -6283,6 +6300,62 @@ func exampleValue(p spec.Param) string {
 		return "42"
 	}
 	return "example-value"
+}
+
+func descriptionExampleValue(description string) (string, bool) {
+	lower := strings.ToLower(description)
+	for _, marker := range []string{"e.g.", "eg.", "for example"} {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(description[idx+len(marker):])
+		rest = strings.TrimLeft(rest, ": \t")
+		if value := firstShellSafeDescriptionToken(rest); value != "" {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func defaultSliceExampleValue(v any) (string, bool) {
+	switch t := v.(type) {
+	case []string:
+		if len(t) == 0 {
+			return "", false
+		}
+		return stringifyDefault(t[0]), true
+	case []any:
+		if len(t) == 0 {
+			return "", false
+		}
+		return stringifyDefault(t[0]), true
+	default:
+		return "", false
+	}
+}
+
+func firstShellSafeDescriptionToken(s string) string {
+	for _, delimiter := range []string{",", ";", ".", "\n", "\r", " or ", " and "} {
+		if idx := strings.Index(s, delimiter); idx >= 0 {
+			s = s[:idx]
+		}
+	}
+	s = strings.Trim(s, " \t`'\"()[]{}")
+	if s == "" || strings.ContainsAny(s, " \t") {
+		return ""
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == ':' || r == '/' || r == '.' {
+			continue
+		}
+		return ""
+	}
+	return s
+}
+
+func exampleNeedsTODO(line string) bool {
+	return strings.Contains(line, "example-value")
 }
 
 func (g *Generator) exampleLine(commandPath, endpointName string, endpoint spec.Endpoint) string {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6242,7 +6242,7 @@ func exampleValue(p spec.Param) string {
 	}
 
 	if p.Default != nil {
-		if s, ok := defaultSliceExampleValue(p.Default); ok && strings.TrimSpace(s) != "" {
+		if s, ok := defaultSliceExampleValue(p.Default); ok && strings.TrimSpace(s) != "" && firstShellSafeDescriptionToken(s) == s {
 			return s
 		}
 	}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8440,6 +8440,45 @@ func TestGeneratedCommandExampleKeepsDispatchParamDefault(t *testing.T) {
 	assert.Contains(t, string(listSrc), `dispatch-default-pp-cli domain list --limit 50`)
 }
 
+func TestGeneratedCommandExampleUsesSchemaHintsForRequiredParams(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("schema-hints")
+	apiSpec.Resources["reports"] = spec.Resource{
+		Description: "Reports",
+		Endpoints: map[string]spec.Endpoint{
+			"create": {
+				Method:      "POST",
+				Path:        "/reports",
+				Description: "Create report",
+				Params: []spec.Param{
+					{Name: "exampleParam", Type: "string", Required: true, Example: "from-example", Description: "Explicit example"},
+					{Name: "enumParam", Type: "string", Required: true, Enum: []string{"snippet"}, Description: "Enum parameter"},
+					{Name: "defaultParam", Type: "string", Required: true, Default: []any{"from-default"}, Description: "Default parameter"},
+					{Name: "app", Type: "string", Required: true, Description: "App name, e.g. INSTANTLY, SMARTLEAD"},
+					{Name: "fallback", Type: "string", Required: true, Description: "Fallback parameter"},
+				},
+				Body: []spec.Param{
+					{Name: "kind", Type: "string", Required: true, Example: "summary", Description: "Report kind"},
+				},
+			},
+			"list": {
+				Method:      "GET",
+				Path:        "/reports",
+				Description: "List reports",
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	source := readGeneratedFile(t, outputDir, "internal", "cli", "reports_create.go")
+	assert.Contains(t, source, `schema-hints-pp-cli reports create --example-param from-example --enum-param snippet --default-param from-default --app INSTANTLY --fallback example-value --kind summary`)
+	assert.Contains(t, source, `// TODO: replace placeholder example values before relying on this for live dogfood.`)
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGeneratedCommandExamplePrefersNarrativeQuickStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -66,7 +66,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 		Aliases: []string{"{{.Endpoint.Alias}}"},
 {{- end}}
 		Short: "{{oneline .Endpoint.Description}}",
-		Example: {{printf "%q" (exampleLine .CommandPath .EndpointName .Endpoint)}},
+{{- $example := exampleLine .CommandPath .EndpointName .Endpoint}}
+{{- if exampleNeedsTODO $example}}
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+{{- end}}
+		Example: {{printf "%q" $example}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -52,7 +52,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 		Use:   "{{.PromotedName}}{{positionalArgs .Endpoint}}",
 		Short: "{{oneline .Endpoint.Description}}",
 		Long:  "{{oneline .Endpoint.Description}}",
-		Example: {{printf "%q" (promotedExampleLine .PromotedName .Endpoint)}},
+{{- $example := promotedExampleLine .PromotedName .Endpoint}}
+{{- if exampleNeedsTODO $example}}
+		// TODO: replace placeholder example values before relying on this for live dogfood.
+{{- end}}
+		Example: {{printf "%q" $example}},
 		Annotations: map[string]string{"pp:endpoint": {{printf "%q" (printf "%s.%s" .ResourceName .EndpointName)}}, "pp:method": {{printf "%q" (upper .Endpoint.Method)}}, "pp:path": {{printf "%q" .EffectivePath}}{{if .IsReadOnly}}, "mcp:read-only": "true"{{end}}{{if .Endpoint.HappyArgs}}, "pp:happy-args": {{printf "%q" .Endpoint.HappyArgs}}{{end}}},
 		RunE: func(cmd *cobra.Command, args []string) error {
 {{- if endpointHasRequiredInput .Endpoint}}

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -4142,6 +4142,7 @@ func mapParameters(pathItem *openapi3.PathItem, op *openapi3.Operation) []spec.P
 			Enum:        schemaEnum(schema),
 			Format:      schemaFormat(schema),
 		}
+		param.Example = parameterExample(parameter, schema)
 		if parameter.In == openapi3.ParameterInQuery {
 			if !urlNameOverridesRead {
 				urlNameOverrides = readParamURLNameOverrides(pathItem, op)
@@ -4576,6 +4577,7 @@ func mapRequestBody(requestBodyRef *openapi3.RequestBodyRef, method, path string
 			Fields:      mapBodyFields(paramSchema, inferCSVArrays),
 			Enum:        schemaEnum(paramSchema),
 			Format:      schemaFormat(paramSchema),
+			Example:     schemaExample(paramSchema),
 		}
 		if inferCSVArrays && isStringArraySchema(paramSchema) {
 			param.ItemType = "string"
@@ -5844,6 +5846,44 @@ func schemaFormat(schema *openapi3.Schema) string {
 		return ""
 	}
 	return strings.TrimSpace(schema.Format)
+}
+
+func schemaExample(schema *openapi3.Schema) any {
+	if schema == nil {
+		return nil
+	}
+	if schema.Example != nil {
+		return schema.Example
+	}
+	for _, example := range schema.Examples {
+		if example != nil {
+			return example
+		}
+	}
+	return nil
+}
+
+func parameterExample(parameter *openapi3.Parameter, schema *openapi3.Schema) any {
+	if parameter == nil {
+		return schemaExample(schema)
+	}
+	if parameter.Example != nil {
+		return parameter.Example
+	}
+	if len(parameter.Examples) > 0 {
+		names := make([]string, 0, len(parameter.Examples))
+		for name := range parameter.Examples {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			ref := parameter.Examples[name]
+			if ref != nil && ref.Value != nil && ref.Value.Value != nil {
+				return ref.Value.Value
+			}
+		}
+	}
+	return schemaExample(schema)
 }
 
 func schemaDescription(schema *openapi3.Schema) string {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -3266,6 +3266,62 @@ func TestReclassifyPathParamDefaults(t *testing.T) {
 	assert.Equal(t, "PICK", params[2].Default, "enum default should be first value")
 }
 
+func TestParseParameterExamples(t *testing.T) {
+	parsed, err := Parse([]byte(`
+openapi: 3.1.0
+info:
+  title: Parameter Examples
+  version: 1.0.0
+paths:
+  /reports:
+    get:
+      operationId: listReports
+      parameters:
+        - name: parameterExample
+          in: query
+          required: true
+          example: from-parameter
+          schema:
+            type: string
+        - name: namedExample
+          in: query
+          required: true
+          examples:
+            beta:
+              value: from-named
+          schema:
+            type: string
+        - name: schemaExample
+          in: query
+          required: true
+          schema:
+            type: string
+            example: from-schema
+        - name: schemaExamples
+          in: query
+          required: true
+          schema:
+            type: string
+            examples:
+              - from-schema-list
+      responses:
+        '200':
+          description: ok
+`))
+	require.NoError(t, err)
+
+	params := parsed.Resources["reports"].Endpoints["list"].Params
+	byName := map[string]spec.Param{}
+	for _, param := range params {
+		byName[param.Name] = param
+	}
+
+	assert.Equal(t, "from-parameter", byName["parameterExample"].Example)
+	assert.Equal(t, "from-named", byName["namedExample"].Example)
+	assert.Equal(t, "from-schema", byName["schemaExample"].Example)
+	assert.Equal(t, "from-schema-list", byName["schemaExamples"].Example)
+}
+
 func TestParsePreservesDefaultedPathParamsDuringGlobalFilter(t *testing.T) {
 	data := []byte(`
 openapi: 3.0.0

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2186,6 +2186,7 @@ type Param struct {
 	PathParam   bool     `yaml:"path_param,omitempty" json:"path_param,omitempty"` // true for path params rendered as flags (e.g., pagination)
 	GlobalScope bool     `yaml:"global_scope,omitempty" json:"global_scope,omitempty"`
 	Default     any      `yaml:"default" json:"default"`
+	Example     any      `yaml:"example,omitempty" json:"example,omitempty"`
 	Description string   `yaml:"description" json:"description"`
 	Fields      []Param  `yaml:"fields" json:"fields"`                     // for nested objects
 	Enum        []string `yaml:"enum,omitempty" json:"enum,omitempty"`     // enum constraints for the parameter
@@ -2480,6 +2481,12 @@ func bodyParamFromSchemaNode(name string, node *yaml.Node) (Param, error) {
 		Description: schemaDescriptionFromNode(node, name),
 		Enum:        schemaStringSlice(yamlMappingValue(node, "enum")),
 		Format:      strings.TrimSpace(schemaScalarValue(yamlMappingValue(node, "format"))),
+	}
+	if exampleNode := yamlMappingValue(node, "example"); exampleNode != nil {
+		var exampleValue any
+		if err := exampleNode.Decode(&exampleValue); err == nil {
+			param.Example = exampleValue
+		}
 	}
 	if required := yamlMappingValue(node, "required"); required != nil && required.Kind == yaml.ScalarNode {
 		var requiredBool bool

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -18,8 +18,9 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 	var stdinBody bool
 
 	cmd := &cobra.Command{
-		Use:         "create",
-		Short:       "Create a store record",
+		Use:   "create",
+		Short: "Create a store record",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
 		Example:     "  public-param-golden-pp-cli stores create --store-code example-value",
 		Annotations: map[string]string{"pp:endpoint": "stores.create", "pp:method": "POST", "pp:path": "/stores"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -17,8 +17,9 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 	var flagLocationId string
 
 	cmd := &cobra.Command{
-		Use:         "find",
-		Short:       "Find nearby stores by address",
+		Use:   "find",
+		Short: "Find nearby stores by address",
+		// TODO: replace placeholder example values before relying on this for live dogfood.
 		Example:     "  public-param-golden-pp-cli stores find --address example-value --city example-value --location-id 550e8400-e29b-41d4-a716-446655440000",
 		Annotations: map[string]string{"pp:endpoint": "stores.find", "pp:method": "GET", "pp:path": "/power/store-locator", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

Generated command examples now use real schema hints for required parameters instead of falling back to `example-value` when the spec already exposes a usable value. Explicit OpenAPI parameter/schema examples flow into `spec.Param`, enum values still win over generic name heuristics, array-shaped defaults such as `default: ["snippet"]` render as the first usable flag value, and simple `e.g. TOKEN, TOKEN2` descriptions can provide a shell-safe fallback when formal enum metadata is missing.

When a required example still has no usable hint, generated command source now gets an adjacent TODO comment so polish/dogfood passes can see that the placeholder needs manual replacement without changing the runtime help invocation.

Closes #2478

## Verification

- `go test ./internal/generator -run 'TestExampleValue|TestGeneratedCommandExample'`
- `go test ./internal/openapi -run 'TestParseParameterExamples'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-public-param-names`
- `go test -p 1 ./...`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
