### PR TITLE
fix(cli): guard unresolved path params

### DIFF
--- a/internal/generator/client_unresolved_path_test.go
+++ b/internal/generator/client_unresolved_path_test.go
@@ -1,0 +1,102 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedClientRejectsUnresolvedPathParamsBeforeHTTP(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("pathguard")
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/widgets",
+					Description: "List widgets",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(clientGo), "func rejectUnresolvedPathParams(path string) error")
+
+	behaviorTest := `package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cfgpkg "pathguard-pp-cli/internal/config"
+)
+
+func TestPathParamGuardRejectsUnresolvedPathBeforeHTTP(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	c := New(&cfgpkg.Config{BaseURL: srv.URL}, time.Second, 0)
+	c.HTTPClient = srv.Client()
+	c.NoCache = true
+
+	_, err := c.Get(context.Background(), "/widgets/{widget_id}", nil)
+	if err == nil {
+		t.Fatal("expected unresolved path parameter error")
+	}
+	if !strings.Contains(err.Error(), "unresolved path parameter {widget_id}") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("server was called before unresolved path parameter was rejected")
+	}
+}
+
+func TestPathParamGuardAllowsResolvedPath(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.URL.Path != "/widgets/widget_123" {
+			t.Fatalf("path = %q, want /widgets/widget_123", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(&cfgpkg.Config{BaseURL: srv.URL}, time.Second, 0)
+	c.HTTPClient = srv.Client()
+	c.NoCache = true
+
+	if _, err := c.Get(context.Background(), "/widgets/widget_123", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("server was not called for resolved path")
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "client", "path_guard_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/client", "-run", "TestPathParamGuard", "-count=1")
+}

--- a/internal/generator/client_unresolved_path_test.go
+++ b/internal/generator/client_unresolved_path_test.go
@@ -34,7 +34,7 @@ func TestGeneratedClientRejectsUnresolvedPathParamsBeforeHTTP(t *testing.T) {
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
 	require.NoError(t, err)
-	assert.Contains(t, string(clientGo), "func rejectUnresolvedPathParams(path string) error")
+	assert.Contains(t, string(clientGo), "func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error")
 
 	behaviorTest := `package client
 
@@ -97,6 +97,110 @@ func TestPathParamGuardAllowsResolvedPath(t *testing.T) {
 }
 `
 	testPath := filepath.Join(outputDir, "internal", "client", "path_guard_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
+	runGoCommandRequired(t, outputDir, "test", "./internal/client", "-run", "TestPathParamGuard", "-count=1")
+}
+
+func TestGeneratedClientWithEndpointTemplateVarsRejectsOnlyUndeclaredPathParams(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("pathguard-template")
+	apiSpec.BaseURL = "https://{shop}.example.com"
+	apiSpec.EndpointTemplateVars = []string{"shop", "api_version"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/api/{api_version}/widgets",
+					Description: "List widgets",
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(clientGo), "rejectUnresolvedPathParams(path, templateVarEnvNames)")
+
+	behaviorTest := `package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cfgpkg "pathguard-template-pp-cli/internal/config"
+)
+
+func TestPathParamGuardAllowsDeclaredTemplateVars(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.URL.Path != "/api/v1/widgets" {
+			t.Fatalf("path = %q, want /api/v1/widgets", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	c := New(&cfgpkg.Config{
+		BaseURL: srv.URL,
+		TemplateVars: map[string]string{
+			"api_version": "v1",
+			"shop": "tenant",
+		},
+	}, time.Second, 0)
+	c.HTTPClient = srv.Client()
+	c.NoCache = true
+
+	if _, err := c.Get(context.Background(), "/api/{api_version}/widgets", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("server was not called for declared template variable path")
+	}
+}
+
+func TestPathParamGuardRejectsUndeclaredTemplateVarsBeforeBuildURL(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	c := New(&cfgpkg.Config{
+		BaseURL: srv.URL,
+		TemplateVars: map[string]string{
+			"api_version": "v1",
+			"shop": "tenant",
+		},
+	}, time.Second, 0)
+	c.HTTPClient = srv.Client()
+	c.NoCache = true
+
+	_, err := c.Get(context.Background(), "/api/{api_version}/widgets/{widget_id}", nil)
+	if err == nil {
+		t.Fatal("expected unresolved path parameter error")
+	}
+	if !strings.Contains(err.Error(), "unresolved path parameter {widget_id}") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("server was called before unresolved path parameter was rejected")
+	}
+}
+`
+	testPath := filepath.Join(outputDir, "internal", "client", "path_guard_template_vars_test.go")
 	require.NoError(t, os.WriteFile(testPath, []byte(behaviorTest), 0o644))
 	runGoCommandRequired(t, outputDir, "test", "./internal/client", "-run", "TestPathParamGuard", "-count=1")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -168,6 +168,7 @@ type Generator struct {
 
 func New(s *spec.APISpec, outputDir string) *Generator {
 	s.InferEndpointTemplateVarsFromBaseURLs()
+	s.EnrichPathParams()
 	s.PromoteGlobalPathTemplateVars()
 	// Resolve the creator + contributors (the canonical attribution model),
 	// preserving persisted values across regens so a regen never flips the

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -331,7 +331,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -343,6 +343,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -360,8 +364,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -1146,6 +1149,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
+	if err := rejectUnresolvedPathParams(path, {{if .EndpointTemplateVars}}templateVarEnvNames{{else}}nil{{end}}); err != nil {
+		return nil, 0, err
+	}
 {{- if .EndpointTemplateVars}}
 	// EndpointTemplateVars are declared in the spec — resolve {placeholder}
 	// markers in BaseURL (and, for non-proxy clients, the request path)
@@ -1155,10 +1161,6 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	var endpointVars map[string]string
 	if c.Config != nil {
 		endpointVars = c.Config.TemplateVars
-	}
-{{- else}}
-	if err := rejectUnresolvedPathParams(path); err != nil {
-		return nil, 0, err
 	}
 {{- end}}
 {{- if .HasTierRouting}}

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -331,6 +331,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 {{- if .UsesHTTP2DisabledTransport}}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -1123,6 +1156,10 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if c.Config != nil {
 		endpointVars = c.Config.TemplateVars
 	}
+{{- else}}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
+	}
 {{- end}}
 {{- if .HasTierRouting}}
 	requestBaseURL := c.baseURLForRequest()
@@ -1134,6 +1171,11 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if urlErr != nil {
 		return nil, 0, urlErr
 	}
+	resolvedPath, pathErr := buildURL("", path, endpointVars)
+	if pathErr != nil {
+		return nil, 0, pathErr
+	}
+	path = resolvedPath
 {{- else}}
 	targetURL := {{if .HasTierRouting}}requestBaseURL{{else}}c.BaseURL{{end}}
 {{- end}}

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -58,6 +58,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 	return &http.Client{Timeout: timeout, Jar: jar}
 }
@@ -429,6 +462,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// client_credentials mint happens unnecessarily.
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
+	}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path
 

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -58,7 +58,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -70,6 +70,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -87,8 +91,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -463,7 +466,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
-	if err := rejectUnresolvedPathParams(path); err != nil {
+	if err := rejectUnresolvedPathParams(path, nil); err != nil {
 		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -63,6 +63,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 	return &http.Client{Timeout: timeout, Jar: jar}
 }
@@ -449,6 +482,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// client_credentials mint happens unnecessarily.
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
+	}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path
 

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -63,7 +63,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -75,6 +75,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -92,8 +96,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -483,7 +486,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
-	if err := rejectUnresolvedPathParams(path); err != nil {
+	if err := rejectUnresolvedPathParams(path, nil); err != nil {
 		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -58,7 +58,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -70,6 +70,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -87,8 +91,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -473,7 +476,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
-	if err := rejectUnresolvedPathParams(path); err != nil {
+	if err := rejectUnresolvedPathParams(path, nil); err != nil {
 		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -58,6 +58,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 	return &http.Client{Timeout: timeout, Jar: jar}
 }
@@ -439,6 +472,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// client_credentials mint happens unnecessarily.
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
+	}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -59,6 +59,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 	return &http.Client{Timeout: timeout, Jar: jar}
 }
@@ -527,6 +560,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// client_credentials mint happens unnecessarily.
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
+	}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -59,7 +59,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -71,6 +71,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -88,8 +92,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -561,7 +564,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
-	if err := rejectUnresolvedPathParams(path); err != nil {
+	if err := rejectUnresolvedPathParams(path, nil); err != nil {
 		return nil, 0, err
 	}
 	targetURL := c.BaseURL + path

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -161,6 +161,39 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
+func rejectUnresolvedPathParams(path string) error {
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			return nil
+		}
+		rest := path[start+1:]
+		end := strings.IndexByte(rest, '}')
+		if end < 0 {
+			return nil
+		}
+		name := rest[:end]
+		if isPathPlaceholderName(name) {
+			return fmt.Errorf("unresolved path parameter {%s}", name)
+		}
+		path = rest[end+1:]
+	}
+}
+
+func isPathPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	first := name[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
 	return &http.Client{Timeout: timeout, Jar: jar}
 }
@@ -539,6 +572,9 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	// client_credentials mint happens unnecessarily.
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
+	}
+	if err := rejectUnresolvedPathParams(path); err != nil {
+		return nil, 0, err
 	}
 	requestBaseURL := c.baseURLForRequest()
 	targetURL := requestBaseURL + path

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -161,7 +161,7 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("%s %s returned HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
-func rejectUnresolvedPathParams(path string) error {
+func rejectUnresolvedPathParams(path string, allowedTemplateVars map[string]string) error {
 	for {
 		start := strings.IndexByte(path, '{')
 		if start < 0 {
@@ -173,6 +173,10 @@ func rejectUnresolvedPathParams(path string) error {
 			return nil
 		}
 		name := rest[:end]
+		if _, ok := allowedTemplateVars[name]; ok {
+			path = rest[end+1:]
+			continue
+		}
 		if isPathPlaceholderName(name) {
 			return fmt.Errorf("unresolved path parameter {%s}", name)
 		}
@@ -190,8 +194,7 @@ func isPathPlaceholderName(name string) bool {
 		}
 		return false
 	}
-	first := name[0]
-	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+	return true
 }
 
 func newHTTPClient(timeout time.Duration, jar http.CookieJar) *http.Client {
@@ -573,7 +576,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 	if !readOnlyIntent && isMutatingVerb(method) && cliutil.IsVerifyEnv() && !cliutil.IsVerifyLiveHTTPEnv() {
 		return verifyShortCircuitEnvelope(method, path), http.StatusOK, nil
 	}
-	if err := rejectUnresolvedPathParams(path); err != nil {
+	if err := rejectUnresolvedPathParams(path, nil); err != nil {
 		return nil, 0, err
 	}
 	requestBaseURL := c.baseURLForRequest()


### PR DESCRIPTION
## Intent

Closes #2909.

Prevent generated clients from sending requests whose path still contains an unresolved `{name}` placeholder.

## Approach

- Re-run path-param enrichment inside the generator constructor as an idempotent backstop for programmatic generation.
- Emit a generated client guard that rejects unresolved path params before auth resolution or HTTP request creation.
- Resolve proxy-envelope paths through endpoint template variables when that feature is enabled.
- Add a generated-runtime test proving the guard errors before a local server is called and still allows resolved paths.

## Output Contract

Generated `internal/client/client.go` now includes the unresolved path guard. Golden fixtures were updated for the affected generated clients.

## Verification

- go test ./internal/generator -run 'TestGeneratedClientRejectsUnresolvedPathParamsBeforeHTTP|TestPromotedCommandSubstitutesFlagPathParams|TestPathParamArgsIndex' -count=1\n- go test ./internal/spec -run 'TestEnrichEndpointPathParams|TestEnrichPathParams' -count=1\n- scripts/verify-generator-output.sh\n- go test ./...\n- scripts/golden.sh verify