### PR TITLE
fix(cli): redact credential JSON keys in artifacts

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -170,6 +170,7 @@ var piiJSONScalarKeys = map[string]bool{
 	"cardlast4":       true,
 	"clientsecret":    true,
 	"csrf":            true,
+	"csrftoken":       true,
 	"customeremail":   true,
 	"customername":    true,
 	"email":           true,
@@ -197,7 +198,7 @@ var piiJSONScalarKeys = map[string]bool{
 	"zip":             true,
 }
 
-var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:access[_ -]?token|address1?|address2|api[_ -]?key|api[_ -]?token|apikey|billing[_ -]?address|card[_ -]?last[_ -]?4|client[_ -]?secret|csrf|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|password|phone(?:[_ -]?number)?|postal[_ -]?code|refresh[_ -]?token|secret|session(?:[_ -]?token)?|shipping[_ -]?address|street(?:[_ -]?address)?|token|websocket[_ -]?url|zip)"\s*:`)
+var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:access[_ -]?token|address1?|address2|api[_ -]?key|api[_ -]?token|billing[_ -]?address|card[_ -]?last[_ -]?4|client[_ -]?secret|csrf(?:[_ -]?token)?|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|password|phone(?:[_ -]?number)?|postal[_ -]?code|refresh[_ -]?token|secret|session(?:[_ -]?token)?|shipping[_ -]?address|street(?:[_ -]?address)?|token|websocket[_ -]?url|zip)"\s*:`)
 
 // RedactPIIText returns text with customer-PII shapes replaced before the
 // text is written to durable artifacts. JSON input preserves non-PII fields

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -160,11 +160,16 @@ var piiDetectors = []piiDetector{
 const PIIRedactedSentinel = "<redacted>"
 
 var piiJSONScalarKeys = map[string]bool{
+	"accesstoken":     true,
 	"address":         true,
 	"address1":        true,
 	"address2":        true,
+	"apikey":          true,
+	"apitoken":        true,
 	"billingaddress":  true,
 	"cardlast4":       true,
+	"clientsecret":    true,
+	"csrf":            true,
 	"customeremail":   true,
 	"customername":    true,
 	"email":           true,
@@ -176,16 +181,23 @@ var piiJSONScalarKeys = map[string]bool{
 	"last4":           true,
 	"mobile":          true,
 	"name":            true,
+	"password":        true,
 	"phone":           true,
 	"phonenumber":     true,
 	"postalcode":      true,
+	"refreshtoken":    true,
+	"secret":          true,
+	"session":         true,
+	"sessiontoken":    true,
 	"shippingaddress": true,
 	"street":          true,
 	"streetaddress":   true,
+	"token":           true,
+	"websocketurl":    true,
 	"zip":             true,
 }
 
-var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:address1?|address2|billing[_ -]?address|card[_ -]?last[_ -]?4|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|phone(?:[_ -]?number)?|postal[_ -]?code|shipping[_ -]?address|street(?:[_ -]?address)?|zip)"\s*:`)
+var piiJSONKeyNeedleRE = regexp.MustCompile(`(?i)"(?:access[_ -]?token|address1?|address2|api[_ -]?key|api[_ -]?token|apikey|billing[_ -]?address|card[_ -]?last[_ -]?4|client[_ -]?secret|csrf|customer[_ -]?(?:email|name)|email|first[_ -]?name|full[_ -]?name|invoice(?:[_ -]?number)?|last[_ -]?name|last[_ -]?4|mobile|name|password|phone(?:[_ -]?number)?|postal[_ -]?code|refresh[_ -]?token|secret|session(?:[_ -]?token)?|shipping[_ -]?address|street(?:[_ -]?address)?|token|websocket[_ -]?url|zip)"\s*:`)
 
 // RedactPIIText returns text with customer-PII shapes replaced before the
 // text is written to durable artifacts. JSON input preserves non-PII fields

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -71,6 +71,8 @@ func TestRedactPIIJSONKeys_RedactsCredentialKeys(t *testing.T) {
 		"session",
 		"session_token",
 		"csrf",
+		"csrf_token",
+		"csrfToken",
 		"websocket_url",
 	} {
 		t.Run(key, func(t *testing.T) {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -29,6 +29,17 @@ func TestRedactPIIText_RedactsJSONPII(t *testing.T) {
 	require.Contains(t, got, `"status":"active"`)
 }
 
+func TestRedactPIIText_RedactsJSONCredentialsAndPII(t *testing.T) {
+	token := strings.Repeat("a", 40)
+	got := RedactPIIText(`{"token":"` + token + `","email":"a@b.com","status":"ok"}`)
+
+	require.NotContains(t, got, token)
+	require.NotContains(t, got, "a@b.com")
+	require.Contains(t, got, `"token":"<redacted>"`)
+	require.Contains(t, got, `"email":"<redacted>"`)
+	require.Contains(t, got, `"status":"ok"`)
+}
+
 func TestRedactPIIText_LeavesStructuralJSONUnchanged(t *testing.T) {
 	input := `{"id":42,"status":"active"}`
 
@@ -43,6 +54,42 @@ func TestRedactPIIJSONKeys_RedactsWithoutPatternSweep(t *testing.T) {
 	require.Contains(t, got, `"name":"<redacted>"`)
 	require.Contains(t, got, "jane@example.com")
 	require.Contains(t, got, `"id":42`)
+}
+
+func TestRedactPIIJSONKeys_RedactsCredentialKeys(t *testing.T) {
+	for _, key := range []string{
+		"token",
+		"api_token",
+		"api-key",
+		"api key",
+		"apikey",
+		"access_token",
+		"refresh_token",
+		"client_secret",
+		"secret",
+		"password",
+		"session",
+		"session_token",
+		"csrf",
+		"websocket_url",
+	} {
+		t.Run(key, func(t *testing.T) {
+			got, changed := RedactPIIJSONKeys(`{"` + key + `":"credential-value","status":"ok"}`)
+
+			require.True(t, changed)
+			require.NotContains(t, got, "credential-value")
+			require.Contains(t, got, `"`+key+`":"<redacted>"`)
+			require.Contains(t, got, `"status":"ok"`)
+		})
+	}
+}
+
+func TestRedactPIIJSONKeys_LeavesCredentialCountersUnchanged(t *testing.T) {
+	input := `{"token_count":5,"status":"ok"}`
+	got, changed := RedactPIIJSONKeys(input)
+
+	require.False(t, changed)
+	require.Equal(t, input, got)
 }
 
 func TestRedactPIIJSONKeys_RedactsNDJSON(t *testing.T) {


### PR DESCRIPTION
## Intent

Prevent live-dogfood proof samples from preserving credential-shaped JSON fields when APIs echo caller credentials in response bodies.

Closes #3000

## Approach

Adds credential-bearing JSON key variants to the existing artifact redaction key set and needle regex, so parsed JSON, NDJSON, and fragment scrubbing use the same redaction path as existing PII keys. Adds regression coverage for token plus email redaction, credential key variants, and the `token_count` negative case.

## Scope

Primary area: `internal/artifacts` scorer/artifact redaction.

Why this belongs in this repo: the leak is in the Printing Press artifact scrubber before proof samples are promoted to publishable manuscripts.

## Catalog Justification

N/A

## Risk

Low. Proof samples keep structural fields while replacing sensitive scalar values under credential-bearing keys. Non-credential keys such as `token_count` are unchanged.

## Output Contract

N/A

## Verification

- `go test ./internal/artifacts -run 'TestRedactPII(Text_RedactsJSONCredentialsAndPII|JSONKeys_(RedactsCredentialKeys|LeavesCredentialCountersUnchanged))'`\n- `go test ./internal/artifacts -count=1`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n- `git diff --check`\n\nNot fully green locally: `go test ./...` failed in unchanged `internal/pipeline` tests (`TestRunLiveDogfoodProcessRetriesTransientAuth401`, `TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap`, and `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged`). A focused rerun of those tests reproduced the pipeline failures. `golangci-lint` was not installed locally.