### PR TITLE
fix(cli): skip live dogfood placeholder fixture reads

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/mcpdesc"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/piiplaceholders"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -6442,7 +6443,7 @@ func exampleValue(p spec.Param) string {
 	if nameLower == "id" ||
 		strings.HasSuffix(nameLower, "_id") ||
 		(strings.HasSuffix(nameLower, "id") && len(nameLower) > 2 && !isNumericOrBool) {
-		return "550e8400-e29b-41d4-a716-446655440000"
+		return piiplaceholders.SyntheticUUID
 	}
 	if strings.Contains(nameLower, "email") {
 		return "user@example.com"

--- a/internal/piiplaceholders/placeholders.go
+++ b/internal/piiplaceholders/placeholders.go
@@ -14,6 +14,7 @@ const (
 	SyntheticMoney          = "12.34"
 	SyntheticDate           = "2026-01-15"
 	SyntheticCookieValue    = "your-cookie-here"
+	SyntheticUUID           = "550e8400-e29b-41d4-a716-446655440000"
 	PrimarySyntheticASIN    = "B0EXAMPLE1"
 )
 

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -631,7 +631,6 @@ func findListCompanion(candidates []liveDogfoodCommand) *liveDogfoodCommand {
 //
 // Returns:
 //   - (newArgs, false, "", source)   - placeholders substituted; run happy_path with newArgs
-//   - (happyArgs, false, "", source) - store was empty; run the synthetic example unchanged
 //   - (nil, true, reason, "")        - chain broke before an ID fixture source was available
 //   - (happyArgs, false, "", "")     - no positionals at all; pass-through unchanged
 func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string, string) {
@@ -680,7 +679,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
-				return happyArgs, false, "", "synthetic"
+				return nil, true, reasonRequiredParamFixture, ""
 			}
 			return nil, true, fmt.Sprintf("no list companion at depth %d for %q", i, name), ""
 		}
@@ -703,7 +702,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 					resolved = append(resolved, id)
 					continue
 				} else if storeAvailable {
-					return happyArgs, false, "", "synthetic"
+					return nil, true, reasonRequiredParamFixture, ""
 				}
 				return nil, true, fmt.Sprintf(
 					"list companion previously failed at depth %d for %q", i, name), ""
@@ -720,7 +719,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
-				return happyArgs, false, "", "synthetic"
+				return nil, true, reasonRequiredParamFixture, ""
 			}
 			return nil, true, fmt.Sprintf(
 				"list companion failed at depth %d: exit %d", i, run.exitCode), ""
@@ -734,7 +733,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 				resolved = append(resolved, id)
 				continue
 			} else if storeAvailable {
-				return happyArgs, false, "", "synthetic"
+				return nil, true, reasonRequiredParamFixture, ""
 			}
 			return nil, true, fmt.Sprintf(
 				"no id parseable from companion at depth %d", i), ""
@@ -749,6 +748,70 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 		fixtureSource = "store"
 	}
 	return substitutePositionals(happyArgs, command.Path, resolved), false, "", fixtureSource
+}
+
+func happyPathSyntheticParamFixtureSkip(command liveDogfoodCommand, happyArgs []string) string {
+	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) != "" {
+		return ""
+	}
+	if liveDogfoodCommandMutates(command) {
+		return ""
+	}
+	if !happyArgsContainSyntheticFlagPlaceholder(happyArgs, command.Path) {
+		return ""
+	}
+	return reasonRequiredParamFixture
+}
+
+func happyArgsContainSyntheticFlagPlaceholder(happyArgs, commandPath []string) bool {
+	start := min(len(commandPath), len(happyArgs))
+	for i := start; i < len(happyArgs); i++ {
+		arg := happyArgs[i]
+		if arg == "--" {
+			return false
+		}
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if flag, value, ok := strings.Cut(arg, "="); ok {
+			if liveDogfoodSyntheticFixtureFlagValue(flag, value) {
+				return true
+			}
+			continue
+		}
+		if i+1 < len(happyArgs) && !strings.HasPrefix(happyArgs[i+1], "-") && liveDogfoodSyntheticFixtureFlagValue(arg, happyArgs[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func liveDogfoodSyntheticFixtureFlagValue(flag, value string) bool {
+	if !liveDogfoodSyntheticExampleValue(value) {
+		return false
+	}
+	flag = strings.TrimLeft(strings.TrimSpace(flag), "-")
+	if flag == "" {
+		return false
+	}
+	name := strings.ToLower(strings.ReplaceAll(flag, "_", "-"))
+	if name == "id" || name == "ids" || strings.HasSuffix(name, "-id") || strings.HasSuffix(name, "-ids") {
+		return true
+	}
+	if strings.HasSuffix(name, "id") && len(name) > 2 {
+		return true
+	}
+	return strings.Contains(name, "token") || strings.Contains(name, "key")
+}
+
+func liveDogfoodSyntheticExampleValue(value string) bool {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	switch value {
+	case "example-value", "550e8400-e29b-41d4-a716-446655440000", "your-token-here":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveStoreFixtureID(placeholder string, parentPath []string, ctx resolveCtx) (string, bool, bool) {
@@ -1145,6 +1208,10 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
 	resolvedArgs, resolveSkipped, resolveReason, fixtureSource := resolveCommandPositionals(command, happyArgs, ctx)
+	syntheticParamSkip := ""
+	if fixtureSkip == "" && !resolveSkipped {
+		syntheticParamSkip = happyPathSyntheticParamFixtureSkip(command, resolvedArgs)
+	}
 	switch {
 	case fixtureSkip != "":
 		results = append(results,
@@ -1155,6 +1222,11 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		results = append(results,
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, resolveReason),
 			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, resolveReason),
+		)
+	case syntheticParamSkip != "":
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, syntheticParamSkip),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, syntheticParamSkip),
 		)
 	default:
 		happyArgs = resolvedArgs

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/piiplaceholders"
 )
 
 type LiveDogfoodStatus string
@@ -807,7 +809,7 @@ func liveDogfoodSyntheticFixtureFlagValue(flag, value string) bool {
 func liveDogfoodSyntheticExampleValue(value string) bool {
 	value = strings.Trim(strings.TrimSpace(value), `"'`)
 	switch value {
-	case "example-value", "550e8400-e29b-41d4-a716-446655440000", "your-token-here":
+	case "example-value", piiplaceholders.SyntheticUUID, "your-token-here":
 		return true
 	default:
 		return false

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -1363,6 +1363,16 @@ func TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx(t *testing.T) {
 	require.NotNil(t, summaryJSON, "expected reports summary json_fidelity result")
 	assert.Equal(t, LiveDogfoodStatusSkip, summaryJSON.Status)
 	assert.Equal(t, reasonRequiredParamFixture, summaryJSON.Reason)
+
+	eventsHappy := findResultByCommandKind(report, "events list", LiveDogfoodTestHappy)
+	require.NotNil(t, eventsHappy, "expected events list happy_path result")
+	assert.Equal(t, LiveDogfoodStatusSkip, eventsHappy.Status)
+	assert.Equal(t, reasonRequiredParamFixture, eventsHappy.Reason)
+
+	eventsJSON := findResultByCommandKind(report, "events list", LiveDogfoodTestJSON)
+	require.NotNil(t, eventsJSON, "expected events list json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, eventsJSON.Status)
+	assert.Equal(t, reasonRequiredParamFixture, eventsJSON.Reason)
 }
 
 func TestRunLiveDogfoodSkipsMutatingCommandsWithoutRunnableExample(t *testing.T) {
@@ -1495,6 +1505,9 @@ if [ "$1" = "agent-context" ]; then
     {"name":"reports","subcommands":[
       {"name":"prospects"},
       {"name":"summary"}
+    ]},
+    {"name":"events","subcommands":[
+      {"name":"list","annotations":{"pp:method":"GET","mcp:read-only":"true"}}
     ]}
   ]
 }
@@ -1552,6 +1565,31 @@ fi
 if [ "$1" = "reports" ] && [ "$2" = "summary" ]; then
   echo 'summary'
   exit 0
+fi
+
+if [ "$1" = "events" ] && [ "$2" = "list" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+List calendar events.
+
+Usage:
+  fixture-pp-cli events list [flags]
+
+Examples:
+  fixture-pp-cli events list --account-id 550e8400-e29b-41d4-a716-446655440000 --calendar-ids example-value --start 2026-01-15T09:00:00Z --end 2026-01-15T10:00:00Z
+
+Flags:
+      --account-id string     Account id
+      --calendar-ids string   Calendar ids
+      --end string            End time
+      --json                  Output JSON
+      --start string          Start time
+HELP
+  exit 0
+fi
+
+if [ "$1" = "events" ] && [ "$2" = "list" ]; then
+  echo 'unexpected events list invocation with synthetic required query params' >&2
+  exit 9
 fi
 
 echo "unexpected args: $*" >&2
@@ -3916,15 +3954,19 @@ func TestRunLiveDogfoodStoreFixtureSourceUsesSyncedResourceID(t *testing.T) {
 	assert.Equal(t, "store", jsonResult.FixtureSource)
 }
 
-func TestRunLiveDogfoodStoreFixtureSourceMarksSyntheticWhenStoreEmpty(t *testing.T) {
+func TestRunLiveDogfoodStoreFixtureSourceSkipsWhenStoreEmpty(t *testing.T) {
 	dir, binaryName := writeLiveDogfoodStoreFixture(t, false)
 	report := runRichFixtureMatrix(t, dir, binaryName)
 
 	happy := findResultByCommandKind(report, "tasks get-task", LiveDogfoodTestHappy)
 	require.NotNil(t, happy, "expected tasks get-task happy_path result")
-	assert.Equal(t, LiveDogfoodStatusFail, happy.Status)
-	assert.Equal(t, []string{"tasks", "get-task", "example-id"}, happy.Args)
-	assert.Equal(t, "synthetic", happy.FixtureSource)
+	assert.Equal(t, LiveDogfoodStatusSkip, happy.Status)
+	assert.Equal(t, reasonRequiredParamFixture, happy.Reason)
+
+	jsonResult := findResultByCommandKind(report, "tasks get-task", LiveDogfoodTestJSON)
+	require.NotNil(t, jsonResult, "expected tasks get-task json_fidelity result")
+	assert.Equal(t, LiveDogfoodStatusSkip, jsonResult.Status)
+	assert.Equal(t, reasonRequiredParamFixture, jsonResult.Reason)
 }
 
 func TestRunLiveDogfoodResolveSuccessSinglePositional(t *testing.T) {
@@ -4656,4 +4698,19 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "example-value"}, args,
 		"empty pp:happy-args must fall through to Example derivation")
+}
+
+func TestHappyArgsContainSyntheticFlagPlaceholder(t *testing.T) {
+	assert.True(t, happyArgsContainSyntheticFlagPlaceholder(
+		[]string{"events", "list", "--account-id", "550e8400-e29b-41d4-a716-446655440000", "--calendar-ids", "example-value"},
+		[]string{"events", "list"},
+	))
+	assert.True(t, happyArgsContainSyntheticFlagPlaceholder(
+		[]string{"users", "get-by-ids", "--ids=example-value"},
+		[]string{"users", "get-by-ids"},
+	))
+	assert.False(t, happyArgsContainSyntheticFlagPlaceholder(
+		[]string{"widgets", "search", "--query", "example-value"},
+		[]string{"widgets", "search"},
+	))
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4709,6 +4709,10 @@ func TestHappyArgsContainSyntheticFlagPlaceholder(t *testing.T) {
 		[]string{"users", "get-by-ids", "--ids=example-value"},
 		[]string{"users", "get-by-ids"},
 	))
+	assert.True(t, happyArgsContainSyntheticFlagPlaceholder(
+		[]string{"keys", "list", "--api-key", "your-token-here"},
+		[]string{"keys", "list"},
+	))
 	assert.False(t, happyArgsContainSyntheticFlagPlaceholder(
 		[]string{"widgets", "search", "--query", "example-value"},
 		[]string{"widgets", "search"},


### PR DESCRIPTION
## Summary
- Skip live-dogfood happy and JSON probes for read commands whose Example only supplies generated placeholder values for opaque fixture flags such as IDs.
- Treat empty sibling-list or empty store fixture resolution as blocked fixture instead of running synthetic positional IDs.
- Add regression coverage for required query placeholders and empty store resolution.

Closes #2978

## Tests
- go test ./internal/pipeline -run 'TestRunLiveDogfood(SkipsHappyPathOnRequiredParam4xx|StoreFixtureSource(SkipsWhenStoreEmpty|UsesSyncedResourceID))|TestLiveDogfoodRequiredParamFixtureReason|TestLiveDogfoodHappyArgsHonorsPPHappyArgs|TestHappyArgsContainSyntheticFlagPlaceholder|TestRunCommandTestsWithoutHappyArgsKeepsGenericFailure' -count=1\n- go test ./internal/pipeline -list 'TestRunLiveDogfood(SkipsHappyPathOnRequiredParam4xx|StoreFixtureSource(SkipsWhenStoreEmpty|UsesSyncedResourceID))|TestLiveDogfoodRequiredParamFixtureReason|TestLiveDogfoodHappyArgsHonorsPPHappyArgs|TestHappyArgsContainSyntheticFlagPlaceholder|TestRunCommandTestsWithoutHappyArgsKeepsGenericFailure'\n- go test ./...\n- go fmt ./...\n- go build -o ./cli-printing-press ./cmd/cli-printing-press\n\nNote: golangci-lint is not installed in this runtime, so I could not run golangci-lint run ./....