### PR TITLE
fix(cli): add resumable MCP cursors

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -395,6 +395,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"mcpInputName":                 mcpInputName,
 		"mcpToolInputParams":           mcpToolInputParams,
 		"mcpParamBindings":             mcpParamBindings,
+		"mcpEndpointPageable":          mcpEndpointPageable,
+		"mcpPageConfig":                mcpPageConfig,
 		"mcpGlobalTemplateInputParams": mcpGlobalTemplateInputParams,
 		"mcpGlobalTemplateBindings":    mcpGlobalTemplateBindings,
 		// endpointNeedsClientLimit reports whether a list endpoint needs
@@ -5075,6 +5077,9 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 		requestContentType = endpoint.RequestContentType
 	}
 	for _, p := range endpoint.Params {
+		if isMCPPaginationCursorParam(endpoint, p) {
+			continue
+		}
 		loc := "query"
 		if strings.Contains(pathTemplate, "{"+p.Name+"}") {
 			loc = "path"
@@ -5117,12 +5122,51 @@ func mcpParamBindings(endpoint spec.Endpoint, pathTemplate string) []mcpParamBin
 
 func mcpToolInputParams(endpoint spec.Endpoint) []spec.Param {
 	params := make([]spec.Param, 0, len(endpoint.Params)+len(endpoint.Body))
-	params = append(params, endpoint.Params...)
+	for _, p := range endpoint.Params {
+		if isMCPPaginationCursorParam(endpoint, p) {
+			continue
+		}
+		params = append(params, p)
+	}
 	if endpoint.BodyJSONFallback {
 		return params
 	}
 	params = append(params, mcpBodyInputParams(endpoint)...)
 	return params
+}
+
+func mcpEndpointPageable(endpoint spec.Endpoint) bool {
+	if !strings.EqualFold(strings.TrimSpace(endpoint.Method), "GET") {
+		return false
+	}
+	if endpoint.Pagination == nil {
+		return false
+	}
+	if strings.TrimSpace(endpoint.Pagination.CursorParam) == "" {
+		return false
+	}
+	return !endpoint.UsesBinaryResponse()
+}
+
+func mcpPageConfig(endpoint spec.Endpoint) string {
+	if !mcpEndpointPageable(endpoint) {
+		return "mcpPageConfig{}"
+	}
+	return fmt.Sprintf("mcpPageConfig{CursorParam: %q, LimitParam: %q, NextCursorPath: %q}",
+		endpoint.Pagination.CursorParam,
+		endpoint.Pagination.LimitParam,
+		endpoint.Pagination.NextCursorPath,
+	)
+}
+
+func isMCPPaginationCursorParam(endpoint spec.Endpoint, p spec.Param) bool {
+	if !mcpEndpointPageable(endpoint) {
+		return false
+	}
+	if p.PathParam || p.Positional {
+		return false
+	}
+	return p.Name == endpoint.Pagination.CursorParam || p.WireName() == endpoint.Pagination.CursorParam
 }
 
 func mcpGlobalTemplateInputParams(endpoint spec.Endpoint, pathTemplate string, vars []string) []spec.Param {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5152,9 +5152,8 @@ func mcpPageConfig(endpoint spec.Endpoint) string {
 	if !mcpEndpointPageable(endpoint) {
 		return "mcpPageConfig{}"
 	}
-	return fmt.Sprintf("mcpPageConfig{CursorParam: %q, LimitParam: %q, NextCursorPath: %q}",
+	return fmt.Sprintf("mcpPageConfig{CursorParam: %q, NextCursorPath: %q}",
 		endpoint.Pagination.CursorParam,
-		endpoint.Pagination.LimitParam,
 		endpoint.Pagination.NextCursorPath,
 	)
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14432,7 +14432,7 @@ func TestGenerateOperationRoutingPathParamDefault(t *testing.T) {
 	mcpGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
 	require.NoError(t, err)
 	assert.Regexp(t,
-		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/graphql/\{pathQueryId\}/Followers",\s*true,\s*false,\s*nil,\s*\[]mcpParamBinding\{.*WireName: "pathQueryId".*\},\s*\[]string\{[^}]*"pathQueryId"`),
+		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/graphql/\{pathQueryId\}/Followers",\s*true,\s*false,\s*nil,\s*mcpPageConfig\{\},\s*\[]mcpParamBinding\{.*WireName: "pathQueryId".*\},\s*\[]string\{[^}]*"pathQueryId"`),
 		string(mcpGo),
 		"MCP handler must receive the routing path param so it can substitute the URL")
 }
@@ -16380,11 +16380,11 @@ func TestGenerateMCPHandlerPreservesQueryPositionals(t *testing.T) {
 	// Call sites still pass both names — the upstream emit is unchanged;
 	// the fix lives entirely inside the handler body.
 	assert.Regexp(t,
-		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/search/movie",\s*true,\s*false,\s*nil,\s*\[]mcpParamBinding\{.*WireName: "query".*\},\s*\[]string\{[^}]*"query"`),
+		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/search/movie",\s*true,\s*false,\s*nil,\s*mcpPageConfig\{\},\s*\[]mcpParamBinding\{.*WireName: "query".*\},\s*\[]string\{[^}]*"query"`),
 		tools,
 		"search call site must still pass `query` in positionalParams (handler decides path vs query at runtime)")
 	assert.Regexp(t,
-		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/movie/\{movieId\}",\s*true,\s*false,\s*nil,\s*\[]mcpParamBinding\{.*WireName: "movieId".*\},\s*\[]string\{[^}]*"movieId"`),
+		regexp.MustCompile(`makeAPIHandler\("GET",\s*"/movie/\{movieId\}",\s*true,\s*false,\s*nil,\s*mcpPageConfig\{\},\s*\[]mcpParamBinding\{.*WireName: "movieId".*\},\s*\[]string\{[^}]*"movieId"`),
 		tools,
 		"get-by-id call site must pass `movieId` in positionalParams")
 

--- a/internal/generator/mcp_bound_package_test.go
+++ b/internal/generator/mcp_bound_package_test.go
@@ -184,7 +184,7 @@ func TestGenerateMCPToolsUseOpaqueCursorForResumableListEndpoints(t *testing.T) 
 		"resumable MCP list tools should expose a canonical opaque cursor input")
 	assert.NotContains(t, toolsCode, `mcplib.WithString("after"`,
 		"resumable MCP list tools should not expose the raw upstream cursor parameter")
-	assert.Contains(t, toolsCode, `mcpPageConfig{CursorParam: "after", LimitParam: "limit", NextCursorPath: "next_cursor"}`,
+	assert.Contains(t, toolsCode, `mcpPageConfig{CursorParam: "after", NextCursorPath: "next_cursor"}`,
 		"generated handler should receive the upstream cursor metadata needed to continue safely")
 	assert.Contains(t, toolsCode, `bound.EndpointPageResponse(method, data, bound.PageOptions{`,
 		"typed MCP responses should route resumable endpoints through the cursor-aware bound path")

--- a/internal/generator/mcp_bound_package_test.go
+++ b/internal/generator/mcp_bound_package_test.go
@@ -135,3 +135,59 @@ func TestToolResultJSONBoundsLargeSearchLikeArray(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "mcp", "tool_result_json_budget_test.go"), []byte(testSrc), 0o644))
 	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestToolResultJSONBoundsLargeSearchLikeArray")
 }
+
+func TestGenerateMCPToolsUseOpaqueCursorForResumableListEndpoints(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-resumable-cursor")
+	apiSpec.Resources = map[string]spec.Resource{
+		"groups": {
+			Description: "Groups",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/groups",
+					Description: "List groups",
+					Params: []spec.Param{
+						{Name: "limit", Type: "integer"},
+						{Name: "after", Type: "string"},
+					},
+					Pagination: &spec.Pagination{
+						Type:           "cursor",
+						LimitParam:     "limit",
+						CursorParam:    "after",
+						NextCursorPath: "next_cursor",
+					},
+					Response: spec.ResponseDef{Type: "array", Item: "Group"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Group": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{MCP: true}
+	require.NoError(t, gen.Generate())
+
+	toolsSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "mcp", "tools.go"))
+	require.NoError(t, err)
+	toolsCode := stripGoComments(string(toolsSrc))
+	assert.Contains(t, toolsCode, `mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response"))`,
+		"resumable MCP list tools should expose a canonical opaque cursor input")
+	assert.NotContains(t, toolsCode, `mcplib.WithString("after"`,
+		"resumable MCP list tools should not expose the raw upstream cursor parameter")
+	assert.Contains(t, toolsCode, `mcpPageConfig{CursorParam: "after", LimitParam: "limit", NextCursorPath: "next_cursor"}`,
+		"generated handler should receive the upstream cursor metadata needed to continue safely")
+	assert.Contains(t, toolsCode, `bound.EndpointPageResponse(method, data, bound.PageOptions{`,
+		"typed MCP responses should route resumable endpoints through the cursor-aware bound path")
+
+	requireGeneratedCompiles(t, outputDir)
+}

--- a/internal/generator/multipart_test.go
+++ b/internal/generator/multipart_test.go
@@ -79,7 +79,7 @@ func TestGenerateMultipartRequestBodyUsesMultipartClient(t *testing.T) {
 	assert.NotContains(t, promotedSrc, `"stdin"`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
-	assert.Contains(t, mcpSrc, `makeAPIHandler("POST", "/assets", false, false, nil, []mcpParamBinding`)
+	assert.Contains(t, mcpSrc, `makeAPIHandler("POST", "/assets", false, false, nil, mcpPageConfig{}, []mcpParamBinding`)
 	assert.Contains(t, mcpSrc, `Format: "binary"`)
 	assert.Contains(t, mcpSrc, `RequestContentType: "multipart/form-data"`)
 	assert.Contains(t, mcpSrc, `multipartFileFields[binding.WireName] = fmt.Sprintf("%v", v)`)

--- a/internal/generator/templates/mcp_bound.go.tmpl
+++ b/internal/generator/templates/mcp_bound.go.tmpl
@@ -54,7 +54,7 @@ func EndpointResponse(method string, data json.RawMessage) string {
 // falls back to EndpointResponse's bounded preview contract.
 func EndpointPageResponse(method string, data json.RawMessage, opts PageOptions) string {
 	if opts.CursorParam == "" && opts.Cursor == "" && opts.NextCursorPath == "" {
-		return endpointResponse(method, data, opts)
+		return endpointResponse(method, data, PageOptions{})
 	}
 	return endpointResponse(method, data, opts)
 }

--- a/internal/generator/templates/mcp_bound.go.tmpl
+++ b/internal/generator/templates/mcp_bound.go.tmpl
@@ -4,7 +4,9 @@
 package bound
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -23,15 +25,65 @@ const (
 	textResultNote = "MCP command output exceeded the tool result budget. Rerun with narrower flags, --agent, --compact, --select, or --limit where available."
 )
 
+// PageOptions describes resumable list context for typed MCP endpoint results.
+// Cursor is the opaque value supplied by the MCP caller. CursorParam is the
+// upstream request parameter name that can resume another API page, when one
+// exists. NextCursorPath is the dotted response path containing the upstream
+// cursor for the following API page.
+type PageOptions struct {
+	Cursor         string
+	CursorParam    string
+	NextCursorPath string
+}
+
+type endpointCursor struct {
+	Version        int    `json:"v"`
+	Offset         int    `json:"o,omitempty"`
+	UpstreamCursor string `json:"u,omitempty"`
+}
+
 // EndpointResponse renders a typed endpoint response within the MCP result
 // budget. GET array responses are always wrapped so agents get count metadata;
 // other small responses pass through unchanged.
 func EndpointResponse(method string, data json.RawMessage) string {
+	return endpointResponse(method, data, PageOptions{})
+}
+
+// EndpointPageResponse renders a typed endpoint response with resumable list
+// cursors. It only changes recognized GET list shapes; opaque or non-list data
+// falls back to EndpointResponse's bounded preview contract.
+func EndpointPageResponse(method string, data json.RawMessage, opts PageOptions) string {
+	if opts.CursorParam == "" && opts.Cursor == "" && opts.NextCursorPath == "" {
+		return endpointResponse(method, data, opts)
+	}
+	return endpointResponse(method, data, opts)
+}
+
+// UpstreamCursor unwraps the upstream API cursor embedded in an opaque MCP
+// cursor. It returns an empty string for local continuation cursors that resume
+// within the current API page.
+func UpstreamCursor(cursor string) (string, error) {
+	state, err := decodeEndpointCursor(cursor)
+	if err != nil {
+		return "", err
+	}
+	return state.UpstreamCursor, nil
+}
+
+func endpointResponse(method string, data json.RawMessage, opts PageOptions) string {
 	trimmed := strings.TrimSpace(string(data))
 	if strings.EqualFold(method, "GET") && len(trimmed) > 0 && trimmed[0] == '[' {
 		var items []json.RawMessage
 		if json.Unmarshal(data, &items) == nil {
+			if opts.CursorParam != "" {
+				return string(boundedPageListEnvelope("items", items, data, endpointListNote, opts, nil, ""))
+			}
 			return string(boundedListEnvelope("items", items, len(data), endpointListNote))
+		}
+	}
+	if strings.EqualFold(method, "GET") && opts.CursorParam != "" {
+		if out, ok := boundedSingleArrayPageObject(data, opts); ok {
+			return string(out)
 		}
 	}
 	if len(data) <= MaxBytes {
@@ -137,6 +189,35 @@ func boundedSingleArrayObject(data json.RawMessage) ([]byte, bool) {
 	return out, true
 }
 
+func boundedSingleArrayPageObject(data json.RawMessage, opts PageOptions) ([]byte, bool) {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) != nil {
+		return nil, false
+	}
+	arrayField := ""
+	var items []json.RawMessage
+	for key, raw := range obj {
+		trimmed := strings.TrimSpace(string(raw))
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			continue
+		}
+		var candidate []json.RawMessage
+		if json.Unmarshal(raw, &candidate) != nil {
+			continue
+		}
+		if arrayField != "" {
+			return nil, false
+		}
+		arrayField = key
+		items = candidate
+	}
+	if arrayField == "" {
+		return nil, false
+	}
+	nextUpstream := extractStringPath(data, opts.NextCursorPath)
+	return boundedPageListEnvelope(arrayField, items, data, endpointListNote, opts, obj, nextUpstream), true
+}
+
 func boundedListEnvelope(field string, items []json.RawMessage, originalBytes int, note string) []byte {
 	build := func(subset []json.RawMessage) any {
 		out := map[string]any{
@@ -153,6 +234,61 @@ func boundedListEnvelope(field string, items []json.RawMessage, originalBytes in
 		return out
 	}
 	return fitJSONItems(items, build)
+}
+
+func boundedPageListEnvelope(field string, items []json.RawMessage, original json.RawMessage, note string, opts PageOptions, base map[string]json.RawMessage, nextUpstream string) []byte {
+	state := endpointCursor{Version: 1}
+	if opts.Cursor != "" {
+		if decoded, err := decodeEndpointCursor(opts.Cursor); err == nil {
+			state = decoded
+		}
+	}
+	start := state.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start > len(items) {
+		start = len(items)
+	}
+
+	build := func(subset []json.RawMessage, itemPreview string, nextCursor string) any {
+		var out map[string]any
+		if base == nil {
+			out = map[string]any{}
+		} else {
+			out = make(map[string]any, len(base)+8)
+			for key, raw := range base {
+				if key == field {
+					continue
+				}
+				out[key] = raw
+			}
+		}
+		if nextUpstream != "" || state.UpstreamCursor != "" {
+			out["count"] = -1
+		} else {
+			out["count"] = len(items)
+		}
+		out[field] = subset
+		out["returned_count"] = len(subset)
+		if itemPreview != "" {
+			out["item_preview"] = itemPreview
+		}
+		if nextCursor != "" {
+			out["truncated"] = true
+			out["next_cursor"] = nextCursor
+			out["original_bytes"] = len(original)
+			out["max_bytes"] = MaxBytes
+			out["note"] = note
+		}
+		return out
+	}
+
+	out := fitJSONPageItems(items, start, state.UpstreamCursor, nextUpstream, build)
+	if len(out) > MaxBytes {
+		return []byte(previewEnvelope(original, endpointPreviewNote))
+	}
+	return out
 }
 
 func fitJSONItems(items []json.RawMessage, build func([]json.RawMessage) any) []byte {
@@ -173,6 +309,119 @@ func fitJSONItems(items []json.RawMessage, build func([]json.RawMessage) any) []
 	return out
 }
 
+func fitJSONPageItems(items []json.RawMessage, start int, currentUpstream, nextUpstream string, build func([]json.RawMessage, string, string) any) []byte {
+	remaining := len(items) - start
+	if remaining < 0 {
+		remaining = 0
+	}
+	limit := remaining
+	if limit > MaxItems {
+		limit = MaxItems
+	}
+	for n := limit; n > 0; n-- {
+		next := nextPageCursor(start+n, len(items), currentUpstream, nextUpstream)
+		out, err := json.Marshal(build(items[start:start+n], "", next))
+		if err != nil {
+			continue
+		}
+		if len(out) <= MaxBytes {
+			return out
+		}
+	}
+	if start < len(items) {
+		next := nextPageCursor(start+1, len(items), currentUpstream, nextUpstream)
+		previewLimit := maxPreviewBytes
+		for previewLimit >= 0 {
+			out, err := json.Marshal(build(nil, previewString(items[start], previewLimit), next))
+			if err == nil && len(out) <= MaxBytes {
+				return out
+			}
+			if previewLimit == 0 {
+				break
+			}
+			if previewLimit < 512 {
+				previewLimit = 0
+			} else {
+				previewLimit -= 512
+			}
+		}
+	}
+	next := nextPageCursor(len(items), len(items), currentUpstream, nextUpstream)
+	out, _ := json.Marshal(build(nil, "", next))
+	return out
+}
+
+func nextPageCursor(nextOffset, itemCount int, currentUpstream, nextUpstream string) string {
+	state := endpointCursor{Version: 1}
+	switch {
+	case nextOffset < itemCount:
+		state.Offset = nextOffset
+		state.UpstreamCursor = currentUpstream
+	case nextUpstream != "":
+		state.UpstreamCursor = nextUpstream
+	default:
+		return ""
+	}
+	return encodeEndpointCursor(state)
+}
+
+func encodeEndpointCursor(state endpointCursor) string {
+	if state.Version == 0 {
+		state.Version = 1
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeEndpointCursor(cursor string) (endpointCursor, error) {
+	if cursor == "" {
+		return endpointCursor{Version: 1}, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return endpointCursor{}, fmt.Errorf("invalid MCP cursor")
+	}
+	var state endpointCursor
+	if err := json.Unmarshal(data, &state); err != nil {
+		return endpointCursor{}, fmt.Errorf("invalid MCP cursor")
+	}
+	if state.Version != 1 {
+		return endpointCursor{}, fmt.Errorf("unsupported MCP cursor version")
+	}
+	if state.Offset < 0 {
+		return endpointCursor{}, fmt.Errorf("invalid MCP cursor offset")
+	}
+	return state, nil
+}
+
+func extractStringPath(data json.RawMessage, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	var v any
+	if json.Unmarshal(data, &v) != nil {
+		return ""
+	}
+	for _, part := range strings.Split(path, ".") {
+		obj, ok := v.(map[string]any)
+		if !ok {
+			return ""
+		}
+		v, ok = obj[part]
+		if !ok {
+			return ""
+		}
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
 func previewEnvelope(data []byte, note string) string {
 	limit := len(data)
 	if limit > maxPreviewBytes {
@@ -181,6 +430,7 @@ func previewEnvelope(data []byte, note string) string {
 	for limit >= 0 {
 		out, err := json.Marshal(map[string]any{
 			"truncated":      true,
+			"resumable":      false,
 			"original_bytes": len(data),
 			"max_bytes":      MaxBytes,
 			"preview":        previewString(data, limit),
@@ -200,6 +450,7 @@ func previewEnvelope(data []byte, note string) string {
 	}
 	out, _ := json.Marshal(map[string]any{
 		"truncated":      true,
+		"resumable":      false,
 		"original_bytes": len(data),
 		"max_bytes":      MaxBytes,
 		"note":           note,

--- a/internal/generator/templates/mcp_bound_test.go.tmpl
+++ b/internal/generator/templates/mcp_bound_test.go.tmpl
@@ -5,6 +5,7 @@ package bound
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -46,6 +47,217 @@ func TestEndpointResponseBoundsListResponses(t *testing.T) {
 	}
 	if envelope.OriginalBytes != len(data) {
 		t.Fatalf("original_bytes = %d, want %d", envelope.OriginalBytes, len(data))
+	}
+}
+
+func TestEndpointPageResponseEmitsOpaqueCursorForTruncatedList(t *testing.T) {
+	items := make([]map[string]string, 0, MaxItems+25)
+	for i := 0; i < MaxItems+25; i++ {
+		items = append(items, map[string]string{
+			"id":      "item-" + strconv.Itoa(i),
+			"payload": strings.Repeat("x", 1600),
+		})
+	}
+	data, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	text := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor"})
+	if len(text) > MaxBytes {
+		t.Fatalf("bounded result length = %d, want <= %d", len(text), MaxBytes)
+	}
+
+	var envelope struct {
+		Items         []json.RawMessage `json:"items"`
+		Truncated     bool              `json:"truncated"`
+		ReturnedCount int               `json:"returned_count"`
+		NextCursor    string            `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("bounded list result must remain valid JSON: %v\n%s", err, text)
+	}
+	if !envelope.Truncated {
+		t.Fatalf("bounded list result did not mark truncation: %s", text)
+	}
+	if envelope.ReturnedCount != len(envelope.Items) {
+		t.Fatalf("returned_count = %d, want item count %d", envelope.ReturnedCount, len(envelope.Items))
+	}
+	if envelope.NextCursor == "" {
+		t.Fatalf("truncated resumable list result did not include next_cursor: %s", text)
+	}
+	if strings.Contains(envelope.NextCursor, "item-") || strings.Contains(envelope.NextCursor, "cursor") {
+		t.Fatalf("next_cursor should be opaque, got %q", envelope.NextCursor)
+	}
+}
+
+func TestEndpointPageResponseContinuesFromOpaqueCursor(t *testing.T) {
+	items := make([]map[string]string, 0, MaxItems+25)
+	for i := 0; i < MaxItems+25; i++ {
+		items = append(items, map[string]string{
+			"id":      "item-" + strconv.Itoa(i),
+			"payload": strings.Repeat("x", 1600),
+		})
+	}
+	data, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	firstText := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor"})
+	var first struct {
+		Items      []map[string]string `json:"items"`
+		NextCursor string              `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(firstText), &first); err != nil {
+		t.Fatalf("first page must remain valid JSON: %v\n%s", err, firstText)
+	}
+	if first.NextCursor == "" {
+		t.Fatalf("first page did not include next_cursor: %s", firstText)
+	}
+
+	secondText := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor", Cursor: first.NextCursor})
+	var second struct {
+		Items         []map[string]string `json:"items"`
+		ReturnedCount int                 `json:"returned_count"`
+	}
+	if err := json.Unmarshal([]byte(secondText), &second); err != nil {
+		t.Fatalf("second page must remain valid JSON: %v\n%s", err, secondText)
+	}
+	if len(first.Items) == 0 || len(second.Items) == 0 {
+		t.Fatalf("expected both pages to return items: first=%s second=%s", firstText, secondText)
+	}
+	if got, want := second.Items[0]["id"], items[len(first.Items)]["id"]; got != want {
+		t.Fatalf("second page first id = %q, want %q", got, want)
+	}
+	if second.ReturnedCount != len(second.Items) {
+		t.Fatalf("returned_count = %d, want item count %d", second.ReturnedCount, len(second.Items))
+	}
+}
+
+func TestEndpointPageResponseWrapsUpstreamCursorOpaquely(t *testing.T) {
+	items := []map[string]string{
+		{"id": "item-0", "payload": "small"},
+		{"id": "item-1", "payload": "small"},
+	}
+	data, err := json.Marshal(map[string]any{
+		"items":       items,
+		"next_cursor": "server-next-token",
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	text := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor", NextCursorPath: "next_cursor"})
+	if len(text) > MaxBytes {
+		t.Fatalf("bounded result length = %d, want <= %d", len(text), MaxBytes)
+	}
+
+	var envelope struct {
+		Items         []map[string]string `json:"items"`
+		ReturnedCount int                 `json:"returned_count"`
+		NextCursor    string              `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("page result must remain valid JSON: %v\n%s", err, text)
+	}
+	if envelope.ReturnedCount != len(items) {
+		t.Fatalf("returned_count = %d, want %d", envelope.ReturnedCount, len(items))
+	}
+	if envelope.NextCursor == "" {
+		t.Fatalf("page with upstream cursor did not include next_cursor: %s", text)
+	}
+	if strings.Contains(envelope.NextCursor, "server-next-token") {
+		t.Fatalf("next_cursor leaked upstream cursor: %q", envelope.NextCursor)
+	}
+}
+
+func TestEndpointPageResponseOversizedFirstItemReturnsPreviewAndAdvances(t *testing.T) {
+	items := []map[string]string{
+		{"id": "too-large", "payload": strings.Repeat("x", MaxBytes+10000)},
+		{"id": "next", "payload": "small"},
+	}
+	data, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	firstText := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor"})
+	if len(firstText) > MaxBytes {
+		t.Fatalf("bounded result length = %d, want <= %d", len(firstText), MaxBytes)
+	}
+
+	var first struct {
+		Items         []json.RawMessage `json:"items"`
+		ItemPreview   string            `json:"item_preview"`
+		ReturnedCount int               `json:"returned_count"`
+		NextCursor    string            `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(firstText), &first); err != nil {
+		t.Fatalf("first page must remain valid JSON: %v\n%s", err, firstText)
+	}
+	if len(first.Items) != 0 || first.ReturnedCount != 0 {
+		t.Fatalf("oversized first item should not claim to return a full item: %s", firstText)
+	}
+	if first.ItemPreview == "" {
+		t.Fatalf("oversized first item should include item_preview: %s", firstText)
+	}
+	if first.NextCursor == "" {
+		t.Fatalf("oversized first item should advance with next_cursor: %s", firstText)
+	}
+
+	secondText := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor", Cursor: first.NextCursor})
+	var second struct {
+		Items []map[string]string `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(secondText), &second); err != nil {
+		t.Fatalf("second page must remain valid JSON: %v\n%s", err, secondText)
+	}
+	if len(second.Items) == 0 || second.Items[0]["id"] != "next" {
+		t.Fatalf("second page should advance past oversized item, got %s", secondText)
+	}
+}
+
+func TestEndpointPageResponseMultiArrayObjectUsesNonResumablePreview(t *testing.T) {
+	items := make([]map[string]string, 0, MaxItems+25)
+	users := make([]map[string]string, 0, MaxItems+25)
+	for i := 0; i < MaxItems+25; i++ {
+		items = append(items, map[string]string{"id": "item-" + strconv.Itoa(i), "payload": strings.Repeat("x", 1600)})
+		users = append(users, map[string]string{"id": "user-" + strconv.Itoa(i), "payload": strings.Repeat("y", 1600)})
+	}
+	data, err := json.Marshal(map[string]any{
+		"items": items,
+		"users": users,
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+
+	text := EndpointPageResponse("GET", data, PageOptions{CursorParam: "cursor"})
+	if len(text) > MaxBytes {
+		t.Fatalf("bounded result length = %d, want <= %d", len(text), MaxBytes)
+	}
+
+	var envelope struct {
+		Truncated  bool   `json:"truncated"`
+		Resumable  *bool  `json:"resumable"`
+		Preview    string `json:"preview"`
+		NextCursor string `json:"next_cursor"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("preview result must remain valid JSON: %v\n%s", err, text)
+	}
+	if !envelope.Truncated {
+		t.Fatalf("multi-array preview should be marked truncated: %s", text)
+	}
+	if envelope.Resumable == nil || *envelope.Resumable {
+		t.Fatalf("multi-array preview should explicitly be non-resumable: %s", text)
+	}
+	if envelope.NextCursor != "" {
+		t.Fatalf("non-resumable preview must not include next_cursor: %s", text)
+	}
+	if envelope.Preview == "" {
+		t.Fatalf("non-resumable preview should include bounded preview text: %s", text)
 	}
 }
 

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -60,6 +60,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- range mcpToolInputParams $endpoint}}
 			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" (mcpInputName .)}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
+{{- if mcpEndpointPageable $endpoint}}
+			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
+{{- end}}
 {{- range mcpGlobalTemplateInputParams $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}
 			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" (mcpInputName .)}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
 {{- end}}
@@ -81,9 +84,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{printf "%q" (effectiveTier $.APISpec $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveEndpointPath $resource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveEndpointPath $resource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveEndpointPath $resource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -95,6 +98,9 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDescription({{printf "%q" (composeMCPSubDesc $.APISpec $resource $subResource $endpoint $.MCPPublicCount $.MCPTotalCount)}}),
 {{- range mcpToolInputParams $endpoint}}
 			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" (mcpInputName .)}}{{if .Required}}, mcplib.Required(){{end}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
+{{- end}}
+{{- if mcpEndpointPageable $endpoint}}
+			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
 {{- end}}
 {{- range mcpGlobalTemplateInputParams $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}
 			mcplib.{{mcpBindingFunc .Type}}({{printf "%q" (mcpInputName .)}}, mcplib.Description({{printf "%q" (mcpParamDesc .)}})),
@@ -117,9 +123,9 @@ func RegisterTools(s *server.MCPServer) {
 {{- end}}
 		),
 {{- if $.HasTierRouting}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{printf "%q" (effectiveSubTier $.APISpec $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- else}}
-		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}[]mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
+		makeAPIHandler({{printf "%q" (upper $endpoint.Method)}}, {{printf "%q" (effectiveSubEndpointPath $resource $subResource $endpoint)}}, {{if $isReadOnly}}true{{else}}false{{end}}, {{if $endpoint.UsesBinaryResponse}}true{{else}}false{{end}}, {{if $endpoint.HeaderOverrides}}map[string]string{ {{- range $endpoint.HeaderOverrides}}{{printf "%q" .Name}}: {{printf "%q" .Value}},{{end}} }{{else}}nil{{end}}, {{if $.HasRequiredRoles}}{{if $endpoint.RequiresRole}}cli.Persona{{pascal $endpoint.RequiresRole}}{{else}}cli.Persona(""){{end}}, {{end}}{{mcpPageConfig $endpoint}}, []mcpParamBinding{ {{- range mcpParamBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint)}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}{{if .BodyPath}}, BodyPath: []string{ {{- range .BodyPath}}{{printf "%q" .}},{{end}} }{{end}}{{if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{if .RequestContentType}}, RequestContentType: {{printf "%q" .RequestContentType}}{{end}}{{if .Default}}, Default: {{printf "%q" .Default}}{{end}}},{{end}}{{- range mcpGlobalTemplateBindings $endpoint (effectiveSubEndpointPath $resource $subResource $endpoint) $.GlobalPathTemplateVars}}{PublicName: {{printf "%q" .PublicName}}, WireName: {{printf "%q" .WireName}}, Location: {{printf "%q" .Location}}},{{end}} }, []string{ {{- range $endpoint.Params}}{{if or .Positional .PathParam}}{{printf "%q" .Name}},{{end}}{{end}} }),
 {{- end}}
 	)
 {{- end}}
@@ -189,6 +195,12 @@ type mcpParamBinding struct {
 {{- if $hasMCPParamDefault}}
 	Default    string
 {{- end}}
+}
+
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
 }
 
 func formatMCPParamValue(v any) string {
@@ -275,9 +287,9 @@ func setNestedBodyArg(body map[string]any, path []string, value any) {
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
 {{- if .HasTierRouting}}
-func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 {{- else}}
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, {{if .HasRequiredRoles}}requiredRole cli.Persona, {{end}}pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 {{- end}}
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 {{- if .HasRequiredRoles}}
@@ -312,6 +324,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -685,12 +715,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -199,7 +199,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -41,7 +41,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/health", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/health", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("items_list",
@@ -50,7 +50,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/api/items/search", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("POST", "/api/items/search", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_create",
@@ -58,7 +58,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/api/quotes/generate", false, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("POST", "/api/quotes/generate", false, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_delete",
@@ -67,7 +67,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("DELETE", "/api/quotes/{quote_id}", false, false, nil, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
+		makeAPIHandler("DELETE", "/api/quotes/{quote_id}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_get",
@@ -77,7 +77,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/api/quotes/{quote_id}", true, false, nil, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
+		makeAPIHandler("GET", "/api/quotes/{quote_id}", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_list",
@@ -86,7 +86,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/api/quotes", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/api/quotes", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_update",
@@ -94,7 +94,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("quote_id", mcplib.Required(), mcplib.Description("Quote id")),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("PATCH", "/api/quotes/{quote_id}", false, false, nil, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
+		makeAPIHandler("PATCH", "/api/quotes/{quote_id}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("quotes_update-status",
@@ -103,7 +103,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/api/quotes/{quote_id}", false, false, nil, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
+		makeAPIHandler("POST", "/api/quotes/{quote_id}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "quote_id", WireName: "quote_id", Location: "path"}}, []string{"quote_id"}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -149,6 +149,12 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
+}
+
 func formatMCPParamValue(v any) string {
 	switch tv := v.(type) {
 	case string:
@@ -186,7 +192,7 @@ func formatMCPParamValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -206,6 +212,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -343,12 +367,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -151,7 +151,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -41,7 +41,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -87,6 +87,12 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
+}
+
 func formatMCPParamValue(v any) string {
 	switch tv := v.(type) {
 	case string:
@@ -124,7 +130,7 @@ func formatMCPParamValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -144,6 +150,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -288,12 +312,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -89,7 +89,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -41,7 +41,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/currencies", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/currencies", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_create",
@@ -52,7 +52,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/projects", false, false, nil, []mcpParamBinding{{PublicName: "name", WireName: "name", Location: "body"}, {PublicName: "owner_email", WireName: "owner_email", Location: "body"}, {PublicName: "visibility", WireName: "visibility", Location: "body"}}, []string{}),
+		makeAPIHandler("POST", "/projects", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "name", WireName: "name", Location: "body"}, {PublicName: "owner_email", WireName: "owner_email", Location: "body"}, {PublicName: "visibility", WireName: "visibility", Location: "body"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_get",
@@ -62,19 +62,19 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}", true, false, nil, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_list",
 			mcplib.WithDescription("List projects. Optional: status, limit (default: 25), cursor. Returns array of Project."),
 			mcplib.WithString("status", mcplib.Description("Status")),
 			mcplib.WithNumber("limit", mcplib.Description("Limit")),
-			mcplib.WithString("cursor", mcplib.Description("Cursor")),
+			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects", true, false, nil, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}, {PublicName: "cursor", WireName: "cursor", Location: "query"}}, []string{}),
+		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_avatar_upload-project",
@@ -85,7 +85,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("file", mcplib.Description("File")),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("PUT", "/projects/{projectId}/avatar", false, false, nil, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path", RequestContentType: "multipart/form-data"}, {PublicName: "overwrite", WireName: "overwrite", Location: "query", RequestContentType: "multipart/form-data"}, {PublicName: "caption", WireName: "caption", Location: "body", RequestContentType: "multipart/form-data"}, {PublicName: "file", WireName: "file", Location: "body", Format: "binary", RequestContentType: "multipart/form-data"}}, []string{"projectId"}),
+		makeAPIHandler("PUT", "/projects/{projectId}/avatar", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path", RequestContentType: "multipart/form-data"}, {PublicName: "overwrite", WireName: "overwrite", Location: "query", RequestContentType: "multipart/form-data"}, {PublicName: "caption", WireName: "caption", Location: "body", RequestContentType: "multipart/form-data"}, {PublicName: "file", WireName: "file", Location: "body", Format: "binary", RequestContentType: "multipart/form-data"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_list-project",
@@ -93,12 +93,12 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("projectId", mcplib.Required(), mcplib.Description("Project id")),
 			mcplib.WithString("priority", mcplib.Description("Priority")),
 			mcplib.WithNumber("limit", mcplib.Description("Limit")),
-			mcplib.WithString("cursor", mcplib.Description("Cursor")),
+			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}, {PublicName: "cursor", WireName: "cursor", Location: "query"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_update-project",
@@ -111,7 +111,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithString("title", mcplib.Description("Title")),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("PATCH", "/projects/{projectId}/tasks/{taskId}", false, false, nil, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "taskId", WireName: "taskId", Location: "path"}, {PublicName: "notify", WireName: "notify", Location: "query"}, {PublicName: "completed", WireName: "completed", Location: "body"}, {PublicName: "priority", WireName: "priority", Location: "body"}, {PublicName: "title", WireName: "title", Location: "body"}}, []string{"projectId", "taskId"}),
+		makeAPIHandler("PATCH", "/projects/{projectId}/tasks/{taskId}", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "taskId", WireName: "taskId", Location: "path"}, {PublicName: "notify", WireName: "notify", Location: "query"}, {PublicName: "completed", WireName: "completed", Location: "body"}, {PublicName: "priority", WireName: "priority", Location: "body"}, {PublicName: "title", WireName: "title", Location: "body"}}, []string{"projectId", "taskId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("public_get-status",
@@ -120,7 +120,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/public/status", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/public/status", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("reports_export_report-year",
@@ -130,7 +130,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/reports/{year}/export", true, true, map[string]string{"Accept": "application/octet-stream"}, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
+		makeAPIHandler("GET", "/reports/{year}/export", true, true, map[string]string{"Accept": "application/octet-stream"}, mcpPageConfig{}, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("reports_summary_get-report-year",
@@ -140,7 +140,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/reports/{year}/summary", true, false, nil, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
+		makeAPIHandler("GET", "/reports/{year}/summary", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "year", WireName: "year", Location: "path"}}, []string{"year"}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -189,6 +189,12 @@ type mcpParamBinding struct {
 	Default            string
 }
 
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
+}
+
 func formatMCPParamValue(v any) string {
 	switch tv := v.(type) {
 	case string:
@@ -235,7 +241,7 @@ func mcpMultipartFieldValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -255,6 +261,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -443,12 +467,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -74,7 +74,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
+		makeAPIHandler("GET", "/projects", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "status", WireName: "status", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "25"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_avatar_upload-project",
@@ -98,7 +98,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
+		makeAPIHandler("GET", "/projects/{projectId}/tasks", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{{PublicName: "projectId", WireName: "projectId", Location: "path"}, {PublicName: "priority", WireName: "priority", Location: "query"}, {PublicName: "limit", WireName: "limit", Location: "query", Default: "50"}}, []string{"projectId"}),
 	)
 	s.AddTool(
 		mcplib.NewTool("projects_tasks_update-project",
@@ -191,7 +191,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -81,6 +81,12 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
+}
+
 func formatMCPParamValue(v any) string {
 	switch tv := v.(type) {
 	case string:
@@ -118,7 +124,7 @@ func formatMCPParamValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -138,6 +144,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -282,12 +306,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -83,7 +83,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -80,7 +80,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/mcp/tools.go
@@ -41,7 +41,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("POST", "/stores", false, false, nil, []mcpParamBinding{{PublicName: "dry_run", WireName: "$dry_run", Location: "query"}, {PublicName: "store-code", WireName: "store_code", Location: "body"}}, []string{}),
+		makeAPIHandler("POST", "/stores", false, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "dry_run", WireName: "$dry_run", Location: "query"}, {PublicName: "store-code", WireName: "store_code", Location: "body"}}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("stores_find",
@@ -53,7 +53,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/power/store-locator", true, false, nil, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}, {PublicName: "locationId", WireName: "location_id", Location: "query"}}, []string{}),
+		makeAPIHandler("GET", "/power/store-locator", true, false, nil, mcpPageConfig{}, []mcpParamBinding{{PublicName: "address", WireName: "s", Location: "query"}, {PublicName: "city", WireName: "c", Location: "query"}, {PublicName: "locationId", WireName: "location_id", Location: "query"}}, []string{}),
 	)
 
 	// Context tool — front-loaded domain knowledge for agents.
@@ -76,6 +76,12 @@ type mcpParamBinding struct {
 	PublicName string
 	WireName   string
 	Location   string
+}
+
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
 }
 
 func formatMCPParamValue(v any) string {
@@ -115,7 +121,7 @@ func formatMCPParamValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -135,6 +141,24 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -272,12 +296,23 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -41,16 +41,17 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items/enterprise", "enterprise", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items/enterprise", "enterprise", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("items_list",
 			mcplib.WithDescription("List free items. (public)"),
+			mcplib.WithString("cursor", mcplib.Description("Opaque pagination cursor returned by a previous MCP response")),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items", "free", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items", "free", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("items_premium",
@@ -59,7 +60,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items/premium", "paid", true, false, nil, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items/premium", "paid", true, false, nil, mcpPageConfig{}, []mcpParamBinding{}, []string{}),
 	)
 	// Search tool — faster than iterating list endpoints for finding specific items
 	s.AddTool(
@@ -105,6 +106,12 @@ type mcpParamBinding struct {
 	Location   string
 }
 
+type mcpPageConfig struct {
+	CursorParam    string
+	LimitParam     string
+	NextCursorPath string
+}
+
 func formatMCPParamValue(v any) string {
 	switch tv := v.(type) {
 	case string:
@@ -142,7 +149,7 @@ func formatMCPParamValue(v any) string {
 }
 
 // makeAPIHandler creates a generic MCP tool handler for an API endpoint.
-func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
+func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResponse bool, headerOverrides map[string]string, pageConfig mcpPageConfig, bindings []mcpParamBinding, positionalParams []string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 		c, err := newMCPClient()
 		if err != nil {
@@ -163,6 +170,24 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 		pathParams := make(map[string]bool, len(positionalParams))
 		params := make(map[string]string)
 		bodyArgs := make(map[string]any)
+		mcpCursor := ""
+		if pageConfig.CursorParam != "" {
+			knownArgs["cursor"] = true
+			if v, ok := args["cursor"]; ok {
+				s, ok := v.(string)
+				if !ok {
+					return mcplib.NewToolResultError("cursor must be an opaque string returned by a previous MCP response"), nil
+				}
+				mcpCursor = s
+				upstreamCursor, err := bound.UpstreamCursor(s)
+				if err != nil {
+					return mcplib.NewToolResultError(err.Error()), nil
+				}
+				if upstreamCursor != "" {
+					params[pageConfig.CursorParam] = upstreamCursor
+				}
+			}
+		}
 		var headers map[string]string
 		if len(headerOverrides) > 0 {
 			headers = make(map[string]string, len(headerOverrides)+1)
@@ -307,12 +332,23 @@ func makeAPIHandler(method, pathTemplate, tier string, readOnly bool, binaryResp
 			}
 			return mcplib.NewToolResultText(string(out)), nil
 		}
+		if pageConfig.CursorParam != "" {
+			return mcpToolPageResultText(method, data, pageConfig, mcpCursor), nil
+		}
 		return mcpToolResultText(method, data), nil
 	}
 }
 
 func mcpToolResultText(method string, data json.RawMessage) *mcplib.CallToolResult {
 	return mcplib.NewToolResultText(bound.EndpointResponse(method, data))
+}
+
+func mcpToolPageResultText(method string, data json.RawMessage, pageConfig mcpPageConfig, cursor string) *mcplib.CallToolResult {
+	return mcplib.NewToolResultText(bound.EndpointPageResponse(method, data, bound.PageOptions{
+		Cursor:         cursor,
+		CursorParam:    pageConfig.CursorParam,
+		NextCursorPath: pageConfig.NextCursorPath,
+	}))
 }
 
 func newMCPClient() (*client.Client, error) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -51,7 +51,7 @@ func RegisterTools(s *server.MCPServer) {
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),
 		),
-		makeAPIHandler("GET", "/items", "free", true, false, nil, mcpPageConfig{CursorParam: "cursor", LimitParam: "limit", NextCursorPath: ""}, []mcpParamBinding{}, []string{}),
+		makeAPIHandler("GET", "/items", "free", true, false, nil, mcpPageConfig{CursorParam: "cursor", NextCursorPath: ""}, []mcpParamBinding{}, []string{}),
 	)
 	s.AddTool(
 		mcplib.NewTool("items_premium",
@@ -108,7 +108,6 @@ type mcpParamBinding struct {
 
 type mcpPageConfig struct {
 	CursorParam    string
-	LimitParam     string
 	NextCursorPath string
 }
 


### PR DESCRIPTION
## Summary
- add cursor-aware bounded MCP response envelopes for generated typed endpoint list tools
- expose a canonical opaque `cursor` MCP argument for pageable GET endpoints and hide the raw upstream cursor parameter from the tool schema
- add generated-output coverage for local continuation, upstream cursor wrapping, oversized first items, and non-resumable multi-array fallback

Closes #3211.
Part of #3090.

## What remains in #3090 after this PR
- #3099 still owns store-backed MCP search/sql/list UX: empty-store guidance, domain table mismatch, projection/concise/raw behavior, and any keyset/checkpoint pagination contract for local store results.
- #3089/#3205 still own compact CLI/search/wrapped-array projection behavior outside typed endpoint MCP pagination.
- #3171 still owns the CLI `--agent` envelope work.
- #3212/#3213 still own query-parameter/client edge cases and should stay separate unless their fixes expose another shared MCP contract issue.

## Verification
- `go fmt ./...`
- `go test ./...`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-mcp-api generate-tier-routing-api generate-public-param-names generate-fastapi-operationids`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
