### PR TITLE
feat(publish): lightweight blobless+sparse library clone + force-add MCP source

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -542,7 +542,8 @@ func TestPublishSkillTracksCanonicalUpstreamAndOverwriteFlow(t *testing.T) {
 
 	assert.Contains(t, skill, "git remote add upstream")
 	assert.Contains(t, skill, "mvanhorn/printing-press-library")
-	assert.Contains(t, skill, "git fetch upstream")
+	assert.Contains(t, skill, "git fetch --filter=blob:none --depth 1 upstream")
+	assert.Contains(t, skill, "git fetch --filter=blob:none --depth 1 origin")
 	assert.Contains(t, skill, "git reset --hard upstream/main")
 	assert.Contains(t, skill, "git push --force-with-lease")
 }
@@ -561,7 +562,9 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	// no longer has an in-PR auto-fix path for either.
 	assert.Contains(t, skill, "Fail on changes to generated artifacts")
 	assert.Contains(t, skill, "Do NOT regenerate or commit `cli-skills/pp-<api-slug>/SKILL.md` or")
-	assert.Contains(t, skill, "git add library/\ngit commit")
+	assert.Contains(t, skill, "git add library/")
+	assert.Contains(t, skill, `git add -f "library/<category>/<api-slug>/cmd/<api-slug>-pp-mcp/"`)
+	assert.Contains(t, skill, `git commit -m "feat(<api-slug>): add <api-slug>"`)
 	assert.NotContains(t, skill, "git add library/ cli-skills/")
 	assert.NotContains(t, skill, "git add library/ cli-skills/ registry.json")
 	assert.NotContains(t, skill, "REGISTRY_HAS_ENTRY")
@@ -810,7 +813,7 @@ func TestPublishSkillOffersRetroForPolishHandoff(t *testing.T) {
 func TestPublishSkillPRBodyIncludesStableNovelCommands(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
 
-	snapshotState := strings.Index(skill, "PREEXISTING_MERGED_PATHS=$(ls")
+	snapshotState := strings.Index(skill, "PREEXISTING_MERGED_PATHS=$(git -C")
 	packageCopy := strings.Index(skill, `cp -R "$STAGED_CLI_DIR/." "$PUBLISH_SWAP_DIR/"`)
 	require.NotEqual(t, -1, snapshotState)
 	require.NotEqual(t, -1, packageCopy)

--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -546,6 +546,11 @@ func TestPublishSkillTracksCanonicalUpstreamAndOverwriteFlow(t *testing.T) {
 	assert.Contains(t, skill, "git fetch --filter=blob:none --depth 1 origin")
 	assert.Contains(t, skill, "git reset --hard upstream/main")
 	assert.Contains(t, skill, "git push --force-with-lease")
+
+	subsequentStart := strings.Index(skill, "### Subsequent publishes")
+	require.NotEqual(t, -1, subsequentStart)
+	subsequentBlock := skill[subsequentStart:]
+	assert.Contains(t, subsequentBlock, "sparse-checkout set tools cli-skills library/<category>")
 }
 
 func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -629,6 +629,13 @@ else
   # Also sync origin (fork) so git push works cleanly
   git push origin main --force-with-lease 2>/dev/null || true
 fi
+
+# Existing managed clones may already be sparse for a different publish
+# category. Refresh the cone for the current target category before Step 6 uses
+# filesystem-based removal and copy operations.
+if git -C "$PUBLISH_REPO_DIR" config --bool core.sparseCheckout | grep -qx true; then
+  git -C "$PUBLISH_REPO_DIR" sparse-checkout set tools cli-skills library/<category>
+fi
 ```
 
 Verify the clone is healthy:

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -618,12 +618,12 @@ cd "$PUBLISH_REPO_DIR"
 
 if [ "$(jq -r .access $PUBLISH_CONFIG)" = "push" ]; then
   # Push access: origin IS the upstream
-  git fetch origin
+  git fetch --filter=blob:none --depth 1 origin
   git checkout main
   git reset --hard origin/main
 else
   # Fork: origin is the fork, upstream is canonical
-  git fetch upstream
+  git fetch --filter=blob:none --depth 1 upstream
   git checkout main
   git reset --hard upstream/main
   # Also sync origin (fork) so git push works cleanly
@@ -670,6 +670,18 @@ PREEXISTING_MERGED_PATHS=$(git -C "$PUBLISH_REPO_DIR" ls-tree -r --name-only HEA
 PREEXISTING_MERGED_COLLISION=false
 if [ -n "$PREEXISTING_MERGED_PATHS" ]; then
   PREEXISTING_MERGED_COLLISION=true
+  # If this is a category-change reprint, materialize the existing category path
+  # before Step 6 runs filesystem-based ledger preservation and removal.
+  if git -C "$PUBLISH_REPO_DIR" config --bool core.sparseCheckout | grep -qx true; then
+    while IFS= read -r EXISTING_MERGED_PATH; do
+      [ -n "$EXISTING_MERGED_PATH" ] || continue
+      if [ "$EXISTING_MERGED_PATH" != "library/<category>/<api-slug>" ]; then
+        git -C "$PUBLISH_REPO_DIR" sparse-checkout add "$EXISTING_MERGED_PATH"
+      fi
+    done <<EOF
+$PREEXISTING_MERGED_PATHS
+EOF
+  fi
 fi
 ```
 
@@ -1179,11 +1191,12 @@ cd "$PUBLISH_REPO_DIR"
 git add library/
 # The library .gitignore has a `*-pp-mcp` rule intended for the built MCP
 # binary, but the pattern also matches the generated MCP *source* directory
-# `cmd/<cli-name>-pp-mcp/`. A plain `git add library/` silently skips it, and
+# `cmd/<api-slug>-pp-mcp/`. A plain `git add library/` silently skips it, and
 # the PR then fails the "Validate MCPB manifest contract" CI check with
-# "cmd/<cli-name>-pp-mcp directory is missing". Force-add the source so the MCP
-# entry point ships. (The built binary is still ignored; only main.go is added.)
-git add -f "library/<category>/<api-slug>/cmd/<cli-name>-pp-mcp/main.go" 2>/dev/null || true
+# "cmd/<api-slug>-pp-mcp directory is missing". Force-add the source directory
+# so all MCP entry-point files ship. The built binary stays ignored because it
+# lives at the packaged CLI root, not under cmd/.
+git add -f "library/<category>/<api-slug>/cmd/<api-slug>-pp-mcp/" 2>/dev/null || true
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -535,7 +535,16 @@ If `$PUBLISH_REPO_DIR` does not exist:
    else
      REPO_URL="https://github.com/mvanhorn/printing-press-library.git"
    fi
-   git clone --depth 50 "$REPO_URL" "$PUBLISH_REPO_DIR"
+   # Lightweight clone: blobless + shallow + sparse. The publish flow only
+   # touches the target CLI's own directory — it no longer regenerates the
+   # cli-skills/registry mirror (see Step 6) — so materializing every other
+   # CLI's source is wasted bandwidth and disk (a full clone is multiple GB;
+   # this is tens of MB). The cone keeps `tools`, `cli-skills`, and the target
+   # `library/<category>` so the in-category find/rm/copy operations below work
+   # on a real working tree. Cross-category collision checks use `git ls-tree`
+   # (which reads the full tree from the blobless clone) instead of `ls`.
+   git clone --filter=blob:none --depth 1 --sparse "$REPO_URL" "$PUBLISH_REPO_DIR"
+   git -C "$PUBLISH_REPO_DIR" sparse-checkout set tools cli-skills library/<category>
    ```
 
    **No push access** (`HAS_PUSH` is `false`):
@@ -558,10 +567,13 @@ If `$PUBLISH_REPO_DIR` does not exist:
      UPSTREAM_URL="https://github.com/mvanhorn/printing-press-library.git"
    fi
 
-   git clone --depth 50 "$FORK_URL" "$PUBLISH_REPO_DIR"
+   # Lightweight clone (blobless + shallow + sparse) — see the push-access
+   # branch above for the rationale and cone contents.
+   git clone --filter=blob:none --depth 1 --sparse "$FORK_URL" "$PUBLISH_REPO_DIR"
    cd "$PUBLISH_REPO_DIR"
+   git sparse-checkout set tools cli-skills library/<category>
    git remote add upstream "$UPSTREAM_URL"
-   git fetch upstream
+   git fetch --filter=blob:none --depth 1 upstream
    ```
 
 4. **Cache the config:**
@@ -651,7 +663,10 @@ exists in the public library tree. Step 6 removes and replaces
 after packaging must use this pre-package snapshot, not a fresh `ls`.
 
 ```bash
-PREEXISTING_MERGED_PATHS=$(ls "$PUBLISH_REPO_DIR/library"/*/"<api-slug>" 2>/dev/null || true)
+# Read from the git tree, not the working dir: the sparse checkout only
+# materializes the target category, but a slug can collide in any category.
+PREEXISTING_MERGED_PATHS=$(git -C "$PUBLISH_REPO_DIR" ls-tree -r --name-only HEAD \
+  | sed -n 's#^\(library/[^/]*/<api-slug>\)/.*#\1#p' | sort -u || true)
 PREEXISTING_MERGED_COLLISION=false
 if [ -n "$PREEXISTING_MERGED_PATHS" ]; then
   PREEXISTING_MERGED_COLLISION=true
@@ -1057,8 +1072,9 @@ Present the format to the user:
 **3. Verify each suggestion is non-colliding** before presenting:
 
 ```bash
-# Check merged
-ls "$PUBLISH_REPO_DIR/library"/*/"<suggestion>" 2>/dev/null
+# Check merged (read the git tree, not the sparse working dir)
+git -C "$PUBLISH_REPO_DIR" ls-tree -r --name-only HEAD \
+  | sed -n 's#^\(library/[^/]*/<suggestion>\)/.*#\1#p' | sort -u
 # Check open PRs
 gh pr list --repo mvanhorn/printing-press-library --head "feat/<suggestion>" --state open --json number
 ```
@@ -1161,6 +1177,13 @@ git checkout -B feat/<api-slug>
 ```bash
 cd "$PUBLISH_REPO_DIR"
 git add library/
+# The library .gitignore has a `*-pp-mcp` rule intended for the built MCP
+# binary, but the pattern also matches the generated MCP *source* directory
+# `cmd/<cli-name>-pp-mcp/`. A plain `git add library/` silently skips it, and
+# the PR then fails the "Validate MCPB manifest contract" CI check with
+# "cmd/<cli-name>-pp-mcp directory is missing". Force-add the source so the MCP
+# entry point ships. (The built binary is still ignored; only main.go is added.)
+git add -f "library/<category>/<api-slug>/cmd/<cli-name>-pp-mcp/main.go" 2>/dev/null || true
 git commit -m "feat(<api-slug>): add <api-slug>"
 ```
 


### PR DESCRIPTION
## Summary

Two improvements to the `printing-press-publish` skill, both found while publishing a real CLI (a reverse-engineered, MCP-enabled CLI) to the public library.

### 1. Lightweight clone of the public library (blobless + shallow + sparse)

Step 5 currently does `git clone --depth 50` of `mvanhorn/printing-press-library`. That repo is a historical collection of hundreds of CLIs, so the working tree is multiple GB — a lot of bandwidth and disk to publish a single CLI, and painful on space-constrained machines (this surfaced as a "no space left on device" failure mid-publish).

Since the skill no longer regenerates or commits the `cli-skills/`/`registry.json` mirror (Step 6 already documents that the library regenerates them post-merge), the publish flow only touches the **target CLI's own directory**. So there's no need to materialize every other CLI's source.

This PR switches both clone paths (push-access and fork) to:

```bash
git clone --filter=blob:none --depth 1 --sparse "$REPO_URL" "$PUBLISH_REPO_DIR"
git -C "$PUBLISH_REPO_DIR" sparse-checkout set tools cli-skills library/<category>
```

The cone keeps `tools`, `cli-skills`, and the target `library/<category>` so the in-category find/rm/copy operations in Step 6 keep working on a real working tree. Cross-category collision checks (Step 5 pre-package snapshot and the Step 7 rename-suggestion check) are switched from `ls` to `git ls-tree`, which reads the full tree from the blobless clone and therefore stays correct despite the sparse working tree.

Result in practice: the clone drops from multiple GB to ~tens of MB.

### 2. Force-add the generated MCP source dir (`.gitignore` `*-pp-mcp` gotcha)

The library `.gitignore` has a `*-pp-mcp` rule meant for the built MCP **binary**, but the pattern also matches the generated MCP **source** directory `cmd/<cli-name>-pp-mcp/`. A plain `git add library/` silently skips `cmd/<cli-name>-pp-mcp/main.go`, and the PR then fails the **Validate MCPB manifest contract** CI check with `cmd/<cli-name>-pp-mcp directory is missing` (the manifest advertises an MCP binary with no entry point in the diff).

Step 8 now force-adds the source after `git add library/`:

```bash
git add -f "library/<category>/<api-slug>/cmd/<cli-name>-pp-mcp/main.go" 2>/dev/null || true
```

The built binary stays ignored; only `main.go` is added.

## Notes / scope

- Category-change reprints (a slug moving to a different category) would need the old path added to the sparse cone before the Step 6 `rm`; this is a rare path and left as a follow-up — the collision detection already surfaces it to the user.
- No behavioral change to packaging, validation, secret/PII scanning, or PR creation.
