### PR TITLE
fix(cli): route Substack writer endpoints globally

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -456,12 +456,14 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"endpointTemplateVarsHasUndefaulted": func(vars []string) bool {
 			return endpointTemplateVarsAny(vars, s, func(v string) bool { return v == "" })
 		},
-		"safeName":                       safeSQLName,
-		"resourceIDFieldOverrideEntries": resourceIDFieldOverrideEntries,
-		"criticalResourceEntries":        criticalResourceEntries,
-		"isBackfillColumn":               isStoreBackfillColumn,
-		"hasBackfillColumns":             hasStoreBackfillColumns,
-		"backfillDecl":                   storeBackfillDecl,
+		"hasSubstackPublicationIDTemplateResolver": hasSubstackPublicationIDTemplateResolver,
+		"substackPublicationIDTemplatePath":        substackPublicationIDTemplatePath,
+		"safeName":                                 safeSQLName,
+		"resourceIDFieldOverrideEntries":           resourceIDFieldOverrideEntries,
+		"criticalResourceEntries":                  criticalResourceEntries,
+		"isBackfillColumn":                         isStoreBackfillColumn,
+		"hasBackfillColumns":                       hasStoreBackfillColumns,
+		"backfillDecl":                             storeBackfillDecl,
 		"safeNameSuffix": func(name, suffix string) string {
 			return safeSQLName(name + suffix)
 		},
@@ -632,6 +634,46 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 func endpointTemplateVarsAny(vars []string, s *spec.APISpec, predicate func(string) bool) bool {
 	for _, name := range vars {
 		if predicate(s.EndpointTemplateDefault(name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSubstackPublicationIDTemplateResolver(s *spec.APISpec) bool {
+	if s == nil || !strings.EqualFold(s.Name, "substack") || !s.IsEndpointTemplateVar("publication_id") {
+		return false
+	}
+	return specWalkEndpoints(s, func(_ string, endpoint spec.Endpoint) bool {
+		return substackPublicationIDTemplatePath(s, endpoint.Path)
+	})
+}
+
+func substackPublicationIDTemplatePath(s *spec.APISpec, path string) bool {
+	return s != nil && strings.EqualFold(s.Name, "substack") && strings.Contains(path, "{publication_id}")
+}
+
+func specWalkEndpoints(s *spec.APISpec, visit func(resourceName string, endpoint spec.Endpoint) bool) bool {
+	if s == nil {
+		return false
+	}
+	for resourceName, resource := range s.Resources {
+		if resourceWalkEndpoints(resourceName, resource, visit) {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceWalkEndpoints(resourceName string, resource spec.Resource, visit func(resourceName string, endpoint spec.Endpoint) bool) bool {
+	for _, endpoint := range resource.Endpoints {
+		if visit(resourceName, endpoint) {
+			return true
+		}
+	}
+	for subResourceName, subResource := range resource.SubResources {
+		name := resourceName + "." + subResourceName
+		if resourceWalkEndpoints(name, subResource, visit) {
 			return true
 		}
 	}

--- a/internal/generator/substack_writer_routes_test.go
+++ b/internal/generator/substack_writer_routes_test.go
@@ -1,0 +1,223 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSubstackGlobalWriterRoutes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := substackWriterRoutesSpec()
+	outputDir := filepath.Join(t.TempDir(), "substack-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, rootSrc, `templateVarPublicationId string`)
+	assert.Contains(t, rootSrc, `"publication-id"`)
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	assert.Contains(t, configSrc, `os.Getenv("SUBSTACK_PUBLICATION_ID")`)
+	assert.Contains(t, configSrc, `cfg.TemplateVars["publication_id"] = v`)
+
+	draftsSrc := readGeneratedFile(t, outputDir, "internal", "cli", "drafts_create.go")
+	assert.Contains(t, draftsSrc, `"pp:path": "https://substack.com/api/v1/drafts?publication_id={publication_id}"`)
+	assert.Contains(t, draftsSrc, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`)
+	assert.NotContains(t, draftsSrc, `trevinsays.substack.com`)
+
+	imagesSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_images.go")
+	assert.Contains(t, imagesSrc, `"pp:path": "https://substack.com/api/v1/image"`)
+	assert.Contains(t, imagesSrc, `path := "https://substack.com/api/v1/image"`)
+	assert.NotContains(t, imagesSrc, `{publication}.substack.com/api/v1/image`)
+
+	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+	assert.Contains(t, helpersSrc, `func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client, flags *rootFlags) error`)
+	assert.Contains(t, helpersSrc, `c.Get(ctx, "/user/profile/self", nil)`)
+	assert.Contains(t, helpersSrc, `dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"`)
+
+	writeSubstackWriterGeneratedRuntimeTest(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func writeSubstackWriterGeneratedRuntimeTest(t *testing.T, outputDir string) {
+	t.Helper()
+	content := `package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestDraftCreateDryRunUsesExplicitPublicationID(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--publication", "trevinsays",
+		"--publication-id", "7019888",
+		"drafts", "create",
+		"--title", "CLI verification dry-run",
+		"--body", "Verification only.",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute dry-run: %v; stderr=%s", err, stderr.String())
+	}
+	var envelope struct {
+		Path string ` + "`json:\"path\"`" + `
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &envelope); err != nil {
+		t.Fatalf("parse stdout JSON %q: %v", stdout.String(), err)
+	}
+	if got, want := envelope.Path, "https://substack.com/api/v1/drafts?publication_id=7019888"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestDraftCreateDryRunWithoutPublicationIDDoesNotLookupLiveProfile(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+	t.Setenv("SUBSTACK_BASE_URL", "http://127.0.0.1:1")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--publication", "trevinsays",
+		"drafts", "create",
+		"--title", "CLI verification dry-run",
+		"--body", "Verification only.",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute dry-run without publication id should not perform live lookup: %v; stderr=%s", err, stderr.String())
+	}
+	var envelope struct {
+		Path string ` + "`json:\"path\"`" + `
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &envelope); err != nil {
+		t.Fatalf("parse stdout JSON %q: %v", stdout.String(), err)
+	}
+	if got, want := envelope.Path, "https://substack.com/api/v1/drafts?publication_id=<resolved-at-runtime>"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestPublicationIDResolverLooksUpProfileWhenNotDryRun(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+	var sawProfile bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/profile/self" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		sawProfile = true
+		_, _ = w.Write([]byte(` + "`" + `{"primaryPublication":{"id":7019888,"subdomain":"trevinsays"}}` + "`" + `))
+	}))
+	defer server.Close()
+	t.Setenv("SUBSTACK_BASE_URL", server.URL)
+
+	flags := &rootFlags{}
+	c, err := flags.newClient()
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	c.Config.TemplateVars["publication"] = "trevinsays"
+	if err := resolveSubstackPublicationIDTemplate(t.Context(), c, flags); err != nil {
+		t.Fatalf("resolveSubstackPublicationIDTemplate: %v", err)
+	}
+	if !sawProfile {
+		t.Fatalf("profile endpoint was not queried")
+	}
+	if got, want := c.Config.TemplateVars["publication_id"], "7019888"; got != want {
+		t.Fatalf("publication_id = %q, want %q", got, want)
+	}
+}
+
+func TestImagesDryRunUsesGlobalUploadEndpoint(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--publication", "trevinsays",
+		"images",
+		"--image", "data:image/png;base64,AAAA",
+		"--dry-run",
+		"--agent",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute image dry-run: %v; stderr=%s", err, stderr.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("trevinsays.substack.com")) || bytes.Contains(stdout.Bytes(), []byte("{publication}")) {
+		t.Fatalf("stdout = %q, should not use publication-host image endpoint", stdout.String())
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "substack_writer_routes_test.go"), []byte(content), 0o644))
+}
+
+func substackWriterRoutesSpec() *spec.APISpec {
+	return &spec.APISpec{
+		Name:                         "substack",
+		DisplayName:                  "Substack",
+		Version:                      "0.1.0",
+		BaseURL:                      "https://{publication}.substack.com/api/v1",
+		EndpointTemplateVars:         []string{"publication", "publication_id"},
+		EndpointTemplateEnvOverrides: map[string]string{"publication": "SUBSTACK_PUBLICATION", "publication_id": "SUBSTACK_PUBLICATION_ID"},
+		GlobalPathTemplateVars:       []string{"publication", "publication_id"},
+		EndpointTemplateVarDefaults:  map[string]string{},
+		Auth:                         spec.AuthConfig{Type: "cookie", EnvVars: []string{"SUBSTACK_COOKIE"}},
+		Config:                       spec.ConfigSpec{Format: "toml", Path: "~/.config/substack-pp-cli/config.toml"},
+		Resources: map[string]spec.Resource{
+			"drafts": {
+				Description: "Manage drafts",
+				Endpoints: map[string]spec.Endpoint{
+					"create": {
+						Method:      "POST",
+						Path:        "https://substack.com/api/v1/drafts?publication_id={publication_id}",
+						Description: "Create a draft",
+						Body: []spec.Param{
+							{Name: "title", Type: "string", Required: true},
+							{Name: "body", Type: "string", Required: true},
+						},
+					},
+					"list": {
+						Method:      "GET",
+						Path:        "/drafts",
+						Description: "List drafts",
+					},
+				},
+			},
+			"images": {
+				Description: "Upload images",
+				Endpoints: map[string]spec.Endpoint{
+					"upload": {
+						Method:      "POST",
+						Path:        "https://substack.com/api/v1/image",
+						Description: "Upload an image",
+						Body:        []spec.Param{{Name: "image", Type: "string", Required: true}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/generator/substack_writer_routes_test.go
+++ b/internal/generator/substack_writer_routes_test.go
@@ -38,7 +38,13 @@ func TestGenerateSubstackGlobalWriterRoutes(t *testing.T) {
 	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
 	assert.Contains(t, helpersSrc, `func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client, flags *rootFlags) error`)
 	assert.Contains(t, helpersSrc, `c.Get(ctx, "/user/profile/self", nil)`)
-	assert.Contains(t, helpersSrc, `dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"`)
+	assert.Contains(t, helpersSrc, `dryRunPublicationIDPlaceholder`)
+	assert.Contains(t, helpersSrc, `"<resolved-at-runtime>"`)
+	assert.Contains(t, helpersSrc, `dryRunPublicationIDResolvedMarker`)
+	assert.Contains(t, helpersSrc, `"__pp_substack_publication_id_dry_run_resolved"`)
+	assert.Contains(t, helpersSrc, `dec := json.NewDecoder(bytes.NewReader(raw))`)
+	assert.Contains(t, helpersSrc, `dec.UseNumber()`)
+	assert.Contains(t, helpersSrc, `case json.Number:`)
 
 	writeSubstackWriterGeneratedRuntimeTest(t, outputDir)
 	runGoCommand(t, outputDir, "test", "./internal/cli")
@@ -119,6 +125,53 @@ func TestDraftCreateDryRunWithoutPublicationIDDoesNotLookupLiveProfile(t *testin
 	}
 }
 
+func TestDraftCreateDryRunRejectsExplicitPlaceholderPublicationID(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"--publication", "trevinsays",
+		"--publication-id", "<resolved-at-runtime>",
+		"drafts", "create",
+		"--title", "CLI verification dry-run",
+		"--body", "Verification only.",
+		"--dry-run",
+		"--agent",
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("explicit placeholder publication id should be rejected")
+	}
+	if got := err.Error(); !bytes.Contains([]byte(got), []byte(` + "`invalid publication_id \"<resolved-at-runtime>\"`" + `)) {
+		t.Fatalf("error = %q, want invalid publication_id", got)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no request envelope", stdout.String())
+	}
+}
+
+func TestPublicationIDResolverDryRunPlaceholderIsIdempotent(t *testing.T) {
+	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
+	flags := &rootFlags{dryRun: true}
+	c, err := flags.newClient()
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	if err := resolveSubstackPublicationIDTemplate(t.Context(), c, flags); err != nil {
+		t.Fatalf("first resolveSubstackPublicationIDTemplate: %v", err)
+	}
+	if err := resolveSubstackPublicationIDTemplate(t.Context(), c, flags); err != nil {
+		t.Fatalf("second resolveSubstackPublicationIDTemplate: %v", err)
+	}
+	if got, want := c.Config.TemplateVars["publication_id"], "<resolved-at-runtime>"; got != want {
+		t.Fatalf("publication_id = %q, want %q", got, want)
+	}
+}
+
 func TestPublicationIDResolverLooksUpProfileWhenNotDryRun(t *testing.T) {
 	t.Setenv("SUBSTACK_CONFIG", filepath.Join(t.TempDir(), "missing.toml"))
 	var sawProfile bool
@@ -127,7 +180,7 @@ func TestPublicationIDResolverLooksUpProfileWhenNotDryRun(t *testing.T) {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 		sawProfile = true
-		_, _ = w.Write([]byte(` + "`" + `{"primaryPublication":{"id":7019888,"subdomain":"trevinsays"}}` + "`" + `))
+		_, _ = w.Write([]byte(` + "`" + `{"primaryPublication":{"id":9007199254740993,"subdomain":"trevinsays"}}` + "`" + `))
 	}))
 	defer server.Close()
 	t.Setenv("SUBSTACK_BASE_URL", server.URL)
@@ -144,7 +197,7 @@ func TestPublicationIDResolverLooksUpProfileWhenNotDryRun(t *testing.T) {
 	if !sawProfile {
 		t.Fatalf("profile endpoint was not queried")
 	}
-	if got, want := c.Config.TemplateVars["publication_id"], "7019888"; got != want {
+	if got, want := c.Config.TemplateVars["publication_id"], "9007199254740993"; got != want {
 		t.Fatalf("publication_id = %q, want %q", got, want)
 	}
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -28,6 +28,9 @@ import (
 {{- if .IsAsync}}
 	"time"
 {{- end}}
+{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
+	"strings"
+{{- end}}
 {{ if $isGraphQLEndpoint}}
 	"{{modulePath}}/internal/client"
 
@@ -161,6 +164,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 
 			path := "{{.EffectivePath}}"
+{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
+			if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+				return err
+			}
+			path = strings.ReplaceAll(path, "{publication_id}", c.Config.TemplateVars["publication_id"])
+{{- end}}
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -27,6 +27,9 @@ import (
 {{- if and $hasJSONBody (bodyHasStringBackedBool .Endpoint)}}
 	"strconv"
 {{- end}}
+{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
+	"strings"
+{{- end}}
 
 {{ if .Endpoint.RequiresRole}}
 	"{{modulePath}}/internal/config"
@@ -129,6 +132,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 
 			path := "{{.EffectivePath}}"
+{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
+			if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+				return err
+			}
+			path = strings.ReplaceAll(path, "{publication_id}", c.Config.TemplateVars["publication_id"])
+{{- end}}
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -5,7 +5,7 @@
 package cli
 
 import (
-{{- if .HasDataLayer}}
+{{- if or .HasDataLayer (hasSubstackPublicationIDTemplateResolver .APISpec)}}
 	"bytes"
 {{- end}}
 	"context"
@@ -58,7 +58,10 @@ func formatCLIParamValue(v any) string {
 
 {{- if hasSubstackPublicationIDTemplateResolver .APISpec}}
 
-const dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"
+const (
+	dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"
+	dryRunPublicationIDResolvedMarker = "__pp_substack_publication_id_dry_run_resolved"
+)
 
 func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client, flags *rootFlags) error {
 	if c == nil || c.Config == nil {
@@ -68,14 +71,19 @@ func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client,
 		c.Config.TemplateVars = map[string]string{}
 	}
 	if id := strings.TrimSpace(c.Config.TemplateVars["publication_id"]); id != "" {
+		if id == dryRunPublicationIDPlaceholder && c.Config.TemplateVars[dryRunPublicationIDResolvedMarker] == "true" {
+			return nil
+		}
 		if !validSubstackPublicationID(id) {
 			return fmt.Errorf("invalid publication_id %q: use the numeric Substack publication_id", id)
 		}
 		c.Config.TemplateVars["publication_id"] = id
 		return nil
 	}
+	delete(c.Config.TemplateVars, dryRunPublicationIDResolvedMarker)
 	if flags != nil && flags.dryRun {
 		c.Config.TemplateVars["publication_id"] = dryRunPublicationIDPlaceholder
+		c.Config.TemplateVars[dryRunPublicationIDResolvedMarker] = "true"
 		return nil
 	}
 	raw, err := c.Get(ctx, "/user/profile/self", nil)
@@ -98,8 +106,8 @@ func substackPublicationTemplateVar(c *client.Client, name string) string {
 }
 
 func validSubstackPublicationID(id string) bool {
-	if id == "" || id == dryRunPublicationIDPlaceholder {
-		return id == dryRunPublicationIDPlaceholder
+	if id == "" {
+		return false
 	}
 	for _, r := range id {
 		if r < '0' || r > '9' {
@@ -111,7 +119,9 @@ func validSubstackPublicationID(id string) bool {
 
 func substackPublicationIDFromProfile(raw []byte, publication string) (string, error) {
 	var profile map[string]any
-	if err := json.Unmarshal(raw, &profile); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&profile); err != nil {
 		return "", fmt.Errorf("parsing /user/profile/self response: %w", err)
 	}
 	wantPublication := strings.TrimSpace(strings.ToLower(publication))
@@ -166,6 +176,11 @@ func jsonNumberString(v any) string {
 	switch x := v.(type) {
 	case string:
 		return strings.TrimSpace(x)
+	case json.Number:
+		id := strings.TrimSpace(x.String())
+		if validSubstackPublicationID(id) {
+			return id
+		}
 	case float64:
 		if x == float64(int64(x)) {
 			return fmt.Sprintf("%d", int64(x))

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -56,6 +56,125 @@ func formatCLIParamValue(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 
+{{- if hasSubstackPublicationIDTemplateResolver .APISpec}}
+
+const dryRunPublicationIDPlaceholder = "<resolved-at-runtime>"
+
+func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client, flags *rootFlags) error {
+	if c == nil || c.Config == nil {
+		return fmt.Errorf("could not resolve publication_id: client is nil")
+	}
+	if c.Config.TemplateVars == nil {
+		c.Config.TemplateVars = map[string]string{}
+	}
+	if id := strings.TrimSpace(c.Config.TemplateVars["publication_id"]); id != "" {
+		if !validSubstackPublicationID(id) {
+			return fmt.Errorf("invalid publication_id %q: use the numeric Substack publication_id", id)
+		}
+		c.Config.TemplateVars["publication_id"] = id
+		return nil
+	}
+	if flags != nil && flags.dryRun {
+		c.Config.TemplateVars["publication_id"] = dryRunPublicationIDPlaceholder
+		return nil
+	}
+	raw, err := c.Get(ctx, "/user/profile/self", nil)
+	if err != nil {
+		return fmt.Errorf("resolving publication_id via /user/profile/self: %w", err)
+	}
+	id, err := substackPublicationIDFromProfile(raw, substackPublicationTemplateVar(c, "publication"))
+	if err != nil {
+		return err
+	}
+	c.Config.TemplateVars["publication_id"] = id
+	return nil
+}
+
+func substackPublicationTemplateVar(c *client.Client, name string) string {
+	if c == nil || c.Config == nil || c.Config.TemplateVars == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.Config.TemplateVars[name])
+}
+
+func validSubstackPublicationID(id string) bool {
+	if id == "" || id == dryRunPublicationIDPlaceholder {
+		return id == dryRunPublicationIDPlaceholder
+	}
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func substackPublicationIDFromProfile(raw []byte, publication string) (string, error) {
+	var profile map[string]any
+	if err := json.Unmarshal(raw, &profile); err != nil {
+		return "", fmt.Errorf("parsing /user/profile/self response: %w", err)
+	}
+	wantPublication := strings.TrimSpace(strings.ToLower(publication))
+	if pub, ok := profile["primaryPublication"].(map[string]any); ok {
+		id := jsonNumberString(pub["id"])
+		if id != "" && substackPublicationMatches(pub, wantPublication) {
+			return id, nil
+		}
+	}
+	for _, key := range []string{"publications", "publicationUsers"} {
+		items, ok := profile[key].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range items {
+			pub, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			id := jsonNumberString(pub["id"])
+			if id == "" {
+				id = jsonNumberString(pub["publication_id"])
+			}
+			if id != "" && substackPublicationMatches(pub, wantPublication) {
+				return id, nil
+			}
+		}
+	}
+	if wantPublication == "" {
+		return "", fmt.Errorf("could not infer publication_id from /user/profile/self; pass --publication-id or set SUBSTACK_PUBLICATION_ID")
+	}
+	return "", fmt.Errorf("could not infer publication_id for publication %q from /user/profile/self; pass --publication-id or set SUBSTACK_PUBLICATION_ID", publication)
+}
+
+func substackPublicationMatches(pub map[string]any, wantPublication string) bool {
+	if wantPublication == "" {
+		return true
+	}
+	for _, key := range []string{"subdomain", "custom_domain"} {
+		got := strings.TrimSpace(strings.ToLower(jsonNumberString(pub[key])))
+		if got == "" {
+			continue
+		}
+		if got == wantPublication || strings.TrimSuffix(got, ".substack.com") == wantPublication {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonNumberString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case float64:
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+	}
+	return ""
+}
+{{- end}}
+
 // noColor is set by the --no-color flag
 var noColor bool
 


### PR DESCRIPTION
## Summary
- add generated Substack writer-route support for `publication_id` template resolution
- route generated draft creation through `https://substack.com/api/v1/drafts?publication_id=...`
- keep generated image upload on `https://substack.com/api/v1/image`
- add generated-output regression coverage for explicit/env/dry-run/profile lookup behavior

Closes #3016.

Related downstream generated-library issue/PR:
- mvanhorn/printing-press-library#1239
- mvanhorn/printing-press-library#1240

## Verification
- `go test ./internal/generator -run 'TestGenerateSubstackGlobalWriterRoutes' -count=1`
- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...` not run: `golangci-lint` is not installed in this environment
