### PR TITLE
fix(pipeline): skip TestClaimOutputDir_PermissionError on Windows

### DIFF
--- a/internal/pipeline/claim_test.go
+++ b/internal/pipeline/claim_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -54,16 +55,18 @@ func TestClaimOutputDir_MaxRetries(t *testing.T) {
 }
 
 func TestClaimOutputDir_PermissionError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denial via unrooted path is not portable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("test requires non-root")
 	}
-	// Parent dir that doesn't exist and can't be created — on macOS /proc doesn't exist,
+	// Parent dir that doesn't exist and can't be created - on macOS /proc doesn't exist,
 	// so use a path that will fail os.MkdirAll
 	base := "/nonexistent-root-dir/fakedir/notion-pp-cli"
-
 	_, err := ClaimOutputDir(base)
 	assert.Error(t, err)
-	// Should NOT contain "could not claim" — should be the underlying OS error
+	// Should NOT contain "could not claim" - should be the underlying OS error
 	assert.NotContains(t, err.Error(), "could not claim")
 }
 


### PR DESCRIPTION
## What changed
Skipped `TestClaimOutputDir_PermissionError` on Windows.

## Why
`os.Getuid()` always returns `-1` on Windows, so the existing
non-root guard never fires. The test then uses a Unix-style path
(`/nonexistent-root-dir/...`) which Windows does not fail the same
way, causing `ClaimOutputDir` to return `nil` instead of an error.
The subsequent `err.Error()` call panics on nil.

Also cleaned up garbled comment characters (â€" → -) left by
copy-paste from a non-UTF-8 source.

## Repo fit
Touches only `internal/pipeline/claim_test.go`.
No production code changed. No golden output affected.

## Verification
go test ./internal/pipeline/... -run TestClaimOutputDir_PermissionError -v
Result: `--- SKIP: TestClaimOutputDir_PermissionError (0.00s)`
Previously: `panic: runtime error: invalid memory address or nil pointer dereference`

## AI / Automation disclosure
Human-reviewed: AI assistance was used to identify the bug and
craft the fix; the change was reviewed by me before submission.