### PR TITLE
fix(cli): make dogfood --live + promote gate cookie-auth aware

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1868,7 +1868,12 @@ func finalizeLiveDogfoodReport(report *LiveDogfoodReport, authType string) {
 		// cookie-auth-no-harness-session skip marker) rather than the FAIL the
 		// no-live-signal path would otherwise produce. Pass the captured session
 		// via the config-override env var to exercise the matrix for real.
-		if isBrowserSessionAuthType(authType) {
+		//
+		// Only take the clean-skip path when nothing genuinely failed. A
+		// non-auth defect (e.g. a crashing --help) records a real FAIL that the
+		// session-less 401s must not mask: with report.Failed > 0 we fall
+		// through to the no-live-signal FAIL so the gate still sees the defect.
+		if isBrowserSessionAuthType(authType) && report.Failed == 0 {
 			report.Skipped++
 			report.Tests = append(report.Tests, LiveDogfoodTestResult{
 				Command: "live-dogfood",

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -44,6 +44,21 @@ const reasonMutatingDryRunOnly = "mutating command dry-run only"
 const reasonMutatingErrorPath = "mutating command; error_path would call live API without --dry-run"
 const reasonMutatingRunnableFixture = "blocked-fixture: mutating command requires runnable example"
 const reasonNoLiveSignal = "no live happy/json pass; credential-unavailable skips cannot certify acceptance"
+
+// reasonCookieAuthNoHarnessSession is the Skip reason emitted when a
+// cookie/composed/session_handshake CLI yields no live signal because the
+// sandboxed dogfood HOME carries no captured browser session. The resulting
+// 401s are a harness artifact, not a CLI defect: pass the captured session via
+// the config-override env var to exercise the matrix for real. Mirrors the
+// gate's phase5SkipReasonCookieAuthNoHarnessSession so the runner-written skip
+// marker is accepted by `lock promote`.
+const reasonCookieAuthNoHarnessSession = "cookie-auth-no-harness-session"
+
+// liveDogfoodVerdictCookieAuthNoSession is the report Verdict for a clean
+// cookie-auth skip outcome. Distinct from PASS/FAIL so the CLI exits 0 (the
+// 401s are not a defect) and writeLiveDogfoodAcceptance emits a skip marker
+// instead of a fail acceptance marker.
+const liveDogfoodVerdictCookieAuthNoSession = "skip-cookie-auth-no-session"
 const reasonUnavailableRunnerCredentials = "unavailable for runner credentials"
 const reasonFileFixtureRequired = "file fixture required"
 const reasonRequiredParamFixture = "blocked-fixture: required API parameter"
@@ -193,7 +208,8 @@ func RunLiveDogfood(opts LiveDogfoodOptions) (*LiveDogfoodReport, error) {
 		report.Tests = append(report.Tests, runLiveDogfoodCommand(command, ctx)...)
 	}
 
-	finalizeLiveDogfoodReport(report)
+	_, _, authType := resolveLiveDogfoodAcceptanceIdentity(opts.CLIDir)
+	finalizeLiveDogfoodReport(report, authType)
 	// The Phase 5.6 acceptance gate's contract is "marker from the runner on
 	// every outcome": pass → promote, fail → hold-path, missing → "Phase 5
 	// was skipped or not recorded." Writing only on PASS forced operators to
@@ -1823,7 +1839,7 @@ func liveDogfoodUsageSuffix(help string) string {
 	return ""
 }
 
-func finalizeLiveDogfoodReport(report *LiveDogfoodReport) {
+func finalizeLiveDogfoodReport(report *LiveDogfoodReport, authType string) {
 	hasUnavailableRunnerSkip := false
 	hasLiveHappyOrJSONPass := false
 	for _, result := range report.Tests {
@@ -1845,6 +1861,24 @@ func finalizeLiveDogfoodReport(report *LiveDogfoodReport) {
 		}
 	}
 	if hasUnavailableRunnerSkip && !hasLiveHappyOrJSONPass {
+		// Browser-session auth (cookie/composed/session_handshake) cannot be
+		// exercised by the sandboxed dogfood HOME: it carries no captured
+		// session, so every command 401s. That is a harness artifact, not a CLI
+		// defect — record a clean skip outcome (CLI exits 0; the gate accepts a
+		// cookie-auth-no-harness-session skip marker) rather than the FAIL the
+		// no-live-signal path would otherwise produce. Pass the captured session
+		// via the config-override env var to exercise the matrix for real.
+		if isBrowserSessionAuthType(authType) {
+			report.Skipped++
+			report.Tests = append(report.Tests, LiveDogfoodTestResult{
+				Command: "live-dogfood",
+				Kind:    LiveDogfoodTestHappy,
+				Status:  LiveDogfoodStatusSkip,
+				Reason:  reasonCookieAuthNoHarnessSession,
+			})
+			report.Verdict = liveDogfoodVerdictCookieAuthNoSession
+			return
+		}
 		report.Failed++
 		report.MatrixSize++
 		report.Tests = append(report.Tests, LiveDogfoodTestResult{
@@ -1866,6 +1900,19 @@ func finalizeLiveDogfoodReport(report *LiveDogfoodReport) {
 	}
 }
 
+// isBrowserSessionAuthType reports whether the auth type relies on a captured
+// browser session (cookie jar / handshake) rather than an env-var credential.
+// These cannot be exercised by the sandboxed dogfood HOME without injecting the
+// session via the config-override env var.
+func isBrowserSessionAuthType(authType string) bool {
+	switch strings.ToLower(strings.TrimSpace(authType)) {
+	case "cookie", "composed", "session_handshake":
+		return true
+	default:
+		return false
+	}
+}
+
 func writeLiveDogfoodAcceptance(opts LiveDogfoodOptions, report *LiveDogfoodReport) error {
 	// Identity (api_name/run_id) is recorded so `lock promote`'s cross-check
 	// in validatePhase5Marker can reject stale markers. Three sources, in
@@ -1879,6 +1926,26 @@ func writeLiveDogfoodAcceptance(opts LiveDogfoodOptions, report *LiveDogfoodRepo
 	apiName, runID, authType := resolveLiveDogfoodAcceptanceIdentity(opts.CLIDir)
 	if authType == "" {
 		authType = "none"
+	}
+
+	// Browser-session auth with no captured session: emit a skip marker (the
+	// gate reads phase5-skip.json beside the acceptance path), not a fail
+	// acceptance marker. The 401-cascade is a harness artifact, not a defect.
+	if report.Verdict == liveDogfoodVerdictCookieAuthNoSession {
+		skipMarker := Phase5GateMarker{
+			SchemaVersion: 1,
+			APIName:       apiName,
+			RunID:         runID,
+			Status:        "skip",
+			Level:         "none",
+			SkipReason:    phase5SkipReasonCookieAuthNoHarnessSession,
+			AuthContext: Phase5AuthContext{
+				Type:                    authType,
+				BrowserSessionAvailable: false,
+			},
+		}
+		skipPath := filepath.Join(filepath.Dir(opts.WriteAcceptancePath), Phase5SkipFilename)
+		return writeLiveDogfoodMarkerFile(skipPath, skipMarker)
 	}
 
 	status := "pass"
@@ -1904,15 +1971,19 @@ func writeLiveDogfoodAcceptance(opts LiveDogfoodOptions, report *LiveDogfoodRepo
 		},
 		FailureSummary: failureSummary,
 	}
+	return writeLiveDogfoodMarkerFile(opts.WriteAcceptancePath, marker)
+}
+
+func writeLiveDogfoodMarkerFile(path string, marker Phase5GateMarker) error {
 	data, err := json.MarshalIndent(marker, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshaling phase5 acceptance marker: %w", err)
+		return fmt.Errorf("marshaling phase5 marker: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(opts.WriteAcceptancePath), 0o755); err != nil {
-		return fmt.Errorf("creating phase5 acceptance directory: %w", err)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating phase5 marker directory: %w", err)
 	}
-	if err := os.WriteFile(opts.WriteAcceptancePath, data, 0o644); err != nil {
-		return fmt.Errorf("writing phase5 acceptance marker: %w", err)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing phase5 marker: %w", err)
 	}
 	return nil
 }

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2213,6 +2213,20 @@ func TestFinalizeLiveDogfoodReportVerdictGate(t *testing.T) {
 			},
 			want: "PASS",
 		},
+		{
+			// A genuine non-auth failure (e.g. a crashing --help) alongside the
+			// session-less 401 skips must NOT be masked by the cookie-auth
+			// clean-skip path: report.Failed > 0 keeps the verdict FAIL so the
+			// gate still sees the real defect.
+			name:     "cookie auth with a genuine failure stays FAIL, not a clean skip",
+			level:    "full",
+			authType: "cookie",
+			results: []LiveDogfoodTestResult{
+				{Status: LiveDogfoodStatusFail, Kind: LiveDogfoodTestHappy, Args: []string{"widgets", "list"}},
+				{Status: LiveDogfoodStatusSkip, Reason: reasonUnavailableRunnerCredentials},
+			},
+			want: "FAIL",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -478,6 +478,99 @@ exit 99
 	assert.Equal(t, cookieOriginalBody, string(gotCookies), "live dogfood must not mutate the operator's real cookies")
 }
 
+// TestRunLiveDogfoodCookieAuthNoSessionSkips covers issue #3104: a cookie-auth
+// CLI run in the sandboxed dogfood HOME (no captured session) 401s every
+// command. Those 401s are a harness artifact, not a CLI defect, so the runner
+// records a clean skip verdict (CLI exits 0) and writes a phase5-skip.json the
+// promote gate accepts — instead of counting the 401s as failures.
+func TestRunLiveDogfoodCookieAuthNoSessionSkips(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	const binaryName = "fixture-pp-cli"
+
+	// Sandboxed HOME so the cookie jar is absent — mirror the real harness.
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion: 1,
+		APIName:       "fixture",
+		RunID:         "run-cookie-no-session",
+		AuthType:      "cookie",
+		SpecFormat:    "openapi3",
+	}))
+	writeStubBinary(t, dir, binaryName, `set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"account","subcommands":[{"name":"show"}]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Show the authenticated account.
+
+Usage:
+  fixture-pp-cli account show [flags]
+
+Examples:
+  fixture-pp-cli account show
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+if [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  echo "HTTP 401: couldn't authenticate; login required" >&2
+  exit 1
+fi
+
+echo "unexpected args: $*" >&2
+exit 99
+`)
+
+	markerPath := filepath.Join(t.TempDir(), Phase5AcceptanceFilename)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:              dir,
+		BinaryName:          binaryName,
+		Level:               "full",
+		Timeout:             2 * time.Second,
+		WriteAcceptancePath: markerPath,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, liveDogfoodVerdictCookieAuthNoSession, report.Verdict, report.Tests)
+	assert.Equal(t, 0, report.Failed, "cookie-auth 401s must not count as failures")
+
+	// The runner writes the skip marker, not the fail acceptance marker.
+	_, err = os.Stat(markerPath)
+	assert.True(t, os.IsNotExist(err), "no fail acceptance marker should be written for the cookie-auth skip")
+	skipPath := filepath.Join(filepath.Dir(markerPath), Phase5SkipFilename)
+	data, err := os.ReadFile(skipPath)
+	require.NoError(t, err, "cookie-auth skip must write a phase5-skip.json marker")
+	var marker Phase5GateMarker
+	require.NoError(t, json.Unmarshal(data, &marker))
+	assert.Equal(t, "skip", marker.Status)
+	assert.Equal(t, phase5SkipReasonCookieAuthNoHarnessSession, marker.SkipReason)
+	assert.Equal(t, "cookie", marker.AuthContext.Type)
+
+	// The promote gate accepts the skip marker.
+	validation := ValidatePhase5Gate(filepath.Dir(skipPath), CLIManifest{
+		APIName: marker.APIName, RunID: marker.RunID, AuthType: "cookie",
+	})
+	assert.True(t, validation.Passed, validation.Detail)
+	assert.Equal(t, "skip", validation.Status)
+}
+
 func TestRunLiveDogfoodSyncsOAuth2RefreshConfigBackToOperatorHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a shell script as the fake binary; skip on Windows")
@@ -1982,10 +2075,11 @@ func TestFinalizeLiveDogfoodReportVerdictGate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		level   string
-		results []LiveDogfoodTestResult
-		want    string
+		name     string
+		level    string
+		authType string
+		results  []LiveDogfoodTestResult
+		want     string
 	}{
 		{
 			name:  "quick all pass classic",
@@ -2095,6 +2189,30 @@ func TestFinalizeLiveDogfoodReportVerdictGate(t *testing.T) {
 			},
 			want: "FAIL",
 		},
+		{
+			// Cookie auth with no captured session: the sandboxed HOME 401s
+			// every command. That is a harness artifact, so the no-live-signal
+			// outcome becomes a clean skip verdict, not a FAIL.
+			name:     "cookie auth credential-unavailable skips become a clean skip",
+			level:    "full",
+			authType: "cookie",
+			results: []LiveDogfoodTestResult{
+				{Status: LiveDogfoodStatusSkip, Reason: reasonUnavailableRunnerCredentials},
+			},
+			want: liveDogfoodVerdictCookieAuthNoSession,
+		},
+		{
+			// A cookie-auth CLI that did get one real live pass (session
+			// injected) certifies normally, not as a skip.
+			name:     "cookie auth with a live pass certifies normally",
+			level:    "full",
+			authType: "cookie",
+			results: []LiveDogfoodTestResult{
+				{Status: LiveDogfoodStatusPass, Kind: LiveDogfoodTestHappy, Args: []string{"account", "show"}},
+				{Status: LiveDogfoodStatusSkip, Reason: reasonUnavailableRunnerCredentials},
+			},
+			want: "PASS",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2104,7 +2222,7 @@ func TestFinalizeLiveDogfoodReportVerdictGate(t *testing.T) {
 				Verdict: "PASS",
 				Tests:   tt.results,
 			}
-			finalizeLiveDogfoodReport(report)
+			finalizeLiveDogfoodReport(report, tt.authType)
 			assert.Equal(t, tt.want, report.Verdict, "Passed=%d Failed=%d Skipped=%d MatrixSize=%d",
 				report.Passed, report.Failed, report.Skipped, report.MatrixSize)
 		})

--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -19,6 +19,14 @@ const (
 	phase5SkipReasonExternalCredentialsUnavailable = "external_credentials_unavailable"
 	phase5SkipReasonLANUnreachableFromHost         = "lan-unreachable-from-generation-host"
 	phase5SkipReasonLocalSourceRequiresDatabase    = "local_source_requires_operator_database"
+	// phase5SkipReasonCookieAuthNoHarnessSession records that a
+	// cookie/composed/session_handshake CLI could not be exercised live
+	// because the sandboxed dogfood HOME carried no captured browser session.
+	// The 401s this produces are a harness artifact, not a CLI defect; the
+	// live runner emits the matching skip. Valid only for browser-session
+	// auth types — credentialed auth (api_key/bearer/oauth2) keeps using
+	// auth_required_no_credential.
+	phase5SkipReasonCookieAuthNoHarnessSession = "cookie-auth-no-harness-session"
 )
 
 var phase5AcceptedAcceptanceLevels = []string{
@@ -297,7 +305,15 @@ func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, str
 	}
 	switch authType {
 	case "cookie", "composed", "session_handshake":
-		return false, "browser-session auth APIs require phase5 acceptance; missing API key is not a valid skip"
+		// The sandboxed dogfood HOME carries no captured browser session, so
+		// every command 401s — a harness artifact, not a CLI defect. Accept the
+		// runner-emitted no-harness-session skip; reject any other skip reason
+		// (e.g. auth_required_no_credential) so missing-credential excuses can't
+		// substitute for it.
+		if skipReason == phase5SkipReasonCookieAuthNoHarnessSession {
+			return true, ""
+		}
+		return false, "browser-session auth APIs require phase5 acceptance or a cookie-auth-no-harness-session skip; missing API key is not a valid skip"
 	default:
 		return false, fmt.Sprintf("phase5 skip not allowed for auth type %q", authType)
 	}

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -527,6 +527,46 @@ func TestValidatePhase5Gate_CookieAuthNotSkippedByMissingAPIKey(t *testing.T) {
 	assert.Contains(t, result.Detail, "browser-session")
 }
 
+func TestValidatePhase5Gate_CookieAuthNoHarnessSessionSkipAllowed(t *testing.T) {
+	for _, authType := range []string{"cookie", "composed", "session_handshake"} {
+		t.Run(authType, func(t *testing.T) {
+			proofsDir := t.TempDir()
+			manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: authType}
+			writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
+				SchemaVersion: 1,
+				APIName:       "test",
+				RunID:         "run-1",
+				Status:        "skip",
+				Level:         "none",
+				SkipReason:    phase5SkipReasonCookieAuthNoHarnessSession,
+				AuthContext:   Phase5AuthContext{Type: authType, BrowserSessionAvailable: false},
+			})
+
+			result := ValidatePhase5Gate(proofsDir, manifest)
+			require.True(t, result.Passed, result.Detail)
+			assert.Equal(t, "skip", result.Status)
+		})
+	}
+}
+
+func TestValidatePhase5Gate_CookieAuthRejectsWrongSkipReason(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "cookie"}
+	writePhase5GateMarker(t, proofsDir, Phase5SkipFilename, Phase5GateMarker{
+		SchemaVersion: 1,
+		APIName:       "test",
+		RunID:         "run-1",
+		Status:        "skip",
+		Level:         "none",
+		SkipReason:    "operator deferred",
+		AuthContext:   Phase5AuthContext{Type: "cookie"},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.False(t, result.Passed)
+	assert.Contains(t, result.Detail, "cookie-auth-no-harness-session")
+}
+
 func TestValidatePhase5Gate_SkipCannotOverrideManifestAuthType(t *testing.T) {
 	proofsDir := t.TempDir()
 	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "cookie"}

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -4042,6 +4042,26 @@ cli-printing-press dogfood --live \
 
 Use `--level quick` only when the user selected Quick Check in Step 1.
 
+**Cookie / composed / session-handshake auth.** The runner executes the binary
+in a sandboxed HOME with no captured browser session, so a CLI whose auth is a
+cookie jar will 401 every command unless you hand it the session. To exercise
+the matrix for real, point the CLI's config-override env var (the
+`<PREFIX>_CONFIG`-style override, e.g. `<API>_CONFIG`) at a `config.toml` that
+carries the captured session, and export it before the `dogfood --live` call:
+
+```bash
+<API>_CONFIG="$SESSION_DIR/config.toml" cli-printing-press dogfood --live \
+  --dir "$CLI_WORK_DIR" --level full --json \
+  --write-acceptance "$PROOFS_DIR/phase5-acceptance.json"
+```
+
+If no captured session is available to the harness, the runner does not count
+the 401s as failures: it records a clean skip verdict
+(`skip-cookie-auth-no-session`) and writes `phase5-skip.json` with
+`skip_reason: "cookie-auth-no-harness-session"` (see Step 4). The promote gate
+accepts that skip marker, so do not hand-author or fabricate a pass marker for a
+cookie-auth CLI you could not exercise.
+
 The live dogfood runner enumerates the CLI's `agent-context` command tree,
 runs help, happy-path, JSON-fidelity, and error-path checks where applicable,
 captures subprocess exit codes directly without shell pipes, and emits a
@@ -4205,11 +4225,38 @@ generation host cannot reach the user's LAN hardware, write:
 }
 ```
 
+If a cookie / composed / session-handshake CLI could not be exercised because
+no captured session was available to the harness (the sandboxed HOME has no
+cookie jar, so every command 401s), the runner writes this skip marker for you
+on a `skip-cookie-auth-no-session` verdict — do not hand-author it:
+
+`$PROOFS_DIR/phase5-skip.json`
+
+```json
+{
+  "schema_version": 1,
+  "api_name": "<api>",
+  "run_id": "<run-id>",
+  "status": "skip",
+  "level": "none",
+  "skip_reason": "cookie-auth-no-harness-session",
+  "auth_context": {
+    "type": "cookie|composed|session_handshake",
+    "browser_session_available": false
+  }
+}
+```
+
+Prefer the inject-session path in Step 2 (pass the captured session via the
+`<API>_CONFIG` override) so the matrix runs for real; the skip is the floor when
+no session is available.
+
 Do **not** write a skip marker for ordinary `auth.type: none` cloud/public APIs.
 No-auth APIs are testable and require `phase5-acceptance.json` unless they match
-the LAN-only carve-out above. Do **not** use missing API key as the skip reason
-for cookie, composed, or session-handshake auth; those require browser session
-proof or a hold decision.
+the LAN-only carve-out above. Do **not** use missing API key
+(`auth_required_no_credential`) as the skip reason for cookie, composed, or
+session-handshake auth; inject the session, or rely on the runner-emitted
+`cookie-auth-no-harness-session` skip when none is available.
 
 ## Phase 5.5: Polish
 


### PR DESCRIPTION
## Intent

`cli-printing-press dogfood --live` runs the printed binary in a sandboxed HOME (empty `HOME`/`XDG`), so cookie / composed / session-handshake CLIs cannot read `~/.local/share/<cli>/credentials.toml` and every command 401s. Those 401s are a harness artifact, not a CLI defect — the same commands return real data with the real HOME. The runner counted them as failures, and the promote phase5 gate had no cookie-auth path (only `quick`/`full` acceptance; `level: "manual"` rejected), so cookie-auth CLIs churned on false failures with no first-class way to record a live validation.

Issue: Fixes #3104

## Approach

**Design: skip-by-default with a documented inject path.** The inject path (pass the captured session via the `<API>_CONFIG`-style config override) already worked through the existing acceptance marker — the issue confirmed it produces a genuine 16/16 pass. The missing piece was the *skip* path, so this PR adds it and documents both.

- **Runner (`live_dogfood.go`):** `finalizeLiveDogfoodReport` now takes the resolved `auth.type`. When the no-live-signal condition is reached (credential-unavailable skips, no live happy/json pass) AND the auth type is `cookie`/`composed`/`session_handshake`, it records a clean skip verdict (`skip-cookie-auth-no-session`) instead of the no-live-signal FAIL. `writeLiveDogfoodAcceptance` then writes `phase5-skip.json` (beside the acceptance path) with `skip_reason: "cookie-auth-no-harness-session"` rather than a fail acceptance marker. The CLI exits 0.
- **Gate (`phase5_gate.go`):** accepts the new `cookie-auth-no-harness-session` skip reason for browser-session auth types only. Any other reason for cookie auth (e.g. `auth_required_no_credential`) is still rejected, so a missing-credential excuse cannot substitute for it.
- **Skill (`SKILL.md`, Phase 5):** documents the inject-session path (export `<API>_CONFIG` pointing at a `config.toml` carrying the session before `dogfood --live`) and the runner-emitted cookie-auth skip marker the promote gate accepts when no session is available. Kept domain-neutral with `<API>` placeholders.

Mirrors the existing "auth required, no API key -> skip" path; the skip is the floor, the inject path is preferred.

## Scope

Primary area: scorer (`dogfood --live` runner) + promote phase5 gate + generation skill (Phase 5).

Why this belongs in this repo: this is a generic harness/scoring gap that affects every cookie/composed/session-handshake CLI, not one printed CLI. The surfacing CLI was browser-sniffed cookie-auth; the fix generalizes across all browser-session auth types via `auth.type`.

## Catalog Justification

N/A — no catalog changes.

## Risk

- The new skip path only fires for `cookie`/`composed`/`session_handshake` auth AND only on the no-live-signal branch; credentialed auth (api_key/bearer/oauth2) and no-auth paths are unchanged.
- A cookie-auth CLI that *does* get a live pass (session injected) still certifies normally via the acceptance marker — covered by a unit test.
- `phase5-skip.json`'s `skip_reason` is a free-form string in the published `schema phase5-skip` JSON schema (minLength 1, not an enum), so the new reason is schema-valid and the golden suite stays green (`schema-phase5-skip` PASS).

## Output Contract

N/A — no generator/template/manifest/command-output shape changes. The phase5 marker JSON schemas (`schema phase5-marker`, `schema phase5-skip`) are unchanged; `skip_reason` was already free-form. `scripts/golden.sh verify` passes 31/31 including both schema cases.

## Verification

- `go build -o ./cli-printing-press ./cmd/cli-printing-press` — success
- `go test ./...` — 6504 passed in 44 packages
- `scripts/golden.sh verify` — 31/31 PASS
- `golangci-lint run ./internal/pipeline/...` — no issues
- `go fmt` / `gofmt -l` — clean
- New tests: runner end-to-end cookie-auth-no-session skip (verdict + skip marker written + gate accepts); finalize table cases for cookie skip vs cookie-with-live-pass; gate accepts `cookie-auth-no-harness-session` for cookie/composed/session_handshake and rejects a wrong reason.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(No generator/template change — pipeline scorer + gate + skill only.)

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF6Mc6UjYQbGVtp91YG1P3
