### PR TITLE
fix(skills): guard publish reprint workflows

### DIFF
--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -1044,7 +1044,11 @@ Present three options via AskUserQuestion:
 
 #### Update path (own PR)
 
-This is the existing update flow. Set `EXISTING_PR_NUMBER` from the detection step and proceed to Step 8, which handles force-push and PR description update.
+This is the existing update flow with a divergence guard. Set
+`EXISTING_PR_NUMBER` from the detection step and proceed to Step 8, which
+fetches the current PR branch head, checks for branch-only fixes that the new
+package would revert, and only then handles force-push and PR description
+update.
 
 #### Replace path
 
@@ -1138,7 +1142,69 @@ Exit the publish flow. If Step 6 already wrote files into `$PUBLISH_REPO_DIR`, c
 
 **If `EXISTING_PR_NUMBER` is set** (updating an existing PR):
 
-Always overwrite the branch — the intent is clearly to update:
+Fetch and inspect the current PR branch before replacing it. The publish
+clone's `main` plus the newly packaged `library/<category>/<api-slug>/` tree is
+the proposed update. The remote PR branch may also contain accepted review
+fixes from the drive-to-green loop. Those branch-only edits must not be erased
+silently.
+
+```bash
+UPDATE_BRANCH="feat/<api-slug>"
+UPDATE_BASE_REF="refs/printing-press-update-base/<api-slug>"
+
+git fetch origin "+$UPDATE_BRANCH:$UPDATE_BASE_REF"
+
+# Show the scoped change from the current PR head to the new packaged working
+# tree. This is informational for clean updates and mandatory context for holds.
+git diff --stat "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/"
+
+# Branch-only paths are files that exist on the current PR branch but are absent
+# from the new packaged working tree. These are always a hold because a
+# force-push would delete them.
+WORKTREE_PATHS=$(find "library/<category>/<api-slug>" -type f -print 2>/dev/null | sort)
+BRANCH_ONLY_PATHS=$(comm -23 \
+  <(git ls-tree -r --name-only "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/" | sort) \
+  <(printf '%s\n' "$WORKTREE_PATHS"))
+
+# Modified paths need human review only when a branch patch relative to main is
+# not present in the new packaged working tree. A strict superset passes: if the
+# branch patch can be reverse-applied from the working tree, the fix is still
+# there even if the file also has fresh generated changes.
+BRANCH_ONLY_EDITS=$(git diff --name-only main "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/" | while read -r path; do
+  [ -n "$path" ] || continue
+  if git diff main "$UPDATE_BASE_REF" -- "$path" | git apply --check --reverse >/dev/null 2>&1; then
+    continue
+  else
+    printf '%s\n' "$path"
+  fi
+done | sort -u)
+
+if [ -n "$BRANCH_ONLY_PATHS$BRANCH_ONLY_EDITS" ]; then
+  echo "HOLD: updating PR #$EXISTING_PR_NUMBER would overwrite branch-only changes."
+  if [ -n "$BRANCH_ONLY_PATHS" ]; then
+    echo "Files present on the PR branch but missing from the new package:"
+    printf '%s\n' "$BRANCH_ONLY_PATHS" | sed 's/^/- /'
+  fi
+  if [ -n "$BRANCH_ONLY_EDITS" ]; then
+    echo "Files edited on the PR branch and changed again by the new package:"
+    printf '%s\n' "$BRANCH_ONLY_EDITS" | sed 's/^/- /'
+  fi
+  echo "Do not push yet. Reconcile by restoring the branch-only fixes onto the new tree, or ask the user for explicit overwrite confirmation after showing the paths above."
+  exit 1
+fi
+```
+
+If the guard exits, offer the user two choices via `AskUserQuestion`:
+
+- **Reconcile first** — restore the named branch-only files or edits onto the
+  new packaged tree, keep or add matching `.printing-press-patches/<id>.json`
+  records for code-level fixes, rerun Step 6 verification, then rerun this
+  divergence guard.
+- **Overwrite intentionally** — only after the user confirms the listed paths
+  are obsolete, continue and include a PR-body note naming the overwritten
+  branch-only paths.
+
+If the guard finds no branch-only paths or edits, overwrite the local branch:
 
 ```bash
 git checkout -B feat/<api-slug>
@@ -1212,6 +1278,9 @@ Push to origin (which is the fork for non-push users, or the upstream for push u
 **If updating an existing PR** (`EXISTING_PR_NUMBER` is set):
 
 ```bash
+# Only run this after the update-path divergence guard above has passed, or
+# after the user explicitly confirmed an intentional overwrite of the named
+# branch-only paths.
 git push --force-with-lease -u origin feat/<api-slug>
 ```
 

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -1142,8 +1142,8 @@ Exit the publish flow. If Step 6 already wrote files into `$PUBLISH_REPO_DIR`, c
 
 **If `EXISTING_PR_NUMBER` is set** (updating an existing PR):
 
-Fetch and inspect the current PR branch before replacing it. The publish
-clone's `main` plus the newly packaged `library/<category>/<api-slug>/` tree is
+Fetch and inspect the current PR branch before replacing it. The latest
+`origin/main` plus the newly packaged `library/<category>/<api-slug>/` tree is
 the proposed update. The remote PR branch may also contain accepted review
 fixes from the drive-to-green loop. Those branch-only edits must not be erased
 silently.
@@ -1152,7 +1152,7 @@ silently.
 UPDATE_BRANCH="feat/<api-slug>"
 UPDATE_BASE_REF="refs/printing-press-update-base/<api-slug>"
 
-git fetch origin "+$UPDATE_BRANCH:$UPDATE_BASE_REF"
+git fetch origin "+main:refs/remotes/origin/main" "+$UPDATE_BRANCH:$UPDATE_BASE_REF"
 
 # Show the scoped change from the current PR head to the new packaged working
 # tree. This is informational for clean updates and mandatory context for holds.
@@ -1164,15 +1164,15 @@ git diff --stat "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/"
 WORKTREE_PATHS=$(find "library/<category>/<api-slug>" -type f -print 2>/dev/null | sort)
 BRANCH_ONLY_PATHS=$(comm -23 \
   <(git ls-tree -r --name-only "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/" | sort) \
-  <(printf '%s\n' "$WORKTREE_PATHS"))
+  <([ -n "$WORKTREE_PATHS" ] && printf '%s\n' "$WORKTREE_PATHS" || true))
 
-# Modified paths need human review only when a branch patch relative to main is
-# not present in the new packaged working tree. A strict superset passes: if the
-# branch patch can be reverse-applied from the working tree, the fix is still
-# there even if the file also has fresh generated changes.
-BRANCH_ONLY_EDITS=$(git diff --name-only main "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/" | while read -r path; do
+# Modified paths need human review only when a branch patch relative to
+# origin/main is not present in the new packaged working tree. A strict superset
+# passes: if the branch patch can be reverse-applied from the working tree, the
+# fix is still there even if the file also has fresh generated changes.
+BRANCH_ONLY_EDITS=$(git diff --name-only origin/main "$UPDATE_BASE_REF" -- "library/<category>/<api-slug>/" | while read -r path; do
   [ -n "$path" ] || continue
-  if git diff main "$UPDATE_BASE_REF" -- "$path" | git apply --check --reverse >/dev/null 2>&1; then
+  if git diff origin/main "$UPDATE_BASE_REF" -- "$path" | git apply --check --reverse >/dev/null 2>&1; then
     continue
   else
     printf '%s\n' "$path"

--- a/skills/printing-press-reprint/SKILL.md
+++ b/skills/printing-press-reprint/SKILL.md
@@ -137,13 +137,29 @@ can lag even when `run_id` matches; this step closes that gap.
 
 The index ships in one of two shapes: the per-patch directory
 `.printing-press-patches/` (current) or the legacy single-array
-`.printing-press-patches.json` (older CLIs not yet normalized). Prefer the
-directory; fall back to the legacy file.
+`.printing-press-patches.json` (older CLIs not yet normalized). Always check
+both shapes when reachable. Prefer the directory when it contains patch files,
+but never let an absent legacy single-file index set `PATCH_COUNT=0` until the
+directory fallback has been read.
 
 ```bash
 PATCHES_DIR="$LIB_TARGET/.printing-press-patches"
 PATCHES_LEGACY="$LIB_TARGET/.printing-press-patches.json"
 if [[ -n "$LIB_PATH" ]]; then
+  # Fetch the legacy shape if present, but do not treat a 404 as proof that no
+  # patches exist. Current library entries may carry only the per-patch
+  # directory below.
+  tmp=$(mktemp)
+  if gh api -H "Accept: application/vnd.github.v3.raw" \
+       "repos/mvanhorn/printing-press-library/contents/$LIB_PATH/.printing-press-patches.json" \
+       > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$PATCHES_LEGACY"
+  else
+    rm -f "$tmp"
+  fi
+
+  # Fetch the current directory shape independently. This is the required
+  # fallback when `.printing-press-patches.json` is absent.
   listing=$(gh api "repos/mvanhorn/printing-press-library/contents/$LIB_PATH/.printing-press-patches" 2>/dev/null || true)
   if jq -e 'type == "array"' <<<"$listing" >/dev/null 2>&1; then
     mkdir -p "$PATCHES_DIR"
@@ -156,21 +172,17 @@ if [[ -n "$LIB_PATH" ]]; then
           rm -f "$tmp"
         fi
       done
-  else
-    tmp=$(mktemp)
-    if gh api -H "Accept: application/vnd.github.v3.raw" \
-         "repos/mvanhorn/printing-press-library/contents/$LIB_PATH/.printing-press-patches.json" \
-         > "$tmp" 2>/dev/null; then
-      mv "$tmp" "$PATCHES_LEGACY"
-    else
-      rm -f "$tmp"
-    fi
   fi
 fi
 
-# Count from whichever shape is present locally; PATCHES_SOURCE is what Phase D reads.
+# Count from the first non-empty shape locally; PATCHES_SOURCE is what Phase D reads.
 if [[ -d "$PATCHES_DIR" ]]; then
-  PATCH_COUNT=$(find "$PATCHES_DIR" -maxdepth 1 -name '*.json' ! -name '_meta.json' | wc -l | tr -d ' ')
+  DIR_PATCH_COUNT=$(find "$PATCHES_DIR" -maxdepth 1 -name '*.json' ! -name '_meta.json' | wc -l | tr -d ' ')
+else
+  DIR_PATCH_COUNT=0
+fi
+if [[ "$DIR_PATCH_COUNT" != "0" ]]; then
+  PATCH_COUNT="$DIR_PATCH_COUNT"
   PATCHES_SOURCE="$PATCHES_DIR"
 elif [[ -f "$PATCHES_LEGACY" ]]; then
   PATCH_COUNT=$(jq '(.patches // []) | length' "$PATCHES_LEGACY" 2>/dev/null || echo 0)


### PR DESCRIPTION
## Summary

Reprint now treats the per-patch `.printing-press-patches/` directory as a first-class fallback when the legacy `.printing-press-patches.json` file is absent, so directory-only patch stores still produce a Prior Patches handoff.

Publish update-path now snapshots the current PR branch before force-push, surfaces branch-only files or unreproduced branch patches scoped to the target CLI, and requires reconcile or explicit overwrite before continuing.

Closes #3086.
Closes #3046.

## Validation

- `git diff --check -- skills/printing-press-reprint/SKILL.md skills/printing-press-publish/SKILL.md`
- `rg -n "absent legacy|directory fallback|DIR_PATCH_COUNT|Fetch the current directory shape|PATCH_COUNT=0" skills/printing-press-reprint/SKILL.md`
- `rg -n "divergence guard|branch-only|UPDATE_BASE_REF|git apply --check --reverse|force-with-lease" skills/printing-press-publish/SKILL.md`
- Reviewed issue ownership with `gh issue view 3086` and `gh issue view 3046`; both were assigned to `tmchow` and already claimed.

No Go test run: this PR only changes Markdown workflow instructions.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
