### PR TITLE
fix(cli): skip novel wiring on command file collisions

### DIFF
--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -113,7 +113,7 @@ func (g *Generator) novelFeatureChildrenByParent() map[string][]novelFeatureChil
 		if len(children) > 0 && len(node.path) > 0 {
 			parentPath := strings.Join(node.path, " ")
 			for _, child := range children {
-				if novelFeatureStubCollidesWithGeneratedCommand(child.path, generatedPaths) {
+				if g.novelFeatureStubShouldSkip(child.path, generatedPaths) {
 					continue
 				}
 				out[parentPath] = append(out[parentPath], novelFeatureChildRender{Ident: novelFeatureStubIdent(child.path)})
@@ -144,12 +144,15 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generated
 	data := g.novelFeatureCommandData(node)
 	data.Children = renderedChildren
 	outPath := filepath.Join("internal", "cli", novelFeatureStubFileName(node.path))
-	if novelFeatureStubCollidesWithGeneratedCommand(node.path, generatedPaths) {
+	if g.novelFeatureStubShouldSkipGenerated(node.path, generatedPaths) {
 		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to generated command path; skipping novel stub\n", data.CommandPath)
 		return nil, nil
 	}
-	if _, err := os.Stat(filepath.Join(g.OutputDir, outPath)); err == nil {
+	if exists, hasConstructor := g.novelFeatureStubExistingFileConstructorStatus(node.path); exists {
 		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to existing %s; leaving existing file unchanged\n", data.CommandPath, outPath)
+		if !hasConstructor {
+			return nil, nil
+		}
 		return &data, nil
 	}
 	if err := g.renderTemplate("novel_feature_command.go.tmpl", outPath, data); err != nil {
@@ -168,6 +171,29 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generated
 	}
 
 	return &data, nil
+}
+
+func (g *Generator) novelFeatureStubShouldSkip(parts []string, generatedPaths map[string]struct{}) bool {
+	return g.novelFeatureStubShouldSkipGenerated(parts, generatedPaths) || g.novelFeatureStubExistingFileMissingConstructor(parts)
+}
+
+func (g *Generator) novelFeatureStubShouldSkipGenerated(parts []string, generatedPaths map[string]struct{}) bool {
+	return novelFeatureStubCollidesWithGeneratedCommand(parts, generatedPaths)
+}
+
+func (g *Generator) novelFeatureStubExistingFileMissingConstructor(parts []string) bool {
+	exists, hasConstructor := g.novelFeatureStubExistingFileConstructorStatus(parts)
+	return exists && !hasConstructor
+}
+
+func (g *Generator) novelFeatureStubExistingFileConstructorStatus(parts []string) (bool, bool) {
+	outPath := filepath.Join("internal", "cli", novelFeatureStubFileName(parts))
+	data, err := os.ReadFile(filepath.Join(g.OutputDir, outPath))
+	if err != nil {
+		return false, false
+	}
+	constructor := "func newNovel" + novelFeatureStubIdent(parts) + "Cmd("
+	return true, strings.Contains(string(data), constructor)
 }
 
 func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFeatureCommandRender {

--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -149,10 +149,11 @@ func (g *Generator) renderNovelFeatureNode(node *novelFeatureStubNode, generated
 		return nil, nil
 	}
 	if exists, hasConstructor := g.novelFeatureStubExistingFileConstructorStatus(node.path); exists {
-		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to existing %s; leaving existing file unchanged\n", data.CommandPath, outPath)
 		if !hasConstructor {
+			fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to existing %s without expected constructor %s; skipping novel stub\n", data.CommandPath, outPath, novelFeatureStubConstructorName(node.path))
 			return nil, nil
 		}
+		fmt.Fprintf(os.Stderr, "warning: novel feature command %q maps to existing %s; leaving existing file unchanged\n", data.CommandPath, outPath)
 		return &data, nil
 	}
 	if err := g.renderTemplate("novel_feature_command.go.tmpl", outPath, data); err != nil {
@@ -192,8 +193,12 @@ func (g *Generator) novelFeatureStubExistingFileConstructorStatus(parts []string
 	if err != nil {
 		return false, false
 	}
-	constructor := "func newNovel" + novelFeatureStubIdent(parts) + "Cmd("
+	constructor := "func " + novelFeatureStubConstructorName(parts) + "("
 	return true, strings.Contains(string(data), constructor)
+}
+
+func novelFeatureStubConstructorName(parts []string) string {
+	return "newNovel" + novelFeatureStubIdent(parts) + "Cmd"
 }
 
 func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFeatureCommandRender {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -215,8 +216,6 @@ func TestGeneratorSkipsNovelFeatureWiringForAbsorbedEndpointCollisions(t *testin
 }
 
 func TestGeneratorSkipsNovelFeatureWiringForExistingCommandFileCollisions(t *testing.T) {
-	t.Parallel()
-
 	apiSpec := minimalSpec("existingnovel")
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	require.NoError(t, os.MkdirAll(filepath.Join(outputDir, "internal", "cli"), 0o755))
@@ -244,7 +243,10 @@ func newItemsAuditCmd(flags *rootFlags) *cobra.Command {
 			Example:     "existingnovel-pp-cli items audit --dry-run",
 		},
 	}
-	require.NoError(t, gen.Generate())
+	stderr, err := captureNovelFeatureStderr(t, gen.Generate)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, `warning: novel feature command "items audit" maps to existing internal/cli/items_audit.go without expected constructor newNovelItemsAuditCmd; skipping novel stub`)
+	assert.NotContains(t, stderr, `warning: novel feature command "items audit" maps to existing internal/cli/items_audit.go; leaving existing file unchanged`)
 
 	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
 	assert.Contains(t, root, "rootCmd.AddCommand(newExportCmd(flags))")
@@ -254,13 +256,32 @@ func newItemsAuditCmd(flags *rootFlags) *cobra.Command {
 	assert.NotContains(t, parent, "newNovelItemsAuditCmd")
 	requireGeneratedCompiles(t, outputDir)
 
-	require.NoError(t, gen.Generate())
+	stderr, err = captureNovelFeatureStderr(t, gen.Generate)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, `warning: novel feature command "items audit" maps to existing internal/cli/items_audit.go without expected constructor newNovelItemsAuditCmd; skipping novel stub`)
+	assert.NotContains(t, stderr, `warning: novel feature command "items audit" maps to existing internal/cli/items_audit.go; leaving existing file unchanged`)
 	root = readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
 	assert.Contains(t, root, "rootCmd.AddCommand(newExportCmd(flags))")
 	assert.NotContains(t, root, "newNovelExportCmd")
 	parent = readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
 	assert.NotContains(t, parent, "newNovelItemsAuditCmd")
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func captureNovelFeatureStderr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	oldErr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	callErr := fn()
+	os.Stderr = oldErr
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	return string(data), callErr
 }
 
 func TestGeneratorWiresNovelChildrenUnderPromotedResource(t *testing.T) {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -275,8 +275,10 @@ func captureNovelFeatureStderr(t *testing.T, fn func() error) (string, error) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	os.Stderr = w
+	defer func() {
+		os.Stderr = oldErr
+	}()
 	callErr := fn()
-	os.Stderr = oldErr
 	require.NoError(t, w.Close())
 	data, err := io.ReadAll(r)
 	require.NoError(t, err)

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -214,6 +214,55 @@ func TestGeneratorSkipsNovelFeatureWiringForAbsorbedEndpointCollisions(t *testin
 	assert.NotContains(t, parent, "newNovelScenariosRunCmd")
 }
 
+func TestGeneratorSkipsNovelFeatureWiringForExistingCommandFileCollisions(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("existingnovel")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, os.MkdirAll(filepath.Join(outputDir, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "items_audit.go"), []byte(`package cli
+
+import "github.com/spf13/cobra"
+
+func newItemsAuditCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{Use: "audit"}
+}
+`), 0o644))
+
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Bulk export",
+			Command:     "export --format json",
+			Description: "Export data with extra filtering.",
+			Example:     "existingnovel-pp-cli export --format json",
+		},
+		{
+			Name:        "Item audit",
+			Command:     "items audit --dry-run",
+			Description: "Audit items from a hand-authored child command.",
+			Example:     "existingnovel-pp-cli items audit --dry-run",
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	root := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, root, "rootCmd.AddCommand(newExportCmd(flags))")
+	assert.NotContains(t, root, "newNovelExportCmd")
+
+	parent := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	assert.NotContains(t, parent, "newNovelItemsAuditCmd")
+	requireGeneratedCompiles(t, outputDir)
+
+	require.NoError(t, gen.Generate())
+	root = readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.Contains(t, root, "rootCmd.AddCommand(newExportCmd(flags))")
+	assert.NotContains(t, root, "newNovelExportCmd")
+	parent = readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
+	assert.NotContains(t, parent, "newNovelItemsAuditCmd")
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func TestGeneratorWiresNovelChildrenUnderPromotedResource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Suppress novel stub registrations when an existing command file lacks the expected `newNovel...Cmd` constructor.
- Preserve regen wiring for existing generated novel stubs that already contain the expected constructor.
- Add regression coverage for root framework command collisions and child command file collisions.

Closes #2861

## Tests
- `go test ./internal/generator -run 'TestGeneratorSkipsNovelFeatureWiringFor(ExistingCommandFileCollisions|AbsorbedEndpointCollisions)$' -count=1`\n- `go test ./internal/pipeline -run '^TestRunBrowserSessionProofTestPassesValidDoctorProof$' -count=1`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh`\n- `go test ./internal/generator -count=1`\n- `go test ./...` failed once in `internal/pipeline/TestRunBrowserSessionProofTestPassesValidDoctorProof` because the generated `doctor --json` subprocess was killed; the isolated rerun listed above passed.