### PR TITLE
fix(cli): sync --dry-run must not mutate sync_state (dependent resources + cursor clears)

### DIFF
--- a/internal/generator/sync_dryrun_test.go
+++ b/internal/generator/sync_dryrun_test.go
@@ -1,0 +1,70 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedSyncDryRunDoesNotMutateSyncState guards the fix for #2935: a
+// `sync --dry-run` must not write the sync_state table. The flat (main-loop)
+// path already short-circuited on the {"dry_run":true} sentinel, but the
+// dependent-resource loop called db.SaveSyncState unconditionally at its tail,
+// and the --full / --latest-only cursor clears ran regardless of --dry-run.
+// This asserts the generated sync.go carries all three guards.
+func TestGeneratedSyncDryRunDoesNotMutateSyncState(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "syncdryrun",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Resources: map[string]spec.Resource{
+			"parents": {
+				Description: "Parents",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/parents", Description: "List parents", Response: spec.ResponseDef{Type: "array"}},
+				},
+			},
+			"children": {
+				Description: "Children",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {Method: "GET", Path: "/parents/{parentId}/children", Description: "List children", Response: spec.ResponseDef{Type: "array"}},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "parents", Path: "/parents", Method: "GET"},
+		},
+		DependentSyncResources: []profiler.DependentResource{
+			{Name: "children", ParentResource: "parents", ParentIDParam: "parentId", Path: "/parents/{parentId}/children", Method: "GET"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+
+	// Both the flat loop and the dependent loop must short-circuit on the
+	// dry-run sentinel before any SaveSyncState. The dependent guard is the
+	// #2935 fix; the flat guard pre-existed. Two occurrences == both guarded.
+	if n := strings.Count(syncSrc, "if isDryRunResponse(data) {"); n < 2 {
+		t.Fatalf("expected the dry-run sentinel guard in both the flat and dependent sync loops (>=2 occurrences), found %d", n)
+	}
+	// The --full and --latest-only cursor clears must skip under --dry-run.
+	require.Contains(t, syncSrc, "if full && !c.DryRun {",
+		"--full cursor clear must be guarded by !c.DryRun")
+	require.Contains(t, syncSrc, "if !c.DryRun {",
+		"--latest-only cursor clear must be guarded by !c.DryRun")
+}

--- a/internal/generator/sync_dryrun_test.go
+++ b/internal/generator/sync_dryrun_test.go
@@ -65,6 +65,11 @@ func TestGeneratedSyncDryRunDoesNotMutateSyncState(t *testing.T) {
 	// The --full and --latest-only cursor clears must skip under --dry-run.
 	require.Contains(t, syncSrc, "if full && !c.DryRun {",
 		"--full cursor clear must be guarded by !c.DryRun")
-	require.Contains(t, syncSrc, "if !c.DryRun {",
+	latestOnlyIdx := strings.Index(syncSrc, "if latestOnly {")
+	require.NotEqual(t, -1, latestOnlyIdx, "expected latestOnly block in generated sync")
+	latestOnlyBlock := syncSrc[latestOnlyIdx:]
+	require.Contains(t, latestOnlyBlock, "Skip under --dry-run:",
+		"--latest-only cursor clear must document the dry-run guard")
+	require.Contains(t, latestOnlyBlock, "if !c.DryRun {",
 		"--latest-only cursor clear must be guarded by !c.DryRun")
 }

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -254,8 +254,9 @@ Resource scoping:
 				return usageErr(err)
 			}
 
-			// --full: clear all sync cursors before starting
-			if full {
+			// --full: clear all sync cursors before starting.
+			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
+			if full && !c.DryRun {
 				for _, resource := range resources {
 					_ = db.SaveSyncState(resource, "", 0)
 				}
@@ -276,11 +277,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off".
-					for _, resource := range resources {
-						existing, _, _, _ := db.GetSyncState(resource)
-						if existing != "" {
-							_ = db.SaveSyncState(resource, "", 0)
+					// "resume from wherever I left off". Skip under --dry-run:
+					// a preview must not mutate sync-state (issue #2935).
+					if !c.DryRun {
+						for _, resource := range resources {
+							existing, _, _, _ := db.GetSyncState(resource)
+							if existing != "" {
+								_ = db.SaveSyncState(resource, "", 0)
+							}
 						}
 					}
 				} else if humanFriendly {
@@ -2458,6 +2462,17 @@ func syncDependentResource(ctx context.Context, c interface {
 					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, err))
 				}
 				break
+			}
+
+			// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+			// of a real response when --dry-run is set. A preview must not mutate
+			// sync-state, so return before the SaveSyncState at the end of this
+			// function — mirroring syncResource's guard above. (issue #2935)
+			if isDryRunResponse(data) {
+				if !humanFriendly {
+					fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", dep.Name)
+				}
+				return syncResult{Resource: dep.Name, Count: 0, Duration: time.Since(started)}
 			}
 
 {{ if $hasHTMLSync}}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -142,8 +142,9 @@ Resource scoping:
 				return usageErr(err)
 			}
 
-			// --full: clear all sync cursors before starting
-			if full {
+			// --full: clear all sync cursors before starting.
+			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
+			if full && !c.DryRun {
 				for _, resource := range resources {
 					_ = db.SaveSyncState(resource, "", 0)
 				}
@@ -164,11 +165,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off".
-					for _, resource := range resources {
-						existing, _, _, _ := db.GetSyncState(resource)
-						if existing != "" {
-							_ = db.SaveSyncState(resource, "", 0)
+					// "resume from wherever I left off". Skip under --dry-run:
+					// a preview must not mutate sync-state (issue #2935).
+					if !c.DryRun {
+						for _, resource := range resources {
+							existing, _, _, _ := db.GetSyncState(resource)
+							if existing != "" {
+								_ = db.SaveSyncState(resource, "", 0)
+							}
 						}
 					}
 				} else if humanFriendly {
@@ -1637,6 +1641,17 @@ func syncDependentResource(ctx context.Context, c interface {
 					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, err))
 				}
 				break
+			}
+
+			// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+			// of a real response when --dry-run is set. A preview must not mutate
+			// sync-state, so return before the SaveSyncState at the end of this
+			// function — mirroring syncResource's guard above. (issue #2935)
+			if isDryRunResponse(data) {
+				if !humanFriendly {
+					fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", dep.Name)
+				}
+				return syncResult{Resource: dep.Name, Count: 0, Duration: time.Since(started)}
 			}
 
 			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -142,8 +142,9 @@ Resource scoping:
 				return usageErr(err)
 			}
 
-			// --full: clear all sync cursors before starting
-			if full {
+			// --full: clear all sync cursors before starting.
+			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
+			if full && !c.DryRun {
 				for _, resource := range resources {
 					_ = db.SaveSyncState(resource, "", 0)
 				}
@@ -164,11 +165,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off".
-					for _, resource := range resources {
-						existing, _, _, _ := db.GetSyncState(resource)
-						if existing != "" {
-							_ = db.SaveSyncState(resource, "", 0)
+					// "resume from wherever I left off". Skip under --dry-run:
+					// a preview must not mutate sync-state (issue #2935).
+					if !c.DryRun {
+						for _, resource := range resources {
+							existing, _, _, _ := db.GetSyncState(resource)
+							if existing != "" {
+								_ = db.SaveSyncState(resource, "", 0)
+							}
 						}
 					}
 				} else if humanFriendly {
@@ -1622,6 +1626,17 @@ func syncDependentResource(ctx context.Context, c interface {
 					fmt.Fprintln(syncEvents, syncErrorJSON(dep.Name, parentID, err))
 				}
 				break
+			}
+
+			// Dry-run sentinel: client.dryRun returns `{"dry_run": true}` instead
+			// of a real response when --dry-run is set. A preview must not mutate
+			// sync-state, so return before the SaveSyncState at the end of this
+			// function — mirroring syncResource's guard above. (issue #2935)
+			if isDryRunResponse(data) {
+				if !humanFriendly {
+					fmt.Fprintf(syncEvents, `{"event":"sync_dryrun","resource":"%s"}`+"\n", dep.Name)
+				}
+				return syncResult{Resource: dep.Name, Count: 0, Duration: time.Since(started)}
 			}
 
 			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -139,8 +139,9 @@ Resource scoping:
 				return usageErr(err)
 			}
 
-			// --full: clear all sync cursors before starting
-			if full {
+			// --full: clear all sync cursors before starting.
+			// Skip under --dry-run: a preview must not mutate sync-state (issue #2935).
+			if full && !c.DryRun {
 				for _, resource := range resources {
 					_ = db.SaveSyncState(resource, "", 0)
 				}
@@ -161,11 +162,14 @@ Resource scoping:
 					maxPages = 1
 					// Clear the cursor so we start from the head each time;
 					// the goal of --latest-only is "refresh the top" not
-					// "resume from wherever I left off".
-					for _, resource := range resources {
-						existing, _, _, _ := db.GetSyncState(resource)
-						if existing != "" {
-							_ = db.SaveSyncState(resource, "", 0)
+					// "resume from wherever I left off". Skip under --dry-run:
+					// a preview must not mutate sync-state (issue #2935).
+					if !c.DryRun {
+						for _, resource := range resources {
+							existing, _, _, _ := db.GetSyncState(resource)
+							if existing != "" {
+								_ = db.SaveSyncState(resource, "", 0)
+							}
 						}
 					}
 				} else if humanFriendly {


### PR DESCRIPTION
Fixes #2935.

`sync --dry-run` is documented as side-effect-free, but it mutated the local `sync_state` table for **dependent (cascaded) resources** and cleared cursors under `--full`/`--latest-only`.

## Root cause

The flat (main-loop) sync path already short-circuits a dry run on the `{"dry_run": true}` sentinel before any `db.SaveSyncState(...)`. Three sibling write-sites were not guarded:

- `internal/generator/templates/sync.go.tmpl` — the dependent-resource loop (`syncDependentResource`) called `db.SaveSyncState(dep.Name, "", totalCount)` **unconditionally** at its tail. Under `--dry-run`, each per-parent fetch returns the sentinel, the loop stores 0 rows, then this line stamps `count=0` + a fresh timestamp for the dependent resource.
- The `--full` cursor clear (`if full { ... SaveSyncState(resource, "", 0) }`) and the `--latest-only` clear ran regardless of `--dry-run`.

## Fix

- The dependent loop now returns on `isDryRunResponse(data)` before its terminal `SaveSyncState`, mirroring `syncResource`'s existing guard.
- The `--full` / `--latest-only` cursor clears are guarded by `!c.DryRun`.

## Test

`internal/generator/sync_dryrun_test.go` generates a connector with a dependent-sync resource and asserts the generated `sync.go` carries the dry-run sentinel guard in **both** the flat and dependent loops (`>=2` occurrences) plus the `!c.DryRun` guards on the cursor clears.

Found while triaging a generated connector (Axcient x360Recover) against a live tenant; the connector-side bridge fix shipped at servosity/msp-skills#80. The companion D1 (MCP numeric path-param scientific-notation) was already fixed upstream in 4.24.0 via `formatMCPParamValue` — no change needed there.
