### PR TITLE
fix(cli): guard read-only mcp positional write sinks

### DIFF
--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -4,6 +4,7 @@
 package cobratree
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -19,6 +20,10 @@ const (
 	// Without it, hosts like Claude Desktop default to "could write or
 	// delete" and demand permission per call.
 	ReadOnlyAnnotation = "mcp:read-only"
+	// PositionalWriteSinksAnnotation lists zero-based positional argument
+	// indexes that write to user-visible files when populated. It is enforced
+	// only on commands that also carry ReadOnlyAnnotation.
+	PositionalWriteSinksAnnotation = "mcp:write-positionals"
 )
 
 type commandKind int
@@ -104,6 +109,30 @@ func isMCPHidden(cmd *cobra.Command) bool {
 
 func isMCPReadOnly(cmd *cobra.Command) bool {
 	return annotationIsTrue(cmd, ReadOnlyAnnotation)
+}
+
+func positionalWriteSinkIndexes(cmd *cobra.Command) map[int]bool {
+	if cmd == nil || cmd.Annotations == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(cmd.Annotations[PositionalWriteSinksAnnotation])
+	if raw == "" {
+		return nil
+	}
+	out := map[int]bool{}
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		idx, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || idx < 0 {
+			continue
+		}
+		out[idx] = true
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func annotationIsTrue(cmd *cobra.Command, key string) bool {

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -16,7 +16,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -28,10 +28,8 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
-			for _, t := range tokens {
-				if strings.HasPrefix(t, "-") {
-					return mcplib.NewToolResultError(fmt.Sprintf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)), nil
-				}
+			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
+				return mcplib.NewToolResultError(err.Error()), nil
 			}
 			finalArgs = append(finalArgs, tokens...)
 		}
@@ -41,6 +39,27 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 		}
 		return mcplib.NewToolResultText(out), nil
 	}
+}
+
+func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
+	for _, t := range tokens {
+		if t != "-" && strings.HasPrefix(t, "-") {
+			return fmt.Errorf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)
+		}
+	}
+	if !readOnly || len(positionalWriteSinks) == 0 {
+		return nil
+	}
+	for i, t := range tokens {
+		if !positionalWriteSinks[i] {
+			continue
+		}
+		if strings.TrimSpace(t) == "" || t == "-" {
+			continue
+		}
+		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", i+1, t)
+	}
+	return nil
 }
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -119,7 +119,7 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 			return "", true
 		}
 		for _, t := range tokens {
-			if strings.HasPrefix(t, "-") {
+			if t != "-" && strings.HasPrefix(t, "-") {
 				return t, false
 			}
 		}
@@ -143,6 +143,7 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 		// the CLI is invoked via exec.CommandContext (no /bin/sh), so
 		// $VAR / && / | are inert. Pin that they don't trip the guard.
 		{"shell metachars in positional", `name with $VAR && pipe|stuff`, true, ""},
+		{"lone dash allowed as stdout escape", "-", true, ""},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // TestSplitShellArgs pins the whitespace + quote splitting used by
@@ -111,12 +113,17 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 // caught at unit-test scope rather than only via end-to-end MCP runs.
 func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 	guard := func(raw string) (rejected string, ok bool) {
-		for _, t := range SplitShellArgs(raw) {
+		tokens := SplitShellArgs(raw)
+		err := validatePositionalArgsForMCP(tokens, false, nil)
+		if err == nil {
+			return "", true
+		}
+		for _, t := range tokens {
 			if strings.HasPrefix(t, "-") {
 				return t, false
 			}
 		}
-		return "", true
+		return "", false
 	}
 	cases := []struct {
 		name        string
@@ -148,6 +155,53 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 				t.Errorf("guard(%q) blocked = %q, want %q", tc.in, tok, tc.wantBlocked)
 			}
 		})
+	}
+}
+
+func TestReadOnlyPositionalWriteSinksRejectFileOutput(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		readOnly  bool
+		sinks     map[int]bool
+		wantError bool
+	}{
+		{"unmarked read-only positional stays allowed", "out.json", true, nil, false},
+		{"write sink rejects file path", "out.json", true, map[int]bool{0: true}, true},
+		{"write sink permits stdout dash", "-", true, map[int]bool{0: true}, false},
+		{"write sink ignored outside read-only tool", "out.json", false, map[int]bool{0: true}, false},
+		{"later write sink rejects second positional", "team out.json", true, map[int]bool{1: true}, true},
+		{"later write sink allows missing optional positional", "team", true, map[int]bool{1: true}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePositionalArgsForMCP(SplitShellArgs(tc.raw), tc.readOnly, tc.sinks)
+			if tc.wantError && err == nil {
+				t.Fatalf("validatePositionalArgsForMCP(%q) succeeded, want error", tc.raw)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("validatePositionalArgsForMCP(%q) returned error: %v", tc.raw, err)
+			}
+		})
+	}
+}
+
+func TestPositionalWriteSinkIndexesParsesAnnotation(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "export-unmatched [path]",
+		Annotations: map[string]string{
+			PositionalWriteSinksAnnotation: "0, 2;3",
+		},
+	}
+	got := positionalWriteSinkIndexes(cmd)
+	for _, idx := range []int{0, 2, 3} {
+		if !got[idx] {
+			t.Fatalf("positionalWriteSinkIndexes missing index %d from %#v", idx, got)
+		}
+	}
+	if got[1] {
+		t.Fatalf("positionalWriteSinkIndexes unexpectedly included index 1: %#v", got)
 	}
 }
 

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -35,10 +35,11 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if commandTakesArgs(cmd) {
 			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
 		}
-		if isMCPReadOnly(cmd) {
+		readOnly := isMCPReadOnly(cmd)
+		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -38,7 +38,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if isMCPReadOnly(cmd) {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3702,6 +3702,7 @@ If an extension genuinely cannot live in a separate file (a `case` branch in a t
 
 - `cmd.Annotations["mcp:hidden"] = "true"` — exclude the command from the MCP surface entirely. Use only for debug/internal commands that should not become agent tools.
 - `cmd.Annotations["mcp:read-only"] = "true"` — declare that this command does not modify external state. The MCP server attaches `readOnlyHint: true` to the resulting tool, so hosts like Claude Desktop don't bucket it under "write/delete tools" and demand permission per call. Apply this to every novel command whose only effect is reading from the API or the local store: lookups, comparisons, aggregations, render-only views, status checks. Skip it for commands that mutate external state (orders, posts, deletes) or write to user-visible files outside the local cache.
+- `cmd.Annotations["mcp:write-positionals"] = "0"` — mark zero-based positional indexes that write to user-visible files when populated. Use this with `mcp:read-only` only when the command is otherwise read-only and the positional has a stdout-safe escape such as `-`. The MCP shell-out wrapper rejects non-stdout values for those positionals so a read-only-hinted tool cannot write files through the free-form `args` field. Use comma-separated indexes for multiple write sinks.
 
 Endpoint-mirror tools the generator emits from the spec already get the right annotations automatically (`GET` → read-only, `DELETE` → destructive, etc.) — `mcp:read-only` is only needed on hand-authored Cobra commands the spec doesn't cover.
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
@@ -35,10 +35,11 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if commandTakesArgs(cmd) {
 			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
 		}
-		if isMCPReadOnly(cmd) {
+		readOnly := isMCPReadOnly(cmd)
+		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
@@ -38,7 +38,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if isMCPReadOnly(cmd) {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -4,6 +4,7 @@
 package cobratree
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -19,6 +20,10 @@ const (
 	// Without it, hosts like Claude Desktop default to "could write or
 	// delete" and demand permission per call.
 	ReadOnlyAnnotation = "mcp:read-only"
+	// PositionalWriteSinksAnnotation lists zero-based positional argument
+	// indexes that write to user-visible files when populated. It is enforced
+	// only on commands that also carry ReadOnlyAnnotation.
+	PositionalWriteSinksAnnotation = "mcp:write-positionals"
 )
 
 type commandKind int
@@ -104,6 +109,30 @@ func isMCPHidden(cmd *cobra.Command) bool {
 
 func isMCPReadOnly(cmd *cobra.Command) bool {
 	return annotationIsTrue(cmd, ReadOnlyAnnotation)
+}
+
+func positionalWriteSinkIndexes(cmd *cobra.Command) map[int]bool {
+	if cmd == nil || cmd.Annotations == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(cmd.Annotations[PositionalWriteSinksAnnotation])
+	if raw == "" {
+		return nil
+	}
+	out := map[int]bool{}
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		idx, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || idx < 0 {
+			continue
+		}
+		out[idx] = true
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func annotationIsTrue(cmd *cobra.Command, key string) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -28,10 +28,8 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
-			for _, t := range tokens {
-				if strings.HasPrefix(t, "-") {
-					return mcplib.NewToolResultError(fmt.Sprintf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)), nil
-				}
+			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
+				return mcplib.NewToolResultError(err.Error()), nil
 			}
 			finalArgs = append(finalArgs, tokens...)
 		}
@@ -41,6 +39,27 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string) server.
 		}
 		return mcplib.NewToolResultText(out), nil
 	}
+}
+
+func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
+	for _, t := range tokens {
+		if t != "-" && strings.HasPrefix(t, "-") {
+			return fmt.Errorf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)
+		}
+	}
+	if !readOnly || len(positionalWriteSinks) == 0 {
+		return nil
+	}
+	for i, t := range tokens {
+		if !positionalWriteSinks[i] {
+			continue
+		}
+		if strings.TrimSpace(t) == "" || t == "-" {
+			continue
+		}
+		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", i+1, t)
+	}
+	return nil
 }
 
 // blockedRootFlags are root-level CLI flags that an MCP client must not be

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -119,7 +119,7 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 			return "", true
 		}
 		for _, t := range tokens {
-			if strings.HasPrefix(t, "-") {
+			if t != "-" && strings.HasPrefix(t, "-") {
 				return t, false
 			}
 		}
@@ -143,6 +143,7 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 		// the CLI is invoked via exec.CommandContext (no /bin/sh), so
 		// $VAR / && / | are inert. Pin that they don't trip the guard.
 		{"shell metachars in positional", `name with $VAR && pipe|stuff`, true, ""},
+		{"lone dash allowed as stdout escape", "-", true, ""},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // TestSplitShellArgs pins the whitespace + quote splitting used by
@@ -111,12 +113,17 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 // caught at unit-test scope rather than only via end-to-end MCP runs.
 func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 	guard := func(raw string) (rejected string, ok bool) {
-		for _, t := range SplitShellArgs(raw) {
+		tokens := SplitShellArgs(raw)
+		err := validatePositionalArgsForMCP(tokens, false, nil)
+		if err == nil {
+			return "", true
+		}
+		for _, t := range tokens {
 			if strings.HasPrefix(t, "-") {
 				return t, false
 			}
 		}
-		return "", true
+		return "", false
 	}
 	cases := []struct {
 		name        string
@@ -148,6 +155,53 @@ func TestArgsFieldRejectsFlagLikeTokens(t *testing.T) {
 				t.Errorf("guard(%q) blocked = %q, want %q", tc.in, tok, tc.wantBlocked)
 			}
 		})
+	}
+}
+
+func TestReadOnlyPositionalWriteSinksRejectFileOutput(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		readOnly  bool
+		sinks     map[int]bool
+		wantError bool
+	}{
+		{"unmarked read-only positional stays allowed", "out.json", true, nil, false},
+		{"write sink rejects file path", "out.json", true, map[int]bool{0: true}, true},
+		{"write sink permits stdout dash", "-", true, map[int]bool{0: true}, false},
+		{"write sink ignored outside read-only tool", "out.json", false, map[int]bool{0: true}, false},
+		{"later write sink rejects second positional", "team out.json", true, map[int]bool{1: true}, true},
+		{"later write sink allows missing optional positional", "team", true, map[int]bool{1: true}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePositionalArgsForMCP(SplitShellArgs(tc.raw), tc.readOnly, tc.sinks)
+			if tc.wantError && err == nil {
+				t.Fatalf("validatePositionalArgsForMCP(%q) succeeded, want error", tc.raw)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("validatePositionalArgsForMCP(%q) returned error: %v", tc.raw, err)
+			}
+		})
+	}
+}
+
+func TestPositionalWriteSinkIndexesParsesAnnotation(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "export-unmatched [path]",
+		Annotations: map[string]string{
+			PositionalWriteSinksAnnotation: "0, 2;3",
+		},
+	}
+	got := positionalWriteSinkIndexes(cmd)
+	for _, idx := range []int{0, 2, 3} {
+		if !got[idx] {
+			t.Fatalf("positionalWriteSinkIndexes missing index %d from %#v", idx, got)
+		}
+	}
+	if got[1] {
+		t.Fatalf("positionalWriteSinkIndexes unexpectedly included index 1: %#v", got)
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -35,10 +35,11 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if commandTakesArgs(cmd) {
 			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
 		}
-		if isMCPReadOnly(cmd) {
+		readOnly := isMCPReadOnly(cmd)
+		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -38,7 +38,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if isMCPReadOnly(cmd) {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, isMCPReadOnly(cmd), positionalWriteSinkIndexes(cmd)))
 	})
 }
 


### PR DESCRIPTION
## Summary
- add generated cobratree support for `mcp:write-positionals`, a zero-based annotation for positional args that write user-visible files
- reject non-stdout values for those positionals when the mirrored command is also `mcp:read-only`
- update generated cobratree tests, golden fixtures, and Printing Press skill guidance

Closes #2911

## Verification
- `go test ./internal/generator -run 'TestMCPRegistersCobraTreeMirror|TestMCPNovelFeatureToolNameSanitization|TestMCPFrameworkCommandClassificationIsTopLevelOnly'`\n- `go test ./internal/generator -run 'TestTemplatesEmitReadOnlyAnnotation|TestGeneratedFrameworkCommandsEmitReadOnlyAnnotations'`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh`\n- `go fmt ./...`\n- `go test ./...`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n\nNote: `golangci-lint run ./...` could not run locally because `golangci-lint` is not installed in this environment.\n