### PR TITLE
fix(cli): floor x/sys>=v0.46.0, x/crypto>=v0.53.0, quic-go>=v0.60.0 + 0700 dirs in printed CLIs

### DIFF
--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -339,6 +339,10 @@ require (
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )
+
+// Floor the transitively-pulled x/sys (via tinygo.org/x/bluetooth) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect
 `
 
 const deviceMainTemplate = `// Copyright {{.CurrentYear}}. Licensed under Apache-2.0. See LICENSE.

--- a/internal/generator/fleet_hardening_test.go
+++ b/internal/generator/fleet_hardening_test.go
@@ -1,12 +1,17 @@
 package generator
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +61,40 @@ func TestGeneratedFleetHardening(t *testing.T) {
 	require.Contains(t, deliverGo, "os.MkdirAll(dir, 0o700)",
 		"the agent-deliver dir must be created mode 0700 (gosec G301)")
 	require.NotContains(t, deliverGo, "os.MkdirAll(dir, 0o755)")
+}
+
+// TestNoWorldReadableMkdirAllInTemplates is the fleet-wide regression guard for
+// gosec G301: no emitted template may create a directory world-readable
+// (`0o755`). Scoped to template source because the alternative — generating
+// every feature combination (store, deliver, share, session-handshake, ...) and
+// asserting on each emitted file — is impractical; this catches a future
+// template edit reintroducing the mode regardless of which feature emits it.
+// The generator's own `MkdirAll` calls (build-time output dirs in *.go) are out
+// of scope — they don't ship in printed CLIs.
+func TestNoWorldReadableMkdirAllInTemplates(t *testing.T) {
+	t.Parallel()
+
+	var offenders []string
+	err := filepath.WalkDir("templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".tmpl") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if strings.Contains(line, "MkdirAll") && strings.Contains(line, "0o755") {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+strconv.Itoa(i+1))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, offenders, "emitted templates must create dirs with 0o700, not world-readable 0o755 (gosec G301): %v", offenders)
 }
 
 func generateForHardeningTest(t *testing.T, apiSpec *spec.APISpec) string {

--- a/internal/generator/fleet_hardening_test.go
+++ b/internal/generator/fleet_hardening_test.go
@@ -1,0 +1,73 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedFleetHardening locks the two fleet-wide hardening defaults from
+// issue #3012: the go.mod template floors golang.org/x/sys above the vulnerable
+// transitive version (GO-2026-5024), and the per-user data/deliver dirs are
+// created mode 0700 rather than world-readable 0o755 (gosec G301).
+func TestGeneratedFleetHardening(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "fleethardening",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/fleethardening-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"widgets": {
+				Description: "Widgets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/widgets",
+						Description: "List widgets",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := generateForHardeningTest(t, apiSpec)
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	require.Contains(t, goMod, "golang.org/x/sys v0.46.0",
+		"go.mod must floor golang.org/x/sys at >= v0.46.0 to clear GO-2026-5024")
+
+	storeGo := readGeneratedFile(t, outputDir, "internal", "store", "store.go")
+	require.Contains(t, storeGo, "os.MkdirAll(filepath.Dir(dbPath), 0o700)",
+		"the SQLite mirror dir must be created mode 0700 (gosec G301)")
+	require.NotContains(t, storeGo, "os.MkdirAll(filepath.Dir(dbPath), 0o755)")
+
+	deliverGo := readGeneratedFile(t, outputDir, "internal", "cli", "deliver.go")
+	require.Contains(t, deliverGo, "os.MkdirAll(dir, 0o700)",
+		"the agent-deliver dir must be created mode 0700 (gosec G301)")
+	require.NotContains(t, deliverGo, "os.MkdirAll(dir, 0o755)")
+}
+
+func generateForHardeningTest(t *testing.T, apiSpec *spec.APISpec) string {
+	t.Helper()
+	outputDir := strings.TrimSuffix(t.TempDir(), "/") + "/" + naming.CLI(apiSpec.Name)
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	gen.profile = &profiler.APIProfile{
+		SyncableResources: []profiler.SyncableResource{
+			{Name: "widgets", Path: "/widgets", Method: "GET"},
+		},
+	}
+	require.NoError(t, gen.Generate())
+	return outputDir
+}

--- a/internal/generator/templates/deliver.go.tmpl
+++ b/internal/generator/templates/deliver.go.tmpl
@@ -74,7 +74,7 @@ func deliverFile(path string, body []byte) error {
 	// file if the process is interrupted mid-write.
 	dir := filepath.Dir(path)
 	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("creating deliver dir: %w", err)
 		}
 	}

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -31,3 +31,7 @@ require modernc.org/sqlite v1.37.0
 {{- if .VisionSet.MCP}}
 require github.com/mark3labs/mcp-go v0.47.0
 {{- end}}
+
+// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -32,6 +32,7 @@ require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0
 {{- end}}
 
-// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
-// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+// Floor x/sys above the vulnerable v0.31.0. It is pulled only transitively
+// (modernc.org/sqlite, golang.org/x/net, ...), so MVS needs this explicit
+// floor; tidy drops it for CLIs that pull no x/sys at all.
 require golang.org/x/sys v0.46.0 // indirect

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -36,3 +36,12 @@ require github.com/mark3labs/mcp-go v0.47.0
 // (modernc.org/sqlite, golang.org/x/net, ...), so MVS needs this explicit
 // floor; tidy drops it for CLIs that pull no x/sys at all.
 require golang.org/x/sys v0.46.0 // indirect
+{{- if .UsesBrowserHTTPTransport}}
+
+// Floor the HTTP/3 transitive deps pulled in only via github.com/enetx/surf
+// above their vulnerable versions (osv flags module presence; govulncheck
+// reachability = 0 for these REST CLIs). Emitted only when the surf transport
+// is present, so MVS keeps the floor; tidy drops it for CLIs without surf.
+require golang.org/x/crypto v0.53.0 // indirect
+require github.com/quic-go/quic-go v0.60.0 // indirect
+{{- end}}

--- a/internal/generator/templates/session_handshake.go.tmpl
+++ b/internal/generator/templates/session_handshake.go.tmpl
@@ -307,7 +307,7 @@ func (m *SessionManager) saveToDisk() {
 	if err != nil {
 		return
 	}
-	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
 	_ = os.WriteFile(path, data, 0o600)
 }
 

--- a/internal/generator/templates/share.go.tmpl
+++ b/internal/generator/templates/share.go.tmpl
@@ -106,7 +106,7 @@ func EnsureRepo(ctx context.Context, opts Options) error {
 		return nil
 	}
 	if strings.TrimSpace(opts.Remote) != "" {
-		if err := os.MkdirAll(filepath.Dir(opts.RepoPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(opts.RepoPath), 0o700); err != nil {
 			return fmt.Errorf("mkdir share parent: %w", err)
 		}
 		if err := runGit(ctx, "", "clone", opts.Remote, opts.RepoPath); err != nil {
@@ -119,7 +119,7 @@ func EnsureRepo(ctx context.Context, opts Options) error {
 		}
 		return nil
 	}
-	if err := os.MkdirAll(opts.RepoPath, 0o755); err != nil {
+	if err := os.MkdirAll(opts.RepoPath, 0o700); err != nil {
 		return fmt.Errorf("mkdir share repo: %w", err)
 	}
 	if err := runGit(ctx, opts.RepoPath, "init"); err != nil {
@@ -215,7 +215,7 @@ func Export(ctx context.Context, s *store.Store, opts Options) (Manifest, error)
 	if err := os.RemoveAll(dataDir); err != nil {
 		return Manifest{}, fmt.Errorf("reset tables dir: %w", err)
 	}
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return Manifest{}, fmt.Errorf("mkdir tables dir: %w", err)
 	}
 	schemaVersion, err := s.SchemaVersion()

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -122,7 +122,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // retry-on-SQLITE_BUSY loop and propagates ctx.Err() back to the caller
 // instead of waiting out the full migrationLockTimeout.
 func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )
+
+// Floor the transitively-pulled x/sys (via tinygo.org/x/bluetooth) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )
+
+// Floor the transitively-pulled x/sys (via tinygo.org/x/bluetooth) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )
+
+// Floor the transitively-pulled x/sys (via tinygo.org/x/bluetooth) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	tinygo.org/x/bluetooth v0.15.0
 )
+
+// Floor the transitively-pulled x/sys (via tinygo.org/x/bluetooth) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -10,3 +10,7 @@ require (
 )
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0
+
+// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -11,6 +11,7 @@ require (
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0
 
-// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
-// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+// Floor x/sys above the vulnerable v0.31.0. It is pulled only transitively
+// (modernc.org/sqlite, golang.org/x/net, ...), so MVS needs this explicit
+// floor; tidy drops it for CLIs that pull no x/sys at all.
 require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -10,3 +10,7 @@ require (
 )
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0
+
+// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
+// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -11,6 +11,7 @@ require (
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0
 
-// Floor the transitively-pulled x/sys (via modernc.org/sqlite) above the
-// vulnerable v0.31.0; tidy drops it for CLIs that pull no x/sys at all.
+// Floor x/sys above the vulnerable v0.31.0. It is pulled only transitively
+// (modernc.org/sqlite, golang.org/x/net, ...), so MVS needs this explicit
+// floor; tidy drops it for CLIs that pull no x/sys at all.
 require golang.org/x/sys v0.46.0 // indirect

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -121,7 +121,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // retry-on-SQLITE_BUSY loop and propagates ctx.Err() back to the caller
 // instead of waiting out the full migrationLockTimeout.
 func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -118,7 +118,7 @@ func OpenReadOnly(dbPath string) (*Store, error) {
 // retry-on-SQLITE_BUSY loop and propagates ctx.Err() back to the caller
 // instead of waiting out the full migrationLockTimeout.
 func OpenWithContext(ctx context.Context, dbPath string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 


### PR DESCRIPTION
## Intent

Two fleet-wide generated-code defaults that every printed CLI inherited and had to suppress downstream (surfaced shipping the `quickbooks` connector against a production QBO tenant).

Issue: Closes #3012

## Approach

- **x/sys (GO-2026-5024):** the go.mod templates don't pin `golang.org/x/sys`; printed CLIs pull it transitively (standard CLIs via `modernc.org/sqlite`→`libc`/`memory`; device CLIs via `tinygo.org/x/bluetooth`) and `go mod tidy` resolved it to a vulnerable version. Added an explicit `golang.org/x/sys v0.46.0 // indirect` floor to both `go.mod.tmpl` and the device `deviceGoModTemplate`, so MVS lifts the selection; tidy drops it for CLIs that pull no x/sys.
- **MkdirAll (gosec G301):** `store.go.tmpl` and `deliver.go.tmpl` created the per-user data/deliver dirs world-readable (`0o755`); the local SQLite mirror can hold financial data. Emit `0o700`.

## Scope

Primary area: generator (go.mod templates + store/deliver `MkdirAll`).

Why this belongs in this repo: both are generated-code defaults every printed CLI inherits — fixing them in the press clears the advisory/lint fleet-wide on the next regen, instead of per-connector suppression.

## Catalog Justification

N/A

## Risk

Build + verify unaffected: confirmed `go mod tidy` keeps x/sys at v0.46.0 (MVS) and all generated cases build. The unconditional x/sys require is dropped by tidy for any CLI that doesn't pull it. Goldens updated for the 6 `go.mod` and 2 `store.go` fixtures.

## Output Contract

Changes generated `go.mod` (adds the x/sys floor) and `store.go`/`deliver.go` (`0o700`). 8 golden fixtures updated (`generate-golden-api`, `-cookie-auth`, the 4 `generate-device-ble*`, `generate-learn-loop-api`, `generate-sync-walker-api`). New generated-output test `TestGeneratedFleetHardening` asserts the emitted `go.mod` floors x/sys and the emitted `store.go`/`deliver.go` create dirs `0o700`.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run: `go test ./...` (full, pass); `scripts/golden.sh verify`/`update`; `scripts/verify-generator-output.sh` (tidy+build of all cases); `go vet`; `gofmt`. Closed-loop on a freshly generated CLI: `osv-scanner --lockfile=go.mod` → "No issues found" (GO-2026-5024 gone); `gosec -include=G301` → exit 0; x/sys resolves to v0.46.0 after tidy. (`golangci-lint` not installed locally; pre-push hook + CI cover it.)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
