### PR TITLE
fix(generator): mark tail command no-error-path-probe

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -742,7 +742,7 @@ func TestGenerateAgentContextCommand(t *testing.T) {
 	// agent-context only reads CLI tree state and emits JSON to stdout.
 	// The runtime walker uses this annotation to set readOnlyHint on
 	// the resulting MCP tool so hosts skip the per-call permission prompt.
-	assert.Regexp(t, `Annotations:\s+map\[string\]string\{"mcp:read-only":\s*"true"\}`, src,
+	assert.Regexp(t, `Annotations:\s+map\[string\]string\{[^}]*"mcp:read-only":\s*"true"[^}]*\}`, src,
 		"agent_context.go must carry mcp:read-only annotation")
 
 	// The subcommand must be registered in root.go so the CLI picks it up.
@@ -16847,7 +16847,10 @@ func TestToKebab_SnakeCaseInput(t *testing.T) {
 // export.go.tmpl (--output writes user files), import/sync/feedback/graphql_sync (writes).
 func TestTemplatesEmitReadOnlyAnnotation(t *testing.T) {
 	t.Parallel()
-	annotationRE := regexp.MustCompile(`Annotations:\s+map\[string\]string\{"mcp:read-only":\s*"true"\}`)
+	// Match the read-only annotation inside an Annotations map literal,
+	// tolerating additional annotations (e.g. pp:no-error-path-probe on tail).
+	// [^}]* stays within a single map literal so per-command counts hold.
+	annotationRE := regexp.MustCompile(`Annotations:\s+map\[string\]string\{[^}]*"mcp:read-only":\s*"true"[^}]*\}`)
 
 	cases := []struct {
 		template string

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -24,7 +24,7 @@ func newTailCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "tail [resource]",
 		Short:       "Stream live changes by polling the API at regular intervals",
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:no-error-path-probe": "true"},
 		Long: `Tail streams live data changes by polling the API at configurable intervals.
 Events are emitted as NDJSON to stdout for piping to other tools.
 Gracefully shuts down on SIGTERM/SIGINT.


### PR DESCRIPTION
## What

The generated `tail` command is a resilient poller: on a failed initial fetch it prints `warning: initial fetch failed: ...` and `return nil` (exit 0). dogfood's `error_path` probe runs `tail <invalid-resource>` and expects a non-zero exit, so **every printed CLI with a data layer fails the `error_path` check on `tail`** unless it's hand-annotated with `pp:no-error-path-probe`.

This adds `"pp:no-error-path-probe": "true"` to the `tail` command template so dogfood skips the inapplicable `error_path` probe.

## Why it's a generator fix (not per-CLI)

`tail.go.tmpl` is emitted for every CLI with a syncable data layer, so the failure is deterministic and recurs on every such CLI:

- **stripe**: Phase 5 live dogfood `error_path` on `tail __printing_press_invalid__` → exit 0, scored FAIL; cleared only by a manual annotation.
- **twilio** (`library/twilio/internal/cli/tail.go`): byte-identical template (warning + `return nil`), zero `pp:no-error-path-probe` annotations — would fail the same probe.

## Changes

- `internal/generator/templates/tail.go.tmpl`: add `pp:no-error-path-probe` to the tail command Annotations.
- `internal/generator/generator_test.go`: broaden `TestTemplatesEmitReadOnlyAnnotation`'s regex to match the `mcp:read-only` annotation inside an `Annotations` map literal that carries additional annotations (the prior regex assumed read-only was the sole entry, so the new tail annotation broke the exact match). `[^}]*` stays within a single map literal, so the per-command match counts are unchanged.

## Verification

- `go test ./internal/generator/` → `ok` (full package).
- `go test ./internal/pipeline/` → `ok` (annotation consumer).
- End-to-end: rebuilt the binary, generated a CLI, confirmed `internal/cli/tail.go` now emits `Annotations: map[string]string{"mcp:read-only": "true", "pp:no-error-path-probe": "true"}`.

## Alternative considered

Make `tail` return a non-zero error when the *initial* fetch fails (before entering the poll loop) — arguably more correct, but changes runtime behavior. Went with the annotation as the low-risk fix; happy to switch if you'd prefer the behavioral change.

fix #2968

🤖 Generated with [Claude Code](https://claude.com/claude-code)