### PR TITLE
fix(cli): classify bot-wall reachability bodies

### DIFF
--- a/internal/reachability/detect.go
+++ b/internal/reachability/detect.go
@@ -9,8 +9,9 @@ import (
 // Label vocabulary matches internal/browsersniff/analysis.go's
 // ProtectionObservation labels so probe and post-capture analyzer agree.
 type Protection struct {
-	Label    string
-	Evidence string
+	Label        string
+	Evidence     string
+	BodyEvidence string
 }
 
 // classifyResponse returns protection signals detected in the response.
@@ -21,6 +22,13 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	body := strings.ToLower(bodySnippet)
 	h := lowerHeaders(headers)
 	server := h["server"]
+	contentType := h["content-type"]
+	jsonBody := strings.Contains(contentType, "json")
+	htmlBody := strings.Contains(contentType, "html") ||
+		(!jsonBody && (strings.Contains(body, "<html") ||
+			strings.Contains(body, "<script") ||
+			strings.Contains(body, "<div") ||
+			strings.Contains(body, "<iframe")))
 
 	if v := h["cf-mitigated"]; v == "challenge" {
 		out = append(out, Protection{Label: "bot_challenge", Evidence: "cf-mitigated: challenge"})
@@ -32,13 +40,17 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	if h["x-vercel-challenge-token"] != "" {
 		out = append(out, Protection{Label: "vercel_challenge", Evidence: "x-vercel-challenge-token present"})
 	}
-	if strings.Contains(body, "vercel security checkpoint") {
-		out = append(out, Protection{Label: "vercel_challenge", Evidence: "Vercel Security Checkpoint page"})
+	if htmlBody && strings.Contains(body, "vercel security checkpoint") {
+		out = append(out, Protection{Label: "vercel_challenge", Evidence: "Vercel Security Checkpoint page", BodyEvidence: "vercel_security_checkpoint"})
 	}
 
 	if h["aws-waf-token"] != "" || hasHeaderPrefix(h, "x-amzn-waf") ||
-		strings.Contains(body, "awswaf") || strings.Contains(body, "aws-waf") {
-		out = append(out, Protection{Label: "aws_waf", Evidence: "AWS WAF marker"})
+		(htmlBody && (strings.Contains(body, "awswaf") || strings.Contains(body, "aws-waf"))) {
+		p := Protection{Label: "aws_waf", Evidence: "AWS WAF marker"}
+		if htmlBody && (strings.Contains(body, "awswaf") || strings.Contains(body, "aws-waf")) {
+			p.BodyEvidence = "aws_waf"
+		}
+		out = append(out, p)
 	}
 
 	// CDN fingerprints (cf-ray, server: cloudflare, x-akamai-transformed)
@@ -52,40 +64,50 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	// DataDome and PerimeterX header presence stays a strong signal — those
 	// products only ship as bot mitigation, not as plain CDN.
 	cfFingerprint := strings.Contains(server, "cloudflare") || h["cf-ray"] != ""
-	contentType := h["content-type"]
-	htmlBody := strings.Contains(contentType, "html") ||
-		strings.Contains(body, "<html") ||
-		strings.Contains(body, "<script") ||
-		strings.Contains(body, "<div")
 	turnstileBody := htmlBody && strings.Contains(body, "challenges.cloudflare.com/turnstile")
-	cfChallengeBody := strings.Contains(body, "cf-chl") ||
+	impervaBody := htmlBody && (strings.Contains(body, "_incapsula_resource") ||
+		strings.Contains(body, "incapsula") ||
+		strings.Contains(body, "visid_incap") ||
+		strings.Contains(body, "incap_ses"))
+	cfChallengeBody := htmlBody && (strings.Contains(body, "cf-chl") ||
 		turnstileBody ||
 		strings.Contains(body, "just a moment") ||
 		strings.Contains(body, "checking your browser") ||
-		strings.Contains(body, "ddos protection by cloudflare")
+		strings.Contains(body, "ddos protection by cloudflare"))
 	akamaiFingerprint := h["x-akamai-transformed"] != ""
+	hcaptchaBody := htmlBody && (strings.Contains(body, "hcaptcha.com") ||
+		strings.Contains(body, "h-captcha") ||
+		strings.Contains(body, "data-hcaptcha"))
+	recaptchaBody := htmlBody && (strings.Contains(body, "google.com/recaptcha") ||
+		strings.Contains(body, "g-recaptcha") ||
+		strings.Contains(body, "data-sitekey") && strings.Contains(body, "recaptcha"))
 
 	switch {
 	case cfChallengeBody:
-		out = append(out, Protection{Label: "cloudflare", Evidence: "Cloudflare challenge marker in body"})
+		out = append(out, Protection{Label: "cloudflare", Evidence: "Cloudflare challenge marker in body", BodyEvidence: "cloudflare_challenge"})
 	case cfFingerprint && status >= 400:
 		out = append(out, Protection{Label: "cloudflare", Evidence: "Cloudflare error response"})
 	case akamaiFingerprint && status >= 400:
 		out = append(out, Protection{Label: "akamai", Evidence: "Akamai error response"})
-	case h["x-datadome"] != "" || strings.Contains(body, "datadome"):
+	case h["x-datadome"] != "":
 		out = append(out, Protection{Label: "datadome", Evidence: "DataDome marker"})
-	case strings.Contains(body, "perimeterx") || strings.Contains(body, "_px"):
-		out = append(out, Protection{Label: "perimeterx", Evidence: "PerimeterX marker"})
+	case htmlBody && strings.Contains(body, "datadome"):
+		out = append(out, Protection{Label: "datadome", Evidence: "DataDome marker", BodyEvidence: "datadome"})
+	case htmlBody && (strings.Contains(body, "perimeterx") || strings.Contains(body, "_px")):
+		out = append(out, Protection{Label: "perimeterx", Evidence: "PerimeterX marker", BodyEvidence: "perimeterx"})
+	case impervaBody:
+		out = append(out, Protection{Label: "imperva", Evidence: "Imperva/Incapsula marker", BodyEvidence: "imperva"})
 	}
 
 	switch {
 	case turnstileBody:
-		out = append(out, Protection{Label: "captcha", Evidence: "Cloudflare Turnstile interstitial"})
-	case strings.Contains(body, "fill out the captcha to unblock"):
-		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA unblock shell"})
-	case strings.Contains(body, "recaptcha") || strings.Contains(body, "hcaptcha") ||
-		strings.Contains(body, "g-recaptcha"):
-		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA widget"})
+		out = append(out, Protection{Label: "captcha", Evidence: "Cloudflare Turnstile interstitial", BodyEvidence: "cloudflare_turnstile"})
+	case htmlBody && strings.Contains(body, "fill out the captcha to unblock"):
+		out = append(out, Protection{Label: "captcha", Evidence: "CAPTCHA unblock shell", BodyEvidence: "captcha"})
+	case hcaptchaBody:
+		out = append(out, Protection{Label: "captcha", Evidence: "hCaptcha widget", BodyEvidence: "hcaptcha"})
+	case recaptchaBody:
+		out = append(out, Protection{Label: "captcha", Evidence: "reCAPTCHA widget", BodyEvidence: "recaptcha"})
 	}
 
 	if (status == 403 || status == 429) && len(out) == 0 {
@@ -152,6 +174,22 @@ func protectionsToEvidence(protections []Protection) []string {
 		}
 		seen[p.Evidence] = true
 		out = append(out, p.Evidence)
+	}
+	return out
+}
+
+func protectionsToBodyEvidence(protections []Protection) []string {
+	if len(protections) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range protections {
+		if p.BodyEvidence == "" || seen[p.BodyEvidence] {
+			continue
+		}
+		seen[p.BodyEvidence] = true
+		out = append(out, p.BodyEvidence)
 	}
 	return out
 }

--- a/internal/reachability/detect.go
+++ b/internal/reachability/detect.go
@@ -66,7 +66,7 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 	cfFingerprint := strings.Contains(server, "cloudflare") || h["cf-ray"] != ""
 	turnstileBody := htmlBody && strings.Contains(body, "challenges.cloudflare.com/turnstile")
 	impervaBody := htmlBody && (strings.Contains(body, "_incapsula_resource") ||
-		strings.Contains(body, "incapsula") ||
+		strings.Contains(body, "incapsula_resource") ||
 		strings.Contains(body, "visid_incap") ||
 		strings.Contains(body, "incap_ses"))
 	cfChallengeBody := htmlBody && (strings.Contains(body, "cf-chl") ||
@@ -80,7 +80,7 @@ func classifyResponse(status int, headers http.Header, bodySnippet string) []Pro
 		strings.Contains(body, "data-hcaptcha"))
 	recaptchaBody := htmlBody && (strings.Contains(body, "google.com/recaptcha") ||
 		strings.Contains(body, "g-recaptcha") ||
-		strings.Contains(body, "data-sitekey") && strings.Contains(body, "recaptcha"))
+		(strings.Contains(body, "data-sitekey") && strings.Contains(body, "recaptcha")))
 
 	switch {
 	case cfChallengeBody:

--- a/internal/reachability/detect_test.go
+++ b/internal/reachability/detect_test.go
@@ -111,6 +111,15 @@ func TestClassifyResponse(t *testing.T) {
 			wantBody:   []string{"imperva", "hcaptcha"},
 		},
 		{
+			name:   "imperva vendor mention on 200 is not a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Content-Type": {"text/html"},
+			},
+			body:        "<html><p>Imperva Incapsula migration notes and vendor comparison.</p></html>",
+			emptyResult: true,
+		},
+		{
 			name:   "cf-turnstile widget markup without script is not a protection signal",
 			status: 200,
 			headers: http.Header{

--- a/internal/reachability/detect_test.go
+++ b/internal/reachability/detect_test.go
@@ -14,6 +14,7 @@ func TestClassifyResponse(t *testing.T) {
 		headers     http.Header
 		body        string
 		wantLabels  []string
+		wantBody    []string
 		emptyResult bool
 	}{
 		{
@@ -32,6 +33,7 @@ func TestClassifyResponse(t *testing.T) {
 			},
 			body:       "<html>Vercel Security Checkpoint</html>",
 			wantLabels: []string{"bot_challenge", "vercel_challenge", "vercel_challenge"},
+			wantBody:   []string{"vercel_security_checkpoint"},
 		},
 		{
 			name:   "cloudflare cf-mitigated",
@@ -43,6 +45,7 @@ func TestClassifyResponse(t *testing.T) {
 			},
 			body:       "<html>Just a moment...</html>",
 			wantLabels: []string{"bot_challenge", "cloudflare"},
+			wantBody:   []string{"cloudflare_challenge"},
 		},
 		{
 			// Regression: cf-ray + server:cloudflare on a normal 200 means
@@ -94,6 +97,18 @@ func TestClassifyResponse(t *testing.T) {
 			body: `<html><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
 				<p>You will be forwarded to the requested page shortly.</p></html>`,
 			wantLabels: []string{"cloudflare", "captcha"},
+			wantBody:   []string{"cloudflare_challenge", "cloudflare_turnstile"},
+		},
+		{
+			name:   "imperva incapsula hcaptcha shell on 200 is a protection signal",
+			status: 200,
+			headers: http.Header{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			body: `<html><head><script src="/_Incapsula_Resource?SWKMTFSR=1"></script></head>
+				<body><iframe src="https://newassets.hcaptcha.com/captcha/v1/index.html"></iframe></body></html>`,
+			wantLabels: []string{"imperva", "captcha"},
+			wantBody:   []string{"imperva", "hcaptcha"},
 		},
 		{
 			name:   "cf-turnstile widget markup without script is not a protection signal",
@@ -114,6 +129,7 @@ func TestClassifyResponse(t *testing.T) {
 			},
 			body:       "<html><p>Fill out the captcha to unblock this page.</p></html>",
 			wantLabels: []string{"captcha"},
+			wantBody:   []string{"captcha"},
 		},
 		{
 			name:        "turnstile word in normal json is not a protection signal",
@@ -127,6 +143,13 @@ func TestClassifyResponse(t *testing.T) {
 			status:      200,
 			headers:     http.Header{"Content-Type": {"application/json"}},
 			body:        `{"cf-turnstile":false,"captcha_required":false}`,
+			emptyResult: true,
+		},
+		{
+			name:        "hcaptcha key in normal json is not a protection signal",
+			status:      200,
+			headers:     http.Header{"Content-Type": {"application/json"}},
+			body:        `{"hcaptcha_required":false,"captcha_provider":"hcaptcha"}`,
 			emptyResult: true,
 		},
 		{
@@ -156,6 +179,7 @@ func TestClassifyResponse(t *testing.T) {
 			},
 			body:       `<div class="g-recaptcha"></div>`,
 			wantLabels: []string{"captcha"},
+			wantBody:   []string{"recaptcha"},
 		},
 		{
 			name:   "403 html with no markers becomes protected_web",
@@ -190,6 +214,7 @@ func TestClassifyResponse(t *testing.T) {
 				labels[i] = p.Label
 			}
 			assert.ElementsMatch(t, tt.wantLabels, labels)
+			assert.ElementsMatch(t, tt.wantBody, protectionsToBodyEvidence(got))
 		})
 	}
 }

--- a/internal/reachability/probe.go
+++ b/internal/reachability/probe.go
@@ -75,6 +75,7 @@ func Probe(ctx context.Context, url string, opts Options) (*Result, error) {
 		if pr.Status > 0 && len(pr.Evidence) == 0 && statusIsClear(pr.Status) && !stdlibCleared(result) {
 			result.Mode = ModeBrowserHTTP
 			result.Confidence = 0.85
+			result.BodyEvidence = bodyEvidenceFromProbes(result.Probes)
 			result.Recommendation = Recommendation{
 				Runtime:   ModeBrowserHTTP,
 				Rationale: "Surf with Chrome TLS fingerprint cleared the protection that blocked plain stdlib HTTP.",
@@ -105,6 +106,7 @@ func stdlibCleared(result *Result) bool {
 func classifyStdlibSuccess(result *Result, partial bool) {
 	result.Mode = ModeStandardHTTP
 	result.Confidence = 0.95
+	result.BodyEvidence = bodyEvidenceFromProbes(result.Probes)
 	result.Recommendation = Recommendation{
 		Runtime:   ModeStandardHTTP,
 		Rationale: "Plain stdlib HTTP returned a non-error response; no special transport needed.",
@@ -186,6 +188,7 @@ func statusIsClear(status int) bool {
 // no rung returned a clear pass.
 func classifyFailure(result *Result, partial bool) {
 	result.Partial = partial
+	result.BodyEvidence = bodyEvidenceFromProbes(result.Probes)
 
 	hasProtection := false
 	allTransportErrors := true
@@ -269,8 +272,24 @@ func runRung(ctx context.Context, url string, transport Transport, opts Options)
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, bodyReadCap))
 	protections := classifyResponse(resp.StatusCode, resp.Header, string(body))
 	pr.Evidence = protectionsToEvidence(protections)
+	pr.BodyEvidence = protectionsToBodyEvidence(protections)
 	pr.ElapsedMS = time.Since(start).Milliseconds()
 	return pr
+}
+
+func bodyEvidenceFromProbes(probes []ProbeResult) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, pr := range probes {
+		for _, marker := range pr.BodyEvidence {
+			if seen[marker] {
+				continue
+			}
+			seen[marker] = true
+			out = append(out, marker)
+		}
+	}
+	return out
 }
 
 // buildClient constructs the *http.Client for one probe rung. Tests

--- a/internal/reachability/probe_test.go
+++ b/internal/reachability/probe_test.go
@@ -61,11 +61,28 @@ func json200(_ *http.Request) (*http.Response, error) {
 	}, nil
 }
 
+func jsonCaptchaFields200(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"application/json; charset=utf-8"}},
+		Body:       respBody(`{"hcaptcha_required":false,"turnstile_enabled":false,"captcha_provider":"hcaptcha"}`),
+	}, nil
+}
+
 func xml200(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 200,
 		Header:     http.Header{"Content-Type": {"application/xml; charset=utf-8"}},
 		Body:       respBody(`<StoreModel><ok>true</ok></StoreModel>`),
+	}, nil
+}
+
+func impervaHcaptchaShell(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"text/html; charset=utf-8"}},
+		Body: respBody(`<html><head><script src="/_Incapsula_Resource?SWKMTFSR=1"></script></head>
+			<body><iframe src="https://newassets.hcaptcha.com/captcha/v1/index.html"></iframe></body></html>`),
 	}, nil
 }
 
@@ -118,6 +135,28 @@ func TestProbe_StdlibPasses(t *testing.T) {
 	assert.False(t, result.Recommendation.NeedsBrowserCapture)
 }
 
+func TestProbe_CleanHTML_RemainsStandardHTTP(t *testing.T) {
+	result, err := Probe(context.Background(), "https://example.com", Options{
+		HTTPClientFactory: fakeFactory(ok200, ok200),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ModeStandardHTTP, result.Mode)
+	assert.Empty(t, result.BodyEvidence)
+	assert.Empty(t, result.Probes[0].BodyEvidence)
+	assert.False(t, result.Recommendation.NeedsBrowserCapture)
+}
+
+func TestProbe_JSONAPIWithCaptchaFields_RemainsStandardHTTP(t *testing.T) {
+	result, err := Probe(context.Background(), "https://api.example.com/session/check", Options{
+		HTTPClientFactory: fakeFactory(jsonCaptchaFields200, jsonCaptchaFields200),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ModeStandardHTTP, result.Mode)
+	assert.Empty(t, result.BodyEvidence)
+	assert.Empty(t, result.Probes[0].Evidence)
+	assert.False(t, result.Recommendation.NeedsBrowserCapture)
+}
+
 func TestProbe_StdlibJSONSurfXMLMarksImpersonationUnsafe(t *testing.T) {
 	result, err := Probe(context.Background(), "https://example.com/api/stores/123", Options{
 		HTTPClientFactory: fakeFactory(json200, xml200),
@@ -165,6 +204,20 @@ func TestProbe_BothTurnstileInterstitials_RecommendsBrowserCapture(t *testing.T)
 	assert.Equal(t, ModeBrowserClearanceHTTP, result.Mode)
 	assert.Equal(t, 200, result.Probes[0].Status)
 	assert.NotEmpty(t, result.Probes[0].Evidence)
+	assert.True(t, result.Recommendation.NeedsBrowserCapture)
+	assert.True(t, result.Recommendation.NeedsClearanceCookie)
+}
+
+func TestProbe_BothImpervaHcaptchaShells_RecommendsBrowserCaptureWithBodyEvidence(t *testing.T) {
+	result, err := Probe(context.Background(), "https://www.example.com", Options{
+		HTTPClientFactory: fakeFactory(impervaHcaptchaShell, impervaHcaptchaShell),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ModeBrowserClearanceHTTP, result.Mode)
+	assert.ElementsMatch(t, []string{"imperva", "hcaptcha"}, result.BodyEvidence)
+	require.Len(t, result.Probes, 2)
+	assert.ElementsMatch(t, []string{"imperva", "hcaptcha"}, result.Probes[0].BodyEvidence)
+	assert.ElementsMatch(t, []string{"imperva", "hcaptcha"}, result.Probes[1].BodyEvidence)
 	assert.True(t, result.Recommendation.NeedsBrowserCapture)
 	assert.True(t, result.Recommendation.NeedsClearanceCookie)
 }

--- a/internal/reachability/render_test.go
+++ b/internal/reachability/render_test.go
@@ -15,8 +15,11 @@ func TestRenderJSON(t *testing.T) {
 		URL:        "https://food52.com",
 		Mode:       ModeBrowserHTTP,
 		Confidence: 0.85,
+		BodyEvidence: []string{
+			"vercel_security_checkpoint",
+		},
 		Probes: []ProbeResult{
-			{Transport: TransportStdlib, Status: 429, ElapsedMS: 412, Evidence: []string{"x-vercel-mitigated: challenge"}},
+			{Transport: TransportStdlib, Status: 429, ElapsedMS: 412, Evidence: []string{"x-vercel-mitigated: challenge"}, BodyEvidence: []string{"vercel_security_checkpoint"}},
 			{Transport: TransportSurfChrome, Status: 200, ElapsedMS: 387},
 		},
 		Recommendation: Recommendation{
@@ -31,9 +34,12 @@ func TestRenderJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 	assert.Equal(t, "browser_http", decoded["mode"])
 	assert.Equal(t, "https://food52.com", decoded["url"])
+	assert.Equal(t, []any{"vercel_security_checkpoint"}, decoded["body_evidence"])
 	probes, ok := decoded["probes"].([]any)
 	require.True(t, ok)
 	assert.Len(t, probes, 2)
+	firstProbe := probes[0].(map[string]any)
+	assert.Equal(t, []any{"vercel_security_checkpoint"}, firstProbe["body_evidence"])
 }
 
 func TestRenderTable_FullPath(t *testing.T) {

--- a/internal/reachability/types.go
+++ b/internal/reachability/types.go
@@ -60,6 +60,7 @@ type Result struct {
 	URL               string         `json:"url"`
 	Mode              Mode           `json:"mode"`
 	Confidence        float64        `json:"confidence"`
+	BodyEvidence      []string       `json:"body_evidence,omitempty"`
 	Probes            []ProbeResult  `json:"probes"`
 	Recommendation    Recommendation `json:"recommendation"`
 	ImpersonationSafe *bool          `json:"impersonation_safe,omitempty"`
@@ -70,12 +71,13 @@ type Result struct {
 
 // ProbeResult is one rung of the probe ladder.
 type ProbeResult struct {
-	Transport   Transport `json:"transport"`
-	Status      int       `json:"status,omitempty"`
-	ElapsedMS   int64     `json:"elapsed_ms"`
-	Evidence    []string  `json:"evidence,omitempty"`
-	ContentType string    `json:"content_type,omitempty"`
-	Error       string    `json:"error,omitempty"`
+	Transport    Transport `json:"transport"`
+	Status       int       `json:"status,omitempty"`
+	ElapsedMS    int64     `json:"elapsed_ms"`
+	Evidence     []string  `json:"evidence,omitempty"`
+	BodyEvidence []string  `json:"body_evidence,omitempty"`
+	ContentType  string    `json:"content_type,omitempty"`
+	Error        string    `json:"error,omitempty"`
 }
 
 // Recommendation tells the caller what runtime to ship and what consent


### PR DESCRIPTION
## Summary

- classify bot-wall HTML body markers, including Imperva/Incapsula and hCaptcha widgets, as reachability protection evidence
- expose `body_evidence` on `probe-reachability` JSON results and probe rungs for transparent marker attribution
- keep clean HTML and JSON/API responses on `standard_http` by scoping provider-name checks to challenge-like HTML markers

Fixes #2990.

## Validation

- `go test ./internal/reachability`
- `go test ./internal/cli -timeout 20m`
- `go test ./... -timeout 20m`
- `scripts/golden.sh verify`
