### PR TITLE
fix(skills): resolve amend publish status by slug

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -643,6 +643,26 @@ func TestAmendSkillRequiresUpstreamBreadcrumbsForTemporaryPatches(t *testing.T) 
 	assert.NotContains(t, skill, "workflow rejects PRs where one is present without the other")
 }
 
+func TestAmendSkillResolvesPublishedStatusByPublicLibrarySlug(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md"))
+	transcript := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-amend", "references", "transcript-parsing.md"))
+
+	assert.Contains(t, skill, "Resolve target paths and publish status")
+	assert.Contains(t, skill, "Normalize the input to the bare CLI slug")
+	assert.Contains(t, skill, "looking up that slug in the public library")
+	assert.Contains(t, skill, "`~/printing-press-library/library/*/<slug>`")
+	assert.Contains(t, skill, "Do not infer publish status from the local working copy's git remotes")
+	assert.Contains(t, skill, "do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished")
+	assert.Contains(t, skill, "Only use `published_status: local-only` when the slug is absent from the public library")
+
+	assert.Contains(t, transcript, "resolve publish status by slug lookup in the public library before consulting local working-copy state")
+	assert.Contains(t, transcript, "Do not infer publish status from the local CLI working copy's git remotes")
+	assert.Contains(t, transcript, "a remote-less local checkout may still correspond to a published CLI")
+	assert.Contains(t, transcript, "do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished")
+	assert.Contains(t, transcript, "published_status: published")
+	assert.Contains(t, transcript, "not on local git remotes or `$PRESS_LIBRARY/<slug>` presence")
+}
+
 func TestGeneratedAgentsTemplatePointsToCatalogForPatchMechanics(t *testing.T) {
 	template := readContractFile(t, filepath.Join("..", "generator", "templates", "agents.md.tmpl"))
 

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -654,8 +654,12 @@ func TestAmendSkillResolvesPublishedStatusByPublicLibrarySlug(t *testing.T) {
 	assert.Contains(t, skill, "Do not infer publish status from the local working copy's git remotes")
 	assert.Contains(t, skill, "do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished")
 	assert.Contains(t, skill, "Only use `published_status: local-only` when the slug is absent from the public library")
+	assert.Contains(t, skill, "target_binary_check: { local: \"1.0.0\", published: \"1.0.0\", status: \"current\" }\npublished_status: published")
+	assert.Contains(t, skill, "published_status: published\nscope_tier: bugs+features")
 
 	assert.Contains(t, transcript, "resolve publish status by slug lookup in the public library before consulting local working-copy state")
+	assert.Contains(t, transcript, "First enumerate top-level categories with `gh api repos/mvanhorn/printing-press-library/contents/library")
+	assert.Contains(t, transcript, "then iterate those category names with `gh api repos/mvanhorn/printing-press-library/contents/library/<category>/<slug>`")
 	assert.Contains(t, transcript, "Do not infer publish status from the local CLI working copy's git remotes")
 	assert.Contains(t, transcript, "a remote-less local checkout may still correspond to a published CLI")
 	assert.Contains(t, transcript, "do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished")

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -379,6 +379,7 @@ findings_suppressed:
   - id: F3
     reason: "Duplicate of PR #571 (merged 2026-05-13)"
 target_binary_check: { local: "1.0.0", published: "1.0.0", status: "current" }
+published_status: published
 ```
 
 ## Phase 3 — Scope Confirmation Checkpoint (User-in-Loop #1)
@@ -463,6 +464,7 @@ If Phase 2 suppressed every finding (everything was a duplicate), Phase 3 report
 Phase 3 emits to Phase 4:
 
 ```yaml
+published_status: published
 scope_tier: bugs+features            # or bugs|all|custom
 findings_active: [...]               # the user-confirmed subset
 findings_deferred_path: <path>       # where the deferred file landed

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -208,7 +208,7 @@ Read `references/transcript-parsing.md` for the full procedure. Summary of what 
 
 4. **Auto-detect target CLI** — count occurrences of each `<slug>-pp-cli` in the signals, propose the most-touched CLI as the default. Confirm with `AskUserQuestion` (single CLI: simple yes/no; multiple close: pick from list). When the user passed an explicit `<cli-name-or-path>` argument, skip auto-detect.
 
-5. **Resolve target paths** — accept short name, full name, or absolute path (per R4). Look up the public-library category by walking `~/printing-press-library/library/*/` for a matching directory. The category is needed by U7's PR open phase and is captured here so it doesn't have to be re-derived.
+5. **Resolve target paths and publish status** — accept short name, full name, or absolute path (per R4). Normalize the input to the bare CLI slug, then resolve publish status by looking up that slug in the public library (`~/printing-press-library/library/*/<slug>` when a local clone exists, otherwise the same path via `gh api`). Do not infer publish status from the local working copy's git remotes, and do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished. If the slug is found in the public library, record `target_category`, `published_status: published`, and route the run through the managed-clone upstream PR path. Only use `published_status: local-only` when the slug is absent from the public library. The category is needed by U7's PR open phase and is captured here so it doesn't have to be re-derived.
 
 Each finding emitted by 1a carries `provenance: transcript`. Output flows into Phase 2 as the structured finding list documented in `references/transcript-parsing.md`.
 

--- a/skills/printing-press-amend/references/transcript-parsing.md
+++ b/skills/printing-press-amend/references/transcript-parsing.md
@@ -70,17 +70,24 @@ When the user explicitly passed a target as the skill argument, skip auto-detect
 ### Path resolution for the chosen target
 
 Accept any of:
-- short name: `superhuman` → `$PRESS_LIBRARY/superhuman/`
-- full name: `superhuman-pp-cli` → strip `-pp-cli`, resolve as short name
-- absolute path: `$PRESS_LIBRARY/superhuman` → use as-is
+- short name: `superhuman` -> slug `superhuman`
+- full name: `superhuman-pp-cli` -> strip `-pp-cli`, slug `superhuman`
+- absolute path: `$PRESS_LIBRARY/superhuman` -> basename slug `superhuman`
 
-If the resolved path doesn't exist locally, search `~/printing-press-library/library/*/` for a directory whose name matches the slug, and fall back to that as the target. The skill operates on the managed clone (per the Pre-Implementation Decisions in the plan), so the local-library path is informational; the actual edits land in the managed clone created in U7.
+After normalizing the slug, resolve publish status by slug lookup in the public library before consulting local working-copy state:
+
+1. If a local public-library clone exists, search `~/printing-press-library/library/*/<slug>` for a matching directory.
+2. If that clone is absent or stale enough to miss the slug, query GitHub for the same public-library path, for example `gh api repos/mvanhorn/printing-press-library/contents/library/<category>/<slug>` after finding candidate category directories.
+3. If the slug is found, set `published_status: published`, set `target_category` from the matched parent directory, and route all edits through the managed clone opened later in the amend flow.
+4. Only set `published_status: local-only` when the slug is absent from the public library.
+
+Do not infer publish status from the local CLI working copy's git remotes. Printed-library CLIs can intentionally have no `origin`, and a remote-less local checkout may still correspond to a published CLI. Likewise, do not treat a missing `$PRESS_LIBRARY/<slug>` working copy as unpublished; the local-library path is only informational once the public-library slug lookup succeeds. The skill operates on the managed clone (per the Pre-Implementation Decisions in the plan), so the actual edits land in the managed clone created in U7.
 
 ## Edge cases
 
 - **Empty / unreadable transcript** — emit "no active session transcript found at `<path>`; pass an explicit `<cli-name-or-path>` argument and re-run, or use `--transcript <path>` to point at a saved session" and exit cleanly.
 - **Transcript with zero `<slug>-pp-cli` invocations** — emit "no `<slug>-pp-cli` invocations found in this session; if you dogfooded a CLI in a different session, point me at that transcript" and exit.
-- **Transcript references a CLI that's not in the public library** — emit a warning and ask the user to confirm; the CLI may be local-only (pre-publish) or under a different slug.
+- **Transcript references a CLI that's not in the public library by slug** — emit a warning and ask the user to confirm; the CLI may be local-only (pre-publish) or under a different slug. This warning must be based on the public-library slug lookup, not on local git remotes or `$PRESS_LIBRARY/<slug>` presence.
 - **Signal extraction returns < 2 candidates** — proceed but note in the user-facing summary that the signal yield was low; the user may want to resume after more dogfooding.
 
 ## Output shape
@@ -91,6 +98,7 @@ Phase 1 emits a structured finding list to the next phase:
 target_cli: superhuman-pp-cli
 target_dir: $PRESS_LIBRARY/superhuman   # may be informational; managed-clone path resolved later
 target_category: productivity                      # resolved from the public library, used by U7
+published_status: published
 findings:
   - id: F1
     category: missing-folder-coverage

--- a/skills/printing-press-amend/references/transcript-parsing.md
+++ b/skills/printing-press-amend/references/transcript-parsing.md
@@ -77,7 +77,7 @@ Accept any of:
 After normalizing the slug, resolve publish status by slug lookup in the public library before consulting local working-copy state:
 
 1. If a local public-library clone exists, search `~/printing-press-library/library/*/<slug>` for a matching directory.
-2. If that clone is absent or stale enough to miss the slug, query GitHub for the same public-library path, for example `gh api repos/mvanhorn/printing-press-library/contents/library/<category>/<slug>` after finding candidate category directories.
+2. If that clone is absent or stale enough to miss the slug, query GitHub for the same public-library path. First enumerate top-level categories with `gh api repos/mvanhorn/printing-press-library/contents/library --jq '.[] | select(.type == "dir") | .name'`, then iterate those category names with `gh api repos/mvanhorn/printing-press-library/contents/library/<category>/<slug>` until the slug is found or every category has been checked.
 3. If the slug is found, set `published_status: published`, set `target_category` from the matched parent directory, and route all edits through the managed clone opened later in the amend flow.
 4. Only set `published_status: local-only` when the slug is absent from the public library.
 


### PR DESCRIPTION
## Summary

- Updates `/printing-press-amend` target resolution so published status comes from public-library slug lookup, not local working-copy remotes or local-library presence.
- Records the `published_status` output shape and routes found slugs through the managed-clone upstream PR path.
- Adds a contract test to keep the amend skill and transcript reference aligned on this behavior.

## Verification

- `go test ./internal/pipeline -run TestAmendSkillResolvesPublishedStatusByPublicLibrarySlug`
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-amend`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./internal/pipeline -run 'TestLiveCheck_(RebuildsStaleStageBinaryBeforeSampling|SkipsStageRebuildWhenBinaryIsFresh|SkipsStageRebuildWhenFreshFallbackBinaryExists|RebuildsPreferredStageBinaryDespiteFreshLowerPriorityFallback|RebuildsStageBinaryWhenInternalSourceIsNewer)|TestRunOneFeatureCheck_PopulatesOutputSample'`\n- `go test ./internal/pipeline -run 'TestLiveCheck_(PassOnQueryOnlyJSONOutput|FailOnIrrelevantOutput|FailOnExitError|LocalDataSourceRealFailureStillFails)|TestLiveCheck_LocalDataSourceUnsyncedFailureSkipsAndExcludesPassRate'`\n\nFull-suite notes: `go test ./...` and `go test -p 1 ./...` both failed locally in `internal/pipeline` live-check tests with 5s timeouts. The specific timeout tests changed between runs, and each reported selector passed when rerun alone.\n\nCloses #2948