### PR TITLE
fix(cli): bound MCP store result envelopes

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3879,10 +3879,12 @@ func TestGenerateMCPSQLToolUsesReadOnlyStore(t *testing.T) {
 		"handleSQL must use store.OpenReadOnly, not OpenWithContext")
 	assert.NotRegexp(t, `(?s)func handleSearch\(.*store\.OpenWithContext\(`, mcpCode,
 		"handleSearch must use store.OpenReadOnly, not OpenWithContext")
-	assert.Regexp(t, `(?s)func handleSQL\(.*store\.OpenReadOnly\(`, mcpCode,
-		"handleSQL must open the store via OpenReadOnly")
-	assert.Regexp(t, `(?s)func handleSearch\(.*store\.OpenReadOnly\(`, mcpCode,
-		"handleSearch must open the store via OpenReadOnly")
+	assert.Regexp(t, `(?s)func openMCPReadOnlyStore\(.*store\.OpenReadOnly\(`, mcpCode,
+		"MCP store-backed helpers must open the store via OpenReadOnly")
+	assert.Regexp(t, `(?s)func handleSQL\(.*openMCPReadOnlyStore\(`, mcpCode,
+		"handleSQL must open the store through the read-only MCP helper")
+	assert.Regexp(t, `(?s)func handleSearch\(.*openMCPReadOnlyStore\(`, mcpCode,
+		"handleSearch must open the store through the read-only MCP helper")
 
 	assert.Contains(t, mcpCode, `func validateReadOnlyQuery(`,
 		"mcp package must expose validateReadOnlyQuery — the gate that handleSQL must call before opening the store")
@@ -3982,6 +3984,27 @@ func TestGenerateMCPSQLToolSurfacesRowErrors(t *testing.T) {
 	// Compile-check the emission: the cols, err := redeclaration reusing the
 	// err already bound by db.Query must still build.
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateMCPStoreGuidanceTestsPass(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("mcp-store-guidance")
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Manage widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/widgets", Description: "List widgets"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Search: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	runGoCommand(t, outputDir, "test", "./internal/mcp", "-run", "TestMCP(Search|SQL)(MissingStore|EmptyStore|DomainTable)")
 }
 
 func TestGenerateMCPToolResultTextBudgetTestsPass(t *testing.T) {

--- a/internal/generator/templates/mcp_bound.go.tmpl
+++ b/internal/generator/templates/mcp_bound.go.tmpl
@@ -98,8 +98,10 @@ func endpointResponse(method string, data json.RawMessage, opts PageOptions) str
 }
 
 // JSON renders an arbitrary JSON value within the MCP result budget. Small
-// results pass through unchanged; oversized arrays become bounded list
-// envelopes before falling back to a preview envelope.
+// results pass through unchanged; oversized arrays and single-array objects
+// become bounded list envelopes before falling back to a preview envelope. The
+// object path preserves metadata fields such as count/status while truncating
+// the large array field.
 func JSON(v any) (string, error) {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {

--- a/internal/generator/templates/mcp_bound.go.tmpl
+++ b/internal/generator/templates/mcp_bound.go.tmpl
@@ -124,6 +124,11 @@ func JSON(v any) (string, error) {
 			return string(boundedListEnvelope("items", items, len(compact), jsonResultNote)), nil
 		}
 	}
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		if out, ok := boundedSingleArrayObjectWithNote(compact, jsonResultNote); ok {
+			return string(out), nil
+		}
+	}
 	return previewEnvelope(compact, jsonResultNote), nil
 }
 
@@ -138,6 +143,10 @@ func Text(out string) string {
 }
 
 func boundedSingleArrayObject(data json.RawMessage) ([]byte, bool) {
+	return boundedSingleArrayObjectWithNote(data, endpointListNote)
+}
+
+func boundedSingleArrayObjectWithNote(data json.RawMessage, note string) ([]byte, bool) {
 	var obj map[string]json.RawMessage
 	if json.Unmarshal(data, &obj) != nil {
 		return nil, false
@@ -178,7 +187,7 @@ func boundedSingleArrayObject(data json.RawMessage) ([]byte, bool) {
 			out["_pp_returned_count"] = len(subset)
 			out["_pp_original_bytes"] = len(data)
 			out["_pp_max_bytes"] = MaxBytes
-			out["_pp_note"] = endpointListNote
+			out["_pp_note"] = note
 		}
 		return out
 	}

--- a/internal/generator/templates/mcp_bound_test.go.tmpl
+++ b/internal/generator/templates/mcp_bound_test.go.tmpl
@@ -449,6 +449,47 @@ func TestJSONBoundsLargeArrays(t *testing.T) {
 	}
 }
 
+func TestJSONBoundsSingleArrayObject(t *testing.T) {
+	results := make([]map[string]string, 0, MaxItems+25)
+	for i := 0; i < MaxItems+25; i++ {
+		results = append(results, map[string]string{
+			"id":      "row-" + strconv.Itoa(i),
+			"payload": strings.Repeat("result payload ", 160),
+		})
+	}
+
+	text, err := JSON(map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": "ready",
+		"resumable":    false,
+	})
+	if err != nil {
+		t.Fatalf("JSON returned error: %v", err)
+	}
+	if len(text) > MaxBytes {
+		t.Fatalf("bounded result length = %d, want <= %d", len(text), MaxBytes)
+	}
+	var envelope struct {
+		Results       []json.RawMessage `json:"results"`
+		StoreStatus   string            `json:"store_status"`
+		Truncated     bool              `json:"_pp_truncated"`
+		ReturnedCount int               `json:"_pp_returned_count"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("bounded single-array object must remain valid JSON: %v\n%s", err, text)
+	}
+	if !envelope.Truncated {
+		t.Fatalf("bounded single-array object did not mark truncation: %s", text)
+	}
+	if envelope.StoreStatus != "ready" {
+		t.Fatalf("store_status = %q, want preserved metadata", envelope.StoreStatus)
+	}
+	if envelope.ReturnedCount != len(envelope.Results) {
+		t.Fatalf("returned_count = %d, want result count %d", envelope.ReturnedCount, len(envelope.Results))
+	}
+}
+
 func TestJSONReturnsCompactFullArrayWhenIndentedOutputExceedsBudget(t *testing.T) {
 	rows := make([]map[string]string, 11000)
 

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -773,6 +773,13 @@ func mcpDBPath() (string, error) {
 
 {{- if or .VisionSet.Search .VisionSet.Store}}
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -791,15 +798,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run {{.Name}}-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -843,7 +850,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -854,10 +861,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -1077,7 +1083,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -1089,10 +1095,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -18,6 +18,9 @@ import (
 {{- if $hasFormRequest}}
 	"net/url"
 {{- end}}
+{{- if or .VisionSet.Search .VisionSet.Store}}
+	"os"
+{{- end}}
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -31,7 +34,7 @@ import (
 	"{{modulePath}}/internal/config"
 	"{{modulePath}}/internal/mcp/bound"
 	"{{modulePath}}/internal/mcp/cobratree"
-{{- if .VisionSet.Store}}
+{{- if or .VisionSet.Search .VisionSet.Store}}
 	"{{modulePath}}/internal/store"
 {{- end}}
 )
@@ -768,6 +771,42 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+{{- if or .VisionSet.Search .VisionSet.Store}}
+
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run {{.Name}}-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run {{.Name}}-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run {{.Name}}-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+{{- end}}
+
 {{- if .VisionSet.Search}}
 
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -786,9 +825,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -796,8 +835,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 {{- end}}
 
@@ -968,15 +1032,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -1005,8 +1069,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='{{firstResource .Resources}}', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 {{- end}}
 

--- a/internal/generator/templates/mcp_tools_test.go.tmpl
+++ b/internal/generator/templates/mcp_tools_test.go.tmpl
@@ -4,6 +4,9 @@
 package mcp
 
 import (
+{{- if or .VisionSet.Search .VisionSet.Store}}
+	"context"
+{{- end}}
 	"encoding/json"
 	"path/filepath"
 	"strings"
@@ -12,6 +15,9 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/mcp/bound"
+{{- if or .VisionSet.Search .VisionSet.Store}}
+	"{{modulePath}}/internal/store"
+{{- end}}
 )
 
 func TestMCPPathResolutionMatchesCLIResolverWithHomeEnv(t *testing.T) {
@@ -89,6 +95,189 @@ func resetMCPPathEnv(t *testing.T) string {
 	t.Cleanup(restore)
 	return home
 }
+
+{{- if .VisionSet.Search}}
+
+func TestMCPSearchMissingStoreIsActionable(t *testing.T) {
+	resetMCPPathEnv(t)
+
+	result, err := handleSearch(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "alpha"},
+	}})
+	if err != nil {
+		t.Fatalf("handleSearch returned transport error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("handleSearch missing store IsError = %v, want true", result != nil && result.IsError)
+	}
+	text := mcpTextContent(t, result)
+	for _, want := range []string{"No local data store found", "data.db", "Run", "sync"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing-store error %q missing %q", text, want)
+		}
+	}
+}
+
+func TestMCPSearchEmptyStoreReturnsActionableEnvelope(t *testing.T) {
+	resetMCPPathEnv(t)
+	path, err := mcpDBPath()
+	if err != nil {
+		t.Fatalf("mcpDBPath() error = %v", err)
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("creating empty store: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing empty store: %v", err)
+	}
+
+	result, err := handleSearch(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "alpha"},
+	}})
+	if err != nil {
+		t.Fatalf("handleSearch returned transport error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleSearch empty store IsError = %v, want false", result != nil && result.IsError)
+	}
+	text := mcpTextContent(t, result)
+	if len(text) > bound.MaxBytes {
+		t.Fatalf("empty-store envelope length = %d, want <= %d", len(text), bound.MaxBytes)
+	}
+	var envelope struct {
+		Count       int               `json:"count"`
+		Results     []json.RawMessage `json:"results"`
+		StoreStatus string            `json:"store_status"`
+		Resumable   bool              `json:"resumable"`
+		NextStep    string            `json:"next_step"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("empty-store result must be valid JSON: %v\n%s", err, text)
+	}
+	if envelope.Count != 0 || len(envelope.Results) != 0 {
+		t.Fatalf("empty-store envelope returned rows: %s", text)
+	}
+	if envelope.StoreStatus != "empty" {
+		t.Fatalf("store_status = %q, want empty in %s", envelope.StoreStatus, text)
+	}
+	if envelope.Resumable {
+		t.Fatalf("empty-store envelope should not claim cursor support: %s", text)
+	}
+	if !strings.Contains(envelope.NextStep, "sync") {
+		t.Fatalf("empty-store next_step should mention sync: %s", text)
+	}
+}
+{{- end}}
+
+{{- if .VisionSet.Store}}
+
+func TestMCPSQLMissingStoreIsActionable(t *testing.T) {
+	resetMCPPathEnv(t)
+
+	result, err := handleSQL(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "SELECT 1"},
+	}})
+	if err != nil {
+		t.Fatalf("handleSQL returned transport error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("handleSQL missing store IsError = %v, want true", result != nil && result.IsError)
+	}
+	text := mcpTextContent(t, result)
+	for _, want := range []string{"No local data store found", "data.db", "Run", "sync"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing-store error %q missing %q", text, want)
+		}
+	}
+}
+
+func TestMCPSQLEmptyStoreReturnsActionableEnvelope(t *testing.T) {
+	resetMCPPathEnv(t)
+	path, err := mcpDBPath()
+	if err != nil {
+		t.Fatalf("mcpDBPath() error = %v", err)
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("creating empty store: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing empty store: %v", err)
+	}
+
+	result, err := handleSQL(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "SELECT * FROM resources"},
+	}})
+	if err != nil {
+		t.Fatalf("handleSQL returned transport error: %v", err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("handleSQL empty store IsError = %v, want false", result != nil && result.IsError)
+	}
+	text := mcpTextContent(t, result)
+	if len(text) > bound.MaxBytes {
+		t.Fatalf("empty-store envelope length = %d, want <= %d", len(text), bound.MaxBytes)
+	}
+	var envelope struct {
+		Count       int                `json:"count"`
+		Rows        []map[string]any   `json:"rows"`
+		Columns     []string           `json:"columns"`
+		StoreStatus string             `json:"store_status"`
+		Resumable   bool               `json:"resumable"`
+		NextStep    string             `json:"next_step"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		t.Fatalf("empty-store SQL result must be valid JSON: %v\n%s", err, text)
+	}
+	if envelope.Count != 0 || len(envelope.Rows) != 0 {
+		t.Fatalf("empty-store SQL envelope returned rows: %s", text)
+	}
+	if len(envelope.Columns) == 0 {
+		t.Fatalf("empty-store SQL envelope should preserve columns: %s", text)
+	}
+	if envelope.StoreStatus != "empty" {
+		t.Fatalf("store_status = %q, want empty in %s", envelope.StoreStatus, text)
+	}
+	if envelope.Resumable {
+		t.Fatalf("empty-store SQL envelope should not claim cursor support: %s", text)
+	}
+	if !strings.Contains(envelope.NextStep, "sync") {
+		t.Fatalf("empty-store SQL next_step should mention sync: %s", text)
+	}
+}
+
+func TestMCPSQLDomainTableMismatchIsActionable(t *testing.T) {
+	resetMCPPathEnv(t)
+	path, err := mcpDBPath()
+	if err != nil {
+		t.Fatalf("mcpDBPath() error = %v", err)
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("creating empty store: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing empty store: %v", err)
+	}
+
+	result, err := handleSQL(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "SELECT * FROM widgets"},
+	}})
+	if err != nil {
+		t.Fatalf("handleSQL returned transport error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("handleSQL domain-table mismatch IsError = %v, want true", result != nil && result.IsError)
+	}
+	text := mcpTextContent(t, result)
+	for _, want := range []string{"resources(resource_type, id, data)", "resource_type", "json_extract", "widgets"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("domain-table mismatch error %q missing %q", text, want)
+		}
+	}
+}
+{{- end}}
 
 // TestValidateReadOnlyQuery_AllowsSelectAndWITH pins the contract: the MCP
 // sql tool's allowlist accepts SELECT and WITH-prefix queries, including

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -421,6 +421,13 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -439,15 +446,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run fastapi-operationids-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -488,7 +495,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -499,10 +506,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -719,7 +725,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -731,10 +737,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -420,6 +421,39 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run fastapi-operationids-golden-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run fastapi-operationids-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run fastapi-operationids-golden-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -436,9 +470,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -446,8 +480,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
@@ -615,15 +674,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -652,8 +711,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='health', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 
 // toolResultJSON renders v as the indented JSON body of an MCP text result,

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -365,6 +366,39 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run printing-press-rich-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run printing-press-rich-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run printing-press-rich-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -381,9 +415,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -391,8 +425,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
@@ -560,15 +619,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -597,8 +656,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='items', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 
 // toolResultJSON renders v as the indented JSON body of an MCP text result,

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/mcp/tools.go
@@ -366,6 +366,13 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -384,15 +391,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run printing-press-rich-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -433,7 +440,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -444,10 +451,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -664,7 +670,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -676,10 +682,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -520,6 +521,39 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run printing-press-golden-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run printing-press-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run printing-press-golden-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -536,9 +570,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -546,8 +580,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
@@ -715,15 +774,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -752,8 +811,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='currencies', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 
 // toolResultJSON renders v as the indented JSON body of an MCP text result,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/tools.go
@@ -521,6 +521,13 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -539,15 +546,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run printing-press-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -588,7 +595,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -599,10 +606,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -819,7 +825,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -831,10 +837,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -359,6 +360,39 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run mcp-cloudflare-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run mcp-cloudflare-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run mcp-cloudflare-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -375,9 +409,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -385,8 +419,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
@@ -554,15 +613,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -591,8 +650,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='items', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 
 // toolResultJSON renders v as the indented JSON body of an MCP text result,

--- a/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-mcp-api/mcp-cloudflare/internal/mcp/tools.go
@@ -360,6 +360,13 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -378,15 +385,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run mcp-cloudflare-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -427,7 +434,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -438,10 +445,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -658,7 +664,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -670,10 +676,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -385,6 +386,39 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, mcplib.NewToolResultError(mcpMissingStoreMessage(path))
+		}
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("checking local data store %s: %v", path, err))
+	}
+	db, err := store.OpenReadOnly(path)
+	if err != nil {
+		return nil, mcplib.NewToolResultError(fmt.Sprintf("opening local data store %s: %v. Run tier-routing-golden-pp-cli sync to refresh the store, or use live endpoint MCP tools for unsynced data.", path, err))
+	}
+	return db, nil
+}
+
+func mcpMissingStoreMessage(path string) string {
+	return fmt.Sprintf("No local data store found at %s. Run tier-routing-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
+}
+
+func mcpStoreStatus(db *store.Store) (string, error) {
+	status, err := db.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) == 0 {
+		return "empty", nil
+	}
+	return "ready", nil
+}
+
+func mcpEmptyStoreNextStep() string {
+	return "Run tier-routing-golden-pp-cli sync to populate the local SQLite store before using MCP search/sql."
+}
+
 func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 	args := req.GetArguments()
 	query, ok := args["query"].(string)
@@ -401,9 +435,9 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
@@ -411,8 +445,33 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
+}
+
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+	if results == nil {
+		results = []json.RawMessage{}
+	}
+	out := map[string]any{
+		"count":        len(results),
+		"results":      results,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(results) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
+		}
+	}
+	return out
 }
 
 // validateReadOnlyQuery gates the MCP sql tool. The agent contract advertised
@@ -580,15 +639,15 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("resolving database: %v", err)), nil
 	}
-	db, err := store.OpenReadOnly(path)
-	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("opening database: %v", err)), nil
+	db, toolErr := openMCPReadOnlyStore(path)
+	if toolErr != nil {
+		return toolErr, nil
 	}
 	defer db.Close()
 
 	rows, err := db.DB().QueryContext(ctx, query)
 	if err != nil {
-		return mcplib.NewToolResultError(fmt.Sprintf("query failed: %v", err)), nil
+		return mcplib.NewToolResultError(mcpSQLQueryError(err)), nil
 	}
 	defer rows.Close()
 
@@ -617,8 +676,42 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	if err := rows.Err(); err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("reading rows: %v", err)), nil
 	}
+	storeStatus, err := mcpStoreStatus(db)
+	if err != nil {
+		return mcplib.NewToolResultError(fmt.Sprintf("reading store status: %v", err)), nil
+	}
 
-	return toolResultJSON(results)
+	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
+}
+
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	out := map[string]any{
+		"count":        len(rows),
+		"columns":      columns,
+		"rows":         rows,
+		"store_status": storeStatus,
+		"resumable":    false,
+	}
+	if len(rows) == 0 {
+		switch storeStatus {
+		case "empty":
+			out["next_step"] = mcpEmptyStoreNextStep()
+		default:
+			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
+		}
+	}
+	return out
+}
+
+func mcpSQLQueryError(err error) string {
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "no such table") {
+		return fmt.Sprintf("query failed: %v. Synced records live in resources(resource_type, id, data), not one SQL table per resource. Filter by resource_type, for example resource_type='items', and read JSON fields with json_extract(data,'$.field').", err)
+	}
+	return fmt.Sprintf("query failed: %v", err)
 }
 
 // toolResultJSON renders v as the indented JSON body of an MCP text result,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/mcp/tools.go
@@ -386,6 +386,13 @@ func mcpDBPath() (string, error) {
 	return filepath.Join(dir, "data.db"), nil
 }
 
+type mcpStoreStatusKind string
+
+const (
+	mcpStoreStatusEmpty mcpStoreStatusKind = "empty"
+	mcpStoreStatusReady mcpStoreStatusKind = "ready"
+)
+
 func openMCPReadOnlyStore(path string) (*store.Store, *mcplib.CallToolResult) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -404,15 +411,15 @@ func mcpMissingStoreMessage(path string) string {
 	return fmt.Sprintf("No local data store found at %s. Run tier-routing-golden-pp-cli sync before using MCP search/sql, or use live endpoint MCP tools for unsynced data.", path)
 }
 
-func mcpStoreStatus(db *store.Store) (string, error) {
+func mcpStoreStatus(db *store.Store) (mcpStoreStatusKind, error) {
 	status, err := db.Status()
 	if err != nil {
 		return "", err
 	}
 	if len(status) == 0 {
-		return "empty", nil
+		return mcpStoreStatusEmpty, nil
 	}
-	return "ready", nil
+	return mcpStoreStatusReady, nil
 }
 
 func mcpEmptyStoreNextStep() string {
@@ -453,7 +460,7 @@ func handleSearch(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.Call
 	return toolResultJSON(mcpSearchEnvelope(results, storeStatus))
 }
 
-func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string]any {
+func mcpSearchEnvelope(results []json.RawMessage, storeStatus mcpStoreStatusKind) map[string]any {
 	if results == nil {
 		results = []json.RawMessage{}
 	}
@@ -464,10 +471,9 @@ func mcpSearchEnvelope(results []json.RawMessage, storeStatus string) map[string
 		"resumable":    false,
 	}
 	if len(results) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "No local search matches. Try a broader query, a lower-specificity FTS expression, or sync again if data may be stale."
 		}
 	}
@@ -684,7 +690,7 @@ func handleSQL(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToo
 	return toolResultJSON(mcpSQLEnvelope(results, cols, storeStatus))
 }
 
-func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string) map[string]any {
+func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus mcpStoreStatusKind) map[string]any {
 	if rows == nil {
 		rows = []map[string]any{}
 	}
@@ -696,10 +702,9 @@ func mcpSQLEnvelope(rows []map[string]any, columns []string, storeStatus string)
 		"resumable":    false,
 	}
 	if len(rows) == 0 {
-		switch storeStatus {
-		case "empty":
+		if storeStatus == mcpStoreStatusEmpty {
 			out["next_step"] = mcpEmptyStoreNextStep()
-		default:
+		} else {
 			out["next_step"] = "The read-only SQL query returned no rows. Check resource_type filters, json_extract paths, or run sync again if data may be stale."
 		}
 	}


### PR DESCRIPTION
## Summary

MCP `search` and `sql` now give agents bounded, actionable store responses instead of raw `null`/array payloads or low-level SQLite open errors. Missing stores explain how to run `sync` or fall back to live endpoint tools, empty stores return structured envelopes with `store_status` and `next_step`, and SQL table-name mistakes now point agents at the canonical `resources(resource_type, id, data)` shape with `json_extract` guidance.

This closes #3099 as the store-backed MCP slice of #3090. It deliberately does not solve the neighboring CLI-output and agent-mode work tracked by #3089/#3205, #3171, or #3212/#3213; it also leaves true keyset/cursor pagination for store reads out of scope because arbitrary SQL and FTS search do not have a safe stable continuation contract yet.

## What Changed

- Store-backed MCP `search`/`sql` now share a read-only opener that preflights the local `data.db` path and returns human-actionable MCP tool errors for missing or unreadable stores.
- `search` now returns an envelope with `count`, `results`, `store_status`, `resumable: false`, and `next_step` for empty/no-match cases.
- `sql` now returns an envelope with `count`, `columns`, `rows`, `store_status`, `resumable: false`, and `next_step` for empty/no-row cases.
- SQL `no such table` errors now explain that synced records live in `resources(resource_type, id, data)`, not one table per domain resource.
- `bound.JSON` now bounds oversized single-array JSON objects so the new envelopes preserve metadata while staying under the MCP response budget.

## Verification

- `go test ./internal/generator -run TestGenerateMCPStoreGuidanceTestsPass -count=1`
- `go test ./internal/generator -run 'TestGenerateMCPStoreGuidanceTestsPass|TestGenerateMCPSharedBoundPackageAndConsumers|TestGenerateMCPToolResultTextBudgetTestsPass|TestGenerateMCPToolsUseOpaqueCursorForResumableListEndpoints|TestGenerateMCPSQLToolUsesReadOnlyStore|TestGenerateMCPSQLToolSurfacesRowErrors' -count=1`
- `go test ./internal/generator -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-mcp-api generate-tier-routing-api generate-fastapi-operationids`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `go test ./internal/pipeline -run TestRunLiveDogfoodProcessRetriesTransientAuth401 -count=1`
- `go test ./...` final pass after rerunning a transient `internal/pipeline` 5s timeout

Closes #3099.
Part of #3090.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
