### PR TITLE
fix(generator): omit optional query params with empty/invalid spec defaults; trim enum tokens

### DIFF
--- a/internal/generator/const_default_test.go
+++ b/internal/generator/const_default_test.go
@@ -119,6 +119,16 @@ func TestDefaultValDropsEmptyDefaults(t *testing.T) {
 			},
 			want: `"no"`,
 		},
+		{
+			name: "string enum padded default trimmed to match validator",
+			p: spec.Param{
+				Name:    "includeTBA",
+				Type:    "string",
+				Default: " no",
+				Enum:    []string{"yes", " no", " only"},
+			},
+			want: `"no"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/generator/const_default_test.go
+++ b/internal/generator/const_default_test.go
@@ -81,6 +81,53 @@ func TestParamIsConstDefault(t *testing.T) {
 	}
 }
 
+func TestDefaultValDropsEmptyDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    spec.Param
+		want string
+	}{
+		{
+			name: "array empty string default",
+			p:    spec.Param{Name: "classification", Type: "array", Default: ""},
+			want: `""`,
+		},
+		{
+			name: "string empty default",
+			p:    spec.Param{Name: "keyword", Type: "string", Default: ""},
+			want: `""`,
+		},
+		{
+			name: "string enum prose default dropped",
+			p: spec.Param{
+				Name:    "includeTBA",
+				Type:    "string",
+				Default: "no if date parameter sent, yes otherwise",
+				Enum:    []string{"yes", " no", " only"},
+			},
+			want: `""`,
+		},
+		{
+			name: "string enum trimmed member default kept",
+			p: spec.Param{
+				Name:    "includeTBA",
+				Type:    "string",
+				Default: "no",
+				Enum:    []string{"yes", " no", " only"},
+			},
+			want: `"no"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, defaultVal(tt.p))
+		})
+	}
+}
+
 // TestGenerateMarksConstDefaultFlagsHidden is the end-to-end check that
 // when an endpoint Param has a single-value enum whose only value equals
 // the default, the generated command registers the flag (so the wire-side

--- a/internal/generator/enum_validation_test.go
+++ b/internal/generator/enum_validation_test.go
@@ -65,6 +65,12 @@ func TestEnumParamEmitsValidation(t *testing.T) {
 		"the old warn-and-continue enum behavior must be gone")
 }
 
+func TestEnumLiteralTrimsValues(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `"yes", "no", "only"`, enumLiteral([]string{"yes", " no", " only"}))
+}
+
 // TestEnumParamPromotedCommandRejects covers the promoted-command template's
 // enum path (command_promoted.go.tmpl), which carries the same warn→reject
 // change as the endpoint template but is otherwise only validated by reading

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -6168,7 +6168,14 @@ func defaultVal(p spec.Param) string {
 		// Coerce the default value to match the declared param type
 		switch primitiveKind(p.Type) {
 		case "string":
-			return fmt.Sprintf("%q", fmt.Sprintf("%v", p.Default))
+			// Trim before emitting so a whitespace-padded default that was
+			// kept by stringDefaultOutsideEnum (which compares trimmed values)
+			// still matches the trimmed enum validator built by enumLiteral —
+			// otherwise the generated CLI rejects its own default. Trimming a
+			// non-enum string default is harmless (surrounding whitespace in a
+			// spec default is noise, like the other sloppy defaults this path
+			// normalizes).
+			return fmt.Sprintf("%q", strings.TrimSpace(fmt.Sprintf("%v", p.Default)))
 		case "bool":
 			switch v := p.Default.(type) {
 			case bool:

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -357,29 +357,10 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			e, _ := lookupEndpointForTemplate(api, ref)
 			return e
 		},
-		"effectiveEndpointPath":    effectiveEndpointPath,
-		"effectiveSubEndpointPath": effectiveSubEndpointPath,
-		"enumLiteral": func(values []string) string {
-			// Render a string slice as a Go []string literal for template embedding.
-			// Example: ["asc","desc"] → `"asc", "desc"`. Returns empty string when
-			// the slice is empty so callers can {{if}}-gate the block.
-			if len(values) == 0 {
-				return ""
-			}
-			parts := make([]string, len(values))
-			for i, v := range values {
-				parts[i] = fmt.Sprintf("%q", v)
-			}
-			return strings.Join(parts, ", ")
-		},
-		"enumDescriptionHint": func(values []string) string {
-			// Appends " (one of: a, b, c)" to a flag description when the param
-			// has enum constraints. Returns empty string when the slice is empty.
-			if len(values) == 0 {
-				return ""
-			}
-			return " (one of: " + strings.Join(values, ", ") + ")"
-		},
+		"effectiveEndpointPath":        effectiveEndpointPath,
+		"effectiveSubEndpointPath":     effectiveSubEndpointPath,
+		"enumLiteral":                  enumLiteral,
+		"enumDescriptionHint":          enumDescriptionHint,
 		"jsonStringParam":              isJSONStringParam,
 		"jsonEnumSuggestion":           jsonEnumSuggestion,
 		"bodyMap":                      bodyMap,
@@ -6139,8 +6120,51 @@ func hasTemporalMarker(s string) bool {
 	return false
 }
 
+func enumLiteral(values []string) string {
+	// Render a string slice as a Go []string literal for template embedding.
+	// Example: ["asc","desc"] -> `"asc", "desc"`. Returns empty string when
+	// the slice is empty so callers can {{if}}-gate the block.
+	values = trimmedEnumValues(values)
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, len(values))
+	for i, v := range values {
+		parts[i] = fmt.Sprintf("%q", v)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func enumDescriptionHint(values []string) string {
+	// Appends " (one of: a, b, c)" to a flag description when the param
+	// has enum constraints. Returns empty string when the slice is empty.
+	values = trimmedEnumValues(values)
+	if len(values) == 0 {
+		return ""
+	}
+	return " (one of: " + strings.Join(values, ", ") + ")"
+}
+
+func trimmedEnumValues(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		trimmed = append(trimmed, value)
+	}
+	return trimmed
+}
+
 func defaultVal(p spec.Param) string {
 	if p.Default != nil {
+		if defaultShouldUseZero(p) || stringDefaultOutsideEnum(p) {
+			return zeroVal(p.Type)
+		}
 		// Coerce the default value to match the declared param type
 		switch primitiveKind(p.Type) {
 		case "string":
@@ -6180,6 +6204,37 @@ func defaultVal(p spec.Param) string {
 		}
 	}
 	return zeroVal(p.Type)
+}
+
+func defaultShouldUseZero(p spec.Param) bool {
+	if v, ok := p.Default.(string); ok && v == "" {
+		return true
+	}
+	switch primitiveKind(p.Type) {
+	case "object", "array":
+		data, err := json.Marshal(p.Default)
+		if err != nil {
+			return true
+		}
+		switch string(data) {
+		case `""`, "[]", "{}", "null":
+			return true
+		}
+	}
+	return false
+}
+
+func stringDefaultOutsideEnum(p spec.Param) bool {
+	if primitiveKind(p.Type) != "string" || len(p.Enum) == 0 {
+		return false
+	}
+	defaultText := strings.TrimSpace(fmt.Sprintf("%v", p.Default))
+	for _, enumValue := range p.Enum {
+		if defaultText == strings.TrimSpace(enumValue) {
+			return false
+		}
+	}
+	return true
 }
 
 func zeroVal(t string) string {


### PR DESCRIPTION
## Problem

Generated CLIs send optional query params **even when the user didn't set them**, and bake malformed spec `default`s verbatim. When a spec has a sloppy default (common), the generated CLI silently returns wrong results or 400s. Found via the Ticketmaster Discovery spec (downstream: every `events` query returned 0; a bare `events list` 400'd), but the defect is in the generator.

Three spec shapes were mishandled in `internal/generator/generator.go`:

1. **Empty default baked as a non-empty literal.** `{type: array, default: ""}` → `defaultVal`'s object/array branch did `json.Marshal` + `%q`, producing the Go literal for the 2-char string `""`. That passes the generated `if flag != ""` guard and is sent as a real empty filter → the API matches nothing. (Live: `city=New York` = 10000 events; `+ classificationName=""` = 0.)
2. **Non-enum prose default sent verbatim.** `{default: "no if date parameter sent, yes otherwise", enum: [...]}` → the sentence became the flag default and was sent → `400`.
3. **Enum allowed-set not trimmed.** A spec enum `["yes"," no"," only"]` (leading spaces, as authored) produced a generated validator that rejected a valid `no`.

## Fix

- `defaultVal` now returns `zeroVal(p.Type)` when the default is empty/falsy (`defaultShouldUseZero`) or is a string default outside the param's trimmed enum (`stringDefaultOutsideEnum`) — so the value defaults to the real zero and the existing emission guard omits it.
- `enumLiteral` / `enumDescriptionHint` trim tokens (`trimmedEnumValues`), so the allowed-set and help text are clean.

Genuine non-empty, in-enum defaults are unchanged (`default:"no"` stays `"no"`; `default:5` stays `5`).

## Proof

- Full golden suite green (`go build/vet/test ./...`).
- New unit tests: `TestDefaultValDropsEmptyDefaults`, `TestEnumLiteralTrimsValues`.
- **End-to-end:** regenerating the Ticketmaster spec on the patched generator now emits `classification-name`/`include-tba` defaults of `""` (omitted at request time) and a trimmed enum; a bare `events list --keyword phish --dry-run` no longer leaks `classificationName=""` / the prose `includeTBA`.

Fixes #3076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
