### PR TITLE
fix(test): drain captured stdout pipe to prevent deadlock

### DIFF
--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -26,16 +26,26 @@ func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 
 	outCh := make(chan string, 1)
 	go func() {
+		defer r.Close()
 		out, _ := io.ReadAll(r)
 		outCh <- string(out)
 	}()
 
+	stdoutRestored := false
+	restoreStdout := func() {
+		if stdoutRestored {
+			return
+		}
+		w.Close()
+		os.Stdout = origStdout
+		stdoutRestored = true
+	}
+	defer restoreStdout()
+
 	execErr := fn()
-	w.Close()
-	os.Stdout = origStdout
+	restoreStdout()
 
 	out := <-outCh
-	r.Close()
 	return out, execErr
 }
 
@@ -47,6 +57,27 @@ func captureStdout(t *testing.T, fn func()) string {
 	})
 	require.NoError(t, err)
 	return out
+}
+
+func TestRunWithCapturedStdoutRestoresStdoutAfterPanic(t *testing.T) {
+	origStdout := os.Stdout
+	var didPanic bool
+	var restored bool
+
+	func() {
+		defer func() {
+			didPanic = recover() != nil
+			restored = os.Stdout == origStdout
+			os.Stdout = origStdout
+		}()
+
+		_, _ = runWithCapturedStdout(t, func() error {
+			panic("boom")
+		})
+	}()
+
+	require.True(t, didPanic)
+	assert.True(t, restored, "stdout should be restored while unwinding a panic")
 }
 
 func TestCatalogListJSON(t *testing.T) {

--- a/internal/cli/catalog_test.go
+++ b/internal/cli/catalog_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 // runWithCapturedStdout executes fn while capturing os.Stdout via a pipe.
+//
+// The pipe is drained by a background goroutine that starts before fn runs, so
+// fn never blocks on a full OS pipe buffer. Draining only after fn returned
+// would deadlock once fn writes more than the buffer holds (notably smaller on
+// Windows), so the reader must run concurrently with the writer.
 func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -19,13 +24,19 @@ func runWithCapturedStdout(t *testing.T, fn func() error) (string, error) {
 	origStdout := os.Stdout
 	os.Stdout = w
 
+	outCh := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		outCh <- string(out)
+	}()
+
 	execErr := fn()
 	w.Close()
 	os.Stdout = origStdout
 
-	out, _ := io.ReadAll(r)
+	out := <-outCh
 	r.Close()
-	return string(out), execErr
+	return out, execErr
 }
 
 func captureStdout(t *testing.T, fn func()) string {


### PR DESCRIPTION
## Intent

Fix a pre-existing deadlock in the `internal/cli` test helper
`runWithCapturedStdout` that hangs `TestCatalogListJSON` (and any other test
using the helper) on Windows.

Issue: N/A

## Approach

`runWithCapturedStdout` redirects `os.Stdout` to an `os.Pipe`, runs the command,
and only reads the pipe **after** the command returns:

```go
os.Stdout = w
execErr := fn()        // writes all output to the pipe
w.Close()
out, _ := io.ReadAll(r) // only drained here, after fn() returned
```

Any command whose output exceeds the OS pipe buffer blocks on write before it
can return, so the reader never runs and the test hangs until the global test
timeout. The pipe buffer is notably smaller on Windows, so this reproduces there
first; it is a latent deadlock everywhere once captured output is large enough.

The fix drains the pipe in a goroutine started **before** the command runs, so
the writer never blocks:

```go
outCh := make(chan string, 1)
go func() { out, _ := io.ReadAll(r); outCh <- string(out) }()
execErr := fn()
w.Close()
out := <-outCh
```

## Scope

Primary area: `internal/cli/catalog_test.go` (test helper only).

Why this belongs in this repo: it's a generator-repo test-harness bug. No
production code changes.

## Risk

Very low. Test-only change to how stdout is captured; corrects a deadlock and
leaves observable behavior identical for tests whose output already fit the
buffer.

## Output Contract

N/A — no template, generated-file, manifest, MCP-schema, scorecard, catalog, or
pipeline output changes.

## Verification

Commands run (Windows, Go 1.26.4):

- `go test ./internal/cli/ -run TestCatalog -timeout 90s` → ok in ~9s (was a
  90s+ deadlock / `panic: test timed out` before the fix)
- Confirmed the deadlock reproduces on a clean checkout (helper hangs
  regardless of this change's catalog context), so the fix is independent of any
  catalog content.

- [ ] Generator/template change: N/A (test-only change)
- [ ] Generator/template change: N/A
- [ ] Generator/template change: N/A

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
