### PR TITLE
fix(substack): route draft writer endpoints globally

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -171,6 +171,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 	s.InferEndpointTemplateVarsFromBaseURLs()
 	s.EnrichPathParams()
 	s.PromoteGlobalPathTemplateVars()
+	normalizeSubstackGlobalWriterRoutes(s)
 	// Resolve the creator + contributors (the canonical attribution model),
 	// preserving persisted values across regens so a regen never flips the
 	// creator to whoever is running the generator. The legacy
@@ -634,6 +635,88 @@ func hasSubstackPublicationIDTemplateResolver(s *spec.APISpec) bool {
 
 func substackPublicationIDTemplatePath(s *spec.APISpec, path string) bool {
 	return s != nil && strings.EqualFold(s.Name, "substack") && strings.Contains(path, "{publication_id}")
+}
+
+func normalizeSubstackGlobalWriterRoutes(s *spec.APISpec) {
+	if s == nil || !strings.EqualFold(s.Name, "substack") || !s.IsEndpointTemplateVar("publication_id") {
+		return
+	}
+	for resourceName, resource := range s.Resources {
+		for endpointName, endpoint := range resource.Endpoints {
+			if normalized, ok := substackGlobalWriterPath(resourceName, endpointName, endpoint.Path); ok {
+				endpoint.Path = normalized
+				resource.Endpoints[endpointName] = endpoint
+			}
+		}
+		for subName, sub := range resource.SubResources {
+			for endpointName, endpoint := range sub.Endpoints {
+				if normalized, ok := substackGlobalWriterPath(subName, endpointName, endpoint.Path); ok {
+					endpoint.Path = normalized
+					sub.Endpoints[endpointName] = endpoint
+				}
+			}
+			resource.SubResources[subName] = sub
+		}
+		s.Resources[resourceName] = resource
+	}
+}
+
+func substackGlobalWriterPath(resourceName, endpointName, path string) (string, bool) {
+	resourceName = strings.ToLower(strings.TrimSpace(resourceName))
+	endpointName = strings.ToLower(strings.TrimSpace(endpointName))
+	path = strings.TrimSpace(path)
+	if resourceName == "images" && substackImageUploadPath(path) {
+		return "https://substack.com/api/v1/image", path != "https://substack.com/api/v1/image"
+	}
+	if resourceName != "drafts" {
+		return "", false
+	}
+	if !substackDraftsPath(path) {
+		return "", false
+	}
+	if endpointName == "" {
+		return "", false
+	}
+	trimmed := strings.TrimPrefix(path, "https://{publication}.substack.com/api/v1")
+	trimmed = strings.TrimPrefix(trimmed, "https://substack.com/api/v1")
+	if !strings.HasPrefix(trimmed, "/drafts") {
+		trimmed = "/drafts"
+	}
+	normalized := "https://substack.com/api/v1" + ensurePublicationIDQuery(trimmed)
+	return normalized, normalized != path
+}
+
+func substackImageUploadPath(path string) bool {
+	if path == "/image" || strings.HasPrefix(path, "/image?") {
+		path = "https://substack.com/api/v1" + path
+	}
+	for _, prefix := range []string{
+		"https://substack.com/api/v1/image",
+		"https://{publication}.substack.com/api/v1/image",
+	} {
+		if path == prefix || strings.HasPrefix(path, prefix+"?") {
+			return true
+		}
+	}
+	return false
+}
+
+func substackDraftsPath(path string) bool {
+	if strings.HasPrefix(path, "/drafts") {
+		return true
+	}
+	return strings.HasPrefix(path, "https://{publication}.substack.com/api/v1/drafts") || strings.HasPrefix(path, "https://substack.com/api/v1/drafts")
+}
+
+func ensurePublicationIDQuery(path string) string {
+	if strings.Contains(path, "publication_id=") {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + "publication_id={publication_id}"
 }
 
 func specWalkEndpoints(s *spec.APISpec, visit func(resourceName string, endpoint spec.Endpoint) bool) bool {

--- a/internal/generator/substack_writer_routes_test.go
+++ b/internal/generator/substack_writer_routes_test.go
@@ -30,10 +30,32 @@ func TestGenerateSubstackGlobalWriterRoutes(t *testing.T) {
 	assert.Contains(t, draftsSrc, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`)
 	assert.NotContains(t, draftsSrc, `trevinsays.substack.com`)
 
+	draftsListSrc := readGeneratedFile(t, outputDir, "internal", "cli", "drafts_list.go")
+	assert.Contains(t, draftsListSrc, `"pp:path": "https://substack.com/api/v1/drafts?publication_id={publication_id}"`)
+	assert.Contains(t, draftsListSrc, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`)
+	assert.NotContains(t, draftsListSrc, `{publication}.substack.com/api/v1/drafts`)
+
+	draftsUpdateSrc := readGeneratedFile(t, outputDir, "internal", "cli", "drafts_update.go")
+	assert.Contains(t, draftsUpdateSrc, `"pp:path": "https://substack.com/api/v1/drafts/{draft_id}?publication_id={publication_id}"`)
+	assert.Contains(t, draftsUpdateSrc, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`)
+	assert.NotContains(t, draftsUpdateSrc, `{publication}.substack.com/api/v1/drafts`)
+
+	for _, file := range []string{"drafts_get.go", "drafts_delete.go", "drafts_prepublish.go", "drafts_publish.go", "drafts_schedule.go"} {
+		src := readGeneratedFile(t, outputDir, "internal", "cli", file)
+		assert.Contains(t, src, `https://substack.com/api/v1/drafts/{draft_id}`)
+		assert.Contains(t, src, `publication_id={publication_id}`)
+		assert.Contains(t, src, `resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags)`)
+		assert.NotContains(t, src, `{publication}.substack.com/api/v1/drafts`)
+	}
+
 	imagesSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_images.go")
 	assert.Contains(t, imagesSrc, `"pp:path": "https://substack.com/api/v1/image"`)
 	assert.Contains(t, imagesSrc, `path := "https://substack.com/api/v1/image"`)
 	assert.NotContains(t, imagesSrc, `{publication}.substack.com/api/v1/image`)
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	assert.Contains(t, syncSrc, `"drafts": "https://substack.com/api/v1/drafts?publication_id={publication_id}"`)
+	assert.NotContains(t, syncSrc, `"drafts":          publicationAPIPath("/drafts")`)
 
 	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
 	assert.Contains(t, helpersSrc, `func resolveSubstackPublicationIDTemplate(ctx context.Context, c *client.Client, flags *rootFlags) error`)
@@ -257,6 +279,43 @@ func substackWriterRoutesSpec() *spec.APISpec {
 						Method:      "GET",
 						Path:        "/drafts",
 						Description: "List drafts",
+					},
+					"update": {
+						Method:      "PUT",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}",
+						Description: "Update a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
+						Body:        []spec.Param{{Name: "title", Type: "string"}},
+					},
+					"get": {
+						Method:      "GET",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}",
+						Description: "Get a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
+					},
+					"delete": {
+						Method:      "DELETE",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}",
+						Description: "Delete a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
+					},
+					"prepublish": {
+						Method:      "POST",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}/prepublish",
+						Description: "Prepublish a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
+					},
+					"publish": {
+						Method:      "POST",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}/publish",
+						Description: "Publish a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
+					},
+					"schedule": {
+						Method:      "POST",
+						Path:        "https://{publication}.substack.com/api/v1/drafts/{draft_id}/schedule",
+						Description: "Schedule a draft",
+						Params:      []spec.Param{{Name: "draft_id", Type: "string", Required: true, Positional: true, PathParam: true}},
 					},
 				},
 			},

--- a/internal/generator/templates/auto_refresh.go.tmpl
+++ b/internal/generator/templates/auto_refresh.go.tmpl
@@ -210,6 +210,14 @@ func runAutoRefresh(ctx context.Context, flags *rootFlags, db *store.Store, reso
 			return ctx.Err()
 		default:
 		}
+{{- if eq .Name "substack"}}
+		if resource == "drafts" {
+			if err := resolveSubstackPublicationIDTemplate(ctx, c, flags); err != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", resource, err))
+				continue
+			}
+		}
+{{- end}}
 		result := syncResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, "", false, 1, true{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, os.Stderr{{end}})
 		if result.Err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", resource, result.Err))

--- a/internal/generator/templates/channel_workflow.go.tmpl
+++ b/internal/generator/templates/channel_workflow.go.tmpl
@@ -296,6 +296,14 @@ and full resync. After archiving, use 'search' for instant full-text search.`,
 			}
 
 			for _, resource := range resources {
+{{- if eq .Name "substack"}}
+				if resource == "drafts" {
+					if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, err)
+						continue
+					}
+				}
+{{- end}}
 				res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, s, resource, "", full, 100, false{{if .Pagination.DateRangeParam}}, ""{{end}}{{if not (isGraphQL .APISpec)}}, nil, syncEventWriter{{end}})
 				if res.Err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  %s: error: %v\n", resource, res.Err)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -336,6 +336,14 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
+{{- if eq .Name "substack"}}
+						if resource == "drafts" {
+							if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+								results <- syncResult{Resource: resource, Err: err}
+								continue
+							}
+						}
+{{- end}}
 						res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, sinceTS, full, maxPages, effectiveLatestOnly{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams, syncEventWriter)
 						results <- res
 					}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -326,6 +326,21 @@ Resource scoping:
 				concurrency = 1
 			}
 
+{{ if eq .Name "substack"}}
+			needsSubstackDraftPublicationID := false
+			for _, resource := range resources {
+				if resource == "drafts" {
+					needsSubstackDraftPublicationID = true
+					break
+				}
+			}
+			if needsSubstackDraftPublicationID {
+				if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+					return err
+				}
+			}
+
+{{- end}}
 			started := time.Now()
 			work := make(chan string, len(resources))
 			results := make(chan syncResult, len(resources))
@@ -336,14 +351,6 @@ Resource scoping:
 				go func() {
 					defer wg.Done()
 					for resource := range work {
-{{- if eq .Name "substack"}}
-						if resource == "drafts" {
-							if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
-								results <- syncResult{Resource: resource, Err: err}
-								continue
-							}
-						}
-{{- end}}
 						res := syncResource(cmd.Context(), {{if .HasTierRouting}}syncClientForResource(c, resource){{else}}c{{end}}, db, resource, sinceTS, full, maxPages, effectiveLatestOnly{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams, syncEventWriter)
 						results <- res
 					}


### PR DESCRIPTION
## Summary
- normalizes Substack draft writer endpoints to global `https://substack.com/api/v1/drafts...publication_id={publication_id}` routes during generation
- keeps Substack image upload on global `https://substack.com/api/v1/image`
- makes generated Substack sync, auto-refresh, and archive workflows resolve `publication_id` before refreshing the draft resource
- adds generator regression coverage for generated draft list/update/sync routing

## Why
Custom-domain writer sessions can authenticate successfully but receive 403s when draft operations route through `https://{publication}.substack.com/api/v1/drafts`. The known working contract is the global Substack API with numeric `publication_id`.

## Broader sweep
Against the installed `substack-pp-cli 2026.6.6`:
- `drafts create --dry-run --publication-id 7019888` already used the global draft route
- image upload dry-run already used global `/api/v1/image`
- `drafts list --data-source live --publication-id 7019888 --subdomain trevinsays` still hit the publication host and returned 403
- dry-run sweep showed the problem was broader: `drafts get/update/delete/prepublish/publish/schedule` plus draft freshness/sync/portfolio draft paths still routed to the publication host
- non-draft portfolio endpoints also showed custom-domain 403s, but this PR intentionally limits itself to the documented working draft/image global routes

Printed-CLI companion PR: mvanhorn/printing-press-library#1336

## Tests
- `go test ./internal/generator -run TestGenerateSubstackGlobalWriterRoutes -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- companion printed CLI: `cd library/media-and-entertainment/substack && go test ./...`
- companion dry-run smoke verified draft freshness/read output used `https://substack.com/api/v1/drafts...publication_id=7019888` and did not include `trevinsays.substack.com/api/v1/drafts`

No live writes, publishes, deletes, scheduling, or image uploads were performed.
