### PR TITLE
fix(cli): normalize verify-skill line endings

### DIFF
--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -165,7 +165,9 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 			Evidence: fmt.Sprintf("expected canonical block:\n%s", expected),
 		}, true, false, nil
 	}
-	if got == expected {
+	normalizedExpected := normalizeCanonicalSectionLineEndings(expected)
+	normalizedGot := normalizeCanonicalSectionLineEndings(got)
+	if normalizedGot == normalizedExpected {
 		return canonicalFinding{}, false, false, nil
 	}
 	return canonicalFinding{
@@ -173,8 +175,13 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 		Severity: "error",
 		Command:  "(file: SKILL.md)",
 		Detail:   "install section drift: hand-edit detected in a generator-owned section. Regenerate the printed CLI to restore the canonical text — do not edit this section by hand.",
-		Evidence: fmt.Sprintf("expected (from generator):\n%s\n\ngot (from SKILL.md):\n%s", expected, got),
+		Evidence: fmt.Sprintf("expected (from generator):\n%s\n\ngot (from SKILL.md):\n%s", normalizedExpected, normalizedGot),
 	}, true, false, nil
+}
+
+func normalizeCanonicalSectionLineEndings(section string) string {
+	section = strings.ReplaceAll(section, "\r\n", "\n")
+	return strings.ReplaceAll(section, "\r", "\n")
 }
 
 // ExtractInstallSectionForTest re-exports the generator's extractor so

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -697,6 +697,24 @@ func TestVerifySkill_CanonicalSectionsPassesOnFreshFixture(t *testing.T) {
 	require.Contains(t, string(out), "canonical-sections passed")
 }
 
+// TestVerifySkill_CanonicalSectionsAllowsCRLFLineEndings guards against the
+// Windows false drift from issue #3035: a generator-owned SKILL.md install
+// section must not fail solely because the file was written or checked out
+// with CRLF line endings.
+func TestVerifySkill_CanonicalSectionsAllowsCRLFLineEndings(t *testing.T) {
+	t.Parallel()
+	bin := buildPrintingPressBinary(t)
+	crlfInstallSection := strings.ReplaceAll(
+		generator.CanonicalSkillInstallSection("myapi", "productivity"),
+		"\n",
+		"\r\n",
+	)
+	dir := writeCanonicalFixture(t, "myapi", "productivity", crlfInstallSection)
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "canonical-sections").CombinedOutput()
+	require.NoError(t, err, "CRLF-only install section drift must pass canonical-sections: %s", string(out))
+	require.Contains(t, string(out), "canonical-sections passed")
+}
+
 // TestVerifySkill_CanonicalSectionsCatchesFlagStrip is the regression
 // guard for the trigger-dev SKILL slip — an automation loop stripped
 // `--cli-only` from the npx installer line to silence a verify-skill


### PR DESCRIPTION
## Summary

- Normalize line endings before `verify-skill` compares the generator-owned `SKILL.md` install section.
- Keep missing/malformed sections and real text drift failing the `canonical-sections` check.
- Add a regression test for CRLF-only install-section drift on Windows-style files.

Closes #3035.

## Why

A freshly generated Windows CLI can produce or check out `SKILL.md` with CRLF line endings, while `generator.CanonicalSkillInstallSection` uses LF. The verifier was treating that invisible line-ending difference as a hand-edit to generator-owned text, blocking shipcheck for otherwise clean generated CLIs.

## Validation

- `go test -p=1 ./internal/cli -run 'TestVerifySkill_CanonicalSections' -count=1`
- `go test -p=1 ./internal/cli -run 'TestVerifySkill' -count=1`
- `go test -p=1 ./internal/cli -count=1`
- `git diff --check`

## Review

Author/self-review completed before opening; this is ready for maintainer review.
