### PR TITLE
fix(cli): flag oauth2 refresh missing client id

### DIFF
--- a/internal/generator/oauth2_refresh_test.go
+++ b/internal/generator/oauth2_refresh_test.go
@@ -39,7 +39,11 @@ func TestGenerateOAuth2RefreshAuth(t *testing.T) {
 	assert.Contains(t, configSrc, `return "Bearer " + c.AccessToken`)
 	assert.NotContains(t, configSrc, `c.AuthSource = "bearer_refresh"`)
 	assert.Contains(t, clientSrc, `"grant_type":    {"refresh_token"}`)
+	assert.Contains(t, clientSrc, `OAuth2 client ID is required when a refresh token is configured`)
 	assert.Contains(t, clientSrc, `tokenURL = "https://auth.example.com/oauth/token"`)
+	assert.Contains(t, doctorSrc, `report["auth"] = "misconfigured (oauth2 refresh)"`)
+	assert.Contains(t, doctorSrc, "cfg.AuthSource = \"oauth2_refresh\"\n					report[\"auth_source\"] = cfg.AuthSource\n					report[\"auth_hint\"] = \"refresh token is configured but OAuth2 client ID is missing")
+	assert.Contains(t, doctorSrc, `refresh token is configured but OAuth2 client ID is missing`)
 	assert.Contains(t, doctorSrc, `report["auth"] = "configured (oauth2 refresh)"`)
 	assert.Contains(t, doctorSrc, `report["auth_source"] = cfg.AuthSource`)
 	assert.Contains(t, doctorSrc, `report["auth_hint"] = "export OAUTH_REFRESH_REFRESH_TOKEN=<your-oauth-refresh-value>"`)
@@ -225,4 +229,74 @@ func TestOAuth2RefreshTokenUsedBeforeRequest(t *testing.T) {
 `, "__MODULE_PATH__", modulePath)
 
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "oauth2_refresh_test.go"), []byte(runtimeTest), 0o644))
+}
+
+func TestOAuth2RefreshFailsBeforeNetworkWithoutClientID(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("oauth2-refresh-missing-client")
+	apiSpec.Auth = spec.AuthConfig{
+		Type:     spec.AuthTypeOAuth2Refresh,
+		Header:   "Authorization",
+		TokenURL: "https://auth.example.com/oauth/token",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "oauth2-refresh-missing-client-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	writeOAuth2RefreshMissingClientRuntimeTest(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "^TestOAuth2RefreshFailsBeforeNetworkWithoutClientID$")
+}
+
+func writeOAuth2RefreshMissingClientRuntimeTest(t *testing.T, outputDir string) {
+	t.Helper()
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	modulePath := strings.TrimSpace(strings.TrimPrefix(strings.SplitN(goMod, "\n", 2)[0], "module "))
+	require.NotEmpty(t, modulePath)
+
+	runtimeTest := strings.ReplaceAll(`package client
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"__MODULE_PATH__/internal/config"
+)
+
+func TestOAuth2RefreshFailsBeforeNetworkWithoutClientID(t *testing.T) {
+	called := false
+	cfg := &config.Config{
+		BaseURL:      "https://api.example.com",
+		TokenURL:     "https://auth.example.com/oauth/token",
+		RefreshToken: "refresh-123",
+		TokenExpiry:  time.Now().Add(-time.Minute),
+		Path:         filepath.Join(t.TempDir(), "config.toml"),
+	}
+	c := New(cfg, time.Second, 0)
+	c.HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		t.Fatalf("refresh should fail before network when client ID is missing")
+		return nil, nil
+	})}
+
+	_, err := c.authHeader(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "OAuth2 client ID is required") {
+		t.Fatalf("authHeader err = %v", err)
+	}
+	if called {
+		t.Fatalf("token endpoint was called")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+`, "__MODULE_PATH__", modulePath)
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "oauth2_refresh_missing_client_test.go"), []byte(runtimeTest), 0o644))
 }

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2078,6 +2078,9 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.Config.RefreshToken == "" {
 		return nil
 	}
+	if strings.TrimSpace(c.Config.ClientID) == "" {
+		return fmt.Errorf("refreshing access token: OAuth2 client ID is required when a refresh token is configured; set client_id in config or the client ID environment variable")
+	}
 
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -301,6 +301,11 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 {{- if .Auth.Instructions}}
 					report["auth_instructions"] = {{printf "%q" .Auth.Instructions}}
 {{- end}}
+				} else if strings.TrimSpace(cfg.ClientID) == "" {
+					report["auth"] = "misconfigured (oauth2 refresh)"
+					cfg.AuthSource = "oauth2_refresh"
+					report["auth_source"] = cfg.AuthSource
+					report["auth_hint"] = "refresh token is configured but OAuth2 client ID is missing; set client_id in config or the client ID environment variable"
 				} else {
 					authConfigured = true
 					report["auth"] = "configured (oauth2 refresh)"

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -873,6 +873,9 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.Config.RefreshToken == "" {
 		return nil
 	}
+	if strings.TrimSpace(c.Config.ClientID) == "" {
+		return fmt.Errorf("refreshing access token: OAuth2 client ID is required when a refresh token is configured; set client_id in config or the client ID environment variable")
+	}
 
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -756,6 +756,9 @@ func (c *Client) refreshAccessToken(ctx context.Context) error {
 	if c.Config.RefreshToken == "" {
 		return nil
 	}
+	if strings.TrimSpace(c.Config.ClientID) == "" {
+		return fmt.Errorf("refreshing access token: OAuth2 client ID is required when a refresh token is configured; set client_id in config or the client ID environment variable")
+	}
 
 	tokenURL := c.Config.TokenURL
 	if tokenURL == "" {


### PR DESCRIPTION
## Intent

Fix the generator-side OAuth2 refresh-token readiness gap behind the X import bug. A generated OAuth2 refresh CLI should not present a refresh token as usable when the OAuth2 client ID is missing; the refresh request already sends `client_id`, so failing locally with a clear error is better than a later opaque token-endpoint failure.

Related library patch: mvanhorn/printing-press-library#1124

## Approach

- In generated clients, fail before network refresh when `refresh_token` is configured but `client_id` is empty.
- In generated doctor output for `auth.type: oauth2_refresh`, report `misconfigured (oauth2 refresh)` with an actionable hint when the refresh token exists but the client ID is missing.
- Add generator tests plus a generated runtime regression test proving the client does not call the token endpoint in that state.

## Verification

- `gofmt -w internal/generator/oauth2_refresh_test.go`
- `go test ./internal/generator -run 'TestGenerateOAuth2RefreshAuth|TestOAuth2RefreshFailsBeforeNetworkWithoutClientID|TestOAuth2RefreshDefaultsEnvVars|TestOAuth2RefreshExplicitEnvVarsKeepClientSecretOptional|TestOAuth2RefreshRequiresTokenURL' -count=1`
- `go test ./internal/generator -run 'TestOAuth2Refresh' -count=1`
- `go test ./internal/generator -count=1`
- `go test ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
