### PR TITLE
fix(cli): emit patch go directives

### DIFF
--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -289,8 +289,8 @@ func deviceCommandCallable(command devicespec.DeviceCommand) bool {
 func (g *DeviceGenerator) render(relPath, tmplText string, data deviceTemplateData) error {
 	tmpl, err := template.New(relPath).Funcs(template.FuncMap{
 		"quote":              func(value string) string { return fmt.Sprintf("%q", value) },
-		"goDirectiveVersion": currentGoDirectiveVersion,
-		"goToolchainVersion": currentGoToolchainVersion,
+		"goDirectiveVersion": resolveCurrentGoDirectiveVersion,
+		"goToolchainVersion": resolveCurrentGoToolchainVersion,
 	}).Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("parse %s template: %w", relPath, err)

--- a/internal/generator/device.go
+++ b/internal/generator/device.go
@@ -288,7 +288,9 @@ func deviceCommandCallable(command devicespec.DeviceCommand) bool {
 
 func (g *DeviceGenerator) render(relPath, tmplText string, data deviceTemplateData) error {
 	tmpl, err := template.New(relPath).Funcs(template.FuncMap{
-		"quote": func(value string) string { return fmt.Sprintf("%q", value) },
+		"quote":              func(value string) string { return fmt.Sprintf("%q", value) },
+		"goDirectiveVersion": currentGoDirectiveVersion,
+		"goToolchainVersion": currentGoToolchainVersion,
 	}).Parse(tmplText)
 	if err != nil {
 		return fmt.Errorf("parse %s template: %w", relPath, err)
@@ -332,9 +334,9 @@ func (g *DeviceGenerator) renderEmbedded(relPath, tmplName string, data deviceTe
 
 const deviceGoModTemplate = `module {{.ModulePath}}
 
-go 1.26
+go {{goDirectiveVersion}}
 
-toolchain go1.26.4
+toolchain {{goToolchainVersion}}
 
 require (
 	github.com/mark3labs/mcp-go v0.47.0

--- a/internal/generator/device_test.go
+++ b/internal/generator/device_test.go
@@ -190,6 +190,7 @@ func TestGeneratedBLEDeviceEmitsMCPSurface(t *testing.T) {
 	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
 	assert.Contains(t, string(goMod), "github.com/mark3labs/mcp-go")
+	assert.Contains(t, string(goMod), "\ngo "+currentGoDirectiveVersion()+"\n")
 
 	requireGeneratedCompiles(t, outputDir) // builds ./... including the MCP binary
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -340,7 +340,9 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return naming.CLI(s.Name)
 		},
-		"graphqlQueryField": graphqlQueryField,
+		"goDirectiveVersion": currentGoDirectiveVersion,
+		"goToolchainVersion": currentGoToolchainVersion,
+		"graphqlQueryField":  graphqlQueryField,
 		"graphqlFieldSelection": func(typeName string, types map[string]spec.TypeDef) []string {
 			return graphqlFieldSelection(typeName, types)
 		},

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -340,8 +340,8 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 			}
 			return naming.CLI(s.Name)
 		},
-		"goDirectiveVersion": currentGoDirectiveVersion,
-		"goToolchainVersion": currentGoToolchainVersion,
+		"goDirectiveVersion": resolveCurrentGoDirectiveVersion,
+		"goToolchainVersion": resolveCurrentGoToolchainVersion,
 		"graphqlQueryField":  graphqlQueryField,
 		"graphqlFieldSelection": func(typeName string, types map[string]spec.TypeDef) []string {
 			return graphqlFieldSelection(typeName, types)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2373,7 +2373,7 @@ func TestGenerateBrowserChromeTransport(t *testing.T) {
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
 	assert.Contains(t, string(gomod), "go "+currentGoDirectiveVersion()+"\n")
-	assert.Contains(t, string(gomod), "toolchain go1.26.4")
+	assert.Contains(t, string(gomod), "toolchain "+currentGoToolchainVersion())
 	assert.Contains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
@@ -3641,7 +3641,7 @@ func TestGenerateStandardTransportForOfficialAPI(t *testing.T) {
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
 	assert.Contains(t, string(gomod), "go "+currentGoDirectiveVersion()+"\n")
-	assert.Contains(t, string(gomod), "toolchain go1.26.4")
+	assert.Contains(t, string(gomod), "toolchain "+currentGoToolchainVersion())
 	assert.NotContains(t, string(gomod), "github.com/enetx/surf")
 
 	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -2372,7 +2372,7 @@ func TestGenerateBrowserChromeTransport(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26\n")
+	assert.Contains(t, string(gomod), "go "+currentGoDirectiveVersion()+"\n")
 	assert.Contains(t, string(gomod), "toolchain go1.26.4")
 	assert.Contains(t, string(gomod), "github.com/enetx/surf")
 
@@ -3640,7 +3640,7 @@ func TestGenerateStandardTransportForOfficialAPI(t *testing.T) {
 
 	gomod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gomod), "go 1.26\n")
+	assert.Contains(t, string(gomod), "go "+currentGoDirectiveVersion()+"\n")
 	assert.Contains(t, string(gomod), "toolchain go1.26.4")
 	assert.NotContains(t, string(gomod), "github.com/enetx/surf")
 

--- a/internal/generator/go_version.go
+++ b/internal/generator/go_version.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -10,20 +11,34 @@ import (
 var goRuntimeVersionRE = regexp.MustCompile(`go([0-9]+\.[0-9]+)(?:\.([0-9]+))?`)
 
 func currentGoDirectiveVersion() string {
+	version, _ := resolveCurrentGoDirectiveVersion()
+	return version
+}
+
+func currentGoToolchainVersion() string {
+	version, _ := resolveCurrentGoToolchainVersion()
+	return version
+}
+
+func resolveCurrentGoDirectiveVersion() (string, error) {
 	if version := goDirectiveVersionFromRuntime(runtime.Version()); version != "" {
-		return version
+		return version, nil
 	}
 	out, err := exec.Command("go", "env", "GOVERSION").Output()
 	if err == nil {
 		if version := goDirectiveVersionFromRuntime(strings.TrimSpace(string(out))); version != "" {
-			return version
+			return version, nil
 		}
 	}
-	panic("could not determine Go toolchain version")
+	return "", fmt.Errorf("could not determine Go toolchain version from runtime %q or go env GOVERSION", runtime.Version())
 }
 
-func currentGoToolchainVersion() string {
-	return "go" + currentGoDirectiveVersion()
+func resolveCurrentGoToolchainVersion() (string, error) {
+	version, err := resolveCurrentGoDirectiveVersion()
+	if err != nil {
+		return "", err
+	}
+	return "go" + version, nil
 }
 
 func goDirectiveVersionFromRuntime(version string) string {

--- a/internal/generator/go_version.go
+++ b/internal/generator/go_version.go
@@ -1,0 +1,38 @@
+package generator
+
+import (
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var goRuntimeVersionRE = regexp.MustCompile(`go([0-9]+\.[0-9]+)(?:\.([0-9]+))?`)
+
+func currentGoDirectiveVersion() string {
+	if version := goDirectiveVersionFromRuntime(runtime.Version()); version != "" {
+		return version
+	}
+	out, err := exec.Command("go", "env", "GOVERSION").Output()
+	if err == nil {
+		if version := goDirectiveVersionFromRuntime(strings.TrimSpace(string(out))); version != "" {
+			return version
+		}
+	}
+	panic("could not determine Go toolchain version")
+}
+
+func currentGoToolchainVersion() string {
+	return "go" + currentGoDirectiveVersion()
+}
+
+func goDirectiveVersionFromRuntime(version string) string {
+	match := goRuntimeVersionRE.FindStringSubmatch(version)
+	if match == nil {
+		return ""
+	}
+	if match[2] == "" {
+		return match[1] + ".0"
+	}
+	return match[1] + "." + match[2]
+}

--- a/internal/generator/go_version_test.go
+++ b/internal/generator/go_version_test.go
@@ -1,0 +1,48 @@
+package generator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoDirectiveVersionFromRuntime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "patch", version: "go1.26.4", want: "1.26.4"},
+		{name: "minor", version: "go1.26", want: "1.26.0"},
+		{name: "devel", version: "devel go1.27-abc123", want: "1.27.0"},
+		{name: "suffix", version: "go1.26.4 X:cacheprog", want: "1.26.4"},
+		{name: "unknown", version: "unknown", want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, goDirectiveVersionFromRuntime(tt.version))
+		})
+	}
+}
+
+func TestGeneratedGoModUsesPatchGoDirective(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("patch-directive")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
+	assert.Contains(t, goMod, "\ngo "+currentGoDirectiveVersion()+"\n")
+	assert.Contains(t, goMod, "\ntoolchain "+currentGoToolchainVersion()+"\n")
+	assert.NotContains(t, goMod, "\ngo 1.26\n")
+}

--- a/internal/generator/go_version_test.go
+++ b/internal/generator/go_version_test.go
@@ -25,7 +25,6 @@ func TestGoDirectiveVersionFromRuntime(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -93,16 +93,18 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 
 	// Build template FuncMap (subset of the full generator's FuncMap)
 	funcs := template.FuncMap{
-		"title":           cases.Title(language.English).String,
-		"lower":           strings.ToLower,
-		"upper":           strings.ToUpper,
-		"pascal":          toPascal,
-		"camel":           toCamel,
-		"snake":           naming.Snake,
-		"kebab":           toKebab,
-		"currentYear":     func() string { return strconv.Itoa(time.Now().Year()) },
-		"copyrightHolder": func() string { return copyrightHolderString(creator, "", owner) },
-		"modulePath":      func() string { return naming.CLI(cliName) },
+		"title":              cases.Title(language.English).String,
+		"lower":              strings.ToLower,
+		"upper":              strings.ToUpper,
+		"pascal":             toPascal,
+		"camel":              toCamel,
+		"snake":              naming.Snake,
+		"kebab":              toKebab,
+		"currentYear":        func() string { return strconv.Itoa(time.Now().Year()) },
+		"copyrightHolder":    func() string { return copyrightHolderString(creator, "", owner) },
+		"modulePath":         func() string { return naming.CLI(cliName) },
+		"goDirectiveVersion": currentGoDirectiveVersion,
+		"goToolchainVersion": currentGoToolchainVersion,
 		// Stub: plan-generated scaffolds never declare auth env vars. The full
 		// generator's hasNonCookieAuth (which inspects the real spec.AuthConfig)
 		// is registered separately on its own FuncMap.

--- a/internal/generator/plan_generate.go
+++ b/internal/generator/plan_generate.go
@@ -103,8 +103,8 @@ func GenerateFromPlan(planSpec *PlanSpec, outputDir string) error {
 		"currentYear":        func() string { return strconv.Itoa(time.Now().Year()) },
 		"copyrightHolder":    func() string { return copyrightHolderString(creator, "", owner) },
 		"modulePath":         func() string { return naming.CLI(cliName) },
-		"goDirectiveVersion": currentGoDirectiveVersion,
-		"goToolchainVersion": currentGoToolchainVersion,
+		"goDirectiveVersion": resolveCurrentGoDirectiveVersion,
+		"goToolchainVersion": resolveCurrentGoToolchainVersion,
 		// Stub: plan-generated scaffolds never declare auth env vars. The full
 		// generator's hasNonCookieAuth (which inspects the real spec.AuthConfig)
 		// is registered separately on its own FuncMap.

--- a/internal/generator/plan_generate_test.go
+++ b/internal/generator/plan_generate_test.go
@@ -54,6 +54,7 @@ func TestGenerateFromPlan_BasicScaffold(t *testing.T) {
 	goMod, err := os.ReadFile(filepath.Join(outputDir, "go.mod"))
 	require.NoError(t, err)
 	assert.Contains(t, string(goMod), naming.CLI("screencap"))
+	assert.Contains(t, string(goMod), "\ngo "+currentGoDirectiveVersion()+"\n")
 
 	// Verify root.go contains command registrations
 	rootGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "root.go"))

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -1,8 +1,8 @@
 module {{modulePath}}
 
-go 1.26
+go {{goDirectiveVersion}}
 
-toolchain go1.26.4
+toolchain {{goToolchainVersion}}
 
 require (
 {{- if .UsesBrowserHTTPTransport}}

--- a/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
+++ b/testdata/golden/expected/generate-device-ble-control/ble-desk-lamp/go.mod
@@ -1,6 +1,6 @@
 module ble-desk-lamp-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 

--- a/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
+++ b/testdata/golden/expected/generate-device-ble-opaque/ble-opaque-binary/go.mod
@@ -1,6 +1,6 @@
 module ble-opaque-binary-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 

--- a/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
+++ b/testdata/golden/expected/generate-device-ble-session/ble-session-appliance/go.mod
@@ -1,6 +1,6 @@
 module ble-session-appliance-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/go.mod
@@ -1,6 +1,6 @@
 module ble-temperature-sensor-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -1,6 +1,6 @@
 module golden-api-cookie-auth-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -1,6 +1,6 @@
 module printing-press-golden-pp-cli
 
-go 1.26
+go 1.26.4
 
 toolchain go1.26.4
 


### PR DESCRIPTION
## Summary
- emit generated `go.mod` directives with the full patch Go version from the active toolchain
- share the directive/toolchain version helper across standard, plan, and device generators
- update generated-output goldens from `go 1.26` to `go 1.26.4` on this toolchain

Closes #2860.

## Validation
- `go test ./internal/generator -run 'TestGoDirectiveVersionFromRuntime|TestGeneratedGoModUsesPatchGoDirective|TestGenerateBrowserChromeTransport|TestGenerateStandardTransportForOfficialAPI|TestGenerateFromPlan_BasicScaffold|TestGeneratedBLEDeviceEmitsMCPSurface' -count=1`\n- `scripts/golden.sh verify`\n- `scripts/verify-generator-output.sh`\n- `go test ./... -timeout=20m`\n\nNote: an earlier parallel `scripts/golden.sh verify` collided with `scripts/verify-generator-output.sh` because both write under `.gotmp`; rerunning golden by itself passed all 32 cases.