### PR TITLE
fix(cli): bind MCP array/object body params natively (WithArray/WithObject)

### DIFF
--- a/internal/generator/body_nested_object_test.go
+++ b/internal/generator/body_nested_object_test.go
@@ -204,13 +204,18 @@ resources:
 	mcpGot := string(mcpSrc)
 	for _, want := range []string{
 		`mcplib.WithString("query", mcplib.Required(), mcplib.Description("GraphQL document"))`,
-		`mcplib.WithString("variables", mcplib.Description("GraphQL variables"))`,
+		`mcplib.WithObject("variables", mcplib.Description("GraphQL variables"))`,
 		`mcplib.WithBoolean("serializer-settings-include-nulls"`,
-		`mcplib.WithString("queries"`,
+		`mcplib.WithArray("queries"`,
 		`PublicName: "serializer-settings-include-nulls", WireName: "includeNulls", Location: "body", BodyPath: []string{"serializerSettings", "includeNulls"}`,
 		`setNestedBodyArg(bodyArgs, binding.BodyPath, v)`,
 	} {
 		require.Containsf(t, mcpGot, want, "expected generated MCP fragment %q", want)
 	}
 	require.NotContains(t, mcpGot, `mcplib.WithString("queries-query"`)
+
+	// formatMCPParamValue must JSON-encode a native composite in its default
+	// branch (a query/path-located array/object param now arrives as []any /
+	// map[string]any instead of a string); Go's "%v" would emit "[a b c]".
+	require.Regexp(t, `(?s)func formatMCPParamValue\(v any\) string \{.*?json\.Marshal\(v\)`, mcpGot)
 }

--- a/internal/generator/cursor_param_test.go
+++ b/internal/generator/cursor_param_test.go
@@ -144,6 +144,34 @@ func TestMCPBindingFunc(t *testing.T) {
 	}
 }
 
+// TestMCPParamDefaultValue pins that a composite (array/object) param default is
+// serialized as JSON — matching how native array/object live values are now
+// encoded — while scalar defaults keep their "%v" rendering. Without the JSON
+// branch an array default would be injected on the wire as Go's "[a b c]".
+func TestMCPParamDefaultValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		p      spec.Param
+		want   string
+		wantOK bool
+	}{
+		{"nil default", spec.Param{Type: "array"}, "", false},
+		{"scalar int", spec.Param{Type: "integer", Default: 25}, "25", true},
+		{"scalar string", spec.Param{Type: "string", Default: "later"}, "later", true},
+		{"array default", spec.Param{Type: "array", Default: []any{"a", "b"}}, `["a","b"]`, true},
+		{"object default", spec.Param{Type: "object", Default: map[string]any{"k": "v"}}, `{"k":"v"}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := mcpParamDefaultValue(tt.p)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestDefaultAndZeroValuesAcceptSpecScalarAliases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/cursor_param_test.go
+++ b/internal/generator/cursor_param_test.go
@@ -116,7 +116,8 @@ func TestCobraFlagFuncAcceptsSpecScalarAliases(t *testing.T) {
 
 // TestMCPBindingFunc pins that OpenAPI-parsed shapes ("int", "float",
 // "bool") and internal-spec literals ("integer", "number", "boolean")
-// produce the same MCP binding.
+// produce the same MCP binding, and that array/object params bind to their
+// native MCP type (WithArray/WithObject) rather than the WithString default.
 func TestMCPBindingFunc(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -131,8 +132,8 @@ func TestMCPBindingFunc(t *testing.T) {
 		{"bool", "WithBoolean"},
 		{"string", "WithString"},
 		{"", "WithString"},
-		{"object", "WithString"},
-		{"array", "WithString"},
+		{"object", "WithObject"},
+		{"array", "WithArray"},
 		{"INTEGER", "WithNumber"},
 	}
 	for _, tt := range tests {

--- a/internal/generator/form_test.go
+++ b/internal/generator/form_test.go
@@ -50,6 +50,7 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 					RequestContentType: "application/x-www-form-urlencoded",
 					Body: []spec.Param{
 						{Name: "struct_data", Type: "string", Format: "json", Required: true, Description: "JSON-encoded query payload"},
+						{Name: "facets", Type: "array", Description: "Facet filters"},
 					},
 				},
 			},
@@ -90,6 +91,15 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	assert.Contains(t, mcpSrc, `RequestContentType: "application/x-www-form-urlencoded"`)
 	assert.Contains(t, mcpSrc, `formFields := url.Values{}`)
 	assert.Contains(t, mcpSrc, `data, _, err = c.PostFormWithParams(ctx, path, params, formFields)`)
+
+	// An array/object body param binds to its native JSON type even on an
+	// x-www-form-urlencoded endpoint (not WithString), then flows through
+	// mcpFormFieldValue, which JSON-encodes a native composite rather than
+	// rendering it with Go's "%v". This is the form twin of the multipart path
+	// and locks it against a future helper refactor silently re-breaking it.
+	assert.Contains(t, mcpSrc, `mcplib.WithArray("facets"`)
+	assert.Contains(t, mcpSrc, `formFields.Set(binding.WireName, mcpFormFieldValue(v))`)
+	assert.Regexp(t, `(?s)func mcpFormFieldValue\(v any\) string \{.*?json\.Marshal\(v\)`, mcpSrc)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -4746,18 +4746,25 @@ func cobraFlagFunc(t string) string {
 }
 
 // mcpBindingFunc returns the mcplib.With* function name used in MCP tool
-// input-schema registration so numeric fields bind as JSON numbers (not
-// quoted strings) and pass through the generic makeAPIHandler intact.
-// Funnels through primitiveKind so OpenAPI-parsed shapes ("int", "float",
-// "bool") and internal-spec literals ("integer", "number", "boolean")
-// produce the same binding. Object/array bodies fall back to WithString
-// because they ride the --body-json fallback or a JSON-string flag.
+// input-schema registration so each field binds to its native JSON type and
+// passes through the generic makeAPIHandler intact. Funnels through
+// primitiveKind so OpenAPI-parsed shapes ("int", "float", "bool") and
+// internal-spec literals ("integer", "number", "boolean") produce the same
+// binding. Array/object params bind natively (WithArray/WithObject): the
+// handler's body path stores the parsed value verbatim and JSON-marshals it,
+// so a native []any/map serializes as a real array/object instead of a quoted
+// JSON string. The body_json polymorphic (oneOf/anyOf) fallback is hardcoded
+// as WithString in the template and is NOT routed through this function.
 func mcpBindingFunc(t string) string {
 	switch primitiveKind(t) {
 	case "int", "float":
 		return "WithNumber"
 	case "bool":
 		return "WithBoolean"
+	case "array":
+		return "WithArray"
+	case "object":
+		return "WithObject"
 	default:
 		return "WithString"
 	}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5211,6 +5211,17 @@ func mcpParamDefaultValue(p spec.Param) (string, bool) {
 	if p.Default == nil {
 		return "", false
 	}
+	// An array/object param now binds natively (WithArray/WithObject) and its
+	// live values are JSON-encoded; serialize a composite default the same way
+	// so an omitted-arg default isn't injected as Go's "%v" rendering
+	// ("[a b c]" / "map[...]") where the wire expects JSON.
+	switch primitiveKind(p.Type) {
+	case "array", "object":
+		if b, err := json.Marshal(p.Default); err == nil {
+			s := string(b)
+			return s, s != "" && s != "null"
+		}
+	}
 	v := fmt.Sprintf("%v", p.Default)
 	return v, v != ""
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -16372,7 +16372,10 @@ func TestGenerateBodyNameAcrossCLISurfaces(t *testing.T) {
 	assert.NotContains(t, searchSource, `body["startAfter"] = parsedStartAfter`)
 
 	mcpSource := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
-	assert.Contains(t, mcpSource, `mcplib.WithString("startAfter", mcplib.Description("Pagination cursor"))`)
+	// CLI takes the array cursor as a JSON-string flag (StringVar + json.Unmarshal
+	// above); MCP binds it as a native array. The BodyName mapping (startAfter ->
+	// searchAfter) holds across both surfaces.
+	assert.Contains(t, mcpSource, `mcplib.WithArray("startAfter", mcplib.Description("Pagination cursor"))`)
 	assert.Contains(t, mcpSource, `PublicName: "startAfter", WireName: "searchAfter", Location: "body"`)
 }
 

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -85,6 +85,17 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	assert.Contains(t, mcpSrc, `multipartFileFields[binding.WireName] = fmt.Sprintf("%v", v)`)
 	assert.Contains(t, mcpSrc, `data, _, err = c.PostMultipartWithParams(ctx, path, params, multipartFields, multipartFileFields)`)
 
+	// An object/array body param binds to its native JSON type even on a
+	// multipart endpoint (not WithString). The non-file field then flows
+	// through mcpMultipartFieldValue, which JSON-encodes a native composite
+	// rather than rendering it with Go's "%v". This locks the multipart path
+	// that became live once array/object params stopped binding as WithString —
+	// without it, a future refactor of the helper could silently reintroduce a
+	// malformed multipart field for composite params.
+	assert.Contains(t, mcpSrc, `mcplib.WithObject("metadata"`)
+	assert.Contains(t, mcpSrc, `multipartFields[binding.WireName] = mcpMultipartFieldValue(v)`)
+	assert.Regexp(t, `(?s)func mcpMultipartFieldValue\(v any\) string \{.*?json\.Marshal\(v\)`, mcpSrc)
+
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
 }

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -216,6 +216,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -174,6 +174,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -112,6 +112,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -214,6 +214,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -106,6 +106,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -103,6 +103,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -130,6 +130,14 @@ func formatMCPParamValue(v any) string {
 		}
 		return strconv.FormatFloat(f, 'f', -1, 32)
 	default:
+		// Composite values (a native []any / map[string]any from an array or
+		// object param) reach this path when bound to a query or path slot;
+		// JSON-encode them so the wire value is valid JSON rather than Go's
+		// "[a b c]" / "map[...]" rendering. Body params never come through
+		// here — they are stored natively in bodyArgs and marshalled there.
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
 		return fmt.Sprintf("%v", v)
 	}
 }


### PR DESCRIPTION
## Problem

`mcpBindingFunc` mapped **array**/**object** params to `mcplib.WithString`, so generated MCP tools declared them as JSON-Schema `type:"string"`. For **body** params this is a wire-correctness bug: the generic handler stores the value verbatim (`bodyArgs[wire] = v`) and JSON-marshals the body map, so an array param shipped as a *stringified* array — `{"tags":"[...]"}` — to APIs that expect `{"tags":[...]}`. The CLI path was unaffected (it `json.Unmarshal`s the JSON-string flag before building the body); only the MCP path sent the malformed value. See #3074.

## Fix

- `mcpBindingFunc`: `array → WithArray`, `object → WithObject`. The handler then serializes the native `[]any` / `map[string]any` correctly with **no body-path change**.
- `formatMCPParamValue`: JSON-encode a native composite in its `default` branch (covers the rare query/path-located array/object param so it emits valid JSON instead of Go's `%v`).
- Object params with declared fields still flatten to dotted scalar flags, so `WithObject` only targets opaque objects; the `body_json` oneOf/anyOf fallback stays `WithString`.

## Consumer impact / migration

This changes the MCP tool input-schema for affected params from `string` to `array`/`object`. **Agents now pass a native array/object, not a JSON-encoded string.** Because the old stringified form was already non-functional on the wire (the API received a quoted string where it required an array), no *working* caller is broken — but a host that validates args against the input schema will now correctly reject the old string form. Already-published CLIs with array/object body params are reprint/amend candidates.

## CLI surface unchanged

Array/object **flags** remain JSON-string (`--tags '[...]'`) — cobra cannot accept a native array. Intentional asymmetry: **CLI = JSON-string flag, MCP = native typed**.

## Tests

- `TestMCPBindingFunc` — unit mapping incl. array→`WithArray`, object→`WithObject` (mutation guard: revert the cases → red).
- `TestGenerateInternalYAMLBodyObjectSchema` — generated MCP output object→`WithObject`, array→`WithArray`; CLI-side `StringVar`/`json.Unmarshal` assertions kept (locks the asymmetry); asserts `formatMCPParamValue`'s `json.Marshal` default branch.
- `TestGenerateBodyNameAcrossCLISurfaces` — array cursor (`startAfter`) MCP binding native; CLI flag stays string.
- `TestGenerateMultipartRequestBodyUsesMultipartClient` / `TestGenerateFormRequestBodyUsesFormClient` — object/array body param on `multipart/form-data` and `x-www-form-urlencoded` endpoints binds native and flows through the `json.Marshal` field helper.
- Golden fixtures regenerated (`scripts/golden.sh update`).

Gates green locally: `go build ./...`, `go vet ./...`, `go test ./...`, `scripts/golden.sh verify`, `scripts/verify-generator-output.sh`.

> **Note for maintainers:** the `internal/generator` package test run is ~9–10 min on my machine and brushes the default 10-minute `go test` timeout (pre-existing; this PR only adds schema-shape assertions + golden regen). CI may want a longer `-timeout` for that package to avoid a spurious timeout-red.

Fixes #3074
