### PR TITLE
fix(ci): honor latest codeowner review state

### DIFF
--- a/.github/workflows/ready-to-merge-guard.yml
+++ b/.github/workflows/ready-to-merge-guard.yml
@@ -71,9 +71,16 @@ jobs:
           approved="$(
             jq -r '
               [ .[]
-                | select(.state == "APPROVED")
-                | .user.login
-              ] | unique | join(",")
+                | select(.user.login == "tmchow" or .user.login == "mvanhorn")
+                | select(.state != "COMMENTED")
+                | {user: .user.login, state, submitted_at}
+              ]
+              | sort_by(.submitted_at)
+              | reduce .[] as $review ({}; .[$review.user] = $review.state)
+              | to_entries
+              | map(select(.value == "APPROVED") | .key)
+              | unique
+              | join(",")
             ' <<<"${reviews_json}"
           )"
           if grep -q 'tmchow' <<<"${approved}" || grep -q 'mvanhorn' <<<"${approved}"; then


### PR DESCRIPTION
## Summary
- Follow-up to #3061 Greptile feedback after the PR merged.
- Compute codeowner approval from each codeowner's latest review state, not any historical APPROVED review.
- Prevent approve-then-changes-requested from clearing the ready-to-merge guard incorrectly.

## Verification
- `jq` fixture checks for approve→changes-requested, changes-requested→approve, and both-codeowner approval cases
- `bash -n` on extracted workflow `run:` script
- `git diff --check`
