### PR TITLE
fix(cli): unify generated agent envelopes

### DIFF
--- a/internal/generator/agent_envelope_test.go
+++ b/internal/generator/agent_envelope_test.go
@@ -1,0 +1,415 @@
+package generator
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedPrintJSONFilteredAgentWrapsTypedOutputs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/items" {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"created","name":"Created item"}`))
+	}))
+	defer server.Close()
+
+	apiSpec := minimalSpec("agent-envelope")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources["items"].Endpoints["create"] = spec.Endpoint{
+		Method:      "POST",
+		Path:        "/items",
+		Description: "Create item",
+		Response:    spec.ResponseDef{Type: "object"},
+	}
+	outputDir := filepath.Join(t.TempDir(), "agent-envelope-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Search: true, Analytics: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "agent_envelope_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func decodeAgentEnvelope(t *testing.T, raw []byte) map[string]json.RawMessage {
+	t.Helper()
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("agent output must be valid JSON: %v\n%s", err, raw)
+	}
+	if _, ok := payload["meta"]; !ok {
+		t.Fatalf("agent output missing top-level meta: %s", raw)
+	}
+	if _, ok := payload["results"]; !ok {
+		t.Fatalf("agent output missing top-level results: %s", raw)
+	}
+	if _, ok := payload["data"]; ok {
+		t.Fatalf("agent output must use results as the only data field, got data too: %s", raw)
+	}
+	return payload
+}
+
+func TestPrintJSONFilteredAgentWrapsBareArray(t *testing.T) {
+	var out bytes.Buffer
+	rows := []map[string]any{{"id": "one", "name": "Alpha"}, {"id": "two", "name": "Beta"}}
+	flags := &rootFlags{agent: true, asJSON: true, compact: true}
+
+	if err := printJSONFiltered(&out, rows, flags); err != nil {
+		t.Fatalf("printJSONFiltered returned error: %v", err)
+	}
+
+	payload := decodeAgentEnvelope(t, out.Bytes())
+	var meta struct {
+		Source string `+"`json:\"source\"`"+`
+	}
+	if err := json.Unmarshal(payload["meta"], &meta); err != nil {
+		t.Fatalf("meta must be an object: %v\n%s", err, out.String())
+	}
+	if meta.Source == "" {
+		t.Fatalf("meta.source must be populated for agent output: %s", out.String())
+	}
+	var results []json.RawMessage
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must contain the original array shape: %v\n%s", err, out.String())
+	}
+	if len(results) != 2 {
+		t.Fatalf("results length = %d, want 2; output=%s", len(results), out.String())
+	}
+}
+
+func TestPrintJSONFilteredAgentWrapsDomainObject(t *testing.T) {
+	var out bytes.Buffer
+	result := map[string]any{"resource_type": "items", "count": 7}
+	flags := &rootFlags{agent: true, asJSON: true, compact: true}
+
+	if err := printJSONFiltered(&out, result, flags); err != nil {
+		t.Fatalf("printJSONFiltered returned error: %v", err)
+	}
+
+	payload := decodeAgentEnvelope(t, out.Bytes())
+	var results map[string]any
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must contain the original object shape: %v\n%s", err, out.String())
+	}
+	if results["resource_type"] != "items" || results["count"] != float64(7) {
+		t.Fatalf("results = %#v, want original domain object; output=%s", results, out.String())
+	}
+}
+
+func TestPrintJSONFilteredJSONModeStaysBareObject(t *testing.T) {
+	var out bytes.Buffer
+	result := map[string]any{"resource_type": "items", "count": 7}
+	flags := &rootFlags{asJSON: true}
+
+	if err := printJSONFiltered(&out, result, flags); err != nil {
+		t.Fatalf("printJSONFiltered returned error: %v", err)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json output must be valid JSON: %v\n%s", err, out.String())
+	}
+	if _, ok := payload["meta"]; ok {
+		t.Fatalf("--json without --agent must stay backward-compatible, got envelope: %s", out.String())
+	}
+	if _, ok := payload["results"]; ok {
+		t.Fatalf("--json without --agent must stay backward-compatible, got results envelope: %s", out.String())
+	}
+	if _, ok := payload["count"]; !ok {
+		t.Fatalf("--json output lost original object fields: %s", out.String())
+	}
+}
+
+func TestGeneratedAnalyticsCommandAgentUsesEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"analytics", "--type", "items", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("analytics --agent failed: %v\nstderr=%s", err, stderr.String())
+	}
+
+	payload := decodeAgentEnvelope(t, stdout.Bytes())
+	var meta struct {
+		Source string `+"`json:\"source\"`"+`
+	}
+	if err := json.Unmarshal(payload["meta"], &meta); err != nil {
+		t.Fatalf("meta must be an object: %v\n%s", err, stdout.String())
+	}
+	if meta.Source != "local" {
+		t.Fatalf("analytics meta.source = %q, want local; output=%s", meta.Source, stdout.String())
+	}
+	var results map[string]any
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must contain analytics object: %v\n%s", err, stdout.String())
+	}
+	if results["resource_type"] != "items" {
+		t.Fatalf("analytics results = %#v, want resource_type items; output=%s", results, stdout.String())
+	}
+	if _, ok := results["count"]; !ok {
+		t.Fatalf("analytics results missing count: %#v; output=%s", results, stdout.String())
+	}
+}
+
+func TestGeneratedMutationCommandAgentUsesResultsEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"items", "create", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("items create --agent failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	payload := decodeAgentEnvelope(t, stdout.Bytes())
+	var meta struct {
+		Source string `+"`json:\"source\"`"+`
+	}
+	if err := json.Unmarshal(payload["meta"], &meta); err != nil {
+		t.Fatalf("meta must be an object: %v\n%s", err, stdout.String())
+	}
+	if meta.Source != "live" {
+		t.Fatalf("mutation meta.source = %q, want live; output=%s", meta.Source, stdout.String())
+	}
+	var results map[string]any
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must contain mutation response object: %v\n%s", err, stdout.String())
+	}
+	if results["id"] != "created" {
+		t.Fatalf("results should preserve live mutation response: %#v; output=%s", results, stdout.String())
+	}
+}
+
+func TestGeneratedMutationCommandJSONKeepsDataEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"items", "create", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("items create --json failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json output must be valid JSON: %v\n%s", err, stdout.String())
+	}
+	if _, ok := payload["data"]; !ok {
+		t.Fatalf("--json mutation output must keep data field for compatibility: %s", stdout.String())
+	}
+	if _, ok := payload["results"]; ok {
+		t.Fatalf("--json without --agent must not add results field: %s", stdout.String())
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPrintJSONFiltered|TestGeneratedAnalyticsCommandAgentUsesEnvelope|TestGeneratedMutationCommand", "-count=1")
+}
+
+func TestGeneratedNoStoreEndpointAgentWrapsFallthroughOutput(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/items":
+			_, _ = w.Write([]byte(`[{"id":"one","name":"Alpha"}]`))
+		case "/widgets":
+			_, _ = w.Write([]byte(`{"meta":{"total":1,"page":1},"results":[{"id":"nested","name":"Nested shape"}]}`))
+		case "/gadgets":
+			_, _ = w.Write([]byte(`{"results":[{"id":"flat","name":"Single-key wrapper"}]}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	apiSpec := minimalSpec("agent-endpoint")
+	apiSpec.BaseURL = server.URL
+	apiSpec.Resources["widgets"] = spec.Resource{
+		Description: "Manage widgets",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {Method: "GET", Path: "/widgets", Description: "List widgets"},
+		},
+	}
+	apiSpec.Resources["gadgets"] = spec.Resource{
+		Description: "Manage gadgets",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {Method: "GET", Path: "/gadgets", Description: "List gadgets"},
+		},
+	}
+	outputDir := filepath.Join(t.TempDir(), "agent-endpoint-pp-cli")
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: false, Export: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "agent_endpoint_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestNoStoreEndpointAgentWrapsBareArray(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"items", "list", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("items list --agent failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("agent output must be valid JSON: %v\n%s", err, stdout.String())
+	}
+	if _, ok := payload["meta"]; !ok {
+		t.Fatalf("agent endpoint output missing meta: %s", stdout.String())
+	}
+	if _, ok := payload["results"]; !ok {
+		t.Fatalf("agent endpoint output missing results: %s", stdout.String())
+	}
+	var meta struct {
+		Source string `+"`json:\"source\"`"+`
+	}
+	if err := json.Unmarshal(payload["meta"], &meta); err != nil {
+		t.Fatalf("meta must be an object: %v\n%s", err, stdout.String())
+	}
+	if meta.Source != "live" {
+		t.Fatalf("endpoint meta.source = %q, want live; output=%s", meta.Source, stdout.String())
+	}
+	var results []map[string]any
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must preserve endpoint array: %v\n%s", err, stdout.String())
+	}
+	if len(results) != 1 || results[0]["id"] != "one" {
+		t.Fatalf("results = %#v, want live endpoint row; output=%s", results, stdout.String())
+	}
+}
+
+func TestNoStoreEndpointJSONRemainsBareArray(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"items", "list", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("items list --json failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("--json endpoint output must remain the bare array: %v\n%s", err, stdout.String())
+	}
+	if len(rows) != 1 || rows[0]["id"] != "one" {
+		t.Fatalf("rows = %#v, want live endpoint row; output=%s", rows, stdout.String())
+	}
+}
+
+func TestNoStoreEndpointAgentWrapsNaturalMetaResultsObject(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"widgets", "list", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("widgets list --agent failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("agent output must be valid JSON: %v\n%s", err, stdout.String())
+	}
+	var topMeta struct {
+		Source string `+"`json:\"source\"`"+`
+	}
+	if err := json.Unmarshal(payload["meta"], &topMeta); err != nil {
+		t.Fatalf("top-level meta must be an object: %v\n%s", err, stdout.String())
+	}
+	if topMeta.Source != "live" {
+		t.Fatalf("top-level meta.source = %q, want live; output=%s", topMeta.Source, stdout.String())
+	}
+
+	var results map[string]json.RawMessage
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results must preserve natural endpoint object: %v\n%s", err, stdout.String())
+	}
+	if _, ok := results["meta"]; !ok {
+		t.Fatalf("results should preserve endpoint meta field: %s", stdout.String())
+	}
+	if _, ok := results["results"]; !ok {
+		t.Fatalf("results should preserve endpoint results field: %s", stdout.String())
+	}
+}
+
+func TestNoStoreEndpointAgentFlattensSingleKeyCollectionWrapper(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MYAPI_TOKEN", "test-token")
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"gadgets", "list", "--agent"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("gadgets list --agent failed: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("agent output must be valid JSON: %v\n%s", err, stdout.String())
+	}
+	var results []map[string]any
+	if err := json.Unmarshal(payload["results"], &results); err != nil {
+		t.Fatalf("results should be the flattened endpoint collection: %v\n%s", err, stdout.String())
+	}
+	if len(results) != 1 || results[0]["id"] != "flat" {
+		t.Fatalf("results = %#v, want flattened live endpoint row; output=%s", results, stdout.String())
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestNoStoreEndpoint", "-count=1")
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -7774,12 +7774,12 @@ func TestGeneratedHelpers_ConditionalDataLayerFunctions(t *testing.T) {
 	assert.NotContains(t, content, "DataProvenance")
 	assert.NotContains(t, content, "printProvenance")
 	assert.NotContains(t, content, "wrapWithProvenance")
-	assert.NotContains(t, content, "unwrapSingleKeyArray")
 	assert.NotContains(t, content, "defaultDBPath")
 
 	// Core helpers should still be present
 	assert.Contains(t, content, "classifyAPIError")
 	assert.Contains(t, content, "printOutputWithFlags")
+	assert.Contains(t, content, "unwrapSingleKeyArray")
 }
 
 // TestGeneratedHelpers_WrapWithProvenanceUnwrapsSingleKeyEnvelope guards

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -752,6 +752,9 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -790,7 +793,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)
@@ -867,7 +874,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 			return nil
 {{- else}}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 {{- end}}
 {{- end}}
 		},

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -420,7 +420,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 {{- end}}
 		},
 	}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -5,9 +5,7 @@
 package cli
 
 import (
-{{- if or .HasDataLayer (hasSubstackPublicationIDTemplateResolver .APISpec)}}
 	"bytes"
-{{- end}}
 	"context"
 	"encoding/json"
 	"errors"
@@ -1480,6 +1478,69 @@ func printJSONFiltered(w io.Writer, v any, flags *rootFlags) error {
 	return printOutputWithFlags(w, json.RawMessage(raw), flags)
 }
 
+// wrapAgentOutput gives --agent callers one parseable top-level envelope for
+// generated command families that build typed Go values instead of endpoint
+// response bytes. The raw value is preserved under results so --json without
+// --agent can stay backward-compatible while shell agents get stable metadata.
+func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage, error) {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, ok := meta["source"]; !ok {
+		meta["source"] = "local"
+	}
+	if source, _ := meta["source"].(string); source == "live" {
+		data = unwrapSingleKeyArray(data)
+	}
+	var results any
+	if json.Valid(data) {
+		results = data
+	} else {
+		results = string(data)
+	}
+	envelope := map[string]any{
+		"meta":    meta,
+		"results": results,
+	}
+	return json.Marshal(envelope)
+}
+
+// unwrapSingleKeyArray flattens single-key collection envelopes
+// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
+// emits a stable .results[] across APIs. Multi-key objects pass
+// through so cursor/pagination fields stay accessible; non-array
+// values pass through so non-collection responses aren't reshaped.
+//
+// The wrapper-key set is intentionally narrower than
+// extractPaginatedItems (which also walks domain-specific keys like
+// "messages", "members", "values" used by social/messaging APIs).
+// This helper only flattens canonical collection envelopes for
+// --json output; the pagination walker has a broader remit.
+func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
+	leading := bytes.TrimLeft(data, " \t\r\n")
+	if len(leading) == 0 || leading[0] != '{' {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if len(obj) != 1 {
+		return data
+	}
+	for key, val := range obj {
+		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
+			return data
+		}
+		trimmed := bytes.TrimLeft(val, " \t\r\n")
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return data
+		}
+		return val
+	}
+	return data
+}
+
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
 // Supports dotted paths like "events.shortName" to descend into nested structures.
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
@@ -1637,6 +1698,10 @@ func camelToKebab(s string) string {
 
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
+	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
 	// --select wins over --compact when both are set: an explicit field list
 	// is the user's authoritative request, so the high-gravity allow-list
 	// must not strip those fields out before --select can pick them. When
@@ -1646,6 +1711,13 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
 		data = compactFields(data)
+	}
+	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
+		wrapped, err := wrapAgentOutput(data, agentMeta)
+		if err != nil {
+			return err
+		}
+		data = wrapped
 	}
 	// --quiet: suppress all output, exit code communicates result
 	if flags.quiet {
@@ -2541,42 +2613,6 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 		prefix = "API unreachable. "
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
-}
-
-// unwrapSingleKeyArray flattens single-key collection envelopes
-// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
-//
-// The wrapper-key set is intentionally narrower than
-// extractPaginatedItems (which also walks domain-specific keys like
-// "messages", "members", "values" used by social/messaging APIs).
-// This helper only flattens canonical collection envelopes for
-// --json output; the pagination walker has a broader remit.
-func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
-	leading := bytes.TrimLeft(data, " \t\r\n")
-	if len(leading) == 0 || leading[0] != '{' {
-		return data
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if len(obj) != 1 {
-		return data
-	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
-	}
-	return data
 }
 
 // wrapWithProvenance wraps response data in a provenance envelope:

--- a/internal/generator/templates/teach_playbook_test.go.tmpl
+++ b/internal/generator/templates/teach_playbook_test.go.tmpl
@@ -47,9 +47,7 @@ func TestTeachPlaybook_HappyPath(t *testing.T) {
 		t.Fatalf("teach-playbook: %v (stderr=%q)", err, stderr)
 	}
 	var resp map[string]any
-	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
-		t.Fatalf("decode: %v (stdout=%q)", err, stdout)
-	}
+	unmarshalAgentResults(t, stdout, &resp)
 	if v, _ := resp["recorded"].(bool); !v {
 		t.Errorf("recorded should be true, got %v", resp)
 	}

--- a/internal/generator/templates/teach_test.go.tmpl
+++ b/internal/generator/templates/teach_test.go.tmpl
@@ -19,6 +19,26 @@ import (
 	"{{modulePath}}/internal/store"
 )
 
+func unmarshalAgentResults(t *testing.T, stdout string, out any) {
+	t.Helper()
+	var envelope struct {
+		Meta    map[string]any  `json:"meta"`
+		Results json.RawMessage `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("agent envelope JSON: %v (stdout=%q)", err, stdout)
+	}
+	if src, _ := envelope.Meta["source"].(string); src == "" {
+		t.Fatalf("agent envelope missing meta.source: %q", stdout)
+	}
+	if len(envelope.Results) == 0 {
+		t.Fatalf("agent envelope missing results: %q", stdout)
+	}
+	if err := json.Unmarshal(envelope.Results, out); err != nil {
+		t.Fatalf("agent envelope results JSON: %v (stdout=%q)", err, stdout)
+	}
+}
+
 // withTempLearnHome points HOME at a fresh temp dir and clears the
 // per-CLI no-learn env var so every test gets the default "learning
 // on" behavior. Returns the temp HOME so callers can resolve the
@@ -184,9 +204,7 @@ func TestRecallCommand_FoundAndNotFound(t *testing.T) {
 		t.Fatalf("recall: %v", err)
 	}
 	var env recallEnvelope
-	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
-		t.Fatalf("recall JSON: %v (stdout=%q)", err, stdout)
-	}
+	unmarshalAgentResults(t, stdout, &env)
 	if !env.Found || len(env.Results) != 2 {
 		t.Errorf("recall: want found+2 results, got %+v", env)
 	}
@@ -200,9 +218,7 @@ func TestRecallCommand_FoundAndNotFound(t *testing.T) {
 		t.Fatalf("recall unrelated: %v", err)
 	}
 	env = recallEnvelope{}
-	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
-		t.Fatalf("recall unrelated JSON: %v", err)
-	}
+	unmarshalAgentResults(t, stdout, &env)
 	if env.Found || len(env.Results) != 0 {
 		t.Errorf("unrelated recall: want empty, got %+v", env)
 	}
@@ -252,9 +268,7 @@ func TestRecallCommand_RespectsNoLearnEnvVar(t *testing.T) {
 		t.Fatalf("recall with NO_LEARN: %v", err)
 	}
 	var env recallEnvelope
-	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
-		t.Fatalf("recall JSON: %v", err)
-	}
+	unmarshalAgentResults(t, stdout, &env)
 	if env.Found {
 		t.Errorf("NO_LEARN should suppress recall results; got %+v", env)
 	}
@@ -331,9 +345,7 @@ func TestLearningsForget_TargetedAndAll(t *testing.T) {
 		t.Fatalf("forget Y: %v", err)
 	}
 	var resp map[string]any
-	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
-		t.Fatalf("forget JSON: %v", err)
-	}
+	unmarshalAgentResults(t, stdout, &resp)
 	if v, _ := resp["deleted"].(float64); v != 1 {
 		t.Errorf("forget Y: want deleted=1, got %v", resp["deleted"])
 	}
@@ -348,9 +360,7 @@ func TestLearningsForget_TargetedAndAll(t *testing.T) {
 		t.Fatalf("forget all: %v", err)
 	}
 	resp = nil
-	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
-		t.Fatalf("forget all JSON: %v", err)
-	}
+	unmarshalAgentResults(t, stdout, &resp)
 	if v, _ := resp["deleted"].(float64); v < 1 {
 		t.Errorf("forget all: want deleted>=1, got %v", resp["deleted"])
 	}
@@ -373,9 +383,7 @@ func TestTeachPattern_HappyPath(t *testing.T) {
 		t.Fatalf("teach-pattern: %v", err)
 	}
 	var resp map[string]any
-	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
-		t.Fatalf("teach-pattern JSON: %v (stdout=%q)", err, stdout)
-	}
+	unmarshalAgentResults(t, stdout, &resp)
 	if v, _ := resp["recorded"].(bool); !v {
 		t.Errorf("teach-pattern: want recorded=true, got %v", resp)
 	}
@@ -411,9 +419,7 @@ func TestTeachLookup_HappyPath(t *testing.T) {
 		t.Fatalf("teach-lookup: %v", err)
 	}
 	var resp map[string]any
-	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
-		t.Fatalf("teach-lookup JSON: %v (stdout=%q)", err, stdout)
-	}
+	unmarshalAgentResults(t, stdout, &resp)
 	if v, _ := resp["recorded"].(bool); !v {
 		t.Errorf("teach-lookup: want recorded=true, got %v", resp)
 	}
@@ -508,9 +514,7 @@ func TestRecallCommand_EnvelopeCarriesQueryEntities(t *testing.T) {
 		t.Fatalf("recall: %v", err)
 	}
 	var env recallEnvelope
-	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
-		t.Fatalf("recall JSON: %v (stdout=%q)", err, stdout)
-	}
+	unmarshalAgentResults(t, stdout, &env)
 	if env.Normalized == "" {
 		t.Errorf("cold recall should still populate normalized; got %q", env.Normalized)
 	}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -80,7 +80,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1005,6 +1005,69 @@ func printJSONFiltered(w io.Writer, v any, flags *rootFlags) error {
 	return printOutputWithFlags(w, json.RawMessage(raw), flags)
 }
 
+// wrapAgentOutput gives --agent callers one parseable top-level envelope for
+// generated command families that build typed Go values instead of endpoint
+// response bytes. The raw value is preserved under results so --json without
+// --agent can stay backward-compatible while shell agents get stable metadata.
+func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage, error) {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, ok := meta["source"]; !ok {
+		meta["source"] = "local"
+	}
+	if source, _ := meta["source"].(string); source == "live" {
+		data = unwrapSingleKeyArray(data)
+	}
+	var results any
+	if json.Valid(data) {
+		results = data
+	} else {
+		results = string(data)
+	}
+	envelope := map[string]any{
+		"meta":    meta,
+		"results": results,
+	}
+	return json.Marshal(envelope)
+}
+
+// unwrapSingleKeyArray flattens single-key collection envelopes
+// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
+// emits a stable .results[] across APIs. Multi-key objects pass
+// through so cursor/pagination fields stay accessible; non-array
+// values pass through so non-collection responses aren't reshaped.
+//
+// The wrapper-key set is intentionally narrower than
+// extractPaginatedItems (which also walks domain-specific keys like
+// "messages", "members", "values" used by social/messaging APIs).
+// This helper only flattens canonical collection envelopes for
+// --json output; the pagination walker has a broader remit.
+func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
+	leading := bytes.TrimLeft(data, " \t\r\n")
+	if len(leading) == 0 || leading[0] != '{' {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if len(obj) != 1 {
+		return data
+	}
+	for key, val := range obj {
+		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
+			return data
+		}
+		trimmed := bytes.TrimLeft(val, " \t\r\n")
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return data
+		}
+		return val
+	}
+	return data
+}
+
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
 // Supports dotted paths like "events.shortName" to descend into nested structures.
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
@@ -1162,6 +1225,10 @@ func camelToKebab(s string) string {
 
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
+	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
 	// --select wins over --compact when both are set: an explicit field list
 	// is the user's authoritative request, so the high-gravity allow-list
 	// must not strip those fields out before --select can pick them. When
@@ -1171,6 +1238,13 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
 		data = compactFields(data)
+	}
+	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
+		wrapped, err := wrapAgentOutput(data, agentMeta)
+		if err != nil {
+			return err
+		}
+		data = wrapped
 	}
 	// --quiet: suppress all output, exit code communicates result
 	if flags.quiet {
@@ -2035,42 +2109,6 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 		prefix = "API unreachable. "
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
-}
-
-// unwrapSingleKeyArray flattens single-key collection envelopes
-// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
-//
-// The wrapper-key set is intentionally narrower than
-// extractPaginatedItems (which also walks domain-specific keys like
-// "messages", "members", "values" used by social/messaging APIs).
-// This helper only flattens canonical collection envelopes for
-// --json output; the pagination walker has a broader remit.
-func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
-	leading := bytes.TrimLeft(data, " \t\r\n")
-	if len(leading) == 0 || leading[0] != '{' {
-		return data
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if len(obj) != 1 {
-		return data
-	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
-	}
-	return data
 }
 
 // wrapWithProvenance wraps response data in a provenance envelope:

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -80,7 +80,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -80,7 +80,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -74,7 +74,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_items.go
@@ -81,7 +81,7 @@ func newItemsPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -111,6 +111,9 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -149,7 +152,11 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -97,6 +97,9 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -135,7 +138,11 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -78,7 +78,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -71,7 +71,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -118,6 +118,9 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -156,7 +159,11 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -118,6 +118,9 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -156,7 +159,11 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -872,6 +872,69 @@ func printJSONFiltered(w io.Writer, v any, flags *rootFlags) error {
 	return printOutputWithFlags(w, json.RawMessage(raw), flags)
 }
 
+// wrapAgentOutput gives --agent callers one parseable top-level envelope for
+// generated command families that build typed Go values instead of endpoint
+// response bytes. The raw value is preserved under results so --json without
+// --agent can stay backward-compatible while shell agents get stable metadata.
+func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage, error) {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, ok := meta["source"]; !ok {
+		meta["source"] = "local"
+	}
+	if source, _ := meta["source"].(string); source == "live" {
+		data = unwrapSingleKeyArray(data)
+	}
+	var results any
+	if json.Valid(data) {
+		results = data
+	} else {
+		results = string(data)
+	}
+	envelope := map[string]any{
+		"meta":    meta,
+		"results": results,
+	}
+	return json.Marshal(envelope)
+}
+
+// unwrapSingleKeyArray flattens single-key collection envelopes
+// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
+// emits a stable .results[] across APIs. Multi-key objects pass
+// through so cursor/pagination fields stay accessible; non-array
+// values pass through so non-collection responses aren't reshaped.
+//
+// The wrapper-key set is intentionally narrower than
+// extractPaginatedItems (which also walks domain-specific keys like
+// "messages", "members", "values" used by social/messaging APIs).
+// This helper only flattens canonical collection envelopes for
+// --json output; the pagination walker has a broader remit.
+func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
+	leading := bytes.TrimLeft(data, " \t\r\n")
+	if len(leading) == 0 || leading[0] != '{' {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if len(obj) != 1 {
+		return data
+	}
+	for key, val := range obj {
+		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
+			return data
+		}
+		trimmed := bytes.TrimLeft(val, " \t\r\n")
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return data
+		}
+		return val
+	}
+	return data
+}
+
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
 // Supports dotted paths like "events.shortName" to descend into nested structures.
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
@@ -1029,6 +1092,10 @@ func camelToKebab(s string) string {
 
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
+	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
 	// --select wins over --compact when both are set: an explicit field list
 	// is the user's authoritative request, so the high-gravity allow-list
 	// must not strip those fields out before --select can pick them. When
@@ -1038,6 +1105,13 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
 		data = compactFields(data)
+	}
+	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
+		wrapped, err := wrapAgentOutput(data, agentMeta)
+		if err != nil {
+			return err
+		}
+		data = wrapped
 	}
 	// --quiet: suppress all output, exit code communicates result
 	if flags.quiet {
@@ -1902,42 +1976,6 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 		prefix = "API unreachable. "
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
-}
-
-// unwrapSingleKeyArray flattens single-key collection envelopes
-// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
-//
-// The wrapper-key set is intentionally narrower than
-// extractPaginatedItems (which also walks domain-specific keys like
-// "messages", "members", "values" used by social/messaging APIs).
-// This helper only flattens canonical collection envelopes for
-// --json output; the pagination walker has a broader remit.
-func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
-	leading := bytes.TrimLeft(data, " \t\r\n")
-	if len(leading) == 0 || leading[0] != '{' {
-		return data
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if len(obj) != 1 {
-		return data
-	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
-	}
-	return data
 }
 
 // wrapWithProvenance wraps response data in a provenance envelope:

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 78
+    "total": 80
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -954,6 +954,69 @@ func printJSONFiltered(w io.Writer, v any, flags *rootFlags) error {
 	return printOutputWithFlags(w, json.RawMessage(raw), flags)
 }
 
+// wrapAgentOutput gives --agent callers one parseable top-level envelope for
+// generated command families that build typed Go values instead of endpoint
+// response bytes. The raw value is preserved under results so --json without
+// --agent can stay backward-compatible while shell agents get stable metadata.
+func wrapAgentOutput(data json.RawMessage, meta map[string]any) (json.RawMessage, error) {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	if _, ok := meta["source"]; !ok {
+		meta["source"] = "local"
+	}
+	if source, _ := meta["source"].(string); source == "live" {
+		data = unwrapSingleKeyArray(data)
+	}
+	var results any
+	if json.Valid(data) {
+		results = data
+	} else {
+		results = string(data)
+	}
+	envelope := map[string]any{
+		"meta":    meta,
+		"results": results,
+	}
+	return json.Marshal(envelope)
+}
+
+// unwrapSingleKeyArray flattens single-key collection envelopes
+// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
+// emits a stable .results[] across APIs. Multi-key objects pass
+// through so cursor/pagination fields stay accessible; non-array
+// values pass through so non-collection responses aren't reshaped.
+//
+// The wrapper-key set is intentionally narrower than
+// extractPaginatedItems (which also walks domain-specific keys like
+// "messages", "members", "values" used by social/messaging APIs).
+// This helper only flattens canonical collection envelopes for
+// --json output; the pagination walker has a broader remit.
+func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
+	leading := bytes.TrimLeft(data, " \t\r\n")
+	if len(leading) == 0 || leading[0] != '{' {
+		return data
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return data
+	}
+	if len(obj) != 1 {
+		return data
+	}
+	for key, val := range obj {
+		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
+			return data
+		}
+		trimmed := bytes.TrimLeft(val, " \t\r\n")
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return data
+		}
+		return val
+	}
+	return data
+}
+
 // filterFields keeps only the specified fields (comma-separated) from JSON objects/arrays.
 // Supports dotted paths like "events.shortName" to descend into nested structures.
 // Arrays are traversed element-wise: "events.shortName" keeps shortName on each event.
@@ -1111,6 +1174,10 @@ func camelToKebab(s string) string {
 
 // printOutputWithFlags routes output through the right format based on flags.
 func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) error {
+	return printOutputWithFlagsMeta(w, data, flags, map[string]any{"source": "local"})
+}
+
+func printOutputWithFlagsMeta(w io.Writer, data json.RawMessage, flags *rootFlags, agentMeta map[string]any) error {
 	// --select wins over --compact when both are set: an explicit field list
 	// is the user's authoritative request, so the high-gravity allow-list
 	// must not strip those fields out before --select can pick them. When
@@ -1120,6 +1187,13 @@ func printOutputWithFlags(w io.Writer, data json.RawMessage, flags *rootFlags) e
 		data = filterFields(data, flags.selectFields)
 	} else if flags.compact {
 		data = compactFields(data)
+	}
+	if flags.agent && flags.asJSON && !flags.csv && !flags.plain && !flags.quiet {
+		wrapped, err := wrapAgentOutput(data, agentMeta)
+		if err != nil {
+			return err
+		}
+		data = wrapped
 	}
 	// --quiet: suppress all output, exit code communicates result
 	if flags.quiet {
@@ -1984,42 +2058,6 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 		prefix = "API unreachable. "
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
-}
-
-// unwrapSingleKeyArray flattens single-key collection envelopes
-// ({"results":[...]}, {"data":[...]}, etc.) so the agent envelope
-// emits a stable .results[] across APIs. Multi-key objects pass
-// through so cursor/pagination fields stay accessible; non-array
-// values pass through so non-collection responses aren't reshaped.
-//
-// The wrapper-key set is intentionally narrower than
-// extractPaginatedItems (which also walks domain-specific keys like
-// "messages", "members", "values" used by social/messaging APIs).
-// This helper only flattens canonical collection envelopes for
-// --json output; the pagination walker has a broader remit.
-func unwrapSingleKeyArray(data json.RawMessage) json.RawMessage {
-	leading := bytes.TrimLeft(data, " \t\r\n")
-	if len(leading) == 0 || leading[0] != '{' {
-		return data
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return data
-	}
-	if len(obj) != 1 {
-		return data
-	}
-	for key, val := range obj {
-		if key != "results" && key != "data" && key != "items" && key != "nodes" && key != "entries" && key != "records" {
-			return data
-		}
-		trimmed := bytes.TrimLeft(val, " \t\r\n")
-		if len(trimmed) == 0 || trimmed[0] != '[' {
-			return data
-		}
-		return val
-	}
-	return data
 }
 
 // wrapWithProvenance wraps response data in a provenance envelope:

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -116,6 +116,9 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -154,7 +157,11 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -135,6 +135,9 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -173,7 +176,11 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -91,7 +91,7 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 	cmd.Flags().StringVar(&flagStatus, "status", "", "Status (one of: draft, active, archived)")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -99,7 +99,7 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Priority (one of: low, normal, high)")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -139,6 +139,9 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -177,7 +180,11 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -74,7 +74,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/promoted_things.go
@@ -63,7 +63,7 @@ func newThingsPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -109,6 +109,9 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -147,7 +150,11 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -126,6 +126,9 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 					"status":   statusCode,
 					"success":  statusCode >= 200 && statusCode < 300 && (partialFailure == nil || flags.allowPartialFailure),
 				}
+				if flags.agent {
+					envelope["meta"] = map[string]any{"source": "live"}
+				}
 				if partialFailure != nil {
 					envelope["partial_failure"] = partialFailure
 				}
@@ -164,7 +167,11 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 				if len(filtered) > 0 {
 					var parsed any
 					if err := json.Unmarshal(filtered, &parsed); err == nil {
-						envelope["data"] = parsed
+						if flags.agent {
+							envelope["results"] = parsed
+						} else {
+							envelope["data"] = parsed
+						}
 					}
 				}
 				envelopeJSON, err := json.Marshal(envelope)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -70,7 +70,7 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 	cmd.Flags().StringVar(&flagS, "address", "", "Street address")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -74,7 +74,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -88,7 +88,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -72,7 +72,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -72,7 +72,7 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 	cmd.Flags().BoolVar(&flagAll, "all", false, "Fetch all pages")

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -72,7 +72,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 					return nil
 				}
 			}
-			return printOutputWithFlags(cmd.OutOrStdout(), data, flags)
+			return printOutputWithFlagsMeta(cmd.OutOrStdout(), data, flags, map[string]any{"source": "live"})
 		},
 	}
 


### PR DESCRIPTION
## Summary

- add a shared generated `--agent` envelope helper so raw typed outputs and no-store endpoint fallthroughs use `{meta, results}`
- keep explicit non-agent `--json` shapes backward-compatible, including mutation `data` envelopes and bare array reads
- switch mutating endpoint `--agent` envelopes from `data` to `results` while adding `meta.source = live`
- update generated learn-loop tests and golden fixtures for the new agent envelope contract

Closes #3171.
Part of #3090.

## Verification

- `go test ./internal/generator -run TestGeneratedPrintJSONFilteredAgentWrapsTypedOutputs -count=1`
- `go test ./internal/generator -run TestGeneratedNoStoreEndpointAgentWrapsFallthroughOutput -count=1`
- `go test ./internal/generator -run TestGenerateLearnCLICommandsCompileAndTest -count=1`
- `go test ./internal/generator -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh generate-golden-api generate-golden-api-rich-auth generate-embedded-paged-api generate-fastapi-operationids generate-graphql-shared-endpoint generate-public-param-names generate-sync-walker-api generate-tier-routing-api generate-learn-loop-api`
- `go fmt ./...`
- `go test ./...`
- `go build -o ./cli-printing-press ./cmd/cli-printing-press`
- `golangci-lint run ./...`
- `git diff --check`