### PR TITLE
fix(cli): preserve Windows companion CLI fallback

### DIFF
--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -236,7 +236,10 @@ func TestMCPCobraTreeSiblingCLIPathUsesWindowsExecutableSuffix(t *testing.T) {
 	var testSrc strings.Builder
 	testSrc.WriteString(`package cobratree
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestCLIExecutableNameUsesWindowsSuffix(t *testing.T) {
 	if got := cliExecutableName("windows"); got != "pathcheck-pp-cli.exe" {
@@ -247,6 +250,28 @@ func TestCLIExecutableNameUsesWindowsSuffix(t *testing.T) {
 	}
 	if got := cliExecutableName("darwin"); got != "pathcheck-pp-cli" {
 		t.Fatalf("cliExecutableName(darwin) = %q, want pathcheck-pp-cli", got)
+	}
+}
+
+func TestSiblingCLICandidatesUseWindowsSuffixThenFallback(t *testing.T) {
+	exePath := filepath.Join("tmp", "bin", "pathcheck-pp-mcp.exe")
+	windowsCandidates := siblingCLICandidates("windows", exePath)
+	if len(windowsCandidates) != 2 {
+		t.Fatalf("windows candidates length = %d, want 2: %#v", len(windowsCandidates), windowsCandidates)
+	}
+	if got, want := filepath.Base(windowsCandidates[0]), "pathcheck-pp-cli.exe"; got != want {
+		t.Fatalf("windows candidates[0] = %q, want %q", got, want)
+	}
+	if got, want := filepath.Base(windowsCandidates[1]), "pathcheck-pp-cli"; got != want {
+		t.Fatalf("windows candidates[1] = %q, want %q", got, want)
+	}
+
+	linuxCandidates := siblingCLICandidates("linux", filepath.Join("tmp", "bin", "pathcheck-pp-mcp"))
+	if len(linuxCandidates) != 1 {
+		t.Fatalf("linux candidates length = %d, want 1: %#v", len(linuxCandidates), linuxCandidates)
+	}
+	if got, want := filepath.Base(linuxCandidates[0]), "pathcheck-pp-cli"; got != want {
+		t.Fatalf("linux candidates[0] = %q, want %q", got, want)
 	}
 }
 `)

--- a/internal/generator/templates/cobratree/cli_path.go.tmpl
+++ b/internal/generator/templates/cobratree/cli_path.go.tmpl
@@ -13,17 +13,26 @@ import (
 // SiblingCLIPath resolves the companion CLI via sibling-of-executable,
 // {{envPrefix .Name}}_CLI_PATH env var, then PATH.
 func SiblingCLIPath() (string, error) {
-	cliName := cliExecutableName(runtime.GOOS)
 	if exe, err := os.Executable(); err == nil {
-		candidate := filepath.Join(filepath.Dir(exe), cliName)
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+		for _, candidate := range siblingCLICandidates(runtime.GOOS, exe) {
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate, nil
+			}
 		}
 	}
 	if v := os.Getenv("{{envPrefix .Name}}_CLI_PATH"); v != "" {
 		return v, nil
 	}
-	return exec.LookPath(cliName)
+	return exec.LookPath(cliExecutableName(runtime.GOOS))
+}
+
+func siblingCLICandidates(goos, exePath string) []string {
+	dir := filepath.Dir(exePath)
+	name := "{{.Name}}-pp-cli"
+	if goos == "windows" {
+		return []string{filepath.Join(dir, name+".exe"), filepath.Join(dir, name)}
+	}
+	return []string{filepath.Join(dir, name)}
 }
 
 func cliExecutableName(goos string) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/cli_path.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/cli_path.go
@@ -13,17 +13,26 @@ import (
 // SiblingCLIPath resolves the companion CLI via sibling-of-executable,
 // PRINTING_PRESS_GOLDEN_CLI_PATH env var, then PATH.
 func SiblingCLIPath() (string, error) {
-	cliName := cliExecutableName(runtime.GOOS)
 	if exe, err := os.Executable(); err == nil {
-		candidate := filepath.Join(filepath.Dir(exe), cliName)
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+		for _, candidate := range siblingCLICandidates(runtime.GOOS, exe) {
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate, nil
+			}
 		}
 	}
 	if v := os.Getenv("PRINTING_PRESS_GOLDEN_CLI_PATH"); v != "" {
 		return v, nil
 	}
-	return exec.LookPath(cliName)
+	return exec.LookPath(cliExecutableName(runtime.GOOS))
+}
+
+func siblingCLICandidates(goos, exePath string) []string {
+	dir := filepath.Dir(exePath)
+	name := "printing-press-golden-pp-cli"
+	if goos == "windows" {
+		return []string{filepath.Join(dir, name+".exe"), filepath.Join(dir, name)}
+	}
+	return []string{filepath.Join(dir, name)}
 }
 
 func cliExecutableName(goos string) string {


### PR DESCRIPTION
## Summary

Windows generated MCP servers now check both sibling companion CLI names when resolving shell-out tools: the target-platform `.exe` name first, then the extensionless fallback. That keeps Windows installs working when the companion binary is staged as `<cli>-pp-cli.exe` while preserving the existing extensionless bundle fallback and non-Windows behavior.

The generated-output test now asserts the Windows candidate order and the Linux single-candidate path, and the golden fixture reflects the emitted resolver contract.

Closes #2503

## Tests

- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/generator -run '^TestMCPCobraTreeSiblingCLIPathUsesWindowsExecutableSuffix$' -count=1`
- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api`
- `golangci-lint run ./...`
