### PR TITLE
fix(cli): prune phantom which index entries

### DIFF
--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1044,6 +1044,11 @@ resources:
 	require.Len(t, manifest.NovelFeatures, 1)
 	assert.Equal(t, "Built insight", manifest.NovelFeatures[0].Name)
 	assert.Equal(t, "items insight", manifest.NovelFeatures[0].Command)
+
+	which, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "which.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(which), `Command: "items insight"`)
+	assert.NotContains(t, string(which), "items planned")
 }
 
 func TestGenerateCmdAppliesBrowserClearanceReachability(t *testing.T) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -628,8 +628,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return out
 		},
-		"whichFallbackEntries": buildWhichFallbackEntries,
-		"firstCommandExample":  firstCommandExample,
+		"firstCommandExample": firstCommandExample,
 	}
 	return g
 }
@@ -681,56 +680,6 @@ func resourceWalkEndpoints(resourceName string, resource spec.Resource, visit fu
 		}
 	}
 	return false
-}
-
-func buildWhichFallbackEntries(resources map[string]spec.Resource) []NovelFeature {
-	var entries []NovelFeature
-	var resNames []string
-	for name := range resources {
-		resNames = append(resNames, name)
-	}
-	sort.Strings(resNames)
-	for _, rName := range resNames {
-		r := resources[rName]
-		appendEndpoint := func(command string, endpoint spec.Endpoint) {
-			description := strings.TrimSpace(endpoint.Description)
-			if description == "" {
-				description = "Run " + command
-			}
-			entries = append(entries, NovelFeature{
-				Command:     command,
-				Description: description,
-				Group:       rName,
-			})
-		}
-
-		var endpointNames []string
-		for eName := range r.Endpoints {
-			endpointNames = append(endpointNames, eName)
-		}
-		sort.Strings(endpointNames)
-		for _, eName := range endpointNames {
-			appendEndpoint(rName+" "+eName, r.Endpoints[eName])
-		}
-
-		var subNames []string
-		for subName := range r.SubResources {
-			subNames = append(subNames, subName)
-		}
-		sort.Strings(subNames)
-		for _, subName := range subNames {
-			sub := r.SubResources[subName]
-			var subEndpointNames []string
-			for eName := range sub.Endpoints {
-				subEndpointNames = append(subEndpointNames, eName)
-			}
-			sort.Strings(subEndpointNames)
-			for _, eName := range subEndpointNames {
-				appendEndpoint(rName+" "+subName+" "+eName, sub.Endpoints[eName])
-			}
-		}
-	}
-	return entries
 }
 
 // HelperFlags controls which helper functions are emitted in helpers.go.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10799,7 +10799,7 @@ func TestGenerateGraphQLBFFUsesSemanticCommandSurface(t *testing.T) {
 	assert.Contains(t, string(productsHelp), "makers")
 }
 
-func TestGenerateWhichFallsBackToCommandTree(t *testing.T) {
+func TestGenerateWhichDoesNotFallbackToEndpointGuesses(t *testing.T) {
 	t.Parallel()
 
 	outputDir := filepath.Join(t.TempDir(), "whichfallback-pp-cli")
@@ -10844,17 +10844,17 @@ func TestGenerateWhichFallsBackToCommandTree(t *testing.T) {
 	whichGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "which.go"))
 	require.NoError(t, err)
 	whichSrc := string(whichGo)
-	assert.Contains(t, whichSrc, `Command: "products list"`)
-	assert.Contains(t, whichSrc, `Description: "List products"`)
-	assert.Contains(t, whichSrc, `Command: "products reviews list"`)
+	assert.Contains(t, whichSrc, `var whichIndex = []whichEntry{}`)
+	assert.NotContains(t, whichSrc, `Command: "products list"`)
+	assert.NotContains(t, whichSrc, `Command: "products reviews list"`)
 	assert.Contains(t, whichSrc, `"pp:typed-exit-codes": "0,2"`)
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	binaryPath := filepath.Join(outputDir, "whichfallback-pp-cli")
 	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/whichfallback-pp-cli")
 	whichOut, err := exec.Command(binaryPath, "which", "reviews", "--json").CombinedOutput()
-	require.NoError(t, err, string(whichOut))
-	assert.Contains(t, string(whichOut), "products reviews list")
+	require.Error(t, err)
+	assert.Contains(t, string(whichOut), "no curated capability index")
 }
 
 func graphQLBFFCaptureEntry(operationName, variablesJSON, hash string) browsersniff.EnrichedEntry {

--- a/internal/generator/templates/which.go.tmpl
+++ b/internal/generator/templates/which.go.tmpl
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// whichEntry is one row of the curated capability index. The index is
-// seeded at generation time from the same NovelFeature list that drives
-// the SKILL.md feature section, so the command a `which` query returns
-// is guaranteed to exist and to match what the skill advertises.
+// whichEntry is one row of the curated capability index. The index is seeded
+// at generation time from the verified NovelFeature list that drives the
+// SKILL.md feature section, so the command a `which` query returns is
+// guaranteed to exist and to match what the skill advertises.
 type whichEntry struct {
 	Command      string `json:"command"`
 	Description  string `json:"description"`
@@ -29,10 +29,6 @@ type whichEntry struct {
 var whichIndex = []whichEntry{
 {{- range .NovelFeatures}}
 	{Command: {{printf "%q" .Command}}, Description: {{printf "%q" .Description}}, Group: {{printf "%q" .Group}}, WhyItMatters: {{printf "%q" .WhyItMatters}}},
-{{- else}}
-{{- range whichFallbackEntries .Resources}}
-	{Command: {{printf "%q" .Command}}, Description: {{printf "%q" .Description}}, Group: {{printf "%q" .Group}}},
-{{- end}}
 {{- end}}
 }
 

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -87,12 +87,18 @@ func TestRankWhich_NoMatchReturnsEmpty(t *testing.T) {
 // zero NovelFeatures ship an empty index, and that is still a valid
 // state (which returns the "no curated index" error at runtime).
 func TestWhichIndex_ExistsAndIsWellFormed(t *testing.T) {
+	root := newRootCmd(&rootFlags{})
 	for i, e := range whichIndex {
 		if e.Command == "" {
 			t.Errorf("whichIndex[%d] has empty Command - template rendered bad data", i)
+			continue
 		}
 		if strings.TrimSpace(e.Description) == "" {
 			t.Errorf("whichIndex[%d] (%s) has empty Description - template rendered bad data", i, e.Command)
+		}
+		found, remaining, err := root.Find(strings.Fields(e.Command))
+		if err != nil || found == nil || len(remaining) > 0 {
+			t.Errorf("whichIndex[%d] command %q does not resolve in the Cobra tree (remaining=%v, err=%v)", i, e.Command, remaining, err)
 		}
 	}
 }

--- a/internal/generator/templates/which_test.go.tmpl
+++ b/internal/generator/templates/which_test.go.tmpl
@@ -97,8 +97,8 @@ func TestWhichIndex_ExistsAndIsWellFormed(t *testing.T) {
 			t.Errorf("whichIndex[%d] (%s) has empty Description - template rendered bad data", i, e.Command)
 		}
 		found, remaining, err := root.Find(strings.Fields(e.Command))
-		if err != nil || found == nil || len(remaining) > 0 {
-			t.Errorf("whichIndex[%d] command %q does not resolve in the Cobra tree (remaining=%v, err=%v)", i, e.Command, remaining, err)
+		if err != nil || len(remaining) > 0 {
+			t.Errorf("whichIndex[%d] command %q does not resolve in the Cobra tree (found=%v, remaining=%v, err=%v)", i, e.Command, found, remaining, err)
 		}
 	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/which.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// whichEntry is one row of the curated capability index. The index is
-// seeded at generation time from the same NovelFeature list that drives
-// the SKILL.md feature section, so the command a `which` query returns
-// is guaranteed to exist and to match what the skill advertises.
+// whichEntry is one row of the curated capability index. The index is seeded
+// at generation time from the verified NovelFeature list that drives the
+// SKILL.md feature section, so the command a `which` query returns is
+// guaranteed to exist and to match what the skill advertises.
 type whichEntry struct {
 	Command      string `json:"command"`
 	Description  string `json:"description"`
@@ -26,18 +26,7 @@ type whichEntry struct {
 // its hero features. Endpoint-level commands are discoverable via
 // `--help`; `which` exists to resolve a natural-language capability
 // query to one of the commands the skill says matter most.
-var whichIndex = []whichEntry{
-	{Command: "currencies list", Description: "List supported currencies", Group: "currencies"},
-	{Command: "projects create", Description: "Create project", Group: "projects"},
-	{Command: "projects get", Description: "Get project", Group: "projects"},
-	{Command: "projects list", Description: "List projects", Group: "projects"},
-	{Command: "projects avatar upload-project", Description: "Upload project avatar", Group: "projects"},
-	{Command: "projects tasks list-project", Description: "List project tasks", Group: "projects"},
-	{Command: "projects tasks update-project", Description: "Update project task", Group: "projects"},
-	{Command: "public get-status", Description: "Get public service status", Group: "public"},
-	{Command: "reports export report-year", Description: "Download the annual report as a binary file", Group: "reports"},
-	{Command: "reports summary get-report-year", Description: "Get a report summary for a year", Group: "reports"},
-}
+var whichIndex = []whichEntry{}
 
 // whichMatch pairs an index entry with its ranking score for a query.
 // Higher score means stronger match. The ranker is naive (exact token


### PR DESCRIPTION
## Intent

Closes #3094.

Stop generated `which` indexes from advertising command paths that are not guaranteed to exist.

## Approach

`whichIndex` now renders only curated novel features supplied to the generator, which are already loaded from `novel_features_built` when dogfood has verified them. The old endpoint fallback was removed because it guessed paths such as `items list` that can differ from the actual Cobra tree.

Generated `which` tests now assert every indexed command resolves in the generated root command tree. The generate command regression also verifies that a built subset reaches `which.go` and planned-only features do not.

## Scope

Primary area: generator and generated CLI tests.

Why this belongs in this repo: the symptom is a printed CLI advertising phantom commands, but the reusable Printing Press template and generator contract produced that surface.

## Catalog Justification

N/A.

## Risk

Generated CLIs without curated novel features now return the existing no-curated-index error from `which` instead of listing endpoint guesses. Endpoint discovery remains available through `--help`.

## Output Contract

Updated `generate-golden-api` to show an empty `whichIndex` when no verified novel features are present. Added emitted-code assertions and a generated test that verifies `whichIndex` command paths resolve in Cobra.

## Verification

- `go test ./internal/cli -run 'TestGenerateCmdCarriesVerifiedNovelFeaturesIntoManifest'`\n- `go test ./internal/pipeline -run 'TestSyncCLITranscendenceDocsSyncsNovelFeatureGoSurfaces|TestCheckNovelFeatures'`\n- `go test ./internal/generator -run 'TestProjectManagementWorkflowsEmitSyncHints|TestAuthHeaderBearerORCaseFallsThroughToAccessToken'`\n- `go test ./internal/generator -run 'TestGenerateWhichDoesNotFallbackToEndpointGuesses'`\n- `go test ./internal/pipeline -run 'TestRunSideEffectSafeCommandTestsUsesHappyArgsWithoutNoArgProbe|TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap'`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh generate-golden-api`\n- `go fmt ./...`\n- `go test ./...`\n