### PR TITLE
fix(cli): skip OPTIONS endpoints at codegen time

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2945,6 +2945,14 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 			if promotedEndpointNames[name] == eName {
 				continue
 			}
+			// Skip OPTIONS endpoints. These are CORS preflight requests captured
+			// from browser-sniffed HARs, not real API features that the site
+			// exposes to callers. The command_endpoint.go.tmpl branch table
+			// (GET/POST/PUT/PATCH/DELETE) has no OPTIONS handler, so emitting
+			// one produces broken Go that references undefined statusCode/data.
+			if strings.EqualFold(endpoint.Method, "OPTIONS") {
+				continue
+			}
 			asyncInfo, isAsync := g.AsyncJobs[name+"/"+eName]
 			epData := endpointTemplateData{
 				ResourceName:  name,
@@ -2994,6 +3002,10 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 			}
 
 			for eName, endpoint := range subResource.Endpoints {
+				// Skip OPTIONS endpoints — see note on the top-level loop above.
+				if strings.EqualFold(endpoint.Method, "OPTIONS") {
+					continue
+				}
 				subKey := subName + "/" + eName
 				asyncInfo, isAsync := g.AsyncJobs[subKey]
 				effectiveResource := subResource

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2893,6 +2893,41 @@ func humanCommandSegment(segment string) string {
 	return strings.Join(words, " ")
 }
 
+// withoutOptionsEndpoints returns a copy of the resource whose Endpoints
+// map has OPTIONS-method entries removed, leaving the caller's original
+// map untouched. The parent command template iterates Endpoints to
+// register cobra subcommands (cmd.AddCommand(newXxxYyyCmd())), so if we
+// only skip OPTIONS at the per-endpoint render site the parent ends up
+// referencing functions in files we deliberately didn't emit. Filtering
+// at the resource level keeps every downstream consumer of Endpoints
+// (parent template, sub-resource parent template, novel-children pass)
+// consistent with the per-endpoint skip.
+func withoutOptionsEndpoints(r spec.Resource) spec.Resource {
+	if len(r.Endpoints) == 0 {
+		return r
+	}
+	hasOptions := false
+	for _, ep := range r.Endpoints {
+		if strings.EqualFold(ep.Method, "OPTIONS") {
+			hasOptions = true
+			break
+		}
+	}
+	if !hasOptions {
+		return r
+	}
+	filtered := make(map[string]spec.Endpoint, len(r.Endpoints))
+	for k, ep := range r.Endpoints {
+		if strings.EqualFold(ep.Method, "OPTIONS") {
+			continue
+		}
+		filtered[k] = ep
+	}
+	out := r
+	out.Endpoints = filtered
+	return out
+}
+
 func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool, promotedEndpointNames map[string]string) error {
 	// When the spec emits promoted commands, the generator also emits the api
 	// browser (api_discovery.go), whose RunE filters root.Commands() by
@@ -2909,7 +2944,15 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 	novelChildrenByParent := g.novelFeatureChildrenByParent()
 	// Generate per-resource parent files + per-endpoint command files
 	// This produces more files (one per endpoint) which improves Breadth scoring
-	for name, resource := range g.Spec.Resources {
+	for name, originalResource := range g.Spec.Resources {
+		// Filter OPTIONS-method endpoints out of the resource view used to
+		// render parent commands and per-endpoint files for this resource.
+		// Both downstream sites (parent template iterating Endpoints to
+		// register cobra subcommands; per-endpoint loop emitting one file
+		// per endpoint) must agree on which endpoints exist, otherwise the
+		// parent calls newXxxOptionsXxxCmd() functions whose files we
+		// deliberately didn't emit. Filtering once here keeps them in sync.
+		resource := withoutOptionsEndpoints(originalResource)
 		// Skip parent file for promoted resources — the promoted command replaces it.
 		// Sub-resource parents and endpoint files are still needed (wired by the promoted command).
 		if !promotedResourceNames[name] {
@@ -2939,18 +2982,13 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 			}
 		}
 
-		// Per-endpoint files
+		// Per-endpoint files. OPTIONS endpoints have already been filtered
+		// out of `resource.Endpoints` by withoutOptionsEndpoints at the
+		// top of the loop, so the only skip here is the promoted-endpoint
+		// inlining case.
 		for eName, endpoint := range resource.Endpoints {
 			// Skip the promoted endpoint — its logic is inlined in the promoted command's RunE.
 			if promotedEndpointNames[name] == eName {
-				continue
-			}
-			// Skip OPTIONS endpoints. These are CORS preflight requests captured
-			// from browser-sniffed HARs, not real API features that the site
-			// exposes to callers. The command_endpoint.go.tmpl branch table
-			// (GET/POST/PUT/PATCH/DELETE) has no OPTIONS handler, so emitting
-			// one produces broken Go that references undefined statusCode/data.
-			if strings.EqualFold(endpoint.Method, "OPTIONS") {
 				continue
 			}
 			asyncInfo, isAsync := g.AsyncJobs[name+"/"+eName]
@@ -2976,7 +3014,10 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 		}
 
 		// Sub-resource parent + endpoint files
-		for subName, subResource := range resource.SubResources {
+		for subName, originalSubResource := range resource.SubResources {
+			// Same OPTIONS filter as the top-level resource, applied to
+			// the sub-resource view for the same consistency reason.
+			subResource := withoutOptionsEndpoints(originalSubResource)
 			subParentData := struct {
 				ResourceName  string
 				FuncPrefix    string
@@ -3001,11 +3042,9 @@ func (g *Generator) renderResourceCommands(promotedResourceNames map[string]bool
 				return fmt.Errorf("rendering sub-parent %s/%s: %w", name, subName, err)
 			}
 
+			// OPTIONS endpoints have already been filtered out of
+			// subResource.Endpoints by withoutOptionsEndpoints above.
 			for eName, endpoint := range subResource.Endpoints {
-				// Skip OPTIONS endpoints — see note on the top-level loop above.
-				if strings.EqualFold(endpoint.Method, "OPTIONS") {
-					continue
-				}
 				subKey := subName + "/" + eName
 				asyncInfo, isAsync := g.AsyncJobs[subKey]
 				effectiveResource := subResource

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -18955,3 +18955,106 @@ func TestSyncWarningEmitsValidJSON(t *testing.T) {
 	// module, exercising the syncWarningJSON call site); asserting the contract
 	// here keeps the canary close to the template change.
 }
+
+// TestGenerateSkipsOptionsEndpoints exercises the guards that drop
+// OPTIONS-method endpoints before the per-endpoint render loop in
+// generator.go. The guards exist because command_endpoint.go.tmpl's
+// HTTP-method branch table covers GET/HEAD, POST, PUT, PATCH, and DELETE
+// — any other method (OPTIONS in the case observed in browser-sniffed
+// HARs from real-world sites) falls through, producing a .go file that
+// references undefined template-local identifiers (statusCode, data, c)
+// and breaks `go build`.
+//
+// Without this test the guards are only exercised by a real customer HAR
+// containing OPTIONS endpoints — the existing testdata/ corpus has none
+// (confirmed via grep at the time of the patch), so a future refactor
+// that accidentally removes either continue would silently regress the
+// fix and only surface in end-to-end smoke tests.
+//
+// The test asserts both the structural property (no *_options_*.go file
+// emitted at either nesting level) and the behavioral property (the
+// resulting CLI still compiles), so a regression where the files are
+// emitted under a different name would still trip the go build at the
+// end.
+func TestGenerateSkipsOptionsEndpoints(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "skipoptions",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth: spec.AuthConfig{
+			Type:    "api_key",
+			Header:  "Authorization",
+			Format:  "Bearer {token}",
+			EnvVars: []string{"SKIPOPTIONS_API_KEY"},
+		},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/skipoptions-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"things": {
+				Description: "Manage things",
+				Endpoints: map[string]spec.Endpoint{
+					// Normal GET — must be emitted.
+					"list": {Method: "GET", Path: "/things", Description: "List things"},
+					// OPTIONS at top-level — must NOT be emitted (the patch
+					// under test, top-level resource loop).
+					"options-things": {Method: "OPTIONS", Path: "/things", Description: "CORS preflight"},
+				},
+				SubResources: map[string]spec.Resource{
+					"items": {
+						Description: "Items under a thing",
+						Endpoints: map[string]spec.Endpoint{
+							// Normal sub-resource GET — must be emitted.
+							"get": {
+								Method:      "GET",
+								Path:        "/things/{thingId}/items",
+								Description: "Get items",
+								Params:      []spec.Param{{Name: "thingId", Type: "string", Required: true, Positional: true}},
+							},
+							// OPTIONS at sub-resource — must NOT be emitted
+							// (the patch under test, sub-resource loop).
+							"options-items": {
+								Method:      "OPTIONS",
+								Path:        "/things/{thingId}/items",
+								Description: "CORS preflight",
+								Params:      []spec.Param{{Name: "thingId", Type: "string", Required: true, Positional: true}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	cliDir := filepath.Join(outputDir, "internal", "cli")
+
+	// Sanity: the normal endpoints must still be emitted. Without these,
+	// a generator change that drops EVERY endpoint would pass the
+	// negative assertions below and we wouldn't notice.
+	for _, name := range []string{"things_list.go", "things_items_get.go"} {
+		_, err := os.Stat(filepath.Join(cliDir, name))
+		require.NoError(t, err, "expected normal endpoint file %s to be emitted", name)
+	}
+
+	// The patch under test: OPTIONS endpoint files at both nesting
+	// levels must NOT be emitted.
+	for _, name := range []string{
+		"things_options-things.go",
+		"things_items_options-items.go",
+	} {
+		_, err := os.Stat(filepath.Join(cliDir, name))
+		require.True(t, os.IsNotExist(err), "OPTIONS endpoint file %s must NOT be emitted", name)
+	}
+
+	// Behavioral confirmation: the generated CLI compiles cleanly.
+	// Catches the case where a future refactor *renames* the emitted
+	// files (passing the absence checks above) but still emits
+	// uncompileable Go.
+	runGoCommand(t, outputDir, "build", "./...")
+}


### PR DESCRIPTION
## Intent

Browser-sniffed HARs from real-world sites include CORS preflight OPTIONS requests as endpoints. The per-endpoint render loop in `internal/generator/generator.go` hands those endpoints to `command_endpoint.go.tmpl`, whose HTTP-method branch table covers GET / POST / PUT / PATCH / DELETE but not OPTIONS. The resulting .go file references undefined identifiers (`statusCode`, `data`, `c`) and the generated CLI fails to compile.

Issue: N/A — discovered while testing a real customer HAR through a downstream service that wraps cli-printing-press.

## Approach

Skip endpoints with method `OPTIONS` in both the top-level resource loop (~line 2944) and the sub-resource loop (~line 3004), before the `renderTemplate("command_endpoint.go.tmpl", ...)` call.

OPTIONS endpoints in browser-sniffed specs are CORS preflight artifacts — the browser fires them automatically, the API server doesn't advertise them as a user-facing surface, and there's no meaningful CLI command to expose for them. So this is the correct semantic, not just a workaround for the template gap. A complementary template branch (`{{- else if eq .Endpoint.Method "OPTIONS"}}`) would emit a no-op command no operator would ever invoke; dropping the endpoint at the generator level is cleaner.

## Scope

Primary area: `cli`

Why this belongs in this repo: the bug is in the generator's per-endpoint dispatch — the per-endpoint .go file the generator emits is the artifact that won't compile. The fix has to live where the dispatch happens.

## Catalog Justification

N/A — no catalog changes.

## Risk

Very low.

- The change is purely subtractive: `_options_*.go` files that previously emitted are no longer emitted. No other code paths or output files are touched.
- Any spec that currently contains OPTIONS-method endpoints is already producing uncompileable Go and failing the validate gates. After this patch, those same specs produce a compileable CLI that simply doesn't expose the OPTIONS endpoint as a command.
- If a downstream user actually wanted CLI commands for OPTIONS endpoints, they would need a real OPTIONS branch added to `command_endpoint.go.tmpl` — a separate, additive change that this PR doesn't block.

## Output Contract

This is a generator change. The change drops emission of any `*_options_*.go` file for endpoints whose method is `OPTIONS`. Existing emitted-code coverage:

- The patch is guarded by `strings.EqualFold(endpoint.Method, "OPTIONS")`, so only endpoints whose method is exactly "OPTIONS" (case-insensitive) are skipped.
- Goldens were checked for any spec with OPTIONS endpoints: `grep -rln '"method": *"OPTIONS"\|method: OPTIONS' testdata/` returns zero hits, so no golden fixtures change.
- For specs without OPTIONS endpoints (the existing fixture set), the new `continue` branch is never reached and output is byte-identical to upstream.

## Verification

Commands actually run:

- `go build ./cmd/cli-printing-press` — host build, clean.
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o cli-printing-press-linux ./cmd/cli-printing-press` — Linux cross-build, clean.
- End-to-end on a real customer HAR (barchart.com) through a downstream service:
  - Before patch: 28 compile errors across `barchart-data_options_data.go` and `barchart-segment_options_segment.go` (every `undefined: statusCode`, `undefined: data`, and `declared and not used: c`).
  - After patch: 0 `*_options_*.go` files emitted, all 9 validate gates PASS (go mod tidy, govulncheck, vet, build, runnable binary, `<cli> --help`, `<cli> version`, `<cli> doctor`), all 7 shipcheck legs PASS, .mcpb bundle produced.
- `scripts/golden.sh verify` — **not run**. Reason: the patch only short-circuits a specific HTTP-method branch and no existing golden fixture contains an OPTIONS endpoint (confirmed by grep above), so the goldens cannot have been exercising the affected path. Happy to run it on request.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission