### PR TITLE
fix(cli): unwrap HAL embedded sync envelopes

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4031,6 +4031,20 @@ func TestExtractPageItemsGeoJSON(t *testing.T) {
 	}
 }
 
+func TestExtractPageItemsBareArray(t *testing.T) {
+	body := []byte(` + "`" + `[{"id":"one"},{"id":"two"}]` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("bare array: want 2 items, got %d", len(items))
+	}
+	if cursor != "" {
+		t.Fatalf("bare array: want empty cursor, got %q", cursor)
+	}
+	if hasMore {
+		t.Fatalf("bare array: want hasMore=false")
+	}
+}
+
 func TestExtractPageItemsGeoJSONPascal(t *testing.T) {
 	body := []byte(` + "`" + `{
 		"Type": "FeatureCollection",
@@ -4124,6 +4138,29 @@ func TestExtractPageItemsPipedriveAdditionalDataEnvelope(t *testing.T) {
 	}
 	if !hasMore {
 		t.Fatalf("want hasMore=true when additional_data.next_cursor is present")
+	}
+}
+
+func TestExtractPageItemsHALEmbeddedEnvelope(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"_embedded": {
+			"events": [{"id":"evt-1"},{"id":"evt-2"}]
+		},
+		"_links": {
+			"next": {
+				"href": "https://api.example.com/events?page=2&cursor=hal-next"
+			}
+		}
+	}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 HAL _embedded items, got %d", len(items))
+	}
+	if cursor != "hal-next" {
+		t.Fatalf("want cursor hal-next, got %q", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("want hasMore=true when _links.next cursor is present")
 	}
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -4164,6 +4164,32 @@ func TestExtractPageItemsHALEmbeddedEnvelope(t *testing.T) {
 	}
 }
 
+func TestExtractPageItemsFallsBackFromLinksToHALLinks(t *testing.T) {
+	body := []byte(` + "`" + `{
+		"_embedded": {
+			"events": [{"id":"evt-1"},{"id":"evt-2"}]
+		},
+		"links": {
+			"next": "https://api.example.com/events?page=2"
+		},
+		"_links": {
+			"next": {
+				"href": "https://api.example.com/events?page=2&cursor=hal-next"
+			}
+		}
+	}` + "`" + `)
+	items, cursor, hasMore := extractPageItems(json.RawMessage(body), "cursor")
+	if len(items) != 2 {
+		t.Fatalf("want 2 HAL _embedded items, got %d", len(items))
+	}
+	if cursor != "hal-next" {
+		t.Fatalf("want cursor hal-next, got %q", cursor)
+	}
+	if !hasMore {
+		t.Fatalf("want hasMore=true when fallback _links.next cursor is present")
+	}
+}
+
 func TestExtractPageItemsJSONAPILinksNext(t *testing.T) {
 	body := []byte(` + "`" + `{
 		"data": [{"id":"pet_1"},{"id":"pet_2"}],

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1366,6 +1366,16 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 		}
 	}
 
+	if raw, ok := envelope["_embedded"]; ok {
+		var embedded map[string]json.RawMessage
+		if json.Unmarshal(raw, &embedded) == nil {
+			if items, ok := extractItemsFromEnvelope(embedded); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
@@ -1830,27 +1840,47 @@ func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
 	return false, false
 }
 
-// nextCursorFromLinks extracts JSON:API-style pagination cursors from
-// {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
+// nextCursorFromLinks extracts pagination cursors from JSON:API
+// {"links":{"next":"https://example.com/items?page[cursor]=..."}} and HAL
+// {"_links":{"next":{"href":"https://example.com/items?cursor=..."}}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
-	rawLinks, ok := envelope["links"]
-	if !ok {
-		return ""
+	for _, key := range []string{"links", "_links"} {
+		rawLinks, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var links map[string]json.RawMessage
+		if json.Unmarshal(rawLinks, &links) != nil {
+			continue
+		}
+		rawNext, ok := links["next"]
+		if !ok {
+			continue
+		}
+		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
 	}
-	var links map[string]json.RawMessage
-	if json.Unmarshal(rawLinks, &links) != nil {
-		return ""
-	}
-	rawNext, ok := links["next"]
-	if !ok {
-		return ""
-	}
-	var nextURL string
-	if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
-		return ""
-	}
+	return ""
+}
 
-	return cursorFromNextURL(nextURL, cursorParam)
+func paginationLinkURL(raw json.RawMessage) string {
+	var nextURL string
+	if json.Unmarshal(raw, &nextURL) == nil {
+		return nextURL
+	}
+	var link map[string]json.RawMessage
+	if json.Unmarshal(raw, &link) != nil {
+		return ""
+	}
+	rawHref, ok := link["href"]
+	if !ok {
+		return ""
+	}
+	if json.Unmarshal(rawHref, &nextURL) != nil {
+		return ""
+	}
+	return nextURL
 }
 
 // nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1858,7 +1858,9 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 			continue
 		}
 		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
-			return cursorFromNextURL(nextURL, cursorParam)
+			if cursor := cursorFromNextURL(nextURL, cursorParam); cursor != "" {
+				return cursor
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1237,7 +1237,9 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 			continue
 		}
 		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
-			return cursorFromNextURL(nextURL, cursorParam)
+			if cursor := cursorFromNextURL(nextURL, cursorParam); cursor != "" {
+				return cursor
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -857,6 +857,16 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 		}
 	}
 
+	if raw, ok := envelope["_embedded"]; ok {
+		var embedded map[string]json.RawMessage
+		if json.Unmarshal(raw, &embedded) == nil {
+			if items, ok := extractItemsFromEnvelope(embedded); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
@@ -1209,27 +1219,47 @@ func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
 	return false, false
 }
 
-// nextCursorFromLinks extracts JSON:API-style pagination cursors from
-// {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
+// nextCursorFromLinks extracts pagination cursors from JSON:API
+// {"links":{"next":"https://example.com/items?page[cursor]=..."}} and HAL
+// {"_links":{"next":{"href":"https://example.com/items?cursor=..."}}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
-	rawLinks, ok := envelope["links"]
-	if !ok {
-		return ""
+	for _, key := range []string{"links", "_links"} {
+		rawLinks, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var links map[string]json.RawMessage
+		if json.Unmarshal(rawLinks, &links) != nil {
+			continue
+		}
+		rawNext, ok := links["next"]
+		if !ok {
+			continue
+		}
+		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
 	}
-	var links map[string]json.RawMessage
-	if json.Unmarshal(rawLinks, &links) != nil {
-		return ""
-	}
-	rawNext, ok := links["next"]
-	if !ok {
-		return ""
-	}
-	var nextURL string
-	if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
-		return ""
-	}
+	return ""
+}
 
-	return cursorFromNextURL(nextURL, cursorParam)
+func paginationLinkURL(raw json.RawMessage) string {
+	var nextURL string
+	if json.Unmarshal(raw, &nextURL) == nil {
+		return nextURL
+	}
+	var link map[string]json.RawMessage
+	if json.Unmarshal(raw, &link) != nil {
+		return ""
+	}
+	rawHref, ok := link["href"]
+	if !ok {
+		return ""
+	}
+	if json.Unmarshal(rawHref, &nextURL) != nil {
+		return ""
+	}
+	return nextURL
 }
 
 // nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1233,7 +1233,9 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 			continue
 		}
 		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
-			return cursorFromNextURL(nextURL, cursorParam)
+			if cursor := cursorFromNextURL(nextURL, cursorParam); cursor != "" {
+				return cursor
+			}
 		}
 	}
 	return ""

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -853,6 +853,16 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 		}
 	}
 
+	if raw, ok := envelope["_embedded"]; ok {
+		var embedded map[string]json.RawMessage
+		if json.Unmarshal(raw, &embedded) == nil {
+			if items, ok := extractItemsFromEnvelope(embedded); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
@@ -1205,27 +1215,47 @@ func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
 	return false, false
 }
 
-// nextCursorFromLinks extracts JSON:API-style pagination cursors from
-// {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
+// nextCursorFromLinks extracts pagination cursors from JSON:API
+// {"links":{"next":"https://example.com/items?page[cursor]=..."}} and HAL
+// {"_links":{"next":{"href":"https://example.com/items?cursor=..."}}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
-	rawLinks, ok := envelope["links"]
-	if !ok {
-		return ""
+	for _, key := range []string{"links", "_links"} {
+		rawLinks, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var links map[string]json.RawMessage
+		if json.Unmarshal(rawLinks, &links) != nil {
+			continue
+		}
+		rawNext, ok := links["next"]
+		if !ok {
+			continue
+		}
+		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
 	}
-	var links map[string]json.RawMessage
-	if json.Unmarshal(rawLinks, &links) != nil {
-		return ""
-	}
-	rawNext, ok := links["next"]
-	if !ok {
-		return ""
-	}
-	var nextURL string
-	if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
-		return ""
-	}
+	return ""
+}
 
-	return cursorFromNextURL(nextURL, cursorParam)
+func paginationLinkURL(raw json.RawMessage) string {
+	var nextURL string
+	if json.Unmarshal(raw, &nextURL) == nil {
+		return nextURL
+	}
+	var link map[string]json.RawMessage
+	if json.Unmarshal(raw, &link) != nil {
+		return ""
+	}
+	rawHref, ok := link["href"]
+	if !ok {
+		return ""
+	}
+	if json.Unmarshal(rawHref, &nextURL) != nil {
+		return ""
+	}
+	return nextURL
 }
 
 // nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -822,6 +822,16 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 		}
 	}
 
+	if raw, ok := envelope["_embedded"]; ok {
+		var embedded map[string]json.RawMessage
+		if json.Unmarshal(raw, &embedded) == nil {
+			if items, ok := extractItemsFromEnvelope(embedded); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractSingleObjectArraySibling(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
@@ -1174,27 +1184,47 @@ func envelopeExplicitHasMore(envelope map[string]json.RawMessage) (bool, bool) {
 	return false, false
 }
 
-// nextCursorFromLinks extracts JSON:API-style pagination cursors from
-// {"links":{"next":"https://example.com/items?page[cursor]=..."}}.
+// nextCursorFromLinks extracts pagination cursors from JSON:API
+// {"links":{"next":"https://example.com/items?page[cursor]=..."}} and HAL
+// {"_links":{"next":{"href":"https://example.com/items?cursor=..."}}}.
 func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string) string {
-	rawLinks, ok := envelope["links"]
-	if !ok {
-		return ""
+	for _, key := range []string{"links", "_links"} {
+		rawLinks, ok := envelope[key]
+		if !ok {
+			continue
+		}
+		var links map[string]json.RawMessage
+		if json.Unmarshal(rawLinks, &links) != nil {
+			continue
+		}
+		rawNext, ok := links["next"]
+		if !ok {
+			continue
+		}
+		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
+			return cursorFromNextURL(nextURL, cursorParam)
+		}
 	}
-	var links map[string]json.RawMessage
-	if json.Unmarshal(rawLinks, &links) != nil {
-		return ""
-	}
-	rawNext, ok := links["next"]
-	if !ok {
-		return ""
-	}
-	var nextURL string
-	if json.Unmarshal(rawNext, &nextURL) != nil || nextURL == "" {
-		return ""
-	}
+	return ""
+}
 
-	return cursorFromNextURL(nextURL, cursorParam)
+func paginationLinkURL(raw json.RawMessage) string {
+	var nextURL string
+	if json.Unmarshal(raw, &nextURL) == nil {
+		return nextURL
+	}
+	var link map[string]json.RawMessage
+	if json.Unmarshal(raw, &link) != nil {
+		return ""
+	}
+	rawHref, ok := link["href"]
+	if !ok {
+		return ""
+	}
+	if json.Unmarshal(rawHref, &nextURL) != nil {
+		return ""
+	}
+	return nextURL
 }
 
 // nextCursorFromTopLevelURL extracts a cursor from top-level absolute or relative next URLs.

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1202,7 +1202,9 @@ func nextCursorFromLinks(envelope map[string]json.RawMessage, cursorParam string
 			continue
 		}
 		if nextURL := paginationLinkURL(rawNext); nextURL != "" {
-			return cursorFromNextURL(nextURL, cursorParam)
+			if cursor := cursorFromNextURL(nextURL, cursorParam); cursor != "" {
+				return cursor
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary
- Teach generated sync extraction to unwrap HAL `_embedded` envelopes.
- Parse HAL `_links.next.href` cursors alongside existing JSON:API `links.next` cursors.
- Add generated-runtime regression coverage and refresh generated `sync.go` goldens.

Closes #3082

## Tests
- `go test ./internal/generator -run TestSyncExtractPaginationNestedCursor -count=1`
- `go fmt ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./internal/pipeline -run 'Test(RunLiveDogfoodWritesAcceptanceMarkerOnPass|RunLiveDogfoodWritesFailMarkerOnFail|RunLiveDogfoodLocalDatastoreManifestPreservesOperatorHome|HelpScanIndicatesSideEffect)$' -count=1`
- `go test ./...` failed in `internal/pipeline` while other batch workers were also running full suites: live dogfood `agent-context` subprocesses hit 15s timeouts and `TestHelpScanIndicatesSideEffect` failed. The exact failing tests passed on the targeted rerun above.
- `golangci-lint run ./...` not run because `golangci-lint` is not installed in this environment.
