### PR TITLE
fix(cli): harden validation gates

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -125,14 +125,12 @@ var piiDetectors = []piiDetector{
 	},
 	{
 		kind: PIIKindPhoneUS,
-		// US-shaped 10-digit phone with optional +1 prefix and
-		// parens/separators. NANP requires the area code and the
-		// exchange code to each start with 2-9 — leading 0 or 1 is
-		// not a real US phone. That constraint filters out 10-digit
-		// product UPCs (`0190074442`) and coordinate-shaped numerics
-		// (`106.0512973`) without rejecting any real phone shape.
+		// Formatted US phone with optional +1 prefix. NANP requires the
+		// area code and the exchange code to each start with 2-9; requiring
+		// separators/parentheses avoids treating bare 10-digit IDs, DNS SOA
+		// serials, and epoch timestamps as customer phone numbers.
 		// Catches "(415) 555-0123", "415-555-0123", "+1 415 555 0123".
-		pattern: regexp.MustCompile(`\b(?:\+?1[\s.\-]?)?\(?[2-9]\d{2}\)?[\s.\-]?[2-9]\d{2}[\s.\-]?\d{4}\b`),
+		pattern: regexp.MustCompile(`(?:\+?1[\s.\-]+)?(?:\([2-9]\d{2}\)[\s.\-]*|\b[2-9]\d{2}[\s.\-]+)[2-9]\d{2}[\s.\-]+\d{4}\b`),
 	},
 	{
 		kind: PIIKindZipPlus4,

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -274,6 +274,7 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "parens-space-dash", line: `"phone": "(415) 234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "all-dashes", line: `"phone": "415-234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "country-code", line: `"phone": "+1 415 234 5678"`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "country-code-dashes", line: `"phone": "+1-415-234-5678"`, expectKinds: []string{PIIKindPhoneUS}},
 		{name: "fictional-exchange-dashes", line: `"phone": "415-555-0123"`, expectKinds: nil},
 		{name: "fictional-exchange-parens", line: `"phone": "(212) 555-0100"`, expectKinds: nil},
 		{name: "fictional-exchange-country-code", line: `"phone": "+1 415 555 0199"`, expectKinds: nil},
@@ -286,6 +287,8 @@ func TestFindPII_PhoneUS(t *testing.T) {
 		{name: "no-product-upc-leading-zero", line: `"upc": "0190074442"`, expectKinds: nil},
 		{name: "no-coordinate-leading-one", line: `"lng": 106.0512973`, expectKinds: nil},
 		{name: "no-epoch-timestamp", line: `"updated_at": 1700000000`, expectKinds: nil},
+		{name: "no-dns-soa-serial", line: `"soa_serial": 2026062501`, expectKinds: nil},
+		{name: "no-bare-ten-digit-id", line: `"customer_id": "4152345678"`, expectKinds: nil},
 		// Boundary cases that prove the constraint is on the leading
 		// digit of each quadrant, not on the whole string.
 		{name: "no-area-code-leading-zero", line: `"phone": "015-555-0123"`, expectKinds: nil},
@@ -312,8 +315,8 @@ func TestFindPII_PhoneUS_GitHubContextIDSkips(t *testing.T) {
 		{name: "comment-id", line: `see comment id 3249672558`, expectKinds: nil},
 		{name: "issuecomment-anchor", line: `https://github.com/o/r/pull/12#issuecomment-3249672648`, expectKinds: nil},
 		{name: "comments-url-path", line: `https://github.com/o/r/issues/5/comments/3249672700`, expectKinds: nil},
-		{name: "bare-real-phone-no-github-token", line: `contact 4152345678`, expectKinds: []string{PIIKindPhoneUS}},
-		{name: "bare-commit-word-near-real-phone-still-flags", line: `we will commit then call 4152345678`, expectKinds: []string{PIIKindPhoneUS}},
+		{name: "bare-real-phone-no-github-token", line: `contact 4152345678`, expectKinds: nil},
+		{name: "bare-commit-word-near-real-phone-skips", line: `we will commit then call 4152345678`, expectKinds: nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/narrativecheck/narrativecheck.go
+++ b/internal/narrativecheck/narrativecheck.go
@@ -1,5 +1,5 @@
 // Package narrativecheck validates that command strings in
-// research.json's narrative.quickstart and narrative.recipes resolve
+// research.json's narrative command fields and command-shaped prose snippets resolve
 // against a built printed-CLI binary's Cobra tree.
 //
 // The narrative is LLM-authored (or hand-edited) and easily drifts from
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/pipeline"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/shellargs"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
@@ -33,8 +34,13 @@ import (
 type Section string
 
 const (
-	SectionQuickstart Section = "quickstart"
-	SectionRecipes    Section = "recipes"
+	SectionQuickstart    Section = "quickstart"
+	SectionRecipes       Section = "recipes"
+	SectionHeadline      Section = "headline"
+	SectionValueProp     Section = "value_prop"
+	SectionAuthNarrative Section = "auth_narrative"
+	SectionWhenToUse     Section = "when_to_use"
+	SectionTroubleshoot  Section = "troubleshoots.fix"
 )
 
 // Status is a command's classification after the --help walk.
@@ -224,11 +230,19 @@ func loadCommands(researchPath string) ([]sectionCommand, error) {
 	// Decode just the narrative subtree we care about. Tolerates extra
 	// fields in research.json (the schema is wider than narrative).
 	var doc struct {
+		APIName   string `json:"api_name"`
 		Narrative struct {
-			Quickstart []struct {
+			Headline      string `json:"headline"`
+			ValueProp     string `json:"value_prop"`
+			AuthNarrative string `json:"auth_narrative"`
+			Quickstart    []struct {
 				Command string `json:"command"`
 			} `json:"quickstart"`
-			Recipes []struct {
+			Troubleshoots []struct {
+				Fix string `json:"fix"`
+			} `json:"troubleshoots"`
+			WhenToUse string `json:"when_to_use"`
+			Recipes   []struct {
 				Command string `json:"command"`
 			} `json:"recipes"`
 		} `json:"narrative"`
@@ -248,7 +262,59 @@ func loadCommands(researchPath string) ([]sectionCommand, error) {
 			out = append(out, sectionCommand{Section: SectionRecipes, Command: cmd})
 		}
 	}
+	codeSpanCommands := []struct {
+		section Section
+		text    string
+	}{
+		{section: SectionHeadline, text: doc.Narrative.Headline},
+		{section: SectionValueProp, text: doc.Narrative.ValueProp},
+		{section: SectionAuthNarrative, text: doc.Narrative.AuthNarrative},
+		{section: SectionWhenToUse, text: doc.Narrative.WhenToUse},
+	}
+	for _, tip := range doc.Narrative.Troubleshoots {
+		codeSpanCommands = append(codeSpanCommands, struct {
+			section Section
+			text    string
+		}{section: SectionTroubleshoot, text: tip.Fix})
+	}
+	expectedBinaries := narrativeBinaryNames(doc.APIName)
+	for _, entry := range codeSpanCommands {
+		for _, cmd := range extractNarrativeCodeSpanCommands(entry.text, expectedBinaries) {
+			out = append(out, sectionCommand{Section: entry.section, Command: cmd})
+		}
+	}
 	return out, nil
+}
+
+var markdownCodeSpanRE = regexp.MustCompile("`([^`\\n]+)`")
+
+func narrativeBinaryNames(apiName string) map[string]bool {
+	slug := naming.Slug(apiName)
+	if slug == "" {
+		return nil
+	}
+	return map[string]bool{
+		naming.CLI(slug):       true,
+		naming.LegacyCLI(slug): true,
+	}
+}
+
+func extractNarrativeCodeSpanCommands(text string, expectedBinaries map[string]bool) []string {
+	if len(expectedBinaries) == 0 || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	var commands []string
+	for _, match := range markdownCodeSpanRE.FindAllStringSubmatch(text, -1) {
+		code := strings.TrimSpace(match[1])
+		tokens, err := shellargs.Split(code)
+		if err != nil || len(tokens) < 2 {
+			continue
+		}
+		if expectedBinaries[tokens[0]] && len(extractSubcommandWords(code)) > 0 {
+			commands = append(commands, code)
+		}
+	}
+	return commands
 }
 
 // classify mirrors the bash recipe's wordlist rule: drop the leading

--- a/internal/narrativecheck/narrativecheck_test.go
+++ b/internal/narrativecheck/narrativecheck_test.go
@@ -132,6 +132,45 @@ func TestLoadCommands_Shapes(t *testing.T) {
 			t.Errorf("expected single non-empty command, got %+v", got)
 		}
 	})
+
+	t.Run("prose code spans with cli binary are included", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, `{"api_name":"demo-api","narrative":{
+			"headline":"Use `+"`demo-api-pp-cli reports status --json`"+` for status and `+"`--json`"+` for machine output.",
+			"value_prop":"HTTP `+"`429`"+` is not a command.",
+			"auth_narrative":"Refresh credentials with `+"`demo-api-cli auth refresh`"+`.",
+			"when_to_use":"Prefer `+"`demo-api-pp-cli search --query foo`"+` when exploring.",
+			"troubleshoots":[{"fix":"Run `+"`demo-api-pp-cli doctor`"+` before retrying."}],
+			"quickstart":[{"command":"demo-api-pp-cli widgets list"}],
+			"recipes":[{"command":"demo-api-pp-cli widgets export"}]
+		}}`)
+
+		got, err := loadCommands(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var sections []Section
+		var commands []string
+		for _, cmd := range got {
+			sections = append(sections, cmd.Section)
+			commands = append(commands, cmd.Command)
+		}
+		wantSections := []Section{
+			SectionQuickstart,
+			SectionRecipes,
+			SectionHeadline,
+			SectionAuthNarrative,
+			SectionWhenToUse,
+			SectionTroubleshoot,
+		}
+		if !reflect.DeepEqual(sections, wantSections) {
+			t.Fatalf("sections = %#v, want %#v; commands=%#v", sections, wantSections, commands)
+		}
+		if slices.Contains(commands, "--json") || slices.Contains(commands, "429") {
+			t.Fatalf("flag-only and non-command code spans should be ignored, got %#v", commands)
+		}
+	})
 }
 
 // TestValidate_EndToEnd builds a tiny stub binary that responds OK to

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -641,13 +641,27 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
-		// Sync might not accept --db flag - try without.
+		// Sync might not accept --resources or --full; keep --db when
+		// possible so downstream sql probes read the same temporary store.
+		syncErr = runCLI(binary, []string{"sync", "--db", dbPath}, env, 30*time.Second)
+	}
+	if syncErr != nil {
+		syncErrors = append(syncErrors, syncErr)
+		// Sync might not accept --db either; try the bare command before
+		// deciding the pipeline crashed.
 		syncErr = runCLI(binary, []string{"sync", "--full"}, env, 30*time.Second)
+	}
+	if syncErr != nil {
+		syncErrors = append(syncErrors, syncErr)
+		syncErr = runCLI(binary, []string{"sync"}, env, 30*time.Second)
 	}
 	if syncErr != nil {
 		syncErrors = append(syncErrors, syncErr)
 		if allSyncAttemptsWereUnknownCommand(syncErrors) {
 			return true, "WARN: no sync command — data-pipeline check skipped"
+		}
+		if flag, ok := firstUnknownSyncFlag(syncErrors); ok {
+			return false, fmt.Sprintf("FAIL: sync rejected flag %s", flag)
 		}
 		return false, "FAIL: sync crashed"
 	}
@@ -729,6 +743,32 @@ func allSyncAttemptsWereUnknownCommand(errs []error) bool {
 func isUnknownSyncCommandError(err error) bool {
 	text := strings.ToLower(err.Error())
 	return strings.Contains(text, "unknown command \"sync\"")
+}
+
+func firstUnknownSyncFlag(errs []error) (string, bool) {
+	for _, err := range errs {
+		if flag, ok := unknownSyncFlag(err); ok {
+			return flag, true
+		}
+	}
+	return "", false
+}
+
+func unknownSyncFlag(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	text := strings.ToLower(err.Error())
+	for _, marker := range []string{"unknown flag: ", "unknown shorthand flag: "} {
+		if _, after, ok := strings.Cut(text, marker); ok {
+			flag := strings.Fields(after)
+			if len(flag) > 0 {
+				return flag[0], true
+			}
+			return "", true
+		}
+	}
+	return "", false
 }
 
 func cliHasSyncCommand(cliDir string) bool {

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -765,7 +765,7 @@ func unknownSyncFlag(err error) (string, bool) {
 			if len(flag) > 0 {
 				return flag[0], true
 			}
-			return "", true
+			return "", false
 		}
 	}
 	return "", false

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -293,6 +294,13 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 		assert.False(t, pass)
 		assert.Equal(t, "FAIL: sync crashed", detail)
 	})
+}
+
+func TestUnknownSyncFlagIgnoresEmptyFlagName(t *testing.T) {
+	flag, ok := unknownSyncFlag(errors.New("unknown flag: "))
+
+	assert.False(t, ok)
+	assert.Empty(t, flag)
 }
 
 func TestRunDataPipelineTestSkipsUnsyncableCLIs(t *testing.T) {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -231,6 +231,24 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 		assert.Contains(t, detail, "items has 2 rows")
 	})
 
+	t.Run("falls back when sync rejects full flag", func(t *testing.T) {
+		binary := buildNoFullSyncDataPipelineProbeBinary(t, 2)
+
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Contains(t, detail, "items has 2 rows")
+	})
+
+	t.Run("reports unknown sync flag distinctly", func(t *testing.T) {
+		binary := buildUnknownFlagSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, "", "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Equal(t, "FAIL: sync rejected flag --full", detail)
+	})
+
 	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
 		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0, 2)
 
@@ -718,6 +736,112 @@ func dbArg(args []string) string {
 	return ""
 }
 `, rowCount))
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildNoFullSyncDataPipelineProbeBinary(t *testing.T, rowCount int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, fmt.Sprintf(`package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "sync":
+		for _, arg := range args[1:] {
+			if arg == "--full" {
+				fmt.Fprintln(os.Stderr, "unknown flag: --full")
+				os.Exit(1)
+			}
+		}
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		if err := os.WriteFile(dbPath+".marker", []byte(dbPath), 0o644); err != nil {
+			os.Exit(1)
+		}
+		return
+	case "sql":
+		dbPath := dbArg(args[1:])
+		if dbPath == "" {
+			os.Exit(1)
+		}
+		usedDB, err := os.ReadFile(dbPath + ".marker")
+		if err != nil || string(usedDB) != dbPath {
+			os.Exit(1)
+		}
+		query := args[len(args)-1]
+		if strings.Contains(query, "sqlite_master") {
+			fmt.Println("items")
+			return
+		}
+		if strings.Contains(query, "count(*)") {
+			fmt.Println(%d)
+			return
+		}
+	}
+	os.Exit(1)
+}
+
+func dbArg(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--db" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+`, rowCount))
+	binaryPath := filepath.Join(dir, "test-cli")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
+	out, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "building test binary: %s", string(out))
+	return binaryPath
+}
+
+func buildUnknownFlagSyncDataPipelineProbeBinary(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	writeTestFile(t, mainFile, `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "sync" {
+		for _, arg := range args[1:] {
+			if arg == "--full" {
+				fmt.Fprintln(os.Stderr, "unknown flag: --full")
+				os.Exit(1)
+			}
+		}
+		fmt.Fprintln(os.Stderr, "sync requires --full")
+		os.Exit(1)
+	}
+	os.Exit(1)
+}
+`)
 	binaryPath := filepath.Join(dir, "test-cli")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, mainFile)
 	out, err := buildCmd.CombinedOutput()


### PR DESCRIPTION
## Summary
- validate command-shaped code spans in narrative prose fields rendered into README/SKILL, while ignoring flag-only and incidental code spans
- make the data-pipeline verifier fall back through older sync surfaces and report unknown sync flags explicitly
- stop treating unformatted 10-digit numeric IDs, DNS serials, and epoch timestamps as US phone PII while preserving formatted phone detection

Closes #3202. Closes #3189. Closes #3173.

## Validation
- go test ./internal/narrativecheck
- go test ./internal/artifacts
- go test ./internal/pipeline -run 'TestRunDataPipelineTestMockModeRequiresRows|TestParseSQLOutput|TestParseCountOutput'\n- go test ./...\n\n---\nBuilt with [Compound Engineering](https://github.com/ivanvc/compound-engineering).\n\n🤖 Generated with [Codex](https://openai.com/codex)