### PR TITLE
docs(skills): add OAuth2 PKCE CLI checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Hand-written novel commands that perform visible actions (open browser tabs, sen
 1. Print by default; require explicit opt-in (`--launch`, `--send`, `--play`, etc.) to actually act.
 2. Short-circuit when `cliutil.IsVerifyEnv()` is true. The verifier sets `PRINTING_PRESS_VERIFY=1` in every mock-mode subprocess; this env-var check is the floor that catches any side-effect command the verifier's heuristic classifier misses.
 
+OAuth browser authorization flows must also avoid impossible machine-mode combinations. If `--json` or another machine-output mode suppresses the authorize URL and `--no-open` or equivalent disables browser launch, either emit a deliberate structured continuation protocol (`authorize_url`, state handle, expiry, next command) or fail fast with an actionable usage error. Do not wait for a callback that no user or machine can initiate. See `skills/printing-press/references/oauth2-pkce-cli-checklist.md`.
+
 Generated endpoint-mirror commands also gate mutating HTTP verbs (DELETE/POST/PUT/PATCH) at the transport layer (`internal/client/client.go`): under `PRINTING_PRESS_VERIFY=1` they short-circuit to a synthetic noop and never dial, while reads that ride a mutating verb (GraphQL/JSON-RPC reads, POST search; codegen-marked `mcp:read-only`) route through `doRead()` and bypass the gate. The command envelope reports `verify_noop: true` / `success: false`. `cli-printing-press verify` re-enables real HTTP to its mock server via `PRINTING_PRESS_VERIFY_LIVE_HTTP=1`; agents and ad-hoc runs leave it unset (mutations no-op), and live verifiers (`live_dogfood`, `workflow_verify`) strip both vars.
 
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -2049,6 +2049,8 @@ If one or more probe-safe endpoints are declared and the user provided credentia
 
 ### OAuth2 Grant Probe
 
+For OAuth2 Authorization Code + PKCE CLI implementation/review requirements, read [references/oauth2-pkce-cli-checklist.md](references/oauth2-pkce-cli-checklist.md).
+
 If the resolved spec declares `auth.type: oauth2` and has an interactive
 authorization URL (`authorizationCode` or `implicit` flow in OpenAPI, or an
 equivalent internal YAML auth field), the generic reachability check is not
@@ -3690,7 +3692,7 @@ For an extension to be durable, put it in its own file beside the emitted one:
 
 - **Custom config fields:** create `internal/config/<api>_config.go` exporting accessors your novel code reads directly. Do not add fields to the emitted `Config` struct.
 - **Custom request headers** (vendor fingerprint, `X-CSRF`, app-version, signed timestamps): create `internal/client/<api>_headers.go` exporting a func that builds the header map; novel code passes that map to `client.GetWithHeaders` / `PostWithHeaders` when it calls the API. The generated `client.go` has no global request mutator, so this pattern only covers requests made directly from novel code — it does not intercept calls from generated endpoint commands. Do not edit the templated header block in `client.go`.
-- **Custom auth flow** (browser-sniffed sessions, vendor SSO, refresh hooks beyond OAuth2): create `internal/cli/<api>_auth.go` (package `cli`, same as the generated `auth.go`) with the API-specific token capture or refresh, and wire it from a novel command rather than editing the templated `auth.go` constructor functions (`newAuthLoginCmd`, `newAuthSetupCmd`, etc.).
+- **Custom auth flow** (browser-sniffed sessions, vendor SSO, refresh hooks beyond OAuth2): create `internal/cli/<api>_auth.go` (package `cli`, same as the generated `auth.go`) with the API-specific token capture or refresh, and wire it from a novel command rather than editing the templated `auth.go` constructor functions (`newAuthLoginCmd`, `newAuthSetupCmd`, etc.). If the custom flow implements OAuth2 Authorization Code + PKCE, read [references/oauth2-pkce-cli-checklist.md](references/oauth2-pkce-cli-checklist.md) before writing or reviewing the command.
 - **Extended store schema** (typed tables beyond `resources`, vendor JSON columns, full-text indexes): create `internal/store/<api>_migrations.go` running its own `CREATE TABLE ... IF NOT EXISTS` from a lazy init invoked by the novel commands that need it. Do not edit the migration slice in `store.go`.
 - **New novel command:** put the command body in its own `internal/cli/<feature>.go` file — it survives regen as a whole hand-authored unit. The `AddCommand` call wiring it into the Cobra tree still goes in `root.go` per the Phase 3 novel-command skeleton above; `cli-printing-press generate --force` re-injects it via the lost-registration merge path. Use standalone `regen-merge` when you want to inspect the merge report before applying. Spec-declared commands are picked up by the generator's typed-tool path and need no hand-wired `AddCommand` at all.
 

--- a/skills/printing-press/references/oauth2-pkce-cli-checklist.md
+++ b/skills/printing-press/references/oauth2-pkce-cli-checklist.md
@@ -1,0 +1,94 @@
+---
+when-to-read: When implementing, reviewing, or generating OAuth2 Authorization Code + PKCE login flows for a printed CLI.
+---
+
+# OAuth2 PKCE CLI Checklist
+
+Use this checklist for printed CLI commands that obtain user-context tokens through an OAuth2 browser authorization flow. It applies to hand-written novel commands and to any future generator/template support for OAuth2 Authorization Code + PKCE.
+
+## Required behavior
+
+- Generate cryptographically random `state` per login attempt.
+- Generate a cryptographically random PKCE verifier per login attempt.
+- Use `code_challenge_method=S256` and a URL-safe SHA-256 `code_challenge`.
+- Validate callback `state` before exchanging any authorization code.
+- Bind loopback callback listeners only to loopback hosts (`127.0.0.1`, `localhost`, or `::1`).
+- Require the redirect URI to match the provider registration and the command's listener.
+- Store access tokens, refresh tokens, scopes, and expiry metadata through the CLI's normal config/storage path.
+- Keep cookie/browser-session login paths distinct from OAuth2 token acquisition paths.
+
+## Timeout handling
+
+Use separate timeout contexts for separate phases:
+
+1. Browser callback wait: long enough for the user to complete login/consent.
+2. Token exchange: shorter network timeout after the callback has arrived.
+
+Do not pass the browser-wait context into the token exchange. A user who authorizes near the callback deadline should not get an ambiguous token-exchange failure caused by leftover callback time.
+
+## Machine-output and browser-launch rules
+
+OAuth login commands often have two ways to get the user to the authorize URL:
+
+- open the browser automatically; or
+- print the authorize URL for manual copy/paste.
+
+Never suppress both paths.
+
+If `--json` or another machine-output mode suppresses human-readable stdout, and `--no-open` disables browser launch, the command must either:
+
+1. fail fast with an actionable usage error; or
+2. implement an explicit machine protocol that emits structured data such as `authorize_url`, `state_id`, `expires_at`, and a documented continuation command.
+
+Do not silently wait for a callback that cannot happen.
+
+Under `cliutil.IsVerifyEnv()`, do not open browsers or dial OS handlers. Prefer a typed verify/dry-run result or a usage error that names the non-opening mode.
+
+## JSON cleanliness
+
+- Do not print prose to stdout in `--json` mode.
+- If warnings are needed in JSON mode, put them in the JSON envelope or write them to stderr only when that matches the CLI's existing error contract.
+- Keep final success output machine-parseable and free of OAuth secrets.
+
+## Test requirements
+
+Add focused tests for:
+
+- authorize URL construction, including `state`, scope, redirect URI, S256 challenge, and response type;
+- callback state mismatch;
+- end-to-end loopback flow with a local token server;
+- token storage metadata, including refresh-token presence, scopes, and expiry when applicable;
+- browser-open failure or `--no-open` URL printing behavior;
+- impossible mode combinations such as `--json --no-open`;
+- timeout behavior for callback wait versus token exchange when practical.
+
+Run `go test -race` for tests involving callback servers, token servers, channels, or goroutines.
+
+## Race-safety rules for tests
+
+HTTP test handlers run in separate goroutines. Do not write a plain `bool`, map, slice, or struct field in an `httptest.Server` handler and read it from the main test goroutine without synchronization.
+
+Use one of:
+
+- `sync/atomic.Bool` or another atomic type;
+- a channel;
+- a mutex-protected struct.
+
+A completed `http.Client.Do` call is not a general synchronization primitive for arbitrary server-side writes.
+
+## Review red flags
+
+Treat these as blockers or at least high-priority review comments:
+
+- plain `bool` or unsynchronized state shared between HTTP handler goroutines and test goroutines;
+- the same context used for both browser callback wait and token exchange;
+- `--json` hides the authorize URL while `--no-open` prevents browser launch;
+- browser auto-open runs under `PRINTING_PRESS_VERIFY=1`;
+- OAuth2 user-context tokens are conflated with app-only bearer tokens or cookie-capture login;
+- callback accepts non-loopback redirect hosts without an explicit, reviewed reason;
+- token responses are logged or printed in full;
+- generated docs tell users to use an app-only bearer token for user-context writes or personal reads.
+
+## When to promote this into generator code
+
+This checklist is enough for hand-written novel OAuth commands. If `cli-printing-press` starts generating OAuth2 PKCE login commands from specs/templates, promote these rules into the generator and golden tests so every printed CLI inherits them by construction.


### PR DESCRIPTION
## Summary
- adds a Printing Press reference checklist for OAuth2 Authorization Code + PKCE CLI flows
- links the checklist from the OAuth2 grant-probe section in the main Printing Press skill
- adds a terse repo-wide invariant for impossible OAuth machine-mode/browser-mode combinations such as `--json --no-open`

## Verification
- `git diff --check`
- reviewed rendered Markdown context in `AGENTS.md`, `skills/printing-press/SKILL.md`, and the new checklist

This captures lessons from the X/Twitter OAuth2 PKCE follow-up: separate callback/token-exchange timeouts, race-safe handler tests, and fail-fast handling for unrecoverable machine-output/browser-launch flag combinations.