### PR TITLE
docs(plane): templated base_url + per-command workspace selection

### DIFF
--- a/catalog/plane.yaml
+++ b/catalog/plane.yaml
@@ -10,7 +10,7 @@ spec_source: official
 verified_date: "2026-05-11"
 homepage: https://developers.plane.so/api-reference/introduction
 auth_key_url: https://app.plane.so/profile/api-tokens
-auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`). Self-hosted base/server URL must carry the workspace prefix `https://<host>/api/v1/workspaces/{slug}` (keep `{slug}` templated — do not bake in one workspace), not the bare host; select the workspace per command with `--workspace <slug>` or `PLANE_SLUG`, or persist a default via `plane-pp-cli workspaces use <slug>` / `plane-pp-cli init`."
+auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`). Self-hosted base/server URL must carry the workspace prefix `https://<host>/api/v1/workspaces/{slug}` (keep `{slug}` templated — do not bake in one workspace), not the bare host; select the workspace per command with `--workspace <slug>` or `PLANE_SLUG`, or persist a default via `plane-pp-cli workspaces use <slug>` or `plane-pp-cli init`."
 auth_env_vars:
   - PLANE_API_KEY
 notes: >
@@ -31,7 +31,7 @@ notes: >
   with the SPA `index.html` at HTTP 200 instead of JSON, making `sync` silently
   store 0 rows. Keep `{slug}` as a literal template variable rather than baking
   in one workspace: it is supplied at runtime via `--workspace <slug>`,
-  `PLANE_SLUG`, or a saved default (`plane-pp-cli workspaces use <slug>` /
-  `init`). Plane's public API cannot enumerate a user's workspaces by API key, so
+  `PLANE_SLUG`, or a saved default (`plane-pp-cli workspaces use <slug>` or
+  `plane-pp-cli init`). Plane's public API cannot enumerate a user's workspaces by API key, so
   the slug is user-supplied (from the browser URL, `app.plane.so/<slug>/`).
   Rate limit: 60 req/min per token.

--- a/catalog/plane.yaml
+++ b/catalog/plane.yaml
@@ -10,7 +10,7 @@ spec_source: official
 verified_date: "2026-05-11"
 homepage: https://developers.plane.so/api-reference/introduction
 auth_key_url: https://app.plane.so/profile/api-tokens
-auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`). Self-hosted base/server URL must be the full workspace prefix `https://<host>/api/v1/workspaces/<slug>`, not the bare host."
+auth_instructions: "Plane Cloud: Profile → API tokens. Self-hosted: Workspace settings → API tokens. Send as header `X-API-Key: <token>` (NOT `Authorization: Bearer`). Self-hosted base/server URL must carry the workspace prefix `https://<host>/api/v1/workspaces/{slug}` (keep `{slug}` templated — do not bake in one workspace), not the bare host; select the workspace per command with `--workspace <slug>` or `PLANE_SLUG`, or persist a default via `plane-pp-cli workspaces use <slug>` / `plane-pp-cli init`."
 auth_env_vars:
   - PLANE_API_KEY
 notes: >
@@ -25,8 +25,13 @@ notes: >
   sync model with project fan-out, plus an `updated_at__gt` incremental
   since-param — a stock `generate` reproduces a working `sync` with no post-print
   annotation. Because the workspace scope lives in the server URL, self-hosted
-  users must set the base/server URL to the full workspace prefix
-  `https://<host>/api/v1/workspaces/<slug>` (NOT the bare `https://<host>`); a
+  users must set the base/server URL to the workspace prefix
+  `https://<host>/api/v1/workspaces/{slug}` (NOT the bare `https://<host>`); a
   bare host resolves the relative workspace paths to the web app, which answers
   with the SPA `index.html` at HTTP 200 instead of JSON, making `sync` silently
-  store 0 rows. Rate limit: 60 req/min per token.
+  store 0 rows. Keep `{slug}` as a literal template variable rather than baking
+  in one workspace: it is supplied at runtime via `--workspace <slug>`,
+  `PLANE_SLUG`, or a saved default (`plane-pp-cli workspaces use <slug>` /
+  `init`). Plane's public API cannot enumerate a user's workspaces by API key, so
+  the slug is user-supplied (from the browser URL, `app.plane.so/<slug>/`).
+  Rate limit: 60 req/min per token.


### PR DESCRIPTION
﻿## Intent

Keep the Plane recipe's guidance in sync with the workspace-targeting feature now shipping in the published `plane-pp-cli`. The recipe currently tells self-hosted users to bake one workspace slug into the server base URL; the CLI now resolves the `{slug}` server variable at runtime, so the recipe should recommend a templated base + per-command workspace selection instead.

Issue: N/A (follow-up to the merged Plane catalog entry #2598)

## Approach

Docs-only edit to `catalog/plane.yaml`:
- `auth_instructions`: recommend the server base carry a **templated** `https://<host>/api/v1/workspaces/{slug}` (literal `{slug}`, not a baked-in workspace), and select the workspace per command with `--workspace <slug>` / `PLANE_SLUG`, or persist a default via `plane-pp-cli workspaces use <slug>` / `init`.
- `notes`: same templated-base guidance, plus a note that Plane's public API cannot enumerate workspaces by API key (the slug is user-supplied from the browser URL). The existing bare-host → SPA-`index.html` → silent-empty-`sync` warning is retained.

The spec (`catalog/specs/plane-spec.yaml`) and the entry's `name`/`description` are untouched.

## Scope

Primary area: `catalog/plane.yaml` (Plane recipe documentation).

Why this belongs in this repo: it is the catalog recipe's own auth/tenant guidance. The corresponding CLI code (the `--workspace` flag and `workspaces`/`init` commands) is being submitted separately to `mvanhorn/printing-press-library`.

## Catalog Justification

Embedded catalog fit: Edits the existing `plane` entry (project-management); no new entry.

Distinct blueprint pattern: Unchanged — Plane remains the only `servers:`-scoped multi-tenant `{slug}` recipe; this PR refines how that tenant variable is supplied at runtime.

Closest existing entries checked: N/A (no new entry; this is an in-place doc refinement of `plane`).

Source provenance: Unchanged — `spec_source: official` (vendor drf-spectacular schema at `/api/schema/`). No spec change.

Auth and tenant assumptions: `X-API-Key` header auth (unchanged). Tenant guidance updated: the `{slug}` stays a literal server-template variable, supplied per-command (`--workspace`/`PLANE_SLUG`) or via a saved default, rather than baked into the base URL.

Safe default surface: Unchanged. Read/sync behavior is unaffected; this only changes prose guidance.

Generation path: Unchanged — `name`/`description` and the spec are untouched, so `generate plane` and the rendered registry/`catalog list` output are byte-identical; the catalog-list golden needs no regen.

Stale-body check: Diff confirmed to touch only `auth_instructions` and the `notes` tail of `catalog/plane.yaml` (9 insertions, 4 deletions); no other files.

## Risk

Documentation-only. No change to the generated CLI, spec, MCP surface, or catalog rendering. The catalog-list golden is unaffected (it renders name + description, both unchanged).

## Output Contract

N/A — no template, generated-file, manifest, or catalog-rendering change. `catalog list` output is unchanged (name/description identical), so no golden update is required.

## Verification

- `git diff origin/main -- catalog/plane.yaml` — only `auth_instructions` + `notes` tail changed; `name`/`description`/spec untouched.
- Confirmed the catalog-list golden (`testdata/golden/expected/catalog-list/stdout.txt`) references only the unchanged Plane description, so it does not need regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
