### PR TITLE
fix(cli): calibrate dogfood auth checks

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1369,6 +1369,7 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 
 	expectedPrefix := ""
 	expectedHeader := ""
+	formatPrefixOverrides := ""
 	formatLower := strings.ToLower(auth.Format)
 	switch {
 	case strings.Contains(formatLower, "bot "):
@@ -1377,9 +1378,16 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	case strings.EqualFold(auth.Type, "bearer_token"):
 		expectedPrefix = auth.HeaderPrefix() + " "
 		if formatPrefix, ok := authFormatSchemePrefix(auth.Format); ok {
+			if prefix := strings.TrimSpace(auth.Prefix); prefix != "" && !strings.EqualFold(strings.TrimSpace(formatPrefix), prefix) {
+				formatPrefixOverrides = prefix
+			}
 			expectedPrefix = formatPrefix
 		}
-		result.SpecScheme = fmt.Sprintf(`bearer token format (expects %q prefix)`, expectedPrefix)
+		if formatPrefixOverrides != "" {
+			result.SpecScheme = fmt.Sprintf(`bearer token format (expects %q prefix from auth.format; auth.prefix %q ignored)`, expectedPrefix, formatPrefixOverrides)
+		} else {
+			result.SpecScheme = fmt.Sprintf(`bearer token format (expects %q prefix)`, expectedPrefix)
+		}
 	case strings.Contains(formatLower, "basic "):
 		result.SpecScheme = `basic auth format (expects "Basic " prefix)`
 		expectedPrefix = "Basic "
@@ -1455,7 +1463,11 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	result.Match = result.GeneratedFmt == expectedPrefix
 	if result.Match {
 		if tokenPreserving {
-			result.Detail = fmt.Sprintf(`spec and generated client both use %q`, strings.TrimSpace(expectedPrefix))
+			if formatPrefixOverrides != "" {
+				result.Detail = fmt.Sprintf(`auth.format %q overrides auth.prefix %q; generated client uses %q`, strings.TrimSpace(expectedPrefix), formatPrefixOverrides, strings.TrimSpace(expectedPrefix))
+			} else {
+				result.Detail = fmt.Sprintf(`spec and generated client both use %q`, strings.TrimSpace(expectedPrefix))
+			}
 		} else {
 			result.Match = false
 			result.Detail = invalidDetail
@@ -1505,7 +1517,7 @@ func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement) O
 	if len(result.Violations) == 0 {
 		result.Detail = "all OAuth-scoped endpoints covered by generated auth scopes"
 	} else if len(generatedScopes) == 0 {
-		result.Detail = "generated auth.go declares no OAuth scopes"
+		result.Detail = "generated auth files declare no OAuth scopes"
 	} else {
 		result.Detail = fmt.Sprintf("%d OAuth-scoped endpoint(s) lack a generated auth scope", len(result.Violations))
 	}

--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -1369,14 +1369,18 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 
 	expectedPrefix := ""
 	expectedHeader := ""
+	formatLower := strings.ToLower(auth.Format)
 	switch {
-	case strings.Contains(strings.ToLower(auth.Format), "bot "):
+	case strings.Contains(formatLower, "bot "):
 		result.SpecScheme = `bot token format (expects "Bot " prefix)`
 		expectedPrefix = "Bot "
 	case strings.EqualFold(auth.Type, "bearer_token"):
-		result.SpecScheme = `bearer token format (expects "Bearer " prefix)`
-		expectedPrefix = "Bearer "
-	case strings.Contains(strings.ToLower(auth.Format), "basic "):
+		expectedPrefix = auth.HeaderPrefix() + " "
+		if formatPrefix, ok := authFormatSchemePrefix(auth.Format); ok {
+			expectedPrefix = formatPrefix
+		}
+		result.SpecScheme = fmt.Sprintf(`bearer token format (expects %q prefix)`, expectedPrefix)
+	case strings.Contains(formatLower, "basic "):
 		result.SpecScheme = `basic auth format (expects "Basic " prefix)`
 		expectedPrefix = "Basic "
 	case strings.EqualFold(auth.Type, "api_key") && strings.EqualFold(auth.In, "header") && strings.TrimSpace(auth.Header) != "":
@@ -1462,6 +1466,14 @@ func checkAuth(dir string, auth apispec.AuthConfig) AuthCheckResult {
 	return result
 }
 
+func authFormatSchemePrefix(format string) (string, bool) {
+	fields := strings.Fields(strings.TrimSpace(format))
+	if len(fields) == 0 || strings.Contains(fields[0], "{") {
+		return "", false
+	}
+	return fields[0] + " ", true
+}
+
 func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement) OAuthScopeCoverageResult {
 	if len(requirements) == 0 {
 		return OAuthScopeCoverageResult{
@@ -1536,11 +1548,21 @@ func oauthScopeRequirementAlternatives(requirement oauthScopeRequirement) [][]st
 }
 
 func generatedOAuthScopes(dir string) []string {
-	file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(dir, "internal", "cli", "auth.go"), nil, 0)
-	if err != nil {
-		return nil
+	var scopes []string
+	for _, path := range []string{
+		filepath.Join(dir, "internal", "cli", "auth.go"),
+		filepath.Join(dir, "internal", "client", "client.go"),
+	} {
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			continue
+		}
+		scopes = append(scopes, generatedOAuthScopesFromFile(file)...)
 	}
+	return uniqueSorted(scopes)
+}
 
+func generatedOAuthScopesFromFile(file *ast.File) []string {
 	scopeVars := scopeJoinVars(file)
 	var scopes []string
 	ast.Inspect(file, func(node ast.Node) bool {
@@ -1562,7 +1584,11 @@ func generatedOAuthScopes(dir string) []string {
 		}
 		return true
 	})
-	return uniqueSorted(scopes)
+	scopeFuncs := wiredScopeResolverFuncs(file)
+	if len(scopeFuncs) > 0 {
+		scopes = append(scopes, returnedScopeLiterals(file, scopeFuncs)...)
+	}
+	return scopes
 }
 
 func scopeJoinVars(file *ast.File) map[string]bool {
@@ -1583,6 +1609,98 @@ func scopeJoinVars(file *ast.File) map[string]bool {
 		return true
 	})
 	return vars
+}
+
+func wiredScopeResolverFuncs(file *ast.File) map[string]bool {
+	funcs := map[string]bool{}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.IfStmt:
+			assign, ok := n.Init.(*ast.AssignStmt)
+			if !ok || n.Body == nil {
+				return true
+			}
+			for i, lhs := range assign.Lhs {
+				scopeVar, ok := dogfoodIdentName(lhs)
+				if !ok || i >= len(assign.Rhs) || !blockSetsScopeFromIdent(n.Body, scopeVar) {
+					continue
+				}
+				if call, ok := assign.Rhs[i].(*ast.CallExpr); ok {
+					if name := dogfoodCallName(call.Fun); name != "" {
+						funcs[name] = true
+					}
+				}
+			}
+		case *ast.CallExpr:
+			if len(n.Args) < 2 || dogfoodSelectorName(n.Fun) != "Set" || dogfoodStringLiteral(n.Args[0]) != "scope" {
+				return true
+			}
+			call, ok := n.Args[1].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if name := dogfoodCallName(call.Fun); name != "" {
+				funcs[name] = true
+			}
+		}
+		return true
+	})
+	return funcs
+}
+
+func blockSetsScopeFromIdent(block *ast.BlockStmt, ident string) bool {
+	found := false
+	ast.Inspect(block, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 || dogfoodSelectorName(call.Fun) != "Set" || dogfoodStringLiteral(call.Args[0]) != "scope" {
+			return true
+		}
+		name, ok := dogfoodIdentName(call.Args[1])
+		if ok && name == ident {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func returnedScopeLiterals(file *ast.File, funcs map[string]bool) []string {
+	var values []string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || !funcs[fn.Name.Name] || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			ret, ok := node.(*ast.ReturnStmt)
+			if !ok {
+				return true
+			}
+			for _, result := range ret.Results {
+				values = append(values, scopeLiteralValues(result)...)
+			}
+			return true
+		})
+	}
+	return values
+}
+
+func scopeLiteralValues(expr ast.Expr) []string {
+	if value := strings.TrimSpace(dogfoodStringLiteral(expr)); value != "" {
+		return []string{value}
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || dogfoodSelectorName(call.Fun) != "ReplaceAll" || len(call.Args) == 0 {
+		return nil
+	}
+	if value := strings.TrimSpace(dogfoodStringLiteral(call.Args[0])); value != "" {
+		return []string{value}
+	}
+	return nil
 }
 
 func appendedStringValues(call *ast.CallExpr, scopeVars map[string]bool) []string {
@@ -1655,6 +1773,7 @@ var authPrefixCandidates = []authPrefixCandidate{
 	{prefix: "Bot ", concatRe: regexp.MustCompile(`"Bot "\s*\+`)},
 	{prefix: "Bearer ", concatRe: regexp.MustCompile(`"Bearer "\s*\+`)},
 	{prefix: "Basic ", concatRe: regexp.MustCompile(`"Basic "\s*\+`)},
+	{prefix: "Token ", concatRe: regexp.MustCompile(`"Token "\s*\+`)},
 }
 
 // composedAuthLiteralScheme classifies the auth scheme that a composed-auth or
@@ -1793,11 +1912,19 @@ func authCandidatesForPrefix(expectedPrefix string) []authPrefixCandidate {
 		return authPrefixCandidates
 	}
 	candidates := make([]authPrefixCandidate, 0, len(authPrefixCandidates))
+	foundExpected := false
 	for _, candidate := range authPrefixCandidates {
 		if candidate.prefix == expectedPrefix {
 			candidates = append(candidates, candidate)
+			foundExpected = true
 			break
 		}
+	}
+	if !foundExpected {
+		candidates = append(candidates, authPrefixCandidate{
+			prefix:   expectedPrefix,
+			concatRe: regexp.MustCompile(regexp.QuoteMeta(strconv.Quote(expectedPrefix)) + `\s*\+`),
+		})
 	}
 	for _, candidate := range authPrefixCandidates {
 		if candidate.prefix != expectedPrefix {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -498,7 +498,7 @@ components:
 	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
 	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
 	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
-	assert.Equal(t, "generated auth.go declares no OAuth scopes", report.OAuthScopeCoverage.Detail)
+	assert.Equal(t, "generated auth files declare no OAuth scopes", report.OAuthScopeCoverage.Detail)
 }
 
 func TestRunDogfoodOAuthScopeCoverageIgnoresUnjoinedScopesVariable(t *testing.T) {
@@ -541,7 +541,7 @@ components:
 	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
 	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
 	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
-	assert.Equal(t, "generated auth.go declares no OAuth scopes", report.OAuthScopeCoverage.Detail)
+	assert.Equal(t, "generated auth files declare no OAuth scopes", report.OAuthScopeCoverage.Detail)
 }
 
 func TestRunDogfoodOAuthScopeCoverageSurvivesUndefinedNonOAuthScheme(t *testing.T) {
@@ -1318,6 +1318,29 @@ func (c *Config) AuthHeader() string {
 	assert.True(t, result.Match)
 	assert.Equal(t, "Token ", result.GeneratedFmt)
 	assert.Contains(t, result.SpecScheme, `"Token " prefix`)
+}
+
+func TestCheckAuthMakesFormatOverPrefixPrecedenceExplicit(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader() string { return configAuthHeader() }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+func (c *Config) AuthHeader() string {
+	return applyAuthFormat("Bearer {token}", map[string]string{"token": c.Token})
+}
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "bearer_token", Prefix: "Token", Format: "Bearer {token}"})
+	assert.True(t, result.Match)
+	assert.Equal(t, "Bearer ", result.GeneratedFmt)
+	assert.Contains(t, result.SpecScheme, `auth.format`)
+	assert.Contains(t, result.SpecScheme, `auth.prefix "Token" ignored`)
+	assert.Contains(t, result.Detail, `auth.format "Bearer" overrides auth.prefix "Token"`)
 }
 
 func TestCheckAuthRejectsBearerTokenPrefixMismatch(t *testing.T) {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -406,6 +406,101 @@ components:
 	assert.Empty(t, report.OAuthScopeCoverage.Violations)
 }
 
+func TestRunDogfoodOAuthScopeCoverageReadsClientCredentialsScopeHelper(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+import (
+	"net/url"
+	"os"
+)
+
+func resolveClientCredentialsScope() string {
+	if scope := os.Getenv("VIDEOS_OAUTH_SCOPE"); scope != "" {
+		return scope
+	}
+	return "all"
+}
+
+func mintClientCredentialsToken() {
+	form := url.Values{}
+	if scope := resolveClientCredentialsScope(); scope != "" {
+		form.Set("scope", scope)
+	}
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [all]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/token
+          scopes:
+            all: Full access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Covered)
+	assert.Empty(t, report.OAuthScopeCoverage.Violations)
+}
+
+func TestRunDogfoodOAuthScopeCoverageIgnoresUnwiredClientCredentialsScopeHelper(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func resolveClientCredentialsScope() string {
+	return "all"
+}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [all]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/token
+          scopes:
+            all: Full access
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAIL", report.Verdict)
+	assert.Equal(t, 1, report.OAuthScopeCoverage.Checked)
+	assert.Equal(t, 0, report.OAuthScopeCoverage.Covered)
+	require.Len(t, report.OAuthScopeCoverage.Violations, 1)
+	assert.Equal(t, "generated auth.go declares no OAuth scopes", report.OAuthScopeCoverage.Detail)
+}
+
 func TestRunDogfoodOAuthScopeCoverageIgnoresUnjoinedScopesVariable(t *testing.T) {
 	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
 func helper() {
@@ -1202,6 +1297,48 @@ func (c *Config) AuthHeader() string {
 	result := checkAuth(dir, apispec.AuthConfig{Type: "bearer_token", Format: "Bearer {token}"})
 	assert.True(t, result.Match)
 	assert.Equal(t, "Bearer ", result.GeneratedFmt)
+}
+
+func TestCheckAuthRecognizesBearerTokenPrefixOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader() string { return configAuthHeader() }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+func (c *Config) AuthHeader() string {
+	return "Token " + c.Token
+}
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "bearer_token", Prefix: "Token"})
+	assert.True(t, result.Match)
+	assert.Equal(t, "Token ", result.GeneratedFmt)
+	assert.Contains(t, result.SpecScheme, `"Token " prefix`)
+}
+
+func TestCheckAuthRejectsBearerTokenPrefixMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "client"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "config"), 0o755))
+
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func authHeader() string { return configAuthHeader() }
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "config", "config.go"), `package config
+func (c *Config) AuthHeader() string {
+	return "Token " + c.Token
+}
+`)
+
+	result := checkAuth(dir, apispec.AuthConfig{Type: "bearer_token", Prefix: "Bearer"})
+	assert.False(t, result.Match)
+	assert.Equal(t, "Token ", result.GeneratedFmt)
+	assert.Contains(t, result.Detail, `spec expects "Bearer" but generated client uses "Token"`)
 }
 
 func TestCheckAuthRecognizesHeaderAPIKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfood auth validation now honors the declared bearer scheme word instead of assuming every `bearer_token` CLI must emit `Authorization: Bearer ...`. Specs that declare `prefix: Token` or a token-prefixed auth format can pass when generated code matches, while a declared `Bearer` spec that emits `Token` still fails with an explicit mismatch.

OAuth scope coverage now recognizes the client-credentials template shape where `resolveClientCredentialsScope()` returns the default scope and its result is wired into `form.Set("scope", scope)`. Unwired helpers still do not count as coverage, so scoped endpoint defects continue to fail.

Fixes #2917
Fixes #2684

## Tests

- `go test ./internal/pipeline -run 'Test(CheckAuthRecognizesBearerTokenPrefixOverride|CheckAuthRejectsBearerTokenPrefixMismatch|CheckAuthRecognizesBearerApplyAuthFormatWithTokenPlaceholder|CheckAuthRejectsBearerApplyAuthFormatWithoutTokenPlaceholder|RunDogfoodOAuthScopeCoverageReadsClientCredentialsScopeHelper|RunDogfoodOAuthScopeCoverageIgnoresUnwiredClientCredentialsScopeHelper|RunDogfoodOAuthScopeCoverageReadsAppendedGeneratedScope|RunDogfoodOAuthScopeCoverageIgnoresUnjoinedScopesVariable)'`
- `go test ./internal/pipeline -run 'Test(RunDogfood|CheckAuth|LoadOpenAPISpecCollectsRootOAuthScopeRequirements|LoadOpenAPISpecCombinesOAuthSchemesWithinRequirement)'`
- `git diff --check HEAD~1..HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
