### PR TITLE
fix(cli): suppress scorer verifier false positives

### DIFF
--- a/internal/cli/verify_skill.go
+++ b/internal/cli/verify_skill.go
@@ -165,7 +165,7 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 			Evidence: fmt.Sprintf("expected canonical block:\n%s", expected),
 		}, true, false, nil
 	}
-	if got == expected {
+	if normalizeLineEndings(got) == normalizeLineEndings(expected) {
 		return canonicalFinding{}, false, false, nil
 	}
 	return canonicalFinding{
@@ -175,6 +175,11 @@ func runCanonicalSectionsCheck(dir string) (finding canonicalFinding, hasFinding
 		Detail:   "install section drift: hand-edit detected in a generator-owned section. Regenerate the printed CLI to restore the canonical text — do not edit this section by hand.",
 		Evidence: fmt.Sprintf("expected (from generator):\n%s\n\ngot (from SKILL.md):\n%s", expected, got),
 	}, true, false, nil
+}
+
+func normalizeLineEndings(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\r", "\n")
 }
 
 // ExtractInstallSectionForTest re-exports the generator's extractor so

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -697,6 +697,19 @@ func TestVerifySkill_CanonicalSectionsPassesOnFreshFixture(t *testing.T) {
 	require.Contains(t, string(out), "canonical-sections passed")
 }
 
+// TestVerifySkill_CanonicalSectionsNormalizesCRLF guards against Windows
+// checkouts rewriting SKILL.md line endings and producing false drift in the
+// generator-owned install section.
+func TestVerifySkill_CanonicalSectionsNormalizesCRLF(t *testing.T) {
+	t.Parallel()
+	bin := buildPrintingPressBinary(t)
+	install := strings.ReplaceAll(generator.CanonicalSkillInstallSection("myapi", "productivity"), "\n", "\r\n")
+	dir := writeCanonicalFixture(t, "myapi", "productivity", install)
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "canonical-sections").CombinedOutput()
+	require.NoError(t, err, "CRLF-only line ending differences must not fail canonical-sections: %s", string(out))
+	require.Contains(t, string(out), "canonical-sections passed")
+}
+
 // TestVerifySkill_CanonicalSectionsCatchesFlagStrip is the regression
 // guard for the trigger-dev SKILL slip — an automation loop stripped
 // `--cli-only` from the npx installer line to silence a verify-skill

--- a/internal/pipeline/mcp_size.go
+++ b/internal/pipeline/mcp_size.go
@@ -481,15 +481,15 @@ func normalizedStringMapLiteral(expr ast.Expr) map[string]string {
 //   - per-tool <= 320 tokens: partial (4)
 //   - per-tool > 320 tokens: 0
 //
-// Large code-orchestrated catalogs are unscored instead. Their catalog
-// payload intentionally scales with endpoint count while the exposed tool
-// count stays fixed at search+execute, so a per-tool average is not a
-// meaningful efficiency signal.
+// Code-orchestrated catalogs are unscored instead. Their catalog payload
+// intentionally scales with endpoint count while the exposed tool count stays
+// fixed at search+execute, so a per-tool average is not a meaningful
+// efficiency signal.
 //
 // Empty or missing MCP surface returns (0, false) so the dimension is
 // added to UnscoredDimensions.
 func scoreMCPTokenEfficiency(dir string) (int, bool) {
-	if canonicalMCPSurfacePath(dir) == mcpCodeOrchPath(dir) && codeOrchEndpointCount(dir) > surfaceStrategyLargeThreshold {
+	if canonicalMCPSurfacePath(dir) == mcpCodeOrchPath(dir) {
 		return 0, false
 	}
 	est := estimateMCPTokens(dir)
@@ -507,34 +507,4 @@ func scoreMCPTokenEfficiency(dir string) (int, bool) {
 	default:
 		return 0, true
 	}
-}
-
-func codeOrchEndpointCount(dir string) int {
-	file, err := parser.ParseFile(token.NewFileSet(), mcpCodeOrchPath(dir), nil, 0)
-	if err != nil {
-		return 0
-	}
-	for _, decl := range file.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok || genDecl.Tok != token.VAR {
-			continue
-		}
-		for _, spec := range genDecl.Specs {
-			valueSpec, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for i, name := range valueSpec.Names {
-				if name.Name != "codeOrchEndpoints" || i >= len(valueSpec.Values) {
-					continue
-				}
-				lit, ok := valueSpec.Values[i].(*ast.CompositeLit)
-				if !ok {
-					return 0
-				}
-				return len(lit.Elts)
-			}
-		}
-	}
-	return 0
 }

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -346,7 +346,7 @@ func TestScoreMCPTokenEfficiency_UnscoredForLargeCodeOrchCatalog(t *testing.T) {
 	dir := writeCodeOrchSurface(t, 200)
 
 	score, scored := scoreMCPTokenEfficiency(dir)
-	assert.False(t, scored, "large code-orchestrated catalogs should be unscored instead of zero-scored")
+	assert.False(t, scored, "code-orchestrated catalogs should always be unscored instead of zero-scored")
 	assert.Equal(t, 0, score)
 
 	sc := &Scorecard{}

--- a/internal/pipeline/mcp_size_test.go
+++ b/internal/pipeline/mcp_size_test.go
@@ -354,12 +354,12 @@ func TestScoreMCPTokenEfficiency_UnscoredForLargeCodeOrchCatalog(t *testing.T) {
 	assert.Contains(t, sc.UnscoredDimensions, DimMCPTokenEfficiency)
 }
 
-func TestScoreMCPTokenEfficiency_ScoresSmallCodeOrchCatalog(t *testing.T) {
+func TestScoreMCPTokenEfficiency_UnscoredForSmallCodeOrchCatalog(t *testing.T) {
 	dir := writeCodeOrchSurface(t, 20)
 
 	score, scored := scoreMCPTokenEfficiency(dir)
-	assert.True(t, scored, "small code-orchestrated catalogs should still use the scoring bands")
-	assert.Greater(t, score, 0)
+	assert.False(t, scored, "code-orchestrated catalogs should be unscored regardless of endpoint count")
+	assert.Equal(t, 0, score)
 }
 
 func TestScoreMCPTokenEfficiency_EndpointMirrorBehaviorUnchanged(t *testing.T) {


### PR DESCRIPTION
## Summary

Code-orchestrated MCP token-efficiency scoring is now treated as unscored based on the selected code-orchestration surface, not endpoint count, so sub-threshold code-orch CLIs no longer receive false 0/10 scores. The verify-skill canonical install-section check now ignores line-ending-only differences, so Windows CRLF checkouts do not report false drift while real text edits still fail.

Fixes mvanhorn/cli-printing-press#3079.
Fixes mvanhorn/cli-printing-press#3035.

## Validation

- `go test ./internal/pipeline -run 'TestScoreMCPTokenEfficiency|TestEstimateMCPTokens_RuntimeSurfaceSelection' -count=1`
- `go test ./internal/cli -run 'TestVerifySkill_CanonicalSections' -count=1`
- `go test ./internal/pipeline ./internal/cli -count=1`
- `go test ./... -count=1`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
