### PR TITLE
feat(generator): sync deletion reconciliation (dependent per-parent mark-and-sweep)

### DIFF
--- a/catalog/specs/plane-spec.yaml
+++ b/catalog/specs/plane-spec.yaml
@@ -698,6 +698,7 @@ paths:
         '404':
           description: Workspace not found
   /projects/:
+    x-pp-tenant-scope-column: workspace
     get:
       operationId: list_projects
       description: Retrieve all projects in a workspace or get details of a specific project.

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -49,6 +49,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
+| `x-pp-tenant-scope-column` | path-item | *reserved for follow-up tenant-scoped reconcile; not parsed yet* | No |
 
 ## `info` Extensions
 
@@ -424,6 +425,44 @@ info:
   title: ServiceTitan CRM
   version: 1.0.0
   x-tenant-env-var: ST_TENANT_ID
+```
+
+### `x-pp-tenant-scope-column`
+
+Declares, on a parent collection's list path-item, the column or field name
+that identifies the tenant (e.g. workspace) scope for each row returned by
+that collection. Use it on list path-items whose synced rows are partitioned
+by a workspace or organization identifier, so that a future deletion-
+reconciliation pass can target only the rows belonging to the active tenant
+rather than pruning the entire table.
+
+This extension is **reserved and forward-looking**. It is consumed by the
+upcoming tenant-scoped deletion-reconciliation and flat fan-out work; the
+follow-up parser will map it to a `tenantScopeColumn` field on the profiled
+resource. The extension is **not parsed in the current release** and has no
+effect on generated output today. Specs without it are unaffected.
+
+Rules:
+- Optional. Absence means no tenant scoping is recorded; the current release
+  behavior is unchanged.
+- Placed on the list path-item object (same level as `get:`, `post:`, etc.),
+  not on an individual operation.
+- Value must be a non-empty string naming the response field that holds the
+  tenant scope (e.g. `workspace`, `workspace_slug`, `org_id`).
+- Only one column per path-item is meaningful; the field names the foreign-key
+  column whose values identify tenant boundaries in the synced rows.
+- Has no effect this round; the parser will begin reading it in the follow-up
+  tenant-scoped reconcile task.
+
+Example:
+
+```yaml
+paths:
+  /projects/:
+    x-pp-tenant-scope-column: workspace
+    get:
+      operationId: list_projects
+      summary: List or retrieve projects
 ```
 
 ### `x-path-template-env-vars`

--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -49,7 +49,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
-| `x-pp-tenant-scope-column` | path-item | *reserved for follow-up tenant-scoped reconcile; not parsed yet* | No |
+| `x-pp-tenant-scope-column` | path item | *reserved for follow-up tenant-scoped reconcile; not parsed yet* | No |
 
 ## `info` Extensions
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -456,6 +456,51 @@ func TestGenerateDedupesResourceRegistryMapEntries(t *testing.T) {
 	runGoCommand(t, outputDir, "test", "./internal/cli", "./internal/store")
 }
 
+// TestGenerate_EmitsReconcile verifies that, for a spec with a single-path-param
+// dependent resource, the generator emits the ReconcilePartition wiring in both
+// store.go and sync.go, and that the generated code compiles successfully.
+func TestGenerate_EmitsReconcile(t *testing.T) {
+	t.Parallel()
+	apiSpec := minimalSpec("emits-reconcile")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"projects": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/projects", Response: spec.ResponseDef{Type: "array"},
+					Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"}, IDField: "id"},
+			},
+		},
+		"modules": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/projects/{projectId}/modules", Response: spec.ResponseDef{Type: "array"},
+					Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"}, IDField: "id"},
+			},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	syncSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(storeSrc), "func (s *Store) ReconcilePartition")
+	assert.Contains(t, string(syncSrc), "ReconcilePartition(")
+	assert.Contains(t, string(syncSrc), "partitionOutcome")
+	assert.Contains(t, string(syncSrc), "reconcile_skipped")
+
+	// Generated reconcile code must COMPILE (string asserts alone can't catch a
+	// template-expansion Go error). Build the generated CLI's cli+store packages.
+	// Deliberately NOT ./internal/cliutil — that package has env-sensitive
+	// credential/path tests that fail on this Windows host (pre-existing baseline,
+	// unrelated to reconcile); a build of ./internal/cli + ./internal/store is the
+	// targeted proof the reconcile wiring is valid Go.
+	runGoCommand(t, outputDir, "build", "./internal/cli", "./internal/store")
+}
+
 // TestGenerateFreshnessHelperEmitted verifies that the cliutil freshness
 // helper and auto-refresh wrapper are emitted when the spec opts into
 // cache, and that the resulting CLI compiles end-to-end and its cliutil

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3083,7 +3083,7 @@ func TestSyncDependentResourceContinuesAfterHTMLExtractionError(t *testing.T) {
 		dependentHTMLSyncClient{},
 		db,
 		dependentResourceDef{Name: "messages", ParentTable: "channels", ParentIDParam: "channelId", PathTemplate: "/channels/{channelId}/messages"},
-		"", false, 1, false, nil, nil,
+		"", false, 1, false, false, nil, nil,
 	)
 	if res.Err != nil {
 		t.Fatalf("syncDependentResource error: %v", res.Err)
@@ -5377,7 +5377,7 @@ func TestSyncDependentResourcePopulatesTypedParentFK(t *testing.T) {
 		dependentParentFKClient{},
 		db,
 		dependentResourceDef{Name: "contacts", ParentTable: "lists", ParentIDParam: "listId", PathTemplate: "/lists/{listId}/contacts"},
-		"", false, 1, false, nil, nil,
+		"", false, 1, false, false, nil, nil,
 	)
 	if res.Err != nil {
 		t.Fatalf("syncDependentResource error: %v", res.Err)
@@ -5543,7 +5543,7 @@ func TestSyncDependentResourceSubstitutesChainedPathParams(t *testing.T) {
 				{Param: "messageId", Field: "id"},
 			},
 		},
-		"", false, 1, false, nil, nil,
+		"", false, 1, false, false, nil, nil,
 	)
 	if res.Err != nil {
 		t.Fatalf("syncDependentResource error: %v", res.Err)
@@ -11450,7 +11450,7 @@ func TestGenerateDependentSyncCompiles(t *testing.T) {
 	// where it gates each dependent.
 	assert.Contains(t, syncContent, "parentFilter := append([]string(nil), resources...)",
 		"sync.go should capture user --resources filter before default expansion")
-	assert.Contains(t, syncContent, "effectiveLatestOnly, parentFilter",
+	assert.Contains(t, syncContent, "effectiveLatestOnly, prune, parentFilter",
 		"sync.go should pass the captured filter into syncDependentResources")
 	assert.Contains(t, syncContent, "parentFilter []string",
 		"syncDependentResources should accept a parent filter")
@@ -11847,7 +11847,7 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 		"maxPages, effectiveLatestOnly",
 		"syncResource call must pass effectiveLatestOnly, not the raw --latest-only flag (issue #928 Greptile follow-up)")
 	assert.Contains(t, syncContent,
-		"maxPages, effectiveLatestOnly, parentFilter",
+		"maxPages, effectiveLatestOnly, prune, parentFilter",
 		"syncDependentResources call must pass effectiveLatestOnly, not the raw --latest-only flag (issue #928 Greptile follow-up)")
 	assert.Contains(t, syncContent, "capExitHit := false",
 		"syncResource must track whether the loop stopped because --max-pages was reached")

--- a/internal/generator/sync_store_template_fixes_test.go
+++ b/internal/generator/sync_store_template_fixes_test.go
@@ -316,7 +316,7 @@ func TestSyncDependentResourceNonJSONBodyEmitsAnomaly(t *testing.T) {
 		fixedBodyClient{body: json.RawMessage(` + "`" + `<html><body>wrong app</body></html>` + "`" + `)},
 		db,
 		dependentResourceDef{Name: "children", ParentTable: "parents", ParentIDParam: "parentId", PathTemplate: "/parents/{parentId}/children"},
-		"", false, 1, false, nil, &events,
+		"", false, 1, false, false, nil, &events,
 	)
 	if res.Err != nil {
 		t.Fatalf("syncDependentResource error: %v", res.Err)

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1979,9 +1979,20 @@ var (
 // RegisterCascadeJunction records a junction to clean when rows of resourceType
 // are reconciled away. Used for runtime-created junctions (e.g. module_issues)
 // that the generated schema does not declare.
+//
+// Registration is idempotent: re-registering the same (Table, FKColumn) for a
+// resourceType is a no-op. The registry is a process-global with no removal path
+// (registrations happen once at startup in the generated binary); dedupe keeps a
+// repeated init() or a test that re-registers across sub-tests from accumulating
+// duplicate cascades.
 func RegisterCascadeJunction(resourceType string, j CascadeJunction) {
 	cascadeMu.Lock()
 	defer cascadeMu.Unlock()
+	for _, existing := range cascadeJunctions[resourceType] {
+		if existing == j {
+			return
+		}
+	}
 	cascadeJunctions[resourceType] = append(cascadeJunctions[resourceType], j)
 }
 
@@ -2016,8 +2027,14 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 	}
 	defer tx.Rollback()
 
-	// Per-call temp table on this txn's connection; cleared each call so a prior
-	// partition's seen-set can't leak into this one.
+	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
+	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
+	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
+	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
+	// drop it), and the unconditional DELETE that follows clears any rows a prior
+	// partition left behind. So the pair is correct whether or not the underlying
+	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
+	// assume a fresh table, only an empty one before insert.
 	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
 		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
 	}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1964,6 +1964,104 @@ func (s *Store) Status() (map[string]int, error) {
 	return status, rows.Err()
 }
 
+// CascadeJunction names a junction table + the FK column referencing the
+// reconciled resource's primary key, to be cleaned when a row is swept.
+type CascadeJunction struct {
+	Table    string
+	FKColumn string
+}
+
+// ReconcilePartition hard-deletes local rows of resourceType in one partition
+// (rows whose data JSON at genericScopeJSONPath equals scopeValue) whose primary
+// key is NOT in seenIDs. It is the mark-and-sweep half of deletion mirroring;
+// the caller must pass the COMPLETE, successfully-enumerated seen-ID set for the
+// partition. Victims are computed from the generic resources table so that
+// legacy rows lacking a typed projection are also cleaned. Cleans, per victim:
+// the typed table row (firing its AFTER DELETE FTS triggers, if any), the
+// generic resources_fts entry (manual, no triggers), the generic resources row,
+// and each cascade junction. Returns the number of generic rows deleted.
+func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValue string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	if genericScopeJSONPath == "" || scopeValue == "" {
+		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// Per-call temp table on this txn's connection; cleared each call so a prior
+	// partition's seen-set can't leak into this one.
+	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
+	}
+	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range seenIDs {
+		if _, err := ins.Exec(id); err != nil {
+			ins.Close()
+			return 0, err
+		}
+	}
+	ins.Close()
+
+	rows, err := tx.Query(
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND json_extract(data, ?) = ?
+		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		resourceType, genericScopeJSONPath, scopeValue,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
+	}
+	var victims []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		victims = append(victims, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	for _, id := range victims {
+		if typedTable != "" {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, typedTable), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: typed delete: %w", resourceType, err)
+			}
+		}
+		if _, err := tx.Exec(`DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(resourceType, id)); err != nil {
+			return 0, fmt.Errorf("reconcile %s: fts delete: %w", resourceType, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
+			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
+		}
+		for _, c := range cascades {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(victims), nil
+}
+
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1971,6 +1971,29 @@ type CascadeJunction struct {
 	FKColumn string
 }
 
+var (
+	cascadeMu        sync.Mutex
+	cascadeJunctions = map[string][]CascadeJunction{}
+)
+
+// RegisterCascadeJunction records a junction to clean when rows of resourceType
+// are reconciled away. Used for runtime-created junctions (e.g. module_issues)
+// that the generated schema does not declare.
+func RegisterCascadeJunction(resourceType string, j CascadeJunction) {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	cascadeJunctions[resourceType] = append(cascadeJunctions[resourceType], j)
+}
+
+// CascadeJunctionsFor returns the registered cascade junctions for resourceType.
+func CascadeJunctionsFor(resourceType string) []CascadeJunction {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	out := make([]CascadeJunction, len(cascadeJunctions[resourceType]))
+	copy(out, cascadeJunctions[resourceType])
+	return out
+}
+
 // ReconcilePartition hard-deletes local rows of resourceType in one partition
 // (rows whose data JSON at genericScopeJSONPath equals scopeValue) whose primary
 // key is NOT in seenIDs. It is the mark-and-sweep half of deletion mirroring;
@@ -2037,6 +2060,9 @@ func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValu
 		return 0, err
 	}
 
+	// Safety: typedTable and cascade Table/FKColumn are TRUSTED generator/registration
+	// metadata (schema-derived or RegisterCascadeJunction), not user input — Sprintf
+	// interpolation here is intentional and safe.
 	for _, id := range victims {
 		if typedTable != "" {
 			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, typedTable), id); err != nil {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2398,6 +2398,12 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+type partitionOutcome struct {
+	complete bool
+	reason   string
+	scopeVal string
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 {{- range .DependentSyncResources}}
@@ -2532,6 +2538,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		pagesFetched := 0
 		lastNextCursor := ""
 
+		outcome := partitionOutcome{scopeVal: parentID}
+		var seenIDs []string
+
 		for {
 			params := map[string]string{}
 {{- if $hasIDWalk}}
@@ -2579,6 +2588,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				// Track access-denial separately so an all-denied dependent
 				// resource can surface as a Warn rather than silent success.
 				if w, ok := isSyncAccessWarning(err); ok {
+					outcome.reason = "access_denied"
 					deniedParents++
 					if firstDenial == nil {
 						firstDenial = w
@@ -2589,8 +2599,10 @@ func syncDependentResource(ctx context.Context, c interface {
 						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
+					outcome.reason = "fetch_error"
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)
 				} else {
+					outcome.reason = "fetch_error"
 					// Non-warning failures were previously silent in JSON mode —
 					// operators only saw the missing rows. Emit a structured
 					// sync_error so the API body and status are inspectable.
@@ -2614,6 +2626,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			if opts, ok := syncHTMLExtractionOptions(dep.Name, dep.ParentTable, c.RequestBaseURL(), c.LastContentType(), path, params); ok {
 				data, err = extractHTMLResponse(data, opts)
 				if err != nil {
+					outcome.reason = "html_extract_error"
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: HTML extraction error for parent %s: %v\n", dep.Name, parentID, err)
 					} else {
@@ -2649,6 +2662,7 @@ func syncDependentResource(ctx context.Context, c interface {
 {{- end}}
 
 			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				outcome.reason = "non_json_200_body"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
 				} else {
@@ -2658,6 +2672,11 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
+				if isEmptyPageResponse(data{{if .QuerySync}}, dataEnvelopeKeysForResource(dep.Name, path){{end}}) {
+					outcome.complete = true // parent legitimately has zero children
+				} else {
+					outcome.reason = "empty_non_list_response"
+				}
 				break
 			}
 
@@ -2686,6 +2705,7 @@ func syncDependentResource(ctx context.Context, c interface {
 
 			stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 			if err != nil {
+				outcome.reason = "upsert_error"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
 				}
@@ -2715,6 +2735,17 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
+			// seenIDs are stored primary keys; extractID resolves the PK the same
+			// way UpsertBatch does. Assumes storageID==id (true for per_parent
+			// resources lacking a composite parent key; composite-key per_parent
+			// resources are out of scope this round).
+			for _, it := range items {
+				if o, derr := store.DecodeJSONObject(it); derr == nil {
+					if id := extractID(dep.Name, o); id != "" {
+						seenIDs = append(seenIDs, id)
+					}
+				}
+			}
 {{- if $hasIDWalk}}
 			if resourceSupportsPagination(dep.Name) && !usesIDWalk && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
@@ -2727,6 +2758,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			pagesFetched++
 
 			if maxPages > 0 && pagesFetched >= maxPages {
+				outcome.reason = "max_pages_cap"
 				if !latestOnly {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items) for parent %s\n", dep.Name, maxPages, totalCount, parentID)
@@ -2740,6 +2772,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// here so dependent-resource page loops cannot burn the budget on a
 			// non-advancing next cursor.
 			if nextCursor != "" && nextCursor == lastNextCursor {
+				outcome.reason = "stuck_cursor"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: API returned the same next cursor across two pages for parent %s; aborting to prevent budget waste.\n", dep.Name, parentID)
 				} else {
@@ -2749,12 +2782,15 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 			lastNextCursor = nextCursor
 			if !resourceSupportsPagination(dep.Name) {
+				outcome.complete = true
 				break
 			}
 {{- if $hasIDWalk}}
 			if !hasMore || len(items) < activePageLimit {
+				outcome.complete = true
 {{- else}}
 			if !hasMore || len(items) < pageSize.limit {
+				outcome.complete = true
 {{- end}}
 				break
 			}
@@ -2767,6 +2803,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				} else {
 					// A cursor-based API reporting has_more without a next cursor
 					// cannot advance safely; stop instead of looping silently.
+					outcome.reason = "cursor_unavailable"
 					break
 				}
 			}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -88,6 +88,7 @@ func applySyncGlobalScopeEnvDefaults(userParams *syncUserParams) {
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
+	var noPrune bool
 	var since string
 	var concurrency int
 	var dbPath string
@@ -411,7 +412,8 @@ Resource scoping:
 
 {{- if .DependentSyncResources}}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams, syncEventWriter)
+			prune := full && !noPrune
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, prune, parentFilter{{if .Pagination.DateRangeParam}}, syncDates{{end}}, userParams, syncEventWriter)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -502,6 +504,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", {{.SyncDefaultConcurrency}}, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -2385,12 +2388,14 @@ func syncClientForResource(c *client.Client, resource string) *client.Client {
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
 // parent-primary-key flow.
 type dependentResourceDef struct {
-	Name          string
-	ParentTable   string
-	ParentIDParam string
-	PathTemplate  string
-	KeyField      string
-	PathParams    []dependentPathParamDef
+	Name                  string
+	ParentTable           string
+	ParentIDParam         string
+	PathTemplate          string
+	KeyField              string
+	PathParams            []dependentPathParamDef
+	ReconcileMode         string
+	GenericScopeJSONPath  string
 }
 
 type dependentPathParamDef struct {
@@ -2407,7 +2412,7 @@ type partitionOutcome struct {
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
 {{- range .DependentSyncResources}}
-		{Name: "{{.Name}}", ParentTable: "{{.ParentResource}}", ParentIDParam: "{{.ParentIDParam}}", PathTemplate: "{{.Path}}", KeyField: "{{.KeyField}}"{{if .PathParams}}, PathParams: []dependentPathParamDef{
+		{Name: "{{.Name}}", ParentTable: "{{.ParentResource}}", ParentIDParam: "{{.ParentIDParam}}", PathTemplate: "{{.Path}}", KeyField: "{{.KeyField}}", ReconcileMode: "{{.ReconcileMode}}", GenericScopeJSONPath: "{{.GenericScopeJSONPath}}"{{if .PathParams}}, PathParams: []dependentPathParamDef{
 {{- range .PathParams}}
 			{Param: "{{.Param}}", Field: "{{.Field}}"},
 {{- end}}
@@ -2430,7 +2435,7 @@ func syncDependentResources(ctx context.Context, c {{if .HasTierRouting}}*client
 	LastContentType() string
 {{- end}}
 	RateLimit() float64
-}{{end}}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
+}{{end}}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool, parentFilter []string{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
 	for _, r := range parentFilter {
 		allow[r] = true
@@ -2440,7 +2445,7 @@ func syncDependentResources(ctx context.Context, c {{if .HasTierRouting}}*client
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, dep.Name){{else}}c{{end}}, db, dep, sinceTS, full, maxPages, latestOnly{{if .Pagination.DateRangeParam}}, dates{{end}}, userParams, syncEvents)
+		res := syncDependentResource(ctx, {{if .HasTierRouting}}syncClientForResource(c, dep.Name){{else}}c{{end}}, db, dep, sinceTS, full, maxPages, latestOnly, prune{{if .Pagination.DateRangeParam}}, dates{{end}}, userParams, syncEvents)
 		results = append(results, res)
 	}
 	return results
@@ -2458,7 +2463,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	LastContentType() string
 {{- end}}
 	RateLimit() float64
-}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams, syncEvents io.Writer) syncResult {
+}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool{{if .Pagination.DateRangeParam}}, dates string{{end}}, userParams *syncUserParams, syncEvents io.Writer) syncResult {
 	started := time.Now()
 	if syncEvents == nil {
 		syncEvents = io.Discard
@@ -2808,6 +2813,20 @@ func syncDependentResource(ctx context.Context, c interface {
 				}
 			}
 			cursor = nextCursor
+		}
+
+		if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
+			deleted, rerr := db.ReconcilePartition(
+				dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
+				seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			)
+			if rerr != nil {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
+			} else if deleted > 0 {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", dep.Name, outcome.scopeVal, deleted)
+			}
+		} else if prune && dep.ReconcileMode == "per_parent" {
+			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", dep.Name, outcome.scopeVal, outcome.reason)
 		}
 
 		// Brief rate-limit pause between parents to avoid hammering the API

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2822,7 +2822,9 @@ func syncDependentResource(ctx context.Context, c interface {
 			)
 			if rerr != nil {
 				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
-			} else if deleted > 0 {
+			} else {
+				// Always emit on a proven-complete sweep, even when deleted==0, so a
+				// clean run is observable (distinguishable from "reconcile never ran").
 				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", dep.Name, outcome.scopeVal, deleted)
 			}
 		} else if prune && dep.ReconcileMode == "per_parent" {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -165,6 +165,11 @@ type SyncableResource struct {
 	// the query injection / envelope unwrap / offset paging only for resources
 	// that carry it.
 	QueryEntity string
+
+	// ReconcileMode mirrors DependentResource.ReconcileMode for flat resources.
+	// Always "none" this round — forward-looking metadata reserved for a
+	// follow-up flat/tenant reconcile pass; no sync logic consumes it yet.
+	ReconcileMode string
 }
 
 // DependentResource describes a child resource that requires iterating a parent
@@ -624,6 +629,12 @@ func Profile(s *spec.APISpec) *APIProfile {
 	p.NeedsSearch = len(listResources) >= 3 && float64(searchEndpointCount)/float64(len(listResources)) < 0.5
 
 	p.SyncableResources = sortedSyncableResources(syncable)
+	// Flat resources carry "none" this round — forward-looking metadata for the
+	// follow-up flat/tenant reconcile. Set explicitly so the value is "none",
+	// not the empty zero value.
+	for i := range p.SyncableResources {
+		p.SyncableResources[i].ReconcileMode = "none"
+	}
 	p.DependentSyncResources = detectDependentResources(parameterized, syncable, shardedSubResources)
 	p.DependentSyncResources = applySpecWalkers(s, p.DependentSyncResources, syncable, s.Types, resourceNameIndex)
 	// Populate reconcile metadata for each dependent resource.
@@ -1699,6 +1710,8 @@ func dependentParentIDParam(path, parentResource, fallback string) string {
 // singularParentField maps a plural parent resource name to the singular field
 // the API body carries for that parent (e.g. "projects" → "project"). Mirrors
 // the childScopeColumnSources convention used by deriveScopeColumns in the store.
+// Known limitation: naive TrimSuffix("s") fails for irregular plurals (e.g.
+// "categories" → "categorie"); acceptable as no current spec carries them.
 func singularParentField(parentResource string) string {
 	return strings.TrimSuffix(parentResource, "s")
 }

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -229,6 +229,20 @@ type DependentResource struct {
 	// in internal YAML, or the `key_field` key under `x-pp-sync-walker` in
 	// OpenAPI). When empty, the existing parent-primary-key flow runs.
 	KeyField string
+
+	// Reconciliation metadata (deletion mark-and-sweep). See sync.go.tmpl.
+	ReconcileMode        string                // "per_parent" | "none"
+	ParentScopeColumn    string                // e.g. "projects_id" (= ParentResource + "_id")
+	GenericScopeJSONPath string                // e.g. "$.project" (json path to the parent UUID in the body)
+	CascadeJunctions     []CascadeJunctionSpec // filled by the novel-junction seam, not the profiler
+}
+
+// CascadeJunctionSpec describes a junction table that must be pruned as part
+// of a per-parent reconciliation cascade. Populated by the novel-junction
+// registration seam (Task 4), not by the profiler itself.
+type CascadeJunctionSpec struct {
+	Table    string
+	FKColumn string
 }
 
 type DependentPathParam struct {
@@ -612,6 +626,18 @@ func Profile(s *spec.APISpec) *APIProfile {
 	p.SyncableResources = sortedSyncableResources(syncable)
 	p.DependentSyncResources = detectDependentResources(parameterized, syncable, shardedSubResources)
 	p.DependentSyncResources = applySpecWalkers(s, p.DependentSyncResources, syncable, s.Types, resourceNameIndex)
+	// Populate reconcile metadata for each dependent resource.
+	// per_parent is safe only for a single-path-param dependent with a PK.
+	for i := range p.DependentSyncResources {
+		dep := &p.DependentSyncResources[i]
+		if len(dep.PathParams) == 1 && dep.IDField != "" {
+			dep.ReconcileMode = "per_parent"
+			dep.ParentScopeColumn = dep.ParentResource + "_id"
+			dep.GenericScopeJSONPath = "$." + singularParentField(dep.ParentResource)
+		} else {
+			dep.ReconcileMode = "none"
+		}
+	}
 	for resource, fields := range searchable {
 		p.SearchableFields[resource] = sortedKeys(fields)
 	}
@@ -1668,6 +1694,13 @@ func dependentParentIDParam(path, parentResource, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+// singularParentField maps a plural parent resource name to the singular field
+// the API body carries for that parent (e.g. "projects" → "project"). Mirrors
+// the childScopeColumnSources convention used by deriveScopeColumns in the store.
+func singularParentField(parentResource string) string {
+	return strings.TrimSuffix(parentResource, "s")
 }
 
 func dependentPathParamFields(path, parentResource string) map[string]string {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1707,12 +1707,38 @@ func dependentParentIDParam(path, parentResource, fallback string) string {
 	return fallback
 }
 
+// parentFieldIrregulars maps plural parent resource names whose singular form a
+// naive TrimSuffix("s") would mangle to the correct singular field. The "-ies →
+// -y" class is handled by rule below; this table is for the residual irregulars.
+var parentFieldIrregulars = map[string]string{
+	"statuses":  "status",
+	"addresses": "address",
+	"buses":     "bus",
+	"classes":   "class",
+	"indexes":   "index",
+	"indices":   "index",
+	"matrices":  "matrix",
+	"people":    "person",
+}
+
 // singularParentField maps a plural parent resource name to the singular field
 // the API body carries for that parent (e.g. "projects" → "project"). Mirrors
 // the childScopeColumnSources convention used by deriveScopeColumns in the store.
-// Known limitation: naive TrimSuffix("s") fails for irregular plurals (e.g.
-// "categories" → "categorie"); acceptable as no current spec carries them.
+// A bare TrimSuffix("s") mangles irregular plurals ("categories" → "categorie"),
+// which would silently break reconciliation (json_extract on a wrong path returns
+// NULL for every row, so ReconcilePartition sweeps nothing). Guard the common
+// English classes: an explicit irregulars table, then the "-ies → -y" rule, then
+// the regular "-s" trim. Genuinely irregular forms outside the table still fall
+// through to TrimSuffix, so a future spec with an exotic plural should add it here.
 func singularParentField(parentResource string) string {
+	if s, ok := parentFieldIrregulars[parentResource]; ok {
+		return s
+	}
+	// "categories" → "category", "activities" → "activity". Guard length so a
+	// 3-letter "-ies" word (none in practice) can't underflow to "".
+	if strings.HasSuffix(parentResource, "ies") && len(parentResource) > 4 {
+		return strings.TrimSuffix(parentResource, "ies") + "y"
+	}
 	return strings.TrimSuffix(parentResource, "s")
 }
 

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3016,9 +3016,12 @@ func TestProfiler_DependentReconcileMetadata(t *testing.T) {
 	assert.Equal(t, "per_parent", dep.ReconcileMode)
 	assert.Equal(t, "projects_id", dep.ParentScopeColumn)
 	assert.Equal(t, "$.project", dep.GenericScopeJSONPath)
+	assert.Empty(t, dep.CascadeJunctions, "profiler must leave CascadeJunctions empty (filled by Task 4 seam)")
 
 	t.Run("negative_two_path_params_yields_none", func(t *testing.T) {
 		// A dependent with 2 path params cannot be safely reconciled per-parent.
+		// Both parent segments are declared as flat resources so the child path
+		// is detected as a dependent (and the negative guard is genuinely exercised).
 		s2 := &spec.APISpec{
 			Name: "deep-nesting",
 			Resources: map[string]spec.Resource{
@@ -3031,27 +3034,41 @@ func TestProfiler_DependentReconcileMetadata(t *testing.T) {
 						},
 					},
 				},
-				"issues": {
+				"projects": {
 					Endpoints: map[string]spec.Endpoint{
 						"list": {
 							Method:   "GET",
-							Path:     "/workspaces/{workspaceId}/projects/{projectId}/issues",
+							Path:     "/projects",
 							Response: spec.ResponseDef{Type: "array"},
-							IDField:  "id",
+						},
+					},
+				},
+				"issues": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:     "GET",
+							Path:       "/workspaces/{workspaceId}/projects/{projectId}/issues",
+							Response:   spec.ResponseDef{Type: "array"},
+							IDField:    "id",
+							Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
 						},
 					},
 				},
 			},
 		}
 		profile2 := Profile(s2)
-		for _, dep2 := range profile2.DependentSyncResources {
-			if dep2.Name == "issues" {
-				assert.Equal(t, "none", dep2.ReconcileMode, "2-path-param dependent must have ReconcileMode=none")
-				return
+		// The 2-placeholder child shards to "projects_issues"; match by Path so the
+		// lookup is robust to the sharded Name.
+		var issues *DependentResource
+		for i := range profile2.DependentSyncResources {
+			if profile2.DependentSyncResources[i].Path == "/workspaces/{workspaceId}/projects/{projectId}/issues" {
+				issues = &profile2.DependentSyncResources[i]
+				break
 			}
 		}
-		// If issues is not found as dependent (path heuristic may skip it), that's fine
-		// for the negative test — what matters is the positive case above passes.
+		require.NotNil(t, issues, "2-path-param child must be detected as a dependent resource")
+		require.Len(t, issues.PathParams, 2, "expected 2 path params so the negative guard is exercised")
+		assert.Equal(t, "none", issues.ReconcileMode, "2-path-param dependent must have ReconcileMode=none")
 	})
 
 	t.Run("negative_no_pk_yields_none", func(t *testing.T) {
@@ -3085,5 +3102,14 @@ func TestProfiler_DependentReconcileMetadata(t *testing.T) {
 		require.Len(t, profile3.DependentSyncResources, 1)
 		assert.Equal(t, "none", profile3.DependentSyncResources[0].ReconcileMode,
 			"dependent with no IDField must have ReconcileMode=none")
+	})
+
+	t.Run("flat_syncables_get_none", func(t *testing.T) {
+		// Every flat SyncableResource carries ReconcileMode "none" this round.
+		require.NotEmpty(t, profile.SyncableResources)
+		for _, sr := range profile.SyncableResources {
+			assert.Equal(t, "none", sr.ReconcileMode,
+				"flat SyncableResource %q must have ReconcileMode=none", sr.Name)
+		}
 	})
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2977,3 +2977,113 @@ func TestIsSamplerEndpoint(t *testing.T) {
 	// "random" must match as a whole path segment, not a substring of another word.
 	assert.False(t, isSamplerEndpoint(spec.Endpoint{Path: "/randomizer-configs"}))
 }
+
+func TestProfiler_DependentReconcileMetadata(t *testing.T) {
+	// A single-path-param dependent resource with a PK must yield per_parent,
+	// scoped by the singular parent field in its body.
+	s := &spec.APISpec{
+		Name: "project-mgmt",
+		Resources: map[string]spec.Resource{
+			"projects": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/projects",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"modules": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/projects/{projectId}/modules",
+						Response:    spec.ResponseDef{Type: "array"},
+						IDField:     "id",
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	require.Len(t, profile.DependentSyncResources, 1)
+	dep := profile.DependentSyncResources[0]
+	assert.Equal(t, "modules", dep.Name)
+	assert.Equal(t, "projects", dep.ParentResource)
+	assert.Equal(t, "per_parent", dep.ReconcileMode)
+	assert.Equal(t, "projects_id", dep.ParentScopeColumn)
+	assert.Equal(t, "$.project", dep.GenericScopeJSONPath)
+
+	t.Run("negative_two_path_params_yields_none", func(t *testing.T) {
+		// A dependent with 2 path params cannot be safely reconciled per-parent.
+		s2 := &spec.APISpec{
+			Name: "deep-nesting",
+			Resources: map[string]spec.Resource{
+				"workspaces": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:   "GET",
+							Path:     "/workspaces",
+							Response: spec.ResponseDef{Type: "array"},
+						},
+					},
+				},
+				"issues": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:   "GET",
+							Path:     "/workspaces/{workspaceId}/projects/{projectId}/issues",
+							Response: spec.ResponseDef{Type: "array"},
+							IDField:  "id",
+						},
+					},
+				},
+			},
+		}
+		profile2 := Profile(s2)
+		for _, dep2 := range profile2.DependentSyncResources {
+			if dep2.Name == "issues" {
+				assert.Equal(t, "none", dep2.ReconcileMode, "2-path-param dependent must have ReconcileMode=none")
+				return
+			}
+		}
+		// If issues is not found as dependent (path heuristic may skip it), that's fine
+		// for the negative test — what matters is the positive case above passes.
+	})
+
+	t.Run("negative_no_pk_yields_none", func(t *testing.T) {
+		// A dependent with no IDField cannot be reconciled per-parent.
+		s3 := &spec.APISpec{
+			Name: "no-pk",
+			Resources: map[string]spec.Resource{
+				"channels": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:   "GET",
+							Path:     "/channels",
+							Response: spec.ResponseDef{Type: "array"},
+						},
+					},
+				},
+				"messages": {
+					Endpoints: map[string]spec.Endpoint{
+						"list": {
+							Method:     "GET",
+							Path:       "/channels/{channelId}/messages",
+							Response:   spec.ResponseDef{Type: "array"},
+							Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+							// No IDField — should yield ReconcileMode "none"
+						},
+					},
+				},
+			},
+		}
+		profile3 := Profile(s3)
+		require.Len(t, profile3.DependentSyncResources, 1)
+		assert.Equal(t, "none", profile3.DependentSyncResources[0].ReconcileMode,
+			"dependent with no IDField must have ReconcileMode=none")
+	})
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2996,11 +2996,11 @@ func TestProfiler_DependentReconcileMetadata(t *testing.T) {
 			"modules": {
 				Endpoints: map[string]spec.Endpoint{
 					"list": {
-						Method:      "GET",
-						Path:        "/projects/{projectId}/modules",
-						Response:    spec.ResponseDef{Type: "array"},
-						IDField:     "id",
-						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+						Method:     "GET",
+						Path:       "/projects/{projectId}/modules",
+						Response:   spec.ResponseDef{Type: "array"},
+						IDField:    "id",
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
 					},
 				},
 			},
@@ -3112,4 +3112,28 @@ func TestProfiler_DependentReconcileMetadata(t *testing.T) {
 				"flat SyncableResource %q must have ReconcileMode=none", sr.Name)
 		}
 	})
+}
+
+func TestSingularParentField(t *testing.T) {
+	cases := map[string]string{
+		// Regular "-s".
+		"projects": "project",
+		"modules":  "module",
+		"cycles":   "cycle",
+		// "-ies → -y" rule. A bare TrimSuffix("s") would yield "categorie",
+		// whose JSON path matches no row and silently sweeps nothing.
+		"categories": "category",
+		"activities": "activity",
+		"companies":  "company",
+		// Residual irregulars from the table.
+		"statuses":  "status",
+		"addresses": "address",
+		"people":    "person",
+		// Already singular / no trailing "s": returned unchanged.
+		"project": "project",
+	}
+	for plural, want := range cases {
+		assert.Equalf(t, want, singularParentField(plural),
+			"singularParentField(%q)", plural)
+	}
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -44,6 +44,7 @@ type syncResult struct {
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
+	var noPrune bool
 	var since string
 	var concurrency int
 	var dbPath string
@@ -273,7 +274,8 @@ Resource scoping:
 				}
 			}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams, syncEventWriter)
+			prune := full && !noPrune
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, prune, parentFilter, userParams, syncEventWriter)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -359,6 +361,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -1513,12 +1516,14 @@ func syncResourcePath(resource string) (string, error) {
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
 // parent-primary-key flow.
 type dependentResourceDef struct {
-	Name          string
-	ParentTable   string
-	ParentIDParam string
-	PathTemplate  string
-	KeyField      string
-	PathParams    []dependentPathParamDef
+	Name                 string
+	ParentTable          string
+	ParentIDParam        string
+	PathTemplate         string
+	KeyField             string
+	PathParams           []dependentPathParamDef
+	ReconcileMode        string
+	GenericScopeJSONPath string
 }
 
 type dependentPathParamDef struct {
@@ -1526,9 +1531,15 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+type partitionOutcome struct {
+	complete bool
+	reason   string
+	scopeVal string
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
-		{Name: "tasks", ParentTable: "projects", ParentIDParam: "projectId", PathTemplate: "/projects/{projectId}/tasks", KeyField: "", PathParams: []dependentPathParamDef{
+		{Name: "tasks", ParentTable: "projects", ParentIDParam: "projectId", PathTemplate: "/projects/{projectId}/tasks", KeyField: "", ReconcileMode: "per_parent", GenericScopeJSONPath: "$.project", PathParams: []dependentPathParamDef{
 			{Param: "projectId", Field: "id"},
 		}},
 	}
@@ -1540,7 +1551,7 @@ func dependentResourceDefs() []dependentResourceDef {
 func syncDependentResources(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
+}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool, parentFilter []string, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
 	for _, r := range parentFilter {
 		allow[r] = true
@@ -1550,7 +1561,7 @@ func syncDependentResources(ctx context.Context, c interface {
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, userParams, syncEvents)
+		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, prune, userParams, syncEvents)
 		results = append(results, res)
 	}
 	return results
@@ -1560,7 +1571,7 @@ func syncDependentResources(ctx context.Context, c interface {
 func syncDependentResource(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
+}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
 	started := time.Now()
 	if syncEvents == nil {
 		syncEvents = io.Discard
@@ -1633,6 +1644,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		pagesFetched := 0
 		lastNextCursor := ""
 
+		outcome := partitionOutcome{scopeVal: parentID}
+		var seenIDs []string
+
 		for {
 			params := map[string]string{}
 			if resourceSupportsPagination(dep.Name) {
@@ -1655,6 +1669,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				// Track access-denial separately so an all-denied dependent
 				// resource can surface as a Warn rather than silent success.
 				if w, ok := isSyncAccessWarning(err); ok {
+					outcome.reason = "access_denied"
 					deniedParents++
 					if firstDenial == nil {
 						firstDenial = w
@@ -1665,8 +1680,10 @@ func syncDependentResource(ctx context.Context, c interface {
 						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
+					outcome.reason = "fetch_error"
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)
 				} else {
+					outcome.reason = "fetch_error"
 					// Non-warning failures were previously silent in JSON mode —
 					// operators only saw the missing rows. Emit a structured
 					// sync_error so the API body and status are inspectable.
@@ -1706,6 +1723,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				outcome.reason = "non_json_200_body"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
 				} else {
@@ -1715,6 +1733,11 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
+				if isEmptyPageResponse(data) {
+					outcome.complete = true // parent legitimately has zero children
+				} else {
+					outcome.reason = "empty_non_list_response"
+				}
 				break
 			}
 
@@ -1743,6 +1766,7 @@ func syncDependentResource(ctx context.Context, c interface {
 
 			stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 			if err != nil {
+				outcome.reason = "upsert_error"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
 				}
@@ -1772,12 +1796,24 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
+			// seenIDs are stored primary keys; extractID resolves the PK the same
+			// way UpsertBatch does. Assumes storageID==id (true for per_parent
+			// resources lacking a composite parent key; composite-key per_parent
+			// resources are out of scope this round).
+			for _, it := range items {
+				if o, derr := store.DecodeJSONObject(it); derr == nil {
+					if id := extractID(dep.Name, o); id != "" {
+						seenIDs = append(seenIDs, id)
+					}
+				}
+			}
 			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 			pagesFetched++
 
 			if maxPages > 0 && pagesFetched >= maxPages {
+				outcome.reason = "max_pages_cap"
 				if !latestOnly {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items) for parent %s\n", dep.Name, maxPages, totalCount, parentID)
@@ -1791,6 +1827,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// here so dependent-resource page loops cannot burn the budget on a
 			// non-advancing next cursor.
 			if nextCursor != "" && nextCursor == lastNextCursor {
+				outcome.reason = "stuck_cursor"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: API returned the same next cursor across two pages for parent %s; aborting to prevent budget waste.\n", dep.Name, parentID)
 				} else {
@@ -1800,9 +1837,11 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 			lastNextCursor = nextCursor
 			if !resourceSupportsPagination(dep.Name) {
+				outcome.complete = true
 				break
 			}
 			if !hasMore || len(items) < pageSize.limit {
+				outcome.complete = true
 				break
 			}
 			if nextCursor == "" {
@@ -1814,10 +1853,27 @@ func syncDependentResource(ctx context.Context, c interface {
 				} else {
 					// A cursor-based API reporting has_more without a next cursor
 					// cannot advance safely; stop instead of looping silently.
+					outcome.reason = "cursor_unavailable"
 					break
 				}
 			}
 			cursor = nextCursor
+		}
+
+		if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
+			deleted, rerr := db.ReconcilePartition(
+				dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
+				seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			)
+			if rerr != nil {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
+			} else {
+				// Always emit on a proven-complete sweep, even when deleted==0, so a
+				// clean run is observable (distinguishable from "reconcile never ran").
+				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", dep.Name, outcome.scopeVal, deleted)
+			}
+		} else if prune && dep.ReconcileMode == "per_parent" {
+			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", dep.Name, outcome.scopeVal, outcome.reason)
 		}
 
 		// Brief rate-limit pause between parents to avoid hammering the API

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1749,6 +1749,147 @@ func (s *Store) Status() (map[string]int, error) {
 	return status, rows.Err()
 }
 
+// CascadeJunction names a junction table + the FK column referencing the
+// reconciled resource's primary key, to be cleaned when a row is swept.
+type CascadeJunction struct {
+	Table    string
+	FKColumn string
+}
+
+var (
+	cascadeMu        sync.Mutex
+	cascadeJunctions = map[string][]CascadeJunction{}
+)
+
+// RegisterCascadeJunction records a junction to clean when rows of resourceType
+// are reconciled away. Used for runtime-created junctions (e.g. module_issues)
+// that the generated schema does not declare.
+//
+// Registration is idempotent: re-registering the same (Table, FKColumn) for a
+// resourceType is a no-op. The registry is a process-global with no removal path
+// (registrations happen once at startup in the generated binary); dedupe keeps a
+// repeated init() or a test that re-registers across sub-tests from accumulating
+// duplicate cascades.
+func RegisterCascadeJunction(resourceType string, j CascadeJunction) {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	for _, existing := range cascadeJunctions[resourceType] {
+		if existing == j {
+			return
+		}
+	}
+	cascadeJunctions[resourceType] = append(cascadeJunctions[resourceType], j)
+}
+
+// CascadeJunctionsFor returns the registered cascade junctions for resourceType.
+func CascadeJunctionsFor(resourceType string) []CascadeJunction {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	out := make([]CascadeJunction, len(cascadeJunctions[resourceType]))
+	copy(out, cascadeJunctions[resourceType])
+	return out
+}
+
+// ReconcilePartition hard-deletes local rows of resourceType in one partition
+// (rows whose data JSON at genericScopeJSONPath equals scopeValue) whose primary
+// key is NOT in seenIDs. It is the mark-and-sweep half of deletion mirroring;
+// the caller must pass the COMPLETE, successfully-enumerated seen-ID set for the
+// partition. Victims are computed from the generic resources table so that
+// legacy rows lacking a typed projection are also cleaned. Cleans, per victim:
+// the typed table row (firing its AFTER DELETE FTS triggers, if any), the
+// generic resources_fts entry (manual, no triggers), the generic resources row,
+// and each cascade junction. Returns the number of generic rows deleted.
+func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValue string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	if genericScopeJSONPath == "" || scopeValue == "" {
+		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
+	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
+	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
+	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
+	// drop it), and the unconditional DELETE that follows clears any rows a prior
+	// partition left behind. So the pair is correct whether or not the underlying
+	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
+	// assume a fresh table, only an empty one before insert.
+	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
+	}
+	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range seenIDs {
+		if _, err := ins.Exec(id); err != nil {
+			ins.Close()
+			return 0, err
+		}
+	}
+	ins.Close()
+
+	rows, err := tx.Query(
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND json_extract(data, ?) = ?
+		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		resourceType, genericScopeJSONPath, scopeValue,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
+	}
+	var victims []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		victims = append(victims, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	// Safety: typedTable and cascade Table/FKColumn are TRUSTED generator/registration
+	// metadata (schema-derived or RegisterCascadeJunction), not user input — Sprintf
+	// interpolation here is intentional and safe.
+	for _, id := range victims {
+		if typedTable != "" {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, typedTable), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: typed delete: %w", resourceType, err)
+			}
+		}
+		if _, err := tx.Exec(`DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(resourceType, id)); err != nil {
+			return 0, fmt.Errorf("reconcile %s: fts delete: %w", resourceType, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
+			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
+		}
+		for _, c := range cascades {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(victims), nil
+}
+
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -44,6 +44,7 @@ type syncResult struct {
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
+	var noPrune bool
 	var since string
 	var concurrency int
 	var dbPath string
@@ -326,6 +327,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1693,6 +1693,147 @@ func (s *Store) Status() (map[string]int, error) {
 	return status, rows.Err()
 }
 
+// CascadeJunction names a junction table + the FK column referencing the
+// reconciled resource's primary key, to be cleaned when a row is swept.
+type CascadeJunction struct {
+	Table    string
+	FKColumn string
+}
+
+var (
+	cascadeMu        sync.Mutex
+	cascadeJunctions = map[string][]CascadeJunction{}
+)
+
+// RegisterCascadeJunction records a junction to clean when rows of resourceType
+// are reconciled away. Used for runtime-created junctions (e.g. module_issues)
+// that the generated schema does not declare.
+//
+// Registration is idempotent: re-registering the same (Table, FKColumn) for a
+// resourceType is a no-op. The registry is a process-global with no removal path
+// (registrations happen once at startup in the generated binary); dedupe keeps a
+// repeated init() or a test that re-registers across sub-tests from accumulating
+// duplicate cascades.
+func RegisterCascadeJunction(resourceType string, j CascadeJunction) {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	for _, existing := range cascadeJunctions[resourceType] {
+		if existing == j {
+			return
+		}
+	}
+	cascadeJunctions[resourceType] = append(cascadeJunctions[resourceType], j)
+}
+
+// CascadeJunctionsFor returns the registered cascade junctions for resourceType.
+func CascadeJunctionsFor(resourceType string) []CascadeJunction {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	out := make([]CascadeJunction, len(cascadeJunctions[resourceType]))
+	copy(out, cascadeJunctions[resourceType])
+	return out
+}
+
+// ReconcilePartition hard-deletes local rows of resourceType in one partition
+// (rows whose data JSON at genericScopeJSONPath equals scopeValue) whose primary
+// key is NOT in seenIDs. It is the mark-and-sweep half of deletion mirroring;
+// the caller must pass the COMPLETE, successfully-enumerated seen-ID set for the
+// partition. Victims are computed from the generic resources table so that
+// legacy rows lacking a typed projection are also cleaned. Cleans, per victim:
+// the typed table row (firing its AFTER DELETE FTS triggers, if any), the
+// generic resources_fts entry (manual, no triggers), the generic resources row,
+// and each cascade junction. Returns the number of generic rows deleted.
+func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValue string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	if genericScopeJSONPath == "" || scopeValue == "" {
+		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
+	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
+	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
+	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
+	// drop it), and the unconditional DELETE that follows clears any rows a prior
+	// partition left behind. So the pair is correct whether or not the underlying
+	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
+	// assume a fresh table, only an empty one before insert.
+	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
+	}
+	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range seenIDs {
+		if _, err := ins.Exec(id); err != nil {
+			ins.Close()
+			return 0, err
+		}
+	}
+	ins.Close()
+
+	rows, err := tx.Query(
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND json_extract(data, ?) = ?
+		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		resourceType, genericScopeJSONPath, scopeValue,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
+	}
+	var victims []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		victims = append(victims, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	// Safety: typedTable and cascade Table/FKColumn are TRUSTED generator/registration
+	// metadata (schema-derived or RegisterCascadeJunction), not user input — Sprintf
+	// interpolation here is intentional and safe.
+	for _, id := range victims {
+		if typedTable != "" {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, typedTable), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: typed delete: %w", resourceType, err)
+			}
+		}
+		if _, err := tx.Exec(`DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(resourceType, id)); err != nil {
+			return 0, fmt.Errorf("reconcile %s: fts delete: %w", resourceType, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
+			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
+		}
+		for _, c := range cascades {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(victims), nil
+}
+
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -44,6 +44,7 @@ type syncResult struct {
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
+	var noPrune bool
 	var since string
 	var concurrency int
 	var dbPath string
@@ -273,7 +274,8 @@ Resource scoping:
 				}
 			}
 			// Sync dependent (parent-child) resources sequentially after flat resources.
-			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, parentFilter, userParams, syncEventWriter)
+			prune := full && !noPrune
+			depResults := syncDependentResources(cmd.Context(), c, db, sinceTS, full, maxPages, effectiveLatestOnly, prune, parentFilter, userParams, syncEventWriter)
 			for _, res := range depResults {
 				if res.Err != nil {
 					if humanFriendly {
@@ -359,6 +361,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")
@@ -1498,12 +1501,14 @@ func syncResourcePath(resource string) (string, error) {
 // or `key_field` under `x-pp-sync-walker` in OpenAPI). Empty KeyField preserves the
 // parent-primary-key flow.
 type dependentResourceDef struct {
-	Name          string
-	ParentTable   string
-	ParentIDParam string
-	PathTemplate  string
-	KeyField      string
-	PathParams    []dependentPathParamDef
+	Name                 string
+	ParentTable          string
+	ParentIDParam        string
+	PathTemplate         string
+	KeyField             string
+	PathParams           []dependentPathParamDef
+	ReconcileMode        string
+	GenericScopeJSONPath string
 }
 
 type dependentPathParamDef struct {
@@ -1511,9 +1516,15 @@ type dependentPathParamDef struct {
 	Field string
 }
 
+type partitionOutcome struct {
+	complete bool
+	reason   string
+	scopeVal string
+}
+
 func dependentResourceDefs() []dependentResourceDef {
 	return []dependentResourceDef{
-		{Name: "leagues", ParentTable: "games", ParentIDParam: "game_key", PathTemplate: "/games/{game_key}/leagues", KeyField: "game_key", PathParams: []dependentPathParamDef{
+		{Name: "leagues", ParentTable: "games", ParentIDParam: "game_key", PathTemplate: "/games/{game_key}/leagues", KeyField: "game_key", ReconcileMode: "none", GenericScopeJSONPath: "", PathParams: []dependentPathParamDef{
 			{Param: "game_key", Field: "game_key"},
 		}},
 	}
@@ -1525,7 +1536,7 @@ func dependentResourceDefs() []dependentResourceDef {
 func syncDependentResources(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, parentFilter []string, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
+}, db *store.Store, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool, parentFilter []string, userParams *syncUserParams, syncEvents io.Writer) []syncResult {
 	allow := make(map[string]bool, len(parentFilter))
 	for _, r := range parentFilter {
 		allow[r] = true
@@ -1535,7 +1546,7 @@ func syncDependentResources(ctx context.Context, c interface {
 		if len(allow) > 0 && !allow[dep.ParentTable] && !allow[dep.Name] {
 			continue
 		}
-		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, userParams, syncEvents)
+		res := syncDependentResource(ctx, c, db, dep, sinceTS, full, maxPages, latestOnly, prune, userParams, syncEvents)
 		results = append(results, res)
 	}
 	return results
@@ -1545,7 +1556,7 @@ func syncDependentResources(ctx context.Context, c interface {
 func syncDependentResource(ctx context.Context, c interface {
 	Get(context.Context, string, map[string]string) (json.RawMessage, error)
 	RateLimit() float64
-}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
+}, db *store.Store, dep dependentResourceDef, sinceTS string, full bool, maxPages int, latestOnly bool, prune bool, userParams *syncUserParams, syncEvents io.Writer) syncResult {
 	started := time.Now()
 	if syncEvents == nil {
 		syncEvents = io.Discard
@@ -1618,6 +1629,9 @@ func syncDependentResource(ctx context.Context, c interface {
 		pagesFetched := 0
 		lastNextCursor := ""
 
+		outcome := partitionOutcome{scopeVal: parentID}
+		var seenIDs []string
+
 		for {
 			params := map[string]string{}
 			if resourceSupportsPagination(dep.Name) {
@@ -1640,6 +1654,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				// Track access-denial separately so an all-denied dependent
 				// resource can surface as a Warn rather than silent success.
 				if w, ok := isSyncAccessWarning(err); ok {
+					outcome.reason = "access_denied"
 					deniedParents++
 					if firstDenial == nil {
 						firstDenial = w
@@ -1650,8 +1665,10 @@ func syncDependentResource(ctx context.Context, c interface {
 						fmt.Fprintln(syncEvents, syncWarningJSON(dep.Name, parentID, w.Status, w.Reason, w.Message))
 					}
 				} else if humanFriendly {
+					outcome.reason = "fetch_error"
 					fmt.Fprintf(os.Stderr, "\n  %s: error for parent %s: %v\n", dep.Name, parentID, err)
 				} else {
+					outcome.reason = "fetch_error"
 					// Non-warning failures were previously silent in JSON mode —
 					// operators only saw the missing rows. Emit a structured
 					// sync_error so the API body and status are inspectable.
@@ -1691,6 +1708,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 && len(data) > 0 && !isJSONResponse(data) {
+				outcome.reason = "non_json_200_body"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\nwarning: %s returned a 200 response with a non-JSON body for parent %s; no rows were stored.\n", dep.Name, parentID)
 				} else {
@@ -1700,6 +1718,11 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
+				if isEmptyPageResponse(data) {
+					outcome.complete = true // parent legitimately has zero children
+				} else {
+					outcome.reason = "empty_non_list_response"
+				}
 				break
 			}
 
@@ -1728,6 +1751,7 @@ func syncDependentResource(ctx context.Context, c interface {
 
 			stored, extractFailures, err := upsertResourceBatch(db, dep.Name, items)
 			if err != nil {
+				outcome.reason = "upsert_error"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: upsert error for parent %s: %v\n", dep.Name, parentID, err)
 				}
@@ -1757,12 +1781,24 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			totalCount += stored
+			// seenIDs are stored primary keys; extractID resolves the PK the same
+			// way UpsertBatch does. Assumes storageID==id (true for per_parent
+			// resources lacking a composite parent key; composite-key per_parent
+			// resources are out of scope this round).
+			for _, it := range items {
+				if o, derr := store.DecodeJSONObject(it); derr == nil {
+					if id := extractID(dep.Name, o); id != "" {
+						seenIDs = append(seenIDs, id)
+					}
+				}
+			}
 			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 			pagesFetched++
 
 			if maxPages > 0 && pagesFetched >= maxPages {
+				outcome.reason = "max_pages_cap"
 				if !latestOnly {
 					if humanFriendly {
 						fmt.Fprintf(os.Stderr, "\n  %s: reached --max-pages limit (%d pages, %d items) for parent %s\n", dep.Name, maxPages, totalCount, parentID)
@@ -1776,6 +1812,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			// here so dependent-resource page loops cannot burn the budget on a
 			// non-advancing next cursor.
 			if nextCursor != "" && nextCursor == lastNextCursor {
+				outcome.reason = "stuck_cursor"
 				if humanFriendly {
 					fmt.Fprintf(os.Stderr, "\n  %s: API returned the same next cursor across two pages for parent %s; aborting to prevent budget waste.\n", dep.Name, parentID)
 				} else {
@@ -1785,9 +1822,11 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 			lastNextCursor = nextCursor
 			if !resourceSupportsPagination(dep.Name) {
+				outcome.complete = true
 				break
 			}
 			if !hasMore || len(items) < pageSize.limit {
+				outcome.complete = true
 				break
 			}
 			if nextCursor == "" {
@@ -1799,10 +1838,27 @@ func syncDependentResource(ctx context.Context, c interface {
 				} else {
 					// A cursor-based API reporting has_more without a next cursor
 					// cannot advance safely; stop instead of looping silently.
+					outcome.reason = "cursor_unavailable"
 					break
 				}
 			}
 			cursor = nextCursor
+		}
+
+		if prune && outcome.complete && dep.ReconcileMode == "per_parent" {
+			deleted, rerr := db.ReconcilePartition(
+				dep.Name, dep.GenericScopeJSONPath, outcome.scopeVal,
+				seenIDs, dep.Name, store.CascadeJunctionsFor(dep.Name),
+			)
+			if rerr != nil {
+				fmt.Fprintf(syncEvents, `{"event":"reconcile_error","resource":"%s","scope":"%s","error":%q}`+"\n", dep.Name, outcome.scopeVal, rerr.Error())
+			} else {
+				// Always emit on a proven-complete sweep, even when deleted==0, so a
+				// clean run is observable (distinguishable from "reconcile never ran").
+				fmt.Fprintf(syncEvents, `{"event":"reconcile","resource":"%s","scope":"%s","deleted":%d}`+"\n", dep.Name, outcome.scopeVal, deleted)
+			}
+		} else if prune && dep.ReconcileMode == "per_parent" {
+			fmt.Fprintf(syncEvents, `{"event":"reconcile_skipped","resource":"%s","scope":"%s","reason":%q}`+"\n", dep.Name, outcome.scopeVal, outcome.reason)
 		}
 
 		// Brief rate-limit pause between parents to avoid hammering the API

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1637,6 +1637,147 @@ func (s *Store) Status() (map[string]int, error) {
 	return status, rows.Err()
 }
 
+// CascadeJunction names a junction table + the FK column referencing the
+// reconciled resource's primary key, to be cleaned when a row is swept.
+type CascadeJunction struct {
+	Table    string
+	FKColumn string
+}
+
+var (
+	cascadeMu        sync.Mutex
+	cascadeJunctions = map[string][]CascadeJunction{}
+)
+
+// RegisterCascadeJunction records a junction to clean when rows of resourceType
+// are reconciled away. Used for runtime-created junctions (e.g. module_issues)
+// that the generated schema does not declare.
+//
+// Registration is idempotent: re-registering the same (Table, FKColumn) for a
+// resourceType is a no-op. The registry is a process-global with no removal path
+// (registrations happen once at startup in the generated binary); dedupe keeps a
+// repeated init() or a test that re-registers across sub-tests from accumulating
+// duplicate cascades.
+func RegisterCascadeJunction(resourceType string, j CascadeJunction) {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	for _, existing := range cascadeJunctions[resourceType] {
+		if existing == j {
+			return
+		}
+	}
+	cascadeJunctions[resourceType] = append(cascadeJunctions[resourceType], j)
+}
+
+// CascadeJunctionsFor returns the registered cascade junctions for resourceType.
+func CascadeJunctionsFor(resourceType string) []CascadeJunction {
+	cascadeMu.Lock()
+	defer cascadeMu.Unlock()
+	out := make([]CascadeJunction, len(cascadeJunctions[resourceType]))
+	copy(out, cascadeJunctions[resourceType])
+	return out
+}
+
+// ReconcilePartition hard-deletes local rows of resourceType in one partition
+// (rows whose data JSON at genericScopeJSONPath equals scopeValue) whose primary
+// key is NOT in seenIDs. It is the mark-and-sweep half of deletion mirroring;
+// the caller must pass the COMPLETE, successfully-enumerated seen-ID set for the
+// partition. Victims are computed from the generic resources table so that
+// legacy rows lacking a typed projection are also cleaned. Cleans, per victim:
+// the typed table row (firing its AFTER DELETE FTS triggers, if any), the
+// generic resources_fts entry (manual, no triggers), the generic resources row,
+// and each cascade junction. Returns the number of generic rows deleted.
+func (s *Store) ReconcilePartition(resourceType, genericScopeJSONPath, scopeValue string, seenIDs []string, typedTable string, cascades []CascadeJunction) (int, error) {
+	if genericScopeJSONPath == "" || scopeValue == "" {
+		return 0, fmt.Errorf("reconcile %s: empty partition scope", resourceType)
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	// Per-call seen-set staging. A TEMP TABLE is connection-scoped, not
+	// transaction-scoped: its lifetime is decoupled from this tx. We deliberately
+	// do not rely on either lifetime — CREATE ... IF NOT EXISTS is a no-op when the
+	// table survived a previous call (standard SQLite keeps it; a ROLLBACK does not
+	// drop it), and the unconditional DELETE that follows clears any rows a prior
+	// partition left behind. So the pair is correct whether or not the underlying
+	// driver (modernc.org/sqlite here) drops temp tables on rollback — we never
+	// assume a fresh table, only an empty one before insert.
+	if _, err := tx.Exec(`CREATE TEMP TABLE IF NOT EXISTS reconcile_seen (id TEXT PRIMARY KEY)`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: temp: %w", resourceType, err)
+	}
+	if _, err := tx.Exec(`DELETE FROM reconcile_seen`); err != nil {
+		return 0, fmt.Errorf("reconcile %s: clear temp: %w", resourceType, err)
+	}
+	ins, err := tx.Prepare(`INSERT OR IGNORE INTO reconcile_seen (id) VALUES (?)`)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range seenIDs {
+		if _, err := ins.Exec(id); err != nil {
+			ins.Close()
+			return 0, err
+		}
+	}
+	ins.Close()
+
+	rows, err := tx.Query(
+		`SELECT id FROM resources
+		 WHERE resource_type = ?
+		   AND json_extract(data, ?) = ?
+		   AND id NOT IN (SELECT id FROM reconcile_seen)`,
+		resourceType, genericScopeJSONPath, scopeValue,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile %s: select victims: %w", resourceType, err)
+	}
+	var victims []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		victims = append(victims, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	// Safety: typedTable and cascade Table/FKColumn are TRUSTED generator/registration
+	// metadata (schema-derived or RegisterCascadeJunction), not user input — Sprintf
+	// interpolation here is intentional and safe.
+	for _, id := range victims {
+		if typedTable != "" {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE id = ?`, typedTable), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: typed delete: %w", resourceType, err)
+			}
+		}
+		if _, err := tx.Exec(`DELETE FROM resources_fts WHERE rowid = ?`, ftsRowID(resourceType, id)); err != nil {
+			return 0, fmt.Errorf("reconcile %s: fts delete: %w", resourceType, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM resources WHERE resource_type = ? AND id = ?`, resourceType, id); err != nil {
+			return 0, fmt.Errorf("reconcile %s: generic delete: %w", resourceType, err)
+		}
+		for _, c := range cascades {
+			if _, err := tx.Exec(fmt.Sprintf(`DELETE FROM "%s" WHERE "%s" = ?`, c.Table, c.FKColumn), id); err != nil {
+				return 0, fmt.Errorf("reconcile %s: cascade %s: %w", resourceType, c.Table, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(victims), nil
+}
+
 // ResolveByName resolves a human-readable name to a UUID from synced data.
 // If the input is already a UUID, it is returned as-is.
 // matchFields are JSON field names to search against (e.g., "name", "key", "email").

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -44,6 +44,7 @@ type syncResult struct {
 func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var resources []string
 	var full bool
+	var noPrune bool
 	var since string
 	var concurrency int
 	var dbPath string
@@ -326,6 +327,7 @@ Resource scoping:
 
 	cmd.Flags().StringSliceVar(&resources, "resources", nil, "Comma-separated resource types to sync. Naming a parent also runs its parent-keyed dependents (see Long help for scoping).")
 	cmd.Flags().BoolVar(&full, "full", false, "Full resync (ignore previous checkpoint)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Disable deletion reconciliation on --full (by default a full sync prunes local rows the API no longer returns for a fully-enumerated parent partition)")
 	cmd.Flags().StringVar(&since, "since", "", "Incremental sync duration (e.g. 7d, 24h, 1w, 30m)")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 4, "Number of parallel sync workers")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database file path (default: resolved data directory data.db)")


### PR DESCRIPTION
## Summary

Adds **sync deletion reconciliation** (mark-and-sweep) at the generator level: after a complete, successful, full enumeration of a dependent (per-parent) resource partition, `sync --full` hard-deletes local rows the API no longer returns. Implemented generically in the profiler + store/sync templates, so any generated CLI with single-path-param dependent resources gains it.

This round ships **dependent per-parent reconcile only**. Flat/tenant-scoped reconcile and the Bug-#1 fan-out generatorization are a deliberate follow-up on the same metadata model.

## Design

- **Profiler** emits per-resource partition metadata on `DependentResource` (`ReconcileMode` = `per_parent`|`none`, `ParentScopeColumn`, `GenericScopeJSONPath`). `per_parent` only for a dependent with exactly one path param and a non-empty PK.
- **Store template** gains a static `ReconcilePartition(resourceType, genericScopeJSONPath, scopeValue, seenIDs, typedTable, cascades)`: computes victims from the generic `resources` table via `json_extract(data, '$.<parent>')` (so it also cleans legacy rows lacking a typed projection), then hard-deletes the typed row (firing its FTS triggers), the generic `resources_fts` entry (manual rowid via the shared `ftsRowID`), the generic `resources` row, and each registered cascade junction — all in one transaction. Plus a `CascadeJunction` registry seam for runtime-created junctions the schema doesn't declare.
- **Sync template** tracks per-partition completeness: every pagination-loop exit is classified, `complete=true` only at the two genuine natural ends (and a legitimately-empty list via `isEmptyPageResponse`); any unclassified exit defaults to **incomplete** (skip). `ReconcilePartition` is called only when `prune && outcome.complete && reconcileMode=="per_parent"`. `--no-prune` disables pruning; `reconcile` / `reconcile_skipped` / `reconcile_error` events are always emitted.

## Safety

Reconcile is destructive and runs only on a **proven-complete** partition. Default for any unclassified loop exit is incomplete. `seenIDs` (the page's stored primary keys, resolved the same way `UpsertBatch` does) is always accumulated before any complete-break, so a completed partition's final page can never be pruned. Empty partition scope returns an error.

## Validation

- Profiler + store unit tests (TDD), incl. a sweep test proving a generic-only "ghost" row (no typed projection) is reconciled while seen rows and other partitions survive.
- `TestGenerate_EmitsReconcile`: generating a CLI from a spec with a single-path-param dependent emits the reconcile wiring and the generated `./internal/cli`+`./internal/store` compile.
- Live A/B on a copy of a real multi-tenant DB (prod byte-untouched): `sync --full` converged a stale partition (86 cached → 3, matching the live API's 3 rows); access-denied/incomplete partitions emitted `reconcile_skipped` with no deletion; `--no-prune` and incremental runs produced zero reconcile events.

## Docs

`docs/SPEC-EXTENSIONS.md` documents the forward-looking `x-pp-tenant-scope-column` extension (reserved for the follow-up tenant-scoped reconcile; not parsed yet); plane catalog spec annotated.


## Catalog Justification

Embedded catalog fit: Not a new catalog entry. This PR adds a single forward-looking annotation — `x-pp-tenant-scope-column: workspace` — to the existing `catalog/specs/plane-spec.yaml`, naming Plane's top-level tenant column for the reserved tenant-scoped reconcile.

Distinct blueprint pattern: No new blueprint or entry. It annotates the existing Plane spec with reserved metadata; the generated CLI shape is unchanged apart from the generic reconcile feature described above.

Closest existing entries checked: The Plane spec being annotated is the entry itself; no new or near-duplicate catalog entry is introduced, so there is nothing to dedupe against.

Source provenance: The `workspace` value is derived from Plane's own data model (workspace is the top-level tenant boundary above projects). No new upstream spec was imported.

Auth and tenant assumptions: Unchanged. The annotation only records which column denotes the tenant partition; it does not alter auth, scoping, or any request path. It is reserved for the follow-up tenant-scoped reconcile and is not parsed today.

Safe default surface: Inert. `x-pp-tenant-scope-column` is not yet read by the generator, so no command, flag, or generated output changes from this annotation. The only behavioral change in the PR is the dependent per-parent reconcile, which is gated on `prune && proven-complete` and disengaged by `--no-prune`.

Generation path: Documented in `docs/SPEC-EXTENSIONS.md` as a reserved extension that the generator currently ignores; it will be consumed by the planned tenant-scoped reconcile pass.

Stale-body check: Body reflects the current branch head (17bd1623) — dependent per-parent reconcile plus the one-line Plane annotation. Flat/tenant-scoped reconcile and the Bug-#1 fan-out generatorization remain explicit follow-ups.
