### PR TITLE
fix(cli): derive cookie domain from base_url when spec omits cookie_domain

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2534,6 +2534,43 @@ func TestGenerateCookieAuthEmitsSetTokenSubcommand(t *testing.T) {
 		"set-token should appear in `auth --help` listing")
 }
 
+// TestGenerateCookieAuthDerivesCookieDomainFromBaseURL verifies that a
+// cookie-auth spec that omits cookie_domain still emits a concrete cookie
+// domain derived from base_url, rather than the empty string that left
+// `auth login --chrome` reading cookies for "" (so the extraction backend
+// returned none). NormalizeCookieDomain runs in Validate, which Generate
+// invokes, so the derived ".example.com" reaches the auth_browser template.
+func TestGenerateCookieAuthDerivesCookieDomainFromBaseURL(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("cookiedomainderive")
+	apiSpec.BaseURL = "https://www.example.com"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "cookie",
+		Header:  "Cookie",
+		In:      "cookie",
+		EnvVars: []string{"COOKIEDOMAINDERIVE_COOKIES"},
+		// CookieDomain intentionally left empty — the generator must derive it.
+	}
+
+	// The generation pipeline validates before generating (see root.go); that
+	// is where NormalizeCookieDomain derives the domain. Mirror that order.
+	require.NoError(t, apiSpec.Validate())
+	require.Equal(t, ".example.com", apiSpec.Auth.CookieDomain,
+		"Validate should derive the cookie domain from base_url")
+
+	outputDir := filepath.Join(t.TempDir(), "cookiedomainderive-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	// The auth_browser template's cookie-capture path binds the target domain
+	// from {{.Auth.CookieDomain}}; before the fix this rendered `domain := ""`.
+	assert.Contains(t, authGo, `domain := ".example.com"`,
+		"cookie-auth CLI without explicit cookie_domain should derive it from base_url")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
 // TestGenerateNoAuthPersistedQueryOmitsSetToken verifies that the
 // auth_browser template does NOT emit set-token when
 // Auth.Type == "none" + a graphql_persisted_query hint routes the spec

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3666,6 +3666,7 @@ func singularize(s string) string {
 
 func (s *APISpec) Validate() error {
 	s.NormalizeAuthEnvVarSpecs()
+	s.NormalizeCookieDomain()
 	s.InferEndpointTemplateVarsFromBaseURLs()
 	if s.Name == "" {
 		return fmt.Errorf("name is required")
@@ -3926,6 +3927,43 @@ func (s *APISpec) NormalizeAuthEnvVarSpecs() {
 		tier.Auth.NormalizeEnvVarSpecs(fmt.Sprintf("tier_routing.tiers.%s.auth", name))
 		s.TierRouting.Tiers[name] = tier
 	}
+}
+
+// NormalizeCookieDomain backfills Auth.CookieDomain for cookie/composed auth
+// when no explicit domain came from the spec field, the x-auth-cookie-domain
+// extension, or the sniffer's bound domain. The browser cookie-capture path
+// (`auth login --chrome`) reads cookies scoped to this domain; an empty value
+// makes it request cookies for "" so the extraction tool returns none. Derive
+// a leading-dot domain from base_url so cookies on the registrable domain and
+// its subdomains both match.
+func (s *APISpec) NormalizeCookieDomain() {
+	if s == nil || s.Auth.CookieDomain != "" {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Auth.Type)) {
+	case "cookie", "composed":
+	default:
+		return
+	}
+	if domain := cookieDomainFromBaseURL(s.BaseURL); domain != "" {
+		s.Auth.CookieDomain = domain
+	}
+}
+
+// cookieDomainFromBaseURL returns a leading-dot cookie domain for a base URL,
+// stripping a leading "www." so the registrable domain and its subdomains both
+// match (e.g. "https://www.example.com" -> ".example.com"). Returns "" when the
+// URL has no host.
+func cookieDomainFromBaseURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return ""
+	}
+	return "." + strings.TrimPrefix(host, "www.")
 }
 
 var publicParamNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -3952,18 +3952,30 @@ func (s *APISpec) NormalizeCookieDomain() {
 
 // cookieDomainFromBaseURL returns a leading-dot cookie domain for a base URL,
 // stripping a leading "www." so the registrable domain and its subdomains both
-// match (e.g. "https://www.example.com" -> ".example.com"). Returns "" when the
-// URL has no host.
+// match (e.g. "https://www.example.com" -> ".example.com"). Returns "" when no
+// host can be recovered.
 func cookieDomainFromBaseURL(raw string) string {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// url.Parse treats a scheme-less string as a relative path (empty Host),
+	// so a base_url like "api.example.com" would otherwise yield no domain.
+	// Prepend a scheme to recover the host in that case.
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	parsed, err := url.Parse(raw)
 	if err != nil {
 		return ""
 	}
 	host := strings.ToLower(parsed.Hostname())
-	if host == "" {
+	// Guard degenerate hosts: a bare "www." trims to "" (would emit "..").
+	bare := strings.TrimPrefix(host, "www.")
+	if bare == "" || bare == "." {
 		return ""
 	}
-	return "." + strings.TrimPrefix(host, "www.")
+	return "." + bare
 }
 
 var publicParamNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$`)

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -5338,6 +5338,18 @@ func TestNormalizeCookieDomain(t *testing.T) {
 			baseURL:    "",
 			wantDomain: "",
 		},
+		{
+			name:       "scheme-less base_url still derives a domain",
+			authType:   "cookie",
+			baseURL:    "api.example.com",
+			wantDomain: ".api.example.com",
+		},
+		{
+			name:       "degenerate www-only host yields no domain",
+			authType:   "cookie",
+			baseURL:    "https://www.",
+			wantDomain: "",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -5297,6 +5297,61 @@ resources:
 	assert.Equal(t, "paid", s.EffectiveTier(s.Resources["results"], s.Resources["results"].Endpoints["premium"]))
 }
 
+func TestNormalizeCookieDomain(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		authType   string
+		baseURL    string
+		preset     string
+		wantDomain string
+	}{
+		{
+			name:       "cookie auth derives leading-dot domain from base_url",
+			authType:   "cookie",
+			baseURL:    "https://www.factor75.com",
+			wantDomain: ".factor75.com",
+		},
+		{
+			name:       "composed auth derives domain too",
+			authType:   "composed",
+			baseURL:    "https://app.example.com",
+			wantDomain: ".app.example.com",
+		},
+		{
+			name:       "explicit cookie_domain is preserved",
+			authType:   "cookie",
+			baseURL:    "https://www.factor75.com",
+			preset:     ".custom.example.com",
+			wantDomain: ".custom.example.com",
+		},
+		{
+			name:       "non-cookie auth is untouched",
+			authType:   "bearer_token",
+			baseURL:    "https://www.example.com",
+			wantDomain: "",
+		},
+		{
+			name:       "no host yields no domain",
+			authType:   "cookie",
+			baseURL:    "",
+			wantDomain: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &APISpec{BaseURL: tc.baseURL}
+			s.Auth.Type = tc.authType
+			s.Auth.CookieDomain = tc.preset
+			s.NormalizeCookieDomain()
+			assert.Equal(t, tc.wantDomain, s.Auth.CookieDomain)
+		})
+	}
+}
+
 func TestInferEndpointTemplateVarsFromBaseURLs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

Cookie/composed-auth CLIs whose spec omits `cookie_domain` (and whose sniffer bound-domain is empty) ship a broken `auth login --chrome`: the generated command reads cookies for an *empty* domain, so the extraction backend returns none and browser-session auth is unusable out of the box. Surfaced on `factor75-pp-cli`:

```
$ factor75-pp-cli auth login --chrome
Reading cookies from Chrome profile "Default" for ...
Error: cookie tool returned no cookies for
```

The generated help text literally reads `read cookies from Chrome for .` — `{{.Auth.CookieDomain}}` is blank.

Issue: Fixes #3198

## Approach

`Auth.CookieDomain` was only ever set from an explicit source (spec `cookie_domain` field, the `x-auth-cookie-domain` OpenAPI extension, or the sniffer's `capture.BoundDomain`, which can be empty). There was no fallback to derive it from `base_url`.

Add `NormalizeCookieDomain()` in `APISpec.Validate()` — the chokepoint every spec source (internal-spec, OpenAPI parser, sniffed) runs through before generation. When auth type is `cookie`/`composed` and `CookieDomain` is empty, derive a leading-dot domain from the `base_url` host (`https://www.example.com` → `.example.com`), stripping a leading `www.` so cookies on the registrable domain and its subdomains both match. Mirrors the existing `browsersniff/reachability.go` host-derivation convention. Explicit `cookie_domain` / `x-auth-cookie-domain` still win (the method no-ops when a domain is already set).

## Scope

Primary area: generator — `internal/spec` auth normalization feeding `internal/generator/templates/auth_browser.go.tmpl`.

Why this belongs in this repo: this is a machine fix, not a printed-CLI fix. The empty-domain symptom recurs on every cookie/composed-auth CLI generated from a spec without an explicit `cookie_domain`; fixing the derivation in the generator fixes all current and future such CLIs.

## Catalog Justification

N/A

## Risk

Low. The method only fires for `cookie`/`composed` auth with an empty `CookieDomain`; all other auth types and any spec with an explicit domain are untouched. The `generate-golden-api-cookie-auth` golden (which sets an explicit `cookie_domain`) is unchanged, confirming no override of explicit values.

## Output Contract

Generator change. Evidence:
- `TestNormalizeCookieDomain` (internal/spec) — unit table: derive for cookie/composed, preserve explicit, skip non-cookie, empty-host → empty.
- `TestGenerateCookieAuthDerivesCookieDomainFromBaseURL` (internal/generator) — validates a cookie-auth spec with no `cookie_domain`, asserts the emitted `auth.go` contains `domain := ".example.com"`, and compiles the generated module via `requireGeneratedCompiles`.
- No new golden fixture: the existing cookie-auth golden carries an explicit domain (the unchanged-on-override case); the new derivation contract is covered by the emitted-code + compile test above.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

Commands run:
- `go test ./...` — 6561 passed
- `scripts/golden.sh verify` — 32 cases pass
- `scripts/verify-generator-output.sh` — 10 cases pass
- `golangci-lint run ./internal/spec/... ./internal/generator/...` — clean

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)