### PR TITLE
fix(cli): emit local data layer for syncable APIs

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -97,9 +97,9 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		// Bump it AND add to mustInclude above when adding always-emitted
 		// templates. Per-spec dynamic files (per-resource command files,
 		// generated tests) account for the difference between fixtures.
-		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 72},
+		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 73},
 		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 77},
-		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 74},
+		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 75},
 	}
 
 	for _, tt := range tests {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -300,10 +300,10 @@ func TestGeneratorNovelFeatureHelpGuardRequiresPositionalUse(t *testing.T) {
 			Example:     "novelargs-pp-cli audit",
 		},
 		{
-			Name:        "Search",
-			Command:     "search --filter [active|inactive]",
+			Name:        "Filter",
+			Command:     "filter --state [active|inactive]",
 			Description: "Search items, filtered by flag.",
-			Example:     "novelargs-pp-cli search --filter active",
+			Example:     "novelargs-pp-cli filter --state active",
 		},
 	}
 	require.NoError(t, gen.Generate())
@@ -328,10 +328,10 @@ func TestGeneratorNovelFeatureHelpGuardRequiresPositionalUse(t *testing.T) {
 	// A bracket/angle placeholder inside a flag-value hint is NOT a positional
 	// (#2592 regression guard): no args-based Help guard, and the flag-value
 	// hint must not leak into the cobra Use string.
-	search := readGeneratedFile(t, outputDir, "internal", "cli", "search.go")
-	assert.NotContains(t, search, "return cmd.Help()")
-	assert.Contains(t, search, "// validate required flags here")
-	assert.NotContains(t, search, "[active|inactive]")
+	filter := readGeneratedFile(t, outputDir, "internal", "cli", "filter.go")
+	assert.NotContains(t, filter, "return cmd.Help()")
+	assert.Contains(t, filter, "// validate required flags here")
+	assert.NotContains(t, filter, "[active|inactive]")
 }
 
 func TestGeneratorNovelFeatureParentShortHasNoTODO(t *testing.T) {

--- a/internal/generator/promoted_poststore_test.go
+++ b/internal/generator/promoted_poststore_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -54,6 +55,15 @@ func TestPromotedHasStorePostRoutesThroughVerbBranch(t *testing.T) {
 		"HasStore + read-only POST must route through the verb branch with a built body")
 	assert.Contains(t, got, `attachFreshness(DataProvenance{Source: "live"}, flags)`,
 		"non-GET HasStore commands must synthesize a live-call prov so the downstream HasStore block compiles")
+	callIdx := strings.Index(got, "c.PostQueryWithParams(cmd.Context(), path, params, body)")
+	provIdx := strings.Index(got, `prov := attachFreshness(DataProvenance{Source: "live"}, flags)`)
+	require.NotEqual(t, -1, callIdx)
+	relErrIdx := strings.Index(got[callIdx:], "if err != nil")
+	require.NotEqual(t, -1, relErrIdx)
+	require.NotEqual(t, -1, provIdx)
+	errIdx := callIdx + relErrIdx
+	assert.Less(t, callIdx, errIdx)
+	assert.Less(t, errIdx, provIdx)
 }
 
 // TestPromotedHasStoreGetStillUsesResolveRead is the byte-compat guard for

--- a/internal/generator/syncable_store_gate_test.go
+++ b/internal/generator/syncable_store_gate_test.go
@@ -1,0 +1,122 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSyncableSmallAPIEmitsLocalDataLayer(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := smallReadWriteSyncableOutputSpec("small-syncable")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	require.FileExists(t, filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "search.go"))
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratePostOnlyAPIStillSkipsLocalDataLayer(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := postOnlyOutputSpec("post-only-output")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	require.NoError(t, gen.Generate())
+
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "search.go"))
+
+	_, err := os.Stat(filepath.Join(outputDir, "internal", "store"))
+	require.True(t, os.IsNotExist(err), "post-only API must not reserve internal/store")
+}
+
+func smallReadWriteSyncableOutputSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"deliveries": {
+			Description: "Manage deliveries",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/deliveries",
+					Description: "List deliveries",
+					Response:    spec.ResponseDef{Type: "object", Item: "DeliveriesResponse"},
+				},
+				"add": {
+					Method:      "POST",
+					Path:        "/add-delivery",
+					Description: "Add delivery",
+					Body: []spec.Param{
+						{Name: "tracking_number", Type: "string", Required: true},
+						{Name: "carrier_code", Type: "string", Required: true},
+						{Name: "description", Type: "string", Required: true},
+					},
+					Response: spec.ResponseDef{Type: "object", Item: "SuccessResponse"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Delivery": {
+			Fields: []spec.TypeField{
+				{Name: "carrier_code", Type: "string"},
+				{Name: "description", Type: "string"},
+				{Name: "status_code", Type: "integer"},
+				{Name: "tracking_number", Type: "string"},
+			},
+		},
+		"DeliveriesResponse": {
+			Fields: []spec.TypeField{
+				{Name: "success", Type: "boolean"},
+				{Name: "error_message", Type: "string"},
+				{Name: "deliveries", Type: "array"},
+			},
+		},
+		"SuccessResponse": {
+			Fields: []spec.TypeField{
+				{Name: "success", Type: "boolean"},
+				{Name: "error_message", Type: "string"},
+			},
+		},
+	}
+	return apiSpec
+}
+
+func postOnlyOutputSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"deliveries": {
+			Description: "Manage deliveries",
+			Endpoints: map[string]spec.Endpoint{
+				"add": {
+					Method:      "POST",
+					Path:        "/add-delivery",
+					Description: "Add delivery",
+					Body: []spec.Param{
+						{Name: "tracking_number", Type: "string", Required: true},
+					},
+					Response: spec.ResponseDef{Type: "object", Item: "SuccessResponse"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"SuccessResponse": {
+			Fields: []spec.TypeField{
+				{Name: "success", Type: "boolean"},
+				{Name: "error_message", Type: "string"},
+			},
+		},
+	}
+	return apiSpec
+}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -292,13 +292,13 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			data, err := c.Get(cmd.Context(), path, params)
 {{- end}}
 {{- end}}
-{{- if and .HasStore (ne (upper .Endpoint.Method) "GET")}}
-			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
-{{- end}}
 {{- end}}
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+{{- if and .HasStore (ne (upper .Endpoint.Method) "GET") (not $supportsAllPagination)}}
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
+{{- end}}
 {{- if $canWriteBack}}
 			var partialFailure *partialFailureReport
 			if !flags.dryRun && statusCode >= 200 && statusCode < 300 {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -653,9 +653,9 @@ func (p *APIProfile) ToVisionaryPlan(apiName string) *vision.VisionaryPlan {
 	plan.Architecture = append(plan.Architecture,
 		vision.ArchitectureDecision{
 			Area:               "persistence",
-			NeedLevel:          lowHigh(p.HighVolume || p.OfflineValuable),
+			NeedLevel:          lowHigh(p.HighVolume || p.OfflineValuable || p.hasSyncableStoreResources()),
 			Decision:           "local store",
-			Rationale:          "Read-heavy or high-volume APIs benefit from local persistence for repeat access and offline workflows.",
+			Rationale:          "Read-heavy, high-volume, or profiler-confirmed syncable APIs benefit from local persistence for repeat access and offline workflows.",
 			ImplementationHint: "Use SQLite-backed storage and cache frequently accessed resources.",
 		},
 		vision.ArchitectureDecision{
@@ -689,13 +689,14 @@ func (p *APIProfile) RecommendedFeatures() []string {
 	}
 
 	var features []string
-	if p.HighVolume {
+	hasSyncableStoreResources := p.hasSyncableStoreResources()
+	if p.HighVolume || hasSyncableStoreResources {
 		features = append(features, "sync")
 	}
-	if p.NeedsSearch {
+	if p.NeedsSearch || hasSyncableStoreResources {
 		features = append(features, "search")
 	}
-	if p.HighVolume || p.NeedsSearch || p.HasDependencies {
+	if p.HighVolume || p.NeedsSearch || p.HasDependencies || hasSyncableStoreResources {
 		features = append(features, "store")
 	}
 
@@ -709,6 +710,13 @@ func (p *APIProfile) RecommendedFeatures() []string {
 	}
 
 	return features
+}
+
+func (p *APIProfile) hasSyncableStoreResources() bool {
+	if p == nil {
+		return false
+	}
+	return len(p.SyncableResources) > 0 || len(p.DependentSyncResources) > 0
 }
 
 // SyncableResourceNames returns the names of the syncable resources.

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -660,7 +660,7 @@ func (p *APIProfile) ToVisionaryPlan(apiName string) *vision.VisionaryPlan {
 		},
 		vision.ArchitectureDecision{
 			Area:               "search",
-			NeedLevel:          lowHigh(p.NeedsSearch),
+			NeedLevel:          lowHigh(p.NeedsSearch || p.hasSyncableStoreResources()),
 			Decision:           "full-text indexing",
 			Rationale:          "Multi-resource list-heavy APIs need a fast local search surface when no dedicated endpoint exists.",
 			ImplementationHint: "Index string fields in FTS5 tables keyed by resource type.",

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -35,7 +35,7 @@ func TestProfilePetstore(t *testing.T) {
 	assert.False(t, profile.HighVolume)
 	assert.False(t, profile.NeedsSearch)
 	assert.False(t, profile.HasRealtime)
-	assert.Equal(t, []string{"export", "import"}, profile.RecommendedFeatures())
+	assert.ElementsMatch(t, []string{"sync", "search", "store", "export", "import"}, profile.RecommendedFeatures())
 }
 
 func TestProfileDiscord(t *testing.T) {
@@ -76,6 +76,16 @@ func TestProfileMinimal(t *testing.T) {
 	assert.False(t, profile.HasChronological)
 	assert.False(t, profile.HasDependencies)
 	assert.Zero(t, profile.CRUDResources)
+	assert.True(t, profile.hasSyncableStoreResources())
+	assert.ElementsMatch(t, []string{"sync", "search", "store", "export", "import"}, profile.RecommendedFeatures())
+}
+
+func TestProfilePostOnlyHasNoLocalStoreFeatures(t *testing.T) {
+	profile := Profile(postOnlySpec())
+
+	assert.False(t, profile.HighVolume)
+	assert.False(t, profile.NeedsSearch)
+	assert.False(t, profile.hasSyncableStoreResources())
 	assert.Equal(t, []string{"export", "import"}, profile.RecommendedFeatures())
 }
 
@@ -287,6 +297,30 @@ func TestToVisionaryPlan(t *testing.T) {
 	assert.Equal(t, []string{"analytics.go.tmpl"}, featureTemplates["analytics"])
 }
 
+func TestToVisionaryPlanSyncableResourceDrivesLocalDataLayer(t *testing.T) {
+	profile := Profile(smallReadWriteSyncableSpec())
+	require.False(t, profile.HighVolume)
+	require.False(t, profile.OfflineValuable)
+	require.False(t, profile.NeedsSearch)
+	require.True(t, profile.hasSyncableStoreResources())
+
+	plan := profile.ToVisionaryPlan("parcel")
+	areas := make(map[string]string)
+	for _, decision := range plan.Architecture {
+		areas[decision.Area] = decision.NeedLevel
+	}
+	assert.Equal(t, "high", areas["persistence"])
+	assert.Equal(t, "low", areas["search"])
+
+	featureTemplates := make(map[string][]string)
+	for _, feature := range plan.Features {
+		featureTemplates[feature.Name] = feature.TemplateNames
+	}
+	assert.Equal(t, []string{"sync.go.tmpl"}, featureTemplates["sync"])
+	assert.Equal(t, []string{"search.go.tmpl"}, featureTemplates["search"])
+	assert.Equal(t, []string{"store.go.tmpl"}, featureTemplates["store"])
+}
+
 func petstoreSpec() *spec.APISpec {
 	return &spec.APISpec{
 		Name: "petstore",
@@ -367,6 +401,75 @@ func petstoreSpec() *spec.APISpec {
 							{Name: "username", Type: "string"},
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+func postOnlySpec() *spec.APISpec {
+	return &spec.APISpec{
+		Name: "post-only",
+		Resources: map[string]spec.Resource{
+			"widgets": {
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method: "POST",
+						Path:   "/widgets",
+						Body: []spec.Param{
+							{Name: "name", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func smallReadWriteSyncableSpec() *spec.APISpec {
+	return &spec.APISpec{
+		Name: "parcel",
+		Resources: map[string]spec.Resource{
+			"deliveries": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/deliveries",
+						Response: spec.ResponseDef{Type: "object", Item: "DeliveriesResponse"},
+					},
+					"add": {
+						Method: "POST",
+						Path:   "/add-delivery",
+						Body: []spec.Param{
+							{Name: "tracking_number", Type: "string"},
+							{Name: "carrier_code", Type: "string"},
+							{Name: "description", Type: "string"},
+						},
+						Response: spec.ResponseDef{Type: "object", Item: "SuccessResponse"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Delivery": {
+				Fields: []spec.TypeField{
+					{Name: "carrier_code", Type: "string"},
+					{Name: "description", Type: "string"},
+					{Name: "status_code", Type: "integer"},
+					{Name: "tracking_number", Type: "string"},
+				},
+			},
+			"DeliveriesResponse": {
+				Fields: []spec.TypeField{
+					{Name: "success", Type: "boolean"},
+					{Name: "error_message", Type: "string"},
+					{Name: "deliveries", Type: "array"},
+				},
+			},
+			"SuccessResponse": {
+				Fields: []spec.TypeField{
+					{Name: "success", Type: "boolean"},
+					{Name: "error_message", Type: "string"},
 				},
 			},
 		},

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -310,7 +310,7 @@ func TestToVisionaryPlanSyncableResourceDrivesLocalDataLayer(t *testing.T) {
 		areas[decision.Area] = decision.NeedLevel
 	}
 	assert.Equal(t, "high", areas["persistence"])
-	assert.Equal(t, "low", areas["search"])
+	assert.Equal(t, "high", areas["search"])
 
 	featureTemplates := make(map[string][]string)
 	for _, feature := range plan.Features {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -27,9 +27,40 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/health"
 			params := map[string]string{}
-			data, err := c.Get(cmd.Context(), path, params)
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
+			}
+			// Print provenance to stderr for human-facing output only.
+			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
+			// --select) and piped stdout suppress this line; the JSON envelope
+			// already carries meta.source for those consumers.
+			// SYNC: keep this gate aligned with command_endpoint.go.tmpl.
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				if json.Unmarshal(data, &countItems) != nil {
+					// Single object, not an array
+					countItems = []json.RawMessage{data}
+				}
+				printProvenance(cmd, len(countItems), prov)
+			}
+			// For JSON output, wrap with provenance envelope. --select wins over
+			// --compact when both are set; --compact only runs when no explicit
+			// fields were requested. Explicit format flags (--csv, --quiet, --plain)
+			// opt out of the auto-JSON path so piped consumers that asked for a
+			// non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var items []map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
@@ -34,10 +34,10 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 			body := map[string]any{}
 			data, _, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 
-			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 			// Print provenance to stderr for human-facing output only.
 			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
 			// --select) and piped stdout suppress this line; the JSON envelope

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
@@ -34,8 +34,40 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 			body := map[string]any{}
 			data, _, err := c.PostQueryWithParams(cmd.Context(), path, params, body)
 
+			prov := attachFreshness(DataProvenance{Source: "live"}, flags)
 			if err != nil {
 				return classifyAPIError(err, flags)
+			}
+			// Print provenance to stderr for human-facing output only.
+			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
+			// --select) and piped stdout suppress this line; the JSON envelope
+			// already carries meta.source for those consumers.
+			// SYNC: keep this gate aligned with command_endpoint.go.tmpl.
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				if json.Unmarshal(data, &countItems) != nil {
+					// Single object, not an array
+					countItems = []json.RawMessage{data}
+				}
+				printProvenance(cmd, len(countItems), prov)
+			}
+			// For JSON output, wrap with provenance envelope. --select wins over
+			// --compact when both are set; --compact only runs when no explicit
+			// fields were requested. Explicit format flags (--csv, --quiet, --plain)
+			// opt out of the auto-JSON path so piped consumers that asked for a
+			// non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
 			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var items []map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -66,6 +66,9 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
+			if !flags.dryRun && statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
+				writeMutationResponseToStore(cmd.Context(), "quotes", data, "")
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -30,10 +30,39 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 			path := "/api/quotes/{quote_id}"
 			path = replacePathParam(path, "quote_id", args[0])
 			params := map[string]string{}
-			data, err := c.Get(cmd.Context(), path, params)
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			// Print provenance to stderr for human-facing output only.
+			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
+			// --select) and piped stdout suppress this line; the JSON envelope
+			// already carries meta.source for those consumers.
+			// SYNC: keep this gate aligned with command_promoted.go.tmpl.
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				_ = json.Unmarshal(data, &countItems)
+				printProvenance(cmd, len(countItems), prov)
+			}
+			// For JSON output, wrap with provenance envelope before passing through flags.
+			// --select wins over --compact when both are set; --compact only runs when
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
+			}
+			// For all other output modes (table, csv, plain, quiet), use the standard pipeline
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var items []map[string]any
 				if json.Unmarshal(data, &items) == nil && len(items) > 0 {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -26,10 +26,39 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/api/quotes"
 			params := map[string]string{}
-			data, err := c.Get(cmd.Context(), path, params)
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}
+			// Print provenance to stderr for human-facing output only.
+			// Machine-format flags (--json, --csv, --compact, --quiet, --plain,
+			// --select) and piped stdout suppress this line; the JSON envelope
+			// already carries meta.source for those consumers.
+			// SYNC: keep this gate aligned with command_promoted.go.tmpl.
+			if wantsHumanTable(cmd.OutOrStdout(), flags) {
+				var countItems []json.RawMessage
+				_ = json.Unmarshal(data, &countItems)
+				printProvenance(cmd, len(countItems), prov)
+			}
+			// For JSON output, wrap with provenance envelope before passing through flags.
+			// --select wins over --compact when both are set; --compact only runs when
+			// no explicit fields were requested. Explicit format flags (--csv, --quiet,
+			// --plain) opt out of the auto-JSON path so piped consumers that asked for
+			// a non-JSON format reach the standard pipeline below.
+			if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !flags.csv && !flags.quiet && !flags.plain) {
+				filtered := data
+				if flags.selectFields != "" {
+					filtered = filterFields(filtered, flags.selectFields)
+				} else if flags.compact {
+					filtered = compactFields(filtered)
+				}
+				wrapped, wrapErr := wrapWithProvenance(filtered, prov)
+				if wrapErr != nil {
+					return wrapErr
+				}
+				return printOutput(cmd.OutOrStdout(), wrapped, true)
+			}
+			// For all other output modes (table, csv, plain, quiet), use the standard pipeline
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				var items []map[string]any
 				if json.Unmarshal(data, &items) == nil && len(items) > 0 {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -70,6 +70,9 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
+			if !flags.dryRun && statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
+				writeMutationResponseToStore(cmd.Context(), "quotes", data, "")
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -70,6 +70,9 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 					}
 				}
 			}
+			if !flags.dryRun && statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure) {
+				writeMutationResponseToStore(cmd.Context(), "quotes", data, "")
+			}
 			if wantsHumanTable(cmd.OutOrStdout(), flags) {
 				// Check if response contains an array (directly or wrapped in "data")
 				var items []map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -41,6 +41,7 @@ type rootFlags struct {
 	deliverSpec         string
 	timeout             time.Duration
 	rateLimit           float64
+	maxAge              time.Duration
 	dataSource          string
 	freshnessMeta       any
 
@@ -171,6 +172,7 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 	rootCmd.PersistentFlags().BoolVar(&flags.agent, "agent", false, "Set all agent-friendly defaults (--json --compact --no-input --no-color --yes)")
 	rootCmd.PersistentFlags().BoolVar(&flags.allowPartialFailure, "allow-partial-failure", false, "Downgrade response-body partial-failure (e.g. partialFailureError) to a warning instead of a non-zero exit")
 	rootCmd.PersistentFlags().StringVar(&flags.dataSource, "data-source", "auto", "Data source for read commands: auto (live with local fallback), live (API only), local (synced data only)")
+	rootCmd.PersistentFlags().DurationVar(&flags.maxAge, "max-age", 30*time.Minute, "Maximum acceptable age of local-store data before a stderr hint suggests sync; 0 disables")
 	rootCmd.PersistentFlags().StringVar(&flags.profileName, "profile", "", "Apply values from a saved profile (see 'fastapi-operationids-golden-pp-cli profile list')")
 	rootCmd.PersistentFlags().StringVar(&flags.deliverSpec, "deliver", "", "Route output to a sink: stdout (default), file:<path>, webhook:<url>")
 	rootCmd.PersistentFlags().Float64Var(&flags.rateLimit, "rate-limit", 0, "Max requests per second (0 to disable)")
@@ -236,6 +238,9 @@ Run 'fastapi-operationids-golden-pp-cli doctor' to verify auth and connectivity.
 	rootCmd.AddCommand(newWhichCmd(flags))
 	rootCmd.AddCommand(newExportCmd(flags))
 	rootCmd.AddCommand(newImportCmd(flags))
+	rootCmd.AddCommand(newSearchCmd(flags))
+	rootCmd.AddCommand(newSyncCmd(flags))
+	rootCmd.AddCommand(newWorkflowCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))
 	rootCmd.AddCommand(newHealthPromotedCmd(flags))
 	rootCmd.AddCommand(newItemsPromotedCmd(flags))

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -19,6 +19,7 @@ import (
 	"fastapi-operationids-golden-pp-cli/internal/client"
 	"fastapi-operationids-golden-pp-cli/internal/config"
 	"fastapi-operationids-golden-pp-cli/internal/mcp/cobratree"
+	"fastapi-operationids-golden-pp-cli/internal/store"
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -104,6 +105,27 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
 		makeAPIHandler("POST", "/api/quotes/{quote_id}", false, false, nil, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
+	)
+	// Search tool — faster than iterating list endpoints for finding specific items
+	s.AddTool(
+		mcplib.NewTool("search",
+			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
+			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		),
+		handleSearch,
+	)
+	// SQL tool — ad-hoc analysis on synced data without API calls
+	s.AddTool(
+		mcplib.NewTool("sql",
+			mcplib.WithDescription("Run read-only SQL against local database. Use for ad-hoc analysis, aggregations, and joins across synced resources. Requires sync first."),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description("SQL query (SELECT or WITH...SELECT). Synced records live in resources(resource_type, id, data); filter by resource_type and use json_extract on data, e.g. SELECT json_extract(data,'$.name') FROM resources WHERE resource_type='items'.")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		),
+		handleSQL,
 	)
 
 	// Context tool — front-loaded domain knowledge for agents.
@@ -457,6 +479,234 @@ func dbPath() string {
 // Note: MCP tools use their own dbPath() because they are in a separate package (main, not cli).
 // The CLI's defaultDBPath() in the cli package uses the same canonical path.
 
+func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return mcplib.NewToolResultError("query is required"), nil
+	}
+
+	limit := 25
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	db, err := store.OpenReadOnly(dbPath())
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	}
+	defer db.Close()
+
+	results, err := db.Search(query, limit)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	return toolResultJSON(results)
+}
+
+// validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
+// to the host is ReadOnlyHintAnnotation(true); a false annotation on a
+// mutating tool lets MCP hosts auto-approve writes and is treated as a real
+// bug per the project's agent-native security model.
+//
+// The gate rejects multi-statement input, then applies an allowlist (SELECT or
+// WITH only) AFTER stripping the leading whitespace, line comments, block
+// comments, and semicolons that SQLite itself ignores before parsing. A naive
+// HasPrefix check on a keyword blocklist is bypassable by prefixing the
+// dangerous statement with "/* x */" or "-- x\n"; a naive leading-keyword
+// allowlist is bypassable by appending "; ATTACH DATABASE ...". Combined with
+// the empirical fact that modernc.org/sqlite's mode=ro does NOT block VACUUM
+// INTO (writes a snapshot to a new file) or ATTACH DATABASE (opens a separate
+// writable handle), either bypass produces silent exfiltration to an
+// attacker-chosen path.
+//
+// SELECT and WITH are the only allowed leading keywords. WITH supports
+// SELECT-form CTEs; CTE-wrapped writes ("WITH x AS (...) INSERT ...") are
+// caught by OpenReadOnly's mode=ro one layer down. PRAGMA, ATTACH, VACUUM,
+// and every other DDL/DML keyword fail at this gate before reaching SQLite.
+func validateReadOnlyQuery(query string) error {
+	stripped := stripLeadingSQLNoise(query)
+	if hasTrailingSQLStatement(stripped) {
+		return fmt.Errorf("only a single SELECT or WITH statement is allowed")
+	}
+	upper := strings.ToUpper(stripped)
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
+		return fmt.Errorf("only SELECT queries are allowed")
+	}
+	return nil
+}
+
+// stripLeadingSQLNoise removes leading whitespace, SQL line comments
+// (-- to end of line), block comments (/* ... */), and statement
+// separators (;) from query. SQLite skips these before parsing the first
+// keyword, so a security gate that does not strip them mismatches what the
+// driver actually executes.
+func stripLeadingSQLNoise(query string) string {
+	for {
+		query = strings.TrimLeft(query, " \t\r\n;")
+		switch {
+		case strings.HasPrefix(query, "--"):
+			if idx := strings.IndexByte(query, '\n'); idx >= 0 {
+				query = query[idx+1:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(query, "/*"):
+			if idx := strings.Index(query[2:], "*/"); idx >= 0 {
+				query = query[2+idx+2:]
+				continue
+			}
+			return ""
+		default:
+			return query
+		}
+	}
+}
+
+// hasTrailingSQLStatement reports whether query contains a statement
+// terminator followed by more executable SQL. A trailing semicolon is allowed;
+// a second statement is not. Semicolons inside string literals, quoted
+// identifiers, bracket identifiers, and comments are ignored to match SQLite's
+// parser shape closely enough for this security gate.
+func hasTrailingSQLStatement(query string) bool {
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	inBracket := false
+	inLineComment := false
+	inBlockComment := false
+
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+		next := byte(0)
+		if i+1 < len(query) {
+			next = query[i+1]
+		}
+
+		switch {
+		case inLineComment:
+			if ch == '\n' {
+				inLineComment = false
+			}
+			continue
+		case inBlockComment:
+			if ch == '*' && next == '/' {
+				inBlockComment = false
+				i++
+			}
+			continue
+		case inSingle:
+			if ch == '\'' {
+				if next == '\'' {
+					i++
+					continue
+				}
+				inSingle = false
+			}
+			continue
+		case inDouble:
+			if ch == '"' {
+				if next == '"' {
+					i++
+					continue
+				}
+				inDouble = false
+			}
+			continue
+		case inBacktick:
+			if ch == '`' {
+				if next == '`' {
+					i++
+					continue
+				}
+				inBacktick = false
+			}
+			continue
+		case inBracket:
+			if ch == ']' {
+				inBracket = false
+			}
+			continue
+		}
+
+		switch {
+		case ch == '-' && next == '-':
+			inLineComment = true
+			i++
+		case ch == '/' && next == '*':
+			inBlockComment = true
+			i++
+		case ch == '\'':
+			inSingle = true
+		case ch == '"':
+			inDouble = true
+		case ch == '`':
+			inBacktick = true
+		case ch == '[':
+			inBracket = true
+		case ch == ';':
+			if stripLeadingSQLNoise(query[i+1:]) != "" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return mcplib.NewToolResultError("query is required"), nil
+	}
+
+	if err := validateReadOnlyQuery(query); err != nil {
+		return mcplib.NewToolResultError(err.Error()), nil
+	}
+
+	db, err := store.OpenReadOnly(dbPath())
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	}
+	defer db.Close()
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading columns: %v", err)), nil
+	}
+	var results []map[string]any
+	for rows.Next() {
+		values := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf("scanning row: %v", err)), nil
+		}
+		row := make(map[string]any)
+		for i, col := range cols {
+			row[col] = values[i]
+		}
+		results = append(results, row)
+	}
+	// rows.Next() stops on a mid-iteration error without failing the loop, so
+	// skipping rows.Err() would return a truncated result set as success.
+	if err := rows.Err(); err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
+	}
+
+	return toolResultJSON(results)
+}
+
 // toolResultJSON renders v as the indented JSON body of an MCP text result,
 // surfacing a marshal failure as a tool error instead of empty content.
 func toolResultJSON(v any) (*mcplib.CallToolResult, error) {
@@ -497,6 +747,9 @@ func handleContext(_ context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToo
 		"query_tips": []string{
 			"Pagination uses cursor-based paging. Pass after parameter for subsequent pages.",
 			"Control page size with the limit parameter (default 100).",
+			"Use the sql tool for ad-hoc analysis on synced data. Run sync first to populate the local database.",
+			"Use the search tool for full-text search across all synced resources. Faster than iterating list endpoints.",
+			"Prefer sql/search over repeated API calls when the data is already synced.",
 		},
 	}
 	return toolResultJSON(ctx)

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -45,6 +45,17 @@ func RegisterTools(s *server.MCPServer) {
 		),
 		makeAPIHandler("GET", "/items", true, false, nil, []mcpParamBinding{}, []string{}),
 	)
+	// Search tool — faster than iterating list endpoints for finding specific items
+	s.AddTool(
+		mcplib.NewTool("search",
+			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
+			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		),
+		handleSearch,
+	)
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(
 		mcplib.NewTool("sql",
@@ -413,6 +424,32 @@ func dbPath() string {
 
 // Note: MCP tools use their own dbPath() because they are in a separate package (main, not cli).
 // The CLI's defaultDBPath() in the cli package uses the same canonical path.
+
+func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return mcplib.NewToolResultError("query is required"), nil
+	}
+
+	limit := 25
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	db, err := store.OpenReadOnly(dbPath())
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	}
+	defer db.Close()
+
+	results, err := db.Search(query, limit)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	return toolResultJSON(results)
+}
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
 // to the host is ReadOnlyHintAnnotation(true); a false annotation on a

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -243,6 +243,7 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.AddCommand(newWhichCmd(flags))
 	rootCmd.AddCommand(newExportCmd(flags))
 	rootCmd.AddCommand(newImportCmd(flags))
+	rootCmd.AddCommand(newSearchCmd(flags))
 	rootCmd.AddCommand(newSyncCmd(flags))
 	rootCmd.AddCommand(newWorkflowCmd(flags))
 	rootCmd.AddCommand(newAPICmd(flags))

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -39,6 +39,17 @@ func RegisterTools(s *server.MCPServer) {
 	// Code-orchestration mode — the full surface is covered by two tools
 	// (<api>_search + <api>_execute). Endpoint-mirror tools are suppressed.
 	RegisterCodeOrchestrationTools(s)
+	// Search tool — faster than iterating list endpoints for finding specific items
+	s.AddTool(
+		mcplib.NewTool("search",
+			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
+			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		),
+		handleSearch,
+	)
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(
 		mcplib.NewTool("sql",
@@ -407,6 +418,32 @@ func dbPath() string {
 
 // Note: MCP tools use their own dbPath() because they are in a separate package (main, not cli).
 // The CLI's defaultDBPath() in the cli package uses the same canonical path.
+
+func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return mcplib.NewToolResultError("query is required"), nil
+	}
+
+	limit := 25
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	db, err := store.OpenReadOnly(dbPath())
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	}
+	defer db.Close()
+
+	results, err := db.Search(query, limit)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	return toolResultJSON(results)
+}
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
 // to the host is ReadOnlyHintAnnotation(true); a false annotation on a

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -59,6 +59,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -59,6 +59,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 		Short: "Sync API data to local SQLite for offline search and analysis",
 		Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
   Resources the API denies access to (HTTP 403, or HTTP 400 with an

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -63,6 +63,17 @@ func RegisterTools(s *server.MCPServer) {
 		),
 		makeAPIHandler("GET", "/items/premium", "paid", true, false, nil, []mcpParamBinding{}, []string{}),
 	)
+	// Search tool — faster than iterating list endpoints for finding specific items
+	s.AddTool(
+		mcplib.NewTool("search",
+			mcplib.WithDescription("Full-text search across all synced data. Faster than paginating list endpoints. Requires sync first."),
+			mcplib.WithString("query", mcplib.Required(), mcplib.Description("Search query (supports FTS5 syntax: AND, OR, NOT, quotes for phrases)")),
+			mcplib.WithNumber("limit", mcplib.Description("Max results (default 25)")),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithDestructiveHintAnnotation(false),
+		),
+		handleSearch,
+	)
 	// SQL tool — ad-hoc analysis on synced data without API calls
 	s.AddTool(
 		mcplib.NewTool("sql",
@@ -432,6 +443,32 @@ func dbPath() string {
 
 // Note: MCP tools use their own dbPath() because they are in a separate package (main, not cli).
 // The CLI's defaultDBPath() in the cli package uses the same canonical path.
+
+func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	args := req.GetArguments()
+	query, ok := args["query"].(string)
+	if !ok || query == "" {
+		return mcplib.NewToolResultError("query is required"), nil
+	}
+
+	limit := 25
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+
+	db, err := store.OpenReadOnly(dbPath())
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	}
+	defer db.Close()
+
+	results, err := db.Search(query, limit)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	return toolResultJSON(results)
+}
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
 // to the host is ReadOnlyHintAnnotation(true); a false annotation on a


### PR DESCRIPTION
## Summary
Small APIs with profiler-confirmed syncable resources now generate the local data layer instead of falling back to export/import only. A one-list, one-write API now emits `internal/store`, `sync`, and `search`; APIs with no syncable resources still skip those surfaces.

This keeps the fix at the profiler decision layer, so existing template selection and store/sync invariants continue to own the emitted files. Golden fixtures were updated where the newly eligible local data layer adds root commands, MCP search/sql support, freshness provenance, or sync help text.

Closes #2501

## Tests
- `go test ./internal/profiler -run 'Test(Profile(Petstore|Minimal|PostOnlyHasNoLocalStoreFeatures)|ToVisionaryPlan(SyncableResourceDrivesLocalDataLayer)?)' -count=1`
- `go test ./internal/generator -run 'Test(GenerateProjectsCompile|GeneratorNovelFeatureHelpGuardRequiresPositionalUse|GenerateSyncableSmallAPIEmitsLocalDataLayer|GeneratePostOnlyAPIStillSkipsLocalDataLayer)' -count=1`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...`
- `golangci-lint run ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
