### PR TITLE
feat(cli): add print readiness report for generate

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -714,7 +714,7 @@ capabilities:
 
 func writeInternalReadinessSpec(t *testing.T, path, name, baseURL, resource string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`name: %s
+	data := fmt.Appendf(nil, `name: %s
 description: %s API
 version: 0.1.0
 base_url: %s
@@ -736,7 +736,8 @@ types:
   Item:
     fields:
       - {name: id, type: string}
-`, name, name, baseURL, name, resource, resource, resource, resource)), 0o644))
+`, name, name, baseURL, name, resource, resource, resource, resource)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
 }
 
 func findingCodes(findings []readinessFinding) []string {

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -514,6 +514,7 @@ types:
 	assert.Contains(t, got, "Verdict: WARN")
 	assert.Contains(t, got, "## Auth Readiness")
 	assert.Contains(t, got, "READYAPP_TOKEN")
+	assert.Contains(t, got, "--output "+outputDir)
 	assert.Contains(t, got, "auth_verify_missing")
 }
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -462,6 +462,291 @@ components:
 	require.Error(t, runGenerate("--lenient", "--strict-refs"))
 }
 
+func TestGenerateReadinessReportMarkdownDoesNotWriteOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "readyapp")
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: readyapp
+description: Ready app API
+version: 0.1.0
+base_url: https://api.readyapp.dev
+auth:
+  type: bearer_token
+  env_vars: [READYAPP_TOKEN]
+  key_url: https://readyapp.dev/keys
+config:
+  format: toml
+  path: ~/.config/readyapp-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+        response:
+          type: array
+          item: Item
+types:
+  Item:
+    fields:
+      - {name: id, type: string}
+      - {name: name, type: string}
+`), 0o644))
+
+	var stdout bytes.Buffer
+	cmd := newGenerateCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--readiness-report",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.NoDirExists(t, outputDir)
+	got := stdout.String()
+	assert.Contains(t, got, "# Print Readiness Report")
+	assert.Contains(t, got, "Verdict: WARN")
+	assert.Contains(t, got, "## Auth Readiness")
+	assert.Contains(t, got, "READYAPP_TOKEN")
+	assert.Contains(t, got, "auth_verify_missing")
+}
+
+func TestGenerateReadinessReportJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	outputDir := filepath.Join(dir, "jsonapp")
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: jsonapp
+description: JSON app API
+version: 0.1.0
+base_url: https://api.jsonapp.dev
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/jsonapp-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+        response: {type: array, item: Item}
+      create:
+        method: POST
+        path: /items
+        description: Create item
+        body:
+          - {name: name, type: string, required: true}
+        response: {type: object, item: Item}
+types:
+  Item:
+    fields:
+      - {name: id, type: string}
+      - {name: name, type: string}
+`), 0o644))
+
+	var stdout bytes.Buffer
+	cmd := newGenerateCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--readiness-report",
+		"--json",
+	})
+	require.NoError(t, cmd.Execute())
+	assert.NoDirExists(t, outputDir)
+
+	var report readinessReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, readinessSchemaVersion, report.SchemaVersion)
+	assert.Equal(t, "ready", report.Verdict)
+	assert.Equal(t, "jsonapp", report.Summary.APIName)
+	assert.Equal(t, 2, report.Summary.EndpointCount)
+	assert.Equal(t, 1, report.Summary.ReadEndpointCount)
+	assert.Equal(t, 1, report.Summary.WriteEndpointCount)
+	assert.Equal(t, []string{"stdio", "http"}, report.MCP.EffectiveTransports)
+	assert.Contains(t, findingCodes(report.Findings), "mutating_commands_present")
+}
+
+func TestGenerateReadinessReportMissingBaseURLIsBlockedFinding(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi.yaml")
+	outputDir := filepath.Join(dir, "missing-base")
+	require.NoError(t, os.WriteFile(specPath, []byte(`openapi: 3.0.0
+info:
+  title: Missing Base API
+  version: 0.1.0
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+`), 0o644))
+
+	var stdout bytes.Buffer
+	cmd := newGenerateCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--readiness-report",
+		"--json",
+	})
+	require.NoError(t, cmd.Execute())
+	assert.NoDirExists(t, outputDir)
+
+	var report readinessReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, "blocked", report.Verdict)
+	assert.Contains(t, findingCodes(report.Findings), "missing_base_url")
+}
+
+func TestGenerateReadinessReportMultiSpecRequiresNameAndReportsMergedSurface(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	firstSpec := filepath.Join(dir, "first.yaml")
+	secondSpec := filepath.Join(dir, "second.yaml")
+	outputDir := filepath.Join(dir, "combo")
+	writeInternalReadinessSpec(t, firstSpec, "first", "https://api.firstapp.dev", "users")
+	writeInternalReadinessSpec(t, secondSpec, "second", "https://api.secondapp.dev", "teams")
+
+	var stdout bytes.Buffer
+	cmd := newGenerateCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--spec", firstSpec,
+		"--spec", secondSpec,
+		"--name", "combo",
+		"--output", outputDir,
+		"--readiness-report",
+		"--json",
+	})
+	require.NoError(t, cmd.Execute())
+	assert.NoDirExists(t, outputDir)
+
+	var report readinessReport
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &report))
+	assert.Equal(t, "combo", report.Summary.APIName)
+	assert.Equal(t, 2, report.Summary.EndpointCount)
+
+	cmd = newGenerateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--spec", firstSpec,
+		"--spec", secondSpec,
+		"--readiness-report",
+	})
+	require.ErrorContains(t, cmd.Execute(), "--name is required when using multiple specs")
+}
+
+func TestGenerateReadinessReportRejectsUnsupportedInputModes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	require.NoError(t, os.WriteFile(planPath, []byte("# Plan\n"), 0o644))
+	devicePath := filepath.Join(dir, "device.yaml")
+	require.NoError(t, os.WriteFile(devicePath, []byte(`version: 1
+name: demo-device
+display_name: Demo Device
+protocol: ble
+ble:
+  services:
+    - uuid: "180a"
+      characteristics:
+        - uuid: "2a29"
+          properties: [read]
+capabilities:
+  telemetry:
+    - name: manufacturer
+      source_characteristic_uuid: "2a29"
+`), 0o644))
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "docs", args: []string{"--docs", "https://docs.example.com", "--readiness-report"}, want: "--readiness-report is not supported with --docs"},
+		{name: "plan", args: []string{"--plan", planPath, "--readiness-report"}, want: "--readiness-report is not supported with --plan"},
+		{name: "device", args: []string{"--spec", devicePath, "--readiness-report"}, want: "--readiness-report is not supported with BLE device specs"},
+		{name: "dry-run", args: []string{"--spec", devicePath, "--readiness-report", "--dry-run"}, want: "--readiness-report cannot be combined with --dry-run"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newGenerateCmd()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+			require.ErrorContains(t, cmd.Execute(), tt.want)
+		})
+	}
+}
+
+func writeInternalReadinessSpec(t *testing.T, path, name, baseURL, resource string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(`name: %s
+description: %s API
+version: 0.1.0
+base_url: %s
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/%s-pp-cli/config.toml
+resources:
+  %s:
+    description: Manage %s
+    endpoints:
+      list:
+        method: GET
+        path: /%s
+        description: List %s
+        response: {type: array, item: Item}
+types:
+  Item:
+    fields:
+      - {name: id, type: string}
+`, name, name, baseURL, name, resource, resource, resource, resource)), 0o644))
+}
+
+func findingCodes(findings []readinessFinding) []string {
+	codes := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		codes = append(codes, finding.Code)
+	}
+	return codes
+}
+
 // TestGenerateCmdForcePreservesIssue907HandEdits exercises the canonical
 // hand-edit shapes that --force must preserve across regen:
 //  1. decl-set additions to a templated client file (added function)

--- a/internal/cli/readiness.go
+++ b/internal/cli/readiness.go
@@ -116,7 +116,8 @@ func buildReadinessReport(apiSpec *spec.APISpec, opts readinessReportOptions) re
 	auth := readinessAuthSummary(apiSpec.Auth)
 	syncable := profile.SyncableResourceNames()
 	dependent := readinessDependentResourceNames(profile.DependentSyncResources)
-	findings := readinessFindings(apiSpec, opts, auth, endpointCount, readCount, writeCount, syncable, dependent)
+	typedEndpointCount := apiSpec.TypedEndpointCount()
+	findings := readinessFindings(apiSpec, opts, auth, endpointCount, typedEndpointCount, readCount, writeCount, syncable, dependent)
 
 	report := readinessReport{
 		SchemaVersion: readinessSchemaVersion,
@@ -146,8 +147,8 @@ func buildReadinessReport(apiSpec *spec.APISpec, opts readinessReportOptions) re
 		},
 		MCP: readinessMCP{
 			EffectiveTransports: apiSpec.EffectiveMCPTransports(),
-			TypedEndpointCount:  apiSpec.TypedEndpointCount(),
-			LargeSurface:        apiSpec.TypedEndpointCount() > spec.DefaultRemoteTransportEndpointThreshold,
+			TypedEndpointCount:  typedEndpointCount,
+			LargeSurface:        typedEndpointCount > spec.DefaultRemoteTransportEndpointThreshold,
 		},
 		Findings:  findings,
 		NextSteps: readinessNextSteps(apiSpec, opts, findings),
@@ -227,7 +228,7 @@ func readinessAuthSummary(auth spec.AuthConfig) readinessAuth {
 	}
 }
 
-func readinessFindings(apiSpec *spec.APISpec, opts readinessReportOptions, auth readinessAuth, endpointCount, readCount, writeCount int, syncable, dependent []string) []readinessFinding {
+func readinessFindings(apiSpec *spec.APISpec, opts readinessReportOptions, auth readinessAuth, endpointCount, typedEndpointCount, readCount, writeCount int, syncable, dependent []string) []readinessFinding {
 	var findings []readinessFinding
 	add := func(severity, category, code, message, recommendation string) {
 		findings = append(findings, readinessFinding{
@@ -261,7 +262,7 @@ func readinessFindings(apiSpec *spec.APISpec, opts readinessReportOptions, auth 
 	if readCount > 0 && len(syncable) == 0 && len(dependent) == 0 {
 		add("warning", "data_layer", "no_syncable_resources", "No syncable resources were detected for the local data layer.", "Confirm list endpoints return arrays or envelopes with stable item IDs.")
 	}
-	if apiSpec.TypedEndpointCount() > spec.DefaultRemoteTransportEndpointThreshold && len(apiSpec.MCP.Transport) == 0 && !apiSpec.HasMCPTransport("http") {
+	if typedEndpointCount > spec.DefaultRemoteTransportEndpointThreshold && len(apiSpec.MCP.Transport) == 0 && !apiSpec.HasMCPTransport("http") {
 		add("warning", "mcp", "large_mcp_surface_stdio_only", "The typed endpoint surface is large and defaults to stdio-only MCP transport.", "Add explicit mcp.transport or MCP intents if remote agent access is important.")
 	}
 	if apiSpec.EffectiveHTTPTransport() != spec.HTTPTransportStandard || apiSpec.SpecSource == "sniffed" {
@@ -323,6 +324,9 @@ func readinessGenerateCommand(apiSpec *spec.APISpec, opts readinessReportOptions
 	}
 	if apiSpec != nil && apiSpec.Name != "" {
 		parts = append(parts, "--name", readinessShellArg(apiSpec.Name))
+	}
+	if opts.OutputDir != "" {
+		parts = append(parts, "--output", readinessShellArg(opts.OutputDir))
 	}
 	return strings.Join(parts, " ")
 }
@@ -403,11 +407,10 @@ func renderReadinessMarkdown(report readinessReport) string {
 		fmt.Fprintf(&b, "- none\n")
 	} else {
 		for _, finding := range report.Findings {
-			fmt.Fprintf(&b, "- %s [%s/%s]: %s", strings.ToUpper(finding.Severity), finding.Category, finding.Code, finding.Message)
+			fmt.Fprintf(&b, "- %s [%s/%s]: %s\n", strings.ToUpper(finding.Severity), finding.Category, finding.Code, finding.Message)
 			if finding.Recommendation != "" {
-				fmt.Fprintf(&b, " Recommendation: %s", finding.Recommendation)
+				fmt.Fprintf(&b, "  Recommendation: %s\n", finding.Recommendation)
 			}
-			fmt.Fprintf(&b, "\n")
 		}
 	}
 	fmt.Fprintf(&b, "\n")

--- a/internal/cli/readiness.go
+++ b/internal/cli/readiness.go
@@ -1,0 +1,470 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/browsersniff"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/generator"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+)
+
+const readinessSchemaVersion = 1
+
+type readinessReportOptions struct {
+	SpecFiles                   []string
+	OutputDir                   string
+	TrafficAnalysis             *browsersniff.TrafficAnalysis
+	PlaceholderBaseURLSpecFiles []string
+	AsJSON                      bool
+}
+
+type readinessReport struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Verdict       string              `json:"verdict"`
+	Inputs        readinessInputs     `json:"inputs"`
+	Summary       readinessSummary    `json:"summary"`
+	Auth          readinessAuth       `json:"auth"`
+	DataLayer     readinessDataLayer  `json:"data_layer"`
+	MCP           readinessMCP        `json:"mcp"`
+	Findings      []readinessFinding  `json:"findings"`
+	NextSteps     []readinessNextStep `json:"next_steps"`
+}
+
+type readinessInputs struct {
+	SpecFiles  []string `json:"spec_files"`
+	OutputDir  string   `json:"output_dir"`
+	SpecSource string   `json:"spec_source,omitempty"`
+}
+
+type readinessSummary struct {
+	APIName            string `json:"api_name"`
+	DisplayName        string `json:"display_name,omitempty"`
+	BaseURL            string `json:"base_url,omitempty"`
+	ResourceCount      int    `json:"resource_count"`
+	EndpointCount      int    `json:"endpoint_count"`
+	ReadEndpointCount  int    `json:"read_endpoint_count"`
+	WriteEndpointCount int    `json:"write_endpoint_count"`
+}
+
+type readinessAuth struct {
+	Type                   string   `json:"type"`
+	Required               bool     `json:"required"`
+	Optional               bool     `json:"optional"`
+	EnvVars                []string `json:"env_vars,omitempty"`
+	RequestEnvVars         []string `json:"request_env_vars,omitempty"`
+	KeyURL                 string   `json:"key_url,omitempty"`
+	VerifyPath             string   `json:"verify_path,omitempty"`
+	VerifyQuery            bool     `json:"verify_query,omitempty"`
+	RequiresBrowserSession bool     `json:"requires_browser_session,omitempty"`
+	BrowserSessionReason   string   `json:"browser_session_reason,omitempty"`
+}
+
+type readinessDataLayer struct {
+	Store                  bool     `json:"store"`
+	Sync                   bool     `json:"sync"`
+	Search                 bool     `json:"search"`
+	Analytics              bool     `json:"analytics"`
+	SyncableResources      []string `json:"syncable_resources,omitempty"`
+	DependentSyncResources []string `json:"dependent_sync_resources,omitempty"`
+	DefaultSyncConcurrency int      `json:"default_sync_concurrency"`
+}
+
+type readinessMCP struct {
+	EffectiveTransports []string `json:"effective_transports"`
+	TypedEndpointCount  int      `json:"typed_endpoint_count"`
+	LargeSurface        bool     `json:"large_surface"`
+}
+
+type readinessFinding struct {
+	Severity       string `json:"severity"`
+	Category       string `json:"category"`
+	Code           string `json:"code"`
+	Message        string `json:"message"`
+	Recommendation string `json:"recommendation,omitempty"`
+}
+
+type readinessNextStep struct {
+	Label   string `json:"label"`
+	Command string `json:"command,omitempty"`
+}
+
+func printReadinessReport(w io.Writer, apiSpec *spec.APISpec, opts readinessReportOptions) error {
+	report := buildReadinessReport(apiSpec, opts)
+	if opts.AsJSON {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	_, err := fmt.Fprint(w, renderReadinessMarkdown(report))
+	return err
+}
+
+func buildReadinessReport(apiSpec *spec.APISpec, opts readinessReportOptions) readinessReport {
+	profile := profiler.Profile(apiSpec)
+	visionSet := generator.SelectVisionTemplates(profile.ToVisionaryPlan(apiSpec.Name))
+	if apiSpec.Streaming.Enabled() {
+		visionSet.Store = true
+		visionSet.Sync = true
+	}
+
+	resourceCount, endpointCount, readCount, writeCount := readinessCounts(apiSpec)
+	auth := readinessAuthSummary(apiSpec.Auth)
+	syncable := profile.SyncableResourceNames()
+	dependent := readinessDependentResourceNames(profile.DependentSyncResources)
+	findings := readinessFindings(apiSpec, opts, auth, endpointCount, readCount, writeCount, syncable, dependent)
+
+	report := readinessReport{
+		SchemaVersion: readinessSchemaVersion,
+		Inputs: readinessInputs{
+			SpecFiles:  append([]string(nil), opts.SpecFiles...),
+			OutputDir:  opts.OutputDir,
+			SpecSource: strings.TrimSpace(apiSpec.SpecSource),
+		},
+		Summary: readinessSummary{
+			APIName:            apiSpec.Name,
+			DisplayName:        apiSpec.EffectiveDisplayName(),
+			BaseURL:            apiSpec.BaseURL,
+			ResourceCount:      resourceCount,
+			EndpointCount:      endpointCount,
+			ReadEndpointCount:  readCount,
+			WriteEndpointCount: writeCount,
+		},
+		Auth: auth,
+		DataLayer: readinessDataLayer{
+			Store:                  visionSet.Store,
+			Sync:                   visionSet.Sync,
+			Search:                 visionSet.Search,
+			Analytics:              visionSet.Analytics,
+			SyncableResources:      syncable,
+			DependentSyncResources: dependent,
+			DefaultSyncConcurrency: apiSpec.SyncDefaultConcurrency(),
+		},
+		MCP: readinessMCP{
+			EffectiveTransports: apiSpec.EffectiveMCPTransports(),
+			TypedEndpointCount:  apiSpec.TypedEndpointCount(),
+			LargeSurface:        apiSpec.TypedEndpointCount() > spec.DefaultRemoteTransportEndpointThreshold,
+		},
+		Findings:  findings,
+		NextSteps: readinessNextSteps(apiSpec, opts, findings),
+	}
+	report.Verdict = readinessVerdict(findings)
+	return report
+}
+
+func readinessCounts(apiSpec *spec.APISpec) (resourceCount, endpointCount, readCount, writeCount int) {
+	if apiSpec == nil {
+		return 0, 0, 0, 0
+	}
+	for _, name := range sortedResourceNames(apiSpec.Resources) {
+		resourceCount++
+		r := apiSpec.Resources[name]
+		e, read, write := readinessEndpointCounts(r.Endpoints)
+		endpointCount += e
+		readCount += read
+		writeCount += write
+		for _, subName := range sortedResourceNames(r.SubResources) {
+			resourceCount++
+			sub := r.SubResources[subName]
+			e, read, write = readinessEndpointCounts(sub.Endpoints)
+			endpointCount += e
+			readCount += read
+			writeCount += write
+		}
+	}
+	return resourceCount, endpointCount, readCount, writeCount
+}
+
+func readinessEndpointCounts(endpoints map[string]spec.Endpoint) (endpointCount, readCount, writeCount int) {
+	for _, name := range sortedEndpointNames(endpoints) {
+		endpointCount++
+		if generator.EndpointIsWriteCommand(endpoints[name], name) {
+			writeCount++
+		} else {
+			readCount++
+		}
+	}
+	return endpointCount, readCount, writeCount
+}
+
+func readinessAuthSummary(auth spec.AuthConfig) readinessAuth {
+	authType := strings.TrimSpace(auth.Type)
+	if authType == "" {
+		authType = "none"
+	}
+	normalized := auth
+	normalized.NormalizeEnvVarSpecs("")
+	var envVars []string
+	var requestEnvVars []string
+	for _, envVar := range normalized.EnvVarSpecs {
+		name := strings.TrimSpace(envVar.Name)
+		if name == "" {
+			continue
+		}
+		envVars = append(envVars, name)
+		if envVar.IsRequestCredential() {
+			requestEnvVars = append(requestEnvVars, name)
+		}
+	}
+	sort.Strings(envVars)
+	sort.Strings(requestEnvVars)
+	required := authType != "none" && !auth.Optional
+	return readinessAuth{
+		Type:                   authType,
+		Required:               required,
+		Optional:               auth.Optional,
+		EnvVars:                envVars,
+		RequestEnvVars:         requestEnvVars,
+		KeyURL:                 strings.TrimSpace(auth.KeyURL),
+		VerifyPath:             strings.TrimSpace(auth.VerifyPath),
+		VerifyQuery:            strings.TrimSpace(auth.VerifyQuery) != "",
+		RequiresBrowserSession: auth.RequiresBrowserSession,
+		BrowserSessionReason:   strings.TrimSpace(auth.BrowserSessionReason),
+	}
+}
+
+func readinessFindings(apiSpec *spec.APISpec, opts readinessReportOptions, auth readinessAuth, endpointCount, readCount, writeCount int, syncable, dependent []string) []readinessFinding {
+	var findings []readinessFinding
+	add := func(severity, category, code, message, recommendation string) {
+		findings = append(findings, readinessFinding{
+			Severity:       severity,
+			Category:       category,
+			Code:           code,
+			Message:        message,
+			Recommendation: recommendation,
+		})
+	}
+
+	if endpointCount == 0 {
+		add("blocker", "surface", "zero_endpoints", "No typed endpoints were found in the parsed spec.", "Use a richer spec or add endpoint definitions before generating.")
+	}
+	if apiSpec.BaseURLIsPlaceholder || apiSpec.BaseURL == spec.PlaceholderBaseURL || len(opts.PlaceholderBaseURLSpecFiles) > 0 {
+		message := "The spec does not declare a usable API base URL."
+		if len(opts.PlaceholderBaseURLSpecFiles) > 0 {
+			message = fmt.Sprintf("The spec does not declare a usable API base URL: %s.", strings.Join(opts.PlaceholderBaseURLSpecFiles, ", "))
+		}
+		add("blocker", "spec", "missing_base_url", message, "Add a real servers block/base_url or supply a base URL through discovery before generating.")
+	}
+	if trafficAnalysisRequiresUnshippablePageContext(opts.TrafficAnalysis) {
+		add("blocker", "reachability", "browser_page_context_required", "Traffic analysis says this target requires live browser page-context execution.", "Re-run discovery for a direct, browser-clearance, or browser-http replayable surface.")
+	}
+	if auth.Required && len(auth.EnvVars) == 0 && auth.KeyURL == "" {
+		add("warning", "auth", "auth_guidance_missing", "Auth is required, but no credential env vars or key URL are declared.", "Add auth env vars and a key URL so generated setup and doctor output are actionable.")
+	}
+	if auth.Required && auth.VerifyPath == "" && !auth.VerifyQuery {
+		add("warning", "auth", "auth_verify_missing", "Auth is required, but no verify path/query is configured.", "Add auth.verify_path or auth.verify_query so doctor can validate credentials precisely.")
+	}
+	if readCount > 0 && len(syncable) == 0 && len(dependent) == 0 {
+		add("warning", "data_layer", "no_syncable_resources", "No syncable resources were detected for the local data layer.", "Confirm list endpoints return arrays or envelopes with stable item IDs.")
+	}
+	if apiSpec.TypedEndpointCount() > spec.DefaultRemoteTransportEndpointThreshold && len(apiSpec.MCP.Transport) == 0 && !apiSpec.HasMCPTransport("http") {
+		add("warning", "mcp", "large_mcp_surface_stdio_only", "The typed endpoint surface is large and defaults to stdio-only MCP transport.", "Add explicit mcp.transport or MCP intents if remote agent access is important.")
+	}
+	if apiSpec.EffectiveHTTPTransport() != spec.HTTPTransportStandard || apiSpec.SpecSource == "sniffed" {
+		add("warning", "transport", "browser_transport_risk", "This spec uses browser-facing or sniffed transport assumptions.", "Review reachability/auth evidence before publishing the generated CLI.")
+	}
+	if writeCount > 0 {
+		add("info", "surface", "mutating_commands_present", fmt.Sprintf("%d mutating endpoint(s) will be generated.", writeCount), "Use --dry-run/--agent and generated confirmation safeguards when testing writes.")
+	}
+	if auth.Optional {
+		add("info", "auth", "auth_optional", "Auth is optional for this spec.", "Generated doctor output should treat missing optional credentials as informational.")
+	}
+	return findings
+}
+
+func readinessVerdict(findings []readinessFinding) string {
+	verdict := "ready"
+	for _, finding := range findings {
+		switch finding.Severity {
+		case "blocker":
+			return "blocked"
+		case "warning":
+			verdict = "warn"
+		}
+	}
+	return verdict
+}
+
+func readinessNextSteps(apiSpec *spec.APISpec, opts readinessReportOptions, findings []readinessFinding) []readinessNextStep {
+	var steps []readinessNextStep
+	for _, finding := range findings {
+		switch finding.Code {
+		case "missing_base_url":
+			steps = append(steps, readinessNextStep{Label: "Add a real API base URL to the spec"})
+		case "auth_guidance_missing":
+			steps = append(steps, readinessNextStep{Label: "Declare credential env vars and an auth key URL"})
+		case "auth_verify_missing":
+			steps = append(steps, readinessNextStep{Label: "Add an auth verify path or query"})
+		case "browser_page_context_required":
+			steps = append(steps, readinessNextStep{Label: "Repeat discovery for a replayable HTTP surface"})
+		}
+	}
+	if apiSpec != nil && apiSpec.Name != "" {
+		steps = append(steps, readinessNextStep{
+			Label:   "Generate after reviewing readiness findings",
+			Command: readinessGenerateCommand(apiSpec, opts),
+		})
+	}
+	return dedupeReadinessNextSteps(steps)
+}
+
+func readinessGenerateCommand(apiSpec *spec.APISpec, opts readinessReportOptions) string {
+	parts := []string{"cli-printing-press", "generate"}
+	if len(opts.SpecFiles) == 0 {
+		parts = append(parts, "--spec", "<spec>")
+	} else {
+		for _, specFile := range opts.SpecFiles {
+			parts = append(parts, "--spec", readinessShellArg(specFile))
+		}
+	}
+	if apiSpec != nil && apiSpec.Name != "" {
+		parts = append(parts, "--name", readinessShellArg(apiSpec.Name))
+	}
+	return strings.Join(parts, " ")
+}
+
+func readinessShellArg(value string) string {
+	if value == "" {
+		return "''"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '-', '_', '.', '/', ':', '@', '+', '=':
+			continue
+		}
+		return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	}
+	return value
+}
+
+func renderReadinessMarkdown(report readinessReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Print Readiness Report\n\n")
+	fmt.Fprintf(&b, "Verdict: %s\n\n", strings.ToUpper(report.Verdict))
+
+	fmt.Fprintf(&b, "## Generated Surface\n")
+	fmt.Fprintf(&b, "- API: %s\n", report.Summary.APIName)
+	if report.Summary.DisplayName != "" && report.Summary.DisplayName != report.Summary.APIName {
+		fmt.Fprintf(&b, "- Display name: %s\n", report.Summary.DisplayName)
+	}
+	if report.Summary.BaseURL != "" {
+		fmt.Fprintf(&b, "- Base URL: %s\n", report.Summary.BaseURL)
+	}
+	fmt.Fprintf(&b, "- Output dir: %s\n", report.Inputs.OutputDir)
+	fmt.Fprintf(&b, "- Resources: %d\n", report.Summary.ResourceCount)
+	fmt.Fprintf(&b, "- Endpoints: %d (%d read, %d write)\n\n", report.Summary.EndpointCount, report.Summary.ReadEndpointCount, report.Summary.WriteEndpointCount)
+
+	fmt.Fprintf(&b, "## Auth Readiness\n")
+	fmt.Fprintf(&b, "- Type: %s\n", report.Auth.Type)
+	fmt.Fprintf(&b, "- Required: %t\n", report.Auth.Required)
+	if len(report.Auth.EnvVars) > 0 {
+		fmt.Fprintf(&b, "- Env vars: %s\n", strings.Join(report.Auth.EnvVars, ", "))
+	}
+	if report.Auth.KeyURL != "" {
+		fmt.Fprintf(&b, "- Key URL: %s\n", report.Auth.KeyURL)
+	}
+	if report.Auth.VerifyPath != "" {
+		fmt.Fprintf(&b, "- Verify path: %s\n", report.Auth.VerifyPath)
+	} else if report.Auth.VerifyQuery {
+		fmt.Fprintf(&b, "- Verify query: configured\n")
+	}
+	if report.Auth.RequiresBrowserSession {
+		fmt.Fprintf(&b, "- Browser session required: %t\n", report.Auth.RequiresBrowserSession)
+	}
+	fmt.Fprintf(&b, "\n")
+
+	fmt.Fprintf(&b, "## Local Data Layer\n")
+	fmt.Fprintf(&b, "- Store: %t\n", report.DataLayer.Store)
+	fmt.Fprintf(&b, "- Sync: %t\n", report.DataLayer.Sync)
+	fmt.Fprintf(&b, "- Search: %t\n", report.DataLayer.Search)
+	fmt.Fprintf(&b, "- Analytics: %t\n", report.DataLayer.Analytics)
+	if len(report.DataLayer.SyncableResources) > 0 {
+		fmt.Fprintf(&b, "- Syncable resources: %s\n", strings.Join(report.DataLayer.SyncableResources, ", "))
+	}
+	if len(report.DataLayer.DependentSyncResources) > 0 {
+		fmt.Fprintf(&b, "- Dependent sync resources: %s\n", strings.Join(report.DataLayer.DependentSyncResources, ", "))
+	}
+	fmt.Fprintf(&b, "- Default sync concurrency: %d\n\n", report.DataLayer.DefaultSyncConcurrency)
+
+	fmt.Fprintf(&b, "## MCP Surface\n")
+	fmt.Fprintf(&b, "- Transports: %s\n", strings.Join(report.MCP.EffectiveTransports, ", "))
+	fmt.Fprintf(&b, "- Typed endpoint count: %d\n", report.MCP.TypedEndpointCount)
+	fmt.Fprintf(&b, "- Large surface: %t\n\n", report.MCP.LargeSurface)
+
+	fmt.Fprintf(&b, "## Findings\n")
+	if len(report.Findings) == 0 {
+		fmt.Fprintf(&b, "- none\n")
+	} else {
+		for _, finding := range report.Findings {
+			fmt.Fprintf(&b, "- %s [%s/%s]: %s", strings.ToUpper(finding.Severity), finding.Category, finding.Code, finding.Message)
+			if finding.Recommendation != "" {
+				fmt.Fprintf(&b, " Recommendation: %s", finding.Recommendation)
+			}
+			fmt.Fprintf(&b, "\n")
+		}
+	}
+	fmt.Fprintf(&b, "\n")
+
+	if len(report.NextSteps) > 0 {
+		fmt.Fprintf(&b, "## Recommended Next Steps\n")
+		for _, step := range report.NextSteps {
+			if step.Command != "" {
+				fmt.Fprintf(&b, "- %s: `%s`\n", step.Label, step.Command)
+			} else {
+				fmt.Fprintf(&b, "- %s\n", step.Label)
+			}
+		}
+		fmt.Fprintf(&b, "\n")
+	}
+	return b.String()
+}
+
+func readinessDependentResourceNames(resources []profiler.DependentResource) []string {
+	names := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		if name := strings.TrimSpace(resource.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedResourceNames(resources map[string]spec.Resource) []string {
+	names := make([]string, 0, len(resources))
+	for name := range resources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedEndpointNames(endpoints map[string]spec.Endpoint) []string {
+	names := make([]string, 0, len(endpoints))
+	for name := range endpoints {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func dedupeReadinessNextSteps(steps []readinessNextStep) []readinessNextStep {
+	seen := map[string]struct{}{}
+	out := make([]readinessNextStep, 0, len(steps))
+	for _, step := range steps {
+		key := step.Label + "\x00" + step.Command
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, step)
+	}
+	return out
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -126,6 +126,7 @@ func newGenerateCmd() *cobra.Command {
 	var polish bool
 	var asJSON bool
 	var dryRun bool
+	var readinessReport bool
 	var specSource string
 	var category string
 	var clientPattern string
@@ -149,6 +150,9 @@ func newGenerateCmd() *cobra.Command {
 		Example: `  # Generate from a local OpenAPI spec
   cli-printing-press generate --spec ./openapi.yaml
 
+  # Inspect readiness before generating files
+  cli-printing-press generate --spec ./openapi.yaml --readiness-report
+
   # Generate from a URL and recreate output while preserving hand-authored CLI files
   cli-printing-press generate --spec https://api.example.com/openapi.json --force
 
@@ -158,10 +162,16 @@ func newGenerateCmd() *cobra.Command {
   # Multiple specs merged into one CLI
   cli-printing-press generate --spec api-v1.yaml --spec api-v2.yaml --name myapi`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if readinessReport && dryRun {
+				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report cannot be combined with --dry-run")}
+			}
 			if dryRun && docsURL != "" {
 				return fmt.Errorf("--dry-run cannot be used with --docs (doc scraping has unavoidable side effects)")
 			}
 			if docsURL != "" {
+				if readinessReport {
+					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with --docs in v1; provide a spec with --spec")}
+				}
 				apiName := cliName
 				if apiName == "" {
 					apiName = "myapi"
@@ -259,6 +269,9 @@ func newGenerateCmd() *cobra.Command {
 			}
 
 			if planFile != "" {
+				if readinessReport {
+					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with --plan in v1; provide a spec with --spec")}
+				}
 				if (generateMCPFlagOverrides{Orchestration: mcpOrchestration, Transport: mcpTransport, EndpointTools: mcpEndpointTools, IntentsPath: mcpIntentsPath}).hasAny() {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--mcp-* flags cannot be used with --plan")}
 				}
@@ -329,6 +342,9 @@ func newGenerateCmd() *cobra.Command {
 				}
 				singleSpecData = data
 				if devicespec.LooksLikeDeviceSpec(data) {
+					if readinessReport {
+						return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with BLE device specs in v1; provide an API spec with --spec")}
+					}
 					deviceSpec, err := devicespec.ParseBytes(data)
 					if err != nil {
 						return &ExitError{Code: ExitSpecError, Err: fmt.Errorf("parsing device spec %s: %w", specFiles[0], err)}
@@ -402,6 +418,7 @@ func newGenerateCmd() *cobra.Command {
 
 			var specs []*spec.APISpec
 			var specRawBytes [][]byte // raw spec data for archiving
+			var placeholderBaseURLSpecFiles []string
 			for i, specFile := range specFiles {
 				var data []byte
 				var err error
@@ -433,6 +450,11 @@ func newGenerateCmd() *cobra.Command {
 
 				enrichSpecFromCatalog(apiSpec, catalogSpecLookupRefs(specFiles, specURL)...)
 				if apiSpec.BaseURLIsPlaceholder {
+					if readinessReport {
+						placeholderBaseURLSpecFiles = append(placeholderBaseURLSpecFiles, specFile)
+						specs = append(specs, apiSpec)
+						continue
+					}
 					return &ExitError{Code: ExitSpecError, Err: fmt.Errorf("spec %s declares no `servers:` block and no per-operation servers; the generator cannot resolve a real base URL and refuses to ship a CLI whose `doctor` would DNS-fail on every call. Add a `servers:` block with the real API host, or run via crowd-sniff with `--base-url` to supply one", specFile)}
 				}
 
@@ -476,9 +498,24 @@ func newGenerateCmd() *cobra.Command {
 			}
 			applyLibraryAttributionForGenerate(apiSpec, reprintContributor)
 
-			absOut, explicitOutput, snapshotDir, err := resolveGenerateOutputDir(outputDir, apiSpec.Name, force, !dryRun)
+			absOut, explicitOutput, snapshotDir, err := resolveGenerateOutputDir(outputDir, apiSpec.Name, force, !dryRun && !readinessReport)
 			if err != nil {
 				return err
+			}
+			if readinessReport {
+				trafficAnalysis, err := loadTrafficAnalysisForGenerate(trafficAnalysisPath, specFiles, apiSpec.SpecSource)
+				if err != nil {
+					return &ExitError{Code: ExitInputError, Err: err}
+				}
+				browsersniff.ApplyReachabilityDefaults(apiSpec, trafficAnalysis)
+				applyHTTPTransportDefault(apiSpec, trafficAnalysis)
+				return printReadinessReport(cmd.OutOrStdout(), apiSpec, readinessReportOptions{
+					SpecFiles:                   specFiles,
+					OutputDir:                   absOut,
+					TrafficAnalysis:             trafficAnalysis,
+					PlaceholderBaseURLSpecFiles: placeholderBaseURLSpecFiles,
+					AsJSON:                      asJSON,
+				})
 			}
 			if dryRun {
 				return printDryRun(apiSpec, absOut, specFiles)
@@ -586,6 +623,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Parse spec and show what would be generated without writing files (remote specs are still fetched)")
+	cmd.Flags().BoolVar(&readinessReport, "readiness-report", false, "Analyze whether the parsed spec is ready to generate a useful CLI without writing files")
 	cmd.Flags().StringVar(&specSource, "spec-source", "", "Spec provenance: official, community, sniffed/browser-sniffed, docs (affects generated client defaults like rate limiting)")
 	cmd.Flags().StringVar(&category, "category", "", "Public-library category for non-catalog generation")
 	cmd.Flags().StringVar(&clientPattern, "client-pattern", "", "HTTP client pattern: rest (default), proxy-envelope (wraps requests in POST envelope)")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -126,7 +126,7 @@ func newGenerateCmd() *cobra.Command {
 	var polish bool
 	var asJSON bool
 	var dryRun bool
-	var readinessReport bool
+	var readinessReportFlag bool
 	var specSource string
 	var category string
 	var clientPattern string
@@ -162,14 +162,14 @@ func newGenerateCmd() *cobra.Command {
   # Multiple specs merged into one CLI
   cli-printing-press generate --spec api-v1.yaml --spec api-v2.yaml --name myapi`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if readinessReport && dryRun {
+			if readinessReportFlag && dryRun {
 				return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report cannot be combined with --dry-run")}
 			}
 			if dryRun && docsURL != "" {
 				return fmt.Errorf("--dry-run cannot be used with --docs (doc scraping has unavoidable side effects)")
 			}
 			if docsURL != "" {
-				if readinessReport {
+				if readinessReportFlag {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with --docs in v1; provide a spec with --spec")}
 				}
 				apiName := cliName
@@ -269,7 +269,7 @@ func newGenerateCmd() *cobra.Command {
 			}
 
 			if planFile != "" {
-				if readinessReport {
+				if readinessReportFlag {
 					return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with --plan in v1; provide a spec with --spec")}
 				}
 				if (generateMCPFlagOverrides{Orchestration: mcpOrchestration, Transport: mcpTransport, EndpointTools: mcpEndpointTools, IntentsPath: mcpIntentsPath}).hasAny() {
@@ -342,7 +342,7 @@ func newGenerateCmd() *cobra.Command {
 				}
 				singleSpecData = data
 				if devicespec.LooksLikeDeviceSpec(data) {
-					if readinessReport {
+					if readinessReportFlag {
 						return &ExitError{Code: ExitInputError, Err: fmt.Errorf("--readiness-report is not supported with BLE device specs in v1; provide an API spec with --spec")}
 					}
 					deviceSpec, err := devicespec.ParseBytes(data)
@@ -450,7 +450,7 @@ func newGenerateCmd() *cobra.Command {
 
 				enrichSpecFromCatalog(apiSpec, catalogSpecLookupRefs(specFiles, specURL)...)
 				if apiSpec.BaseURLIsPlaceholder {
-					if readinessReport {
+					if readinessReportFlag {
 						placeholderBaseURLSpecFiles = append(placeholderBaseURLSpecFiles, specFile)
 						specs = append(specs, apiSpec)
 						continue
@@ -498,11 +498,11 @@ func newGenerateCmd() *cobra.Command {
 			}
 			applyLibraryAttributionForGenerate(apiSpec, reprintContributor)
 
-			absOut, explicitOutput, snapshotDir, err := resolveGenerateOutputDir(outputDir, apiSpec.Name, force, !dryRun && !readinessReport)
+			absOut, explicitOutput, snapshotDir, err := resolveGenerateOutputDir(outputDir, apiSpec.Name, force, !dryRun && !readinessReportFlag)
 			if err != nil {
 				return err
 			}
-			if readinessReport {
+			if readinessReportFlag {
 				trafficAnalysis, err := loadTrafficAnalysisForGenerate(trafficAnalysisPath, specFiles, apiSpec.SpecSource)
 				if err != nil {
 					return &ExitError{Code: ExitInputError, Err: err}
@@ -623,7 +623,7 @@ func newGenerateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&polish, "polish", false, "Run LLM polish pass on generated CLI (requires claude or codex CLI)")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Parse spec and show what would be generated without writing files (remote specs are still fetched)")
-	cmd.Flags().BoolVar(&readinessReport, "readiness-report", false, "Analyze whether the parsed spec is ready to generate a useful CLI without writing files")
+	cmd.Flags().BoolVar(&readinessReportFlag, "readiness-report", false, "Analyze whether the parsed spec is ready to generate a useful CLI without writing files")
 	cmd.Flags().StringVar(&specSource, "spec-source", "", "Spec provenance: official, community, sniffed/browser-sniffed, docs (affects generated client defaults like rate limiting)")
 	cmd.Flags().StringVar(&category, "category", "", "Public-library category for non-catalog generation")
 	cmd.Flags().StringVar(&clientPattern, "client-pattern", "", "HTTP client pattern: rest (default), proxy-envelope (wraps requests in POST envelope)")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1682,6 +1682,13 @@ func endpointIsWriteCommand(endpoint spec.Endpoint, opName string) bool {
 	return !bodyIsAllFilterShape(endpoint.Body)
 }
 
+// EndpointIsWriteCommand reports whether an endpoint mutates external state.
+// It exposes the generator's command classifier to pre-generation diagnostics
+// so reports can match the generated CLI/MCP safety annotations.
+func EndpointIsWriteCommand(endpoint spec.Endpoint, opName string) bool {
+	return endpointIsWriteCommand(endpoint, opName)
+}
+
 // endpointIsReadCommand is the inverse of endpointIsWriteCommand.
 // Templates use this through the IsReadOnly field on their data
 // structs to decide whether to emit Annotations["mcp:read-only"].


### PR DESCRIPTION
## Summary
- add `generate --readiness-report` to inspect API spec readiness without writing generated files
- support both Markdown and JSON report output with verdicts, findings, and next-step commands
- surface auth, local data layer, MCP transport, base URL, browser transport, and mutating-command readiness signals
- add focused generate-command coverage for report output, blocked findings, multi-spec behavior, and unsupported input modes

## Why
Product and contributor workflows need a quick way to understand whether a spec is ready to produce a useful generated CLI before running the full generator. This report makes the pre-generation state visible and actionable.

Closes #3043

## Testing
- `go test ./internal/cli -run 'TestGenerateReadinessReport|TestGenerateCmdLenientMissingLocalSchemaRefs'`
- `go test ./internal/cli`
- `scripts/golden.sh verify`
- `go test ./...`