### PR TITLE
fix(cli): emit Cobra Example in novel-feature scaffold

### DIFF
--- a/internal/generator/novel_feature_stubs.go
+++ b/internal/generator/novel_feature_stubs.go
@@ -17,6 +17,7 @@ type novelFeatureCommandRender struct {
 	Ident          string
 	Use            string
 	Short          string
+	Example        string
 	CommandPath    string
 	ReadOnlyString string
 	HasPositional  bool
@@ -211,6 +212,7 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 	use := node.segment
 	hasPositional := false
 	readOnly := true
+	example := ""
 	var flags []novelFeatureFlagRender
 	if node.feature != nil {
 		short = naming.OneLine(node.feature.Description)
@@ -224,6 +226,7 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 		flags = novelFeatureFlags(*node.feature, node.path, g.Spec.Name)
 		hasPositional = novelFeatureHasPositional(node.feature.Command)
 		use = novelFeatureUse(node.segment, node.feature.Command)
+		example = novelFeatureExample(*node.feature, node.path, g.Spec.Name)
 	} else if len(node.children) > 0 {
 		short = novelFeatureParentShort(node)
 	}
@@ -236,6 +239,7 @@ func (g *Generator) novelFeatureCommandData(node *novelFeatureStubNode) novelFea
 		Ident:          novelFeatureStubIdent(node.path),
 		Use:            use,
 		Short:          short,
+		Example:        example,
 		CommandPath:    commandPath,
 		ReadOnlyString: readOnlyString,
 		HasPositional:  hasPositional,
@@ -489,6 +493,22 @@ func novelFeatureFlags(feature NovelFeature, commandPath []string, apiName strin
 		})
 	}
 	return flags
+}
+
+// novelFeatureExample returns the prefix-stripped runnable form of the
+// feature's research example, suitable for a Cobra Example field. Empty when
+// the feature has no example or the example yields no tokens after stripping
+// the binary/command-path prefix.
+func novelFeatureExample(feature NovelFeature, commandPath []string, apiName string) string {
+	if strings.TrimSpace(feature.Example) == "" {
+		return ""
+	}
+	tokens, err := shellargs.Split(feature.Example)
+	if err != nil {
+		return ""
+	}
+	tokens = dropNovelFeatureExamplePrefix(tokens, commandPath, apiName)
+	return strings.Join(tokens, " ")
 }
 
 func dropNovelFeatureExamplePrefix(tokens []string, commandPath []string, apiName string) []string {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -43,6 +43,9 @@ func TestGeneratorEmitsNovelFeatureCommandStubs(t *testing.T) {
 
 	call := readGeneratedFile(t, outputDir, "internal", "cli", "call.go")
 	assert.Contains(t, call, `Use:         "call"`)
+	// The Cobra Example field carries the prefix-stripped runnable form of the
+	// research example (binary + command path dropped).
+	assert.Contains(t, call, `Example:     "apify/web-scraper --tag skill=reddit-digest --dedupe-key daily --ttl 24h --wait --agent"`)
 	assert.Contains(t, call, `Annotations: map[string]string{"mcp:read-only": "false"}`)
 	assert.Contains(t, call, `StringSliceVar(&flagTag, "tag", nil`)
 	assert.Contains(t, call, `StringVar(&flagDedupeKey, "dedupe-key", ""`)
@@ -97,6 +100,29 @@ func TestNovelFeatureStubsResolveAtRuntime(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "novel_stub_runtime_test.go"), []byte(runtimeTest.String()), 0o644))
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "test", "./internal/cli")
+}
+
+func TestGeneratorOmitsExampleWhenNovelFeatureHasNoExample(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("noexample")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.NovelFeatures = []NovelFeature{
+		{
+			Name:        "Audit cache",
+			Command:     "audit",
+			Description: "Audit local cache state.",
+			// No Example: a feature without research example must emit no
+			// Cobra Example field (never `Example: ""`).
+		},
+	}
+	require.NoError(t, gen.Generate())
+
+	audit := readGeneratedFile(t, outputDir, "internal", "cli", "audit.go")
+	assert.Contains(t, audit, `Use:         "audit"`)
+	assert.NotContains(t, audit, "Example:")
+	requireGeneratedCompiles(t, outputDir)
 }
 
 func TestGeneratorEmitsBoundCtxHelperForNovelCommands(t *testing.T) {

--- a/internal/generator/novel_feature_stubs_test.go
+++ b/internal/generator/novel_feature_stubs_test.go
@@ -61,6 +61,9 @@ func TestGeneratorEmitsNovelFeatureCommandStubs(t *testing.T) {
 
 	classify := readGeneratedFile(t, outputDir, "internal", "cli", "runs_classify.go")
 	assert.Contains(t, classify, `Use:         "classify"`)
+	// Multi-segment command path: dropNovelFeatureExamplePrefix strips the
+	// binary AND both path segments ("runs classify"), leaving only the args.
+	assert.Contains(t, classify, `Example:     "run-123 --limit 10"`)
 	assert.Contains(t, classify, `Annotations: map[string]string{"mcp:read-only": "true"}`)
 	assert.Contains(t, classify, `StringVar(&flagLimit, "limit", ""`)
 	assert.Contains(t, classify, `TODO: implement novel feature %q", "runs classify"`)

--- a/internal/generator/templates/novel_feature_command.go.tmpl
+++ b/internal/generator/templates/novel_feature_command.go.tmpl
@@ -25,6 +25,9 @@ func newNovel{{.Ident}}Cmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   {{printf "%q" .Use}},
 		Short: {{printf "%q" .Short}},
+{{- if .Example}}
+		Example: {{printf "%q" .Example}},
+{{- end}}
 		Annotations: map[string]string{"mcp:read-only": {{printf "%q" .ReadOnlyString}}},
 {{- if .Feature}}
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Intent

Generated novel-feature command files ship without a Cobra `Example:` field, so every novel command fails dogfood's "missing Examples section" help check until an Example is hand-added (13 commands on a recent website-CLI run).

Issue: Refs #2636

## Approach

The scaffold already carried the example text (`feature.Example`, research.json's per-feature `example`) — used for flag inference — but never rendered a Cobra `Example:`. This adds an `Example` field to `novelFeatureCommandRender`, computed by a new `novelFeatureExample` helper that reuses the existing `dropNovelFeatureExamplePrefix` (split → drop binary/command-path prefix → rejoin) so the rendered value is the runnable `<cli> <novel> ...` form. The template renders `Example: {{printf "%q" .Example}},` guarded by `{{if .Example}}` — no `Example:` line when the example is empty.

## Scope

Primary area: generator (`internal/generator/`)

Why this belongs in this repo: the scaffold is generic — recurs on every printed CLI that has `novel_features`. Filling the missing field raises the floor for all of them.

## Catalog Justification

N/A

## Risk

Changes emitted Go for CLIs with novel features (adds an `Example:` line per novel command). Golden suite is clean — no existing golden fixture emits novel-feature scaffolds, so frozen output is unchanged. Empty-example features emit no `Example:` line (no `Example: ""`).

## Output Contract

Generator/template change. Evidence: emitted-code assertion in `TestGeneratorEmitsNovelFeatureCommandStubs` (asserts the prefix-stripped example on `call`); new `TestGeneratorOmitsExampleWhenNovelFeatureHasNoExample` (asserts no `Example:` line for empty example) with `requireGeneratedCompiles`; `scripts/golden.sh verify` clean (31 cases); `scripts/verify-generator-output.sh` PASS (9 cases compiled).

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run: `go build ./...`, `go test ./...` (6497 pass / 44 pkgs), `scripts/golden.sh verify` (clean, 31 cases), `scripts/verify-generator-output.sh` (9 cases), `go fmt ./...`.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FU3Jifes15BAfAAYxVDRkP