### PR TITLE
fix(cli): stop dogfood classifier mislabeling help failures as transport_error

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1965,6 +1965,13 @@ func summarizeLiveDogfoodFailures(report *LiveDogfoodReport) *Phase5FailureSumma
 // best-effort hint, not a contract.
 func classifyLiveDogfoodFailure(t LiveDogfoodTestResult) string {
 	hay := strings.ToLower(t.Reason + " " + t.OutputSample)
+	// The transport keywords are matched against the runner-authored Reason
+	// only, never the combined hay. OutputSample is command-controlled echo:
+	// a help-kind failure carries the full --help text, which on every
+	// printed CLI includes the global flag line "--timeout duration  Request
+	// timeout (default 1m0s)". Scanning that with the bare "timeout" token
+	// mislabels every help failure as transport_error.
+	reason := strings.ToLower(t.Reason)
 	// 4xx is checked before 5xx: a legitimate 5xx response is unlikely to
 	// also mention "http 4", whereas error strings citing 400/401/403/404
 	// frequently start with digit 4 and would otherwise be shadowed if 5xx
@@ -1975,10 +1982,10 @@ func classifyLiveDogfoodFailure(t LiveDogfoodTestResult) string {
 		return "http_4xx"
 	case strings.Contains(hay, "http 5"):
 		return "http_5xx"
-	case strings.Contains(hay, "connection refused") ||
-		strings.Contains(hay, "no such host") ||
-		strings.Contains(hay, "timeout") ||
-		strings.Contains(hay, "dial tcp"):
+	case strings.Contains(reason, "connection refused") ||
+		strings.Contains(reason, "no such host") ||
+		strings.Contains(reason, "timeout") ||
+		strings.Contains(reason, "dial tcp"):
 		return "transport_error"
 	// "invalid json" / "not json" match independently so the runner's own
 	// Reason strings (literal "invalid JSON" at the two emit sites) bucket

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -180,7 +180,25 @@ func TestClassifyLiveDogfoodFailure(t *testing.T) {
 		},
 		{
 			name: "transport_error on connection refused",
-			in:   LiveDogfoodTestResult{Reason: "dial tcp: connection refused", ExitCode: 1},
+			in:   LiveDogfoodTestResult{Reason: "dial tcp 1.2.3.4:443: connect: connection refused", ExitCode: 1},
+			want: "transport_error",
+		},
+		{
+			// Regression: a help-kind failure's OutputSample carries the full
+			// --help text, which includes the global "--timeout duration"
+			// flag line. The transport case must scan Reason only, not the
+			// combined hay, or every help failure mislabels as transport_error.
+			name: "help failure with --timeout flag text is not transport_error",
+			in: LiveDogfoodTestResult{
+				Kind:         LiveDogfoodTestHelp,
+				Reason:       "missing Examples section",
+				OutputSample: "Usage:\n  x [flags]\n\nGlobal Flags:\n      --timeout duration   Request timeout (default 1m0s)\n",
+			},
+			want: "other",
+		},
+		{
+			name: "transport_error on genuine timeout in reason",
+			in:   LiveDogfoodTestResult{Reason: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)", ExitCode: 1},
 			want: "transport_error",
 		},
 		{


### PR DESCRIPTION
## Intent

Live `dogfood --live` `failure_summary` mislabels help-check failures as `transport_error`, sending triage down a network red herring (a run of help failures bucketed entirely as `transport_error`).

Issue: Closes #3109

## Approach

`classifyLiveDogfoodFailure` grepped the combined `Reason + OutputSample` for transport substrings including the bare token `timeout`. A help-kind failure's `OutputSample` is the full `--help` text, which on every printed CLI contains the global flag line `--timeout duration   Request timeout (default 1m0s)` — so `timeout` matched and mislabeled the failure. Fix: match the transport-keyword case against `t.Reason` only (the runner authors Reason; OutputSample is echoed/command-controlled). The `http_4xx`/`http_5xx`/`output_mismatch` cases still scan the combined text (those substrings don't appear in help output); the 4xx-before-5xx ordering is preserved. No schema or bucket-name changes.

## Scope

Primary area: scorer (`internal/pipeline/live_dogfood.go`)

Why this belongs in this repo: every printed CLI's `--help` carries the `--timeout` global flag, so the false positive is fully general across CLIs.

## Catalog Justification

N/A

## Risk

Changes only the failure-bucket hint: help-kind (and other non-transport) failures now classify as `other`/`exit_nonzero` instead of false `transport_error`. Genuine transport failures (Reason mentions `dial tcp`/`connection refused`/`timeout`) still bucket as `transport_error`. Unit-tested both directions.

## Output Contract

The classifier now returns `other` (not `transport_error`) for a help failure whose OutputSample contains the `--timeout` flag text; `failure_summary` schema and bucket names unchanged. Covered by new cases in `live_dogfood_test.go`.

## Verification

- [ ] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [ ] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [ ] Generator/template change: checked emitted definitions and call sites for matching gates

Not a generator/template change (scorer logic only) — the three boxes above are N/A. Commands run: `go build ./...`, `go test ./...` (6498 pass / 44 pkgs), `go test ./internal/pipeline/...`, `go fmt ./...`.

## AI / Automation Disclosure

- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FU3Jifes15BAfAAYxVDRkP