### PR TITLE
fix(cli): block equals-form MCP root flags

### DIFF
--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -62,7 +62,8 @@ var blockedRootFlags = map[string]bool{
 func cliArgsFromMCP(args map[string]any) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
-		if !blockedRootFlags[k] {
+		base, _, hasEquals := strings.Cut(k, "=")
+		if !hasEquals && !blockedRootFlags[base] {
 			keys = append(keys, k)
 		}
 	}

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -62,10 +62,13 @@ var blockedRootFlags = map[string]bool{
 func cliArgsFromMCP(args map[string]any) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
-		base, _, hasEquals := strings.Cut(k, "=")
-		if !hasEquals && !blockedRootFlags[base] {
-			keys = append(keys, k)
+		if strings.Contains(k, "=") {
+			continue
 		}
+		if blockedRootFlags[k] {
+			continue
+		}
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -60,6 +60,10 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"deliver":  "fd:3",
 		"profile":  "attacker",
 		"token":    "stolen-token",
+		// Keys containing "=" must not be emitted verbatim as flag=value.
+		"base-url=https://evil.example.com": true,
+		"config=/tmp/evil.yaml":             true,
+		"token=stolen-token":                true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -63,6 +63,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
+		"limit=99":                          float64(42),
 		"token=stolen-token":                true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -62,7 +62,8 @@ var blockedRootFlags = map[string]bool{
 func cliArgsFromMCP(args map[string]any) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
-		if !blockedRootFlags[k] {
+		base, _, hasEquals := strings.Cut(k, "=")
+		if !hasEquals && !blockedRootFlags[base] {
 			keys = append(keys, k)
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -62,10 +62,13 @@ var blockedRootFlags = map[string]bool{
 func cliArgsFromMCP(args map[string]any) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
-		base, _, hasEquals := strings.Cut(k, "=")
-		if !hasEquals && !blockedRootFlags[base] {
-			keys = append(keys, k)
+		if strings.Contains(k, "=") {
+			continue
 		}
+		if blockedRootFlags[k] {
+			continue
+		}
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -60,6 +60,10 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		"deliver":  "fd:3",
 		"profile":  "attacker",
 		"token":    "stolen-token",
+		// Keys containing "=" must not be emitted verbatim as flag=value.
+		"base-url=https://evil.example.com": true,
+		"config=/tmp/evil.yaml":             true,
+		"token=stolen-token":                true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -63,6 +63,7 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		// Keys containing "=" must not be emitted verbatim as flag=value.
 		"base-url=https://evil.example.com": true,
 		"config=/tmp/evil.yaml":             true,
+		"limit=99":                          float64(42),
 		"token=stolen-token":                true,
 		// Allowed per-command flag passes through.
 		"limit": float64(10),


### PR DESCRIPTION
## Intent

Closes #2906. Prevent structured MCP argument keys containing `=` from being emitted verbatim as CLI flags, which could bypass the cobratree root-flag blocklist.

## Approach

`cliArgsFromMCP` now rejects keys containing `=` before appending sorted structured flags, while still checking the blocklist against the normalized base key. The generated cobratree test template now covers equals-form `base-url`, `config`, and `token` keys, and the generated golden output was updated.

## Verification

- `go fmt ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./internal/mcp/cobratree -run '^TestCliArgsFromMCP_' -count=1` in `.gotmp/generator-output-compile/generate-golden-api/printing-press-golden`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n- `go test ./internal/pipeline -run '^TestRunLiveDogfoodProcessRetriesTransientAuth401$' -count=1`\n- `go test ./internal/pipeline -run '^TestLiveCheck_SmokeTest$' -count=1`\n\nNotes:\n- `go test ./...` was run twice. Both runs failed in unrelated `internal/pipeline` live timing tests, first `TestRunLiveDogfoodProcessRetriesTransientAuth401` timed out after 5s, then `TestLiveCheck_SmokeTest` returned 0 instead of 2 after 5s. Each failing test passed when rerun directly.\n- `golangci-lint run ./...` was not run because `golangci-lint` is not installed in this environment.\n