### PR TITLE
fix(cli): backfill empty creator handle on regen + emit store bare-id accessor

### DIFF
--- a/internal/generator/creator_resolve_test.go
+++ b/internal/generator/creator_resolve_test.go
@@ -33,6 +33,18 @@ func TestResolveCreatorForExisting_ManifestCreatorWins(t *testing.T) {
 	assert.Equal(t, spec.Person{Handle: "trevin-chow", Name: "Trevin Chow"}, resolveCreatorForExisting(dir, ""))
 }
 
+// A persisted creator with a name but an empty handle (printed before
+// github.user resolved) is unpublishable: publish-validate rejects the empty
+// handle and a plain regen would otherwise lock it in. resolveCreatorForExisting
+// backfills only the missing handle from the same-lineage printer field,
+// preserving the display name. A populated handle is never touched — see
+// TestResolveCreatorForExisting_ManifestCreatorWins.
+func TestResolveCreatorForExisting_BackfillsEmptyHandleFromPrinter(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `{"creator": {"name": "ghltshubh"}, "printer": "ghltshubh", "printer_name": "ghltshubh"}`)
+	assert.Equal(t, spec.Person{Handle: "ghltshubh", Name: "ghltshubh"}, resolveCreatorForExisting(dir, ""))
+}
+
 // A pre-transition manifest (no creator) falls back to the legacy printer
 // fields, then owner fields.
 func TestResolveCreatorForExisting_LegacyFallback(t *testing.T) {

--- a/internal/generator/creator_resolve_test.go
+++ b/internal/generator/creator_resolve_test.go
@@ -41,8 +41,11 @@ func TestResolveCreatorForExisting_ManifestCreatorWins(t *testing.T) {
 // TestResolveCreatorForExisting_ManifestCreatorWins.
 func TestResolveCreatorForExisting_BackfillsEmptyHandleFromPrinter(t *testing.T) {
 	dir := t.TempDir()
-	writeManifest(t, dir, `{"creator": {"name": "ghltshubh"}, "printer": "ghltshubh", "printer_name": "ghltshubh"}`)
-	assert.Equal(t, spec.Person{Handle: "ghltshubh", Name: "ghltshubh"}, resolveCreatorForExisting(dir, ""))
+	// Distinct values per field so the assertion pins the source of each: the
+	// handle must come from `printer` (not `printer_name`), and the display name
+	// must be preserved from `creator.name` (not overwritten by `printer_name`).
+	writeManifest(t, dir, `{"creator": {"name": "Shubhankar"}, "printer": "ghltshubh", "printer_name": "Printer Person"}`)
+	assert.Equal(t, spec.Person{Handle: "ghltshubh", Name: "Shubhankar"}, resolveCreatorForExisting(dir, ""))
 }
 
 // A pre-transition manifest (no creator) falls back to the legacy printer

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -533,7 +533,7 @@ func readManifestAttribution(outputDir string) manifestAttribution {
 // resolveCreatorForExisting returns the creator for a regen against an existing
 // tree, preferring persisted attribution over re-derivation so a regen never
 // silently flips the creator to whoever is running the generator:
-//  1. manifest `creator` object
+//  1. manifest `creator` object (backfilling only an empty handle)
 //  2. manifest legacy fields (printer/printer_name, then owner/owner_name)
 //  3. copyright-header parse (manifest-less legacy trees)
 //  4. resolveCreatorForNew() (git config)
@@ -546,7 +546,21 @@ func resolveCreatorForExisting(outputDir, apiName string) spec.Person {
 	}
 	switch {
 	case !a.Creator.IsZero():
-		return a.Creator
+		c := a.Creator
+		// A persisted creator with a name but no handle (printed before
+		// github.user resolved) would otherwise lock in an unpublishable
+		// record: publish-validate rejects an empty handle and a plain regen
+		// never re-derives it. Backfill only the missing handle, preferring the
+		// same-lineage legacy printer field, then git config / gh. A populated
+		// handle is never touched, so manifest-as-authority still holds.
+		if c.Handle == "" {
+			if a.Printer != "" {
+				c.Handle = a.Printer
+			} else if h := resolvePrinterForNew(); h != "" {
+				c.Handle = h
+			}
+		}
+		return c
 	case a.Printer != "":
 		return spec.Person{Handle: a.Printer, Name: a.PrinterName}
 	case a.Owner != "":

--- a/internal/generator/syncable_store_gate_test.go
+++ b/internal/generator/syncable_store_gate_test.go
@@ -21,6 +21,15 @@ func TestGenerateSyncableSmallAPIEmitsLocalDataLayer(t *testing.T) {
 	require.FileExists(t, filepath.Join(outputDir, "internal", "store", "store.go"))
 	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
 	require.FileExists(t, filepath.Join(outputDir, "internal", "cli", "search.go"))
+
+	// The store must expose BareResourceID so novel commands can recover bare
+	// entity ids from the composite (id+NUL+parent) storage keys ListIDs returns
+	// for parent-keyed dependent resources.
+	storeSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "store", "store.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(storeSrc), "func BareResourceID(",
+		"store must expose BareResourceID for composite dependent-resource keys")
+
 	requireGeneratedCompiles(t, outputDir)
 }
 

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1484,6 +1484,18 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	return id + string([]byte{0}) + parentValue
 }
 
+// BareResourceID strips the NUL-delimited parent suffix that resourceStorageID
+// appends to dependent resource types, returning the bare entity id. ListIDs
+// returns composite keys for parent-keyed resources, so callers comparing those
+// ids against bare API ids must run them through this first. For non-composite
+// ids it returns the input unchanged, so it is safe to apply to every id.
+func BareResourceID(storageID string) string {
+	if i := strings.IndexByte(storageID, 0); i >= 0 {
+		return storageID[:i]
+	}
+	return storageID
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1742,6 +1754,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
+// For parent-keyed resource types these are composite storage keys; run them
+// through BareResourceID before comparing against bare API ids.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1378,6 +1378,18 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	return id + string([]byte{0}) + parentValue
 }
 
+// BareResourceID strips the NUL-delimited parent suffix that resourceStorageID
+// appends to dependent resource types, returning the bare entity id. ListIDs
+// returns composite keys for parent-keyed resources, so callers comparing those
+// ids against bare API ids must run them through this first. For non-composite
+// ids it returns the input unchanged, so it is safe to apply to every id.
+func BareResourceID(storageID string) string {
+	if i := strings.IndexByte(storageID, 0); i >= 0 {
+		return storageID[:i]
+	}
+	return storageID
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1527,6 +1539,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
+// For parent-keyed resource types these are composite storage keys; run them
+// through BareResourceID before comparing against bare API ids.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1320,6 +1320,18 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	return id + string([]byte{0}) + parentValue
 }
 
+// BareResourceID strips the NUL-delimited parent suffix that resourceStorageID
+// appends to dependent resource types, returning the bare entity id. ListIDs
+// returns composite keys for parent-keyed resources, so callers comparing those
+// ids against bare API ids must run them through this first. For non-composite
+// ids it returns the input unchanged, so it is safe to apply to every id.
+func BareResourceID(storageID string) string {
+	if i := strings.IndexByte(storageID, 0); i >= 0 {
+		return storageID[:i]
+	}
+	return storageID
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1471,6 +1483,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
+// For parent-keyed resource types these are composite storage keys; run them
+// through BareResourceID before comparing against bare API ids.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1266,6 +1266,18 @@ func resourceStorageID(resourceType, id string, obj map[string]any) string {
 	return id + string([]byte{0}) + parentValue
 }
 
+// BareResourceID strips the NUL-delimited parent suffix that resourceStorageID
+// appends to dependent resource types, returning the bare entity id. ListIDs
+// returns composite keys for parent-keyed resources, so callers comparing those
+// ids against bare API ids must run them through this first. For non-composite
+// ids it returns the input unchanged, so it is safe to apply to every id.
+func BareResourceID(storageID string) string {
+	if i := strings.IndexByte(storageID, 0); i >= 0 {
+		return storageID[:i]
+	}
+	return storageID
+}
+
 // UpsertBatch inserts or replaces multiple records in a single transaction
 // and returns (stored, extractFailures, err). stored counts rows landed in
 // the generic resources table; extractFailures counts items that survived
@@ -1415,6 +1427,8 @@ func (s *Store) GetSyncCursor(resourceType string) string {
 
 // ListIDs returns all IDs from a resource's domain table, or from the generic
 // resources table if no domain table exists. Used by dependent sync to iterate parents.
+// For parent-keyed resource types these are composite storage keys; run them
+// through BareResourceID before comparing against bare API ids.
 //
 // resourceType is never interpolated into SQL directly. We resolve it to a real
 // table name via a parameterized sqlite_master lookup; only that trusted name is


### PR DESCRIPTION
## Intent

Two generator gaps surfaced while publishing `stac-pp-cli` to the public library (printing-press-library#1357) and filed from the STAC retro.

Issue: Closes #3227, Closes #3228

## Approach

**#3227 — backfill empty creator handle (`internal/generator/plan_generate.go`).**
`resolveCreatorForExisting` returned a persisted creator verbatim whenever it was non-zero. A creator with a name but an empty handle (printed before `github.user` resolved) is non-zero, so the partial record was locked in: `publish validate` rejects the empty handle and a plain `generate --force` never re-derived it, leaving a forbidden hand-edit as the only recovery. The fix backfills **only** an empty handle — preferring the same-lineage `printer` field, then the existing git-config/`gh` chain — and never touches a populated handle, so manifest-as-authority still holds.

**#3228 — store bare-id accessor (`internal/generator/templates/store.go.tmpl`).**
The store builds composite (`id`+NUL+parent) storage keys for parent-keyed dependent resources, but `ListIDs` returned them raw with no accessor to recover the bare id. Any novel command or sync-diff comparing those keys against bare API ids silently mismatched (it caused a real `watch` dedup bug in the STAC CLI). Emit a `BareResourceID` helper (no-op for bare ids, mirroring the existing exported `ExtractResourceID`) and document `ListIDs`.

## Scope

Primary area: Generator (`internal/generator/`).

Why this belongs in this repo: Both are generator behaviors that affect every future CLI — the attribution gap fires for any CLI printed where the handle can't resolve (CI, fresh machines), and the composite-key accessor gap fires for any CLI with a parent-keyed dependent resource. The STAC CLI surfaced them, but the durable fixes are in the machine, not that one printed CLI.

## Catalog Justification

N/A

## Risk

- #3227: scoped to an *empty* handle on an otherwise-named creator; a fully-populated creator is returned unchanged (covered by `TestResolveCreatorForExisting_ManifestCreatorWins`). No change to contributor accrual or the creator-is-permanent rule.
- #3228: additive exported helper + a doc comment. Emitted unconditionally in the store template (like `ExtractResourceID`); unused in CLIs without dependent resources, which is fine for an exported helper. Changes generated store output → 3 golden store fixtures updated.

## Output Contract

Changes `store.go.tmpl`, so generated `internal/store/store.go` gains `BareResourceID` + a `ListIDs` doc note. Evidence:
- Emitted-code assertion: `TestGenerateSyncableSmallAPIEmitsLocalDataLayer` now asserts `func BareResourceID(` is emitted, and `requireGeneratedCompiles` compiles the generated store.
- Golden: the 3 store-bearing fixtures (`generate-learn-loop-api`, `generate-query-endpoint-api`, `generate-sync-walker-api`) updated; diff is exactly the new function + doc line.
- `scripts/verify-generator-output.sh` regenerated and compiled 10 cases.

## Verification

- `go test ./...` — pass
- `scripts/golden.sh verify` — 32 cases pass (after intentional update of the 3 store fixtures)
- `scripts/verify-generator-output.sh` — 10 cases generated + compiled
- `go vet ./internal/generator/` — clean; `gofmt` applied
- New tests: `TestResolveCreatorForExisting_BackfillsEmptyHandleFromPrinter`; `BareResourceID` emission assertion in `TestGenerateSyncableSmallAPIEmitsLocalDataLayer`

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [x] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
