### PR TITLE
fix(cli): make live-gate-honest examples, skip interactive auth, validate tail resource

### DIFF
--- a/internal/generator/first_command_example.go
+++ b/internal/generator/first_command_example.go
@@ -116,7 +116,16 @@ func requiredFlagExampleParts(ep spec.Endpoint) []string {
 		for _, p := range ep.Body {
 			if p.Required && p.Type == "string" {
 				val := exampleValue(p)
-				if val == "" {
+				// A string body flag whose value must be valid JSON (the command
+				// emits a json.Valid guard — see isJSONStringParam) cannot use the
+				// scalar "example-value" placeholder: it fails that guard
+				// immediately, so the emitted Example would advertise a command
+				// that errors on first run and the live-dogfood happy-path /
+				// json-fidelity probes (which run the Example verbatim) reject it.
+				// Emit a minimal valid-JSON placeholder instead.
+				if isJSONStringParam(p) {
+					val = jsonStringBodyExamplePlaceholder(p)
+				} else if val == "" {
 					val = "value"
 				}
 				parts = append(parts, "--"+publicFlagName(p), val)
@@ -125,6 +134,22 @@ func requiredFlagExampleParts(ep spec.Endpoint) []string {
 		}
 	}
 	return parts
+}
+
+// jsonStringBodyExamplePlaceholder returns a minimal, valid-JSON value for a
+// JSON-typed string body flag (isJSONStringParam). The value is single-quoted
+// so the rendered example survives a copy-paste into a shell and is parsed back
+// to valid JSON by the quote-aware live-dogfood example tokenizer
+// (shellargs.ArgsAfterBinary strips the quotes). An empty array/object keeps the
+// example runnable without inventing field names the upstream API might reject;
+// the array-vs-object shape follows the param's described body type.
+func jsonStringBodyExamplePlaceholder(p spec.Param) string {
+	desc := strings.TrimSpace(p.Description)
+	lower := strings.ToLower(desc)
+	if strings.HasPrefix(desc, "[") || strings.Contains(lower, "array") {
+		return "'[]'"
+	}
+	return "'{}'"
 }
 
 func requiredFlagExampleValue(ep spec.Endpoint, p spec.Param) string {

--- a/internal/generator/first_command_example_test.go
+++ b/internal/generator/first_command_example_test.go
@@ -391,6 +391,45 @@ func TestFirstCommandExampleHonorsPromotion(t *testing.T) {
 			want: "stores create --store-code example-value",
 		},
 		{
+			// A JSON-typed string body flag (the command emits a json.Valid
+			// guard) must not advertise the scalar "example-value" placeholder,
+			// which fails that guard on first run. It gets a minimal valid-JSON
+			// value instead, single-quoted for shell safety.
+			name: "json body field uses valid-json placeholder",
+			resources: map[string]spec.Resource{
+				"lists": {
+					Endpoints: map[string]spec.Endpoint{
+						"add": {
+							Method: "POST",
+							Path:   "/lists/add.php",
+							Body: []spec.Param{
+								{Name: "lists", Required: true, Type: "string", Description: "JSON array of list objects"},
+							},
+						},
+						"refresh": {Method: "POST", Path: "/lists/refresh"},
+					},
+				},
+			},
+			want: "lists add --lists '[]'",
+		},
+		{
+			name: "json body field with bracketed description uses array placeholder",
+			resources: map[string]spec.Resource{
+				"items": {
+					Endpoints: map[string]spec.Endpoint{
+						"bulk": {
+							Method: "POST",
+							Path:   "/items/bulk",
+							Body: []spec.Param{
+								{Name: "payload", Required: true, Type: "string", Description: `[{"id":1,"name":"foo"}]`},
+							},
+						},
+					},
+				},
+			},
+			want: "items --payload '[]'",
+		},
+		{
 			name: "promoted single-endpoint resource keeps positionals",
 			resources: map[string]spec.Resource{
 				"feed": {

--- a/internal/generator/template_batch3_test.go
+++ b/internal/generator/template_batch3_test.go
@@ -68,6 +68,13 @@ func TestGeneratedTailShortCircuitsFollowUnderDogfood(t *testing.T) {
 	assert.Contains(t, tailSrc, "if !follow {\n\t\t\t\treturn nil\n\t\t\t}")
 	assert.Less(t, strings.Index(tailSrc, "if !follow {"), strings.Index(tailSrc, "ticker := time.NewTicker(interval)"),
 		"tail must return after one poll before creating the follow ticker")
+
+	// An unknown resource must fail fast with a non-zero exit (it would only
+	// 404 forever) — and the validation must run before the poll loop binds.
+	assert.Contains(t, tailSrc, "for _, r := range tailKnownResources() {")
+	assert.Contains(t, tailSrc, `return fmt.Errorf("unknown resource %q; known resources: %v", resource, tailKnownResources())`)
+	assert.Less(t, strings.Index(tailSrc, "known resources: %v"), strings.Index(tailSrc, "c, err := flags.newClient()"),
+		"tail must reject an unknown resource before constructing the client")
 }
 
 func TestGeneratedSyncTreatsArgumentMissing400AsWarning(t *testing.T) {

--- a/internal/generator/templates/tail.go.tmpl
+++ b/internal/generator/templates/tail.go.tmpl
@@ -56,6 +56,21 @@ native streaming instead of polling.`,
 			if resource == "" {
 				return fmt.Errorf("resource name required (e.g., 'tail messages')")
 			}
+			// Reject a resource this CLI does not expose before binding the poll
+			// loop: an unknown name only ever 404s, so failing fast with a
+			// non-zero exit (and the valid set) beats warning once per poll
+			// forever. Also satisfies the invalid-argument contract the dogfood
+			// error-path probe checks.
+			knownResource := false
+			for _, r := range tailKnownResources() {
+				if r == resource {
+					knownResource = true
+					break
+				}
+			}
+			if !knownResource {
+				return fmt.Errorf("unknown resource %q; known resources: %v", resource, tailKnownResources())
+			}
 
 			c, err := flags.newClient()
 			if err != nil {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -460,8 +460,9 @@ func discoverLiveDogfoodCommands(binaryPath string) ([]liveDogfoodCommand, error
 
 // liveDogfoodFrameworkSkip names top-level commands that are framework
 // scaffolding rather than API surface, so live dogfood does not probe them.
-// "login" is the top-level alias for `auth login`: it launches the OAuth
-// browser flow and never makes a probeable API call, so it belongs here
+// "login" and "logout" are top-level aliases for interactive auth lifecycle
+// flows: they launch or tear down browser-backed auth state and never make a
+// probeable API call, so they belong here
 // alongside the other framework commands.
 var liveDogfoodFrameworkSkip = map[string]bool{
 	"agent-context": true,
@@ -469,6 +470,7 @@ var liveDogfoodFrameworkSkip = map[string]bool{
 	"completion":    true,
 	"help":          true,
 	"login":         true,
+	"logout":        true,
 	"version":       true,
 }
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4719,32 +4719,32 @@ func TestHappyArgsContainSyntheticFlagPlaceholder(t *testing.T) {
 	))
 }
 
-// TestCollectLiveDogfoodCommandsSkipsLoginAlias verifies the top-level
-// "login" alias (a peer of `auth login` that launches the OAuth browser
-// flow) is treated as framework scaffolding and excluded from the live
-// dogfood matrix, while real API subtrees survive.
-func TestCollectLiveDogfoodCommandsSkipsLoginAlias(t *testing.T) {
+// TestLiveDogfoodSkipsInteractiveAuthCommands locks in that the live matrix
+// skips promoted login/logout (interactive OAuth lifecycle commands) the same
+// way it already skips the "auth" parent. Probing their happy path would bind a
+// local callback port and block on a browser redirect until the per-command
+// timeout, so they must never enter the command list.
+func TestLiveDogfoodSkipsInteractiveAuthCommands(t *testing.T) {
 	t.Parallel()
 
-	root := dogfoodAgentCommand{
-		Name: "root",
-		Subcommands: []dogfoodAgentCommand{
-			{Name: "login"},
-			{Name: "auth", Subcommands: []dogfoodAgentCommand{{Name: "login"}}},
-			{Name: "posts", Subcommands: []dogfoodAgentCommand{{Name: "list"}}},
-		},
+	roots := []dogfoodAgentCommand{
+		{Name: "login"},
+		{Name: "logout"},
+		{Name: "auth", Subcommands: []dogfoodAgentCommand{{Name: "login"}}},
+		{Name: "tasks", Subcommands: []dogfoodAgentCommand{{Name: "list"}}},
 	}
-
 	var cmds []liveDogfoodCommand
-	for _, sub := range root.Subcommands {
-		collectLiveDogfoodCommands(nil, sub, &cmds)
+	for _, root := range roots {
+		collectLiveDogfoodCommands(nil, root, &cmds)
 	}
 
-	var paths [][]string
+	var names []string
 	for _, c := range cmds {
-		paths = append(paths, c.Path)
+		names = append(names, strings.Join(c.Path, " "))
 	}
-	// Both the top-level "login" alias and the "auth" subtree are framework
-	// skips; only the posts subtree should survive.
-	assert.Equal(t, [][]string{{"posts", "list"}}, paths)
+
+	assert.NotContains(t, names, "login")
+	assert.NotContains(t, names, "logout")
+	assert.NotContains(t, names, "auth login")
+	assert.Contains(t, names, "tasks list", "non-auth commands must still be collected")
 }


### PR DESCRIPTION
## Intent

Three machine-level fixes surfaced by a full `dogfood --live` gate of a freshly-printed CLI (toodledo) at publish time: the gate failed 22 ways, all tracing to generator/scorer behavior rather than CLI bugs. Each fix generalizes across printed CLIs.

Issue: Closes #2994, Closes #2993

## Approach

Three independent fixes:

1. **Generator — valid-JSON example for JSON-body flags.** A required string body param guarded by `json.Valid` (`isJSONStringParam`) was given `--<flag> example-value` in its `Example`, which fails that guard on first run — the emitted `--help` advertised a command that errors immediately, and the live-dogfood happy-path/json-fidelity probes (which run the `Example` verbatim) rejected it. New `jsonStringBodyExamplePlaceholder` emits a minimal valid-JSON value (`'[]'`/`'{}'`), single-quoted so it's shell-copy-pasteable and the quote-aware dogfood tokenizer parses it back to valid JSON.

2. **Scorer — skip interactive auth in the live matrix.** Added `login`/`logout` to `liveDogfoodFrameworkSkip` (which already skips `auth`). Their happy path binds a callback port and waits on a browser redirect, so a live probe can only hang to the per-command timeout.

3. **Generator — `tail` rejects unknown resources.** The generated `tail` accepted any resource and built `GET /<resource>`, 404-polling an unknown name forever (and exiting 0 under dogfood single-poll, failing the error-path probe). It now validates against `tailKnownResources()` and exits non-zero before binding the poll loop.

## Scope

Primary area: generator (`internal/generator/first_command_example.go`, `templates/tail.go.tmpl`) and scorer (`internal/pipeline/live_dogfood.go`).

Why this belongs in this repo: all three are Printing Press behaviors that affect every printed CLI of the relevant shape — any CLI with a JSON-body write mirror, any OAuth CLI with a promoted `login`/`logout`, any sync-capable CLI with `tail`. The printed-CLI-side equivalents were applied separately in the toodledo library PR (mvanhorn/printing-press-library#1205); this PR fixes the machine so future prints don't need them.

## Catalog Justification

N/A

## Risk

Generated-output diff for two surfaces: the `Example` value of JSON-body endpoint mirrors, and the `tail` command body. `scripts/golden.sh verify` passes with no fixture changes (no existing golden fixture exercises a JSON-string body command or `tail`). The example change is gated on `isJSONStringParam`, so plain string/scalar params are unaffected. The dogfood skip is additive set membership.

## Output Contract

Generator/template change. Generated-output evidence:
- `first_command_example_test.go`: new case asserts a json.Valid-guarded body flag's example is valid JSON (`'[]'`), and plain string body flags still emit `example-value`.
- `template_batch3_test.go` (`TestGeneratedTailShortCircuitsFollowUnderDogfood`): asserts generated `tail.go` rejects an unknown resource before constructing the client.
- `live_dogfood_test.go`: new guard test asserts `collectLiveDogfoodCommands` excludes `login`/`logout` while still collecting non-auth commands.
- `scripts/golden.sh verify` passes (31 cases, no diff).

## Verification

- `go test ./internal/generator/` — pass (full package)
- `go test ./internal/pipeline/` — pass (full package)
- `go test ./internal/cli/` — pass (full package, standalone)
- `scripts/golden.sh verify` — pass (31 cases)
- `go vet ./internal/generator/ ./internal/pipeline/` — clean
- `gofmt -l` on changed files — clean
- `go test ./...` — two unrelated environmental failures only: `internal/browsersniff` (`dyld: libsimdjson.31.dylib` missing — a local Homebrew/node dependency, fails on a clean tree too) and parallel-run contention in `internal/cli` publish-package tests (every one passes in isolation, with and without these changes). golangci-lint not run locally (not installed); CI runs it.

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
