### PR TITLE
fix(cli): preserve generated query params

### DIFF
--- a/internal/generator/client_cache_scope_test.go
+++ b/internal/generator/client_cache_scope_test.go
@@ -33,7 +33,8 @@ func TestClientCacheKeyScopesByBaseURLAndAuthIdentity(t *testing.T) {
 	require.Contains(t, body, `authHeader := c.Config.AuthHeader()`, "cache keys should capture AuthHeader() once")
 	require.Contains(t, body, `sha256.Sum256([]byte(authHeader))`, "cache keys should include an auth fingerprint without storing the raw token")
 	require.NotContains(t, body, `sha256.Sum256([]byte(c.Config.AuthHeader()))`, "cache keys should reuse the captured authHeader, not call AuthHeader() twice")
-	require.Contains(t, body, `sort.Strings(paramKeys)`, "cache keys should be deterministic for map params")
+	require.Contains(t, body, `query := url.Values{}`, "cache keys should encode query params with structured delimiters")
+	require.Contains(t, body, `key += "|query=" + query.Encode()`, "cache keys should use url.Values.Encode for deterministic query boundaries")
 }
 
 func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
@@ -69,6 +70,16 @@ func TestGeneratedCacheWritesUsePrivatePermissions(t *testing.T) {
 	require.Contains(t, config, "cliutil.AtomicWritePrivateFile(c.Path, data, 0o600, 0o700)")
 	require.NotContains(t, config, "os.WriteFile(c.Path, data, 0o644)")
 	require.NotContains(t, config, "os.MkdirAll(dir, 0o755)")
+}
+
+func TestGeneratedClientQueryParamContractsPass(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("query-param-contracts")
+	outputDir := filepath.Join(t.TempDir(), "query-param-contracts-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	runGoCommandRequired(t, outputDir, "test", "./internal/client", "-run", "Test(CacheKeyDelimitsSortedQueryParams|GetWithHeadersValuesPreservesRepeatedQueryParams)", "-count=1")
 }
 
 func clientCacheKeyBody(t *testing.T, content string) string {

--- a/internal/generator/embedded_paged_test.go
+++ b/internal/generator/embedded_paged_test.go
@@ -60,6 +60,12 @@ func TestEmbeddedPagedHelperEmitted_NonPromoted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(helpersSrc), "func fetchEmbeddedPagedSubresource(",
 		"helpers.go must emit the shared paginator when at least one endpoint has detected sub-resources")
+	assert.Contains(t, string(helpersSrc), "GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)",
+		"URL-following helpers must depend on the url.Values client path so repeated query params survive passthrough")
+	assert.Contains(t, string(helpersSrc), "c.GetWithHeadersValues(ctx, target, query, nil)",
+		"URL-following helpers must pass parsed query values rather than collapsing them to one string per key")
+	assert.NotContains(t, string(helpersSrc), "func relativizeNextURL(raw string) string",
+		"generated helpers should not emit a dead wrapper around the structured URL passthrough helper")
 	assert.Contains(t, string(helpersSrc), "embeddedPagedSubresourcePageCap",
 		"shared helper must carry the page-count cap so callers can't spin against a misbehaving server")
 

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -610,6 +610,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -633,6 +637,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result{{if .HasHTMLExtraction}}, c.lastContentType{{end}})
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -719,13 +727,12 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 {{- if .EndpointTemplateVars}}
 	// Include resolved template-var values in the cache identity so two
@@ -744,6 +751,21 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 {{- end}}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, {{if .HasHTMLExtraction}}string, {{end}}bool) {

--- a/internal/generator/templates/client_test.go.tmpl
+++ b/internal/generator/templates/client_test.go.tmpl
@@ -5,9 +5,16 @@ package client
 
 import (
 	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
+
+	"{{modulePath}}/internal/config"
 )
 
 func TestTruncateBody(t *testing.T) {
@@ -68,5 +75,58 @@ func TestTruncateBody_UTF8RuneAtBoundary(t *testing.T) {
 	// Partial rune must be dropped, not replaced: 4094 valid bytes + "...".
 	if want := 4094 + 3; len(got) != want {
 		t.Fatalf("len = %d, want %d (partial rune should be dropped, not replaced)", len(got), want)
+	}
+}
+
+func TestCacheKeyDelimitsSortedQueryParams(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{BaseURL: "https://api.example.test"}
+	collidingTwoParams := c.cacheKey("/titles", map[string]string{
+		"country": "USAformat",
+		"year":    "bluray",
+	})
+	collidingThreeParams := c.cacheKey("/titles", map[string]string{
+		"country": "USA",
+		"format":  "bluray",
+		"year":    "",
+	})
+	if collidingTwoParams == collidingThreeParams {
+		t.Fatalf("cache keys collided for adjacent query params: %q", collidingTwoParams)
+	}
+
+	first := c.cacheKey("/titles", map[string]string{"format": "4k", "country": "USA"})
+	second := c.cacheKey("/titles", map[string]string{"country": "USA", "format": "4k"})
+	if first != second {
+		t.Fatalf("cache key should be deterministic regardless of map order: %q != %q", first, second)
+	}
+}
+
+func TestGetWithHeadersValuesPreservesRepeatedQueryParams(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query()["format"]
+		if len(got) != 2 || got[0] != "blu-ray" || got[1] != "4k" {
+			t.Fatalf("format query values = %#v, want [blu-ray 4k]", got)
+		}
+		if got := r.URL.Query().Get("country"); got != "US" {
+			t.Fatalf("country = %q, want US", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := New(&config.Config{BaseURL: server.URL}, time.Second, 0)
+	c.HTTPClient = server.Client()
+	c.NoCache = true
+
+	params := url.Values{
+		"format":  []string{"blu-ray", "4k"},
+		"country": []string{"US"},
+	}
+	if _, err := c.GetWithHeadersValues(context.Background(), "/titles", params, nil); err != nil {
+		t.Fatalf("GetWithHeadersValues returned error: %v", err)
 	}
 }

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -18,7 +18,7 @@ import (
 {{- if or (and (or (eq .Endpoint.Method "POST") (eq .Endpoint.Method "PUT") (eq .Endpoint.Method "PATCH")) (not $isMultipart) (not $isForm)) (and (eq .Endpoint.Method "DELETE") $hasJSONBody)}}
 	"io"
 {{- end}}
-{{- if and (or (eq .Endpoint.Method "POST") (eq .Endpoint.Method "PUT") (eq .Endpoint.Method "PATCH")) $isForm}}
+{{- if or (and (or (eq .Endpoint.Method "POST") (eq .Endpoint.Method "PUT") (eq .Endpoint.Method "PATCH")) $isForm) .Endpoint.EmbeddedPagedSubresources}}
 	"net/url"
 {{- end}}
 	"os"
@@ -928,7 +928,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
 func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "{{.ChildPath}}"
 	for name, val := range pathParams {

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -20,7 +20,7 @@ import (
 {{- end}}
 	"encoding/json"
 	"fmt"
-{{- if and (or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")) $isForm}}
+{{- if or (and (or (eq (upper .Endpoint.Method) "POST") (eq (upper .Endpoint.Method) "PUT") (eq (upper .Endpoint.Method) "PATCH")) $isForm) .Endpoint.EmbeddedPagedSubresources}}
 	"net/url"
 {{- end}}
 	"os"
@@ -477,7 +477,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
 func fetchFull{{$funcPrefix}}{{$endpointCamel}}{{$propCamel}}(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "{{.ChildPath}}"
 	for name, val := range pathParams {

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1329,16 +1329,17 @@ const embeddedPagedSubresourcePageCap = 500
 // describe envelopes in one casing in the schema and serve another on
 // the wire (`NextPageToken` vs `nextPageToken`).
 func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, childPath, nextField string, nextIsURL, nextIsBoolean bool) ([]json.RawMessage, error) {
 	all := make([]json.RawMessage, 0)
 	nextURL := ""
 	for page := 0; page < embeddedPagedSubresourcePageCap; page++ {
 		target := childPath
+		var query url.Values
 		if nextURL != "" {
-			target = relativizeNextURL(nextURL)
+			target, query = relativizeNextURLParts(nextURL)
 		}
-		data, err := c.GetWithHeaders(ctx, target, nil, nil)
+		data, err := c.GetWithHeadersValues(ctx, target, query, nil)
 		if err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: %w", childPath, page+1, err)
 		}
@@ -1391,24 +1392,19 @@ func emitEmbeddedPagedTruncationWarning(childPath string) {
 	}
 }
 
-// relativizeNextURL strips an absolute scheme+host from a next-page URL
-// so the client's BaseURL+path concat doesn't produce a double-prefixed
-// target. Vendors that return absolute next URLs (e.g. for offset-based
-// pagination) would otherwise concatenate against c.BaseURL on every
-// follow-up request and 404 from page 2 onward.
-func relativizeNextURL(raw string) string {
+// relativizeNextURLParts strips an absolute scheme+host from a next-page URL
+// so the client's BaseURL+path concat doesn't produce a double-prefixed target,
+// while preserving repeated query params for the follow-up request.
+func relativizeNextURLParts(raw string) (string, url.Values) {
 	u, err := url.Parse(raw)
 	if err != nil || !u.IsAbs() {
-		return raw
+		return raw, nil
 	}
 	path := u.Path
 	if path == "" {
 		path = "/"
 	}
-	if u.RawQuery != "" {
-		path += "?" + u.RawQuery
-	}
-	return path
+	return path, u.Query()
 }
 
 // caseInsensitiveLookup returns obj[key] tolerating envelope casing

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -94,7 +95,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
 func fetchFullCustomersGetSubscriptions(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/customers/{id}/subscriptions"
 	for name, val := range pathParams {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -855,16 +855,17 @@ const embeddedPagedSubresourcePageCap = 500
 // describe envelopes in one casing in the schema and serve another on
 // the wire (`NextPageToken` vs `nextPageToken`).
 func fetchEmbeddedPagedSubresource(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, childPath, nextField string, nextIsURL, nextIsBoolean bool) ([]json.RawMessage, error) {
 	all := make([]json.RawMessage, 0)
 	nextURL := ""
 	for page := 0; page < embeddedPagedSubresourcePageCap; page++ {
 		target := childPath
+		var query url.Values
 		if nextURL != "" {
-			target = relativizeNextURL(nextURL)
+			target, query = relativizeNextURLParts(nextURL)
 		}
-		data, err := c.GetWithHeaders(ctx, target, nil, nil)
+		data, err := c.GetWithHeadersValues(ctx, target, query, nil)
 		if err != nil {
 			return nil, fmt.Errorf("paginating embedded sub-resource %q page %d: %w", childPath, page+1, err)
 		}
@@ -917,24 +918,19 @@ func emitEmbeddedPagedTruncationWarning(childPath string) {
 	}
 }
 
-// relativizeNextURL strips an absolute scheme+host from a next-page URL
-// so the client's BaseURL+path concat doesn't produce a double-prefixed
-// target. Vendors that return absolute next URLs (e.g. for offset-based
-// pagination) would otherwise concatenate against c.BaseURL on every
-// follow-up request and 404 from page 2 onward.
-func relativizeNextURL(raw string) string {
+// relativizeNextURLParts strips an absolute scheme+host from a next-page URL
+// so the client's BaseURL+path concat doesn't produce a double-prefixed target,
+// while preserving repeated query params for the follow-up request.
+func relativizeNextURLParts(raw string) (string, url.Values) {
 	u, err := url.Parse(raw)
 	if err != nil || !u.IsAbs() {
-		return raw
+		return raw, nil
 	}
 	path := u.Path
 	if path == "" {
 		path = "/"
 	}
-	if u.RawQuery != "" {
-		path += "?" + u.RawQuery
-	}
-	return path
+	return path, u.Query()
 }
 
 // caseInsensitiveLookup returns obj[key] tolerating envelope casing

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -94,7 +95,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
 func fetchFullPagesGetChildren(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/pages/{id}/children"
 	for name, val := range pathParams {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -94,7 +95,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 // exhausted. pathParams must include every {placeholder} in the parent
 // path (e.g. {"id": "<value>"}).
 func fetchFullPlaylistsGetTracks(ctx context.Context, c interface {
-	GetWithHeaders(ctx context.Context, path string, params map[string]string, headers map[string]string) (json.RawMessage, error)
+	GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error)
 }, pathParams map[string]string) ([]json.RawMessage, error) {
 	childPath := "/playlists/{id}/tracks"
 	for name, val := range pathParams {

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -171,6 +171,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -194,6 +198,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -256,16 +264,30 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -180,6 +180,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -203,6 +207,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -269,16 +277,30 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -174,6 +174,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -197,6 +201,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -259,16 +267,30 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -175,6 +175,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -198,6 +202,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -260,16 +268,30 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -272,6 +272,10 @@ func (c *Client) GetWithHeaders(ctx context.Context, path string, params map[str
 	return result, err
 }
 
+func (c *Client) GetWithHeadersValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeaders(ctx, pathWithQueryValues(path, params), nil, headers)
+}
+
 // GetNoCache issues a GET that bypasses the cache read for this call only,
 // then refreshes the cache with the fresh response on success. Use for
 // polling-until-terminal patterns where every call must reflect current
@@ -295,6 +299,10 @@ func (c *Client) GetWithHeadersNoCache(ctx context.Context, path string, params 
 		c.writeCache(path, params, result)
 	}
 	return result, err
+}
+
+func (c *Client) GetWithHeadersNoCacheValues(ctx context.Context, path string, params url.Values, headers map[string]string) (json.RawMessage, error) {
+	return c.GetWithHeadersNoCache(ctx, pathWithQueryValues(path, params), nil, headers)
 }
 
 func (c *Client) responseCacheEnabled(binaryResponse bool) bool {
@@ -359,16 +367,30 @@ func (c *Client) cacheKey(path string, params map[string]string) string {
 			key += "|config_path=" + c.Config.Path
 		}
 	}
-	paramKeys := make([]string, 0, len(params))
-	for k := range params {
-		paramKeys = append(paramKeys, k)
-	}
-	sort.Strings(paramKeys)
-	for _, k := range paramKeys {
-		key += k + "=" + params[k]
+	if len(params) > 0 {
+		query := url.Values{}
+		for k, v := range params {
+			query.Set(k, v)
+		}
+		key += "|query=" + query.Encode()
 	}
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:8])
+}
+
+func pathWithQueryValues(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	separator := "?"
+	if strings.Contains(path, "?") {
+		separator = "&"
+	}
+	return path + separator + encoded
 }
 
 func (c *Client) readCache(path string, params map[string]string) (json.RawMessage, bool) {


### PR DESCRIPTION
## Summary

- encode generated client cache-key query components with `url.Values.Encode()` so adjacent sorted params cannot collide
- add generated `GetWithHeadersValues` / `GetWithHeadersNoCacheValues` paths for repeated query params while preserving existing `map[string]string` call sites
- route embedded URL-following helpers through `url.Values` so repeated params from upstream next URLs survive passthrough

Fixes #3212.
Fixes #3213.
Part of #3090.

## Before / After

Before, generated cache keys concatenated sorted query params as adjacent `key=value` fragments, so shapes like `{country:"USAformat", year:"bluray"}` and `{country:"USA", format:"bluray", year:""}` could hash to the same cache key input. The generated client also only accepted one string per query key, leaving URL passthrough helpers without a non-lossy repeated-param path.

After, cache-key query identity is a single encoded query component with separators, existing simple map callers still work, and generated URL-following helpers can pass `url.Values` through the client without collapsing repeated keys.

## Generated-Output Proof

- Added generated client tests for the cache-key collision shape, deterministic map params, and repeated query-param request construction.
- Added generator coverage that runs those generated client tests.
- Updated embedded-paged generated-output assertions and goldens for the new `url.Values` URL-following path.
- Compiled generated modules for the changed fixture variants.

## Scope

This PR is intentionally limited to generated query-param/cache-key behavior. It does not bundle #3089/#3205 compact wrapped-array work, #3171 `--agent` envelope uniformity, or #3099 MCP store search/sql behavior.

## Verification

- `go fmt ./...`
- `go test ./internal/generator -run 'TestGeneratedClientQueryParamContractsPass|TestEmbeddedPagedHelperEmitted_(NonPromoted|Promoted)|TestClientCacheKeyScopesByBaseURLAndAuthIdentity' -count=1`\n- `go test ./internal/generator -count=1`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-cookie-auth generate-golden-api-oauth2-cc generate-golden-api-oauth2-device-code generate-tier-routing-api generate-embedded-paged-api`\n- `go build -o ./cli-printing-press ./cmd/cli-printing-press`\n- `golangci-lint run ./...`\n- `git diff --check`\n- `go test ./internal/pipeline -run 'TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged|TestRunLiveDogfoodSearchErrorPathNoJSONSupport|TestHelpScanIndicatesSideEffect' -count=1`\n- `go test ./internal/pipeline -count=1`\n- `go test ./...`\n\n## AI / Automation Disclosure\n\n- [ ] No AI or automation was used\n- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission\n- [x] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission\n- [ ] Fully automated: generated and submitted without human review for this specific change\n