### PR TITLE
fix(cli): honor output format flags across generated commands

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -18069,18 +18069,18 @@ func TestSearchTemplateEmitsEmptyJSONEnvelope(t *testing.T) {
 	require.NoError(t, err)
 	body := string(data)
 
-	assert.Contains(t, body, `jsonMode := flags.asJSON || !isTerminal(cmd.OutOrStdout())`,
-		"search.go.tmpl must compute jsonMode so the envelope path runs even on no matches")
+	assert.Contains(t, body, `wantsMachineOutput(flags) || !wantsHumanTable(cmd.OutOrStdout(), flags)`,
+		"search.go.tmpl must route explicit machine formats and default piped output through the envelope path even on no matches")
 
-	// Ordering pin: the jsonMode block must come before the human-mode
+	// Ordering pin: the machine/piped block must come before the human-mode
 	// "No results" stderr line. Reversing the order would skip the JSON
 	// envelope on empty results — the original failure mode.
-	jsonModeIdx := strings.Index(body, "jsonMode := flags.asJSON")
+	machineModeIdx := strings.Index(body, "wantsMachineOutput(flags) || !wantsHumanTable")
 	noResultsIdx := strings.Index(body, `"No results (source: %s)\n"`)
-	require.GreaterOrEqual(t, jsonModeIdx, 0)
+	require.GreaterOrEqual(t, machineModeIdx, 0)
 	require.GreaterOrEqual(t, noResultsIdx, 0)
-	assert.Less(t, jsonModeIdx, noResultsIdx,
-		"jsonMode check must come before the human-mode 'No results' stderr line; otherwise the JSON-envelope path is skipped on empty results")
+	assert.Less(t, machineModeIdx, noResultsIdx,
+		"machine/piped check must come before the human-mode 'No results' stderr line; otherwise the JSON-envelope path is skipped on empty results")
 }
 
 // TestStoreSkipsDeadTablesForResourcesWithoutTypedUpsert pins the gate that

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -18069,13 +18069,13 @@ func TestSearchTemplateEmitsEmptyJSONEnvelope(t *testing.T) {
 	require.NoError(t, err)
 	body := string(data)
 
-	assert.Contains(t, body, `wantsMachineOutput(flags) || !wantsHumanTable(cmd.OutOrStdout(), flags)`,
+	assert.Contains(t, body, `!wantsHumanTable(cmd.OutOrStdout(), flags)`,
 		"search.go.tmpl must route explicit machine formats and default piped output through the envelope path even on no matches")
 
 	// Ordering pin: the machine/piped block must come before the human-mode
 	// "No results" stderr line. Reversing the order would skip the JSON
 	// envelope on empty results — the original failure mode.
-	machineModeIdx := strings.Index(body, "wantsMachineOutput(flags) || !wantsHumanTable")
+	machineModeIdx := strings.Index(body, "!wantsHumanTable(cmd.OutOrStdout(), flags)")
 	noResultsIdx := strings.Index(body, `"No results (source: %s)\n"`)
 	require.GreaterOrEqual(t, machineModeIdx, 0)
 	require.GreaterOrEqual(t, noResultsIdx, 0)

--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -1,0 +1,105 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedHelpersHonorPlainAndHumanFriendlyFlags(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("output-flags")
+	outputDir := filepath.Join(t.TempDir(), "output-flags-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "output_flags_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPrintOutputWithFlagsPlainRendersTSV(t *testing.T) {
+	data := json.RawMessage("[{\"id\":\"one\",\"name\":\"Alpha\"},{\"id\":\"two\",\"name\":\"Beta\"}]")
+	var out bytes.Buffer
+
+	if err := printOutputWithFlags(&out, data, &rootFlags{plain: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "id\tname\n") || !strings.Contains(got, "one\tAlpha\n") || !strings.Contains(got, "two\tBeta\n") {
+		t.Fatalf("--plain should render tab-separated rows, got %q", got)
+	}
+	if strings.Contains(got, "{") || strings.Contains(got, "[") {
+		t.Fatalf("--plain should not fall back to JSON for arrays, got %q", got)
+	}
+}
+
+func TestHumanFriendlyForcesTableAndNoColorStripsANSI(t *testing.T) {
+	oldHumanFriendly, oldNoColor := humanFriendly, noColor
+	humanFriendly, noColor = true, false
+	t.Cleanup(func() {
+		humanFriendly, noColor = oldHumanFriendly, oldNoColor
+	})
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+
+	if !wantsHumanTable(&bytes.Buffer{}, &rootFlags{}) {
+		t.Fatalf("--human-friendly should force human table rendering even when stdout is not a terminal")
+	}
+	if !colorEnabled() {
+		t.Fatalf("--human-friendly should enable color when --no-color/NO_COLOR/TERM=dumb are absent")
+	}
+
+	rows := []map[string]any{{"id": "one", "name": "Alpha"}}
+	var colored bytes.Buffer
+	if err := printAutoTable(&colored, rows); err != nil {
+		t.Fatalf("printAutoTable returned error: %v", err)
+	}
+	if !strings.Contains(colored.String(), "\x1b[1m") {
+		t.Fatalf("--human-friendly should enable ANSI table styling, got %q", colored.String())
+	}
+
+	noColor = true
+	var plain bytes.Buffer
+	if err := printAutoTable(&plain, rows); err != nil {
+		t.Fatalf("printAutoTable returned error: %v", err)
+	}
+	if strings.Contains(plain.String(), "\x1b[") {
+		t.Fatalf("--no-color should strip ANSI styling, got %q", plain.String())
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestHumanFriendlyForcesTableAndNoColorStripsANSI", "-count=1")
+}
+
+func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		filepath.Join("templates", "analytics.go.tmpl"),
+		filepath.Join("templates", "search.go.tmpl"),
+		filepath.Join("templates", "workflows", "pm_load.go.tmpl"),
+		filepath.Join("templates", "workflows", "pm_orphans.go.tmpl"),
+		filepath.Join("templates", "workflows", "pm_stale.go.tmpl"),
+	} {
+		body, err := os.ReadFile(path)
+		require.NoError(t, err, "template must exist: %s", path)
+		src := string(body)
+
+		require.Contains(t, src, "wantsMachineOutput(flags)",
+			"%s must route --json/--csv/--quiet/--plain/--compact/--select through the shared output contract", path)
+		require.NotContains(t, src, "if flags.asJSON {",
+			"%s still branches only on --json, so other documented output flags can be bypassed", path)
+		require.NotContains(t, src, "flags.asJSON || !isTerminal",
+			"%s still lets piped auto-JSON override explicit machine format flags", path)
+	}
+}

--- a/internal/generator/output_flags_contract_test.go
+++ b/internal/generator/output_flags_contract_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,18 @@ func TestPrintOutputWithFlagsPlainRendersTSV(t *testing.T) {
 	}
 }
 
+func TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty(t *testing.T) {
+	data := json.RawMessage("[]")
+	var out bytes.Buffer
+
+	if err := printOutputWithFlags(&out, data, &rootFlags{plain: true}); err != nil {
+		t.Fatalf("printOutputWithFlags returned error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("--plain should render empty arrays as an empty stream, got %q", got)
+	}
+}
+
 func TestHumanFriendlyForcesTableAndNoColorStripsANSI(t *testing.T) {
 	oldHumanFriendly, oldNoColor := humanFriendly, noColor
 	humanFriendly, noColor = true, false
@@ -78,7 +91,7 @@ func TestHumanFriendlyForcesTableAndNoColorStripsANSI(t *testing.T) {
 }
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestHumanFriendlyForcesTableAndNoColorStripsANSI", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintOutputWithFlagsPlainRendersTSV|TestPrintOutputWithFlagsPlainEmptyArrayIsEmpty|TestHumanFriendlyForcesTableAndNoColorStripsANSI", "-count=1")
 }
 
 func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T) {
@@ -86,7 +99,6 @@ func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T
 
 	for _, path := range []string{
 		filepath.Join("templates", "analytics.go.tmpl"),
-		filepath.Join("templates", "search.go.tmpl"),
 		filepath.Join("templates", "workflows", "pm_load.go.tmpl"),
 		filepath.Join("templates", "workflows", "pm_orphans.go.tmpl"),
 		filepath.Join("templates", "workflows", "pm_stale.go.tmpl"),
@@ -102,4 +114,23 @@ func TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate(t *testing.T
 		require.NotContains(t, src, "flags.asJSON || !isTerminal",
 			"%s still lets piped auto-JSON override explicit machine format flags", path)
 	}
+
+	searchPath := filepath.Join("templates", "search.go.tmpl")
+	body, err := os.ReadFile(searchPath)
+	require.NoError(t, err, "template must exist: %s", searchPath)
+	src := string(body)
+	require.Contains(t, src, "!wantsHumanTable(cmd.OutOrStdout(), flags)",
+		"search.go.tmpl must route explicit machine formats and default piped output through the shared output contract")
+	require.Contains(t, src, "outputFlags := *flags",
+		"search.go.tmpl must clear row-shaping flags after applying them before provenance wrapping")
+	selectIdx := strings.Index(src, "data = filterFields(data, flags.selectFields)")
+	wrapIdx := strings.Index(src, "wrapped, err := wrapWithProvenance(data, prov)")
+	require.GreaterOrEqual(t, selectIdx, 0)
+	require.GreaterOrEqual(t, wrapIdx, 0)
+	require.Less(t, selectIdx, wrapIdx,
+		"search.go.tmpl must apply --select to the result array before wrapping it in the provenance envelope")
+	require.NotContains(t, src, "if flags.asJSON {",
+		"search.go.tmpl still branches only on --json, so other documented output flags can be bypassed")
+	require.NotContains(t, src, "flags.asJSON || !isTerminal",
+		"search.go.tmpl still lets piped auto-JSON override explicit machine format flags")
 }

--- a/internal/generator/templates/analytics.go.tmpl
+++ b/internal/generator/templates/analytics.go.tmpl
@@ -54,10 +54,24 @@ Data must be synced first with the sync command.`,
 				if err != nil {
 					return fmt.Errorf("getting status: %w", err)
 				}
-				if flags.asJSON {
-					enc := json.NewEncoder(out)
-					enc.SetIndent("", "  ")
-					return enc.Encode(status)
+				if wantsMachineOutput(flags) {
+					if flags.csv || flags.plain || flags.quiet {
+						type statusRow struct {
+							ResourceType string `json:"resource_type"`
+							Count        int    `json:"count"`
+						}
+						keys := make([]string, 0, len(status))
+						for rt := range status {
+							keys = append(keys, rt)
+						}
+						sort.Strings(keys)
+						rows := make([]statusRow, 0, len(keys))
+						for _, rt := range keys {
+							rows = append(rows, statusRow{ResourceType: rt, Count: status[rt]})
+						}
+						return printJSONFiltered(out, rows, flags)
+					}
+					return printJSONFiltered(out, status, flags)
 				}
 				fmt.Fprintln(out, "Resource Type\tCount")
 				fmt.Fprintln(out, "-------------\t-----")
@@ -76,11 +90,9 @@ Data must be synced first with the sync command.`,
 				return fmt.Errorf("counting: %w", err)
 			}
 
-			if flags.asJSON {
+			if wantsMachineOutput(flags) {
 				result := map[string]any{"resource_type": resourceType, "count": count}
-				enc := json.NewEncoder(out)
-				enc.SetIndent("", "  ")
-				return enc.Encode(result)
+				return printJSONFiltered(out, result, flags)
 			}
 
 			fmt.Fprintf(out, "%s: %d records\n", resourceType, count)
@@ -145,10 +157,8 @@ func runGroupBy(out io.Writer, db *store.Store, resourceType, field string, limi
 		sorted = sorted[:limit]
 	}
 
-	if flags.asJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(sorted)
+	if wantsMachineOutput(flags) {
+		return printJSONFiltered(out, sorted, flags)
 	}
 
 	fmt.Fprintf(out, "%s\tCount\n", field)

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1849,9 +1849,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 // printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object - just print as JSON
 		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -209,7 +209,7 @@ func colorEnabled() bool {
 	if os.Getenv("TERM") == "dumb" {
 		return false
 	}
-	return isTerminal(os.Stdout)
+	return true
 }
 
 func isTerminal(w io.Writer) bool {
@@ -1610,6 +1610,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	if flags.csv {
 		return printCSV(w, data)
 	}
+	// --plain: render arrays as tab-separated rows
+	if flags.plain {
+		return printPlain(w, data)
+	}
 	return printOutput(w, data, flags.asJSON)
 }
 
@@ -1842,6 +1846,53 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 	return nil
 }
 
+// printPlain renders JSON arrays as tab-separated text with a header row.
+func printPlain(w io.Writer, data json.RawMessage) error {
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
+		// Single object or empty - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	keySet := map[string]bool{}
+	for _, item := range items {
+		for k := range item {
+			keySet[k] = true
+		}
+	}
+	var keys []string
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	for _, item := range items {
+		var vals []string
+		for _, k := range keys {
+			vals = append(vals, plainCellValue(item[k]))
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+	return nil
+}
+
+func plainCellValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	var s string
+	if f, ok := v.(float64); ok {
+		s = strconv.FormatFloat(f, 'f', -1, 64)
+	} else {
+		s = fmt.Sprintf("%v", v)
+	}
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
 // printOutput auto-detects arrays and renders as tables, or prints raw JSON for objects.
 func printOutput(w io.Writer, data json.RawMessage, asJSON bool) error {
 	if !asJSON && !isTerminal(w) {
@@ -1944,16 +1995,21 @@ func suggestFlag(unknown string, cmd *cobra.Command) string {
 // wantsHumanTable returns true when output should be a human-friendly table.
 // Smart default: terminal=table, pipe=JSON.
 // - Human in terminal: isTerminal()=true → table
+// - --human-friendly: force human output, even when stdout is piped
 // - Claude Code/Codex bash tool: stdout piped → JSON
 // - --json/--csv/--compact/--agent: machine format → JSON
 func wantsHumanTable(w io.Writer, flags *rootFlags) bool {
-	if flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain {
+	if wantsMachineOutput(flags) {
 		return false
 	}
-	if flags.selectFields != "" {
-		return false
+	if humanFriendly {
+		return true
 	}
 	return isTerminal(w)
+}
+
+func wantsMachineOutput(flags *rootFlags) bool {
+	return flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain || flags.selectFields != ""
 }
 
 func printAutoTable(w io.Writer, items []map[string]any) error {

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -263,23 +263,23 @@ func outputSearchResults(cmd *cobra.Command, flags *rootFlags, results []json.Ra
 		results = results[:limit]
 	}
 
-	jsonMode := flags.asJSON || !isTerminal(cmd.OutOrStdout())
-
-	// JSON mode always emits a valid envelope, including on no matches —
-	// agents pipe stdout through json.loads / jq and need parseable output
-	// regardless of result count. The filtered slice is built via make
-	// above, so it's non-nil even when empty; json.Marshal renders that
-	// as `[]` rather than `null`.
-	if jsonMode {
+	// Machine/piped mode always emits a valid envelope, including on no
+	// matches — agents pipe stdout through json.loads / jq and need parseable
+	// output regardless of result count. Explicit row formats render the result
+	// array directly so --csv/--plain can produce real tabular output.
+	if wantsMachineOutput(flags) || !wantsHumanTable(cmd.OutOrStdout(), flags) {
 		data, err := json.Marshal(results)
 		if err != nil {
 			return err
+		}
+		if flags.csv || flags.plain || flags.quiet {
+			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		}
 		wrapped, err := wrapWithProvenance(data, prov)
 		if err != nil {
 			return err
 		}
-		return printOutput(cmd.OutOrStdout(), wrapped, true)
+		return printOutputWithFlags(cmd.OutOrStdout(), wrapped, flags)
 	}
 
 	if len(results) == 0 {

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -267,7 +267,7 @@ func outputSearchResults(cmd *cobra.Command, flags *rootFlags, results []json.Ra
 	// matches — agents pipe stdout through json.loads / jq and need parseable
 	// output regardless of result count. Explicit row formats render the result
 	// array directly so --csv/--plain can produce real tabular output.
-	if wantsMachineOutput(flags) || !wantsHumanTable(cmd.OutOrStdout(), flags) {
+	if !wantsHumanTable(cmd.OutOrStdout(), flags) {
 		data, err := json.Marshal(results)
 		if err != nil {
 			return err
@@ -275,11 +275,20 @@ func outputSearchResults(cmd *cobra.Command, flags *rootFlags, results []json.Ra
 		if flags.csv || flags.plain || flags.quiet {
 			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
 		}
+		outputFlags := *flags
+		if flags.selectFields != "" {
+			data = filterFields(data, flags.selectFields)
+			outputFlags.selectFields = ""
+			outputFlags.compact = false
+		} else if flags.compact {
+			data = compactFields(data)
+			outputFlags.compact = false
+		}
 		wrapped, err := wrapWithProvenance(data, prov)
 		if err != nil {
 			return err
 		}
-		return printOutputWithFlags(cmd.OutOrStdout(), wrapped, flags)
+		return printOutputWithFlags(cmd.OutOrStdout(), wrapped, &outputFlags)
 	}
 
 	if len(results) == 0 {

--- a/internal/generator/templates/workflows/pm_load.go.tmpl
+++ b/internal/generator/templates/workflows/pm_load.go.tmpl
@@ -144,29 +144,26 @@ person. Helps identify overloaded team members and unbalanced workload.`,
 			}
 			sort.Slice(entries, func(i, j int) bool { return entries[i].Count > entries[j].Count })
 
-			if flags.asJSON {
-				shown := entries
-				if limit > 0 && len(shown) > limit {
-					shown = shown[:limit]
+			shown := entries
+			if limit > 0 && len(shown) > limit {
+				shown = shown[:limit]
+			}
+
+			if wantsMachineOutput(flags) {
+				if flags.csv || flags.plain || flags.quiet {
+					return printJSONFiltered(cmd.OutOrStdout(), shown, flags)
 				}
 				result := map[string]any{
 					"total_count":  total,
 					"showing":      len(shown),
 					"distribution": shown,
 				}
-				enc := json.NewEncoder(cmd.OutOrStdout())
-				enc.SetIndent("", "  ")
-				return enc.Encode(result)
+				return printJSONFiltered(cmd.OutOrStdout(), result, flags)
 			}
 
 			if len(entries) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No items found. Run sync first.")
 				return nil
-			}
-
-			shown := entries
-			if limit > 0 && len(shown) > limit {
-				shown = shown[:limit]
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Workload Distribution (%d total items, showing %d):\n\n", total, len(shown))

--- a/internal/generator/templates/workflows/pm_orphans.go.tmpl
+++ b/internal/generator/templates/workflows/pm_orphans.go.tmpl
@@ -119,15 +119,16 @@ such as assignee, project, priority, or labels. Useful for triaging unowned work
 				items = items[:limit]
 			}
 
-			if flags.asJSON {
+			if wantsMachineOutput(flags) {
+				if flags.csv || flags.plain || flags.quiet {
+					return printJSONFiltered(cmd.OutOrStdout(), items, flags)
+				}
 				result := map[string]any{
 					"total_count": totalCount,
 					"showing":     len(items),
 					"items":       items,
 				}
-				enc := json.NewEncoder(cmd.OutOrStdout())
-				enc.SetIndent("", "  ")
-				return enc.Encode(result)
+				return printJSONFiltered(cmd.OutOrStdout(), result, flags)
 			}
 
 			if len(items) == 0 {

--- a/internal/generator/templates/workflows/pm_stale.go.tmpl
+++ b/internal/generator/templates/workflows/pm_stale.go.tmpl
@@ -227,15 +227,16 @@ the specified number of days. Useful for identifying forgotten or blocked work.`
 				})
 			}
 
-			if flags.asJSON {
+			if wantsMachineOutput(flags) {
+				if flags.csv || flags.plain || flags.quiet {
+					return printJSONFiltered(cmd.OutOrStdout(), items, flags)
+				}
 				result := map[string]any{
 					"total_count": totalCount,
 					"showing":     len(items),
 					"items":       items,
 				}
-				enc := json.NewEncoder(cmd.OutOrStdout())
-				enc.SetIndent("", "  ")
-				return enc.Encode(result)
+				return printJSONFiltered(cmd.OutOrStdout(), result, flags)
 			}
 
 			if len(items) == 0 {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -56,7 +56,7 @@ func colorEnabled() bool {
 	if os.Getenv("TERM") == "dumb" {
 		return false
 	}
-	return isTerminal(os.Stdout)
+	return true
 }
 
 func isTerminal(w io.Writer) bool {
@@ -1135,6 +1135,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	if flags.csv {
 		return printCSV(w, data)
 	}
+	// --plain: render arrays as tab-separated rows
+	if flags.plain {
+		return printPlain(w, data)
+	}
 	return printOutput(w, data, flags.asJSON)
 }
 
@@ -1337,6 +1341,53 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 	return nil
 }
 
+// printPlain renders JSON arrays as tab-separated text with a header row.
+func printPlain(w io.Writer, data json.RawMessage) error {
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
+		// Single object or empty - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	keySet := map[string]bool{}
+	for _, item := range items {
+		for k := range item {
+			keySet[k] = true
+		}
+	}
+	var keys []string
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	for _, item := range items {
+		var vals []string
+		for _, k := range keys {
+			vals = append(vals, plainCellValue(item[k]))
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+	return nil
+}
+
+func plainCellValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	var s string
+	if f, ok := v.(float64); ok {
+		s = strconv.FormatFloat(f, 'f', -1, 64)
+	} else {
+		s = fmt.Sprintf("%v", v)
+	}
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
 // printOutput auto-detects arrays and renders as tables, or prints raw JSON for objects.
 func printOutput(w io.Writer, data json.RawMessage, asJSON bool) error {
 	if !asJSON && !isTerminal(w) {
@@ -1439,16 +1490,21 @@ func suggestFlag(unknown string, cmd *cobra.Command) string {
 // wantsHumanTable returns true when output should be a human-friendly table.
 // Smart default: terminal=table, pipe=JSON.
 // - Human in terminal: isTerminal()=true → table
+// - --human-friendly: force human output, even when stdout is piped
 // - Claude Code/Codex bash tool: stdout piped → JSON
 // - --json/--csv/--compact/--agent: machine format → JSON
 func wantsHumanTable(w io.Writer, flags *rootFlags) bool {
-	if flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain {
+	if wantsMachineOutput(flags) {
 		return false
 	}
-	if flags.selectFields != "" {
-		return false
+	if humanFriendly {
+		return true
 	}
 	return isTerminal(w)
+}
+
+func wantsMachineOutput(flags *rootFlags) bool {
+	return flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain || flags.selectFields != ""
 }
 
 func printAutoTable(w io.Writer, items []map[string]any) error {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1344,9 +1344,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 // printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object - just print as JSON
 		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -55,7 +55,7 @@ func colorEnabled() bool {
 	if os.Getenv("TERM") == "dumb" {
 		return false
 	}
-	return isTerminal(os.Stdout)
+	return true
 }
 
 func isTerminal(w io.Writer) bool {
@@ -998,6 +998,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	if flags.csv {
 		return printCSV(w, data)
 	}
+	// --plain: render arrays as tab-separated rows
+	if flags.plain {
+		return printPlain(w, data)
+	}
 	return printOutput(w, data, flags.asJSON)
 }
 
@@ -1200,6 +1204,53 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 	return nil
 }
 
+// printPlain renders JSON arrays as tab-separated text with a header row.
+func printPlain(w io.Writer, data json.RawMessage) error {
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
+		// Single object or empty - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	keySet := map[string]bool{}
+	for _, item := range items {
+		for k := range item {
+			keySet[k] = true
+		}
+	}
+	var keys []string
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	for _, item := range items {
+		var vals []string
+		for _, k := range keys {
+			vals = append(vals, plainCellValue(item[k]))
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+	return nil
+}
+
+func plainCellValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	var s string
+	if f, ok := v.(float64); ok {
+		s = strconv.FormatFloat(f, 'f', -1, 64)
+	} else {
+		s = fmt.Sprintf("%v", v)
+	}
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
 // printOutput auto-detects arrays and renders as tables, or prints raw JSON for objects.
 func printOutput(w io.Writer, data json.RawMessage, asJSON bool) error {
 	if !asJSON && !isTerminal(w) {
@@ -1302,16 +1353,21 @@ func suggestFlag(unknown string, cmd *cobra.Command) string {
 // wantsHumanTable returns true when output should be a human-friendly table.
 // Smart default: terminal=table, pipe=JSON.
 // - Human in terminal: isTerminal()=true → table
+// - --human-friendly: force human output, even when stdout is piped
 // - Claude Code/Codex bash tool: stdout piped → JSON
 // - --json/--csv/--compact/--agent: machine format → JSON
 func wantsHumanTable(w io.Writer, flags *rootFlags) bool {
-	if flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain {
+	if wantsMachineOutput(flags) {
 		return false
 	}
-	if flags.selectFields != "" {
-		return false
+	if humanFriendly {
+		return true
 	}
 	return isTerminal(w)
+}
+
+func wantsMachineOutput(flags *rootFlags) bool {
+	return flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain || flags.selectFields != ""
 }
 
 func printAutoTable(w io.Writer, items []map[string]any) error {

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1207,9 +1207,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 // printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object - just print as JSON
 		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 70
+    "total": 73
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -1289,9 +1289,12 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 // printPlain renders JSON arrays as tab-separated text with a header row.
 func printPlain(w io.Writer, data json.RawMessage) error {
 	var items []map[string]any
-	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
-		// Single object or empty - just print as JSON
+	if err := json.Unmarshal(data, &items); err != nil {
+		// Single object - just print as JSON
 		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	if len(items) == 0 {
 		return nil
 	}
 	keySet := map[string]bool{}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -56,7 +56,7 @@ func colorEnabled() bool {
 	if os.Getenv("TERM") == "dumb" {
 		return false
 	}
-	return isTerminal(os.Stdout)
+	return true
 }
 
 func isTerminal(w io.Writer) bool {
@@ -1080,6 +1080,10 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 	if flags.csv {
 		return printCSV(w, data)
 	}
+	// --plain: render arrays as tab-separated rows
+	if flags.plain {
+		return printPlain(w, data)
+	}
 	return printOutput(w, data, flags.asJSON)
 }
 
@@ -1282,6 +1286,53 @@ func printCSV(w io.Writer, data json.RawMessage) error {
 	return nil
 }
 
+// printPlain renders JSON arrays as tab-separated text with a header row.
+func printPlain(w io.Writer, data json.RawMessage) error {
+	var items []map[string]any
+	if err := json.Unmarshal(data, &items); err != nil || len(items) == 0 {
+		// Single object or empty - just print as JSON
+		fmt.Fprintln(w, string(data))
+		return nil
+	}
+	keySet := map[string]bool{}
+	for _, item := range items {
+		for k := range item {
+			keySet[k] = true
+		}
+	}
+	var keys []string
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	for _, item := range items {
+		var vals []string
+		for _, k := range keys {
+			vals = append(vals, plainCellValue(item[k]))
+		}
+		fmt.Fprintln(w, strings.Join(vals, "\t"))
+	}
+	return nil
+}
+
+func plainCellValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	var s string
+	if f, ok := v.(float64); ok {
+		s = strconv.FormatFloat(f, 'f', -1, 64)
+	} else {
+		s = fmt.Sprintf("%v", v)
+	}
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
 // printOutput auto-detects arrays and renders as tables, or prints raw JSON for objects.
 func printOutput(w io.Writer, data json.RawMessage, asJSON bool) error {
 	if !asJSON && !isTerminal(w) {
@@ -1384,16 +1435,21 @@ func suggestFlag(unknown string, cmd *cobra.Command) string {
 // wantsHumanTable returns true when output should be a human-friendly table.
 // Smart default: terminal=table, pipe=JSON.
 // - Human in terminal: isTerminal()=true → table
+// - --human-friendly: force human output, even when stdout is piped
 // - Claude Code/Codex bash tool: stdout piped → JSON
 // - --json/--csv/--compact/--agent: machine format → JSON
 func wantsHumanTable(w io.Writer, flags *rootFlags) bool {
-	if flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain {
+	if wantsMachineOutput(flags) {
 		return false
 	}
-	if flags.selectFields != "" {
-		return false
+	if humanFriendly {
+		return true
 	}
 	return isTerminal(w)
+}
+
+func wantsMachineOutput(flags *rootFlags) bool {
+	return flags.asJSON || flags.csv || flags.compact || flags.quiet || flags.plain || flags.selectFields != ""
 }
 
 func printAutoTable(w io.Writer, items []map[string]any) error {


### PR DESCRIPTION
## Intent

Printed CLIs now honor the documented output-format flags across both generated endpoint commands and local analysis/search commands. Before this change, `--human-friendly` could not force human rendering in piped contexts, `--plain` fell back to JSON for array output, and local workflow renderers only checked `--json`, so `--csv`, `--plain`, `--quiet`, `--compact`, and `--select` could be bypassed.

Issue: Fixes #3176

## Approach

The generated helper layer now has one machine-output predicate for every documented machine-format flag and a real TSV renderer for `--plain`. `--human-friendly` forces the human table path and enables ANSI styling unless `--no-color`, `NO_COLOR`, or `TERM=dumb` disables it.

Local analysis and workflow templates now route explicit machine-format requests through `printJSONFiltered` / `printOutputWithFlags` instead of branching only on `--json`. Row-oriented formats such as `--csv` and `--plain` receive arrays where possible, while JSON-style formats retain the richer envelope/metadata shapes.

## Scope

Primary area: generator templates and generated helper goldens.

Why this belongs in this repo: this is systemic generated behavior. The audited symptoms appeared in printed CLIs, but the reusable Printing Press templates are what decide how future CLIs handle output flags.

## Catalog Justification

N/A

## Risk

This changes generated CLI output behavior for explicit format flags. The intended risk is that `--plain` now emits TSV for arrays instead of JSON and `--human-friendly` can produce styled human output even when stdout is not a terminal; `--no-color`, `NO_COLOR`, and `TERM=dumb` remain opt-outs for ANSI styling.

Generated helper goldens were updated, including the expected dogfood dead-function counter increase from the added plain-output helpers.

## Output Contract

Added a generated-runtime regression test that verifies `printOutputWithFlags(..., plain: true)` renders TSV rows and that `--human-friendly` forces table/color behavior while `--no-color` strips ANSI styling.

Added a template contract test that local analysis/search/workflow templates use `wantsMachineOutput(flags)` and no longer branch only on `if flags.asJSON {` or the stale `flags.asJSON || !isTerminal` gate.

Updated golden generated helpers for the affected fixture cases and re-ran generated-output compilation across 10 cases.

## Verification

- [x] `go fmt ./...`
- [x] `go test ./internal/generator -run 'TestGeneratedHelpersHonorPlainAndHumanFriendlyFlags|TestLocalAnalysisTemplatesRouteMachineFormatsThroughSharedGate|TestSearchTemplateEmitsEmptyJSONEnvelope' -count=1`
- [x] `go test ./internal/generator`
- [x] `go test ./...`
- [x] `scripts/golden.sh verify`
- [x] `scripts/verify-generator-output.sh`
- [x] `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- [x] `golangci-lint run ./...`
- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [ ] Fully automated: generated and submitted without human review for this specific change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
