### PR TITLE
docs(skills): document Codex skill install target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,7 @@ This copies the skills to `~/.claude/skills/`.
 
 ## Skill Authoring
 When a machine change alters what an agent should do or what a command guarantees, update the relevant `SKILL.md` in the same change; do not leave the skill as a stale manual workaround for behavior the machine now owns.
-Detail in [`docs/SKILLS.md`](docs/SKILLS.md): workflow parity, the reference-file pattern, and the `context: fork` / `user-invocable` frontmatter fields.
+Detail in [`docs/SKILLS.md`](docs/SKILLS.md): install targets, workflow parity, the reference-file pattern, and the `context: fork` / `user-invocable` frontmatter fields.
 
 ## Code & Comment Hygiene
 ### Write-time defaults

--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ Three CLIs printed by the press, installable today:
 
 Browse the full catalog of printed CLIs at [printingpress.dev](https://printingpress.dev) or in the [Printing Press Library](https://github.com/mvanhorn/printing-press-library), organized by category, most with full MCP servers.
 
+**Codex users:** see [docs/CODEX.md](docs/CODEX.md) to install the Printing Press skills with `--agent codex`, verify the install, and understand how that differs from `/printing-press <api> codex`.
+
 **Cursor users:** see [docs/CURSOR.md](docs/CURSOR.md) for how to install a printed CLI, attach the matching skill, handle auth, and choose CLI vs MCP when your repo does not already document a workflow.
 
 ## Install
 
-You need both the **binary** and the **Claude Code skills**. The skills (`/printing-press <app>`) are the primary interface; they drive the binary behind the scenes.
+You need both the **binary** and the **Printing Press skills**. The skills (`/printing-press <app>`) are the primary interface; they drive the binary behind the scenes.
 
 The binary alone works (research, generation, verification, scoring) but skips the curated agent loop. The skills alone have nothing to call. Install both.
 
-**Prerequisites:** [Go 1.26.4 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code), and Node/npm for `npx`. The skills are tested with Claude Code; other harnesses like Codex may work but aren't tested. **Use Claude Code for the best experience.**
+**Prerequisites:** [Go 1.26.4 or newer](https://go.dev/dl/), [Claude Code](https://claude.ai/code) or another `skills`-supported agent, and Node/npm for `npx`. The skills are tested with Claude Code; install for Codex with `--agent codex` when you want to try the same slash-command workflow there. **Use Claude Code for the best-tested experience.**
 
 ### 1. Install
 
@@ -34,7 +36,7 @@ The binary alone works (research, generation, verification, scoring) but skips t
 curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
 ```
 
-The installer runs `go install` for the generator binary, then refreshes all Printing Press skills through `skills@latest add --skill '*'`. Restart Claude Code after it completes so the refreshed skills are loaded.
+The installer runs `go install` for the generator binary, then refreshes all Printing Press skills through `skills@latest add --skill '*'`. Restart or reload your agent session after it completes so the refreshed skills are loaded.
 
 Use `--cli-only` or `--skills-only` when you only want one side:
 
@@ -42,6 +44,15 @@ Use `--cli-only` or `--skills-only` when you only want one side:
 curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --cli-only
 curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
 ```
+
+Claude Code is the default install target. To install or refresh the skills for Codex instead, pass `--agent codex`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only --agent codex
+npx -y skills@latest list -g -a codex --json
+```
+
+See [docs/CODEX.md](docs/CODEX.md) for the Codex-specific notes.
 
 Verify with `cli-printing-press --version`. If install fails, confirm Go 1.26.4 or newer is installed, Node/npm is installed for `npx`, and `$GOPATH/bin` is on your `PATH`.
 
@@ -59,10 +70,17 @@ Install or update the binary:
 go install github.com/mvanhorn/cli-printing-press/v4/cmd/cli-printing-press@latest
 ```
 
-Use Vercel's [open-agent-skills](https://www.npmjs.com/package/skills) CLI to install the Printing Press skills from this repo into Claude Code:
+Use Vercel's [open-agent-skills](https://www.npmjs.com/package/skills) CLI to install the Printing Press skills from this repo into a supported agent. Claude Code is the default and tested path:
 
 ```bash
 npx -y skills@latest add mvanhorn/cli-printing-press/skills --skill '*' -g -a claude-code -y
+```
+
+For Codex:
+
+```bash
+npx -y skills@latest add mvanhorn/cli-printing-press/skills --skill '*' -g -a codex -y
+npx -y skills@latest list -g -a codex --json
 ```
 
 To refresh the skills later without naming individual skills, rerun the installer in skills-only mode:
@@ -71,11 +89,11 @@ To refresh the skills later without naming individual skills, rerun the installe
 curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only
 ```
 
-Restart Claude Code after refreshing skills so the new skill text is loaded.
+Restart or reload the target agent after refreshing skills so the new skill text is loaded.
 
 </details>
 
-Once installed, you can start Claude Code from any folder.
+Once installed, you can start Claude Code from any folder. Codex users should start a fresh Codex session after installing or refreshing skills.
 
 <details>
 <summary><b>Developer path: load skills from a clone</b></summary>
@@ -498,7 +516,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 
 ## Troubleshooting
 
-**`/printing-press` slash command doesn't appear in Claude Code.** Restart your Claude Code session after installing the skills. Run `npx -y skills@latest list -g -a claude-code` to verify the install. If you're developing from a clone, confirm `claude --plugin-dir .` was run from the cloned repo root or use the persistent local setup in [Local Plugin Development](docs/PLUGIN-DEV.md).
+**`/printing-press` slash command doesn't appear.** Restart or reload the agent session after installing the skills. For Claude Code, run `npx -y skills@latest list -g -a claude-code` to verify the install. For Codex, run `npx -y skills@latest list -g -a codex --json`. If you're developing from a clone in Claude Code, confirm `claude --plugin-dir .` was run from the cloned repo root or use the persistent local setup in [Local Plugin Development](docs/PLUGIN-DEV.md).
 
 **`cli-printing-press: command not found` after a successful `go install`.** `$GOPATH/bin` (default `~/go/bin`) isn't on your `PATH`. Add it to your shell profile.
 
@@ -510,7 +528,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 
 ## Limitations
 
-- **Requires Go 1.26.4 or newer and Claude Code.** No standalone distribution today; the slash command is the supported entry point.
+- **Requires Go 1.26.4 or newer and an agent that can load open-agent-skills.** Claude Code is the tested path; Codex installation is documented but may lag Claude Code behavior.
 - **Generated CLIs are domain-shaped, not vendor-replacements.** A `<api>-pp-cli` covers the agent power-user surface, not every back-office knob a vendor's official CLI ships.
 - **Browser-sniff requires manual capture.** You point a browser at the site (or import a HAR); the press doesn't crawl autonomously.
 - **Live verify is read-only.** Phase 5 runs GET only and never mutates. Real write-path coverage lives in unit tests and the dogfood structural checks.
@@ -521,7 +539,7 @@ Each newly published CLI ships a root `AGENTS.md` operating guide, a research ma
 
 **Why not Speakeasy, Fern, or openapi-generator?** Those wrap endpoints. We wrap endpoints AND generate the discrawl-style data layer (SQLite, FTS5, sync, compound commands) AND the MCP server AND the agent-native UX (typed exit codes, `--compact`, auto-JSON-when-piped). The output is shaped for an agent that will call it thousands of times a day.
 
-**Does it work without Claude?** The binary works standalone (research, generation, verification, scoring), but the curated agent loop — research absorption, novel-feature suggestion, ship cycle — runs through the `/printing-press` slash command in Claude Code. Bring your own agent loop if you want to skip it.
+**Does it work without Claude?** The binary works standalone (research, generation, verification, scoring), and the skills can be installed for Codex with `--agent codex`. The curated agent loop is tested in Claude Code first, so bring your own review discipline if you use another harness.
 
 **Does it require an OpenAPI spec?** No. Three input modes: a spec (`--spec`), a HAR file (`--har`), or just a URL. The browser-sniff gate launches a browser, captures traffic, and reverse-engineers the spec for sites that don't publish one.
 

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -1,0 +1,54 @@
+# Using Printing Press Skills in Codex
+
+Claude Code remains the default and best-tested Printing Press skill host. Codex can also load the same skills through Vercel's `skills` CLI, which is useful when you want the `/printing-press` workflow available in a Codex session.
+
+## 1. Install for Codex
+
+Install the generator binary and the skills, targeting Codex:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --agent codex
+```
+
+If the binary is already current and you only want to refresh skills:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash -s -- --skills-only --agent codex
+```
+
+The installer delegates the on-disk link/copy layout to `skills@latest`; it only selects the agent target and does not force copy mode.
+
+The installer still defaults to Claude Code when `--agent` is omitted:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/scripts/install.sh | bash
+```
+
+## 2. Verify the Skill Install
+
+Check that `skills` sees the global Codex install:
+
+```bash
+npx -y skills@latest list -g -a codex --json
+```
+
+You should see the Printing Press skills in the JSON output, including `printing-press`.
+
+## 3. Restart or Reload Codex
+
+After installing or refreshing skills, start a new Codex session or reload the current one so Codex reads the updated skill text. If `/printing-press` does not appear, rerun the verification command above and then restart the session again.
+
+## 4. `/printing-press <api>` vs `/printing-press <api> codex`
+
+These are different choices:
+
+- `/printing-press <api>` runs the Printing Press workflow in the current agent host. If you installed the skills with `--agent codex`, that means Codex is the host running the skill.
+- `/printing-press <api> codex` enables the skill's Codex delegation mode. In the Claude Code path, Claude keeps orchestration and verification while Phase 3 code-writing tasks are delegated to the Codex CLI.
+
+When the skill detects that it is already inside a Codex sandbox, it disables nested Codex delegation and continues in standard mode. In practice, Codex users should usually run:
+
+```text
+/printing-press <api>
+```
+
+Use the `codex` suffix primarily from Claude Code when you want Claude-hosted orchestration with Codex CLI code-writing delegation.

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -25,6 +25,7 @@ The extracted developer docs are:
 - `docs/ATTRIBUTION.md` — creator + contributors attribution model
 - `docs/CATALOG.md` — catalog validator rationale and wrapper-only shape
 - `docs/ARTIFACTS.md` — local library, manuscripts, and public-library flow
+- `docs/CODEX.md` — installing and using Printing Press skills in Codex
 - `docs/CURSOR.md` — using printed CLIs and skills in Cursor
 - `docs/DOCS.md` — this doc-authoring guidance
 - `docs/PLUGIN-DEV.md` — persistent local plugin development setup

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -2,6 +2,10 @@
 
 Conventions for the skills shipped from this repo (under `skills/`) and any internal skills under `.claude/skills/`. Loaded on-demand when working on skill content; not needed on every interaction.
 
+## Install Targets
+
+The shipped Printing Press skills are installed through the `skills` CLI. Claude Code is the default and tested target (`--agent claude-code`), but the installer can target other supported agents, including Codex (`--agent codex`). Keep install instructions agent-neutral unless the step truly depends on Claude Code behavior, and link Codex-specific setup notes to [CODEX.md](CODEX.md).
+
 ## Workflow Parity
 
 When a machine change alters what an agent should do, what a command now guarantees, or where source-of-truth data lives, update the relevant `SKILL.md` in the same change. Don't leave the skill as a stale manual workaround for behavior the machine now owns.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@ umask 022
 #
 # Options:
 #   --cli-only          Install or update only the Go generator binary.
-#   --skills-only       Install or refresh only the Claude Code skills.
+#   --skills-only       Install or refresh only the Printing Press skills.
 #   -a, --agent NAME    Install skills for an agent supported by `skills`.
 #                       May be repeated. Defaults to claude-code.
 #   --dry-run           Print commands without executing them.
@@ -60,7 +60,7 @@ Usage:
 
 Options:
   --cli-only          Install or update only the Go generator binary.
-  --skills-only       Install or refresh only the Claude Code skills.
+  --skills-only       Install or refresh only the Printing Press skills.
   -a, --agent NAME    Install skills for an agent supported by `skills`.
                        May be repeated. Defaults to claude-code.
   --dry-run           Print commands without executing them.
@@ -430,10 +430,10 @@ print_header() {
       --border normal --border-foreground 39 \
       --padding "0 1" --margin "1 0" \
       "$(gum style --foreground 42 --bold "$PROJECT_NAME installer")" \
-      "$(gum style --foreground 245 "Install the generator binary and Claude Code skills")"
+      "$(gum style --foreground 245 "Install the generator binary and Printing Press skills")"
   else
     printf '\033[1;32m%s installer\033[0m\n' "$PROJECT_NAME"
-    printf '\033[0;90mInstall the generator binary and Claude Code skills\033[0m\n\n'
+    printf '\033[0;90mInstall the generator binary and Printing Press skills\033[0m\n\n'
   fi
 }
 
@@ -443,7 +443,7 @@ print_summary() {
   lines+=("Skills: $SKILLS_STATUS")
   if [[ "$INSTALL_SKILLS" -eq 1 ]]; then
     lines+=("Agents: ${AGENTS[*]}")
-    lines+=("Restart Claude Code so refreshed skills are loaded.")
+    lines+=("Restart or reload the target agent so refreshed skills are loaded.")
   fi
   draw_box 42 "${lines[@]}"
 }


### PR DESCRIPTION
## Intent

Issue: Closes #2983

Document the existing `--agent codex` skill install path so Codex users can install and verify Printing Press skills without losing the README's current guidance that Claude Code is the default and best-tested host.

## Approach

Adds a small Codex-specific guide and links it from the README. The README and installer copy now say "Printing Press skills" / "target agent" where the old copy implied Claude Code was the only install target. The installer behavior is unchanged: `claude-code` remains the default unless `--agent` is provided.

## Scope

Primary area: skills/docs installer guidance

Why this belongs in this repo: this is generator repo install and skill documentation, not a printed-CLI-specific fix. The installer already owns the `--agent` target selection for the repo-shipped Printing Press skills.

## Catalog Justification

Embedded catalog fit: N/A

Distinct blueprint pattern: N/A

Closest existing entries checked: N/A

Source provenance: N/A

Auth and tenant assumptions: N/A

Safe default surface: N/A

Generation path: N/A

Stale-body check: N/A

## Risk

Low. This changes docs and installer display/help text only. No CLI behavior, generator templates, MCP surface, catalog, scorer, verifier, or generated output changes.

## Output Contract

N/A

## Verification

- [x] `bash -n scripts/install.sh`
- [x] `bash scripts/install.sh --help`
- [x] `bash scripts/install.sh --skills-only --agent codex --dry-run --no-gum`
- [x] `bash .github/scripts/validate-skill-docs.sh`
- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
