### PR TITLE
fix(cli): ignore dangling OpenAPI security refs

### DIFF
--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2835,6 +2835,9 @@ func effectiveSecurityRequirements(op *openapi3.Operation, doc *openapi3.T) open
 		if len(requirements) > 0 || securityRequirementsAllowAnonymous(*op.Security) {
 			return requirements
 		}
+		if securityRequirementsReferenceDefinedScheme(doc, *op.Security) {
+			return nil
+		}
 		return definedSecurityRequirements(doc, doc.Security)
 	}
 	if doc == nil {
@@ -2858,17 +2861,33 @@ func definedSecurityRequirements(doc *openapi3.T, requirements openapi3.Security
 			continue
 		}
 		defined := openapi3.SecurityRequirement{}
+		hasUndefined := false
 		for name, scopes := range requirement {
 			if securitySchemeValue(doc.Components.SecuritySchemes[name]) == nil {
-				continue
+				hasUndefined = true
+				break
 			}
 			defined[name] = scopes
 		}
-		if len(defined) > 0 {
+		if !hasUndefined && len(defined) > 0 {
 			filtered = append(filtered, defined)
 		}
 	}
 	return filtered
+}
+
+func securityRequirementsReferenceDefinedScheme(doc *openapi3.T, requirements openapi3.SecurityRequirements) bool {
+	if doc == nil || doc.Components == nil || len(doc.Components.SecuritySchemes) == 0 {
+		return false
+	}
+	for _, requirement := range requirements {
+		for name := range requirement {
+			if securitySchemeValue(doc.Components.SecuritySchemes[name]) != nil {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Ordering rationale: Bearer is the simplest already-minted token shape and

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -2765,7 +2765,7 @@ func candidateSecuritySchemeNames(doc *openapi3.T, usageCounts map[string]int) [
 	var names []string
 
 	if doc.Security != nil {
-		for _, requirement := range doc.Security {
+		for _, requirement := range definedSecurityRequirements(doc, doc.Security) {
 			var requirementNames []string
 			for name := range requirement {
 				requirementNames = append(requirementNames, name)
@@ -2831,12 +2831,44 @@ func securitySchemeOperationUsageCounts(doc *openapi3.T) map[string]int {
 
 func effectiveSecurityRequirements(op *openapi3.Operation, doc *openapi3.T) openapi3.SecurityRequirements {
 	if op != nil && op.Security != nil {
-		return *op.Security
+		requirements := definedSecurityRequirements(doc, *op.Security)
+		if len(requirements) > 0 || securityRequirementsAllowAnonymous(*op.Security) {
+			return requirements
+		}
+		return definedSecurityRequirements(doc, doc.Security)
 	}
 	if doc == nil {
 		return nil
 	}
-	return doc.Security
+	return definedSecurityRequirements(doc, doc.Security)
+}
+
+func definedSecurityRequirements(doc *openapi3.T, requirements openapi3.SecurityRequirements) openapi3.SecurityRequirements {
+	if len(requirements) == 0 {
+		return requirements
+	}
+	if doc == nil || doc.Components == nil || len(doc.Components.SecuritySchemes) == 0 {
+		return nil
+	}
+
+	filtered := make(openapi3.SecurityRequirements, 0, len(requirements))
+	for _, requirement := range requirements {
+		if len(requirement) == 0 {
+			filtered = append(filtered, requirement)
+			continue
+		}
+		defined := openapi3.SecurityRequirement{}
+		for name, scopes := range requirement {
+			if securitySchemeValue(doc.Components.SecuritySchemes[name]) == nil {
+				continue
+			}
+			defined[name] = scopes
+		}
+		if len(defined) > 0 {
+			filtered = append(filtered, defined)
+		}
+	}
+	return filtered
 }
 
 // Ordering rationale: Bearer is the simplest already-minted token shape and
@@ -2988,11 +3020,11 @@ func allEffectiveSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirem
 					continue
 				}
 				if op.Security != nil {
-					requirements = append(requirements, (*op.Security)...)
+					requirements = append(requirements, effectiveSecurityRequirements(op, doc)...)
 					continue
 				}
 				if !rootIncluded {
-					requirements = append(requirements, doc.Security...)
+					requirements = append(requirements, definedSecurityRequirements(doc, doc.Security)...)
 					rootIncluded = true
 				}
 			}
@@ -3001,7 +3033,7 @@ func allEffectiveSecurityRequirements(doc *openapi3.T) openapi3.SecurityRequirem
 	if len(requirements) > 0 {
 		return requirements
 	}
-	return doc.Security
+	return definedSecurityRequirements(doc, doc.Security)
 }
 
 func securitySchemeValue(ref *openapi3.SecuritySchemeRef) *openapi3.SecurityScheme {

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2462,6 +2462,67 @@ func TestHeaderAPIKeyAuthHeaderIsRaw(t *testing.T) {
 	runGo(t, outputDir, "test", "./internal/config", "-run", "TestHeaderAPIKeyAuthHeaderIsRaw")
 }
 
+func TestSelectSecuritySchemeDropsDanglingOperationSecurityRef(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: "3.0.3"
+info:
+  title: Custom Key
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Custom-Key
+paths:
+  /v1/apps:
+    get:
+      operationId: listApps
+      security:
+        - Authorization: []
+      responses: {"200": {description: ok}}
+`)
+
+	parsed, err := Parse(spec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ApiKeyAuth", parsed.Auth.Scheme, "dangling operation security refs must not suppress root auth")
+	assert.Equal(t, "api_key", parsed.Auth.Type)
+	assert.Equal(t, "header", parsed.Auth.In)
+	assert.Equal(t, "X-Custom-Key", parsed.Auth.Header)
+	assert.Equal(t, []string{"CUSTOM_KEY_API_KEY"}, parsed.Auth.EnvVars)
+
+	if testing.Short() {
+		t.Skip("generated CLI compile coverage runs outside short mode")
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(parsed.Name))
+	gen := generator.New(parsed, outputDir)
+	require.NoError(t, gen.Generate())
+
+	clientSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	clientContent := string(clientSrc)
+	require.Contains(t, clientContent, `req.Header.Set("X-Custom-Key", authHeader)`)
+	require.NotContains(t, clientContent, `req.Header.Set("Authorization", authHeader)`)
+
+	configSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "config", "config.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(configSrc), "CUSTOM_KEY_API_KEY")
+
+	authSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "auth.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(authSrc), `"set-token <token>"`)
+
+	runGo(t, outputDir, "mod", "tidy")
+	runGo(t, outputDir, "test", "./...")
+}
+
 func TestSelectSecuritySchemeRespectsRootSecurityFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -2523,6 +2523,60 @@ paths:
 	runGo(t, outputDir, "test", "./...")
 }
 
+func TestEffectiveSecurityRequirementsDropsMixedDanglingRequirement(t *testing.T) {
+	t.Parallel()
+
+	spec := []byte(`openapi: "3.0.3"
+info:
+  title: Mixed Dangling Security
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    BearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /v1/apps:
+    get:
+      operationId: listApps
+      security:
+        - BearerAuth: []
+          DanglingAuth: []
+      responses: {"200": {description: ok}}
+  /v1/widgets:
+    get:
+      operationId: listWidgets
+      security:
+        - BearerAuth: []
+          DanglingAuth: []
+        - ApiKeyAuth: []
+      responses: {"200": {description: ok}}
+`)
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+	doc, err := loader.LoadFromData(spec)
+	require.NoError(t, err)
+
+	appsOp := doc.Paths.Find("/v1/apps").Get
+	assert.Empty(t, effectiveSecurityRequirements(appsOp, doc), "mixed defined/dangling AND requirement must not degrade to single-scheme auth")
+
+	widgetsOp := doc.Paths.Find("/v1/widgets").Get
+	assert.Equal(t, openapi3.SecurityRequirements{{"ApiKeyAuth": []string{}}}, effectiveSecurityRequirements(widgetsOp, doc), "valid alternatives should remain after dropping malformed composites")
+
+	counts := securitySchemeOperationUsageCounts(doc)
+	assert.NotContains(t, counts, "BearerAuth")
+	assert.Equal(t, 1, counts["ApiKeyAuth"])
+}
+
 func TestSelectSecuritySchemeRespectsRootSecurityFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/toolsmanifest_test.go
+++ b/internal/pipeline/toolsmanifest_test.go
@@ -126,6 +126,44 @@ func TestWriteToolsManifest_MultipleResources(t *testing.T) {
 	assert.Equal(t, "/store/inventory", got.Tools[3].Path)
 }
 
+func TestWriteToolsManifest_OpenAPIDanglingOperationSecurityUsesRootAPIKey(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := openapi.Parse([]byte(`openapi: "3.0.3"
+info:
+  title: Custom Key
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Custom-Key
+paths:
+  /v1/apps:
+    get:
+      operationId: listApps
+      security:
+        - Authorization: []
+      responses: {"200": {description: ok}}
+`))
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, WriteToolsManifest(dir, parsed))
+
+	got, err := ReadToolsManifest(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "api_key", got.Auth.Type)
+	assert.Equal(t, "X-Custom-Key", got.Auth.Header)
+	assert.Equal(t, "header", got.Auth.In)
+	assert.Equal(t, []string{"CUSTOM_KEY_API_KEY"}, got.Auth.EnvVars)
+}
+
 func TestWriteToolsManifestWithDescriptionUsesCanonicalManifestDescription(t *testing.T) {
 	dir := t.TempDir()
 	parsed := &spec.APISpec{


### PR DESCRIPTION
## Summary

- Drops undefined OpenAPI security scheme refs before primary auth selection.
- Falls back to the defined root security scheme when operation-level security only names dangling schemes.
- Adds parser, generated CLI, and tools manifest regressions for custom-header apiKey auth.

Closes #2897

## Verification

- `go test ./internal/openapi -run 'TestSelectSecurityScheme(DropsDanglingOperationSecurityRef|APIKeyHeaderBeatsOAuth2Alternative|RespectsRootSecurityFilter|MultiSchemePrefersBearer)$'`\n- `go test ./internal/pipeline -run 'TestWriteToolsManifest_OpenAPIDanglingOperationSecurityUsesRootAPIKey$'`\n- `go test ./...` failed once with a timeout in `TestRunLiveDogfoodProcessRetriesTransientAuth401` after touched packages had passed\n- `go test ./internal/pipeline -run 'TestRunLiveDogfoodProcessRetriesTransientAuth401$' -count=1`\n- `go test ./internal/pipeline -count=1`\n- `scripts/golden.sh verify`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`