### PR TITLE
fix(dogfood): skip top-level login alias in live dogfood matrix

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -458,11 +458,17 @@ func discoverLiveDogfoodCommands(binaryPath string) ([]liveDogfoodCommand, error
 	return commands, nil
 }
 
+// liveDogfoodFrameworkSkip names top-level commands that are framework
+// scaffolding rather than API surface, so live dogfood does not probe them.
+// "login" is the top-level alias for `auth login`: it launches the OAuth
+// browser flow and never makes a probeable API call, so it belongs here
+// alongside the other framework commands.
 var liveDogfoodFrameworkSkip = map[string]bool{
 	"agent-context": true,
 	"auth":          true,
 	"completion":    true,
 	"help":          true,
+	"login":         true,
 	"version":       true,
 }
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4718,3 +4718,33 @@ func TestHappyArgsContainSyntheticFlagPlaceholder(t *testing.T) {
 		[]string{"widgets", "search"},
 	))
 }
+
+// TestCollectLiveDogfoodCommandsSkipsLoginAlias verifies the top-level
+// "login" alias (a peer of `auth login` that launches the OAuth browser
+// flow) is treated as framework scaffolding and excluded from the live
+// dogfood matrix, while real API subtrees survive.
+func TestCollectLiveDogfoodCommandsSkipsLoginAlias(t *testing.T) {
+	t.Parallel()
+
+	root := dogfoodAgentCommand{
+		Name: "root",
+		Subcommands: []dogfoodAgentCommand{
+			{Name: "login"},
+			{Name: "auth", Subcommands: []dogfoodAgentCommand{{Name: "login"}}},
+			{Name: "posts", Subcommands: []dogfoodAgentCommand{{Name: "list"}}},
+		},
+	}
+
+	var cmds []liveDogfoodCommand
+	for _, sub := range root.Subcommands {
+		collectLiveDogfoodCommands(nil, sub, &cmds)
+	}
+
+	var paths [][]string
+	for _, c := range cmds {
+		paths = append(paths, c.Path)
+	}
+	// Both the top-level "login" alias and the "auth" subtree are framework
+	// skips; only the posts subtree should survive.
+	assert.Equal(t, [][]string{{"posts", "list"}}, paths)
+}


### PR DESCRIPTION
## What

Add `login` to `liveDogfoodFrameworkSkip` so the live dogfood matrix does not probe the top-level `login` alias.

## Why

A generated CLI may expose `login` at the top level as a convenience alias for `auth login`. That command launches the OAuth authorization-code browser flow and never issues a probeable API call — it is framework scaffolding, exactly like `auth`, `completion`, `help`, and `version`, all of which are already skipped.

Because `login` was missing from the skip set, `collectLiveDogfoodCommands` treated it as a leaf API command and live dogfood tried to probe it, producing a guaranteed failure for every CLI that exposes the alias. This surfaced while generating an Oura CLI (`oura-pp-cli`), whose OAuth template registers a top-level `login` alias: live dogfood reported a spurious failure on `login` even though the OAuth flow and every real API call succeeded.

## Change

- Add `"login": true` to `liveDogfoodFrameworkSkip`.
- Document the map's intent (framework scaffolding vs. API surface), calling out why `login` belongs there.
- Add `TestCollectLiveDogfoodCommandsSkipsLoginAlias`, a Windows-friendly regression test asserting that a top-level `login` alias and the `auth` subtree are both excluded while real API subtrees survive.

## Verification

- `go build ./...` — pass
- `go vet ./internal/pipeline/` — pass
- `go test ./internal/pipeline/ -run TestCollectLiveDogfoodCommandsSkipsLoginAlias` — pass

No behavior change for CLIs that do not expose a top-level `login` alias.
