### PR TITLE
fix(generator): qualify FTS ORDER BY rank to the FTS table

### DIFF
--- a/internal/generator/templates/insights/similar.go.tmpl
+++ b/internal/generator/templates/insights/similar.go.tmpl
@@ -97,12 +97,12 @@ work items, tickets, or tasks.`,
 			}
 
 			// Use FTS5 to find similar items (exclude the source item)
-			query := `SELECT r.id, r.resource_type, r.data, rank
+			query := `SELECT r.id, r.resource_type, r.data, fts.rank
 				FROM resources_fts fts
 				JOIN resources r ON r.id = fts.id AND r.resource_type = fts.resource_type
 				WHERE resources_fts MATCH ?
 				  AND NOT (r.id = ? AND r.resource_type = ?)
-				ORDER BY rank
+				ORDER BY fts.rank
 				LIMIT ?`
 
 			rows, err := db.DB().Query(query, searchText, itemID, sourceType, limit)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -972,7 +972,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -995,7 +995,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)
@@ -1581,7 +1581,7 @@ func (s *Store) Search{{pascal .Name}}(query string, limit int) ([]json.RawMessa
 		`SELECT t.data FROM {{safeName .Name}} t
 		 JOIN {{safeNameSuffix .Name "_fts"}} ON {{safeNameSuffix .Name "_fts"}}.rowid = t.rowid
 		 WHERE {{safeNameSuffix .Name "_fts"}} MATCH ?
-		 ORDER BY rank LIMIT ?`,
+		 ORDER BY {{safeNameSuffix .Name "_fts"}}.rank LIMIT ?`,
 		matchQuery, limit,
 	)
 	if err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -900,7 +900,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -923,7 +923,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -788,7 +788,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -811,7 +811,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)


### PR DESCRIPTION
## Intent

Fixes #2973

When a synced resource has a domain field named `rank`, the unqualified `ORDER BY rank` in generated store search methods is ambiguous — SQLite errors with `ambiguous column name: rank (1)` at query time.

## Approach

Qualify the `rank` column to the FTS table alias in every emitted search query:

- Generic search (resources_fts aliased `f`) → `ORDER BY f.rank`
- Typed-table search (per-domain FTS table) → `ORDER BY "<table>_fts".rank`
- Insights similar query (resources_fts aliased `fts`) → `ORDER BY fts.rank` + `SELECT ... fts.rank`

Always-correct — FTS5 always exposes a built-in `rank` column, so qualifying it never breaks resources without the field.

## Scope

Primary area: `internal/generator/templates/`

Why this belongs in this repo: the bug is in the generator templates that emit store code for every printed CLI. Fixing it here fixes all future generations.

## Catalog Justification

N/A

## Risk

None. The qualified column reference is semantically identical when no ambiguity exists — it just becomes necessary when one does.

## Output Contract

Golden fixtures updated for the two affected cases (sync-walker, learn-loop). The typed-table template change affects per-domain search methods only when a domain table is generated.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

```
grep -rn "ORDER BY rank" --include="*.go" --include="*.tmpl" .
# (empty — no unqualified references remain)
```

## AI / Automation Disclosure

- [x] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change