### PR TITLE
fix(cli): bound cobratree shell-out MCP results to the tool-result byte budget

### DIFF
--- a/internal/generator/cobratree_shellout_bound_test.go
+++ b/internal/generator/cobratree_shellout_bound_test.go
@@ -1,0 +1,58 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateCobratreeShellOutBoundsResultBytes verifies the generated
+// cobratree shell-out path caps raw companion-CLI stdout to the MCP
+// tool-result byte budget. Typed endpoint tools enforce the same ceiling with
+// a JSON-aware envelope; the shell-out path previously returned unbounded raw
+// stdout, so a verbose command could blow the budget the typed tools protect.
+func TestGenerateCobratreeShellOutBoundsResultBytes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("shellout-bound")
+	outputDir := filepath.Join(t.TempDir(), "shellout-bound-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "mcp", "cobratree", "bound_shell_result_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cobratree
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBoundShellResultCapsOversizedOutput(t *testing.T) {
+	small := "small output"
+	if got := boundShellResult(small); got != small {
+		t.Fatalf("small output must pass through unchanged: got %q", got)
+	}
+
+	big := strings.Repeat("x", 200000)
+	got := boundShellResult(big)
+	if len(got) > mcpShellResultMaxBytes {
+		t.Fatalf("oversized output must be capped to the byte budget %d, got %d bytes", mcpShellResultMaxBytes, len(got))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("truncated result must carry a truncation marker, got prefix %q", got[:min(200, len(got))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/mcp/cobratree", "-run", "TestBoundShellResultCapsOversizedOutput", "-count=1")
+}

--- a/internal/generator/cobratree_shellout_bound_test.go
+++ b/internal/generator/cobratree_shellout_bound_test.go
@@ -36,13 +36,23 @@ func TestBoundShellResultCapsOversizedOutput(t *testing.T) {
 		t.Fatalf("small output must pass through unchanged: got %q", got)
 	}
 
-	big := strings.Repeat("x", 200000)
-	got := boundShellResult(big)
-	if len(got) > mcpShellResultMaxBytes {
-		t.Fatalf("oversized output must be capped to the byte budget %d, got %d bytes", mcpShellResultMaxBytes, len(got))
-	}
-	if !strings.Contains(got, "truncated") {
-		t.Fatalf("truncated result must carry a truncation marker, got prefix %q", got[:min(200, len(got))])
+	// Oversized inputs must always fit the byte budget once wrapped in the JSON
+	// truncation envelope, including JSON-heavy output whose characters expand
+	// under json.Marshal escaping (quotes -> \", backslashes -> \\, control
+	// chars -> \uXXXX). A raw-byte preview limit would overshoot for these.
+	for name, in := range map[string]string{
+		"plain ascii":   strings.Repeat("x", 200000),
+		"all quotes":    strings.Repeat("\"", 200000),
+		"all backslash": strings.Repeat("\\", 200000),
+		"all control":   strings.Repeat("\x01", 200000),
+	} {
+		got := boundShellResult(in)
+		if len(got) > mcpShellResultMaxBytes {
+			t.Fatalf("%s: oversized output must be capped to the budget %d, got %d bytes", name, mcpShellResultMaxBytes, len(got))
+		}
+		if !strings.Contains(got, "truncated") {
+			t.Fatalf("%s: truncated result must carry a truncation marker, got prefix %q", name, got[:min(200, len(got))])
+		}
 	}
 }
 

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -55,31 +55,47 @@ const mcpShellResultMaxBytes = 60000
 // envelope; shell-out stdout is arbitrary text (JSON, tables, CSV), so this
 // returns a JSON truncation envelope carrying a UTF-8-safe byte preview and a
 // note pointing the agent at the output-narrowing flags.
+//
+// json.Marshal escapes quotes, backslashes, and control characters, so an
+// encoded preview can be larger than its raw byte length (CLI output is often
+// itself JSON). Bound the final marshaled envelope, not the raw preview slice:
+// start from a budget-sized preview and shrink until the encoded result fits.
 func boundShellResult(out string) string {
 	if len(out) <= mcpShellResultMaxBytes {
 		return out
 	}
-	limit := mcpShellResultMaxBytes - 1024
-	if limit < 0 {
-		limit = 0
-	}
+	limit := mcpShellResultMaxBytes
 	if limit > len(out) {
 		limit = len(out)
 	}
-	for limit > 0 && !utf8.RuneStart(out[limit]) {
-		limit--
+	for {
+		for limit > 0 && !utf8.RuneStart(out[limit]) {
+			limit--
+		}
+		envelope, err := json.Marshal(map[string]any{
+			"truncated":      true,
+			"original_bytes": len(out),
+			"max_bytes":      mcpShellResultMaxBytes,
+			"preview":        out[:limit],
+			"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
+		})
+		if err != nil {
+			return out[:limit]
+		}
+		if len(envelope) <= mcpShellResultMaxBytes || limit == 0 {
+			return string(envelope)
+		}
+		// Scale the preview down proportionally to the overshoot, guaranteeing
+		// forward progress so the loop always terminates.
+		scaled := int(int64(limit) * int64(mcpShellResultMaxBytes) / int64(len(envelope)))
+		if scaled >= limit {
+			scaled = limit - 1
+		}
+		limit = scaled
+		if limit < 0 {
+			limit = 0
+		}
 	}
-	envelope, err := json.Marshal(map[string]any{
-		"truncated":      true,
-		"original_bytes": len(out),
-		"max_bytes":      mcpShellResultMaxBytes,
-		"preview":        out[:limit],
-		"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
-	})
-	if err != nil {
-		return out[:limit]
-	}
-	return string(envelope)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -6,11 +6,13 @@ package cobratree
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -37,8 +39,47 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		if err != nil {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
-		return mcplib.NewToolResultText(out), nil
+		return mcplib.NewToolResultText(boundShellResult(out)), nil
 	}
+}
+
+// mcpShellResultMaxBytes caps raw companion-CLI stdout returned through the
+// command-mirror shell-out path. It mirrors the typed endpoint tools' result
+// ceiling (mcpToolResultMaxBytes in the mcp package) so a single tool result
+// stays within an MCP host's context budget regardless of which tool surface
+// produced it.
+const mcpShellResultMaxBytes = 60000
+
+// boundShellResult caps oversized command output to the tool-result byte
+// budget. Typed endpoint tools bound their output with a JSON-aware list
+// envelope; shell-out stdout is arbitrary text (JSON, tables, CSV), so this
+// returns a JSON truncation envelope carrying a UTF-8-safe byte preview and a
+// note pointing the agent at the output-narrowing flags.
+func boundShellResult(out string) string {
+	if len(out) <= mcpShellResultMaxBytes {
+		return out
+	}
+	limit := mcpShellResultMaxBytes - 1024
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(out) {
+		limit = len(out)
+	}
+	for limit > 0 && !utf8.RuneStart(out[limit]) {
+		limit--
+	}
+	envelope, err := json.Marshal(map[string]any{
+		"truncated":      true,
+		"original_bytes": len(out),
+		"max_bytes":      mcpShellResultMaxBytes,
+		"preview":        out[:limit],
+		"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
+	})
+	if err != nil {
+		return out[:limit]
+	}
+	return string(envelope)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -55,31 +55,47 @@ const mcpShellResultMaxBytes = 60000
 // envelope; shell-out stdout is arbitrary text (JSON, tables, CSV), so this
 // returns a JSON truncation envelope carrying a UTF-8-safe byte preview and a
 // note pointing the agent at the output-narrowing flags.
+//
+// json.Marshal escapes quotes, backslashes, and control characters, so an
+// encoded preview can be larger than its raw byte length (CLI output is often
+// itself JSON). Bound the final marshaled envelope, not the raw preview slice:
+// start from a budget-sized preview and shrink until the encoded result fits.
 func boundShellResult(out string) string {
 	if len(out) <= mcpShellResultMaxBytes {
 		return out
 	}
-	limit := mcpShellResultMaxBytes - 1024
-	if limit < 0 {
-		limit = 0
-	}
+	limit := mcpShellResultMaxBytes
 	if limit > len(out) {
 		limit = len(out)
 	}
-	for limit > 0 && !utf8.RuneStart(out[limit]) {
-		limit--
+	for {
+		for limit > 0 && !utf8.RuneStart(out[limit]) {
+			limit--
+		}
+		envelope, err := json.Marshal(map[string]any{
+			"truncated":      true,
+			"original_bytes": len(out),
+			"max_bytes":      mcpShellResultMaxBytes,
+			"preview":        out[:limit],
+			"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
+		})
+		if err != nil {
+			return out[:limit]
+		}
+		if len(envelope) <= mcpShellResultMaxBytes || limit == 0 {
+			return string(envelope)
+		}
+		// Scale the preview down proportionally to the overshoot, guaranteeing
+		// forward progress so the loop always terminates.
+		scaled := int(int64(limit) * int64(mcpShellResultMaxBytes) / int64(len(envelope)))
+		if scaled >= limit {
+			scaled = limit - 1
+		}
+		limit = scaled
+		if limit < 0 {
+			limit = 0
+		}
 	}
-	envelope, err := json.Marshal(map[string]any{
-		"truncated":      true,
-		"original_bytes": len(out),
-		"max_bytes":      mcpShellResultMaxBytes,
-		"preview":        out[:limit],
-		"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
-	})
-	if err != nil {
-		return out[:limit]
-	}
-	return string(envelope)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -6,11 +6,13 @@ package cobratree
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -37,8 +39,47 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		if err != nil {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
-		return mcplib.NewToolResultText(out), nil
+		return mcplib.NewToolResultText(boundShellResult(out)), nil
 	}
+}
+
+// mcpShellResultMaxBytes caps raw companion-CLI stdout returned through the
+// command-mirror shell-out path. It mirrors the typed endpoint tools' result
+// ceiling (mcpToolResultMaxBytes in the mcp package) so a single tool result
+// stays within an MCP host's context budget regardless of which tool surface
+// produced it.
+const mcpShellResultMaxBytes = 60000
+
+// boundShellResult caps oversized command output to the tool-result byte
+// budget. Typed endpoint tools bound their output with a JSON-aware list
+// envelope; shell-out stdout is arbitrary text (JSON, tables, CSV), so this
+// returns a JSON truncation envelope carrying a UTF-8-safe byte preview and a
+// note pointing the agent at the output-narrowing flags.
+func boundShellResult(out string) string {
+	if len(out) <= mcpShellResultMaxBytes {
+		return out
+	}
+	limit := mcpShellResultMaxBytes - 1024
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(out) {
+		limit = len(out)
+	}
+	for limit > 0 && !utf8.RuneStart(out[limit]) {
+		limit--
+	}
+	envelope, err := json.Marshal(map[string]any{
+		"truncated":      true,
+		"original_bytes": len(out),
+		"max_bytes":      mcpShellResultMaxBytes,
+		"preview":        out[:limit],
+		"note":           "Command output exceeded the MCP tool-result budget. Re-run with --agent/--compact/--select or a narrower --limit, or use the sql/search tools.",
+	})
+	if err != nil {
+		return out[:limit]
+	}
+	return string(envelope)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {


### PR DESCRIPTION
## Intent

The cobratree command-mirror shell-out path returned raw companion-CLI stdout via `NewToolResultText` with no cap, while typed endpoint tools bound their output to `mcpToolResultMaxBytes` (60000) with a truncation envelope. A verbose mirrored command could therefore blow the byte budget the typed tools protect — the same finding as this issue, at the generator-template level.

Issue: Closes #3177

## Approach

Add a self-contained `boundShellResult` helper in the cobratree package that caps oversized stdout to the same 60000-byte budget with a UTF-8-safe preview envelope and a note pointing the agent at `--agent`/`--compact`/`--select`, a narrower `--limit`, or the `sql`/`search` tools. The cobratree package cannot import the `mcp` package's JSON-aware bounding helpers (`mcp` imports `cobratree`), and shell-out stdout is arbitrary text rather than a typed JSON list, so a text-oriented bound local to cobratree is the right shape; it shares the budget value/contract with the typed path.

## Scope

Primary area: generator template — `internal/generator/templates/cobratree/shellout.go.tmpl`.

Why this belongs in this repo: the shell-out path is the majority agent-callable surface on every printed CLI with the runtime command mirror.

## Catalog Justification

N/A

## Risk

Output larger than 60000 bytes through the shell-out path is now returned as a truncation envelope instead of raw text; this matches the typed tools' existing behavior and is the intended contract for an MCP tool result. Output at or below the budget is unchanged (passthrough).

## Output Contract

Generator/template change. Generated-output evidence: new behavioral test `TestGenerateCobratreeShellOutBoundsResultBytes` generates a CLI, writes a test into its `internal/mcp/cobratree` package, and runs it via `go test` on the generated module — asserting small output passes through unchanged and oversized output is capped to the budget with a truncation marker. One golden `shellout.go` fixture updated (the added helper, constant, import, and call-site change).

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go test ./...` (full suite green, 37 packages ok)
- `go test ./internal/generator -run TestGenerateCobratreeShellOutBoundsResultBytes`
- `scripts/golden.sh verify` (32 cases pass after update)
- `scripts/verify-generator-output.sh` (10 CLIs compile)
- `go vet ./...`

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
