### PR TITLE
feat(catalog): add Metacritic catalog entry and spec

### DIFF
--- a/catalog/metacritic.yaml
+++ b/catalog/metacritic.yaml
@@ -1,0 +1,28 @@
+name: metacritic
+display_name: Metacritic
+description: Browse, search, and compare Metascores and user scores for games, movies, and TV shows, plus critic and user reviews, without a Metacritic account.
+category: media-and-entertainment
+spec_url: https://raw.githubusercontent.com/mvanhorn/cli-printing-press/main/catalog/specs/metacritic-spec.yaml
+spec_format: yaml
+openapi_version: "3.0"
+tier: community
+spec_source: sniffed
+auth_required: false
+client_pattern: rest
+http_transport: standard
+verified_date: "2026-06-16"
+homepage: https://www.metacritic.com
+notes: >
+  Spec reverse-engineered from metacritic.com by inspecting the fetch/XHR calls its
+  web client makes to backend.metacritic.com. One backend serves every medium:
+  mcoTypeId selects it on the browse endpoint (1 = TV shows, 2 = movies, 13 = games)
+  and the {mediaType} path segment selects it on detail, filters, and review
+  endpoints. Every request carries a shared public apiKey embedded in the site's
+  JavaScript, so no user credentials are needed for read access. The non-obvious
+  insight: Metacritic is a cross-media taste graph — every Metascore vs user-score
+  gap is a signal about critic-audience divergence. Covers games, movies, and TV
+  plus search, filters, title detail, and critic/user reviews. Music (albums) is
+  intentionally excluded: unlike the other media it has no backend.metacritic.com
+  API surface — its pages are legacy server-rendered HTML behind Cloudflare, so it
+  needs a browser-chrome / clearance-cookie scrape pattern (cf. allrecipes, kayak)
+  rather than this clean REST client. Tracked as a follow-up.

--- a/catalog/specs/metacritic-spec.yaml
+++ b/catalog/specs/metacritic-spec.yaml
@@ -1,0 +1,464 @@
+openapi: "3.0.3"
+info:
+  title: Metacritic API
+  description: |
+    Undocumented internal JSON API powering metacritic.com (a Fandom property).
+    Reverse-engineered from the site's public web client. Every request carries a
+    shared public `apiKey` that the site embeds in its own JavaScript bundle, so no
+    user credentials are required for read access.
+
+    One backend (`backend.metacritic.com`) serves every media type. The `mcoTypeId`
+    query parameter selects the medium on the browse endpoint: 1 = TV shows,
+    2 = movies, 13 = games. The `{mediaType}` path segment (`games`, `movies`,
+    `shows`) selects the medium on the title-detail, filters, and review endpoints.
+
+    The non-obvious insight: Metacritic is not just a review aggregator, it is a
+    cross-media taste graph. Every gap between a title's Metascore (critics) and
+    user score is a signal about critic-audience divergence.
+
+    Scope: this spec covers games, movies, and TV shows plus search, filters, title
+    detail, and critic/user reviews. Music (albums) is intentionally excluded: it has
+    no backend.metacritic.com API surface — its pages are legacy server-rendered HTML
+    behind Cloudflare — so it needs a browser-chrome / clearance-cookie scrape pattern
+    rather than this clean REST client. Tracked as a follow-up.
+  version: "1.0.0"
+  contact:
+    name: Metacritic (Community, reverse-engineered)
+
+servers:
+  - url: https://backend.metacritic.com
+    description: Metacritic / Fandom content backend
+
+tags:
+  - name: browse
+    description: Browse and rank titles by Metascore across games, movies, and TV
+  - name: search
+    description: Cross-media full-text search
+  - name: filters
+    description: Available filter facets (genres, platforms, networks) per medium
+  - name: titles
+    description: Full detail for a single title
+  - name: reviews
+    description: Critic and user reviews for a title
+
+paths:
+  /finder/metacritic/web:
+    get:
+      operationId: browseTitles
+      summary: Browse and rank titles by Metascore
+      description: |
+        Paginated, sortable list of titles for one medium. `mcoTypeId` selects the
+        medium (1 = TV shows, 2 = movies, 13 = games). Powers the /browse/ pages.
+      tags: [browse]
+      parameters:
+        - $ref: "#/components/parameters/ApiKey"
+        - name: mcoTypeId
+          in: query
+          required: true
+          description: "Media type: 1 = TV shows, 2 = movies, 13 = games"
+          schema:
+            type: integer
+            enum: [1, 2, 13]
+            default: 13
+        - name: offset
+          in: query
+          description: Pagination offset (0-based)
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          description: Number of results per page
+          schema:
+            type: integer
+            default: 24
+            minimum: 1
+            maximum: 100
+        - name: sortBy
+          in: query
+          description: "Sort field; prefix with '-' for descending (e.g. -metaScore)"
+          schema:
+            type: string
+            default: "-metaScore"
+        - name: releaseYearMin
+          in: query
+          description: Earliest release year to include
+          schema:
+            type: integer
+        - name: releaseYearMax
+          in: query
+          description: Latest release year to include
+          schema:
+            type: integer
+        - name: componentName
+          in: query
+          description: Fixed component identifier required by the backend
+          schema:
+            type: string
+            default: results
+        - name: componentType
+          in: query
+          description: Fixed component type required by the backend
+          schema:
+            type: string
+            default: ResultList
+      responses:
+        "200":
+          description: Paginated list of titles
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TitleListResponse"
+
+  /finder/metacritic/search/{query}/web:
+    get:
+      operationId: searchTitles
+      summary: Search titles across all media
+      description: Full-text search spanning games, movies, TV, and people.
+      tags: [search]
+      parameters:
+        - name: query
+          in: path
+          required: true
+          description: Search text
+          schema:
+            type: string
+        - $ref: "#/components/parameters/ApiKey"
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 24
+            minimum: 1
+            maximum: 100
+        - name: componentName
+          in: query
+          schema:
+            type: string
+            default: search
+        - name: componentType
+          in: query
+          schema:
+            type: string
+            default: SearchResults
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TitleListResponse"
+
+  /finder/metacritic/filters/{mediaType}/web:
+    get:
+      operationId: listFilters
+      summary: List available filter facets for a medium
+      description: |
+        Returns the filter facets (genres, platforms, streaming networks, product
+        types) valid for the given medium.
+      tags: [filters]
+      parameters:
+        - $ref: "#/components/parameters/MediaType"
+        - $ref: "#/components/parameters/ApiKey"
+        - name: componentName
+          in: query
+          schema:
+            type: string
+            default: finder-filters
+        - name: componentType
+          in: query
+          schema:
+            type: string
+            default: FilterList
+      responses:
+        "200":
+          description: Filter facets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FilterListResponse"
+
+  /composer/metacritic/pages/{mediaType}/{slug}/web:
+    get:
+      operationId: getTitle
+      summary: Get full detail for a single title
+      description: |
+        Returns the full composed detail payload for a title, including Metascore,
+        user score, summary, release data, and platform/genre metadata.
+      tags: [titles]
+      parameters:
+        - $ref: "#/components/parameters/MediaType"
+        - $ref: "#/components/parameters/Slug"
+        - $ref: "#/components/parameters/ApiKey"
+      responses:
+        "200":
+          description: Title detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TitleDetailResponse"
+        "404":
+          description: Title not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /reviews/metacritic/critic/{mediaType}/{slug}/web:
+    get:
+      operationId: listCriticReviews
+      summary: List critic reviews for a title
+      tags: [reviews]
+      parameters:
+        - $ref: "#/components/parameters/MediaType"
+        - $ref: "#/components/parameters/Slug"
+        - $ref: "#/components/parameters/ApiKey"
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 100
+        - name: componentName
+          in: query
+          schema:
+            type: string
+            default: critic-reviews
+        - name: componentType
+          in: query
+          schema:
+            type: string
+            default: ReviewList
+      responses:
+        "200":
+          description: Critic reviews
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReviewListResponse"
+
+  /reviews/metacritic/user/{mediaType}/{slug}/web:
+    get:
+      operationId: listUserReviews
+      summary: List user reviews for a title
+      tags: [reviews]
+      parameters:
+        - $ref: "#/components/parameters/MediaType"
+        - $ref: "#/components/parameters/Slug"
+        - $ref: "#/components/parameters/ApiKey"
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 100
+        - name: componentName
+          in: query
+          schema:
+            type: string
+            default: user-reviews
+        - name: componentType
+          in: query
+          schema:
+            type: string
+            default: ReviewList
+      responses:
+        "200":
+          description: User reviews
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReviewListResponse"
+
+components:
+  parameters:
+    ApiKey:
+      name: apiKey
+      in: query
+      required: true
+      description: |
+        Shared public web key embedded in the metacritic.com client bundle.
+        Required on every request; no user account or private credential needed.
+      schema:
+        type: string
+        default: "1MOZgmNFxvmljaQR1X9KAij9Mo4xAY3u"
+    MediaType:
+      name: mediaType
+      in: path
+      required: true
+      description: "Medium: games, movies, or shows"
+      schema:
+        type: string
+        enum: [games, movies, shows]
+    Slug:
+      name: slug
+      in: path
+      required: true
+      description: URL slug of the title (e.g. the-legend-of-zelda-ocarina-of-time-1998)
+      schema:
+        type: string
+
+  schemas:
+    TitleListResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            totalResults:
+              type: integer
+              description: Total number of matching titles across all pages
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/TitleSummary"
+
+    TitleSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        type:
+          type: string
+          description: "Entity type, e.g. game-title, movie, show"
+        typeId:
+          type: integer
+        title:
+          type: string
+        slug:
+          type: string
+        premiereYear:
+          type: integer
+          nullable: true
+        releaseDate:
+          type: string
+          nullable: true
+        rating:
+          type: string
+          nullable: true
+        metaScore:
+          type: integer
+          nullable: true
+          description: Aggregated critic score (0-100)
+        userScore:
+          type: number
+          nullable: true
+          description: Aggregated user score (0.0-10.0)
+
+    TitleDetailResponse:
+      type: object
+      properties:
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  item:
+                    $ref: "#/components/schemas/TitleSummary"
+
+    FilterListResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            items:
+              type: array
+              items:
+                type: object
+                properties:
+                  title:
+                    type: string
+                    description: "Facet name, e.g. genres, platforms, streamingNetworkNames"
+                  options:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                        value:
+                          type: string
+
+    ReviewListResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            id:
+              type: string
+            totalResults:
+              type: integer
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/Review"
+
+    Review:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        quote:
+          type: string
+        score:
+          type: integer
+          description: Review score (critics 0-100, users 0-10)
+        url:
+          type: string
+          nullable: true
+        date:
+          type: string
+          nullable: true
+        author:
+          type: string
+          nullable: true
+        publicationName:
+          type: string
+          nullable: true
+          description: Outlet name (critic reviews only)
+
+    ErrorResponse:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: integer
+              reason:
+                type: string
+              message:
+                type: string

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 // runWithCapturedStdout executes fn while capturing os.Stdout via a pipe.
+//
+// The pipe is drained by a background goroutine that starts before fn runs, so
+// fn never blocks on a full OS pipe buffer. Draining only after fn returned
+// would deadlock once fn writes more than the buffer holds (notably smaller on
+// Windows), so the reader must run concurrently with the writer.
 func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -19,13 +24,19 @@ func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 	origStdout := os.Stdout
 	os.Stdout = w
 
+	outCh := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		outCh <- string(out)
+	}()
+
 	execErr := fn()
 	w.Close()
 	os.Stdout = origStdout
 
-	out, _ := io.ReadAll(r)
+	out := <-outCh
 	r.Close()
-	return string(out), execErr
+	return out, execErr
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/testdata/golden/expected/catalog-list/stdout.txt
+++ b/testdata/golden/expected/catalog-list/stdout.txt
@@ -26,6 +26,7 @@ marketing:
   producthunt          Find, monitor, and export Product Hunt launches for launch research, scouting, and competitive tracking without requiring a Product Hunt API application.
 
 media-and-entertainment:
+  metacritic           Browse, search, and compare Metascores and user scores for games, movies, and TV shows, plus critic and user reviews, without a Metacritic account.
   supercut             AI video recording and clipping platform API for recordings, stacks, transcripts, frames, comments, and reactions
 
 monitoring:


### PR DESCRIPTION
## Intent

Add Metacritic to the embedded catalog. Metacritic has no public API, but its
web client is backed by a clean first-party JSON API (`backend.metacritic.com`)
that covers games, movies, and TV from one host. This makes Metacritic a
generatable CLI: browse and rank by Metascore, cross-media search, filter
facets, full title detail, and critic/user reviews — read-only, no account.

This PR also fixes an unrelated pre-existing test deadlock surfaced while
validating the catalog change on Windows.

Issue: N/A

## Approach

Two independent commits:

1. **Catalog entry + spec.** A community `catalog/metacritic.yaml` plus a sniffed
   OpenAPI 3.0 spec at `catalog/specs/metacritic-spec.yaml`. The spec models six
   endpoints across three resources. `mcoTypeId` selects the medium on browse
   (1 = TV, 2 = movies, 13 = games); a `{mediaType}` path segment selects it on
   detail, filters, and reviews. The public web `apiKey` is embedded in the
   site's JS and carried as a parameter default, so generation needs no
   credentials. Modeled on the existing `producthunt` / `postman-explore`
   sniffed-REST entries.

2. **Test harness deadlock fix.** `runWithCapturedStdout` in
   `internal/cli/catalog_test.go` redirected `os.Stdout` to an `os.Pipe` but only
   read the pipe *after* the command returned. Any command whose output exceeds
   the OS pipe buffer (notably smaller on Windows) blocks on write before it can
   return, so the reader never runs and the test hangs until the global timeout.
   The fix drains the pipe in a goroutine started before the command runs.

## Scope

Primary area: `catalog/` (new entry + spec) and `internal/cli/` (test fix).

Why this belongs in this repo: the catalog and embedded specs are the
generator's inputs, and the test guards generator-facing catalog output. Neither
change touches a printed CLI.

## Catalog Justification

Embedded catalog fit: Metacritic is a widely-requested media-and-entertainment
source with no public API; the embedded entry lets `generate metacritic` produce
a CLI directly.

Distinct blueprint pattern: cross-media JSON API behind one host where a single
numeric discriminator (`mcoTypeId`) plus a path segment switch the medium — not
represented by an existing entry.

Closest existing entries checked: `producthunt` and `postman-explore` (both
sniffed-REST, no-auth, `spec_format: yaml` + in-repo spec) — followed their
shape. `kayak` (html-scrape) was rejected as a model because Metacritic
games/movies/TV expose a real JSON API, not embedded-HTML JSON.

Source provenance: `spec_source: sniffed`. Reverse-engineered by inspecting the
fetch/XHR calls the metacritic.com web client makes to `backend.metacritic.com`.

Auth and tenant assumptions: `auth_required: false`. A shared public web
`apiKey` embedded in the site bundle is the only required parameter; no user
account, token, or tenant.

Safe default surface: read-only (browse, search, filters, detail, reviews). No
write/mutating endpoints.

Generation path: `client_pattern: rest`, `http_transport: standard`
(probe-reachability classifies the host as standard HTTP, 0.95 confidence, no
bot protection). `generate --spec ./catalog/specs/metacritic-spec.yaml
--dry-run` parses to 3 resources / 6 endpoints.

Stale-body check: notes and spec description agree on scope, the media mapping,
and the music exclusion.

Music note: music (albums) is intentionally excluded. Unlike the other media it
has no `backend.metacritic.com` API surface — album pages are legacy
server-rendered HTML behind Cloudflare (verified: score present in raw markup,
no JSON-LD, zero API/apiKey references). It would need a browser-chrome /
clearance-cookie scrape pattern (cf. `allrecipes`, `kayak`), so it does not
belong in this clean REST entry and is tracked as a follow-up.

## Risk

Low. The catalog entry is additive (new files only) and validated by the catalog
parser/validator. The test change only affects the in-test stdout-capture helper
and makes a previously-deadlocking test pass; it does not touch production code.

## Output Contract

N/A — no template, generated-file, manifest, MCP-schema, scorecard, or pipeline
output changes. Catalog rendering of the new entry was confirmed via
`catalog show metacritic`.

## Verification

Commands run (Windows, Go 1.26.4):

- `go test ./internal/catalog/...` → ok (entry parses and validates)
- `go vet ./catalog/... ./internal/catalog/... ./internal/cli/...` → clean
- `cli-printing-press catalog show metacritic` → renders correctly
- `cli-printing-press generate --spec ./catalog/specs/metacritic-spec.yaml --name metacritic --dry-run` → 3 resources, 6 endpoints
- Full generate + build of the generated CLI passed all 8 gates (go mod tidy, govulncheck, vet, build, binary, --help, version, doctor)
- Live read-only smoke against the real API: browse games/movies, cross-media search, and critic reviews all returned correct data
- `go test ./internal/cli/ -run TestCatalog` → ok in ~12s (was a 90s+ deadlock before the fix)

- [ ] Generator/template change: N/A (no generator/template change)
- [ ] Generator/template change: N/A
- [ ] Generator/template change: N/A

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
