### PR TITLE
fix(cli): strip trailing punctuation from verify-skill flag tokens

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -73,6 +73,10 @@ COMMON_FLAGS = {"help", "version"}
 CODEBLOCK_BASH = re.compile(r"^[ \t]*```bash[^\n]*\n(.*?)\n[ \t]*```[ \t]*$", re.DOTALL | re.MULTILINE)
 FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 INLINE_CODE = re.compile(r"`[^`\n]*`")
+# Trailing punctuation that prose glues onto a token: quotes/brackets that wrap
+# a quoted command span (`'cli cmd --flag'`) and sentence punctuation. Cobra
+# flag names are `[a-z0-9-]`, so trimming these can never truncate a real name.
+TOKEN_TRAILING_PUNCT = "'\")].,;:"
 SHELL_VAR_RE = re.compile(r"\$(?:\{[^}\n]+\}|[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?])")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
@@ -729,7 +733,7 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flag_name = t.split("=", 1)[0]
+            flag_name = t.split("=", 1)[0].rstrip(TOKEN_TRAILING_PUNCT)
             flags.append(flag_name)
             # Skip a space-separated value (`--flag value`), but NOT when:
             #  - the value is inline (`--flag=value`) — the next token is a

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -381,6 +381,21 @@ func newRrCmd() *cobra.Command {
 
             self.assertEqual([(["issuances", "cited-by"], ["rr", "7-2003"], [])], recipes)
 
+    def test_trailing_quote_is_stripped_from_flag_token(self):
+        """Prose that quotes a full command (`'cli cmd --refresh'`) glues the
+        closing quote onto the flag token; the declaration lookup must see
+        `--refresh`, not `--refresh'`. A genuinely undeclared flag still keeps
+        its real name after the quote is trimmed."""
+        _path, _positional, flags = _cli_invocation_from_tokens(
+            ["entitlements", "--refresh'", "to", "map"], None,
+        )
+        self.assertEqual(["--refresh"], flags)
+
+        _path, _positional, flags = _cli_invocation_from_tokens(
+            ["get", "--bogus')."], None,
+        )
+        self.assertEqual(["--bogus"], flags)
+
     def test_space_separated_long_flag_value_is_not_positional(self):
         cmd_path, positional, flags = _cli_invocation_from_tokens(
             ["search", "--filter", "status=active", "item-123"],

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -73,6 +73,10 @@ COMMON_FLAGS = {"help", "version"}
 CODEBLOCK_BASH = re.compile(r"^[ \t]*```bash[^\n]*\n(.*?)\n[ \t]*```[ \t]*$", re.DOTALL | re.MULTILINE)
 FENCED_CODE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 INLINE_CODE = re.compile(r"`[^`\n]*`")
+# Trailing punctuation that prose glues onto a token: quotes/brackets that wrap
+# a quoted command span (`'cli cmd --flag'`) and sentence punctuation. Cobra
+# flag names are `[a-z0-9-]`, so trimming these can never truncate a real name.
+TOKEN_TRAILING_PUNCT = "'\")].,;:"
 SHELL_VAR_RE = re.compile(r"\$(?:\{[^}\n]+\}|[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?])")
 COMMAND_REFERENCE_SECTION_RE = re.compile(
     r"^##\s+Command\s+Reference\s*$(.*?)(?=^##\s+|\Z)",
@@ -729,7 +733,7 @@ def _cli_invocation_from_tokens(
             i += 1
             continue
         if t.startswith("--"):
-            flag_name = t.split("=", 1)[0]
+            flag_name = t.split("=", 1)[0].rstrip(TOKEN_TRAILING_PUNCT)
             flags.append(flag_name)
             # Skip a space-separated value (`--flag value`), but NOT when:
             #  - the value is inline (`--flag=value`) — the next token is a


### PR DESCRIPTION
## Intent

verify-skill's invocation scanner glued trailing quote, bracket, and sentence-punctuation characters onto extracted `--flag` tokens. README/SKILL prose that quotes a full command (a natural shape for troubleshooting text), e.g. `Run 'cli entitlements --refresh' to map access`, produced false `undeclared-flag` findings for `--refresh'` because the closing apostrophe was part of the looked-up token. The flag is declared; only the token was wrong.

Issue: Closes #2923

## Approach

Trim a shared `TOKEN_TRAILING_PUNCT` set (`'")].,;:`) from the flag name when building it in `_cli_invocation_from_tokens` — the single extraction path that feeds both the `flag-names` and `flag-commands` checks, so one edit covers both. Cobra flag names are `[a-z0-9-]`, so trimming these characters can never truncate a real flag. A genuinely undeclared flag still surfaces under its real name (e.g. `--bogus'` -> `--bogus`).

## Scope

Primary area: scorer (`scripts/verify-skill/verify_skill.py`)

Why this belongs in this repo: verify-skill is the shared scorer leg run by `publish validate` / `publish package` against every printed CLI; the false-positive is triggered by documentation prose style, not API shape, so it affects many CLIs and the fix belongs in the machine.

## Catalog Justification

N/A

## Risk

Low. The change only removes trailing punctuation from a token before declaration lookup. Bash-recipe extraction already used `shlex` and was unaffected; the prose path is where unbalanced quotes fell through to `str.split()`. Negative case preserved: an undeclared flag is still reported under its real name.

## Output Contract

N/A

## Verification

- Added `test_trailing_quote_is_stripped_from_flag_token`; full unit suite passes (`python3 scripts/verify-skill/test_resolve_command_path.py` -> 20 tests OK).
- End-to-end `python3 scripts/verify-skill/verify_skill.py --dir <fixture>`: a declared `--refresh` inside quoted prose no longer fails; an undeclared `--nope` (also quoted) still fails as `--nope`.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(Not a generator/template change; the three boxes above are N/A.)