### PR TITLE
fix(cli): strip raw sniff captures from packaged manuscripts

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -219,6 +219,7 @@ func newPublishPackageCmd() *cobra.Command {
 	var dest string
 	var modulePath string
 	var allowMirrorDeletions bool
+	var includeRawCaptures bool
 	var asJSON bool
 
 	cmd := &cobra.Command{
@@ -439,7 +440,8 @@ func newPublishPackageCmd() *cobra.Command {
 				result.RunID = runID
 				srcMsDir := filepath.Join(msDir, runID)
 				dstMsDir := filepath.Join(outCLIDir, ".manuscripts", runID)
-				if err := pipeline.CopyPublishableManuscriptDir(srcMsDir, dstMsDir); err != nil {
+				manuscriptCopyOptions := pipeline.PublishableManuscriptCopyOptions{IncludeRawCaptures: includeRawCaptures}
+				if err := pipeline.CopyPublishableManuscriptDirWithOptions(srcMsDir, dstMsDir, manuscriptCopyOptions); err != nil {
 					cleanupOnFailure()
 					return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("copying manuscripts: %w", err)}
 				} else {
@@ -496,6 +498,7 @@ func newPublishPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dest, "dest", "", "Publish repo to write into directly (mutually exclusive with --target)")
 	cmd.Flags().StringVar(&modulePath, "module-path", "", "Go module path to set (e.g., github.com/org/repo/library/category/cli-name)")
 	cmd.Flags().BoolVar(&allowMirrorDeletions, "allow-mirror-deletions", false, "Allow the overlay to delete mirror files that have no source counterpart (use only after manual reconciliation)")
+	cmd.Flags().BoolVar(&includeRawCaptures, "include-raw-captures", false, "Include raw browser-sniff captures in bundled manuscripts (private use only)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	return cmd

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -1015,6 +1015,11 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	require.NoError(t, os.MkdirAll(discoveryDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "brief.md"), []byte("# Research Brief"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(proofsDir, "shipcheck.md"), []byte("# Shipcheck"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(researchDir, "test-browser-sniff-spec-samples"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "test-browser-sniff-spec-samples", "sample.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(discoveryDir, "bundles"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "browser-sniff-capture.har"), []byte("cookie: session=secret\nemail: user@example.com\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
 
@@ -1034,6 +1039,9 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	stagedResearch := filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "brief.md")
 	stagedProofs := filepath.Join(result.StagedDir, ".manuscripts", runID, "proofs", "shipcheck.md")
 	stagedHAR := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "browser-sniff-capture.har")
+	stagedProbe := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "probe-001.json")
+	stagedBundles := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "bundles")
+	stagedSamples := filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "test-browser-sniff-spec-samples")
 	stagedTrafficAnalysis := filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "traffic-analysis.json")
 
 	_, err = os.Stat(stagedResearch)
@@ -1042,10 +1050,44 @@ func TestPublishPackageIncludesManuscripts(t *testing.T) {
 	_, err = os.Stat(stagedProofs)
 	assert.NoError(t, err, "shipcheck proofs should be in staged package")
 	assert.NoFileExists(t, stagedHAR, "raw HAR captures should not be bundled into publishable manuscripts")
+	assert.NoFileExists(t, stagedProbe, "raw probe captures should not be bundled into publishable manuscripts")
+	assert.NoDirExists(t, stagedBundles, "raw browser JS bundles should not be bundled into publishable manuscripts")
+	assert.NoDirExists(t, stagedSamples, "raw browser-sniff sample responses should not be bundled into publishable manuscripts")
 
 	_, err = os.Stat(stagedTrafficAnalysis)
 	assert.NoError(t, err, "auth-stripped traffic analysis should remain in staged package")
 	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", "stale-run", "discovery", "stale-capture.har"))
+}
+
+func TestPublishPackageCanIncludeRawCaptures(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+
+	runID := "20260329-100000"
+	researchDir := filepath.Join(home, "manuscripts", "test", runID, "research")
+	discoveryDir := filepath.Join(home, "manuscripts", "test", runID, "discovery")
+	require.NoError(t, os.MkdirAll(filepath.Join(researchDir, "test-browser-sniff-spec-samples"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(discoveryDir, "bundles"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "brief.md"), []byte("# Research Brief"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(researchDir, "test-browser-sniff-spec-samples", "sample.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "probe-001.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "browser-sniff-capture.har"), []byte("sample har"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(discoveryDir, "bundles", "app.js"), []byte("console.log('sample')"), 0o644))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--include-raw-captures", "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "probe-001.json"))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "browser-sniff-capture.har"))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "bundles", "app.js"))
+	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "test-browser-sniff-spec-samples", "sample.json"))
 }
 
 func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
@@ -1061,6 +1103,8 @@ func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
 	require.NoError(t, os.MkdirAll(embeddedDiscovery, 0o755))
 	require.NoError(t, os.MkdirAll(embeddedProofs, 0o755))
 	require.NoError(t, os.MkdirAll(embeddedResearch, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(embeddedDiscovery, "bundles"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(embeddedResearch, "test-browser-sniff-spec-samples"), 0o755))
 	writeTestPhase5GateMarker(t, embeddedProofs, pipeline.Phase5AcceptanceFilename, pipeline.Phase5GateMarker{
 		SchemaVersion: 1,
 		APIName:       "test",
@@ -1073,7 +1117,10 @@ func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
 		AuthContext:   pipeline.Phase5AuthContext{Type: "none"},
 	})
 	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "browser-sniff-capture.har"), []byte("cookie: session=secret\nemail: user@example.com\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(embeddedDiscovery, "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(embeddedResearch, "test-browser-sniff-spec-samples", "sample.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(embeddedResearch, "brief.md"), []byte("# Research Brief"), 0o644))
 
 	target := filepath.Join(t.TempDir(), "staging")
@@ -1088,6 +1135,9 @@ func TestPublishPackageFiltersEmbeddedManuscriptsFallback(t *testing.T) {
 	assert.True(t, result.ManuscriptsIncluded, "embedded manuscripts should be included when archive root is absent")
 	assert.Equal(t, runID, result.RunID)
 	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "browser-sniff-capture.har"))
+	assert.NoFileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "probe-001.json"))
+	assert.NoDirExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "bundles"))
+	assert.NoDirExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "test-browser-sniff-spec-samples"))
 	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "discovery", "traffic-analysis.json"))
 	assert.FileExists(t, filepath.Join(result.StagedDir, ".manuscripts", runID, "research", "brief.md"))
 }

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -667,6 +667,9 @@ func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo, opts Pub
 	if info.IsDir() && filepath.Base(path) == "sources" {
 		return true
 	}
+	if !info.IsDir() && info.Size() >= publishableManuscriptMaxCaptureBytes {
+		return true
+	}
 	if opts.IncludeRawCaptures {
 		return false
 	}
@@ -676,24 +679,33 @@ func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo, opts Pub
 	if strings.EqualFold(filepath.Ext(path), ".har") {
 		return true
 	}
-	return info.Size() >= publishableManuscriptMaxCaptureBytes
+	return false
 }
 
 func isRawBrowserSniffCapture(path string, info fs.FileInfo) bool {
 	clean := filepath.Clean(path)
 	base := filepath.Base(clean)
-	parent := filepath.Base(filepath.Dir(clean))
+	parentPath := filepath.Dir(clean)
 
-	if parent == "discovery" {
+	if pathHasComponent(parentPath, "discovery") {
 		if matched, _ := filepath.Match("probe-*.json", base); matched {
 			return true
 		}
 	}
-	if info.IsDir() && parent == "discovery" && base == "bundles" {
+	if info.IsDir() && pathHasComponent(parentPath, "discovery") && base == "bundles" {
 		return true
 	}
-	if info.IsDir() && parent == "research" && strings.HasSuffix(base, "-browser-sniff-spec-samples") {
+	if info.IsDir() && pathHasComponent(parentPath, "research") && strings.HasSuffix(base, "-browser-sniff-spec-samples") {
 		return true
+	}
+	return false
+}
+
+func pathHasComponent(path, component string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(filepath.Clean(path)), "/") {
+		if part == component {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -639,14 +639,24 @@ func CopyDir(src, dst string) error {
 
 const publishableManuscriptMaxCaptureBytes int64 = 100 * 1024 * 1024
 
-// CopyPublishableManuscriptDir copies manuscript artifacts that may be bundled
-// into published CLIs. Raw HAR captures and huge capture files stay in local
-// runstate only because they can carry cookies, session identifiers, and PII.
-func CopyPublishableManuscriptDir(src, dst string) error {
-	return copyDirFiltered(src, dst, shouldSkipPublishableManuscriptFile)
+type PublishableManuscriptCopyOptions struct {
+	IncludeRawCaptures bool
 }
 
-func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo) bool {
+// CopyPublishableManuscriptDir copies manuscript artifacts that may be bundled
+// into published CLIs. Raw browser-sniff captures stay in local runstate by
+// default because they can carry cookies, session identifiers, and PII.
+func CopyPublishableManuscriptDir(src, dst string) error {
+	return CopyPublishableManuscriptDirWithOptions(src, dst, PublishableManuscriptCopyOptions{})
+}
+
+func CopyPublishableManuscriptDirWithOptions(src, dst string, opts PublishableManuscriptCopyOptions) error {
+	return copyDirFiltered(src, dst, func(path string, info fs.FileInfo) bool {
+		return shouldSkipPublishableManuscriptFile(path, info, opts)
+	})
+}
+
+func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo, opts PublishableManuscriptCopyOptions) bool {
 	// A `sources/` directory holds downloaded third-party reference repos — local
 	// research INPUT, not authored manuscript OUTPUT. Never publish copies of other
 	// projects' code: it is a licensing problem and a secret/PII vector (the only
@@ -657,10 +667,35 @@ func shouldSkipPublishableManuscriptFile(path string, info fs.FileInfo) bool {
 	if info.IsDir() && filepath.Base(path) == "sources" {
 		return true
 	}
+	if opts.IncludeRawCaptures {
+		return false
+	}
+	if isRawBrowserSniffCapture(path, info) {
+		return true
+	}
 	if strings.EqualFold(filepath.Ext(path), ".har") {
 		return true
 	}
 	return info.Size() >= publishableManuscriptMaxCaptureBytes
+}
+
+func isRawBrowserSniffCapture(path string, info fs.FileInfo) bool {
+	clean := filepath.Clean(path)
+	base := filepath.Base(clean)
+	parent := filepath.Base(filepath.Dir(clean))
+
+	if parent == "discovery" {
+		if matched, _ := filepath.Match("probe-*.json", base); matched {
+			return true
+		}
+	}
+	if info.IsDir() && parent == "discovery" && base == "bundles" {
+		return true
+	}
+	if info.IsDir() && parent == "research" && strings.HasSuffix(base, "-browser-sniff-spec-samples") {
+		return true
+	}
+	return false
 }
 
 func copyDirFiltered(src, dst string, skipFile func(path string, info fs.FileInfo) bool) error {

--- a/internal/pipeline/publish.go
+++ b/internal/pipeline/publish.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -702,12 +703,7 @@ func isRawBrowserSniffCapture(path string, info fs.FileInfo) bool {
 }
 
 func pathHasComponent(path, component string) bool {
-	for _, part := range strings.Split(filepath.ToSlash(filepath.Clean(path)), "/") {
-		if part == component {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(filepath.ToSlash(filepath.Clean(path)), "/"), component)
 }
 
 func copyDirFiltered(src, dst string, skipFile func(path string, info fs.FileInfo) bool) error {

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -250,6 +250,54 @@ func TestCopyPublishableManuscriptDirExcludesDownloadedSources(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(dst, "research", "sources", "README.md"))
 }
 
+func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "bundles"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "squire-browser-sniff-spec-samples"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "research"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "capture.har"), []byte("raw har"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "squire-browser-sniff-spec-samples", "sample.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "browser-sniff-report.md"), []byte("# Report"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "brief.md"), []byte("our synthesis"), 0o644))
+
+	require.NoError(t, CopyPublishableManuscriptDir(src, dst))
+
+	assert.NoFileExists(t, filepath.Join(dst, "discovery", "probe-001.json"))
+	assert.NoFileExists(t, filepath.Join(dst, "discovery", "capture.har"))
+	assert.NoDirExists(t, filepath.Join(dst, "discovery", "bundles"))
+	assert.NoDirExists(t, filepath.Join(dst, "research", "squire-browser-sniff-spec-samples"))
+	assert.FileExists(t, filepath.Join(dst, "discovery", "traffic-analysis.json"))
+	assert.FileExists(t, filepath.Join(dst, "discovery", "browser-sniff-report.md"))
+	assert.FileExists(t, filepath.Join(dst, "research", "brief.md"))
+}
+
+func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "bundles"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "squire-browser-sniff-spec-samples"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "sources", "thirdparty"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe-001.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "capture.har"), []byte("raw har"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("console.log('sample')"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "squire-browser-sniff-spec-samples", "sample.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "sources", "thirdparty", "lib.py"), []byte("# third party"), 0o644))
+
+	require.NoError(t, CopyPublishableManuscriptDirWithOptions(src, dst, PublishableManuscriptCopyOptions{IncludeRawCaptures: true}))
+
+	assert.FileExists(t, filepath.Join(dst, "discovery", "probe-001.json"))
+	assert.FileExists(t, filepath.Join(dst, "discovery", "capture.har"))
+	assert.FileExists(t, filepath.Join(dst, "discovery", "bundles", "app.js"))
+	assert.FileExists(t, filepath.Join(dst, "research", "squire-browser-sniff-spec-samples", "sample.json"))
+	assert.NoDirExists(t, filepath.Join(dst, "research", "sources"))
+}
+
 // publishManifestEnvSetup wires PRINTING_PRESS_HOME/SCOPE/REPO_ROOT to a temp dir
 // so RunRoot()/PipelineDir()/PublishedLibraryRoot() resolve under the test sandbox.
 // Returns the temp root and a state seeded with the given run ID.

--- a/internal/pipeline/publish_test.go
+++ b/internal/pipeline/publish_test.go
@@ -255,11 +255,15 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	dst := filepath.Join(t.TempDir(), "dst")
 
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "bundles"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "batch-01"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "discovery", "v2", "bundles"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research", "squire-browser-sniff-spec-samples"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(src, "research"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "probe-001.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "batch-01", "probe-002.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "capture.har"), []byte("raw har"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "v2", "bundles", "app.js"), []byte("window.email='customer@gmail.com'"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "squire-browser-sniff-spec-samples", "sample.json"), []byte(`{"email":"customer@gmail.com"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "traffic-analysis.json"), []byte(`{"auth_stripped":true}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "browser-sniff-report.md"), []byte("# Report"), 0o644))
@@ -268,8 +272,10 @@ func TestCopyPublishableManuscriptDirExcludesRawBrowserSniffCaptures(t *testing.
 	require.NoError(t, CopyPublishableManuscriptDir(src, dst))
 
 	assert.NoFileExists(t, filepath.Join(dst, "discovery", "probe-001.json"))
+	assert.NoFileExists(t, filepath.Join(dst, "discovery", "batch-01", "probe-002.json"))
 	assert.NoFileExists(t, filepath.Join(dst, "discovery", "capture.har"))
 	assert.NoDirExists(t, filepath.Join(dst, "discovery", "bundles"))
+	assert.NoDirExists(t, filepath.Join(dst, "discovery", "v2", "bundles"))
 	assert.NoDirExists(t, filepath.Join(dst, "research", "squire-browser-sniff-spec-samples"))
 	assert.FileExists(t, filepath.Join(dst, "discovery", "traffic-analysis.json"))
 	assert.FileExists(t, filepath.Join(dst, "discovery", "browser-sniff-report.md"))
@@ -288,6 +294,10 @@ func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testin
 	require.NoError(t, os.WriteFile(filepath.Join(src, "discovery", "bundles", "app.js"), []byte("console.log('sample')"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "squire-browser-sniff-spec-samples", "sample.json"), []byte(`{"status":"sample"}`+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(src, "research", "sources", "thirdparty", "lib.py"), []byte("# third party"), 0o644))
+	largeFile, err := os.Create(filepath.Join(src, "large-authored-artifact.bin"))
+	require.NoError(t, err)
+	require.NoError(t, largeFile.Truncate(publishableManuscriptMaxCaptureBytes))
+	require.NoError(t, largeFile.Close())
 
 	require.NoError(t, CopyPublishableManuscriptDirWithOptions(src, dst, PublishableManuscriptCopyOptions{IncludeRawCaptures: true}))
 
@@ -296,6 +306,7 @@ func TestCopyPublishableManuscriptDirCanIncludeRawBrowserSniffCaptures(t *testin
 	assert.FileExists(t, filepath.Join(dst, "discovery", "bundles", "app.js"))
 	assert.FileExists(t, filepath.Join(dst, "research", "squire-browser-sniff-spec-samples", "sample.json"))
 	assert.NoDirExists(t, filepath.Join(dst, "research", "sources"))
+	assert.NoFileExists(t, filepath.Join(dst, "large-authored-artifact.bin"))
 }
 
 // publishManifestEnvSetup wires PRINTING_PRESS_HOME/SCOPE/REPO_ROOT to a temp dir


### PR DESCRIPTION
## Summary
- Exclude raw browser-sniff captures from publishable manuscript bundles by default: discovery probe JSON, HAR files, discovery bundles, and research sample-response directories.
- Add `publish package --include-raw-captures` for explicit private packaging, while continuing to drop downloaded `research/sources` trees.
- Cover archived manuscripts, embedded manuscript fallback, and the opt-in copy path.

Closes #2987

## Tests
- `go test ./internal/pipeline -run '^TestCopyPublishableManuscriptDir'`\n- `go test ./internal/cli -run '^(TestPublishPackageIncludesManuscripts|TestPublishPackageCanIncludeRawCaptures|TestPublishPackageFiltersEmbeddedManuscriptsFallback)$'`\n- `go test ./internal/pipeline -run '^(TestRunLiveDogfoodProcessRetriesTransientAuth401|TestHelpScanIndicatesSideEffect)$' -count=1 -v`\n- `go test ./internal/pipeline -count=1`\n- `scripts/golden.sh verify`\n\nNote: `go test ./...` completed all packages but the first run reported two transient `internal/pipeline` failures, `TestRunLiveDogfoodProcessRetriesTransientAuth401` and `TestHelpScanIndicatesSideEffect`. Both passed when rerun directly, and `go test ./internal/pipeline -count=1` passed.