### PR TITLE
fix(generator): reject empty positional path-param values with a clear error

### DIFF
--- a/internal/generator/path_param_positional_index_test.go
+++ b/internal/generator/path_param_positional_index_test.go
@@ -117,11 +117,15 @@ func TestPathParamArgsIndexUsesPositionalOrdinal(t *testing.T) {
 	}
 
 	// 1) Single positional with a non-positional query before it: args[0],
-	// no len-check (Cobra's MinimumNArgs(1) covers the first positional).
+	// with an explicit empty-string guard because Cobra's MinimumNArgs(1)
+	// allows callers to pass "" from an empty shell variable expansion.
 	tagsList := read(filepath.Join("internal", "cli", "tags_contacts_list-for-tag.go"))
 	assert.Contains(t, tagsList,
 		`path = replacePathParam(path, "tagId", args[0])`,
 		"single positional path param must use args[0] regardless of declared query params before it")
+	assert.Contains(t, tagsList,
+		`if len(args) < 1 || args[0] == ""`,
+		"first positional path param must reject explicit empty strings before URL substitution")
 	assert.NotContains(t, tagsList,
 		`args[2]`,
 		"must not interpolate the full-Params index for the positional")

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -173,7 +173,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
-{{- if gt $pi 0}}
+{{- if or (gt $pi 0) (pathContainsParam $.Endpoint.Path .Name)}}
 			if len(args) < {{add $pi 1}}{{if pathContainsParam $.Endpoint.Path .Name}} || args[{{$pi}}] == ""{{end}} {
 				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), "{{.Name}}"))
 			}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -174,7 +174,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
 {{- if gt $pi 0}}
-			if len(args) < {{add $pi 1}} {
+			if len(args) < {{add $pi 1}}{{if pathContainsParam $.Endpoint.Path .Name}} || args[{{$pi}}] == ""{{end}} {
 				return usageErr(fmt.Errorf("{{.Name}} is required\nUsage: %s <%s>", cmd.CommandPath(), "{{.Name}}"))
 			}
 {{- end}}

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -141,7 +141,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
-			if len(args) < {{add $pi 1}} {
+			if len(args) < {{add $pi 1}}{{if pathContainsParam $.Endpoint.Path .Name}} || args[{{$pi}}] == ""{{end}} {
 				// JSON envelope: {error, usage}. Written first; the
 				// usageErr return preserves exit code 2 across modes.
 				if flags.asJSON {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -29,6 +29,9 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/customers/{id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
+			}
 			path = replacePathParam(path, "id", args[0])
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, cmd.ErrOrStderr())

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -29,6 +29,9 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/pages/{id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
+			}
 			path = replacePathParam(path, "id", args[0])
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, cmd.ErrOrStderr())

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -29,6 +29,9 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/playlists/{id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
+			}
 			path = replacePathParam(path, "id", args[0])
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, cmd.ErrOrStderr())

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -28,6 +28,9 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/api/quotes/{quote_id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
+			}
 			path = replacePathParam(path, "quote_id", args[0])
 			params := map[string]string{}
 			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -28,6 +28,9 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/api/quotes/{quote_id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
+			}
 			path = replacePathParam(path, "quote_id", args[0])
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, cmd.ErrOrStderr())

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -32,6 +32,9 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/api/quotes/{quote_id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
+			}
 			path = replacePathParam(path, "quote_id", args[0])
 			params := map[string]string{}
 			var body map[string]any

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -32,6 +32,9 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/api/quotes/{quote_id}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
+			}
 			path = replacePathParam(path, "quote_id", args[0])
 			params := map[string]string{}
 			var body map[string]any

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -32,6 +32,9 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/projects/{projectId}/avatar"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
+			}
 			path = replacePathParam(path, "projectId", args[0])
 			params := map[string]string{}
 			if flagOverwrite != false {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -46,6 +46,9 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/projects/{projectId}/tasks"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
+			}
 			path = replacePathParam(path, "projectId", args[0])
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "tasks", path, map[string]string{
 				"priority": formatCLIParamValue(flagPriority),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -38,7 +38,7 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/projects/{projectId}/tasks/{taskId}"
 			path = replacePathParam(path, "projectId", args[0])
-			if len(args) < 2 {
+			if len(args) < 2 || args[1] == "" {
 				return usageErr(fmt.Errorf("taskId is required\nUsage: %s <%s>", cmd.CommandPath(), "taskId"))
 			}
 			path = replacePathParam(path, "taskId", args[1])

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -37,6 +37,9 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/projects/{projectId}/tasks/{taskId}"
+			if len(args) < 1 || args[0] == "" {
+				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
+			}
 			path = replacePathParam(path, "projectId", args[0])
 			if len(args) < 2 || args[1] == "" {
 				return usageErr(fmt.Errorf("taskId is required\nUsage: %s <%s>", cmd.CommandPath(), "taskId"))

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -26,7 +26,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			path := "/games/{game_key}/leagues"
-			if len(args) < 1 {
+			if len(args) < 1 || args[0] == "" {
 				// JSON envelope: {error, usage}. Written first; the
 				// usageErr return preserves exit code 2 across modes.
 				if flags.asJSON {


### PR DESCRIPTION
## Problem

Required positional path params are only **presence**-checked (`len(args)`), never checked for an empty value. So an empty-string argument — most commonly a shell expansion of an unset env var — passes the check and gets substituted straight into the request path, producing a malformed URL and a confusing *remote* error.

Real example from a generated `cloudflare-pp-cli` session, where `$CLOUDFLARE_ACCOUNT_ID` was unset:

```
$ cloudflare-pp-cli accounts pages project-get-project ronanrx-com "$CLOUDFLARE_ACCOUNT_ID" --json
Error: GET /accounts//pages/projects/ronanrx-com returned HTTP 400:
  {"success":false,"errors":[{"code":7003,"message":"Could not route to
   /client/v4/accounts/pages/projects/ronanrx-com, perhaps your object
   identifier is invalid?"}]}
```

The `//` is the empty `account_id`. The user/agent has no way to tell from that 400 that the real issue is an empty argument, which drives repeated retries.

## Fix

Both the endpoint and promoted command templates now also reject an **empty value** when the positional is a path param, returning the existing local `"<name> is required"` usage error *before* any request is made:

```go
if len(args) < N+1 || args[N] == "" {   // path params only
    return usageErr(fmt.Errorf("<name> is required\nUsage: ..."))
}
```

- Gated on `pathContainsParam`, so **non-path** positionals are unaffected (no behavior change there).
- Import-safe — uses `== ""`, no new imports in generated files.
- Catches the exact failure mode (empty path segment → malformed URL) at the CLI boundary with the clear message that already exists for the missing-arg case.

## Validation

- Goldens regenerated; the **only** generated-code change is the presence-check line (e.g. `projects_tasks_update-project.go`: `if len(args) < 2 || args[1] == "" {`).
- `scripts/golden.sh verify` — 31/31 pass.
- `go test ./internal/generator/` — pass.
- `go build ./...` — pass.

Surfaced from real generated-CLI session transcripts.