### PR TITLE
fix(cli): strip wrapping quotes from verify-skill prose flag tokens

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -852,7 +852,15 @@ def _extract_prose_invocations(
                 tokens = shlex.split(fragment, posix=True)
             except ValueError:
                 tokens = fragment.split()
-            tokens = [t.strip(".,;:)") for t in tokens if t.strip(".,;:)")]
+            # Strip wrapping/trailing punctuation, including quotes: a
+            # single-quoted prose command like `'<cli> auth login --chrome'`
+            # whose closing quote shlex.split cannot balance falls back to
+            # `fragment.split()` and would otherwise leak `--chrome'`.
+            tokens = [
+                t.strip(TOKEN_TRAILING_PUNCT)
+                for t in tokens
+                if t.strip(TOKEN_TRAILING_PUNCT)
+            ]
             if len(tokens) < 2:
                 continue
 

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -26,6 +26,7 @@ from verify_skill import (  # noqa: E402
     extract_recipes,
     _cli_invocation_from_tokens,
     _extract_function_body,
+    _extract_prose_invocations,
 )
 
 
@@ -469,6 +470,69 @@ class UTF8ReadTest(unittest.TestCase):
                 self.assertIn("한국어", verify_skill.read_utf8(path))
 
             self.assertEqual(seen, ["utf-8"])
+
+
+class TestExtractProseInvocations(unittest.TestCase):
+    """Prose flag extraction must not leak wrapping quotes into flag tokens.
+
+    A single-quoted prose command like `'<cli> auth login --chrome'` cannot be
+    balanced by shlex, so extraction falls back to `str.split()`; without
+    quote stripping the closing quote leaks as the phantom flag `--chrome'`.
+    """
+
+    AUTH_GO = (
+        "package cli\n"
+        'import "github.com/spf13/cobra"\n'
+        "func newAuthCmd() *cobra.Command {\n"
+        '  c := &cobra.Command{Use: "auth"}\n'
+        "  return c\n"
+        "}\n"
+        "func newAuthLoginCmd() *cobra.Command {\n"
+        '  c := &cobra.Command{Use: "login"}\n'
+        '  c.Flags().Bool("chrome", false, "use chrome")\n'
+        "  return c\n"
+        "}\n"
+    )
+
+    def _cli_dir(self, tmp: str) -> Path:
+        return _write_cli(Path(tmp), {"auth.go": self.AUTH_GO})
+
+    def test_single_quoted_command_strips_trailing_quote(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cli_dir = self._cli_dir(tmp)
+            text = "Run 'mycli auth login --chrome' to authenticate."
+            results = _extract_prose_invocations(text, "mycli", cli_dir)
+            flags = [f for _cmd, _pos, fl, _surface in results for f in fl]
+            self.assertIn("--chrome", flags)
+            self.assertNotIn("--chrome'", flags)
+            self.assertFalse(
+                any(f.endswith("'") or f.endswith('"') for f in flags),
+                f"flag tokens leaked a wrapping quote: {flags}",
+            )
+
+    def test_double_quoted_command_strips_trailing_quote(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cli_dir = self._cli_dir(tmp)
+            # An unbalanced double quote in prose also falls back to split().
+            text = 'Tip: "mycli auth login --chrome to start.'
+            results = _extract_prose_invocations(text, "mycli", cli_dir)
+            flags = [f for _cmd, _pos, fl, _surface in results for f in fl]
+            self.assertIn("--chrome", flags)
+            self.assertFalse(
+                any(f.endswith("'") or f.endswith('"') for f in flags),
+                f"flag tokens leaked a wrapping quote: {flags}",
+            )
+
+    def test_undeclared_flag_in_prose_still_extracted(self):
+        # The quote fix must not suppress genuinely undeclared flags: a real
+        # but undeclared flag still surfaces so downstream flag-name checks
+        # can fail it.
+        with tempfile.TemporaryDirectory() as tmp:
+            cli_dir = self._cli_dir(tmp)
+            text = "Run mycli auth login --bogusflag to break things."
+            results = _extract_prose_invocations(text, "mycli", cli_dir)
+            flags = [f for _cmd, _pos, fl, _surface in results for f in fl]
+            self.assertIn("--bogusflag", flags)
 
 
 if __name__ == "__main__":

--- a/scripts/verify-skill/test_resolve_command_path.py
+++ b/scripts/verify-skill/test_resolve_command_path.py
@@ -513,8 +513,12 @@ class TestExtractProseInvocations(unittest.TestCase):
     def test_double_quoted_command_strips_trailing_quote(self):
         with tempfile.TemporaryDirectory() as tmp:
             cli_dir = self._cli_dir(tmp)
-            # An unbalanced double quote in prose also falls back to split().
-            text = 'Tip: "mycli auth login --chrome to start.'
+            # The opening quote sits after the binary, so the extracted
+            # fragment (`auth login --chrome" to authenticate.`) carries an
+            # unbalanced `"` that shlex.split rejects, forcing the
+            # fragment.split() fallback to yield `--chrome"`. Without the
+            # trailing-quote strip the flag token would leak that quote.
+            text = 'Run "mycli auth login --chrome" to authenticate.'
             results = _extract_prose_invocations(text, "mycli", cli_dir)
             flags = [f for _cmd, _pos, fl, _surface in results for f in fl]
             self.assertIn("--chrome", flags)

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -852,7 +852,15 @@ def _extract_prose_invocations(
                 tokens = shlex.split(fragment, posix=True)
             except ValueError:
                 tokens = fragment.split()
-            tokens = [t.strip(".,;:)") for t in tokens if t.strip(".,;:)")]
+            # Strip wrapping/trailing punctuation, including quotes: a
+            # single-quoted prose command like `'<cli> auth login --chrome'`
+            # whose closing quote shlex.split cannot balance falls back to
+            # `fragment.split()` and would otherwise leak `--chrome'`.
+            tokens = [
+                t.strip(TOKEN_TRAILING_PUNCT)
+                for t in tokens
+                if t.strip(TOKEN_TRAILING_PUNCT)
+            ]
             if len(tokens) < 2:
                 continue
 


### PR DESCRIPTION
## Intent

`verify-skill`'s prose flag extractor leaks a trailing quote into flag tokens. A single-quoted command in SKILL.md/README.md prose such as `'<cli> auth login --chrome'` produces the phantom flag token `--chrome'` (trailing single quote), surfacing a false "referenced but not declared" error. `--chrome` is a real flag; only the stray quote is the problem. This recurs for any CLI documenting a flagged command in single quotes in prose, especially cookie-auth CLIs documenting `auth login --chrome`.

Issue: Fixes #3105

## Approach

In `_extract_prose_invocations` (`scripts/verify-skill/verify_skill.py`), the per-token cleanup stripped trailing `.,;:)` but not quotes. A single-quoted prose command cannot be balanced by `shlex.split`, so extraction falls back to `fragment.split()` and the closing quote glues onto the trailing token.

The fix reuses the existing `TOKEN_TRAILING_PUNCT` constant (`'\")].,;:`) — already used by `_cli_invocation_from_tokens` for flag tokens — so the prose token cleanup strips wrapping/trailing single and double quotes too. `str.strip` only removes wrapping/leading/trailing characters, so interior characters in a value are untouched. This keeps the two cleanup sites consistent rather than hard-coding a second punctuation set.

The script is bundled into the binary at `internal/cli/verify_skill_bundled.py`; the canonical source is `scripts/verify-skill/verify_skill.py`. Both are updated (synced via `cp`), and `TestVerifySkillScriptInSync` confirms they match.

Note: the downstream flag-name/flag-command checks already route flag tokens through `_cli_invocation_from_tokens`, which strips the trailing quote (#2964). This change cleans the tokens earlier, at the prose-extraction layer, so the prose extractor's own command-token validation and `find_command_source` lookups also see clean tokens, and the two cleanup sites stay consistent.

## Scope

Primary area: scorer (`verify-skill`).

Why this belongs in this repo: This is a machine/scorer fix. The false positive is generator/scorer-side, not API-specific; it affects every printed CLI whose docs quote a flagged command in single quotes. The printed-CLI symptom (4 false-positive errors blocking `verify-skill` and `publish-validate`) was worked around by rewrapping prose, but the correct fix is in the shared scorer.

## Catalog Justification

N/A

## Risk

Low. The change only broadens which trailing characters are stripped from extracted prose tokens, using a constant already applied elsewhere in the same file. It does not alter generated output, MCP surface, auth, catalog, publish flow, or release behavior. No golden output is affected (scorer-only). A genuinely undeclared flag still surfaces (covered by a negative test).

## Output Contract

N/A

## Verification

- `python3 -m unittest test_resolve_command_path` (from `scripts/verify-skill/`) — 23 tests pass, including 3 new prose-quote tests.
- `go test ./...` — 6496 tests pass across 44 packages (includes `TestVerifySkillScriptInSync` confirming canonical/bundled parity).
- `scripts/golden.sh verify` — not run; scorer-only change does not affect generated/golden output.

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

(Not a generator/template change — scorer-only.)

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change
