### PR TITLE
fix(cli): wire seeded cookie jar for cookie-auth client transport

### DIFF
--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -1,0 +1,138 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCookieAuthClientSeedsJar pins the #2512 transport fix: a cookie-auth
+// client must seed a real net/http cookie jar from the stored cookie credential
+// (env-var session or browser AccessToken), so the captured session rides every
+// request and net/http absorbs Set-Cookie rotation. Before the fix New() built
+// the client with a nil/disk-only jar and the live request branch sent no
+// cookies, so a correctly-authed cookie CLI 401'd on every call.
+func TestCookieAuthClientSeedsJar(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cookieseed")
+	apiSpec.BaseURL = "https://api.cookieseed.example"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "cookie",
+		Header:  "Cookie",
+		Cookies: []string{"session_id", "csrf_token"},
+		EnvVars: []string{"COOKIESEED_SESSION"},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "cookieseed-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+
+	// New() must load the persistent jar AND seed it from the cookie credential.
+	assert.Contains(t, clientSrc, "cookieJar := LoadCookieJar()",
+		"cookie-auth New() must build the persistent jar")
+	assert.Contains(t, clientSrc, "SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())",
+		"cookie-auth New() must seed the jar from the stored cookie credential")
+	assert.Contains(t, clientSrc, "httpClient := newHTTPClient(timeout, cookieJar)",
+		"cookie-auth client must use the seeded jar, not a nil jar")
+	assert.NotContains(t, clientSrc, "newHTTPClient(timeout, nil)",
+		"cookie-auth client must never construct an HTTP client with a nil jar")
+
+	// CookieCredential() must return the RAW cookie-jar string (no Bearer
+	// prefix); the env-var session wins over the file-stored browser cookie.
+	assert.Contains(t, configSrc, "func (c *Config) CookieCredential() string {",
+		"cookie-auth config must emit CookieCredential")
+	assert.Contains(t, configSrc, "return c.CookieseedSession",
+		"CookieCredential must return the env-var session unwrapped")
+	assert.Contains(t, configSrc, "return c.AccessToken",
+		"CookieCredential must fall back to the browser AccessToken unwrapped")
+
+	// The seed/parse helpers must be emitted (gated on HasCookies).
+	jarSrc := readGeneratedFile(t, outputDir, "internal", "client", "cookiejar.go")
+	assert.Contains(t, jarSrc, "func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string)")
+	assert.Contains(t, jarSrc, "func parseCookieJar(s string) []*http.Cookie")
+	assert.Contains(t, jarSrc, "func looksLikeCookieJar(s string) bool")
+
+	// Runtime proof: a seeded jar attaches the stored cookies to a request for
+	// the base URL, and parseCookieJar handles the "k=v; k=v" wire format.
+	runtimeTest := `package client
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"testing"
+)
+
+func TestSeedCookieJarAttachesStoredCookies(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	SeedCookieJar(jar, "https://api.cookieseed.example", "session_id=abc; csrf_token=def")
+
+	u, _ := url.Parse("https://api.cookieseed.example/items")
+	got := map[string]string{}
+	for _, c := range jar.Cookies(u) {
+		got[c.Name] = c.Value
+	}
+	if got["session_id"] != "abc" || got["csrf_token"] != "def" {
+		t.Fatalf("seeded jar did not attach stored cookies for the base URL: %v", got)
+	}
+}
+
+func TestSeedCookieJarIgnoresBareToken(t *testing.T) {
+	jar, _ := cookiejar.New(nil)
+	SeedCookieJar(jar, "https://api.cookieseed.example", "not-a-cookie-jar-token")
+	u, _ := url.Parse("https://api.cookieseed.example/items")
+	if cs := jar.Cookies(u); len(cs) != 0 {
+		t.Fatalf("a bare token must not be parsed into cookies, got %v", cs)
+	}
+}
+
+func TestSeedCookieJarNilJarIsNoop(t *testing.T) {
+	var jar http.CookieJar
+	SeedCookieJar(jar, "https://api.cookieseed.example", "session_id=abc")
+}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDir, "internal", "client", "seed_runtime_test.go"),
+		[]byte(runtimeTest), 0o600))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/client/", "-run", "TestSeedCookieJar")
+}
+
+// TestBearerAuthClientOmitsCookieJarSeed pins the negative: bearer/api_key auth
+// must not emit any cookie-jar seeding, must construct the client with a nil
+// jar, and must not emit the cookiejar.go file at all.
+func TestBearerAuthClientOmitsCookieJarSeed(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("bearerseed")
+	// minimalSpec already uses api_key/Bearer auth with no cookies.
+
+	outputDir := filepath.Join(t.TempDir(), "bearerseed-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+	assert.NotContains(t, clientSrc, "SeedCookieJar",
+		"bearer auth must not seed a cookie jar")
+	assert.NotContains(t, clientSrc, "LoadCookieJar",
+		"bearer auth must not load a cookie jar")
+	assert.NotContains(t, clientSrc, "CookieCredential",
+		"bearer auth must not reference CookieCredential")
+	assert.Contains(t, clientSrc, "newHTTPClient(timeout, nil)",
+		"bearer auth must construct the client with a nil jar")
+
+	if _, err := os.Stat(filepath.Join(outputDir, "internal", "client", "cookiejar.go")); !os.IsNotExist(err) {
+		t.Fatalf("bearer auth must not emit cookiejar.go (stat err=%v)", err)
+	}
+
+	configSrc := readGeneratedFile(t, outputDir, "internal", "config", "config.go")
+	assert.NotContains(t, configSrc, "CookieCredential",
+		"bearer auth config must not emit CookieCredential")
+}

--- a/internal/generator/client_cookie_jar_seed_test.go
+++ b/internal/generator/client_cookie_jar_seed_test.go
@@ -67,6 +67,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"testing"
 )
 
@@ -97,13 +98,55 @@ func TestSeedCookieJarNilJarIsNoop(t *testing.T) {
 	var jar http.CookieJar
 	SeedCookieJar(jar, "https://api.cookieseed.example", "session_id=abc")
 }
+
+// TestSeedCookieJarDoesNotPersist pins the no-clobber contract: seeding the
+// persistent wrapper jar must only touch the in-memory inner jar, never write
+// cookies.json. Otherwise a stale env/credential value overwrites a fresher
+// rotation-refreshed cookie already on disk.
+func TestSeedCookieJarDoesNotPersist(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	jar := LoadCookieJar()
+	SeedCookieJar(jar, "https://api.cookieseed.example", "session_id=abc; csrf_token=def")
+
+	// The seeded cookies must be live on the wrapper for the base URL...
+	u, _ := url.Parse("https://api.cookieseed.example/items")
+	if cs := jar.Cookies(u); len(cs) != 2 {
+		t.Fatalf("seeded wrapper jar did not attach stored cookies: %v", cs)
+	}
+	// ...but seeding must not have written the on-disk cookie file.
+	if _, err := os.Stat(cookieJarPath()); !os.IsNotExist(err) {
+		t.Fatalf("SeedCookieJar must not persist to cookies.json (stat err=%v)", err)
+	}
+}
+
+// TestLooksLikeCookieJarRejectsJWT pins the gate tightening: a base64-padded
+// JWT contains "=" yet is a single bearer token; it must not be parsed into a
+// bogus cookie, while a real name=value pair still passes.
+func TestLooksLikeCookieJarRejectsJWT(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJlQQ=="
+	if looksLikeCookieJar(jwt) {
+		t.Fatalf("JWT-shaped token must be rejected by the cookie-jar gate")
+	}
+	jar, _ := cookiejar.New(nil)
+	SeedCookieJar(jar, "https://api.cookieseed.example", jwt)
+	u, _ := url.Parse("https://api.cookieseed.example/items")
+	if cs := jar.Cookies(u); len(cs) != 0 {
+		t.Fatalf("a JWT bearer token must not seed any cookie, got %v", cs)
+	}
+	if !looksLikeCookieJar("session_id=abc; csrf_token=def") {
+		t.Fatalf("a real cookie-jar string must still pass the gate")
+	}
+	if !looksLikeCookieJar("session_id=abc") {
+		t.Fatalf("a single legit name=value cookie must still pass the gate")
+	}
+}
 `
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outputDir, "internal", "client", "seed_runtime_test.go"),
 		[]byte(runtimeTest), 0o600))
 
 	runGoCommand(t, outputDir, "mod", "tidy")
-	runGoCommand(t, outputDir, "test", "./internal/client/", "-run", "TestSeedCookieJar")
+	runGoCommand(t, outputDir, "test", "./internal/client/", "-run", "TestSeedCookieJar|TestLooksLikeCookieJar")
 }
 
 // TestBearerAuthClientOmitsCookieJarSeed pins the negative: bearer/api_key auth

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -451,7 +451,16 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	}
 {{- else}}
 {{- if .Auth.HasCookies}}
-	httpClient := newHTTPClient(timeout, LoadCookieJar())
+	cookieJar := LoadCookieJar()
+{{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
+	// Seed the jar from a session captured via the env var or stored in
+	// credentials but not yet in cookies.json, so the credential rides every
+	// request and net/http absorbs Set-Cookie rotation across the session.
+	if cfg != nil {
+		SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+	}
+{{- end}}
+	httpClient := newHTTPClient(timeout, cookieJar)
 {{- else}}
 	httpClient := newHTTPClient(timeout, nil)
 {{- end}}
@@ -1394,15 +1403,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 {{- else if and .Auth .Auth.In (eq .Auth.In "cookie")}}
 			req.AddCookie(&http.Cookie{Name: "{{if .Auth.Header}}{{.Auth.Header}}{{else}}api_key{{end}}", Value: authHeader})
 {{- else if eq .Auth.Type "cookie"}}
-			// Cookie-auth: LoadCookieJar is the sole source of outbound
-			// cookies. net/http's Client.send calls jar.Cookies + AddCookie
-			// for each cookie, which concatenates without dedup; a manual
-			// req.Header.Set here would ship every session cookie twice and
-			// trip upstream WAFs. auth login persists the same cookie set
-			// to both the jar and config, so the jar carries every value
-			// SaveTokens stores. authHeader is read only by the dry-run /
-			// signing paths above; intentionally not consumed on the live
-			// wire here.
+			// Cookie-auth: the cookie jar is the sole source of outbound
+			// cookies. New() loads it from cookies.json and seeds it from
+			// the env-var / credentials session via SeedCookieJar, so every
+			// cookie source flows through the jar. net/http's Client.send
+			// calls jar.Cookies + AddCookie for each cookie, which
+			// concatenates without dedup; a manual req.Header.Set here would
+			// ship every session cookie twice and trip upstream WAFs.
+			// authHeader is read only by the dry-run / signing paths above;
+			// intentionally not consumed on the live wire here.
 {{- else}}
 			req.Header.Set("{{if .Auth.Header}}{{.Auth.Header}}{{else}}Authorization{{end}}", authHeader)
 {{- end}}

--- a/internal/generator/templates/config.go.tmpl
+++ b/internal/generator/templates/config.go.tmpl
@@ -710,6 +710,34 @@ func (c *Config) AuthHeader() string {
 {{- end}}
 }
 
+{{- if or (eq .Auth.Type "composed") (eq .Auth.Type "cookie")}}
+
+// CookieCredential returns the raw stored cookie credential for cookie/composed
+// auth with no scheme prefix: the env-var-provided session string wins over the
+// file-stored browser cookie, mirroring AuthHeader's precedence. The value is
+// the cookie-jar string ("name=value; name=value") captured at login or exported
+// via the session env var, suitable for seeding an http.CookieJar so the
+// credential rides every request. Returns "" when no cookie credential is set.
+func (c *Config) CookieCredential() string {
+{{- $canonicalEnvVar := .Auth.CanonicalEnvVar}}
+{{- $isAuthEnvVarORCase := .Auth.IsAuthEnvVarORCase}}
+{{- if $isAuthEnvVarORCase}}
+{{- range .Auth.EnvVarSpecs}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return c.{{resolveEnvVarField .Name}}
+	}
+{{- end}}
+{{- else}}
+	{{- with $canonicalEnvVar}}
+	if c.{{resolveEnvVarField .Name}} != "" {
+		return c.{{resolveEnvVarField .Name}}
+	}
+	{{- end}}
+{{- end}}
+	return c.AccessToken
+}
+{{- end}}
+
 func applyAuthFormat(format string, replacements map[string]string) string {
 	if format == "" {
 		return ""

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -55,6 +55,57 @@ func cookieJarPath() string {
 	return filepath.Join(dir, "cookies.json")
 }
 
+// looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
+// name=value") rather than a bare token. The session env var and the browser
+// AccessToken both store the full Cookie header, so a "=" gates the seed and
+// keeps a stray bearer token from being parsed into a bogus cookie.
+func looksLikeCookieJar(s string) bool {
+	return strings.Contains(s, "=")
+}
+
+// parseCookieJar splits a Cookie-header-style string ("name=value; name=value")
+// into cookies. Pairs without "=" or with an empty name are skipped; values are
+// sanitized to the bytes net/http's jar accepts.
+func parseCookieJar(s string) []*http.Cookie {
+	parts := strings.Split(s, ";")
+	cookies := make([]*http.Cookie, 0, len(parts))
+	for _, part := range parts {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{
+			Name:  name,
+			Value: sanitizeCookieValue(strings.TrimSpace(value)),
+		})
+	}
+	return cookies
+}
+
+// SeedCookieJar seeds jar with the cookies in a Cookie-header-style credential
+// string scoped to baseURL's host, so a session captured via the env var or
+// stored in credentials (not the on-disk cookies.json) still rides every
+// request. Seeding the jar (rather than setting a static Cookie header) lets
+// net/http absorb Set-Cookie rotation — Cloudflare __cf_bm, AWS ALB AWSALB —
+// across a multi-request session that a static header would let go stale.
+// A no-op when the credential is empty, is not a cookie-jar string, or baseURL
+// does not parse.
+func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
+	if jar == nil || !looksLikeCookieJar(cookieStr) {
+		return
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return
+	}
+	cookies := parseCookieJar(cookieStr)
+	if len(cookies) == 0 {
+		return
+	}
+	jar.SetCookies(u, cookies)
+}
+
 // sanitizeCookieValue strips bytes that net/http's cookie jar rejects per
 // RFC 6265 (cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E;
 // excludes whitespace, double-quote, comma, semicolon, backslash, and

--- a/internal/generator/templates/cookiejar.go.tmpl
+++ b/internal/generator/templates/cookiejar.go.tmpl
@@ -57,10 +57,44 @@ func cookieJarPath() string {
 
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
 // name=value") rather than a bare token. The session env var and the browser
-// AccessToken both store the full Cookie header, so a "=" gates the seed and
-// keeps a stray bearer token from being parsed into a bogus cookie.
+// AccessToken both store the full Cookie header, so the seed is gated on a real
+// "name=value" pair. A bare "=" is too loose: a base64-padded JWT ("eyJ...Q==")
+// contains "=" yet is a single bearer token, and strings.Cut would split it into
+// a bogus {name:"eyJ...Q", value:"="} cookie. So require the first segment to be
+// a valid name=value pair whose name is a legal cookie-name token; that screens
+// out JWT/bearer values while still passing a single legit "name=value" cookie.
 func looksLikeCookieJar(s string) bool {
-	return strings.Contains(s, "=")
+	first, _, _ := strings.Cut(s, ";")
+	name, value, ok := strings.Cut(strings.TrimSpace(first), "=")
+	if !ok || value == "" {
+		return false
+	}
+	return isCookieName(strings.TrimSpace(name))
+}
+
+// isCookieName reports whether s is a non-empty RFC 6265 cookie-name token
+// (RFC 2616 token: no controls, spaces, or separators). It additionally rejects
+// "." and "/": these are valid token bytes but appear in JWT/bearer values
+// (header.payload.signature, base64url "/"), which a padded "==" suffix would
+// otherwise sneak past as a name=value pair. Server-set cookie names do not use
+// them in practice, so screening them out separates a real session jar from a
+// bearer token without rejecting legitimate single cookies.
+func isCookieName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b <= 0x20 || b >= 0x7f {
+			return false
+		}
+		switch b {
+		case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"',
+			'/', '[', ']', '?', '=', '{', '}', '.':
+			return false
+		}
+	}
+	return true
 }
 
 // parseCookieJar splits a Cookie-header-style string ("name=value; name=value")
@@ -101,6 +135,16 @@ func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
 	}
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
+		return
+	}
+	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
+	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),
+	// which would clobber fresher rotation-refreshed values (Cloudflare __cf_bm,
+	// AWS ALB AWSALB) already on disk with the stale env/credential ones. Seeding
+	// the inner jar (as loadFromDisk does) keeps the credential live for the
+	// session without touching the persisted set.
+	if cj, ok := jar.(*cookieJar); ok {
+		cj.inner.SetCookies(u, cookies)
 		return
 	}
 	jar.SetCookies(u, cookies)

--- a/internal/generator/templates_test.go
+++ b/internal/generator/templates_test.go
@@ -17,6 +17,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// funcBody returns the source of the function whose declaration starts with
+// decl (including the opening brace), spanning to its matching closing brace.
+// Used to scope NotContains assertions to a single emitted function rather than
+// the whole generated file.
+func funcBody(t *testing.T, src, decl string) string {
+	t.Helper()
+	start := strings.Index(src, decl)
+	require.NotEqual(t, -1, start, "function declaration %q not found", decl)
+	depth := 0
+	for i := start + len(decl) - 1; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced braces after %q", decl)
+	return ""
+}
+
 func TestGoTemplatesEscapeSpecTextInStringLiterals(t *testing.T) {
 	t.Parallel()
 
@@ -511,13 +535,16 @@ func TestAuthHeaderComposedAndCookieApplySchemePrefix(t *testing.T) {
 			require.NoError(t, err)
 			content := string(configSrc)
 
-			// The raw-return literal must appear nowhere in the emitted config — every
-			// composed/cookie return path now flows through ensureAuthScheme. Whole-file
-			// NotContains avoids depending on a fragile slice boundary.
-			require.NotContains(t, content, "return c."+tt.envField+"\n",
-				"%s auth must not return raw env-var token without scheme prefix:\n%s", tt.authType, content)
-			require.NotContains(t, content, "return c.AccessToken\n",
-				"%s auth must not return raw AccessToken without scheme prefix:\n%s", tt.authType, content)
+			// The raw-return literal must appear nowhere in AuthHeader() — every
+			// composed/cookie return path there now flows through ensureAuthScheme.
+			// Scope to the AuthHeader() body: CookieCredential() intentionally
+			// returns the raw cookie-jar string (no scheme) for jar seeding, so a
+			// whole-file NotContains would false-positive on it.
+			authHeaderBody := funcBody(t, content, "func (c *Config) AuthHeader() string {")
+			require.NotContains(t, authHeaderBody, "return c."+tt.envField+"\n",
+				"%s AuthHeader must not return raw env-var token without scheme prefix:\n%s", tt.authType, authHeaderBody)
+			require.NotContains(t, authHeaderBody, "return c.AccessToken\n",
+				"%s AuthHeader must not return raw AccessToken without scheme prefix:\n%s", tt.authType, authHeaderBody)
 
 			// The replacement ensureAuthScheme call must be the wrapper for both paths.
 			require.Contains(t, content,

--- a/testdata/golden/cases/generate-golden-api-cookie-auth/artifacts.txt
+++ b/testdata/golden/cases/generate-golden-api-cookie-auth/artifacts.txt
@@ -1,7 +1,8 @@
 # Locks the cookie-auth CDP WebSocket eval emission shape so future template
 # changes can't silently reorder the import block, rename the helper, or drop
 # the bounded-deadline calls without the golden suite catching the drift.
-# Also locks the cookie-jar wiring: client.go's New() calls LoadCookieJar()
+# Also locks the cookie-jar wiring: client.go's New() loads the persistent jar
+# and seeds it (SeedCookieJar) from the env-var / credentials cookie session
 # when auth.cookies is declared, and a generalized cookiejar.go ships in the
 # client package so subsequent invocations carry the user's session.
 golden-api-cookie-auth/internal/cli/auth.go

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -103,7 +103,14 @@ func New(cfg *config.Config, timeout time.Duration, rateLimit float64) *Client {
 	if dir, err := cliutil.CacheDir(); err == nil {
 		cacheDir = filepath.Join(dir, "http")
 	}
-	httpClient := newHTTPClient(timeout, LoadCookieJar())
+	cookieJar := LoadCookieJar()
+	// Seed the jar from a session captured via the env var or stored in
+	// credentials but not yet in cookies.json, so the credential rides every
+	// request and net/http absorbs Set-Cookie rotation across the session.
+	if cfg != nil {
+		SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())
+	}
+	httpClient := newHTTPClient(timeout, cookieJar)
 	c := &Client{
 		BaseURL:    strings.TrimRight(cfg.BaseURL, "/"),
 		Config:     cfg,
@@ -526,15 +533,15 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		}
 
 		if authHeader != "" {
-			// Cookie-auth: LoadCookieJar is the sole source of outbound
-			// cookies. net/http's Client.send calls jar.Cookies + AddCookie
-			// for each cookie, which concatenates without dedup; a manual
-			// req.Header.Set here would ship every session cookie twice and
-			// trip upstream WAFs. auth login persists the same cookie set
-			// to both the jar and config, so the jar carries every value
-			// SaveTokens stores. authHeader is read only by the dry-run /
-			// signing paths above; intentionally not consumed on the live
-			// wire here.
+			// Cookie-auth: the cookie jar is the sole source of outbound
+			// cookies. New() loads it from cookies.json and seeds it from
+			// the env-var / credentials session via SeedCookieJar, so every
+			// cookie source flows through the jar. net/http's Client.send
+			// calls jar.Cookies + AddCookie for each cookie, which
+			// concatenates without dedup; a manual req.Header.Set here would
+			// ship every session cookie twice and trip upstream WAFs.
+			// authHeader is read only by the dry-run / signing paths above;
+			// intentionally not consumed on the live wire here.
 		}
 		if c.Config != nil {
 			for k, v := range c.Config.Headers {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -55,6 +55,57 @@ func cookieJarPath() string {
 	return filepath.Join(dir, "cookies.json")
 }
 
+// looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
+// name=value") rather than a bare token. The session env var and the browser
+// AccessToken both store the full Cookie header, so a "=" gates the seed and
+// keeps a stray bearer token from being parsed into a bogus cookie.
+func looksLikeCookieJar(s string) bool {
+	return strings.Contains(s, "=")
+}
+
+// parseCookieJar splits a Cookie-header-style string ("name=value; name=value")
+// into cookies. Pairs without "=" or with an empty name are skipped; values are
+// sanitized to the bytes net/http's jar accepts.
+func parseCookieJar(s string) []*http.Cookie {
+	parts := strings.Split(s, ";")
+	cookies := make([]*http.Cookie, 0, len(parts))
+	for _, part := range parts {
+		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		cookies = append(cookies, &http.Cookie{
+			Name:  name,
+			Value: sanitizeCookieValue(strings.TrimSpace(value)),
+		})
+	}
+	return cookies
+}
+
+// SeedCookieJar seeds jar with the cookies in a Cookie-header-style credential
+// string scoped to baseURL's host, so a session captured via the env var or
+// stored in credentials (not the on-disk cookies.json) still rides every
+// request. Seeding the jar (rather than setting a static Cookie header) lets
+// net/http absorb Set-Cookie rotation — Cloudflare __cf_bm, AWS ALB AWSALB —
+// across a multi-request session that a static header would let go stale.
+// A no-op when the credential is empty, is not a cookie-jar string, or baseURL
+// does not parse.
+func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
+	if jar == nil || !looksLikeCookieJar(cookieStr) {
+		return
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return
+	}
+	cookies := parseCookieJar(cookieStr)
+	if len(cookies) == 0 {
+		return
+	}
+	jar.SetCookies(u, cookies)
+}
+
 // sanitizeCookieValue strips bytes that net/http's cookie jar rejects per
 // RFC 6265 (cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E;
 // excludes whitespace, double-quote, comma, semicolon, backslash, and

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/cookiejar.go
@@ -57,10 +57,44 @@ func cookieJarPath() string {
 
 // looksLikeCookieJar reports whether s is a cookie-jar string ("name=value;
 // name=value") rather than a bare token. The session env var and the browser
-// AccessToken both store the full Cookie header, so a "=" gates the seed and
-// keeps a stray bearer token from being parsed into a bogus cookie.
+// AccessToken both store the full Cookie header, so the seed is gated on a real
+// "name=value" pair. A bare "=" is too loose: a base64-padded JWT ("eyJ...Q==")
+// contains "=" yet is a single bearer token, and strings.Cut would split it into
+// a bogus {name:"eyJ...Q", value:"="} cookie. So require the first segment to be
+// a valid name=value pair whose name is a legal cookie-name token; that screens
+// out JWT/bearer values while still passing a single legit "name=value" cookie.
 func looksLikeCookieJar(s string) bool {
-	return strings.Contains(s, "=")
+	first, _, _ := strings.Cut(s, ";")
+	name, value, ok := strings.Cut(strings.TrimSpace(first), "=")
+	if !ok || value == "" {
+		return false
+	}
+	return isCookieName(strings.TrimSpace(name))
+}
+
+// isCookieName reports whether s is a non-empty RFC 6265 cookie-name token
+// (RFC 2616 token: no controls, spaces, or separators). It additionally rejects
+// "." and "/": these are valid token bytes but appear in JWT/bearer values
+// (header.payload.signature, base64url "/"), which a padded "==" suffix would
+// otherwise sneak past as a name=value pair. Server-set cookie names do not use
+// them in practice, so screening them out separates a real session jar from a
+// bearer token without rejecting legitimate single cookies.
+func isCookieName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b <= 0x20 || b >= 0x7f {
+			return false
+		}
+		switch b {
+		case '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"',
+			'/', '[', ']', '?', '=', '{', '}', '.':
+			return false
+		}
+	}
+	return true
 }
 
 // parseCookieJar splits a Cookie-header-style string ("name=value; name=value")
@@ -101,6 +135,16 @@ func SeedCookieJar(jar http.CookieJar, baseURL, cookieStr string) {
 	}
 	cookies := parseCookieJar(cookieStr)
 	if len(cookies) == 0 {
+		return
+	}
+	// Seed the in-memory jar only — never persist. The wrapper's SetCookies
+	// writes through to cookies.json (persistLocked -> mergeAndWriteCookieRows),
+	// which would clobber fresher rotation-refreshed values (Cloudflare __cf_bm,
+	// AWS ALB AWSALB) already on disk with the stale env/credential ones. Seeding
+	// the inner jar (as loadFromDisk does) keeps the credential live for the
+	// session without touching the persisted set.
+	if cj, ok := jar.(*cookieJar); ok {
+		cj.inner.SetCookies(u, cookies)
 		return
 	}
 	jar.SetCookies(u, cookies)


### PR DESCRIPTION
## Intent

Cookie/browser-session auth (`auth.type: cookie` / `composed`) ships broken: the generated client transport sends no cookies on the wire, so a CLI that correctly captured a session (via `auth login --chrome`'s env-var/credentials path or an exported session env var) still 401s on every live call.

Issue: Fixes part of #2512 (transport facet — the seeded-cookie-jar wiring described in the gong-pp-cli comment).

The pre-fix client built its HTTP client from a jar loaded **only** from `cookies.json`. A session captured into the session env var or stored in credentials (`AccessToken`) never reached the wire: the cookie request branch is comment-only, and `AuthHeader()` wraps the value as `Bearer <cookie-string>` (the #2512 facet-1 miswire), which is never sent for `type: cookie`. Result: persistent 401 despite a valid session.

## Approach

`New()` now loads the persistent jar **and** seeds it from the raw cookie credential scoped to the base URL via a new `SeedCookieJar(jar, baseURL, cookieStr)`. Every cookie source (on-disk `cookies.json`, env-var session, credentials `AccessToken`) flows through one jar, and seeding the jar — rather than setting a static `Cookie` header — lets `net/http` absorb `Set-Cookie` rotation (Cloudflare `__cf_bm`, AWS ALB `AWSALB`) across a multi-request session that a static header would let go stale.

- `internal/config/config.go`: new `CookieCredential()` returns the **unwrapped** cookie-jar string (env-var session wins over the file-stored browser cookie, mirroring `AuthHeader()` precedence). Emitted only for cookie/composed auth.
- `internal/client/cookiejar.go`: new `SeedCookieJar` + `parseCookieJar` (`"k=v; k=v"` -> `[]*http.Cookie`, value-sanitized) + `looksLikeCookieJar` gate. Emitted only when `auth.cookies` is declared (`HasCookies`).
- Gated on cookie/composed auth; **bearer/api_key emit no jar wiring and keep a nil jar** (pinned by a negative test).

Note: the facet-1 `Bearer`-not-`Cookie` env-var miswire in `AuthHeader()` is left as-is and remains tracked under #2512 — this PR fixes the live transport regardless of that wrapping, because the wire path now sources cookies from the jar, not `AuthHeader()`.

## Scope

Primary area: generator templates (`internal/generator/templates/`) — `client.go.tmpl`, `config.go.tmpl`, `cookiejar.go.tmpl`.

Why this belongs in this repo: the symptom surfaced in printed CLIs (gong, kdpnichefinder, others on #2512), but the root cause is in the generator's client/auth templates that every cookie-auth CLI inherits. This is a machine change so every future cookie/composed CLI is correct on first print.

## Catalog Justification

N/A — no catalog changes.

## Risk

- Cookie/composed auth only; guarded by `eq .Auth.Type "cookie"/"composed"` and `HasCookies`. Bearer/api_key/oauth2/session_handshake paths are untouched (session_handshake already owns its own jar).
- Generated output changes for cookie-auth CLIs (new `New()` seeding + three new helpers in `cookiejar.go`). Golden fixture `generate-golden-api-cookie-auth` updated accordingly; diff is exactly the seeding wiring.
- No new dependencies (`net/http/cookiejar`, `net/url` already imported by the emitted `cookiejar.go`).

## Output Contract

Generator/template change. Evidence:
- Emitted-code assertions + compiled generated CLI in `internal/generator/client_cookie_jar_seed_test.go`: a cookie-auth fork emits `SeedCookieJar(cookieJar, cfg.BaseURL, cfg.CookieCredential())`, `CookieCredential()` returns the raw session, and a **runtime** test (written into the generated module and run) proves the seeded jar attaches the stored cookies to a request for the base URL, ignores a bare token, and no-ops on a nil jar. Negative test asserts bearer auth emits no jar wiring and no `cookiejar.go`.
- Golden: `generate-golden-api-cookie-auth` updated (`client.go`, `cookiejar.go`); `scripts/golden.sh verify` passes.
- `scripts/verify-generator-output.sh generate-golden-api-cookie-auth` passes (generated module tidies + compiles).

## Verification

Run:
- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — pass
- `go test ./...` — pass (6498 passed, 0 failed)
- `scripts/golden.sh verify` — pass (31 cases)
- `scripts/verify-generator-output.sh generate-golden-api-cookie-auth` — pass
- `golangci-lint run ./internal/generator/...` — pass (no issues)
- `go fmt ./...` — clean

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF6Mc6UjYQbGVtp91YG1P3
