### PR TITLE
fix(cli): harden generated auth client retries

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1608,12 +1608,84 @@ func TestGenerateOAuth2LoginVerifyEnvShortCircuitBeforeBrowserLaunch(t *testing.
 	assert.Less(t, verifyIdx, openBrowserIdx, "verify short-circuit must run before browser launch")
 	assert.Less(t, wouldLaunchIdx, openBrowserIdx, "verify short-circuit output must run before browser launch")
 	assert.Less(t, verifyIdx, listenIdx, "verify short-circuit must run before binding the callback port (no port bind in verify mode)")
+	assert.Contains(t, body, `exec.Command("rundll32", "url.dll,FileProtocolHandler", url)`,
+		"Windows browser opener must hand the full OAuth URL to the default handler")
+	assert.NotContains(t, body, `exec.Command("cmd", "/c", "start", url)`,
+		"bare cmd /c start truncates OAuth query strings at ampersands on Windows")
 
 	// Text assertions alone pass even when the generated auth.go has a compile
 	// error (e.g. redirectURI referenced but never declared). Compile the
 	// generated module so such regressions fail this suite directly.
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestGeneratedClientRetriesFailFastInVerifyAndDogfood(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("retry-env")
+	apiSpec.Resources = map[string]spec.Resource{
+		"items": {
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/items"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "retry-env-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	const runtimeTest = `package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"retry-env-pp-cli/internal/config"
+)
+
+func TestClientMaxRetriesRespectsVerifyAndDogfood(t *testing.T) {
+	if got := clientMaxRetries(); got != 3 {
+		t.Fatalf("clientMaxRetries() = %d, want 3", got)
+	}
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
+	if got := clientMaxRetries(); got != 0 {
+		t.Fatalf("clientMaxRetries() under verify = %d, want 0", got)
+	}
+	t.Setenv("PRINTING_PRESS_VERIFY", "")
+	t.Setenv("PRINTING_PRESS_DOGFOOD", "1")
+	if got := clientMaxRetries(); got != 0 {
+		t.Fatalf("clientMaxRetries() under dogfood = %d, want 0", got)
+	}
+}
+
+func TestClientDoesNotRetry429InVerifyEnv(t *testing.T) {
+	t.Setenv("PRINTING_PRESS_VERIFY", "1")
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, "slow down")
+	}))
+	defer server.Close()
+
+	c := New(&config.Config{BaseURL: server.URL, Path: filepath.Join(t.TempDir(), "config.toml")}, time.Second, 0)
+	_, err := c.Get(context.Background(), "/items", nil)
+	if err == nil {
+		t.Fatal("Get() error = nil, want 429 error")
+	}
+	if calls != 1 {
+		t.Fatalf("server calls = %d, want 1", calls)
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "client", "retry_env_test.go"), []byte(runtimeTest), 0o644))
+	runGoCommand(t, outputDir, "test", "./internal/client", "-run", "TestClient")
 }
 
 func TestGenerateOAuth2DeviceCodeAuth(t *testing.T) {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -1326,7 +1326,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 {{- if and .HasAuthCommand (ne .Auth.TokenURL "")}}
 	refreshedAfterUnauthorized := false
@@ -2466,4 +2466,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1648,6 +1648,11 @@ func validateAuthSubtype(c AuthConfig) error {
 func validateOAuth2Grant(c AuthConfig) error {
 	switch c.OAuth2Grant {
 	case "", OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials, OAuth2GrantDeviceCode:
+		if (c.OAuth2Grant == "" || c.OAuth2Grant == OAuth2GrantAuthorizationCode) && strings.TrimSpace(c.TokenURL) != "" {
+			if err := validateAuthURL("auth.token_url", c.TokenURL); err != nil {
+				return err
+			}
+		}
 		if c.OAuth2Grant == OAuth2GrantClientCredentials && strings.TrimSpace(c.TokenURL) != "" {
 			if err := validateAuthURL("auth.token_url", c.TokenURL); err != nil {
 				return err

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1581,6 +1581,16 @@ func validateHTTPSURL(label, raw string) error {
 	}
 }
 
+func validateAuthURL(label, raw string) error {
+	if strings.ContainsAny(raw, "{}<>") {
+		return fmt.Errorf("%s contains an unresolved placeholder; supply a concrete URL before generation", label)
+	}
+	if err := validateHTTPSURL(label, raw); err != nil {
+		return err
+	}
+	return nil
+}
+
 // validateOAuth2Grant ensures OAuth2Grant is empty or one of the supported
 // values. Empty is accepted (treated as the default). Cross-checking against
 // validateAuthPrefix rejects characters that would break out of the Go
@@ -1638,6 +1648,11 @@ func validateAuthSubtype(c AuthConfig) error {
 func validateOAuth2Grant(c AuthConfig) error {
 	switch c.OAuth2Grant {
 	case "", OAuth2GrantAuthorizationCode, OAuth2GrantClientCredentials, OAuth2GrantDeviceCode:
+		if c.OAuth2Grant == OAuth2GrantClientCredentials && strings.TrimSpace(c.TokenURL) != "" {
+			if err := validateAuthURL("auth.token_url", c.TokenURL); err != nil {
+				return err
+			}
+		}
 		if c.OAuth2Grant == OAuth2GrantDeviceCode {
 			if strings.TrimSpace(c.DeviceAuthorizationURL) == "" {
 				return fmt.Errorf("auth.device_authorization_url is required when auth.oauth2_grant is %q", OAuth2GrantDeviceCode)
@@ -1645,10 +1660,10 @@ func validateOAuth2Grant(c AuthConfig) error {
 			if strings.TrimSpace(c.TokenURL) == "" {
 				return fmt.Errorf("auth.token_url is required when auth.oauth2_grant is %q", OAuth2GrantDeviceCode)
 			}
-			if err := validateHTTPSURL("auth.device_authorization_url", c.DeviceAuthorizationURL); err != nil {
+			if err := validateAuthURL("auth.device_authorization_url", c.DeviceAuthorizationURL); err != nil {
 				return err
 			}
-			if err := validateHTTPSURL("auth.token_url", c.TokenURL); err != nil {
+			if err := validateAuthURL("auth.token_url", c.TokenURL); err != nil {
 				return err
 			}
 		}
@@ -1666,7 +1681,7 @@ func validateOAuth2Refresh(c AuthConfig) error {
 	if strings.TrimSpace(c.TokenURL) == "" {
 		return fmt.Errorf("auth.token_url is required when auth.type is %q", AuthTypeOAuth2Refresh)
 	}
-	if err := validateHTTPSURL("auth.token_url", c.TokenURL); err != nil {
+	if err := validateAuthURL("auth.token_url", c.TokenURL); err != nil {
 		return err
 	}
 	return nil

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -1647,6 +1647,14 @@ func TestOAuth2GrantValidate(t *testing.T) {
 		{name: "explicit authorization_code is valid", cfg: AuthConfig{OAuth2Grant: OAuth2GrantAuthorizationCode}},
 		{name: "client_credentials is valid", cfg: AuthConfig{OAuth2Grant: OAuth2GrantClientCredentials}},
 		{
+			name: "client_credentials rejects placeholder token URL host",
+			cfg: AuthConfig{
+				OAuth2Grant: OAuth2GrantClientCredentials,
+				TokenURL:    "https://{tenant}.example.com/oauth/token",
+			},
+			wantErr: "unresolved placeholder",
+		},
+		{
 			name: "device_code is valid with required endpoints",
 			cfg: AuthConfig{
 				OAuth2Grant:            OAuth2GrantDeviceCode,
@@ -1696,6 +1704,15 @@ func TestOAuth2GrantValidate(t *testing.T) {
 				TokenURL:               "http://login.example.com/token",
 			},
 			wantErr: `auth.token_url uses http://`,
+		},
+		{
+			name: "device_code rejects placeholder token URL host",
+			cfg: AuthConfig{
+				OAuth2Grant:            OAuth2GrantDeviceCode,
+				DeviceAuthorizationURL: "https://login.example.com/device",
+				TokenURL:               "https://{tenant}.example.com/token",
+			},
+			wantErr: "unresolved placeholder",
 		},
 		{
 			name:    "typo (e.g. authorisation) is rejected",

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -1645,6 +1645,21 @@ func TestOAuth2GrantValidate(t *testing.T) {
 	}{
 		{name: "empty is valid (defaults to authorization_code)", cfg: AuthConfig{}},
 		{name: "explicit authorization_code is valid", cfg: AuthConfig{OAuth2Grant: OAuth2GrantAuthorizationCode}},
+		{
+			name: "authorization_code rejects placeholder token URL host",
+			cfg: AuthConfig{
+				OAuth2Grant: OAuth2GrantAuthorizationCode,
+				TokenURL:    "https://{tenant}.example.com/oauth/token",
+			},
+			wantErr: "unresolved placeholder",
+		},
+		{
+			name: "empty default grant rejects placeholder token URL host",
+			cfg: AuthConfig{
+				TokenURL: "https://{tenant}.example.com/oauth/token",
+			},
+			wantErr: "unresolved placeholder",
+		},
 		{name: "client_credentials is valid", cfg: AuthConfig{OAuth2Grant: OAuth2GrantClientCredentials}},
 		{
 			name: "client_credentials rejects placeholder token URL host",

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/internal/client/client.go
@@ -525,7 +525,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -984,4 +984,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-cc/printing-press-oauth2-cc/internal/client/client.go
@@ -538,7 +538,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 	refreshedAfterUnauthorized := false
 
@@ -1185,4 +1185,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }

--- a/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api-oauth2-device-code/printing-press-oauth2-device-code/internal/client/client.go
@@ -528,7 +528,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 	refreshedAfterUnauthorized := false
 
@@ -1067,4 +1067,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/client/client.go
@@ -627,7 +627,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -1071,4 +1071,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/client/client.go
@@ -630,7 +630,7 @@ func (c *Client) doInternal(ctx context.Context, method, path string, params map
 		return c.dryRun(method, targetURL, path, params, bodyBytes, headerOverrides, authHeader)
 	}
 
-	const maxRetries = 3
+	maxRetries := clientMaxRetries()
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -1089,4 +1089,11 @@ func truncateBody(b []byte) string {
 		return string(b)
 	}
 	return strings.ToValidUTF8(string(b[:maxBytes]), "") + "..."
+}
+
+func clientMaxRetries() int {
+	if cliutil.IsVerifyEnv() || cliutil.IsDogfoodEnv() {
+		return 0
+	}
+	return 3
 }


### PR DESCRIPTION
## Summary

Generated clients now fail fast under Printing Press verify/dogfood subprocesses instead of retrying upstream 429/5xx responses until the command timeout. Normal printed CLI users still get the existing three retry attempts.

This also pins the Windows OAuth browser opener to the safe `rundll32 url.dll,FileProtocolHandler` path and rejects auth token URLs that still contain unresolved placeholders before generation ships a broken token mint.

Closes #3238.
Closes #3096.
Closes #3195.

## Validation

- `go test ./internal/spec -run 'TestOAuth2GrantValidate|TestAuthSubtypeValidate|TestAPISpecValidate_RejectsBadAuthPrefix'`
- `go test ./internal/generator -run 'TestGenerateOAuth2LoginVerifyEnvShortCircuitBeforeBrowserLaunch|TestGeneratedClientRetriesFailFastInVerifyAndDogfood'`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
