### PR TITLE
fix(cli): honor live dogfood happy args overlays

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -668,11 +668,11 @@ func findListCompanion(candidates []liveDogfoodCommand) *liveDogfoodCommand {
 //   - (nil, true, reason, "")        - chain broke before an ID fixture source was available
 //   - (happyArgs, false, "", "")     - no positionals at all; pass-through unchanged
 func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string, string) {
-	// pp:happy-args already supplies real positional values, so the args are
-	// authoritative — skip placeholder re-resolution, which would otherwise
-	// overwrite them via the list companion or skip the command when no
-	// companion is reachable.
-	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) != "" {
+	// Explicit pp:happy-args positionals are authoritative — skip placeholder
+	// re-resolution, which would otherwise overwrite them via a list companion.
+	// Flag-only pp:happy-args still allow the normal ID fixture resolver to fill
+	// the command's positional placeholders.
+	if raw := strings.TrimSpace(command.Annotations[happyArgsAnnotation]); raw != "" && len(parseHappyArgsAnnotation(raw).positionals) > 0 {
 		return happyArgs, false, "", ""
 	}
 	placeholders := extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))
@@ -1698,20 +1698,24 @@ func fileExistsRelativeTo(p, cliDir string) bool {
 }
 
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
-	// pp:happy-args supplies real happy-path args, overriding the Example-derived
+	// pp:happy-args supplies real happy-path args, overlaying the Example-derived
 	// placeholders (e.g. "--ids example-value") that strict upstream validators
 	// reject with HTTP 400. Same `;`-separated `--flag=value` / `<name>=value`
 	// grammar the runtime layer uses (parseHappyArgsAnnotation), so a single
 	// annotation drives both surfaces.
 	if raw := strings.TrimSpace(command.Annotations[happyArgsAnnotation]); raw != "" {
 		parsed := parseHappyArgsAnnotation(raw)
-		args := append([]string{}, command.Path...)
-		args = append(args, parsed.positionals...)
-		args = append(args, parsed.flags...)
-		if len(args) > len(command.Path) {
-			return args, true
+		args, hasExample := liveDogfoodExampleArgs(command)
+		if !hasExample {
+			args = append([]string{}, command.Path...)
 		}
+		args = overlayLiveDogfoodHappyArgs(args, command.Path, parsed)
+		return args, len(args) > len(command.Path) || hasExample
 	}
+	return liveDogfoodExampleArgs(command)
+}
+
+func liveDogfoodExampleArgs(command liveDogfoodCommand) ([]string, bool) {
 	examples := extractExamplesSection(command.Help)
 	for line := range strings.SplitSeq(examples, "\n") {
 		candidate := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "$"))
@@ -1724,6 +1728,81 @@ func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
 		}
 	}
 	return nil, false
+}
+
+func overlayLiveDogfoodHappyArgs(args, commandPath []string, parsed happyArgs) []string {
+	out := append([]string{}, args...)
+	if len(parsed.positionals) > 0 {
+		out = overlayLiveDogfoodPositionals(out, commandPath, parsed.positionals)
+	}
+	if len(parsed.flags) > 0 {
+		out = overlayLiveDogfoodFlags(out, commandPath, parsed.flags)
+	}
+	return out
+}
+
+func overlayLiveDogfoodPositionals(args, commandPath, positionals []string) []string {
+	if len(positionals) == 0 {
+		return args
+	}
+	out := append([]string{}, args...)
+	start := min(len(commandPath), len(out))
+	var positionalIndexes []int
+	insertAt := len(out)
+	for i := start; i < len(out); i++ {
+		arg := out[i]
+		if strings.HasPrefix(arg, "-") {
+			if insertAt == len(out) {
+				insertAt = i
+			}
+			if !strings.Contains(arg, "=") && i+1 < len(out) && !strings.HasPrefix(out[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		positionalIndexes = append(positionalIndexes, i)
+	}
+	for i, value := range positionals {
+		if i < len(positionalIndexes) {
+			out[positionalIndexes[i]] = value
+			continue
+		}
+		out = append(out[:insertAt], append([]string{value}, out[insertAt:]...)...)
+		insertAt++
+	}
+	return out
+}
+
+func overlayLiveDogfoodFlags(args, commandPath, flags []string) []string {
+	out := append([]string{}, args...)
+	for i := 0; i+1 < len(flags); i += 2 {
+		flag := flags[i]
+		value := flags[i+1]
+		replaced := false
+		start := min(len(commandPath), len(out))
+		for j := start; j < len(out); j++ {
+			arg := out[j]
+			if strings.HasPrefix(arg, flag+"=") {
+				out[j] = flag + "=" + value
+				replaced = true
+				break
+			}
+			if arg != flag {
+				continue
+			}
+			if j+1 < len(out) && !strings.HasPrefix(out[j+1], "-") {
+				out[j+1] = value
+			} else {
+				out = append(out[:j+1], append([]string{value}, out[j+1:]...)...)
+			}
+			replaced = true
+			break
+		}
+		if !replaced {
+			out = append(out, flag, value)
+		}
+	}
+	return out
 }
 
 func commandSupportsJSON(help string) bool {

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -1822,13 +1822,18 @@ func liveDogfoodFlagHasSeparateValue(args []string, start, flagIndex, positional
 
 func countNonFlagArgs(args []string) int {
 	count := 0
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if arg == "--" {
 			break
 		}
-		if !strings.HasPrefix(arg, "-") {
-			count++
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+			continue
 		}
+		count++
 	}
 	return count
 }

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -667,12 +667,12 @@ func findListCompanion(candidates []liveDogfoodCommand) *liveDogfoodCommand {
 //   - (newArgs, false, "", source)   - placeholders substituted; run happy_path with newArgs
 //   - (nil, true, reason, "")        - chain broke before an ID fixture source was available
 //   - (happyArgs, false, "", "")     - no positionals at all; pass-through unchanged
-func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, ctx resolveCtx) ([]string, bool, string, string) {
+func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, annotatedPositionals int, ctx resolveCtx) ([]string, bool, string, string) {
 	// Explicit pp:happy-args positionals are authoritative — skip placeholder
 	// re-resolution, which would otherwise overwrite them via a list companion.
 	// Flag-only pp:happy-args still allow the normal ID fixture resolver to fill
 	// the command's positional placeholders.
-	if raw := strings.TrimSpace(command.Annotations[happyArgsAnnotation]); raw != "" && len(parseHappyArgsAnnotation(raw).positionals) > 0 {
+	if annotatedPositionals > 0 {
 		return happyArgs, false, "", ""
 	}
 	placeholders := extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))
@@ -785,9 +785,6 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, c
 }
 
 func happyPathSyntheticParamFixtureSkip(command liveDogfoodCommand, happyArgs []string) string {
-	if strings.TrimSpace(command.Annotations[happyArgsAnnotation]) != "" {
-		return ""
-	}
 	if liveDogfoodCommandMutates(command) {
 		return ""
 	}
@@ -1222,7 +1219,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 		return results
 	}
 
-	happyArgs, ok := liveDogfoodHappyArgs(command)
+	happyArgs, ok, parsedHappyArgs := liveDogfoodHappyArgsParsed(command)
 	if !ok {
 		if mutating {
 			results = append(results,
@@ -1241,7 +1238,7 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	}
 
 	fixtureSkip := happyPathFileFixtureSkip(happyArgs, ctx.cliDir)
-	resolvedArgs, resolveSkipped, resolveReason, fixtureSource := resolveCommandPositionals(command, happyArgs, ctx)
+	resolvedArgs, resolveSkipped, resolveReason, fixtureSource := resolveCommandPositionals(command, happyArgs, len(parsedHappyArgs.positionals), ctx)
 	syntheticParamSkip := ""
 	if fixtureSkip == "" && !resolveSkipped {
 		syntheticParamSkip = happyPathSyntheticParamFixtureSkip(command, resolvedArgs)
@@ -1698,6 +1695,11 @@ func fileExistsRelativeTo(p, cliDir string) bool {
 }
 
 func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
+	args, ok, _ := liveDogfoodHappyArgsParsed(command)
+	return args, ok
+}
+
+func liveDogfoodHappyArgsParsed(command liveDogfoodCommand) ([]string, bool, happyArgs) {
 	// pp:happy-args supplies real happy-path args, overlaying the Example-derived
 	// placeholders (e.g. "--ids example-value") that strict upstream validators
 	// reject with HTTP 400. Same `;`-separated `--flag=value` / `<name>=value`
@@ -1709,10 +1711,11 @@ func liveDogfoodHappyArgs(command liveDogfoodCommand) ([]string, bool) {
 		if !hasExample {
 			args = append([]string{}, command.Path...)
 		}
-		args = overlayLiveDogfoodHappyArgs(args, command.Path, parsed)
-		return args, len(args) > len(command.Path) || hasExample
+		args = overlayLiveDogfoodHappyArgs(args, command, parsed)
+		return args, len(args) > len(command.Path) || hasExample, parsed
 	}
-	return liveDogfoodExampleArgs(command)
+	args, ok := liveDogfoodExampleArgs(command)
+	return args, ok, happyArgs{}
 }
 
 func liveDogfoodExampleArgs(command liveDogfoodCommand) ([]string, bool) {
@@ -1730,13 +1733,13 @@ func liveDogfoodExampleArgs(command liveDogfoodCommand) ([]string, bool) {
 	return nil, false
 }
 
-func overlayLiveDogfoodHappyArgs(args, commandPath []string, parsed happyArgs) []string {
+func overlayLiveDogfoodHappyArgs(args []string, command liveDogfoodCommand, parsed happyArgs) []string {
 	out := append([]string{}, args...)
 	if len(parsed.positionals) > 0 {
-		out = overlayLiveDogfoodPositionals(out, commandPath, parsed.positionals)
+		out = overlayLiveDogfoodPositionals(out, command.Path, parsed.positionals)
 	}
 	if len(parsed.flags) > 0 {
-		out = overlayLiveDogfoodFlags(out, commandPath, parsed.flags)
+		out = overlayLiveDogfoodFlags(out, command.Path, parsed.flags, len(extractPositionalPlaceholders(liveDogfoodUsageSuffix(command.Help))))
 	}
 	return out
 }
@@ -1773,7 +1776,7 @@ func overlayLiveDogfoodPositionals(args, commandPath, positionals []string) []st
 	return out
 }
 
-func overlayLiveDogfoodFlags(args, commandPath, flags []string) []string {
+func overlayLiveDogfoodFlags(args, commandPath, flags []string, positionalCount int) []string {
 	out := append([]string{}, args...)
 	for i := 0; i+1 < len(flags); i += 2 {
 		flag := flags[i]
@@ -1790,7 +1793,7 @@ func overlayLiveDogfoodFlags(args, commandPath, flags []string) []string {
 			if arg != flag {
 				continue
 			}
-			if j+1 < len(out) && !strings.HasPrefix(out[j+1], "-") {
+			if liveDogfoodFlagHasSeparateValue(out, start, j, positionalCount) {
 				out[j+1] = value
 			} else {
 				out = append(out[:j+1], append([]string{value}, out[j+1:]...)...)
@@ -1803,6 +1806,31 @@ func overlayLiveDogfoodFlags(args, commandPath, flags []string) []string {
 		}
 	}
 	return out
+}
+
+func liveDogfoodFlagHasSeparateValue(args []string, start, flagIndex, positionalCount int) bool {
+	next := flagIndex + 1
+	if next >= len(args) || strings.HasPrefix(args[next], "-") {
+		return false
+	}
+	remainingPositionals := positionalCount - countNonFlagArgs(args[start:flagIndex])
+	if remainingPositionals <= 0 {
+		return true
+	}
+	return countNonFlagArgs(args[next+1:]) >= remainingPositionals
+}
+
+func countNonFlagArgs(args []string) int {
+	count := 0
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if !strings.HasPrefix(arg, "-") {
+			count++
+		}
+	}
+	return count
 }
 
 func commandSupportsJSON(help string) bool {

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4822,6 +4822,59 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "12"}, args,
 		"flag-form pp:happy-args must override the Example placeholder")
 
+	// Flag-only pp:happy-args overlays the runnable Example but still leaves
+	// positional IDs available for the live fixture resolver. This matches
+	// verify's happy-args behavior: annotated flags do not replace inferred
+	// positionals.
+	flagOnlyPositionalCmd := liveDogfoodCommand{
+		Path: []string{"widgets", "get"},
+		Help: `Usage:
+  cli widgets get <id> [flags]
+
+Examples:
+  cli widgets get 550e8400-e29b-41d4-a716-446655440000 --format=summary
+`,
+		Annotations: map[string]string{happyArgsAnnotation: "--include=stats"},
+	}
+	args, ok = liveDogfoodHappyArgs(flagOnlyPositionalCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"widgets", "get", "550e8400-e29b-41d4-a716-446655440000", "--format=summary", "--include", "stats"}, args)
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fixture-pp-cli")
+	require.NoError(t, os.WriteFile(binaryPath, []byte(`#!/bin/sh
+set -u
+if [ "$1" = "widgets" ] && [ "$2" = "list" ] && [ "${3:-}" = "--help" ]; then
+  echo 'Usage: fixture-pp-cli widgets list [flags]'
+  exit 0
+fi
+if [ "$1" = "widgets" ] && [ "$2" = "list" ] && [ "${3:-}" = "--json" ]; then
+  echo '{"results":[{"id":"real-widget-1"}]}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 99
+`), 0o755))
+	resolved, skipped, reason, _ := resolveCommandPositionals(flagOnlyPositionalCmd, args, resolveCtx{
+		binaryPath: binaryPath,
+		cliDir:     dir,
+		siblings: map[string][]liveDogfoodCommand{
+			"widgets": {{Path: []string{"widgets", "list"}}},
+		},
+		cache:   newCompanionCache(),
+		timeout: time.Second,
+	})
+	require.False(t, skipped, reason)
+	assert.Equal(t, []string{"widgets", "get", "real-widget-1", "--format=summary", "--include", "stats"}, resolved)
+
+	_, skipped, reason, _ = resolveCommandPositionals(flagOnlyPositionalCmd, args, resolveCtx{
+		siblings: map[string][]liveDogfoodCommand{},
+		cache:    newCompanionCache(),
+		timeout:  time.Second,
+	})
+	assert.True(t, skipped)
+	assert.Contains(t, reason, "no list companion")
+
 	// Positional form: <name>=value contributes the value as a positional arg.
 	// resolveCommandPositionals must NOT re-resolve (or skip) it even when the
 	// Usage line carries an <id> placeholder and no list companion is reachable.
@@ -4833,7 +4886,7 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 	args, ok = liveDogfoodHappyArgs(posCmd)
 	require.True(t, ok)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, args)
-	resolved, skipped, reason, _ := resolveCommandPositionals(posCmd, args, resolveCtx{})
+	resolved, skipped, reason, _ = resolveCommandPositionals(posCmd, args, resolveCtx{})
 	assert.False(t, skipped, "pp:happy-args positional must not be skipped: %s", reason)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, resolved,
 		"resolveCommandPositionals must preserve the pp:happy-args positional value")

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -4855,6 +4855,21 @@ Examples:
 	assert.Equal(t, []string{"widgets", "get", "--verbose", "true", "widget-1"}, args,
 		"boolean flag overlay must not consume the following positional")
 
+	filterBoolFlagCmd := liveDogfoodCommand{
+		Path: []string{"widgets", "get"},
+		Help: `Usage:
+  cli widgets get <id> [flags]
+
+Examples:
+  cli widgets get --filter active --verbose widget-1
+`,
+		Annotations: map[string]string{happyArgsAnnotation: "--verbose=true"},
+	}
+	args, ok = liveDogfoodHappyArgs(filterBoolFlagCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"widgets", "get", "--filter", "active", "--verbose", "true", "widget-1"}, args,
+		"preceding flag values must not be counted as consumed positionals")
+
 	// Flag-only pp:happy-args overlays the runnable Example but still leaves
 	// positional IDs available for the live fixture resolver. This matches
 	// verify's happy-args behavior: annotated flags do not replace inferred

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2500,7 +2500,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "list"},
 		Help: "Usage:\n  cli widgets list [flags]\n",
 	}
-	args, skipped, _, _ := resolveCommandPositionals(cmd, []string{"widgets", "list"}, ctx)
+	args, skipped, _, _ := resolveCommandPositionals(cmd, []string{"widgets", "list"}, 0, ctx)
 	assert.False(t, skipped)
 	assert.Equal(t, []string{"widgets", "list"}, args)
 
@@ -2509,7 +2509,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "search"},
 		Help: "Usage:\n  cli widgets search <query> [flags]\n",
 	}
-	_, skipped, reason, _ := resolveCommandPositionals(cmd, []string{"widgets", "search", "x"}, ctx)
+	_, skipped, reason, _ := resolveCommandPositionals(cmd, []string{"widgets", "search", "x"}, 0, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "non-id positional")
 
@@ -2518,7 +2518,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"widgets", "get"},
 		Help: "Usage:\n  cli widgets get <id> [flags]\n",
 	}
-	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"widgets", "get", "x"}, ctx)
+	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"widgets", "get", "x"}, 0, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "no list companion")
 
@@ -2527,7 +2527,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"movies", "get"},
 		Help: "Usage:\n  cli movies get <movieId> [flags]\n",
 	}
-	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"movies", "get", "x"}, ctx)
+	_, skipped, reason, _ = resolveCommandPositionals(cmd, []string{"movies", "get", "x"}, 0, ctx)
 	assert.True(t, skipped)
 	assert.Contains(t, reason, "no list companion")
 
@@ -2536,7 +2536,7 @@ func TestResolveCommandPositionalsSkipPaths(t *testing.T) {
 		Path: []string{"get"},
 		Help: "Usage:\n  cli get <id> <name> [flags]\n",
 	}
-	_, skipped, _, _ = resolveCommandPositionals(cmd, []string{"get", "x", "y"}, ctx)
+	_, skipped, _, _ = resolveCommandPositionals(cmd, []string{"get", "x", "y"}, 0, ctx)
 	assert.True(t, skipped)
 }
 
@@ -2577,7 +2577,7 @@ exit 99
 		storeDBPath: dbPath,
 	}
 
-	args, skipped, reason, source := resolveCommandPositionals(cmd, []string{"projects", "tasks", "get", "example-project", "example-task"}, ctx)
+	args, skipped, reason, source := resolveCommandPositionals(cmd, []string{"projects", "tasks", "get", "example-project", "example-task"}, 0, ctx)
 	require.False(t, skipped, reason)
 	assert.Equal(t, []string{"projects", "tasks", "get", "real-project-1", "real-task-1"}, args)
 	assert.Empty(t, source, "mixed store and companion resolution should not be counted as store-backed")
@@ -4822,6 +4822,39 @@ func TestLiveDogfoodHappyArgsHonorsPPHappyArgs(t *testing.T) {
 	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "12"}, args,
 		"flag-form pp:happy-args must override the Example placeholder")
 
+	// Flag-only overlays must not hide synthetic ID fixtures that remain in
+	// the Example. Those still cannot be sent to a real upstream API.
+	syntheticFlagCmd := liveDogfoodCommand{
+		Path: []string{"users", "get-by-ids"},
+		Help: `Usage:
+  cli users get-by-ids [flags]
+
+Examples:
+  cli users get-by-ids --ids example-value --format=summary
+`,
+		Annotations: map[string]string{happyArgsAnnotation: "--format=json"},
+	}
+	args, ok = liveDogfoodHappyArgs(syntheticFlagCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"users", "get-by-ids", "--ids", "example-value", "--format=json"}, args)
+	assert.Equal(t, reasonRequiredParamFixture, happyPathSyntheticParamFixtureSkip(syntheticFlagCmd, args),
+		"flag-only pp:happy-args must still skip unresolved synthetic ID fixtures")
+
+	boolFlagCmd := liveDogfoodCommand{
+		Path: []string{"widgets", "get"},
+		Help: `Usage:
+  cli widgets get <id> [flags]
+
+Examples:
+  cli widgets get --verbose widget-1
+`,
+		Annotations: map[string]string{happyArgsAnnotation: "--verbose=true"},
+	}
+	args, ok = liveDogfoodHappyArgs(boolFlagCmd)
+	require.True(t, ok)
+	assert.Equal(t, []string{"widgets", "get", "--verbose", "true", "widget-1"}, args,
+		"boolean flag overlay must not consume the following positional")
+
 	// Flag-only pp:happy-args overlays the runnable Example but still leaves
 	// positional IDs available for the live fixture resolver. This matches
 	// verify's happy-args behavior: annotated flags do not replace inferred
@@ -4855,7 +4888,7 @@ fi
 echo "unexpected args: $*" >&2
 exit 99
 `), 0o755))
-	resolved, skipped, reason, _ := resolveCommandPositionals(flagOnlyPositionalCmd, args, resolveCtx{
+	resolved, skipped, reason, _ := resolveCommandPositionals(flagOnlyPositionalCmd, args, 0, resolveCtx{
 		binaryPath: binaryPath,
 		cliDir:     dir,
 		siblings: map[string][]liveDogfoodCommand{
@@ -4867,7 +4900,7 @@ exit 99
 	require.False(t, skipped, reason)
 	assert.Equal(t, []string{"widgets", "get", "real-widget-1", "--format=summary", "--include", "stats"}, resolved)
 
-	_, skipped, reason, _ = resolveCommandPositionals(flagOnlyPositionalCmd, args, resolveCtx{
+	_, skipped, reason, _ = resolveCommandPositionals(flagOnlyPositionalCmd, args, 0, resolveCtx{
 		siblings: map[string][]liveDogfoodCommand{},
 		cache:    newCompanionCache(),
 		timeout:  time.Second,
@@ -4886,7 +4919,7 @@ exit 99
 	args, ok = liveDogfoodHappyArgs(posCmd)
 	require.True(t, ok)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, args)
-	resolved, skipped, reason, _ = resolveCommandPositionals(posCmd, args, resolveCtx{})
+	resolved, skipped, reason, _ = resolveCommandPositionals(posCmd, args, 1, resolveCtx{})
 	assert.False(t, skipped, "pp:happy-args positional must not be skipped: %s", reason)
 	assert.Equal(t, []string{"tweets", "get", "1750000000000000000"}, resolved,
 		"resolveCommandPositionals must preserve the pp:happy-args positional value")


### PR DESCRIPTION
## Summary
- overlays `pp:happy-args` onto runnable live-dogfood examples instead of replacing the whole argv
- lets flag-only happy args keep normal positional ID fixture resolution
- preserves explicit happy-args positionals and skips unresolved synthetic by-id examples instead of probing live APIs

Fixes #3093.
Fixes #3078.

## Validation
- `go test ./internal/pipeline -run 'TestLiveDogfoodHappyArgsHonorsPPHappyArgs|TestResolveCommandPositionalsSkipPaths|TestRunLiveDogfoodSkipsHappyPathOnRequiredParam4xx|TestRunLiveDogfoodErrorPathRealSkipMatchesHappyPathReason'`\n- `go test ./internal/pipeline`\n- `go test ./...`