### PR TITLE
fix(cli): route local collection reads through list store

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7155,14 +7155,13 @@ func localReadIsList(supportsAllPagination bool, apiSpec *spec.APISpec, endpoint
 
 func localReadLooksLikeCollection(endpointName string, endpoint spec.Endpoint) bool {
 	nameLower := strings.ToLower(strings.TrimSpace(endpointName))
-	if nameLower == "list" || nameLower == "all" || nameLower == "index" {
+	if nameLower == "list" {
 		return true
 	}
 	if !localReadNameContainsAny(nameLower, []string{"search", "query", "browse", "find"}) {
 		return false
 	}
-	return strings.EqualFold(endpoint.Response.Type, "array") ||
-		strings.TrimSpace(endpoint.ResponsePath) != ""
+	return strings.EqualFold(endpoint.Response.Type, "array")
 }
 
 func localReadNameContainsAny(s string, needles []string) bool {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -7147,10 +7147,31 @@ func localReadIsList(supportsAllPagination bool, apiSpec *spec.APISpec, endpoint
 	if endpointHasPathScope(endpoint) {
 		return false
 	}
-	if strings.EqualFold(endpointName, "list") {
+	if localReadLooksLikeCollection(endpointName, endpoint) {
 		return true
 	}
 	return networkFallbackReason(apiSpec) == "synthetic_anchor_fallback" && strings.EqualFold(endpoint.Response.Type, "array")
+}
+
+func localReadLooksLikeCollection(endpointName string, endpoint spec.Endpoint) bool {
+	nameLower := strings.ToLower(strings.TrimSpace(endpointName))
+	if nameLower == "list" || nameLower == "all" || nameLower == "index" {
+		return true
+	}
+	if !localReadNameContainsAny(nameLower, []string{"search", "query", "browse", "find"}) {
+		return false
+	}
+	return strings.EqualFold(endpoint.Response.Type, "array") ||
+		strings.TrimSpace(endpoint.ResponsePath) != ""
+}
+
+func localReadNameContainsAny(s string, needles []string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func endpointHasPathScope(endpoint spec.Endpoint) bool {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17257,15 +17257,33 @@ func TestLocalReadIsList(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "collection-name response path",
+			name:         "collection-name wrapped array response path",
 			endpointName: "find",
-			endpoint:     spec.Endpoint{Method: "GET", Path: "/events", Response: spec.ResponseDef{Type: "object"}, ResponsePath: "_embedded.events"},
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/events", Response: spec.ResponseDef{Type: "array"}, ResponsePath: "_embedded.events"},
 			want:         true,
+		},
+		{
+			name:         "collection-name wrapped object response path",
+			endpointName: "find",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/events/latest", Response: spec.ResponseDef{Type: "object"}, ResponsePath: "data.event"},
+			want:         false,
 		},
 		{
 			name:         "non-collection array response without list name",
 			endpointName: "status",
 			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/status", Response: spec.ResponseDef{Type: "array"}},
+			want:         false,
+		},
+		{
+			name:         "unscoped all is not a new collection heuristic",
+			endpointName: "all",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/all", Response: spec.ResponseDef{Type: "array"}},
+			want:         false,
+		},
+		{
+			name:         "unscoped index is not a new collection heuristic",
+			endpointName: "index",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/index", Response: spec.ResponseDef{Type: "array"}},
 			want:         false,
 		},
 		{

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -17245,15 +17245,33 @@ func TestLocalReadIsList(t *testing.T) {
 			want:         true,
 		},
 		{
-			name:         "non-synthetic array response without list name",
+			name:         "collection-name array response without list name",
 			endpointName: "search",
 			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/search", Response: spec.ResponseDef{Type: "array"}},
+			want:         true,
+		},
+		{
+			name:         "find collection endpoint",
+			endpointName: "find",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/events", Response: spec.ResponseDef{Type: "array"}},
+			want:         true,
+		},
+		{
+			name:         "collection-name response path",
+			endpointName: "find",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/events", Response: spec.ResponseDef{Type: "object"}, ResponsePath: "_embedded.events"},
+			want:         true,
+		},
+		{
+			name:         "non-collection array response without list name",
+			endpointName: "status",
+			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/status", Response: spec.ResponseDef{Type: "array"}},
 			want:         false,
 		},
 		{
 			name:         "synthetic array response without list name",
 			apiSpec:      &spec.APISpec{Kind: spec.KindSynthetic},
-			endpointName: "search",
+			endpointName: "status",
 			endpoint:     spec.Endpoint{Method: "GET", Path: "/campaigns/search", Response: spec.ResponseDef{Type: "array"}},
 			want:         true,
 		},
@@ -17295,6 +17313,66 @@ func TestLocalReadIsList(t *testing.T) {
 			assert.Equal(t, tc.want, localReadIsList(tc.supportsAllPagination, tc.apiSpec, tc.endpointName, tc.endpoint))
 		})
 	}
+}
+
+func TestGeneratedCollectionNamedReadUsesLocalList(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "eventfinder",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/eventfinder-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"events": {
+				Description: "Manage events",
+				Endpoints: map[string]spec.Endpoint{
+					"find": {
+						Method:      "GET",
+						Path:        "/events",
+						Description: "Find events",
+						Response:    spec.ResponseDef{Type: "array", Item: "Event"},
+					},
+					"get": {
+						Method:      "GET",
+						Path:        "/events/{id}",
+						Description: "Get event",
+						Params:      []spec.Param{{Name: "id", Type: "string", Positional: true, PathParam: true}},
+						Response:    spec.ResponseDef{Type: "object", Item: "Event"},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Event": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "string"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	findSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "events_find.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(findSrc), `"events", true, path, params`,
+		"collection-style GET endpoints named find must route --data-source local through db.List")
+
+	getSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "events_get.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(getSrc), `"events", false, path, params`,
+		"get-by-id endpoints must continue routing --data-source local through db.Get")
+
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratedSyntheticAnchorCommandFallsBackToLocalStore(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat unscoped collection-style GET reads named search, query, browse, or find as local list reads when their response is list-shaped.
- Preserve path-scoped get-by-id reads as local point lookups.
- Add generated-output coverage for a find collection endpoint and a get-by-id endpoint.

Closes #3088

## Tests
- `go test ./internal/generator -run '^TestLocalReadIsList$|^TestGeneratedCollectionNamedReadUsesLocalList$' -count=1`
- `go test ./internal/generator -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `go test ./...` failed in unrelated `internal/pipeline/live_dogfood_test.go` timeout cases plus `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged`; generator-focused gates above passed.