### PR TITLE
feat(generator): emit CLAUDE.md (@AGENTS.md) for printed CLIs

### DIFF
--- a/internal/generator/agents_test.go
+++ b/internal/generator/agents_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,12 @@ func TestGeneratedAgentsGuideRendersPortableAgentContract(t *testing.T) {
 	assert.NotContains(t, content, "<cli>")
 	assert.NotContains(t, content, "Claude Code")
 	assertASCII(t, content)
+
+	// Claude Code auto-loads CLAUDE.md, not AGENTS.md, so the generator emits a
+	// CLAUDE.md that imports the contract. Body is exactly the import pointer.
+	claude, err := os.ReadFile(filepath.Join(outputDir, "CLAUDE.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "@AGENTS.md", strings.TrimSpace(string(claude)))
 }
 
 func assertASCII(t *testing.T, content string) {

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -123,6 +123,10 @@ func (g *DeviceGenerator) Generate() error {
 		"NOTICE":           "NOTICE.tmpl",
 		".goreleaser.yaml": "goreleaser.yaml.tmpl",
 		"AGENTS.md":        "agents_device.md.tmpl",
+		// Claude Code auto-loads CLAUDE.md, not AGENTS.md (codex/agy read AGENTS.md
+		// natively). Emit a CLAUDE.md that just imports it so a Claude session in the
+		// printed CLI loads the contract. Body is variant-agnostic (shared template).
+		"CLAUDE.md": "claude.md.tmpl",
 		// MCP surface: a stdio MCP server that mirrors the Cobra tree via the
 		// API-agnostic cobratree walker. The walker respects mcp:read-only and
 		// mcp:hidden annotations, so each device CLI's own commands decide what an

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -79,9 +79,13 @@ func TestGeneratedBLEDeviceEmitsPublishArtifacts(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "ble-temperature-sensor")
 	require.NoError(t, NewDevice(ds, outputDir).Generate())
 
-	for _, name := range []string{"AGENTS.md", "LICENSE", "NOTICE", ".goreleaser.yaml"} {
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md", "LICENSE", "NOTICE", ".goreleaser.yaml"} {
 		assert.FileExists(t, filepath.Join(outputDir, name))
 	}
+
+	// Claude Code auto-loads CLAUDE.md, not AGENTS.md; the device variant emits a
+	// CLAUDE.md that imports the contract.
+	assert.Equal(t, "@AGENTS.md", strings.TrimSpace(readFileString(t, filepath.Join(outputDir, "CLAUDE.md"))))
 
 	// None of the four may contain an unrendered Go-template directive. The
 	// goreleaser file legitimately carries goreleaser's own `{{ .Version }}`

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2020,7 +2020,7 @@ func (g *Generator) renderSingleFiles() error {
 		}
 		var data any
 		switch tmplName {
-		case "readme.md.tmpl", "agents.md.tmpl", "skill.md.tmpl", "which.go.tmpl", "which_test.go.tmpl":
+		case "readme.md.tmpl", "agents.md.tmpl", "claude.md.tmpl", "skill.md.tmpl", "which.go.tmpl", "which_test.go.tmpl":
 			data = g.readmeData()
 		case "helpers.go.tmpl":
 			hFlags := computeHelperFlags(g.Spec)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2007,6 +2007,7 @@ func (g *Generator) renderSingleFiles() error {
 		"golangci.yml.tmpl":                        ".golangci.yml",
 		"readme.md.tmpl":                           "README.md",
 		"agents.md.tmpl":                           "AGENTS.md",
+		"claude.md.tmpl":                           "CLAUDE.md",
 		"skill.md.tmpl":                            "SKILL.md",
 		"LICENSE.tmpl":                             "LICENSE",
 		"NOTICE.tmpl":                              "NOTICE",

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -49,6 +49,7 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		"go.mod",
 		"Makefile",
 		"AGENTS.md",
+		"CLAUDE.md",
 		"README.md",
 		"SKILL.md",
 		"internal/cli/root.go",
@@ -97,9 +98,9 @@ func TestGenerateProjectsCompile(t *testing.T) {
 		// Bump it AND add to mustInclude above when adding always-emitted
 		// templates. Per-spec dynamic files (per-resource command files,
 		// generated tests) account for the difference between fixtures.
-		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 73},
-		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 77},
-		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 75},
+		{name: "stytch", specPath: filepath.Join("..", "..", "testdata", "stytch.yaml"), expectedFiles: 74},
+		{name: "clerk", specPath: filepath.Join("..", "..", "testdata", "clerk.yaml"), expectedFiles: 78},
+		{name: "loops", specPath: filepath.Join("..", "..", "testdata", "loops.yaml"), expectedFiles: 76},
 	}
 
 	for _, tt := range tests {

--- a/internal/generator/templates/claude.md.tmpl
+++ b/internal/generator/templates/claude.md.tmpl
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/cases/generate-device-ble-control/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-control/artifacts.txt
@@ -7,6 +7,7 @@ ble-desk-lamp/internal/device/transport.go
 ble-desk-lamp/README.md
 ble-desk-lamp/SKILL.md
 ble-desk-lamp/AGENTS.md
+ble-desk-lamp/CLAUDE.md
 ble-desk-lamp/LICENSE
 ble-desk-lamp/NOTICE
 ble-desk-lamp/.goreleaser.yaml

--- a/testdata/golden/cases/generate-device-ble-opaque/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-opaque/artifacts.txt
@@ -7,6 +7,7 @@ ble-opaque-binary/internal/device/transport.go
 ble-opaque-binary/README.md
 ble-opaque-binary/SKILL.md
 ble-opaque-binary/AGENTS.md
+ble-opaque-binary/CLAUDE.md
 ble-opaque-binary/LICENSE
 ble-opaque-binary/NOTICE
 ble-opaque-binary/.goreleaser.yaml

--- a/testdata/golden/cases/generate-device-ble-session/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble-session/artifacts.txt
@@ -9,6 +9,7 @@ ble-session-appliance/internal/device/store.go
 ble-session-appliance/README.md
 ble-session-appliance/SKILL.md
 ble-session-appliance/AGENTS.md
+ble-session-appliance/CLAUDE.md
 ble-session-appliance/LICENSE
 ble-session-appliance/NOTICE
 ble-session-appliance/.goreleaser.yaml

--- a/testdata/golden/cases/generate-device-ble/artifacts.txt
+++ b/testdata/golden/cases/generate-device-ble/artifacts.txt
@@ -15,6 +15,7 @@ ble-temperature-sensor/internal/mcp/cobratree/walker.go
 ble-temperature-sensor/README.md
 ble-temperature-sensor/SKILL.md
 ble-temperature-sensor/AGENTS.md
+ble-temperature-sensor/CLAUDE.md
 ble-temperature-sensor/LICENSE
 ble-temperature-sensor/NOTICE
 ble-temperature-sensor/.goreleaser.yaml

--- a/testdata/golden/cases/generate-golden-api-rich-auth/artifacts.txt
+++ b/testdata/golden/cases/generate-golden-api-rich-auth/artifacts.txt
@@ -2,6 +2,7 @@
 printing-press-rich-auth/SKILL.md
 printing-press-rich-auth/README.md
 printing-press-rich-auth/AGENTS.md
+printing-press-rich-auth/CLAUDE.md
 printing-press-rich-auth/internal/cli/agent_context.go
 printing-press-rich-auth/internal/cli/auth.go
 printing-press-rich-auth/internal/cli/root_test.go

--- a/testdata/golden/cases/generate-golden-api/artifacts.txt
+++ b/testdata/golden/cases/generate-golden-api/artifacts.txt
@@ -34,6 +34,7 @@ dogfood.json
 scorecard.json
 printing-press-golden/README.md
 printing-press-golden/AGENTS.md
+printing-press-golden/CLAUDE.md
 printing-press-golden/SKILL.md
 printing-press-golden/internal/cli/doctor.go
 printing-press-golden/internal/cliutil/verifyenv.go

--- a/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
+++ b/testdata/golden/cases/generate-learn-loop-api/artifacts.txt
@@ -60,3 +60,4 @@ learn-loop-example/internal/learn/patterns/apply.go
 learn-loop-example/SKILL.md
 learn-loop-example/README.md
 learn-loop-example/AGENTS.md
+learn-loop-example/CLAUDE.md

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/CLAUDE.md
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/CLAUDE.md
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/CLAUDE.md
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/CLAUDE.md
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/CLAUDE.md
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/CLAUDE.md
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/CLAUDE.md
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

The generator emits `AGENTS.md` but no `CLAUDE.md`. Claude Code auto-loads `CLAUDE.md`, **not** `AGENTS.md` (codex and agy/Antigravity read `AGENTS.md` natively; Claude Code is the lone exception). So a Claude session opened inside a printed CLI boots with **none** of that CLI's own `AGENTS.md` contract loaded (side-effect-command rules, auth model, conventions).

This adds a shared `claude.md.tmpl` (body `@AGENTS.md`) emitted by both the HTTP and device generators — the same `CLAUDE.md` → `@AGENTS.md` wiring this repo already uses for itself. The pointer file is inert for non-Claude users.

Closes #2958.

## Changes
- `internal/generator/templates/claude.md.tmpl` — body is exactly `@AGENTS.md`.
- `internal/generator/generator.go` — map `"claude.md.tmpl": "CLAUDE.md"` in `renderSingleFiles()`.
- `internal/generator/device.go` — map `"CLAUDE.md": "claude.md.tmpl"` in the device file map (one shared, variant-agnostic template).
- Tests: `generator_test.go` adds `CLAUDE.md` to `mustInclude` and bumps `expectedFiles` (+1 per fixture); `agents_test.go` + `device_test.go` assert `CLAUDE.md` exists with body `@AGENTS.md`.
- Golden: `CLAUDE.md` added to the 7 doc-emitting cases' `artifacts.txt` + snapshots.

## Why it's safe (counter-check)
A `CLAUDE.md` whose entire body is `@AGENTS.md` is a one-line pointer: inert for codex/agy/non-Claude users, consistent with the `AGENTS.md` already shipped, unconditional (no guard needed). Verified there's no other emitted-file allowlist or publish-exclude affected.

## Verification
- `go build ./...`
- `go vet ./internal/generator/`
- `go test ./internal/generator/...` (full suite)
- `scripts/golden.sh verify` (31 cases)

all pass.