### PR TITLE
fix(cli): index 3-letter all-caps acronyms in generated FTS

### DIFF
--- a/internal/generator/fts_acronym_index_test.go
+++ b/internal/generator/fts_acronym_index_test.go
@@ -1,0 +1,47 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateStoreFTSIndexesAcronyms verifies the generated store package
+// indexes 3-letter all-caps acronyms (API, SQL, AWS, ...) into resources_fts
+// so they are searchable. A prior blanket exclusion of every 3-char all-caps
+// token (intended for currency/country codes) made common technical acronyms
+// unsearchable on every CLI using the generic FTS index.
+func TestGenerateStoreFTSIndexesAcronyms(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("fts-acronyms")
+	outputDir := filepath.Join(t.TempDir(), "fts-acronyms-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "store", "fts_acronym_index_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package store
+
+import "testing"
+
+func TestShouldIndexSearchStringAcronyms(t *testing.T) {
+	for _, acr := range []string{"API", "SQL", "AWS", "XML", "GPU"} {
+		if !shouldIndexSearchString("description", acr) {
+			t.Errorf("shouldIndexSearchString(%q) = false, want true (3-letter acronyms must be searchable)", acr)
+		}
+	}
+	// Sanity: genuinely non-indexable values stay excluded.
+	if shouldIndexSearchString("id", "abc-123") {
+		t.Errorf("identifier-key values must stay unindexed")
+	}
+	if shouldIndexSearchString("x", "a") {
+		t.Errorf("single-character values must stay unindexed")
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/store", "-run", "TestShouldIndexSearchStringAcronyms", "-count=1")
+}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1077,15 +1077,12 @@ func shouldIndexSearchString(key, value string) bool {
 		return false
 	}
 	lower := strings.ToLower(s)
-	upper := strings.ToUpper(s)
 	switch {
 	case IsUUID(s):
 		return false
 	case isoDatePattern.MatchString(s):
 		return false
 	case strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://"):
-		return false
-	case upper == s && len(s) == 3 && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
 		return false
 	}
 	tokens := ftsQueryTokenRE.FindAllString(s, -1)

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1005,15 +1005,12 @@ func shouldIndexSearchString(key, value string) bool {
 		return false
 	}
 	lower := strings.ToLower(s)
-	upper := strings.ToUpper(s)
 	switch {
 	case IsUUID(s):
 		return false
 	case isoDatePattern.MatchString(s):
 		return false
 	case strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://"):
-		return false
-	case upper == s && len(s) == 3 && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
 		return false
 	}
 	tokens := ftsQueryTokenRE.FindAllString(s, -1)

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -899,15 +899,12 @@ func shouldIndexSearchString(key, value string) bool {
 		return false
 	}
 	lower := strings.ToLower(s)
-	upper := strings.ToUpper(s)
 	switch {
 	case IsUUID(s):
 		return false
 	case isoDatePattern.MatchString(s):
 		return false
 	case strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://"):
-		return false
-	case upper == s && len(s) == 3 && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
 		return false
 	}
 	tokens := ftsQueryTokenRE.FindAllString(s, -1)

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -893,15 +893,12 @@ func shouldIndexSearchString(key, value string) bool {
 		return false
 	}
 	lower := strings.ToLower(s)
-	upper := strings.ToUpper(s)
 	switch {
 	case IsUUID(s):
 		return false
 	case isoDatePattern.MatchString(s):
 		return false
 	case strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://"):
-		return false
-	case upper == s && len(s) == 3 && strings.IndexFunc(s, func(r rune) bool { return r < 'A' || r > 'Z' }) == -1:
 		return false
 	}
 	tokens := ftsQueryTokenRE.FindAllString(s, -1)


### PR DESCRIPTION
## Intent

`shouldIndexSearchString` in the generated store dropped any exactly-3-char all-uppercase token (intended for currency/country codes), which also excluded common technical acronyms (API, SQL, AWS, XML, GPU, ...) from the generic `resources_fts` index — making them unsearchable on every CLI using that index.

Issue: Closes #3098

## Approach

Remove the blanket 3-char all-caps exclusion so acronyms index by default; also drop the now-unused `upper` local. The FTS table shape is unchanged (no migration). Existing synced rows pick up the change on their next sync/re-index.

## Scope

Primary area: generator template — `internal/generator/templates/store.go.tmpl` (`shouldIndexSearchString`).

Why this belongs in this repo: the FTS indexing predicate is emitted into every store-backed printed CLI.

## Catalog Justification

N/A

## Risk

Currency/country codes (USD, EUR, ...) now also index — negligible noise, and arguably correct (a user searching "USD" should find rows). No schema change. Existing stores don't retroactively reindex until their next sync (called out so reviewers can decide whether a forced FTS rebuild migration is wanted; not included here to keep the change minimal).

## Output Contract

Generator/template change. Generated-output evidence: new behavioral test `TestGenerateStoreFTSIndexesAcronyms` generates a CLI, writes a test into its `internal/store` package that calls `shouldIndexSearchString` directly, and runs it via `go test` on the generated module — asserting API/SQL/AWS/XML/GPU index while identifier-key and single-char values stay excluded. Three golden `store.go` fixtures updated (the two-line removal).

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go test ./...` (full suite green; one unrelated pre-existing flaky pipeline test, passes isolated on `main` and the branch)
- `go test ./internal/generator -run TestGenerateStoreFTSIndexesAcronyms`
- `scripts/golden.sh verify` (32 cases pass after update)
- `scripts/verify-generator-output.sh` (10 CLIs compile)
- `go vet ./internal/generator`

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
