### PR TITLE
fix(cli): harden publish secret and PII scans

### DIFF
--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -392,6 +392,7 @@ func redactDetectorMatches(det piiDetector, text string) string {
 		match := text[loc[0]:loc[1]]
 		b.WriteString(text[last:loc[0]])
 		if isSyntheticPIIPlaceholder(det.kind, match) ||
+			(det.kind == PIIKindEmail && isBenignEmailContext(text, loc[0], match)) ||
 			(det.kind == PIIKindPhoneUS && isGitHubContextBarePhoneID(text, loc[0], match)) {
 			b.WriteString(match)
 		} else {
@@ -550,6 +551,68 @@ func isRFCReservedEmail(matched string) bool {
 		strings.HasSuffix(domain, ".test") ||
 		strings.HasSuffix(domain, ".invalid") ||
 		strings.HasSuffix(domain, ".localhost")
+}
+
+func isBenignEmailContext(line string, matchStart int, matchedSpan string) bool {
+	return isGitHubNoreplyEmail(matchedSpan) || isURLUserinfoPlaceholderEmail(line, matchStart, matchedSpan)
+}
+
+func isGitHubNoreplyEmail(matched string) bool {
+	lower := strings.ToLower(matched)
+	if !strings.HasSuffix(lower, "@users.noreply.github.com") {
+		return false
+	}
+	local := strings.TrimSuffix(lower, "@users.noreply.github.com")
+	id, handle, ok := strings.Cut(local, "+")
+	if !ok || id == "" || handle == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	for _, r := range handle {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isURLUserinfoPlaceholderEmail(line string, matchStart int, matched string) bool {
+	local, _, ok := strings.Cut(strings.ToLower(matched), "@")
+	if !ok || !map[string]bool{
+		"apikey":   true,
+		"password": true,
+		"pass":     true,
+		"secret":   true,
+		"token":    true,
+	}[local] {
+		return false
+	}
+	prefixStart := matchStart
+	for prefixStart > 0 {
+		r := line[prefixStart-1]
+		if r == '"' || r == '\'' || r == '`' || r == '<' || r == '(' || r == '[' || r == '{' || r == ' ' || r == '\t' || r == '\n' {
+			break
+		}
+		prefixStart--
+	}
+	prefix := strings.ToLower(line[prefixStart:matchStart])
+	if !strings.HasSuffix(prefix, ":") {
+		return false
+	}
+	user := strings.TrimSuffix(prefix, ":")
+	if schemeIdx := strings.LastIndex(user, "://"); schemeIdx != -1 {
+		user = user[schemeIdx+len("://"):]
+	}
+	return map[string]bool{
+		"login":    true,
+		"user":     true,
+		"username": true,
+	}[user]
 }
 
 func isNANPFictionalPhone(matched string) bool {
@@ -820,6 +883,9 @@ func scanPIIFileWithRel(path, relSlash string) ([]PIIFinding, error) {
 			for _, match := range det.pattern.FindAllStringIndex(line, -1) {
 				matchedSpan := line[match[0]:match[1]]
 				if isSyntheticPIIPlaceholder(det.kind, matchedSpan) {
+					continue
+				}
+				if det.kind == PIIKindEmail && isBenignEmailContext(line, match[0], matchedSpan) {
 					continue
 				}
 				if det.kind == PIIKindPhoneUS && isGitHubContextBarePhoneID(line, match[0], matchedSpan) {

--- a/internal/artifacts/pii.go
+++ b/internal/artifacts/pii.go
@@ -564,13 +564,23 @@ func isGitHubNoreplyEmail(matched string) bool {
 	}
 	local := strings.TrimSuffix(lower, "@users.noreply.github.com")
 	id, handle, ok := strings.Cut(local, "+")
-	if !ok || id == "" || handle == "" {
-		return false
-	}
-	for _, r := range id {
-		if r < '0' || r > '9' {
+	if ok {
+		if id == "" || handle == "" {
 			return false
 		}
+		for _, r := range id {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return isGitHubHandleLocalPart(handle)
+	}
+	return isGitHubHandleLocalPart(local)
+}
+
+func isGitHubHandleLocalPart(handle string) bool {
+	if handle == "" {
+		return false
 	}
 	for _, r := range handle {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -255,6 +255,7 @@ func TestFindPII_Email(t *testing.T) {
 		{name: "reserved-localhost-tld", line: `"email": "printer@app.localhost"`, expectKinds: nil},
 		{name: "reserved-invalid-tld", line: `"email": "printer@app.invalid"`, expectKinds: nil},
 		{name: "github-noreply", line: `git author 123456+octocat@users.noreply.github.com`, expectKinds: nil},
+		{name: "github-legacy-noreply", line: `git author octocat@users.noreply.github.com`, expectKinds: nil},
 		{name: "url-userinfo-placeholder", line: `Use https://login:password@api.vendor.example/v1 for Basic auth examples.`, expectKinds: nil},
 		{name: "no-tld", line: `"handle": "alice@example"`, expectKinds: nil},
 		{name: "missing-at", line: `"site": "example.com"`, expectKinds: nil},

--- a/internal/artifacts/pii_test.go
+++ b/internal/artifacts/pii_test.go
@@ -254,8 +254,11 @@ func TestFindPII_Email(t *testing.T) {
 		{name: "reserved-test-tld", line: `"email": "printer@app.test"`, expectKinds: nil},
 		{name: "reserved-localhost-tld", line: `"email": "printer@app.localhost"`, expectKinds: nil},
 		{name: "reserved-invalid-tld", line: `"email": "printer@app.invalid"`, expectKinds: nil},
+		{name: "github-noreply", line: `git author 123456+octocat@users.noreply.github.com`, expectKinds: nil},
+		{name: "url-userinfo-placeholder", line: `Use https://login:password@api.vendor.example/v1 for Basic auth examples.`, expectKinds: nil},
 		{name: "no-tld", line: `"handle": "alice@example"`, expectKinds: nil},
 		{name: "missing-at", line: `"site": "example.com"`, expectKinds: nil},
+		{name: "real-email-still-flags", line: `"email": "customer@gmail.com"`, expectKinds: []string{PIIKindEmail}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -416,11 +416,11 @@ func looksLikeOpaqueCredentialValue(candidate string) bool {
 }
 
 func publicSecretSuppressionReason(line string) (string, bool) {
-	idx := strings.Index(line, publicSecretMarker)
-	if idx == -1 {
+	_, reason, ok := strings.Cut(line, publicSecretMarker)
+	if !ok {
 		return "", false
 	}
-	reason := strings.TrimSpace(line[idx+len(publicSecretMarker):])
+	reason = strings.TrimSpace(reason)
 	reason = strings.TrimLeft(reason, ":=- \t")
 	lowerReason := strings.ToLower(reason)
 	if strings.HasPrefix(lowerReason, "reason=") || strings.HasPrefix(lowerReason, "reason:") {

--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -132,6 +132,10 @@ const structuredCookieLineWindow = 5
 
 var structuredCookieValueLineRE = regexp.MustCompile(`(?i)["']value["']\s*:\s*["']([^"']{8,})["']`)
 var uuidCredentialValueRE = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b`)
+var opaqueCredentialLowerRE = regexp.MustCompile(`[a-z]`)
+var opaqueCredentialUpperRE = regexp.MustCompile(`[A-Z]`)
+var opaqueCredentialDigitRE = regexp.MustCompile(`[0-9]`)
+var opaqueCredentialSymbolRE = regexp.MustCompile(`[._~+/=-]`)
 
 const publicSecretMarker = "pp:public-secret"
 
@@ -396,16 +400,16 @@ func looksLikeOpaqueCredentialValue(candidate string) bool {
 		return false
 	}
 	classes := 0
-	if regexp.MustCompile(`[a-z]`).MatchString(candidate) {
+	if opaqueCredentialLowerRE.MatchString(candidate) {
 		classes++
 	}
-	if regexp.MustCompile(`[A-Z]`).MatchString(candidate) {
+	if opaqueCredentialUpperRE.MatchString(candidate) {
 		classes++
 	}
-	if regexp.MustCompile(`[0-9]`).MatchString(candidate) {
+	if opaqueCredentialDigitRE.MatchString(candidate) {
 		classes++
 	}
-	if regexp.MustCompile(`[._~+/=-]`).MatchString(candidate) {
+	if opaqueCredentialSymbolRE.MatchString(candidate) {
 		classes++
 	}
 	return classes >= 2

--- a/internal/artifacts/secrets.go
+++ b/internal/artifacts/secrets.go
@@ -3,6 +3,8 @@ package artifacts
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -69,54 +71,112 @@ func RedactArchivedSpecSecrets(data []byte) []byte {
 }
 
 type VendorPrefixSecretFinding struct {
-	Path string
-	Line int
-	Kind string
+	Path        string
+	Line        int
+	Kind        string
+	Fingerprint string
+}
+
+type ReviewedSecretSuppression struct {
+	Path        string `json:"path"`
+	Line        int    `json:"line"`
+	Kind        string `json:"kind"`
+	Fingerprint string `json:"fingerprint"`
+	Reason      string `json:"reason"`
+}
+
+type SecretScanResult struct {
+	Findings     []VendorPrefixSecretFinding
+	Suppressions []ReviewedSecretSuppression
 }
 
 type vendorPrefixSecretPattern struct {
-	kind    string
-	pattern *regexp.Regexp
-	accept  func(string) bool
+	kind                    string
+	pattern                 *regexp.Regexp
+	accept                  func(string) bool
+	candidateFromSubmatches func([]string) string
+	allowPublicSuppression  bool
 }
 
 var vendorPrefixSecretPatterns = []vendorPrefixSecretPattern{
-	{kind: "openrouter-api-key", pattern: regexp.MustCompile(`sk-or-v1-[A-Za-z0-9_-]{24,}`)},
-	{kind: "stripe-secret-key", pattern: regexp.MustCompile(`sk_(?:live|test)_[A-Za-z0-9]{16,}`)},
-	{kind: "calcom-api-key", pattern: regexp.MustCompile(`cal_(?:live|test)_[A-Za-z0-9]{16,}`)},
-	{kind: "github-token", pattern: regexp.MustCompile(`(?:ghp|gho|ghs)_[A-Za-z0-9]{36,}`)},
-	{kind: "github-fine-grained-token", pattern: regexp.MustCompile(`github_pat_[A-Za-z0-9_]{60,}`)},
-	{kind: "slack-token", pattern: regexp.MustCompile(`xox[abprs]-[A-Za-z0-9-]{32,}`)},
-	{kind: "slack-app-token", pattern: regexp.MustCompile(`xapp-[A-Za-z0-9-]{32,}`)},
-	{kind: "google-api-key", pattern: regexp.MustCompile(`AIza[A-Za-z0-9_-]{20,}`)},
-	{kind: "mailchimp-api-key", pattern: regexp.MustCompile(`\b[a-f0-9]{32}-us\d{1,2}\b`)},
-	{kind: "linear-api-key", pattern: regexp.MustCompile(`\blin_api_[A-Za-z0-9]{40,}`)},
-	{kind: "anthropic-api-key", pattern: regexp.MustCompile(`\bsk-ant-api03-[A-Za-z0-9_-]{40,}`)},
+	vendorSecretPattern("openrouter-api-key", `sk-or-v1-[A-Za-z0-9_-]{24,}`),
+	vendorSecretPattern("stripe-secret-key", `sk_(?:live|test)_[A-Za-z0-9]{16,}`),
+	vendorSecretPattern("calcom-api-key", `cal_(?:live|test)_[A-Za-z0-9]{16,}`),
+	vendorSecretPattern("github-token", `(?:ghp|gho|ghs)_[A-Za-z0-9]{36,}`),
+	vendorSecretPattern("github-fine-grained-token", `github_pat_[A-Za-z0-9_]{60,}`),
+	vendorSecretPattern("slack-token", `xox[abprs]-[A-Za-z0-9-]{32,}`),
+	vendorSecretPattern("slack-app-token", `xapp-[A-Za-z0-9-]{32,}`),
+	vendorSecretPattern("google-api-key", `AIza[A-Za-z0-9_-]{20,}`),
+	vendorSecretPattern("mailchimp-api-key", `\b[a-f0-9]{32}-us\d{1,2}\b`),
+	vendorSecretPattern("linear-api-key", `\blin_api_[A-Za-z0-9]{40,}`),
+	vendorSecretPattern("anthropic-api-key", `\bsk-ant-api03-[A-Za-z0-9_-]{40,}`),
 	{
-		kind:    "aws-access-key",
-		pattern: regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+		kind:                   "aws-access-key",
+		pattern:                regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`),
+		allowPublicSuppression: true,
 		accept: func(candidate string) bool {
 			return !strings.Contains(candidate, "EXAMPLE")
 		},
 	},
 }
 
+var opaqueCredentialPatterns = []vendorPrefixSecretPattern{
+	opaqueCredentialPattern("opaque-credential:api-key", `api[_-]?key|apiKey|apikey`),
+	opaqueCredentialPattern("opaque-credential:secret", `secret|client[_-]?secret|clientSecret`),
+	opaqueCredentialPattern("opaque-credential:token", `token|access[_-]?token|refresh[_-]?token|accessToken|refreshToken`),
+	opaqueCredentialPattern("opaque-credential:password", `password|passcode`),
+	opaqueCredentialPattern("opaque-credential:session", `session|session[_-]?id|session[_-]?token`),
+}
+
 const structuredCookieLineWindow = 5
 
 var structuredCookieValueLineRE = regexp.MustCompile(`(?i)["']value["']\s*:\s*["']([^"']{8,})["']`)
+var uuidCredentialValueRE = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b`)
+
+const publicSecretMarker = "pp:public-secret"
+
+func vendorSecretPattern(kind, pattern string) vendorPrefixSecretPattern {
+	return vendorPrefixSecretPattern{
+		kind:                   kind,
+		pattern:                regexp.MustCompile(pattern),
+		allowPublicSuppression: true,
+	}
+}
+
+func opaqueCredentialPattern(kind, keyPattern string) vendorPrefixSecretPattern {
+	return vendorPrefixSecretPattern{
+		kind:    kind,
+		pattern: regexp.MustCompile(`(?i)(?:"(?:` + keyPattern + `)"|(?:` + keyPattern + `))\s*:\s*["']?([A-Za-z0-9._~+/=-]{16,})`),
+		candidateFromSubmatches: func(matches []string) string {
+			if len(matches) > 1 {
+				return matches[1]
+			}
+			return ""
+		},
+		accept: looksLikeOpaqueCredentialValue,
+	}
+}
 
 func FindVendorPrefixSecrets(root string) ([]VendorPrefixSecretFinding, error) {
-	return findSecrets(root, vendorPrefixSecretPatterns)
+	result, err := findSecrets(root, vendorPrefixSecretPatterns)
+	return result.Findings, err
 }
 
 func FindPackageSecrets(root string, cookieNames []string) ([]VendorPrefixSecretFinding, error) {
+	result, err := FindPackageSecretsWithSuppressions(root, cookieNames)
+	return result.Findings, err
+}
+
+func FindPackageSecretsWithSuppressions(root string, cookieNames []string) (SecretScanResult, error) {
 	patterns := append([]vendorPrefixSecretPattern(nil), vendorPrefixSecretPatterns...)
+	patterns = append(patterns, opaqueCredentialPatterns...)
 	patterns = append(patterns, cookieSecretPatterns(cookieNames)...)
 	return findSecrets(root, patterns)
 }
 
 func FindSpecDeclaredCookieSecrets(root string, cookieNames []string) ([]VendorPrefixSecretFinding, error) {
-	return findSecrets(root, cookieSecretPatterns(cookieNames))
+	result, err := findSecrets(root, cookieSecretPatterns(cookieNames))
+	return result.Findings, err
 }
 
 func cookieSecretPatterns(cookieNames []string) []vendorPrefixSecretPattern {
@@ -166,8 +226,8 @@ func FormatVendorPrefixSecretFindings(findings []VendorPrefixSecretFinding) stri
 	return strings.Join(lines, "\n")
 }
 
-func findSecrets(root string, patterns []vendorPrefixSecretPattern) ([]VendorPrefixSecretFinding, error) {
-	var findings []VendorPrefixSecretFinding
+func findSecrets(root string, patterns []vendorPrefixSecretPattern) (SecretScanResult, error) {
+	var result SecretScanResult
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -179,53 +239,73 @@ func findSecrets(root string, patterns []vendorPrefixSecretPattern) ([]VendorPre
 		if err != nil {
 			return err
 		}
-		findings = append(findings, fileFindings...)
+		result.Findings = append(result.Findings, fileFindings.Findings...)
+		result.Suppressions = append(result.Suppressions, fileFindings.Suppressions...)
 		return nil
 	})
-	return findings, err
+	return result, err
 }
 
-func scanSecretFile(root, path string, patterns []vendorPrefixSecretPattern) ([]VendorPrefixSecretFinding, error) {
+func scanSecretFile(root, path string, patterns []vendorPrefixSecretPattern) (SecretScanResult, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return SecretScanResult{}, err
 	}
 	defer func() { _ = file.Close() }()
 
 	reader := bufio.NewReaderSize(file, 8192)
 	probe, err := reader.Peek(8192)
 	if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
-		return nil, err
+		return SecretScanResult{}, err
 	}
 	if bytes.Contains(probe, []byte{0}) {
-		return nil, nil
+		return SecretScanResult{}, nil
 	}
 
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
-		return nil, err
+		return SecretScanResult{}, err
 	}
 	rel = filepath.ToSlash(rel)
 
-	var findings []VendorPrefixSecretFinding
+	var result SecretScanResult
 	lineNumber := 0
 	cookieNames := declaredCookieNamesFromPatterns(patterns)
 	pendingCookieNames := map[string]int{}
 	for {
 		line, readErr := reader.ReadString('\n')
 		if readErr != nil && readErr != io.EOF {
-			return nil, readErr
+			return SecretScanResult{}, readErr
 		}
 		if line == "" && readErr == io.EOF {
 			break
 		}
 		lineNumber++
+		lineCandidateFingerprints := map[string]bool{}
 		for _, pattern := range patterns {
-			if vendorPrefixSecretLineMatch(pattern, line) {
-				findings = append(findings, VendorPrefixSecretFinding{
-					Path: rel,
-					Line: lineNumber,
-					Kind: pattern.kind,
+			for _, candidate := range vendorPrefixSecretLineMatches(pattern, line) {
+				fingerprint := secretFingerprint(candidate)
+				if lineCandidateFingerprints[fingerprint] {
+					continue
+				}
+				lineCandidateFingerprints[fingerprint] = true
+				if pattern.allowPublicSuppression {
+					if reason, ok := publicSecretSuppressionReason(line); ok {
+						result.Suppressions = append(result.Suppressions, ReviewedSecretSuppression{
+							Path:        rel,
+							Line:        lineNumber,
+							Kind:        pattern.kind,
+							Fingerprint: fingerprint,
+							Reason:      reason,
+						})
+						continue
+					}
+				}
+				result.Findings = append(result.Findings, VendorPrefixSecretFinding{
+					Path:        rel,
+					Line:        lineNumber,
+					Kind:        pattern.kind,
+					Fingerprint: fingerprint,
 				})
 			}
 		}
@@ -244,10 +324,11 @@ func scanSecretFile(root, path string, patterns []vendorPrefixSecretPattern) ([]
 				if nameLine == lineNumber {
 					continue
 				}
-				findings = append(findings, VendorPrefixSecretFinding{
-					Path: rel,
-					Line: lineNumber,
-					Kind: "cookie-value:" + name,
+				result.Findings = append(result.Findings, VendorPrefixSecretFinding{
+					Path:        rel,
+					Line:        lineNumber,
+					Kind:        "cookie-value:" + name,
+					Fingerprint: secretFingerprint(matches[1]),
 				})
 				delete(pendingCookieNames, name)
 			}
@@ -256,7 +337,7 @@ func scanSecretFile(root, path string, patterns []vendorPrefixSecretPattern) ([]
 			break
 		}
 	}
-	return findings, nil
+	return result, nil
 }
 
 func declaredCookieNamesFromPatterns(patterns []vendorPrefixSecretPattern) []string {
@@ -280,11 +361,75 @@ func structuredCookieNameLineMatch(name, line string) bool {
 	return pattern.MatchString(line)
 }
 
-func vendorPrefixSecretLineMatch(pattern vendorPrefixSecretPattern, line string) bool {
-	for _, candidate := range pattern.pattern.FindAllString(line, -1) {
+func vendorPrefixSecretLineMatches(pattern vendorPrefixSecretPattern, line string) []string {
+	var candidates []string
+	for _, matches := range pattern.pattern.FindAllStringSubmatch(line, -1) {
+		candidate := matches[0]
+		if pattern.candidateFromSubmatches != nil {
+			candidate = pattern.candidateFromSubmatches(matches)
+		}
 		if pattern.accept == nil || pattern.accept(candidate) {
-			return true
+			candidates = append(candidates, strings.TrimRight(candidate, ".,;)}]"))
 		}
 	}
-	return false
+	return candidates
+}
+
+func looksLikeOpaqueCredentialValue(candidate string) bool {
+	candidate = strings.TrimSpace(strings.Trim(candidate, `"'`))
+	if candidate == "" {
+		return false
+	}
+	lower := strings.ToLower(candidate)
+	for _, token := range []string{"<redacted", "redacted", "example", "placeholder", "your-", "your_", "insert-", "changeme"} {
+		if strings.Contains(lower, token) {
+			return false
+		}
+	}
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return false
+	}
+	if uuidCredentialValueRE.MatchString(candidate) {
+		return true
+	}
+	if len(candidate) < 32 {
+		return false
+	}
+	classes := 0
+	if regexp.MustCompile(`[a-z]`).MatchString(candidate) {
+		classes++
+	}
+	if regexp.MustCompile(`[A-Z]`).MatchString(candidate) {
+		classes++
+	}
+	if regexp.MustCompile(`[0-9]`).MatchString(candidate) {
+		classes++
+	}
+	if regexp.MustCompile(`[._~+/=-]`).MatchString(candidate) {
+		classes++
+	}
+	return classes >= 2
+}
+
+func publicSecretSuppressionReason(line string) (string, bool) {
+	idx := strings.Index(line, publicSecretMarker)
+	if idx == -1 {
+		return "", false
+	}
+	reason := strings.TrimSpace(line[idx+len(publicSecretMarker):])
+	reason = strings.TrimLeft(reason, ":=- \t")
+	lowerReason := strings.ToLower(reason)
+	if strings.HasPrefix(lowerReason, "reason=") || strings.HasPrefix(lowerReason, "reason:") {
+		reason = strings.TrimLeft(reason[len("reason"):], ":= \t")
+	}
+	reason = strings.Trim(reason, `"'`)
+	if len(strings.Fields(reason)) < 3 {
+		return "", false
+	}
+	return reason, true
+}
+
+func secretFingerprint(candidate string) string {
+	sum := sha256.Sum256([]byte(candidate))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }

--- a/internal/artifacts/secrets_test.go
+++ b/internal/artifacts/secrets_test.go
@@ -121,6 +121,61 @@ func TestFindVendorPrefixSecretsDetectsMailchimpLinearAndAnthropic(t *testing.T)
 	require.False(t, anthropicShortFlagged, "anthropic payload one char short of 40 must not match")
 }
 
+func TestFindPackageSecretsDetectsCredentialNamedOpaqueValues(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		`{"auth":{"user":{"api_key":"550e8400-e29b-41d4-a716-446655440000"}}}`,
+		`{"api_info":{"secret":"abcdefghijklmnopqrstuvwxyz1234567890"}}`,
+		`{"event_type":"customer.updated","sort_key":"created_at","api_key":"short-id"}`,
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sample.json"), []byte(content), 0o644))
+
+	findings, err := FindPackageSecrets(root, nil)
+	require.NoError(t, err)
+	require.Len(t, findings, 2)
+	require.Equal(t, "opaque-credential:api-key", findings[0].Kind)
+	require.Equal(t, 1, findings[0].Line)
+	require.Equal(t, "opaque-credential:secret", findings[1].Kind)
+	require.Equal(t, 2, findings[1].Line)
+}
+
+func TestFindPackageSecretsAllowsAnnotatedPublicVendorPrefixSecret(t *testing.T) {
+	root := t.TempDir()
+	publicKey := testSecret("AI", "za", "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "internal", "client.go"),
+		[]byte(`const firebaseKey = "`+publicKey+`" // pp:public-secret Firebase web API key is documented public; access is gated by rules.`+"\n"),
+		0o644,
+	))
+
+	result, err := FindPackageSecretsWithSuppressions(root, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Findings)
+	require.Len(t, result.Suppressions, 1)
+	require.Equal(t, "internal/client.go", result.Suppressions[0].Path)
+	require.Equal(t, 1, result.Suppressions[0].Line)
+	require.Equal(t, "google-api-key", result.Suppressions[0].Kind)
+	require.Contains(t, result.Suppressions[0].Reason, "documented public")
+}
+
+func TestFindPackageSecretsRequiresPublicSecretReason(t *testing.T) {
+	root := t.TempDir()
+	publicKey := testSecret("AI", "za", "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "internal", "client.go"),
+		[]byte(`const firebaseKey = "`+publicKey+`" // pp:public-secret`+"\n"),
+		0o644,
+	))
+
+	result, err := FindPackageSecretsWithSuppressions(root, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+	require.Empty(t, result.Suppressions)
+	require.Equal(t, "google-api-key", result.Findings[0].Kind)
+}
+
 func TestFindSpecDeclaredCookieSecretsReportsCookieNameOnly(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("Cookie:session-id=actuallyrealcookievaluexyz; x-main=your-cookie-here; y-main=not-an-example-real-value\n"), 0o644))

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -456,7 +456,7 @@ func newPublishPackageCmd() *cobra.Command {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("reading staged package cookie auth metadata: %w", err)}
 			}
-			findings, err := artifacts.FindPackageSecrets(outCLIDir, cookieNames)
+			secretResult, err := artifacts.FindPackageSecretsWithSuppressions(outCLIDir, cookieNames)
 			if err != nil {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("scanning staged package for secret tokens: %w", err)}
@@ -468,9 +468,13 @@ func newPublishPackageCmd() *cobra.Command {
 				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("scanning staged package for PII: %w", piiErr)}
 			}
 
-			if scanErr := formatCombinedScanError(findings, piiResult.Findings, piiResult.Completion); scanErr != nil {
+			if scanErr := formatCombinedScanError(secretResult.Findings, piiResult.Findings, piiResult.Completion); scanErr != nil {
 				cleanupOnFailure()
 				return &ExitError{Code: ExitPublishError, Err: scanErr}
+			}
+			if err := recordReviewedSecretSuppressions(outCLIDir, secretResult.Suppressions); err != nil {
+				cleanupOnFailure()
+				return &ExitError{Code: ExitPublishError, Err: fmt.Errorf("recording reviewed secret suppressions: %w", err)}
 			}
 
 			// Success — remove stashed old CLI dirs
@@ -1537,6 +1541,20 @@ func stagedPackageCookieNames(dir string) ([]string, error) {
 	default:
 		return nil, nil
 	}
+}
+
+func recordReviewedSecretSuppressions(dir string, suppressions []artifacts.ReviewedSecretSuppression) error {
+	manifestSuppressions := make([]pipeline.ReviewedSecretSuppression, 0, len(suppressions))
+	for _, suppression := range suppressions {
+		manifestSuppressions = append(manifestSuppressions, pipeline.ReviewedSecretSuppression{
+			Path:        suppression.Path,
+			Line:        suppression.Line,
+			Kind:        suppression.Kind,
+			Fingerprint: suppression.Fingerprint,
+			Reason:      suppression.Reason,
+		})
+	}
+	return pipeline.WriteReviewedSecretSuppressions(dir, manifestSuppressions)
 }
 
 // formatCombinedScanError composes the publish-time error message from

--- a/internal/cli/publish_test.go
+++ b/internal/cli/publish_test.go
@@ -1289,6 +1289,39 @@ func TestPublishPackageRejectsVendorPrefixSecretsInStagedCLI(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "failed packaging should clean up the staging target")
 }
 
+func TestPublishPackageRecordsAnnotatedPublicVendorPrefixSecrets(t *testing.T) {
+	home := setLibraryTestEnv(t)
+	cliDir := filepath.Join(home, "library", "test-pp-cli")
+	writePublishableTestCLI(t, cliDir)
+	publicKey := testSecret("AI", "za", "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234")
+	require.NoError(t, os.MkdirAll(filepath.Join(cliDir, "internal", "huckleberry"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cliDir, "internal", "huckleberry", "firestore.go"),
+		[]byte(`package huckleberry
+
+const firebaseWebAPIKey = "`+publicKey+`" // pp:public-secret Firebase web API key is documented public; access is gated by Firestore rules.
+`),
+		0o644,
+	))
+
+	target := filepath.Join(t.TempDir(), "staging")
+	cmd := newPublishCmd()
+	cmd.SetArgs([]string{"package", "--dir", cliDir, "--category", "other", "--target", target, "--json"})
+
+	output, err := runWithCapturedStdout(t, cmd.Execute)
+	require.NoError(t, err)
+
+	var result PackageResult
+	require.NoError(t, json.Unmarshal([]byte(output), &result))
+	manifest, err := pipeline.ReadCLIManifest(result.StagedDir)
+	require.NoError(t, err)
+	require.Len(t, manifest.ReviewedSecretSuppressions, 1)
+	assert.Equal(t, "internal/huckleberry/firestore.go", manifest.ReviewedSecretSuppressions[0].Path)
+	assert.Equal(t, 3, manifest.ReviewedSecretSuppressions[0].Line)
+	assert.Equal(t, "google-api-key", manifest.ReviewedSecretSuppressions[0].Kind)
+	assert.Contains(t, manifest.ReviewedSecretSuppressions[0].Reason, "documented public")
+}
+
 func TestPublishPackageRejectsSpecDeclaredCookieValuesInStagedCLI(t *testing.T) {
 	for _, authType := range []string{"cookie", "composed"} {
 		t.Run(authType, func(t *testing.T) {

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -159,8 +159,17 @@ type CLIManifest struct {
 	// (e.g., USDA nutrition backfill on recipe-goat) rather than every
 	// API call. Drives the MCPB user_config Required field so opt-in
 	// keys don't surface as mandatory in install dialogs.
-	AuthOptional  bool                   `json:"auth_optional,omitempty"`
-	NovelFeatures []NovelFeatureManifest `json:"novel_features,omitempty"`
+	AuthOptional               bool                        `json:"auth_optional,omitempty"`
+	ReviewedSecretSuppressions []ReviewedSecretSuppression `json:"reviewed_secret_suppressions,omitempty"`
+	NovelFeatures              []NovelFeatureManifest      `json:"novel_features,omitempty"`
+}
+
+type ReviewedSecretSuppression struct {
+	Path        string `json:"path"`
+	Line        int    `json:"line"`
+	Kind        string `json:"kind"`
+	Fingerprint string `json:"fingerprint"`
+	Reason      string `json:"reason"`
 }
 
 // CLIReleaseManifest is the skeleton shape consumed by the public library's
@@ -285,6 +294,35 @@ func WriteCLIManifest(dir string, m CLIManifest) error {
 	}
 	if err := WriteReleaseLedgerSkeleton(dir, m); err != nil {
 		return err
+	}
+	return nil
+}
+
+func WriteReviewedSecretSuppressions(dir string, suppressions []ReviewedSecretSuppression) error {
+	path := filepath.Join(dir, CLIManifestFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading CLI manifest: %w", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parsing CLI manifest: %w", err)
+	}
+	if len(suppressions) == 0 {
+		delete(raw, "reviewed_secret_suppressions")
+	} else {
+		encoded, err := json.Marshal(suppressions)
+		if err != nil {
+			return fmt.Errorf("encoding reviewed secret suppressions: %w", err)
+		}
+		raw["reviewed_secret_suppressions"] = encoded
+	}
+	out, err := marshalCLIManifestObject(raw)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(path, out, 0o644); err != nil {
+		return fmt.Errorf("writing CLI manifest: %w", err)
 	}
 	return nil
 }
@@ -572,6 +610,7 @@ func orderedCLIManifestKeys(raw map[string]json.RawMessage) []string {
 		"auth_title",
 		"auth_description",
 		"auth_optional",
+		"reviewed_secret_suppressions",
 		"novel_features",
 	}
 


### PR DESCRIPTION
## Summary

`publish package` now blocks the opaque credential shapes that leaked through browser-sniff manuscripts, not just known vendor-prefixed tokens. Credential-named JSON/YAML fields such as `api_key`, `secret`, `token`, `password`, and `session` are scanned for UUID or high-entropy values, while benign short IDs and spec vocabulary stay clean.

Documented-public vendor keys can now be reviewed without bypassing the gate: an inline `pp:public-secret` annotation must include a reason, and successful packages record the reviewed suppression in `.printing-press.json` with path, line, kind, reason, and a SHA-256 fingerprint. The PII email detector also skips GitHub noreply identities and URL-userinfo placeholders like `login:password@host`, while real personal emails still hard-block.

Closes mvanhorn/cli-printing-press#3015.
Closes mvanhorn/cli-printing-press#3209.
Closes mvanhorn/cli-printing-press#2924.

## Validation

- `go test ./internal/artifacts`
- `go test ./internal/cli -run 'TestPublishPackageRecordsAnnotatedPublicVendorPrefixSecrets|TestPublishPackageRejectsVendorPrefixSecretsInStagedCLI|TestPublishPackageRejectsVendorPrefixSecretsInManuscripts|TestPublishPackageRejectsSpecDeclaredCookieValuesInStagedCLI|TestPublishPackageRejectsPIIInStagedCLI|TestPublishPackageAllowsReservedSyntheticPII|TestPublishPackageRejectsPIIInManuscripts|TestPublishPackageCombinesSecretAndPIIReports'`
- `go test ./internal/pipeline -run 'TestWriteCLIManifest|TestWriteCLIManifestOmitsEmptyOptionalFields'`
- `go test -timeout 5m ./...` fails in `internal/pipeline` on `TestLiveDogfoodHappyArgsHonorsPPHappyArgs` (`list companion failed at depth 0: exit -1`); this is outside the touched scanner/publish files.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
