### PR TITLE
fix(cli): honor auth preference in dogfood manifest

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3344,6 +3344,21 @@ func TestOpenAPIAuthPreferenceForGenerateFromPriorManifest(t *testing.T) {
 		"explicit --auth-preference must override prior manifest")
 }
 
+func TestOpenAPIAuthPreferenceForGenerateSkipsPriorManifestWhenDirUnknown(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, pipeline.WriteCLIManifest(dir, pipeline.CLIManifest{
+		APIName:        "unrelated-api",
+		CLIName:        "unrelated-api-pp-cli",
+		AuthType:       "api_key",
+		AuthPreference: "UnrelatedAuth",
+	}))
+
+	assert.Empty(t, openAPIAuthPreferenceForGenerate("", "", []string{filepath.Join(t.TempDir(), "spec.yaml")}, "", ""),
+		"unknown manifest dir must not fall back to the current working directory")
+}
+
 func TestOpenAPIAuthPreferenceForGenerateFromDefaultPriorManifest(t *testing.T) {
 	pressHome := t.TempDir()
 	t.Setenv("PRINTING_PRESS_HOME", pressHome)

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3317,14 +3317,74 @@ func TestOpenAPIAuthPreferenceForGenerateFromJiraCatalogEntry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "basicAuth", jira.AuthPreference)
 
-	assert.Equal(t, "basicAuth", openAPIAuthPreferenceForGenerate("", "", []string{jira.SpecURL}, ""),
+	assert.Equal(t, "basicAuth", openAPIAuthPreferenceForGenerate("", "", []string{jira.SpecURL}, "", ""),
 		"catalog spec_url match should forward auth_preference without --auth-preference")
-	assert.Equal(t, "OAuth2", openAPIAuthPreferenceForGenerate("OAuth2", "", []string{jira.SpecURL}, ""),
+	assert.Equal(t, "OAuth2", openAPIAuthPreferenceForGenerate("OAuth2", "", []string{jira.SpecURL}, "", ""),
 		"explicit --auth-preference must override catalog")
 
 	localSpec := filepath.Join(t.TempDir(), "swagger.json")
-	assert.Equal(t, "basicAuth", openAPIAuthPreferenceForGenerate("", "jira", []string{localSpec}, ""),
+	assert.Equal(t, "basicAuth", openAPIAuthPreferenceForGenerate("", "jira", []string{localSpec}, "", ""),
 		"catalog slug via --name should resolve auth_preference without https spec refs")
+}
+
+func TestOpenAPIAuthPreferenceForGenerateFromPriorManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, pipeline.WriteCLIManifest(dir, pipeline.CLIManifest{
+		APIName:        "custom-api",
+		CLIName:        "custom-api-pp-cli",
+		AuthType:       "api_key",
+		AuthPreference: "ApiKeyAuth",
+	}))
+
+	assert.Equal(t, "ApiKeyAuth", openAPIAuthPreferenceForGenerate("", "", []string{filepath.Join(dir, "spec.yaml")}, "", dir),
+		"prior manifest auth_preference should be the fallback below flag and catalog")
+	assert.Equal(t, "OAuth2", openAPIAuthPreferenceForGenerate("OAuth2", "", []string{filepath.Join(dir, "spec.yaml")}, "", dir),
+		"explicit --auth-preference must override prior manifest")
+}
+
+func TestOpenAPIAuthPreferenceForGenerateFromDefaultPriorManifest(t *testing.T) {
+	pressHome := t.TempDir()
+	t.Setenv("PRINTING_PRESS_HOME", pressHome)
+
+	specBytes := []byte(`openapi: "3.0.3"
+info:
+  title: Custom Service
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses: {"200": {description: ok}}
+`)
+	specPath := filepath.Join(t.TempDir(), "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, specBytes, 0o644))
+
+	defaultDir := pipeline.DefaultOutputDir("custom-service")
+	require.NoError(t, os.MkdirAll(defaultDir, 0o755))
+	require.NoError(t, pipeline.WriteCLIManifest(defaultDir, pipeline.CLIManifest{
+		APIName:        "custom-service",
+		CLIName:        "custom-service-pp-cli",
+		AuthType:       "api_key",
+		AuthPreference: "ApiKeyAuth",
+	}))
+
+	manifestDir := openAPIAuthPreferenceManifestDir("", "", []string{specPath}, "", specBytes)
+	require.Equal(t, defaultDir, manifestDir)
+	assert.Equal(t, "ApiKeyAuth", openAPIAuthPreferenceForGenerate("", "", []string{specPath}, "", manifestDir),
+		"default-output regen should find the prior manifest before full OpenAPI parsing")
 }
 
 func TestOpenAPIAuthPreferenceForGenerateParsesJiraLikeSpecWithCatalogDefault(t *testing.T) {
@@ -3364,7 +3424,7 @@ paths:
 	jira, err := catalog.LookupFS(catalogfs.FS, "jira")
 	require.NoError(t, err)
 
-	pref := openAPIAuthPreferenceForGenerate("", "", []string{jira.SpecURL}, "")
+	pref := openAPIAuthPreferenceForGenerate("", "", []string{jira.SpecURL}, "", "")
 	require.Equal(t, "basicAuth", pref)
 
 	parsed, err := parseOpenAPISpec(filepath.Join(t.TempDir(), "spec.yaml"), specBytes, openapi.ParseOptions{AuthPreference: pref})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -396,7 +396,8 @@ func newGenerateCmd() *cobra.Command {
 				openapi.SetMaxEndpointsPerResource(maxEndpointsPerResource)
 			}
 
-			openAPIParseAuthPref := openAPIAuthPreferenceForGenerate(authPreference, cliName, specFiles, specURL)
+			authPreferenceManifestDir := openAPIAuthPreferenceManifestDir(outputDir, cliName, specFiles, researchDir, singleSpecData)
+			openAPIParseAuthPref := openAPIAuthPreferenceForGenerate(authPreference, cliName, specFiles, specURL, authPreferenceManifestDir)
 
 			var specs []*spec.APISpec
 			var specRawBytes [][]byte // raw spec data for archiving
@@ -524,20 +525,21 @@ func newGenerateCmd() *cobra.Command {
 				fmt.Fprintln(os.Stderr, "warning: could not derive run_id from --research-dir; phase5 dogfood acceptance will refuse to write without it")
 			}
 			if err := pipeline.WriteManifestForGenerate(pipeline.GenerateManifestParams{
-				APIName:       apiSpec.Name,
-				SpecSrcs:      specFiles,
-				SpecURL:       specURL,
-				OutputDir:     absOut,
-				Description:   generateResult.CatalogDescription,
-				DisplayName:   generateResult.DisplayName,
-				Creator:       apiSpec.Creator,
-				Contributors:  apiSpec.Contributors,
-				Owner:         apiSpec.Owner,
-				Printer:       apiSpec.Printer,
-				PrinterName:   apiSpec.PrinterName,
-				RunID:         runID,
-				Spec:          apiSpec,
-				NovelFeatures: generateResult.NovelFeatures,
+				APIName:        apiSpec.Name,
+				SpecSrcs:       specFiles,
+				SpecURL:        specURL,
+				OutputDir:      absOut,
+				Description:    generateResult.CatalogDescription,
+				DisplayName:    generateResult.DisplayName,
+				Creator:        apiSpec.Creator,
+				Contributors:   apiSpec.Contributors,
+				Owner:          apiSpec.Owner,
+				Printer:        apiSpec.Printer,
+				PrinterName:    apiSpec.PrinterName,
+				RunID:          runID,
+				Spec:           apiSpec,
+				AuthPreference: openAPIParseAuthPref,
+				NovelFeatures:  generateResult.NovelFeatures,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: could not write manifest: %v\n", err)
 			}
@@ -1120,17 +1122,43 @@ func parseOpenAPISpec(specFile string, data []byte, opts openapi.ParseOptions) (
 }
 
 // openAPIAuthPreferenceForGenerate resolves AuthPreference for openapi.ParseWithOptions.
-// Explicit --auth-preference wins; otherwise a matching catalog entry's auth_preference
-// is used so catalog-driven generates pick the intended scheme before spec enrichment.
-func openAPIAuthPreferenceForGenerate(cliAuthPref, cliName string, specFiles []string, specURL string) string {
+// Explicit --auth-preference wins; otherwise a matching catalog entry's
+// auth_preference is used so catalog-driven generates pick the intended scheme
+// before spec enrichment. Existing same-directory manifests are the final
+// durable fallback for reprints of non-catalog CLIs.
+func openAPIAuthPreferenceForGenerate(cliAuthPref, cliName string, specFiles []string, specURL string, outputDir string) string {
 	if s := strings.TrimSpace(cliAuthPref); s != "" {
 		return s
 	}
 	entry := lookupCatalogEntryForGenerateSpec(strings.TrimSpace(cliName), catalogSpecLookupRefs(specFiles, specURL))
-	if entry == nil {
+	if entry != nil {
+		if pref := strings.TrimSpace(entry.AuthPreference); pref != "" {
+			return pref
+		}
+	}
+	if manifest, err := pipeline.ReadCLIManifest(outputDir); err == nil {
+		return strings.TrimSpace(manifest.AuthPreference)
+	}
+	return ""
+}
+
+func openAPIAuthPreferenceManifestDir(outputDir, cliName string, specFiles []string, researchDir string, singleSpecData []byte) string {
+	if strings.TrimSpace(outputDir) != "" {
+		return outputDir
+	}
+	name := strings.TrimSpace(cliName)
+	if name == "" {
+		name = pipeline.LoadAPINameFromResearchDir(researchDir)
+	}
+	if name == "" && len(specFiles) == 1 && len(singleSpecData) > 0 && openapi.IsOpenAPI(singleSpecData) {
+		if parsed, err := parseOpenAPISpec(specFiles[0], singleSpecData, openapi.ParseOptions{Lenient: true}); err == nil {
+			name = parsed.Name
+		}
+	}
+	if name == "" {
 		return ""
 	}
-	return strings.TrimSpace(entry.AuthPreference)
+	return pipeline.DefaultOutputDir(name)
 }
 
 // archiveSpecBytes picks the bytes and filename for the spec snapshot that

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1136,6 +1136,9 @@ func openAPIAuthPreferenceForGenerate(cliAuthPref, cliName string, specFiles []s
 			return pref
 		}
 	}
+	if strings.TrimSpace(outputDir) == "" {
+		return ""
+	}
 	if manifest, err := pipeline.ReadCLIManifest(outputDir); err == nil {
 		return strings.TrimSpace(manifest.AuthPreference)
 	}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -128,6 +128,7 @@ type CLIManifest struct {
 	MCPReady           string            `json:"mcp_ready,omitempty"`
 	APIVersion         string            `json:"api_version,omitempty"` // from the spec's info.version — provenance only, not the CLI version
 	AuthType           string            `json:"auth_type,omitempty"`
+	AuthPreference     string            `json:"auth_preference,omitempty"`
 	AuthEnvVars        []string          `json:"auth_env_vars,omitempty"`
 	AuthEnvVarSpecs    []spec.AuthEnvVar `json:"auth_env_var_specs,omitempty"`
 	// AuthAdditionalHeaders mirrors AuthConfig.AdditionalHeaders so the MCPB
@@ -574,6 +575,7 @@ func orderedCLIManifestKeys(raw map[string]json.RawMessage) []string {
 		"mcp_ready",
 		"api_version",
 		"auth_type",
+		"auth_preference",
 		"auth_env_vars",
 		"auth_env_var_specs",
 		"endpoint_template_vars",
@@ -679,6 +681,7 @@ func populateMCPMetadata(m *CLIManifest, parsed *spec.APISpec) {
 	m.MCPPublicToolCount = public
 	m.MCPReady = computeMCPReady(parsed.Auth.Type)
 	m.AuthType = parsed.Auth.Type
+	m.AuthPreference = strings.TrimSpace(parsed.Auth.Scheme)
 	envVarSpecs := manifestAuthEnvVarSpecs(parsed)
 	m.AuthEnvVars = manifestAuthEnvVarNames(parsed, envVarSpecs)
 	if !spec.AllAuthEnvVarSpecsInferred(envVarSpecs) {
@@ -792,21 +795,22 @@ func manifestAuthEnvVarSpecs(parsed *spec.APISpec) []spec.AuthEnvVar {
 // PipelineState), the standalone generate command only knows the spec
 // sources and output directory.
 type GenerateManifestParams struct {
-	APIName       string
-	SpecSrcs      []string // --spec args (URLs or file paths)
-	SpecURL       string   // --spec-url: explicit provenance URL (when --spec is a local downloaded file)
-	DocsURL       string   // --docs URL, if used
-	OutputDir     string
-	Description   string                 // best generated user-facing catalog description
-	DisplayName   string                 // best generated user-facing catalog display name
-	Creator       spec.Person            // resolved creator (manifest preserve > legacy fields > git config)
-	Contributors  []spec.Person          // resolved contributors, preserved from the existing manifest
-	Owner         string                 // legacy, derived from Creator.Handle (dual-write)
-	Printer       string                 // legacy, derived from Creator.Handle (dual-write)
-	PrinterName   string                 // legacy, derived from Creator.Name (dual-write)
-	RunID         string                 // from --research-dir/state.json when available, legacy basename fallback otherwise
-	Spec          *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
-	NovelFeatures []NovelFeatureManifest // transcendence features from research (nil if unavailable)
+	APIName        string
+	SpecSrcs       []string // --spec args (URLs or file paths)
+	SpecURL        string   // --spec-url: explicit provenance URL (when --spec is a local downloaded file)
+	DocsURL        string   // --docs URL, if used
+	OutputDir      string
+	Description    string                 // best generated user-facing catalog description
+	DisplayName    string                 // best generated user-facing catalog display name
+	Creator        spec.Person            // resolved creator (manifest preserve > legacy fields > git config)
+	Contributors   []spec.Person          // resolved contributors, preserved from the existing manifest
+	Owner          string                 // legacy, derived from Creator.Handle (dual-write)
+	Printer        string                 // legacy, derived from Creator.Handle (dual-write)
+	PrinterName    string                 // legacy, derived from Creator.Name (dual-write)
+	RunID          string                 // from --research-dir/state.json when available, legacy basename fallback otherwise
+	Spec           *spec.APISpec          // parsed spec for MCP metadata (nil if unavailable)
+	AuthPreference string                 // resolved OpenAPI securityScheme preference selected for this generate
+	NovelFeatures  []NovelFeatureManifest // transcendence features from research (nil if unavailable)
 }
 
 // runIDPattern matches legacy and skill-allocated pipeline run_id basenames.
@@ -994,6 +998,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if p.Spec != nil {
 		populateMCPMetadata(&m, p.Spec)
 	}
+	if authPreference := strings.TrimSpace(p.AuthPreference); authPreference != "" {
+		m.AuthPreference = authPreference
+	}
 	if displayName := strings.TrimSpace(p.DisplayName); displayName != "" {
 		m.DisplayName = displayName
 	}
@@ -1053,6 +1060,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	// would otherwise leave the persisted list in place).
 	if preserveExisting && p.Contributors != nil && len(p.Contributors) == 0 {
 		clearFields["contributors"] = struct{}{}
+	}
+	if preserveExisting && strings.TrimSpace(m.AuthPreference) == "" {
+		clearFields["auth_preference"] = struct{}{}
 	}
 	if preserveExisting {
 		if m.SpecURL != "" && m.SpecPath == "" {

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -688,6 +688,60 @@ func TestWriteManifestForGenerateWithSpecURL(t *testing.T) {
 	assert.False(t, got.GeneratedAt.IsZero())
 }
 
+func TestWriteManifestForGenerateRecordsAuthPreference(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:        "multi-auth",
+		OutputDir:      dir,
+		AuthPreference: "ApiKeyAuth",
+		Spec: &spec.APISpec{
+			Name: "multi-auth",
+			Auth: spec.AuthConfig{
+				Type:   "api_key",
+				Scheme: "ApiKeyAuth",
+				In:     "header",
+				Header: "x-api-key",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "api_key", got.AuthType)
+	assert.Equal(t, "ApiKeyAuth", got.AuthPreference)
+}
+
+func TestWriteManifestForGenerateClearsStaleAuthPreference(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, CLIManifest{
+		APIName:        "multi-auth",
+		CLIName:        "multi-auth-pp-cli",
+		AuthType:       "api_key",
+		AuthPreference: "ApiKeyAuth",
+	})
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "multi-auth",
+		OutputDir: dir,
+		Spec: &spec.APISpec{
+			Name: "multi-auth",
+			Auth: spec.AuthConfig{Type: "none"},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, CLIManifestFilename))
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "auth_preference")
+
+	got := readPublishedManifest(t, dir)
+	assert.Equal(t, "none", got.AuthType)
+	assert.Empty(t, got.AuthPreference)
+}
+
 func TestWriteManifestForGenerateWithLocalSpec(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1716,7 +1716,7 @@ func composedAuthLabelFor(prefix string) string {
 var applyAuthFormatInlineMapCallRe = regexp.MustCompile(`(?s)applyAuthFormat\("([^"]*)",\s*map\[string\]string\{(.*?)\}\)`)
 var applyAuthFormatCallRe = regexp.MustCompile(`applyAuthFormat\("([^"]*)"`)
 var authFormatPlaceholderRe = regexp.MustCompile(`\{([^}]+)\}`)
-var requestHeaderSetLiteralRe = regexp.MustCompile(`req\.Header\.Set\("([^"]+)",\s*(?:authHeader|h|[^)]*AuthHeader\(\))\)`)
+var requestHeaderSetLiteralRe = regexp.MustCompile(`req\.Header\.Set\("([^"]+)",\s*(?:authHeader|h|(?:[^()]*|\([^()]*\))*AuthHeader\(\))\)`)
 
 func detectGeneratedAPIKeyHeader(source string, expectedHeader string) string {
 	expectedHeader = strings.TrimSpace(expectedHeader)

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -282,7 +282,7 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 
 	var spec *openAPISpec
 	if specPath != "" {
-		loaded, err := loadDogfoodOpenAPISpec(specPath)
+		loaded, err := loadDogfoodOpenAPISpec(specPath, dogfoodAuthPreferenceFromManifest(dir))
 		if err != nil {
 			return nil, err
 		}
@@ -1138,7 +1138,7 @@ func specSourceLabel(source DogfoodSpecSource) string {
 	return "--spec"
 }
 
-func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
+func loadDogfoodOpenAPISpec(specPath string, authPreference string) (*openAPISpec, error) {
 	data, err := openapiparser.LoadSpecBytes(specPath, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("reading spec: %w", err)
@@ -1154,7 +1154,11 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 
 	summary, summaryErr := loadOpenAPISpecData(data, specPath)
 	nestedDataEnvelopes := detectNestedDataEnvelopeFixtures(data)
-	parsed, parseErr := openapiparser.ParseWithPathLenient(data, specPath)
+	parsed, parseErr := openapiparser.ParseWithOptions(data, openapiparser.ParseOptions{
+		Path:           specPath,
+		Lenient:        true,
+		AuthPreference: strings.TrimSpace(authPreference),
+	})
 	if parseErr == nil {
 		var scopeRequirements []oauthScopeRequirement
 		if summary != nil {
@@ -1174,7 +1178,7 @@ func loadDogfoodOpenAPISpec(specPath string) (*openAPISpec, error) {
 
 	return &openAPISpec{
 		Paths:                  summary.Paths,
-		Auth:                   deriveDogfoodAuth(summary),
+		Auth:                   deriveDogfoodAuth(summary, authPreference),
 		OAuthScopeRequirements: summary.OAuthScopeRequirements,
 		NestedDataEnvelopes:    nestedDataEnvelopes,
 	}, nil
@@ -1199,9 +1203,27 @@ func collectDogfoodResourcePaths(resource apispec.Resource, paths *[]string) {
 	}
 }
 
-func deriveDogfoodAuth(spec *openAPISpecInfo) apispec.AuthConfig {
+func dogfoodAuthPreferenceFromManifest(dir string) string {
+	manifest, err := ReadCLIManifest(dir)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.AuthPreference)
+}
+
+func deriveDogfoodAuth(spec *openAPISpecInfo, authPreference string) apispec.AuthConfig {
 	if spec == nil {
 		return apispec.AuthConfig{Type: "none"}
+	}
+
+	if authPreference := strings.TrimSpace(authPreference); authPreference != "" {
+		for key, scheme := range spec.SecuritySchemes {
+			if strings.EqualFold(key, authPreference) || strings.EqualFold(scheme.Key, authPreference) {
+				if auth, ok := dogfoodAuthConfigForScheme(scheme); ok {
+					return auth
+				}
+			}
+		}
 	}
 
 	candidateKeys := referencedDogfoodSecurityKeys(spec.SecurityRequirements)
@@ -1346,6 +1368,7 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	}
 
 	expectedPrefix := ""
+	expectedHeader := ""
 	switch {
 	case strings.Contains(strings.ToLower(auth.Format), "bot "):
 		result.SpecScheme = `bot token format (expects "Bot " prefix)`
@@ -1356,6 +1379,9 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	case strings.Contains(strings.ToLower(auth.Format), "basic "):
 		result.SpecScheme = `basic auth format (expects "Basic " prefix)`
 		expectedPrefix = "Basic "
+	case strings.EqualFold(auth.Type, "api_key") && strings.EqualFold(auth.In, "header") && strings.TrimSpace(auth.Header) != "":
+		expectedHeader = strings.TrimSpace(auth.Header)
+		result.SpecScheme = fmt.Sprintf(`api key header %q`, expectedHeader)
 	}
 
 	clientData, err := os.ReadFile(filepath.Join(dir, "internal", "client", "client.go"))
@@ -1398,6 +1424,17 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 		default:
 			result.Match = false
 			result.Detail = fmt.Sprintf(`spec expects %q but composed auth format classifies as %q`, strings.TrimSpace(expectedPrefix), literalFmt)
+		}
+		return result
+	}
+
+	if expectedHeader != "" {
+		result.GeneratedFmt = detectGeneratedAPIKeyHeader(combinedSource, expectedHeader)
+		result.Match = strings.EqualFold(result.GeneratedFmt, expectedHeader)
+		if result.Match {
+			result.Detail = fmt.Sprintf(`spec and generated client both use api key header %q`, expectedHeader)
+		} else {
+			result.Detail = fmt.Sprintf(`spec expects api key header %q but generated client uses %q`, expectedHeader, strings.TrimSpace(result.GeneratedFmt))
 		}
 		return result
 	}
@@ -1679,6 +1716,21 @@ func composedAuthLabelFor(prefix string) string {
 var applyAuthFormatInlineMapCallRe = regexp.MustCompile(`(?s)applyAuthFormat\("([^"]*)",\s*map\[string\]string\{(.*?)\}\)`)
 var applyAuthFormatCallRe = regexp.MustCompile(`applyAuthFormat\("([^"]*)"`)
 var authFormatPlaceholderRe = regexp.MustCompile(`\{([^}]+)\}`)
+var requestHeaderSetLiteralRe = regexp.MustCompile(`req\.Header\.Set\("([^"]+)",\s*(?:authHeader|h|[^)]*AuthHeader\(\))\)`)
+
+func detectGeneratedAPIKeyHeader(source string, expectedHeader string) string {
+	expectedHeader = strings.TrimSpace(expectedHeader)
+	if expectedHeader == "" {
+		return "unknown"
+	}
+	for _, match := range requestHeaderSetLiteralRe.FindAllStringSubmatch(source, -1) {
+		header := strings.TrimSpace(match[1])
+		if strings.EqualFold(header, expectedHeader) {
+			return header
+		}
+	}
+	return "unknown"
+}
 
 func detectGeneratedAuthFormat(source string, expectedPrefix string) (string, bool, string) {
 	candidates := authCandidatesForPrefix(expectedPrefix)

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1226,6 +1226,26 @@ func (c *Config) AuthHeader() string { return c.APIKey }
 	assert.Contains(t, result.SpecScheme, "x-api-key")
 }
 
+func TestCheckAuthRecognizesHeaderAPIKeyFromChainedAuthHeaderCall(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func (c *Client) do() {
+	req.Header.Set("x-api-key", c.GetConfig().AuthHeader())
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+func (c *Config) AuthHeader() string { return c.APIKey }
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "api_key", In: "header", Header: "x-api-key", Scheme: "ApiKeyAuth"})
+	assert.True(t, result.Match)
+	assert.Equal(t, "x-api-key", result.GeneratedFmt)
+}
+
 func TestCheckAuthRejectsBearerApplyAuthFormatWithoutTokenPlaceholder(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -1204,6 +1204,28 @@ func (c *Config) AuthHeader() string {
 	assert.Equal(t, "Bearer ", result.GeneratedFmt)
 }
 
+func TestCheckAuthRecognizesHeaderAPIKey(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func (c *Client) do() {
+	authHeader := c.Config.AuthHeader()
+	req.Header.Set("x-api-key", authHeader)
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+func (c *Config) AuthHeader() string { return c.APIKey }
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "api_key", In: "header", Header: "x-api-key", Scheme: "ApiKeyAuth"})
+	assert.True(t, result.Match)
+	assert.Equal(t, "x-api-key", result.GeneratedFmt)
+	assert.Contains(t, result.SpecScheme, "x-api-key")
+}
+
 func TestCheckAuthRejectsBearerApplyAuthFormatWithoutTokenPlaceholder(t *testing.T) {
 	dir := t.TempDir()
 
@@ -1412,6 +1434,47 @@ func (c *Config) AuthHeader() string {
 	result := checkAuth(dir, apispec.AuthConfig{Type: "api_key", Format: "Basic {username}:{password}"})
 	assert.True(t, result.Match)
 	assert.Equal(t, "Basic ", result.GeneratedFmt)
+}
+
+func TestLoadDogfoodOpenAPISpecUsesAuthPreference(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: Multi Auth
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - BearerAuth: []
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+`)
+
+	defaultSpec, err := loadDogfoodOpenAPISpec(specPath, "")
+	require.NoError(t, err)
+	require.Equal(t, "bearer_token", defaultSpec.Auth.Type)
+
+	preferred, err := loadDogfoodOpenAPISpec(specPath, "ApiKeyAuth")
+	require.NoError(t, err)
+	assert.Equal(t, "api_key", preferred.Auth.Type)
+	assert.Equal(t, "ApiKeyAuth", preferred.Auth.Scheme)
+	assert.Equal(t, "x-api-key", preferred.Auth.Header)
 }
 
 func TestDeriveDogfoodVerdict_WiringChecks(t *testing.T) {

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -118,7 +118,7 @@ func RunVerify(cfg VerifyConfig) (*VerifyReport, error) {
 	// 1. Load spec for command classification
 	var spec *openAPISpec
 	if cfg.SpecPath != "" {
-		loaded, err := loadDogfoodOpenAPISpec(cfg.SpecPath)
+		loaded, err := loadDogfoodOpenAPISpec(cfg.SpecPath, "")
 		if err != nil {
 			return nil, fmt.Errorf("loading spec: %w", err)
 		}

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -370,7 +370,7 @@ components:
             pagination:
               type: object
 `)
-	spec, err := loadDogfoodOpenAPISpec(specPath)
+	spec, err := loadDogfoodOpenAPISpec(specPath, "")
 	require.NoError(t, err)
 
 	server, baseURL := startMockServer(spec)
@@ -421,7 +421,7 @@ paths:
                         items:
                           type: object
 `)
-	spec, err := loadDogfoodOpenAPISpec(specPath)
+	spec, err := loadDogfoodOpenAPISpec(specPath, "")
 	require.NoError(t, err)
 	assert.Empty(t, spec.NestedDataEnvelopes)
 

--- a/internal/pipeline/verify.go
+++ b/internal/pipeline/verify.go
@@ -73,7 +73,7 @@ func NewVerifier(dir, specPath string) (*Verifier, error) {
 		SpecPath: specPath,
 	}
 	if specPath != "" {
-		loaded, err := loadDogfoodOpenAPISpec(specPath)
+		loaded, err := loadDogfoodOpenAPISpec(specPath, "")
 		if err != nil {
 			return nil, fmt.Errorf("loading spec: %w", err)
 		}

--- a/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api-unicode/cafe-bistro/.printing-press.json
@@ -4,6 +4,7 @@
   "auth_env_vars": [
     "CAFE_BISTRO_API_KEY"
   ],
+  "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",
   "cli_name": "cafe-bistro-pp-cli",
   "creator": {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -1,9 +1,9 @@
 {
   "auth_check": {
-    "detail": "no bot/bearer/basic scheme detected",
-    "generated_format": "unknown",
+    "detail": "spec and generated client both use api key header \"X-API-Key\"",
+    "generated_format": "X-API-Key",
     "match": true,
-    "spec_scheme": ""
+    "spec_scheme": "api key header \"X-API-Key\""
   },
   "browser_session_check": {
     "detail": "browser-session auth not required",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/.printing-press.json
@@ -4,6 +4,7 @@
   "auth_env_vars": [
     "PRINTING_PRESS_GOLDEN_API_KEY"
   ],
+  "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",
   "cli_name": "printing-press-golden-pp-cli",
   "creator": {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/.printing-press.json
@@ -4,6 +4,7 @@
   "auth_env_vars": [
     "MCP_CLOUDFLARE_API_KEY"
   ],
+  "auth_preference": "ApiKeyAuth",
   "auth_type": "api_key",
   "cli_name": "mcp-cloudflare-pp-cli",
   "creator": {


### PR DESCRIPTION
## Summary

Dogfood and generated manifests now carry the resolved OpenAPI auth scheme instead of falling back to the first scheme in the spec. A CLI generated with `--auth-preference api_key` records that preference in `.printing-press.json`, reuses it on later same-directory regens below explicit flag and catalog precedence, and dogfood parses the bundled spec with the same preference.

Header API-key CLIs now report the generated header name in dogfood auth checks instead of `generated_format: "unknown"`.

Closes #2499

## Tests

- `go test ./internal/cli ./internal/pipeline -run 'TestOpenAPIAuthPreferenceForGenerate|TestWriteManifestForGenerateRecordsAuthPreference|TestCheckAuthRecognizesHeaderAPIKey|TestLoadDogfoodOpenAPISpecUsesAuthPreference'`
- `scripts/golden.sh verify`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
