### PR TITLE
fix(cli): support OData conditions sync filters

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13201,6 +13201,14 @@ func TestGeneratedSyncGatesSinceParamPerResource(t *testing.T) {
 			Format: "toml",
 			Path:   "~/.config/gatedsync-pp-cli/config.toml",
 		},
+		Types: map[string]spec.TypeDef{
+			"Ticket": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "integer"},
+					{Name: "_info", Type: "object"},
+				},
+			},
+		},
 		Resources: map[string]spec.Resource{
 			// Declares since — sync should pass it through.
 			"events": {
@@ -13214,6 +13222,25 @@ func TestGeneratedSyncGatesSinceParamPerResource(t *testing.T) {
 						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
 						Params: []spec.Param{
 							{Name: "since", Type: "string"},
+						},
+					},
+				},
+			},
+			// OData-style APIs declare a conditions param instead of a
+			// literal since param. When the response type documents a
+			// timestamp field, sync should send a formatted conditions
+			// expression through the same per-resource switch.
+			"tickets": {
+				Description: "Tickets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/tickets",
+						Description: "List tickets",
+						Response:    spec.ResponseDef{Type: "array", Item: "Ticket"},
+						Pagination:  &spec.Pagination{CursorParam: "page", LimitParam: "pageSize"},
+						Params: []spec.Param{
+							{Name: "conditions", Type: "string"},
 						},
 					},
 				},
@@ -13276,6 +13303,21 @@ func TestGeneratedSyncGatesSinceParamPerResource(t *testing.T) {
 		"events resource must appear in the per-resource switch")
 	assert.Contains(t, sinceHelperBody, `return "since"`,
 		"events resource must map to its declared param name")
+	assert.Contains(t, sinceHelperBody, `case "tickets":`,
+		"tickets resource must appear in the per-resource switch")
+	assert.Contains(t, sinceHelperBody, `return "conditions"`,
+		"tickets resource must map to the OData conditions param")
+
+	sinceFormatHelperStart := strings.Index(syncContent, "func syncResourceSinceParamFormat(resource string) string")
+	require.NotEqual(t, -1, sinceFormatHelperStart, "sync.go must emit syncResourceSinceParamFormat")
+	sinceFormatHelperBody := syncContent[sinceFormatHelperStart:]
+	if nextFunc := strings.Index(sinceFormatHelperBody[1:], "\nfunc "); nextFunc != -1 {
+		sinceFormatHelperBody = sinceFormatHelperBody[:nextFunc+1]
+	}
+	assert.Contains(t, sinceFormatHelperBody, `case "tickets":`)
+	assert.Contains(t, sinceFormatHelperBody, `return "odata-conditions:_info/lastUpdated"`)
+	assert.Contains(t, syncContent, `fmt.Sprintf("%s > [%s]", field, value)`,
+		"OData conditions format must wrap RFC3339 timestamps in the API's bracketed expression syntax")
 
 	// users declares no since-like param → no case for it (falls through to "").
 	assert.NotContains(t, sinceHelperBody, `case "users":`,
@@ -18777,6 +18819,9 @@ func TestSyncSinceParamFormatForDateOnlyResources(t *testing.T) {
 	}
 	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "date-time"); got != "2026-06-07T12:34:56Z" {
 		t.Fatalf("date-time since value = %q, want original RFC3339", got)
+	}
+	if got := formatSyncSinceValue("2026-06-07T12:34:56Z", "odata-conditions:_info/lastUpdated"); got != "_info/lastUpdated > [2026-06-07T12:34:56Z]" {
+		t.Fatalf("odata conditions since value = %q, want bracketed conditions expression", got)
 	}
 }
 `

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -107,8 +107,14 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
+{{- if .Pagination.SinceParam}}
 	Long: `Sync data from the API into a local SQLite database. Supports resumable
 incremental sync (only fetches new data since last sync) and full resync.
+{{- else}}
+	Long: `Sync data from the API into a local SQLite database. This API does
+not declare temporal sync filters, so sync performs full pagination unless an
+explicit resource declares its own incremental filter.
+{{- end}}
 {{- if .VisionSet.Search}}
 Once synced, use the 'search' command for instant full-text search.
 {{- end}}
@@ -1408,6 +1414,13 @@ func syncResourceSinceParamFormat(resource string) string {
 }
 
 func formatSyncSinceValue(value string, paramFormat string) string {
+	if field, ok := strings.CutPrefix(paramFormat, "odata-conditions:"); ok {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return value
+		}
+		return fmt.Sprintf("%s > [%s]", field, value)
+	}
 	if strings.EqualFold(paramFormat, "date") {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -536,11 +536,11 @@ func Profile(s *spec.APISpec) *APIProfile {
 			if endpoint.ResponsePath != "" {
 				responsePaths[endpoint.ResponsePath]++
 			}
+			if sinceParam, _ := detectEndpointSinceParamAndFormat(endpoint, s.Types); sinceParam != "" {
+				sinceParams[sinceParam]++
+			}
 			for _, param := range endpoint.Params {
 				name := strings.ToLower(param.Name)
-				if isEndpointSinceParamName(name) {
-					sinceParams[param.Name]++
-				}
 				if name == "dates" || name == "date_range" || name == "daterange" {
 					dateRangeParams[param.Name]++
 				}
@@ -1898,6 +1898,7 @@ type parameterizedEntry struct {
 // fields propagate uniformly.
 func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resource, e spec.Endpoint, types map[string]spec.TypeDef, resourceNameIndex map[string]string) syncableMeta {
 	idWalkFilterParam, idWalkLimitParam, idWalkPageSize := detectIDWalkParams(e)
+	sinceParam, sinceParamFormat := detectEndpointSinceParamAndFormat(e, types)
 	return syncableMeta{
 		Path:               e.Path,
 		Method:             strings.ToUpper(e.Method),
@@ -1905,8 +1906,8 @@ func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resour
 		SkipDefaultSync:    isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
 		IDField:            e.IDField,
 		Critical:           e.Critical,
-		SinceParam:         detectEndpointSinceParam(e.Params),
-		SinceParamFormat:   detectEndpointSinceParamFormat(e.Params),
+		SinceParam:         sinceParam,
+		SinceParamFormat:   sinceParamFormat,
 		SupportsPagination: endpointSupportsPagination(e),
 		UsesHTMLResponse:   e.UsesHTMLResponse(),
 		HTMLExtract:        e.HTMLExtract,
@@ -2145,23 +2146,96 @@ func paginationLimitDefault(endpoint spec.Endpoint) (int, bool) {
 // Profile() so per-endpoint detection stays consistent with the
 // PaginationProfile.SinceParam summary.
 func detectEndpointSinceParam(params []spec.Param) string {
-	name, _ := detectEndpointSinceParamAndFormat(params)
+	name, _ := detectEndpointSinceParamAndFormat(spec.Endpoint{Params: params}, nil)
 	return name
 }
 
 func detectEndpointSinceParamFormat(params []spec.Param) string {
-	_, format := detectEndpointSinceParamAndFormat(params)
+	_, format := detectEndpointSinceParamAndFormat(spec.Endpoint{Params: params}, nil)
 	return format
 }
 
-func detectEndpointSinceParamAndFormat(params []spec.Param) (string, string) {
-	for _, p := range params {
+func detectEndpointSinceParamAndFormat(endpoint spec.Endpoint, types map[string]spec.TypeDef) (string, string) {
+	for _, p := range endpoint.Params {
 		name := strings.ToLower(p.Name)
 		if isEndpointSinceParamName(name) {
 			return p.Name, strings.ToLower(strings.TrimSpace(p.Format))
 		}
 	}
+	for _, p := range endpoint.Params {
+		if strings.EqualFold(strings.TrimSpace(p.Name), "conditions") {
+			if field := detectODataConditionsTimestampField(endpoint, types); field != "" {
+				return p.Name, "odata-conditions:" + field
+			}
+		}
+	}
 	return "", ""
+}
+
+func detectODataConditionsTimestampField(endpoint spec.Endpoint, types map[string]spec.TypeDef) string {
+	typeName := strings.TrimSpace(endpoint.Response.Item)
+	if typeName == "" || types == nil {
+		return ""
+	}
+	typeDef, ok := types[typeName]
+	if !ok {
+		return ""
+	}
+	for _, field := range typeDef.Fields {
+		if field.Name == "_info/lastUpdated" {
+			return field.Name
+		}
+	}
+	for _, candidate := range []string{
+		"lastUpdated",
+		"updated_at",
+		"updatedAt",
+		"modified_at",
+		"modifiedAt",
+		"last_modified",
+		"lastModified",
+		"date_updated",
+		"dateUpdated",
+		"updated_date",
+		"modified_date",
+	} {
+		if field := responseTypeFieldByNormalizedName(typeDef, candidate); field != "" {
+			return field
+		}
+	}
+	for _, field := range typeDef.Fields {
+		if strings.TrimSpace(field.Name) == "_info" {
+			return "_info/lastUpdated"
+		}
+	}
+	for _, field := range typeDef.Fields {
+		name := strings.ToLower(field.Name)
+		format := strings.ToLower(strings.TrimSpace(field.Format))
+		if (format == "date" || format == "date-time") && (strings.Contains(name, "updated") || strings.Contains(name, "modified")) {
+			return field.Name
+		}
+	}
+	return ""
+}
+
+func responseTypeFieldByNormalizedName(typeDef spec.TypeDef, candidate string) string {
+	normalizedCandidate := normalizeTemporalFieldName(candidate)
+	for _, field := range typeDef.Fields {
+		if normalizeTemporalFieldName(field.Name) == normalizedCandidate {
+			return field.Name
+		}
+	}
+	return ""
+}
+
+func normalizeTemporalFieldName(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func isEndpointSinceParamName(name string) bool {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2140,21 +2140,6 @@ func paginationLimitDefault(endpoint spec.Endpoint) (int, bool) {
 	return 0, false
 }
 
-// detectEndpointSinceParam returns the actual query parameter name this
-// endpoint declares for incremental temporal filtering, or "" when none is
-// declared. The match list mirrors the profile-level aggregation in
-// Profile() so per-endpoint detection stays consistent with the
-// PaginationProfile.SinceParam summary.
-func detectEndpointSinceParam(params []spec.Param) string {
-	name, _ := detectEndpointSinceParamAndFormat(spec.Endpoint{Params: params}, nil)
-	return name
-}
-
-func detectEndpointSinceParamFormat(params []spec.Param) string {
-	_, format := detectEndpointSinceParamAndFormat(spec.Endpoint{Params: params}, nil)
-	return format
-}
-
 func detectEndpointSinceParamAndFormat(endpoint spec.Endpoint, types map[string]spec.TypeDef) (string, string) {
 	for _, p := range endpoint.Params {
 		name := strings.ToLower(p.Name)
@@ -2204,7 +2189,7 @@ func detectODataConditionsTimestampField(endpoint spec.Endpoint, types map[strin
 		}
 	}
 	for _, field := range typeDef.Fields {
-		if strings.TrimSpace(field.Name) == "_info" {
+		if strings.TrimSpace(field.Name) == "_info" && strings.EqualFold(strings.TrimSpace(field.Type), "object") {
 			return "_info/lastUpdated"
 		}
 	}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2312,6 +2312,18 @@ func TestProfileODataConditionsSinceParamPropagation(t *testing.T) {
 					},
 				},
 			},
+			"badinfo": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v4/system/badinfo",
+						Response: spec.ResponseDef{Type: "array", Item: "BadInfo"},
+						Params: []spec.Param{
+							{Name: "conditions", Type: "string"},
+						},
+					},
+				},
+			},
 		},
 		Types: map[string]spec.TypeDef{
 			"Ticket": {
@@ -2330,6 +2342,12 @@ func TestProfileODataConditionsSinceParamPropagation(t *testing.T) {
 				Fields: []spec.TypeField{
 					{Name: "id", Type: "integer"},
 					{Name: "name", Type: "string"},
+				},
+			},
+			"BadInfo": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "integer"},
+					{Name: "_info", Type: "string"},
 				},
 			},
 		},
@@ -2352,6 +2370,10 @@ func TestProfileODataConditionsSinceParamPropagation(t *testing.T) {
 	require.Contains(t, byName, "users")
 	assert.Empty(t, byName["users"].SinceParam, "conditions without a documented updated field must not hardcode a filter")
 	assert.Empty(t, byName["users"].SinceParamFormat)
+
+	require.Contains(t, byName, "badinfo")
+	assert.Empty(t, byName["badinfo"].SinceParam, "non-object _info fields must not synthesize nested OData filters")
+	assert.Empty(t, byName["badinfo"].SinceParamFormat)
 
 	assert.Equal(t, "conditions", profile.Pagination.SinceParam)
 }

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2266,6 +2266,96 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 	assert.Empty(t, byName["users"].SinceParam, "endpoints without a since-like param yield empty SinceParam — the sync template treats this as 'do not send'")
 }
 
+func TestProfileODataConditionsSinceParamPropagation(t *testing.T) {
+	t.Parallel()
+
+	s := &spec.APISpec{
+		Name: "odata",
+		Resources: map[string]spec.Resource{
+			"tickets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v4/service/tickets",
+						Response: spec.ResponseDef{Type: "array", Item: "Ticket"},
+						Params: []spec.Param{
+							{Name: "conditions", Type: "string"},
+							{Name: "page", Type: "integer"},
+							{Name: "pageSize", Type: "integer"},
+						},
+					},
+				},
+			},
+			"companies": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v4/company/companies",
+						Response: spec.ResponseDef{Type: "array", Item: "Company"},
+						Params: []spec.Param{
+							{Name: "conditions", Type: "string"},
+							{Name: "page", Type: "integer"},
+							{Name: "pageSize", Type: "integer"},
+						},
+					},
+				},
+			},
+			"users": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v4/system/users",
+						Response: spec.ResponseDef{Type: "array", Item: "User"},
+						Params: []spec.Param{
+							{Name: "conditions", Type: "string"},
+						},
+					},
+				},
+			},
+		},
+		Types: map[string]spec.TypeDef{
+			"Ticket": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "integer"},
+					{Name: "_info", Type: "object"},
+				},
+			},
+			"Company": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "integer"},
+					{Name: "lastUpdated", Type: "string", Format: "date-time"},
+				},
+			},
+			"User": {
+				Fields: []spec.TypeField{
+					{Name: "id", Type: "integer"},
+					{Name: "name", Type: "string"},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := make(map[string]SyncableResource, len(profile.SyncableResources))
+	for _, r := range profile.SyncableResources {
+		byName[r.Name] = r
+	}
+
+	require.Contains(t, byName, "tickets")
+	assert.Equal(t, "conditions", byName["tickets"].SinceParam)
+	assert.Equal(t, "odata-conditions:_info/lastUpdated", byName["tickets"].SinceParamFormat)
+
+	require.Contains(t, byName, "companies")
+	assert.Equal(t, "conditions", byName["companies"].SinceParam)
+	assert.Equal(t, "odata-conditions:lastUpdated", byName["companies"].SinceParamFormat)
+
+	require.Contains(t, byName, "users")
+	assert.Empty(t, byName["users"].SinceParam, "conditions without a documented updated field must not hardcode a filter")
+	assert.Empty(t, byName["users"].SinceParamFormat)
+
+	assert.Equal(t, "conditions", profile.Pagination.SinceParam)
+}
+
 func TestProfileSyncableResourceFieldSelectorPropagation(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "selectors",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -57,8 +57,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
-incremental sync (only fetches new data since last sync) and full resync.
+		Long: `Sync data from the API into a local SQLite database. This API does
+not declare temporal sync filters, so sync performs full pagination unless an
+explicit resource declares its own incremental filter.
 Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
@@ -803,6 +804,13 @@ func syncResourceSinceParamFormat(resource string) string {
 }
 
 func formatSyncSinceValue(value string, paramFormat string) string {
+	if field, ok := strings.CutPrefix(paramFormat, "odata-conditions:"); ok {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return value
+		}
+		return fmt.Sprintf("%s > [%s]", field, value)
+	}
 	if strings.EqualFold(paramFormat, "date") {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -57,8 +57,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
-incremental sync (only fetches new data since last sync) and full resync.
+		Long: `Sync data from the API into a local SQLite database. This API does
+not declare temporal sync filters, so sync performs full pagination unless an
+explicit resource declares its own incremental filter.
 Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
@@ -824,6 +825,13 @@ func syncResourceSinceParamFormat(resource string) string {
 }
 
 func formatSyncSinceValue(value string, paramFormat string) string {
+	if field, ok := strings.CutPrefix(paramFormat, "odata-conditions:"); ok {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return value
+		}
+		return fmt.Sprintf("%s > [%s]", field, value)
+	}
 	if strings.EqualFold(paramFormat, "date") {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -57,8 +57,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
-incremental sync (only fetches new data since last sync) and full resync.
+		Long: `Sync data from the API into a local SQLite database. This API does
+not declare temporal sync filters, so sync performs full pagination unless an
+explicit resource declares its own incremental filter.
 Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
@@ -799,6 +800,13 @@ func syncResourceSinceParamFormat(resource string) string {
 }
 
 func formatSyncSinceValue(value string, paramFormat string) string {
+	if field, ok := strings.CutPrefix(paramFormat, "odata-conditions:"); ok {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return value
+		}
+		return fmt.Sprintf("%s > [%s]", field, value)
+	}
 	if strings.EqualFold(paramFormat, "date") {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -57,8 +57,9 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync API data to local SQLite for offline search and analysis",
-		Long: `Sync data from the API into a local SQLite database. Supports resumable
-incremental sync (only fetches new data since last sync) and full resync.
+		Long: `Sync data from the API into a local SQLite database. This API does
+not declare temporal sync filters, so sync performs full pagination unless an
+explicit resource declares its own incremental filter.
 Once synced, use the 'search' command for instant full-text search.
 
 Exit codes & warnings:
@@ -768,6 +769,13 @@ func syncResourceSinceParamFormat(resource string) string {
 }
 
 func formatSyncSinceValue(value string, paramFormat string) string {
+	if field, ok := strings.CutPrefix(paramFormat, "odata-conditions:"); ok {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return value
+		}
+		return fmt.Sprintf("%s > [%s]", field, value)
+	}
 	if strings.EqualFold(paramFormat, "date") {
 		if ts, err := time.Parse(time.RFC3339, value); err == nil {
 			return ts.Format("2006-01-02")


### PR DESCRIPTION
## Summary
- map OData-style `conditions` params to per-resource incremental sync only when a documented timestamp field can be derived
- format OData sync timestamps as `field > [RFC3339]` instead of hardcoding a global field
- stop generated sync help from promising incremental sync when no temporal filters are declared
- refresh affected golden sync outputs

Fixes #3180. Supersedes #3229 with a narrow branch from current `main`; the multi-spec base URL half of #3229 is already merged.

## Validation
- `go test ./internal/profiler ./internal/generator -run 'TestProfileODataConditionsSinceParamPropagation|TestProfileSyncableResourceSinceParamPropagation|TestGeneratedSyncGatesSinceParamPerResource|TestGenerateSyncDataLayerResources'`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh`\n- `go test ./...`\n