### PR TITLE
feat(cli): fold recurring Greptile findings into printed-CLI defaults

### DIFF
--- a/internal/generator/client_invalidate_cache_test.go
+++ b/internal/generator/client_invalidate_cache_test.go
@@ -76,9 +76,13 @@ func TestGenerateEmitsInvalidateCacheSymmetry(t *testing.T) {
 }
 
 // TestGenerateCacheDirIsHTTPSubdir guards #1126: cacheDir must point at
-// ~/.cache/<api>/http (not ~/.cache/<api>) so that invalidateCache's
-// os.RemoveAll only wipes the HTTP cache and leaves sibling state files
-// (SQLite mirrors, FTS5 stores, watchlists) intact.
+// <cache-root>/<api>/http (not <cache-root>/<api>) so that
+// invalidateCache's os.RemoveAll only wipes the HTTP cache and leaves
+// sibling state files (SQLite mirrors, FTS5 stores, watchlists) intact.
+//
+// The cache root is XDG-aware ($XDG_CACHE_HOME with ~/.cache fallback) so
+// the assertions key off the trailing `<api>/http` shape rather than a
+// hardcoded home prefix.
 func TestGenerateCacheDirIsHTTPSubdir(t *testing.T) {
 	t.Parallel()
 
@@ -94,11 +98,22 @@ func TestGenerateCacheDirIsHTTPSubdir(t *testing.T) {
 	clientGo := string(clientGoBytes)
 
 	cliName := naming.CLI(apiSpec.Name)
-	wantSubdir := `filepath.Join(homeDir, ".cache", "` + cliName + `", "http")`
-	wantOldShape := `filepath.Join(homeDir, ".cache", "` + cliName + `")`
+	wantSubdir := `filepath.Join(cacheBase, "` + cliName + `", "http")`
+	wantXDGAware := `os.Getenv("XDG_CACHE_HOME")`
+	wantHomeFallback := `filepath.Join(homeDir, ".cache")`
+	wantOldShape := `filepath.Join(homeDir, ".cache", "` + cliName + `", "http")`
+	wantBareRoot := `filepath.Join(cacheBase, "` + cliName + `")`
 
 	assert.Contains(t, clientGo, wantSubdir,
 		"client.go must place cacheDir under <api>/http so invalidateCache spares siblings (#1126)")
+	assert.Contains(t, clientGo, wantXDGAware,
+		"client.go must consult XDG_CACHE_HOME before falling back to ~/.cache")
+	assert.Contains(t, clientGo, wantHomeFallback,
+		"client.go must fall back to ~/.cache when XDG_CACHE_HOME is unset")
 	assert.NotContains(t, clientGo, wantOldShape,
-		"client.go must not point cacheDir at the bare ~/.cache/<api>/ root (#1126)")
+		"client.go must root cacheDir via cacheBase, not a hardcoded homeDir/.cache")
+	// A bare-root literal would short-circuit the `, "http"` suffix; pin
+	// the same #1126 guard against accidentally regressing the subdir.
+	assert.False(t, strings.Contains(clientGo, wantBareRoot+`)`),
+		"client.go must not point cacheDir at the bare <cache-root>/<api>/ root (#1126)")
 }

--- a/internal/generator/client_invalidate_cache_test.go
+++ b/internal/generator/client_invalidate_cache_test.go
@@ -112,8 +112,8 @@ func TestGenerateCacheDirIsHTTPSubdir(t *testing.T) {
 		"client.go must fall back to ~/.cache when XDG_CACHE_HOME is unset")
 	assert.NotContains(t, clientGo, wantOldShape,
 		"client.go must root cacheDir via cacheBase, not a hardcoded homeDir/.cache")
-	// A bare-root literal would short-circuit the `, "http"` suffix; pin
-	// the same #1126 guard against accidentally regressing the subdir.
-	assert.False(t, strings.Contains(clientGo, wantBareRoot+`)`),
+	// Pin the #1126 subdir guard against accidentally regressing to the
+	// bare <cache-root>/<api>/ root (no "http" suffix).
+	assert.NotContains(t, clientGo, wantBareRoot,
 		"client.go must not point cacheDir at the bare <cache-root>/<api>/ root (#1126)")
 }

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -39,6 +39,8 @@ type novelFeatureChildRender struct {
 type novelFeatureTestRender struct {
 	Owner       string
 	Ident       string
+	CommandPath string
+	CommandArgs []string
 	SkipMessage string
 }
 
@@ -160,6 +162,8 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generated
 		testData := novelFeatureTestRender{
 			Owner:       g.Spec.Owner,
 			Ident:       data.Ident,
+			CommandPath: data.CommandPath,
+			CommandArgs: strings.Fields(data.CommandPath),
 			SkipMessage: "TODO: implement table-driven tests for " + data.CommandPath,
 		}
 		if err := g.renderTemplate("novel_feature_command_test.go.tmpl", testPath, testData); err != nil {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -63,6 +63,10 @@ func TestGeneratorEmitsNovelFeatureCommandStubs(t *testing.T) {
 
 	testSrc := readGeneratedFile(t, outputDir, "internal", "cli", "call_test.go")
 	assert.Contains(t, testSrc, `t.Skip("TODO: implement table-driven tests for call")`)
+	// New smoke test exercises --help on the wired command path so a missing
+	// AddCommand or panicking RunE is caught before review.
+	assert.Contains(t, testSrc, `func TestNovelCallHelpWires(t *testing.T)`)
+	assert.Contains(t, testSrc, `cmd.SetArgs([]string{"call", "--help"})`)
 
 	var runtimeTest strings.Builder
 	runtimeTest.WriteString(`package cli

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -381,8 +381,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "{{.Name}}-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "{{.Name}}-pp-cli", "http")
 {{- if eq .Auth.Type "session_handshake"}}
 	sess := newSessionManager(timeout)
 	httpClient := newHTTPClient(timeout, sess.CookieJar())

--- a/internal/generator/templates/golangci.yml.tmpl
+++ b/internal/generator/templates/golangci.yml.tmpl
@@ -5,6 +5,10 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - bodyclose
+    - noctx
+    - rowserrcheck
+    - sqlclosecheck
 
 formatters:
   enable:

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -1041,7 +1041,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/internal/generator/templates/novel_feature_command_test.go.tmpl
+++ b/internal/generator/templates/novel_feature_command_test.go.tmpl
@@ -3,8 +3,47 @@
 
 package cli
 
-import "testing"
+import (
+	"io"
+	"testing"
+)
 
-func TestNovel{{.Ident}}CommandTODO(t *testing.T) {
+// TestNovel{{.Ident}}HelpWires smoke-tests that the {{.CommandPath}} command
+// resolves at runtime and renders --help without error. Catches wiring
+// regressions (missing AddCommand, panicking RunE on --help, etc.) before
+// review. Always runs — do not delete this test when filling in real cases.
+func TestNovel{{.Ident}}HelpWires(t *testing.T) {
+	cmd := RootCmd()
+	cmd.SetArgs([]string{{"{"}}{{range .CommandArgs}}{{printf "%q" .}}, {{end}}"--help"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("{{.CommandPath}} --help error = %v (novel command not wired correctly?)", err)
+	}
+}
+
+// TestNovel{{.Ident}}Behavior is the placeholder for table-driven tests of
+// the {{.CommandPath}} command's actual behavior. Replace the t.Skip with
+// real cases — reviewers will flag a shipped t.Skip.
+//
+// Suggested shape:
+//
+//	func TestNovel{{.Ident}}Behavior(t *testing.T) {
+//	    cases := []struct {
+//	        name  string
+//	        input ...
+//	        want  ...
+//	    }{
+//	        // {name: "...", input: ..., want: ...},
+//	    }
+//	    for _, tc := range cases {
+//	        tc := tc
+//	        t.Run(tc.name, func(t *testing.T) {
+//	            t.Parallel()
+//	            // assertions here
+//	        })
+//	    }
+//	}
+func TestNovel{{.Ident}}Behavior(t *testing.T) {
 	t.Skip({{printf "%q" .SkipMessage}})
 }

--- a/internal/pipeline/client_env_scanner.go
+++ b/internal/pipeline/client_env_scanner.go
@@ -13,9 +13,24 @@ import (
 	"strings"
 )
 
+// systemEnvVarDenylist names env vars the manifest reconciler must never
+// promote to user_config even when the generated client reads them.
+// XDG_* and HOME/USERPROFILE are platform conventions a user sets globally
+// (or that fall back via the standard library) — they are not credentials
+// or per-CLI knobs an install prompt should collect.
+var systemEnvVarDenylist = map[string]struct{}{
+	"XDG_CACHE_HOME":  {},
+	"XDG_CONFIG_HOME": {},
+	"XDG_DATA_HOME":   {},
+	"XDG_STATE_HOME":  {},
+	"HOME":            {},
+	"USERPROFILE":     {},
+}
+
 // scanClientEnvReads parses every Go source file under <dir>/internal/client/
 // and returns the deduplicated, sorted set of env var names read via
-// os.Getenv("...").
+// os.Getenv("..."), excluding well-known platform-convention vars
+// (systemEnvVarDenylist).
 //
 // The scan is intentionally restricted to internal/client/. Hand-written
 // auth-refresh code in that package is the unambiguous signal the manifest
@@ -67,6 +82,9 @@ func scanClientEnvReads(dir string) ([]string, error) {
 			}
 			name, err := strconv.Unquote(lit.Value)
 			if err != nil || name == "" {
+				return true
+			}
+			if _, deny := systemEnvVarDenylist[name]; deny {
 				return true
 			}
 			seen[name] = struct{}{}

--- a/internal/pipeline/client_env_scanner_test.go
+++ b/internal/pipeline/client_env_scanner_test.go
@@ -443,6 +443,34 @@ func u() string { return os.Getenv("X_USERNAME") }
 	assert.Equal(t, string(first), string(second), "reconcile must be idempotent across consecutive writer runs")
 }
 
+// TestScanClientEnvReadsExcludesSystemEnvVarsFromUserConfig guards the
+// platform-convention denylist: XDG_CACHE_HOME, XDG_CONFIG_HOME, etc. are
+// read by the generated client (e.g. cache root selection) but must never
+// be promoted to user_config — they are user-global settings, not
+// per-CLI credentials, and surfacing them as Required+Sensitive would
+// break install prompts on every printed CLI.
+func TestScanClientEnvReadsExcludesSystemEnvVarsFromUserConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeClientFile(t, dir, "client.go", `package client
+
+import "os"
+
+func cachePath() string {
+	base := os.Getenv("XDG_CACHE_HOME")
+	_ = os.Getenv("XDG_CONFIG_HOME")
+	_ = os.Getenv("XDG_DATA_HOME")
+	_ = os.Getenv("XDG_STATE_HOME")
+	_ = os.Getenv("HOME")
+	_ = os.Getenv("USERPROFILE")
+	return base + os.Getenv("REAL_API_KEY")
+}
+`)
+	got, err := scanClientEnvReads(dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"REAL_API_KEY"}, got,
+		"system env vars (XDG_*, HOME, USERPROFILE) must never reach user_config; only the credential REAL_API_KEY should survive")
+}
+
 // TestScanClientEnvReadsBacktickLiteral guards against a regression that
 // would drop backtick-quoted env var names. strconv.Unquote handles both
 // forms, but the integration is worth a fixture in case the parser path

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -672,7 +672,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -63,8 +63,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "golden-api-cookie-auth-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "golden-api-cookie-auth-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, LoadCookieJar())
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -68,8 +68,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-oauth2-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "printing-press-oauth2-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -63,8 +63,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-oauth2-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "printing-press-oauth2-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -618,7 +618,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -64,8 +64,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "printing-press-golden-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "printing-press-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -773,7 +773,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -612,7 +612,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -166,8 +166,12 @@ func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 }
 
 func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
-	homeDir, _ := os.UserHomeDir()
-	cacheDir := filepath.Join(homeDir, ".cache", "tier-routing-golden-pp-cli", "http")
+	cacheBase := os.Getenv("XDG_CACHE_HOME")
+	if cacheBase == "" {
+		homeDir, _ := os.UserHomeDir()
+		cacheBase = filepath.Join(homeDir, ".cache")
+	}
+	cacheDir := filepath.Join(cacheBase, "tier-routing-golden-pp-cli", "http")
 	httpClient := newHTTPClient(timeout, nil)
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -637,7 +637,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	}
 	defer db.Close()
 
-	rows, err := db.Query(query)
+	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
 	}


### PR DESCRIPTION
## Intent

Issue: Closes #3004

The same Greptile findings repeat on community novel commands. Trevin and Matt routinely ask contributors to "address the Greptile comment" before merge. Each fix lands per-CLI today. Move the defaults into the machine so every print gets them.

## Approach

Five tightly coupled changes:

1. Printed `.golangci.yml` enables `rowserrcheck`, `sqlclosecheck`, `bodyclose`, `noctx`. These catch the four most common findings at CI time in every printed CLI.
2. MCP `handleSQL` switches from `db.Query(query)` to `db.DB().QueryContext(ctx, query)` so the MCP read path propagates cancellation, matching the CLI `sql` command.
3. Client `New()` consults `$XDG_CACHE_HOME` before falling back to `~/.cache`. The `<api>/http` subdir guard from #1126 is preserved.
4. The novel command test template emits a real `TestNovel<Ident>HelpWires` smoke test exercising `--help` through `RootCmd`. The TODO behavior skip stays as a commented table-driven scaffold so reviewers still flag a shipped placeholder.
5. The MCPB env scanner gets a denylist for `XDG_*`, `HOME`, `USERPROFILE` so the new XDG read does NOT get promoted to a Required+Sensitive `user_config` entry.

Change 5 exists to support change 3. Without it, every printed CLI's MCPB manifest would gain an `xdg_cache_home` install prompt.

## Scope

Primary area: `internal/generator/templates/` (printed-CLI shape) and `internal/pipeline/client_env_scanner.go` (manifest reconciliation).

Why this belongs in this repo: every symptom appears on printed CLIs, but the fix shape is the same for all of them. Per AGENTS.md "Default to machine changes."

## Catalog Justification

N/A. No catalog files touched.

## Risk

- Printed CLIs reprinted on this generator gain four new linters. The templates already follow the patterns the linters check (request creation, body close, rows.Err in store and MCP), so I do not expect spurious failures, but novel command code in already-published CLIs may now trip them on reprint. That is the intended signal.
- `db.DB().QueryContext(ctx, query)` is a behavior change for MCP `sql` callers: a disconnected client now cancels the query. Matches the CLI side.
- `$XDG_CACHE_HOME` becomes the preferred cache root. Users who set it (CI, containers, dotfiles) will see new cache locations on reprint. Old cache files at `~/.cache/<api>/http` are left in place.
- Novel command test files no longer auto-skip. They run a real `--help` smoke test that should pass on any wired command. If the command panics on `--help` or is not registered, this PR makes that visible at `go test` time, which is the goal.

## Output Contract

Changes templates and generated files:

- `internal/client/client.go` `New()` body shape
- `internal/mcp/tools.go` `handleSQL` SQL call
- `.golangci.yml` enabled linters
- novel-feature `_test.go` shape

Evidence:

- 9 golden cases updated (`client.go` and `mcp/tools.go` only). `manifest.json` is untouched once the env-scanner denylist landed.
- New emitted-code assertions in `internal/generator/client_invalidate_cache_test.go` (XDG-aware shape) and `internal/generator/novel_feature_stubs_test.go` (smoke test presence).
- `scripts/verify-generator-output.sh` compiles 9 representative generated CLIs against the new templates.

Published-library sweep tool is NOT affected: no `readme.md.tmpl`, `skill.md.tmpl`, agentcookie manifest, or learn-loop template changes.

## Verification

Commands run on this branch:

- `go build -o ./cli-printing-press ./cmd/cli-printing-press`: OK
- `go test ./...`: all packages pass
- `go vet ./...`: clean
- `go fmt ./...`: no drift
- `scripts/golden.sh verify`: `Golden verify passed: 31 case(s)`
- `scripts/verify-generator-output.sh`: `Generated-output verification passed for 9 case(s)`

Generated a fresh `golden-api` CLI from the new templates and confirmed:

- `.golangci.yml` carries the four new linters
- `client.go` uses XDG-aware `cacheBase`
- `mcp/tools.go` uses `db.DB().QueryContext(ctx, ...)`
- `manifest.json` has no `xdg_cache_home` user_config entry

`golangci-lint` is not installed on the host that produced this branch. `go vet` is clean and the added linters are the standard upstream plugins. Happy to add results from a CI run.

- [x] Generator/template change: verified generated output, including emitted-code assertions and compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change