### PR TITLE
fix(cli): qualify FTS ORDER BY rank to the FTS table

### DIFF
--- a/docs/solutions/runtime-errors/fts-order-by-rank-ambiguous-on-rank-column-2026-06-20.md
+++ b/docs/solutions/runtime-errors/fts-order-by-rank-ambiguous-on-rank-column-2026-06-20.md
@@ -1,0 +1,101 @@
+---
+title: "Generated FTS ORDER BY rank is ambiguous when a resource has a typed rank column"
+date: 2026-06-20
+category: runtime-errors
+module: internal/generator/templates
+problem_type: runtime_error
+component: store
+symptoms:
+  - "`search` on a printed CLI whose resource carries a typed `rank` column failed with `SQL logic error: ambiguous column name: rank (1)`"
+  - "Only resources with a `rank` response field (e.g. rankings/standings resources) were affected; rank-less resources searched fine"
+  - "The generic `Search` and the per-resource `Search<Resource>` both failed at query time the first time FTS MATCH produced a row"
+root_cause: code_generation_bug
+resolution_type: code_fix
+severity: high
+tags:
+  - sqlite
+  - fts5
+  - store
+  - search
+  - codegen
+  - ambiguous-column
+related_components:
+  - store
+  - insights
+issue: 2973
+---
+
+# Generated FTS `ORDER BY rank` is ambiguous on rank-fielded resources
+
+## Problem
+
+The store template (`internal/generator/templates/store.go.tmpl`) and the insights similar template (`internal/generator/templates/insights/similar.go.tmpl`) emitted FTS5 search queries with an unqualified `ORDER BY rank`:
+
+```sql
+-- per-resource Search<Resource>
+SELECT t.data FROM events t
+ JOIN events_fts ON events_fts.rowid = t.rowid
+ WHERE events_fts MATCH ?
+ ORDER BY rank LIMIT ?
+
+-- generic Search
+SELECT r.data FROM resources r
+ JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
+ WHERE resources_fts MATCH ?
+ ORDER BY rank LIMIT ?
+```
+
+`rank` is an FTS5 special column exposed by every `USING fts5(...)` table. It is also an extremely common name for a real response field (rankings, standings, priorities). When schema extraction gives the data table a typed `rank` column (`events.rank`, `resources.rank`), the unqualified `ORDER BY rank` resolves against **both** the FTS table's special column and the data table's typed column, and SQLite rejects the query at prepare time:
+
+```
+SQL logic error: ambiguous column name: rank (1)
+```
+
+So `search` broke for every rank-fielded resource (pp-espn etc.) with zero proximate cause — the store opened fine, sync populated the index fine, and the failure surfaced only the first time FTS MATCH returned a row.
+
+## The non-obvious part: qualify with the alias, not the table name
+
+The instinct is to qualify with the FTS table name: `ORDER BY resources_fts.rank`. That **fails** for the generic query, because `resources_fts` is aliased as `f` in the JOIN:
+
+```
+no such column: resources_fts.rank
+```
+
+SQLite resolves `resources_fts MATCH ?` (the FTS5 MATCH operator) to the aliased table by base name — a quirk that makes the base name *look* usable — but for a normal column reference like `.rank`, once a table is aliased the alias is the only valid qualifier. The per-resource query has no alias on its FTS table, so the base name works there; the generic and insights queries are aliased, so the alias is required. The fix qualifies every `rank` reference to whatever name actually scopes it in that query:
+
+| Query | FTS table binding | Correct qualifier |
+|---|---|---|
+| per-resource `Search<Resource>` | `JOIN {{name}}_fts` (no alias) | `{{name}}_fts.rank` |
+| generic `Search` | `JOIN resources_fts f` | `f.rank` |
+| insights `similar` | `FROM resources_fts fts` | `fts.rank` (both the SELECT and ORDER BY) |
+
+The insights query also selected `rank` (not just ordered by it), and that bare `rank` in the SELECT list was equally ambiguous — both had to be qualified.
+
+## Solution
+
+Qualify every FTS5 `rank` reference to its scoping name. Emitted result:
+
+```sql
+-- per-resource
+ORDER BY events_fts.rank LIMIT ?
+-- generic (aliased)
+ORDER BY f.rank
+-- insights similar (aliased)
+SELECT r.id, r.resource_type, r.data, fts.rank ... ORDER BY fts.rank
+```
+
+No behavior change for rank-less resources: the qualifier just names the only `rank` in scope, which is what SQLite resolved to anyway.
+
+## Prevention
+
+`TestGenerateStoreFTSOrderByRankQualified` (`internal/generator/fts_order_by_rank_test.go`) builds a spec with a `rank`-fielded, FTS5-enabled resource, generates the CLI, and asserts:
+
+1. The emitted store.go qualifies the per-resource rank to the FTS table and the generic rank to the `f` alias.
+2. No unqualified `ORDER BY rank` remains anywhere in the store.
+3. The generated `TestSearch<Resource>QuotesFTSQuerySyntax` actually executes against a SQLite DB whose table carries a typed `rank` column — the exact shape that failed before the fix.
+
+Before the fix, (3) fails with the live error `SearchItems("10.0.0.1"): SQL logic error: ambiguous column name: rank`, so the test cannot silently regress. When adding a new FTS query to a template, qualify `rank` to whatever name binds the FTS table in that query (alias if aliased, base name if not) and extend this test.
+
+## Related Issues
+
+- mvanhorn/cli-printing-press#2973 (bug report — "always-correct, zero-downside")

--- a/internal/generator/fts_order_by_rank_test.go
+++ b/internal/generator/fts_order_by_rank_test.go
@@ -1,0 +1,73 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateStoreFTSOrderByRankQualified is the regression test for issue
+// #2973. When a resource has a typed `rank` column alongside an FTS5 index,
+// the FTS5 special `rank` column and the data table's `rank` column collide,
+// and an unqualified `ORDER BY rank` is rejected by SQLite as an ambiguous
+// column name. The generated Search SQL must qualify `rank` to the FTS table
+// so the query is unambiguous for every resource shape.
+//
+// This fixture carries exactly such a resource (a `rank` response field plus
+// the text fields that turn on FTS5), so the emitted store.go is the shape
+// that broke search on rank-fielded CLIs (e.g. pp-espn) before the fix.
+func TestGenerateStoreFTSOrderByRankQualified(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("fts-rank")
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Item": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "title", Type: "string"},
+			{Name: "description", Type: "string"},
+			{Name: "rank", Type: "integer"},
+			{Name: "created_at", Type: "string", Format: "date-time"},
+			{Name: "owner_id", Type: "string"},
+		}},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list":   {Method: "GET", Path: "/items", Description: "List items", Response: spec.ResponseDef{Type: "array", Item: "Item"}},
+				"detail": {Method: "GET", Path: "/items/{id}", Description: "Get an item", Response: spec.ResponseDef{Type: "array", Item: "Item"}},
+				"create": {Method: "POST", Path: "/items", Description: "Create an item"},
+				"update": {Method: "PUT", Path: "/items/{id}", Description: "Update an item"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "fts-rank-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+
+	// Per-resource Search qualifies rank to the resource's FTS table. The
+	// table identifier is double-quoted by the safeName helpers.
+	assert.Contains(t, string(storeSrc), `"items_fts".rank LIMIT ?`,
+		"per-resource Search must qualify rank to the FTS table (issue #2973)")
+	// Generic SearchAll qualifies rank to its resources_fts alias.
+	assert.Contains(t, string(storeSrc), "ORDER BY f.rank",
+		"generic Search must qualify rank to the resources_fts alias (issue #2973)")
+	// No unqualified ORDER BY rank may remain anywhere in the store; on a
+	// rank-fielded resource SQLite would reject it as ambiguous.
+	assert.NotContains(t, string(storeSrc), "ORDER BY rank",
+		"unqualified ORDER BY rank is ambiguous on rank-fielded resources (issue #2973)")
+
+	// Runtime proof: the generated per-resource FTS query must execute against
+	// a SQLite database whose items table carries a typed `rank` column. Before
+	// the fix this failed at query time with "ambiguous column name: rank".
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^TestSearchItemsQuotesFTSQuerySyntax$", "-count=1")
+}

--- a/internal/generator/fts_order_by_rank_test.go
+++ b/internal/generator/fts_order_by_rank_test.go
@@ -71,3 +71,53 @@ func TestGenerateStoreFTSOrderByRankQualified(t *testing.T) {
 	// the fix this failed at query time with "ambiguous column name: rank".
 	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "^TestSearchItemsQuotesFTSQuerySyntax$", "-count=1")
 }
+
+// TestGenerateInsightsSimilarFTSOrderByRankQualified is the insights-path
+// regression for issue #2973. The similar-items command joins resources_fts
+// to the data table and orders by the FTS5 special `rank` column; that column
+// must be qualified to the FTS alias (`fts.rank`) so the query stays
+// unambiguous on rank-fielded resources. The existing store.go test does not
+// exercise the insights template, which renders only when VisionSet.Insights
+// is populated.
+func TestGenerateInsightsSimilarFTSOrderByRankQualified(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("fts-rank-insights")
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Item": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "title", Type: "string"},
+			{Name: "description", Type: "string"},
+			{Name: "rank", Type: "integer"},
+		}},
+	}
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Description: "Manage items",
+			Endpoints: map[string]spec.Endpoint{
+				"list":   {Method: "GET", Path: "/items", Description: "List items", Response: spec.ResponseDef{Type: "array", Item: "Item"}},
+				"detail": {Method: "GET", Path: "/items/{id}", Description: "Get an item", Response: spec.ResponseDef{Type: "array", Item: "Item"}},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "fts-rank-insights-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{
+		Store:    true,
+		Insights: []string{"insights/similar.go.tmpl"},
+	}
+	require.NoError(t, gen.Generate())
+
+	similarSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "similar.go"))
+	require.NoError(t, err)
+
+	// The similar-items FTS query must select and order by the FTS-aliased
+	// rank column, not the bare `rank` identifier.
+	assert.Contains(t, string(similarSrc), "r.data, fts.rank",
+		"similar command SELECT must qualify rank to the FTS alias (issue #2973)")
+	assert.Contains(t, string(similarSrc), "ORDER BY fts.rank",
+		"similar command ORDER BY must qualify rank to the FTS alias (issue #2973)")
+	assert.NotContains(t, string(similarSrc), "ORDER BY rank",
+		"unqualified ORDER BY rank is ambiguous on rank-fielded resources (issue #2973)")
+}

--- a/internal/generator/templates/insights/similar.go.tmpl
+++ b/internal/generator/templates/insights/similar.go.tmpl
@@ -97,12 +97,12 @@ work items, tickets, or tasks.`,
 			}
 
 			// Use FTS5 to find similar items (exclude the source item)
-			query := `SELECT r.id, r.resource_type, r.data, rank
+			query := `SELECT r.id, r.resource_type, r.data, fts.rank
 				FROM resources_fts fts
 				JOIN resources r ON r.id = fts.id AND r.resource_type = fts.resource_type
 				WHERE resources_fts MATCH ?
 				  AND NOT (r.id = ? AND r.resource_type = ?)
-				ORDER BY rank
+				ORDER BY fts.rank
 				LIMIT ?`
 
 			rows, err := db.DB().Query(query, searchText, itemID, sourceType, limit)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -972,7 +972,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -995,7 +995,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)
@@ -1581,7 +1581,7 @@ func (s *Store) Search{{pascal .Name}}(query string, limit int) ([]json.RawMessa
 		`SELECT t.data FROM {{safeName .Name}} t
 		 JOIN {{safeNameSuffix .Name "_fts"}} ON {{safeNameSuffix .Name "_fts"}}.rowid = t.rowid
 		 WHERE {{safeNameSuffix .Name "_fts"}} MATCH ?
-		 ORDER BY rank LIMIT ?`,
+		 ORDER BY {{safeNameSuffix .Name "_fts"}}.rank LIMIT ?`,
 		matchQuery, limit,
 	)
 	if err != nil {

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -900,7 +900,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -923,7 +923,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -788,7 +788,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 			 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 			 WHERE resources_fts MATCH ?
 			 AND r.resource_type = ?
-			 ORDER BY rank
+			 ORDER BY f.rank
 			 LIMIT ?`,
 			matchQuery, resourceType, limit,
 		)
@@ -811,7 +811,7 @@ func (s *Store) Search(query string, limit int, resourceTypes ...string) ([]json
 		`SELECT r.data FROM resources r
 		 JOIN resources_fts f ON r.id = f.id AND r.resource_type = f.resource_type
 		 WHERE resources_fts MATCH ?
-		 ORDER BY rank
+		 ORDER BY f.rank
 		 LIMIT ?`,
 		matchQuery, limit,
 	)


### PR DESCRIPTION
<!--
Maintainer-owned PRs may use a shorter body. Community PRs must keep these sections.
Write for reviewers: explain why this change is right, not every line that changed.
-->

## Intent

`search` is broken on any printed CLI whose resource has a typed `rank` column (rankings, standings, priorities — e.g. pp-espn). The generated FTS5 search SQL emits an unqualified `ORDER BY rank`, which SQLite rejects at query time with `SQL logic error: ambiguous column name: rank (1)` because `rank` is also an FTS5 special column. The store opens fine and sync populates the index; the failure surfaces only the first time FTS MATCH returns a row.

Issue: #2973 (filer: "always-correct, zero-downside")

Refs #2973

## Approach

Qualify every FTS5 `rank` reference to whatever name actually scopes the FTS table in that query, in three templates:

- `internal/generator/templates/store.go.tmpl` — per-resource `Search<Resource>`: `ORDER BY {{safeNameSuffix .Name "_fts"}}.rank` (the per-resource FTS table has no alias, so the base name is the correct qualifier).
- `internal/generator/templates/store.go.tmpl` — generic `Search`/`SearchAll` (two query branches): `ORDER BY f.rank`, where `f` is the existing `resources_fts` alias from the JOIN.
- `internal/generator/templates/insights/similar.go.tmpl` — both the `SELECT … rank` and the `ORDER BY rank` become `fts.rank` (the `resources_fts fts` alias).

The non-obvious part: the qualifier must use the table **alias**, not the base table name. `resources_fts MATCH ?` still accepts the bare table name (an FTS5 quirk that makes the base name *look* usable), but a normal column reference like `.rank` resolves by alias once the table is aliased — so the literal `resources_fts.rank` fails with `no such column` on the aliased generic/similar queries. I verified this directly against SQLite before editing.

For resources without a `rank` column this is a no-op: the qualifier just names the only `rank` in scope, which is what SQLite resolved to anyway.

## Scope

Primary area: `cli` — generator templates that emit the printed-CLI store SQL.

Why this belongs in this repo: this is a generator bug, not a printed-CLI bug. Every past and future printed CLI with a rank-fielded resource inherits the broken query; fixing the machine (templates) fixes them all on next regen. A per-CLI fix in the public library would not compound, but the filer's "always-correct, zero-downside" judgment and the cross-CLI impact make this a machine fix.

## Catalog Justification

N/A — no `catalog/*.yaml` or `catalog/specs/**` changes.

## Risk

Low. The change is four SQL-string qualifications inside generated `SELECT` statements; it touches no Go control flow, no MCP surface, no auth, no publish flow, and no verifier/scorer. The only behavioral effect is that `search` now *works* on rank-fielded resources and is unchanged everywhere else (the qualifier names the sole `rank` in scope). Worst case if wrong: a typo in a table/alias name would surface as an immediate SQLite prepare error in the new regression test, not a silent regression.

## Output Contract

This PR changes templates → generated `store.go` (and `insights/similar.go`) output shifts.

Golden diff (intentional, exactly this and nothing else):
- `testdata/golden/expected/generate-learn-loop-api/.../internal/store/store.go`
- `testdata/golden/expected/generate-sync-walker-api/.../internal/store/store.go`

Both change the generic `Search` query from `ORDER BY rank` → `ORDER BY f.rank` (two occurrences each — the resource-type-filtered branch and the unfiltered branch). No other golden fixture changed.

Per-resource (`Search<Resource>`) and `insights/similar` qualification aren't exercised by these two golden fixtures because their specs have no FTS5 resource / no `similar` artifact; they are covered instead by the new emitted-code + runtime regression test (`TestGenerateStoreFTSOrderByRankQualified`), which builds a rank-fielded FTS5 resource and runs the generated `TestSearchItemsQuotesFTSQuerySyntax` against a SQLite DB with a typed `rank` column.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands actually run (Go 1.26.4):
- `go test ./internal/generator` — clean (0 failures; ~24m on this box). The new `TestGenerateStoreFTSOrderByRankQualified` **fails without the fix** with the live error `SearchItems("10.0.0.1"): SQL logic error: ambiguous column name: rank` and passes with it.
- `scripts/golden.sh verify` — 31/31 pass (after `scripts/golden.sh update`, diff inspected and limited to the two `store.go` fixtures above).
- `scripts/verify-generator-output.sh` — 9/9 generated modules compile (covers `generate-learn-loop-api`, which carries the qualified store.go).
- `go build ./...` + `go vet ./internal/generator` — clean.
- Direct SQLite repro confirmed the fix resolves the ambiguity and that the alias form (`f.rank`/`fts.rank`) is required, not the base table name.

Not run: the full `go test ./...` package run hits the default 10m timeout on the two compile-heaviest packages (`internal/generator`, `internal/cli`) on this hardware; `internal/generator` was re-run with `-timeout 60m` and is fully green with zero `--- FAIL` anywhere in the suite. `govulncheck` needs network (unavailable here) and was not run locally.

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
