### PR TITLE
chore(cli): gitignore local agent skill/plugin installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,18 @@ CLAUDE.local.md
 AGENTS.override.md
 .claude/settings.local.json
 
+# Local project-scoped agent skill/plugin installs. These let private or
+# experimental skills live next to this checkout without being published from
+# this public repo. Note: the repo's own tracked skills live in root `skills/`,
+# which is intentionally NOT ignored here.
+.claude/skills/
+.claude/plugins/
+.skills/
+.agents/
+.codex/
+.cursor/
+.gemini/
+
 # Planning documents stay local — this is a public repo and plans
 # frequently describe in-progress, unreleased, or third-party work.
 # See AGENTS.md "Plan documents stay local" for the rule and rationale.


### PR DESCRIPTION
## What

Ignore local, project-scoped agent skill/plugin install directories so private or experimental skills can live next to a checkout without being committed to this public repo:

`.claude/skills/`, `.claude/plugins/`, `.skills/`, `.agents/`, `.codex/`, `.cursor/`, `.gemini/`

## Why

Lets contributors enable local skills/plugins without those installs leaking into the public repo. Personal Claude Code plugin enablement (e.g. `enabledPlugins`) belongs in the already-ignored `.claude/settings.local.json`, not the shared `.claude/settings.json`.

## Note

The repo's own tracked root `skills/` directory is intentionally **not** ignored — ignoring it would silently drop new committed skill files. Comment in `.gitignore` calls this out.