### PR TITLE
fix(cli): project wrapped-array output

### DIFF
--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -466,6 +466,44 @@ func TestPaginatedGetStopsAtMaxPageSafetyLimitForBodyCursor(t *testing.T) {
 	}
 }
 
+func TestPaginatedGetMergesDomainSpecificWrappedArrayWithMetadataArrays(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{
+			"charges": [{"id":"ch_1","amount":10}],
+			"warnings": [{"code":"slow"}],
+			"cursor": "next-token"
+		}` + "`" + `),
+		json.RawMessage(` + "`" + `{
+			"charges": [{"id":"ch_2","amount":20}],
+			"warnings": [],
+			"cursor": null
+		}` + "`" + `),
+	}}
+	data, err := paginatedGet(context.Background(), client, "/charges", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", "cursor", "")
+	if err != nil {
+		t.Fatalf("paginatedGet returned error: %v", err)
+	}
+	if string(data) == "null" {
+		t.Fatalf("paginatedGet returned null for populated wrapped pages")
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal data: %v\n%s", err, data)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2; data=%s", len(got), data)
+	}
+	if got[0]["id"] != "ch_1" || got[1]["id"] != "ch_2" {
+		t.Fatalf("merged wrong collection: %#v", got)
+	}
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if client.params[1]["cursor"] != "next-token" {
+		t.Fatalf("second request cursor = %q, want next-token", client.params[1]["cursor"])
+	}
+}
+
 func containsAll(s string, needles ...string) bool {
 	for _, needle := range needles {
 		if !strings.Contains(s, needle) {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1281,9 +1281,11 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 
 	var onlyArray []json.RawMessage
 	arrayCount := 0
-	for _, raw := range obj {
-		var candidate []json.RawMessage
-		if json.Unmarshal(raw, &candidate) == nil {
+	for key, raw := range obj {
+		if envelopeMetadataArrayKeys[key] {
+			continue
+		}
+		if candidate, ok := extractPaginatedObjectArray(raw); ok {
 			onlyArray = candidate
 			arrayCount++
 		}
@@ -1292,6 +1294,27 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 		return onlyArray, true
 	}
 	return nil, false
+}
+
+// envelopeMetadataArrayKeys lists sidecar arrays that must not be mistaken for
+// a domain collection when projecting wrapped output or aggregating pages.
+var envelopeMetadataArrayKeys = map[string]bool{
+	"errors": true, "Errors": true,
+	"warnings": true, "Warnings": true,
+}
+
+func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
+	var items []json.RawMessage
+	// Empty fallback arrays are deliberately ignored: without an object item,
+	// there is no signal distinguishing a domain collection from metadata.
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		return nil, false
+	}
+	return items, true
 }
 
 {{- if .HasEmbeddedPaged}}
@@ -1538,21 +1561,8 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
 		// nil slice and would coerce to `[]`.
 		if !matchedAny {
-			pending := map[string]json.RawMessage{}
-			foundArray := false
-			for k, v := range obj {
-				var arr []json.RawMessage
-				if json.Unmarshal(v, &arr) == nil && arr != nil {
-					foundArray = true
-					pending[k] = filterFieldsRec(v, paths)
-				} else {
-					pending[k] = v
-				}
-			}
-			if foundArray {
-				for k, v := range pending {
-					filtered[k] = v
-				}
+			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+				filtered = pending
 			}
 		}
 		result, _ := json.Marshal(filtered)
@@ -1560,6 +1570,45 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 	}
 
 	return data
+}
+
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+	pending := map[string]json.RawMessage{}
+	foundArray := false
+	for k, v := range obj {
+		if envelopeMetadataArrayKeys[k] {
+			pending[k] = v
+			continue
+		}
+		var arr []json.RawMessage
+		if json.Unmarshal(v, &arr) == nil && arr != nil {
+			foundArray = true
+			pending[k] = filterFieldsRec(v, paths)
+			continue
+		}
+		if k == "_embedded" {
+			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+				foundArray = true
+				pending[k] = nested
+				continue
+			}
+		}
+		pending[k] = v
+	}
+	return pending, foundArray
+}
+
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	filtered, found := filterListEnvelopeFields(obj, paths)
+	if !found {
+		return nil, false
+	}
+	result, _ := json.Marshal(filtered)
+	return result, true
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.
@@ -1653,6 +1702,7 @@ func extractResponseData(data json.RawMessage) json.RawMessage {
 var compactVerboseListFields = map[string]bool{
 	"description": true, "body": true, "content": true,
 	"comments": true, "attachments": true, "html": true, "markdown": true,
+	"_links": true, "links": true,
 }
 
 // compactVerboseObjectFields are metadata fields stripped from single-object
@@ -1789,6 +1839,10 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObject(obj); ok {
+		result, _ := json.Marshal(compacted)
+		return result
+	}
 	compact := map[string]any{}
 	for k, v := range obj {
 		if !compactVerboseObjectFields[k] {
@@ -1797,6 +1851,58 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	}
 	result, _ := json.Marshal(compact)
 	return result
+}
+
+func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+	out := map[string]any{}
+	foundArray := false
+	for k, v := range obj {
+		if compactVerboseObjectFields[k] {
+			continue
+		}
+		if envelopeMetadataArrayKeys[k] {
+			out[k] = v
+			continue
+		}
+		if compacted, ok := compactObjectArrayValue(v); ok {
+			foundArray = true
+			out[k] = compacted
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
+			if compacted, ok := compactListEnvelopeObject(nested); ok {
+				foundArray = true
+				out[k] = compacted
+				continue
+			}
+		}
+		out[k] = v
+	}
+	if !foundArray {
+		return nil, false
+	}
+	return out, true
+}
+
+func compactObjectArrayValue(v any) (any, bool) {
+	rawItems, ok := v.([]any)
+	if !ok || len(rawItems) == 0 {
+		return nil, false
+	}
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	compactedRaw := compactListFields(items)
+	var compacted any
+	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
+		return nil, false
+	}
+	return compacted, true
 }
 
 // printCSV renders JSON arrays as CSV with header row.

--- a/internal/generator/wrapped_projection_test.go
+++ b/internal/generator/wrapped_projection_test.go
@@ -1,0 +1,187 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrappedArrayProjectionHelpers_EmittedRuntime(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("wrapped-projection")
+	outputDir := filepath.Join(t.TempDir(), "wrapped-projection-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "wrapped_projection_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func decodeObject(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("invalid object JSON: %v\n%s", err, raw)
+	}
+	return out
+}
+
+func TestCompactFieldsProjectsWrappedArrays(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"meta": {"total": 2},
+		"results": [
+			{"id":"a","name":"Alpha","description":"verbose","body":"payload","_links":{"self":"/a"}},
+			{"id":"b","name":"Beta","description":"verbose","body":"payload","_links":{"self":"/b"}}
+		]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	results, ok := got["results"].([]any)
+	if !ok || len(results) != 2 {
+		t.Fatalf("results = %#v, want two compacted items", got["results"])
+	}
+	first := results[0].(map[string]any)
+	if first["id"] != "a" || first["name"] != "Alpha" {
+		t.Fatalf("first compact row lost identity fields: %#v", first)
+	}
+	for _, key := range []string{"description", "body", "_links"} {
+		if _, ok := first[key]; ok {
+			t.Fatalf("compact wrapped item kept noisy %s field: %#v", key, first)
+		}
+	}
+	if _, ok := got["meta"].(map[string]any); !ok {
+		t.Fatalf("compact should preserve envelope metadata, got %#v", got)
+	}
+}
+
+func TestCompactFieldsProjectsDomainSpecificArrayWrapper(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"request_id": "req-1",
+		"widgets": [
+			{"widget_id":"w1","label":"One","description":"verbose"},
+			{"widget_id":"w2","label":"Two","description":"verbose"}
+		]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	widgets, ok := got["widgets"].([]any)
+	if !ok || len(widgets) != 2 {
+		t.Fatalf("widgets = %#v, want two compacted items", got["widgets"])
+	}
+	first := widgets[0].(map[string]any)
+	if first["widget_id"] != "w1" || first["label"] != "One" {
+		t.Fatalf("domain wrapper lost frequent identity fields: %#v", first)
+	}
+	if _, ok := first["description"]; ok {
+		t.Fatalf("domain wrapper kept verbose description: %#v", first)
+	}
+	if got["request_id"] != "req-1" {
+		t.Fatalf("compact should preserve scalar envelope metadata, got %#v", got["request_id"])
+	}
+}
+
+func TestCompactFieldsProjectsHALEmbeddedArrays(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"_embedded": {
+			"events": [
+				{"id":"evt-1","name":"Launch","description":"verbose","_links":{"self":{"href":"/events/evt-1"}}}
+			]
+		},
+		"_links": {"next": {"href": "/events?cursor=next"}}
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	embedded := got["_embedded"].(map[string]any)
+	events := embedded["events"].([]any)
+	first := events[0].(map[string]any)
+	if first["id"] != "evt-1" || first["name"] != "Launch" {
+		t.Fatalf("HAL embedded row lost identity fields: %#v", first)
+	}
+	for _, key := range []string{"description", "_links"} {
+		if _, ok := first[key]; ok {
+			t.Fatalf("HAL embedded compact row kept noisy %s field: %#v", key, first)
+		}
+	}
+}
+
+func TestCompactFieldsKeepsObjectBlocklistForDetailObjectsWithArrays(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"id": "issue-1",
+		"title": "Bug",
+		"description": "verbose metadata",
+		"body": "primary payload",
+		"comments": [
+			{"id":"comment-1","body":"verbose comment"}
+		]
+	}`+"`"+`)
+
+	got := decodeObject(t, compactFields(input))
+	if got["id"] != "issue-1" || got["title"] != "Bug" {
+		t.Fatalf("detail object lost identity fields: %#v", got)
+	}
+	if got["body"] != "primary payload" {
+		t.Fatalf("detail object should preserve primary body payload: %#v", got)
+	}
+	for _, key := range []string{"description", "comments"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("detail object kept object-path blocklisted %s field: %#v", key, got)
+		}
+	}
+}
+
+func TestSelectFieldsProjectsWrappedSidecarArrays(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"warnings": [{"code":"W1","message":"rate limited"}],
+		"results": [{"id":"evt-1","name":"Launch","description":"verbose"}]
+	}`+"`"+`)
+
+	got := decodeObject(t, filterFields(input, "id"))
+	warnings := got["warnings"].([]any)
+	warning := warnings[0].(map[string]any)
+	if warning["code"] != "W1" || warning["message"] != "rate limited" {
+		t.Fatalf("select should preserve sidecar warning fields: %#v", warning)
+	}
+	results := got["results"].([]any)
+	first := results[0].(map[string]any)
+	if first["id"] != "evt-1" {
+		t.Fatalf("select lost requested result id: %#v", first)
+	}
+	for _, key := range []string{"name", "description"} {
+		if _, ok := first[key]; ok {
+			t.Fatalf("select kept unrequested result %s field: %#v", key, first)
+		}
+	}
+}
+
+func TestSelectFieldsProjectsHALEmbeddedArrays(t *testing.T) {
+	input := json.RawMessage(`+"`"+`{
+		"_embedded": {
+			"events": [
+				{"id":"evt-1","name":"Launch","description":"verbose"}
+			]
+		},
+		"_links": {"next": {"href": "/events?cursor=next"}}
+	}`+"`"+`)
+
+	got := decodeObject(t, filterFields(input, "id,name"))
+	embedded := got["_embedded"].(map[string]any)
+	events := embedded["events"].([]any)
+	first := events[0].(map[string]any)
+	if first["id"] != "evt-1" || first["name"] != "Launch" {
+		t.Fatalf("HAL select lost requested fields: %#v", first)
+	}
+	if _, ok := first["description"]; ok {
+		t.Fatalf("HAL select kept unrequested description: %#v", first)
+	}
+}
+`), 0o644))
+
+	requireGeneratedCompiles(t, outputDir)
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCompactFieldsProjects|TestCompactFieldsKeeps|TestSelectFieldsProjects", "-count=1")
+}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -809,9 +809,11 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 
 	var onlyArray []json.RawMessage
 	arrayCount := 0
-	for _, raw := range obj {
-		var candidate []json.RawMessage
-		if json.Unmarshal(raw, &candidate) == nil {
+	for key, raw := range obj {
+		if envelopeMetadataArrayKeys[key] {
+			continue
+		}
+		if candidate, ok := extractPaginatedObjectArray(raw); ok {
 			onlyArray = candidate
 			arrayCount++
 		}
@@ -820,6 +822,27 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 		return onlyArray, true
 	}
 	return nil, false
+}
+
+// envelopeMetadataArrayKeys lists sidecar arrays that must not be mistaken for
+// a domain collection when projecting wrapped output or aggregating pages.
+var envelopeMetadataArrayKeys = map[string]bool{
+	"errors": true, "Errors": true,
+	"warnings": true, "Warnings": true,
+}
+
+func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
+	var items []json.RawMessage
+	// Empty fallback arrays are deliberately ignored: without an object item,
+	// there is no signal distinguishing a domain collection from metadata.
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		return nil, false
+	}
+	return items, true
 }
 
 // embeddedPagedSubresourcePageCap bounds the page loop in
@@ -1063,21 +1086,8 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
 		// nil slice and would coerce to `[]`.
 		if !matchedAny {
-			pending := map[string]json.RawMessage{}
-			foundArray := false
-			for k, v := range obj {
-				var arr []json.RawMessage
-				if json.Unmarshal(v, &arr) == nil && arr != nil {
-					foundArray = true
-					pending[k] = filterFieldsRec(v, paths)
-				} else {
-					pending[k] = v
-				}
-			}
-			if foundArray {
-				for k, v := range pending {
-					filtered[k] = v
-				}
+			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+				filtered = pending
 			}
 		}
 		result, _ := json.Marshal(filtered)
@@ -1085,6 +1095,45 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 	}
 
 	return data
+}
+
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+	pending := map[string]json.RawMessage{}
+	foundArray := false
+	for k, v := range obj {
+		if envelopeMetadataArrayKeys[k] {
+			pending[k] = v
+			continue
+		}
+		var arr []json.RawMessage
+		if json.Unmarshal(v, &arr) == nil && arr != nil {
+			foundArray = true
+			pending[k] = filterFieldsRec(v, paths)
+			continue
+		}
+		if k == "_embedded" {
+			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+				foundArray = true
+				pending[k] = nested
+				continue
+			}
+		}
+		pending[k] = v
+	}
+	return pending, foundArray
+}
+
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	filtered, found := filterListEnvelopeFields(obj, paths)
+	if !found {
+		return nil, false
+	}
+	result, _ := json.Marshal(filtered)
+	return result, true
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.
@@ -1148,6 +1197,7 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 var compactVerboseListFields = map[string]bool{
 	"description": true, "body": true, "content": true,
 	"comments": true, "attachments": true, "html": true, "markdown": true,
+	"_links": true, "links": true,
 }
 
 // compactVerboseObjectFields are metadata fields stripped from single-object
@@ -1284,6 +1334,10 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObject(obj); ok {
+		result, _ := json.Marshal(compacted)
+		return result
+	}
 	compact := map[string]any{}
 	for k, v := range obj {
 		if !compactVerboseObjectFields[k] {
@@ -1292,6 +1346,58 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	}
 	result, _ := json.Marshal(compact)
 	return result
+}
+
+func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+	out := map[string]any{}
+	foundArray := false
+	for k, v := range obj {
+		if compactVerboseObjectFields[k] {
+			continue
+		}
+		if envelopeMetadataArrayKeys[k] {
+			out[k] = v
+			continue
+		}
+		if compacted, ok := compactObjectArrayValue(v); ok {
+			foundArray = true
+			out[k] = compacted
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
+			if compacted, ok := compactListEnvelopeObject(nested); ok {
+				foundArray = true
+				out[k] = compacted
+				continue
+			}
+		}
+		out[k] = v
+	}
+	if !foundArray {
+		return nil, false
+	}
+	return out, true
+}
+
+func compactObjectArrayValue(v any) (any, bool) {
+	rawItems, ok := v.([]any)
+	if !ok || len(rawItems) == 0 {
+		return nil, false
+	}
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	compactedRaw := compactListFields(items)
+	var compacted any
+	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
+		return nil, false
+	}
+	return compacted, true
 }
 
 // printCSV renders JSON arrays as CSV with header row.

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -802,9 +802,11 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 
 	var onlyArray []json.RawMessage
 	arrayCount := 0
-	for _, raw := range obj {
-		var candidate []json.RawMessage
-		if json.Unmarshal(raw, &candidate) == nil {
+	for key, raw := range obj {
+		if envelopeMetadataArrayKeys[key] {
+			continue
+		}
+		if candidate, ok := extractPaginatedObjectArray(raw); ok {
 			onlyArray = candidate
 			arrayCount++
 		}
@@ -813,6 +815,27 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 		return onlyArray, true
 	}
 	return nil, false
+}
+
+// envelopeMetadataArrayKeys lists sidecar arrays that must not be mistaken for
+// a domain collection when projecting wrapped output or aggregating pages.
+var envelopeMetadataArrayKeys = map[string]bool{
+	"errors": true, "Errors": true,
+	"warnings": true, "Warnings": true,
+}
+
+func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
+	var items []json.RawMessage
+	// Empty fallback arrays are deliberately ignored: without an object item,
+	// there is no signal distinguishing a domain collection from metadata.
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		return nil, false
+	}
+	return items, true
 }
 
 func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bool) {
@@ -926,21 +949,8 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
 		// nil slice and would coerce to `[]`.
 		if !matchedAny {
-			pending := map[string]json.RawMessage{}
-			foundArray := false
-			for k, v := range obj {
-				var arr []json.RawMessage
-				if json.Unmarshal(v, &arr) == nil && arr != nil {
-					foundArray = true
-					pending[k] = filterFieldsRec(v, paths)
-				} else {
-					pending[k] = v
-				}
-			}
-			if foundArray {
-				for k, v := range pending {
-					filtered[k] = v
-				}
+			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+				filtered = pending
 			}
 		}
 		result, _ := json.Marshal(filtered)
@@ -948,6 +958,45 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 	}
 
 	return data
+}
+
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+	pending := map[string]json.RawMessage{}
+	foundArray := false
+	for k, v := range obj {
+		if envelopeMetadataArrayKeys[k] {
+			pending[k] = v
+			continue
+		}
+		var arr []json.RawMessage
+		if json.Unmarshal(v, &arr) == nil && arr != nil {
+			foundArray = true
+			pending[k] = filterFieldsRec(v, paths)
+			continue
+		}
+		if k == "_embedded" {
+			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+				foundArray = true
+				pending[k] = nested
+				continue
+			}
+		}
+		pending[k] = v
+	}
+	return pending, foundArray
+}
+
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	filtered, found := filterListEnvelopeFields(obj, paths)
+	if !found {
+		return nil, false
+	}
+	result, _ := json.Marshal(filtered)
+	return result, true
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.
@@ -1011,6 +1060,7 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 var compactVerboseListFields = map[string]bool{
 	"description": true, "body": true, "content": true,
 	"comments": true, "attachments": true, "html": true, "markdown": true,
+	"_links": true, "links": true,
 }
 
 // compactVerboseObjectFields are metadata fields stripped from single-object
@@ -1147,6 +1197,10 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObject(obj); ok {
+		result, _ := json.Marshal(compacted)
+		return result
+	}
 	compact := map[string]any{}
 	for k, v := range obj {
 		if !compactVerboseObjectFields[k] {
@@ -1155,6 +1209,58 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	}
 	result, _ := json.Marshal(compact)
 	return result
+}
+
+func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+	out := map[string]any{}
+	foundArray := false
+	for k, v := range obj {
+		if compactVerboseObjectFields[k] {
+			continue
+		}
+		if envelopeMetadataArrayKeys[k] {
+			out[k] = v
+			continue
+		}
+		if compacted, ok := compactObjectArrayValue(v); ok {
+			foundArray = true
+			out[k] = compacted
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
+			if compacted, ok := compactListEnvelopeObject(nested); ok {
+				foundArray = true
+				out[k] = compacted
+				continue
+			}
+		}
+		out[k] = v
+	}
+	if !foundArray {
+		return nil, false
+	}
+	return out, true
+}
+
+func compactObjectArrayValue(v any) (any, bool) {
+	rawItems, ok := v.([]any)
+	if !ok || len(rawItems) == 0 {
+		return nil, false
+	}
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	compactedRaw := compactListFields(items)
+	var compacted any
+	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
+		return nil, false
+	}
+	return compacted, true
 }
 
 // printCSV renders JSON arrays as CSV with header row.

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 73
+    "total": 78
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -884,9 +884,11 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 
 	var onlyArray []json.RawMessage
 	arrayCount := 0
-	for _, raw := range obj {
-		var candidate []json.RawMessage
-		if json.Unmarshal(raw, &candidate) == nil {
+	for key, raw := range obj {
+		if envelopeMetadataArrayKeys[key] {
+			continue
+		}
+		if candidate, ok := extractPaginatedObjectArray(raw); ok {
 			onlyArray = candidate
 			arrayCount++
 		}
@@ -895,6 +897,27 @@ func extractPaginatedItems(obj map[string]json.RawMessage) ([]json.RawMessage, b
 		return onlyArray, true
 	}
 	return nil, false
+}
+
+// envelopeMetadataArrayKeys lists sidecar arrays that must not be mistaken for
+// a domain collection when projecting wrapped output or aggregating pages.
+var envelopeMetadataArrayKeys = map[string]bool{
+	"errors": true, "Errors": true,
+	"warnings": true, "Warnings": true,
+}
+
+func extractPaginatedObjectArray(raw json.RawMessage) ([]json.RawMessage, bool) {
+	var items []json.RawMessage
+	// Empty fallback arrays are deliberately ignored: without an object item,
+	// there is no signal distinguishing a domain collection from metadata.
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(items[0], &obj); err != nil {
+		return nil, false
+	}
+	return items, true
 }
 
 func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bool) {
@@ -1008,21 +1031,8 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 		// json.Unmarshal otherwise accepts into a []json.RawMessage as a
 		// nil slice and would coerce to `[]`.
 		if !matchedAny {
-			pending := map[string]json.RawMessage{}
-			foundArray := false
-			for k, v := range obj {
-				var arr []json.RawMessage
-				if json.Unmarshal(v, &arr) == nil && arr != nil {
-					foundArray = true
-					pending[k] = filterFieldsRec(v, paths)
-				} else {
-					pending[k] = v
-				}
-			}
-			if foundArray {
-				for k, v := range pending {
-					filtered[k] = v
-				}
+			if pending, foundArray := filterListEnvelopeFields(obj, paths); foundArray {
+				filtered = pending
 			}
 		}
 		result, _ := json.Marshal(filtered)
@@ -1030,6 +1040,45 @@ func filterFieldsRec(data json.RawMessage, paths [][]string) json.RawMessage {
 	}
 
 	return data
+}
+
+func filterListEnvelopeFields(obj map[string]json.RawMessage, paths [][]string) (map[string]json.RawMessage, bool) {
+	pending := map[string]json.RawMessage{}
+	foundArray := false
+	for k, v := range obj {
+		if envelopeMetadataArrayKeys[k] {
+			pending[k] = v
+			continue
+		}
+		var arr []json.RawMessage
+		if json.Unmarshal(v, &arr) == nil && arr != nil {
+			foundArray = true
+			pending[k] = filterFieldsRec(v, paths)
+			continue
+		}
+		if k == "_embedded" {
+			if nested, ok := filterNestedListEnvelopeFields(v, paths); ok {
+				foundArray = true
+				pending[k] = nested
+				continue
+			}
+		}
+		pending[k] = v
+	}
+	return pending, foundArray
+}
+
+func filterNestedListEnvelopeFields(data json.RawMessage, paths [][]string) (json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	filtered, found := filterListEnvelopeFields(obj, paths)
+	if !found {
+		return nil, false
+	}
+	result, _ := json.Marshal(filtered)
+	return result, true
 }
 
 // matchSelectSegment returns the matching lowercase segment, or "" if no match.
@@ -1093,6 +1142,7 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 var compactVerboseListFields = map[string]bool{
 	"description": true, "body": true, "content": true,
 	"comments": true, "attachments": true, "html": true, "markdown": true,
+	"_links": true, "links": true,
 }
 
 // compactVerboseObjectFields are metadata fields stripped from single-object
@@ -1229,6 +1279,10 @@ func isCompactScalar(v any) bool {
 // under `--agent`/`--compact` is a silent loss; agents who want to omit them
 // can pass `--select` to specify only the fields they need.
 func compactObjectFields(obj map[string]any) json.RawMessage {
+	if compacted, ok := compactListEnvelopeObject(obj); ok {
+		result, _ := json.Marshal(compacted)
+		return result
+	}
 	compact := map[string]any{}
 	for k, v := range obj {
 		if !compactVerboseObjectFields[k] {
@@ -1237,6 +1291,58 @@ func compactObjectFields(obj map[string]any) json.RawMessage {
 	}
 	result, _ := json.Marshal(compact)
 	return result
+}
+
+func compactListEnvelopeObject(obj map[string]any) (map[string]any, bool) {
+	out := map[string]any{}
+	foundArray := false
+	for k, v := range obj {
+		if compactVerboseObjectFields[k] {
+			continue
+		}
+		if envelopeMetadataArrayKeys[k] {
+			out[k] = v
+			continue
+		}
+		if compacted, ok := compactObjectArrayValue(v); ok {
+			foundArray = true
+			out[k] = compacted
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok && k == "_embedded" {
+			if compacted, ok := compactListEnvelopeObject(nested); ok {
+				foundArray = true
+				out[k] = compacted
+				continue
+			}
+		}
+		out[k] = v
+	}
+	if !foundArray {
+		return nil, false
+	}
+	return out, true
+}
+
+func compactObjectArrayValue(v any) (any, bool) {
+	rawItems, ok := v.([]any)
+	if !ok || len(rawItems) == 0 {
+		return nil, false
+	}
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+	}
+	compactedRaw := compactListFields(items)
+	var compacted any
+	if err := json.Unmarshal(compactedRaw, &compacted); err != nil {
+		return nil, false
+	}
+	return compacted, true
 }
 
 // printCSV renders JSON arrays as CSV with header row.


### PR DESCRIPTION
## Summary

Wrapped list output now projects the collection instead of the wrapper. Before this change, `--compact` could leave verbose item payloads untouched inside `{results:[...]}`, domain-specific wrappers, or HAL `_embedded` responses, and `--select id,name` could miss HAL embedded arrays entirely. Cursor-paginated `--all` also now ignores metadata arrays such as `warnings` while finding the real domain collection, so populated wrapped pages do not aggregate into an empty or null result.

Fixes #3089.
Fixes #3205.
Part of #3090.

## What Changed

- Compact/select helper fallback now treats list-shaped envelopes as envelopes and projects object arrays inside them, including HAL `_embedded` arrays.
- Compact list-item projection now drops `_links`/`links` navigation noise unless the user explicitly selects it.
- `paginatedGet` now treats the domain collection as the merge target when a wrapped cursor page also includes metadata arrays.

## Scope Boundary

This deliberately does not bundle #3171. The fix happens before/inside the existing output helpers and page extraction path; it does not redefine the top-level `--agent` envelope vocabulary or make command archetypes uniform. Query-param work from #3212/#3213 is also untouched.

## Generated-Output Proof

Added emitted-runtime tests that generate a CLI and run helper-level regressions for `{results:[...]}`, `{meta, results:[...]}`, HAL `_embedded`, and a domain-specific array wrapper. Added a generated `paginatedGet` regression for cursor pages shaped like `{charges:[...], warnings:[...], cursor:"..."}`.

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestWrappedArrayProjectionHelpers_EmittedRuntime|TestPaginatedGetHandlesNumericCursorAndMissingAllSignal|TestFilterFieldsEnvelopeDescent_EmittedHelper|TestCompactObjectFieldsPreservesPayloadFields' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-embedded-paged-api`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is generator/template behavior covered by emitted-runtime tests, golden output, and generated-output compilation; downstream validation is to reprint affected CLIs and rerun compact/select plus cursor `--all` fixtures.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)