### PR TITLE
fix(cli): align cobratree MCP tool surface

### DIFF
--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -188,8 +188,8 @@ func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 	}
 
 	root := &cobra.Command{Use: "depthcheck-pp-cli"}
-	topSearch := &cobra.Command{
-		Use: "search",
+	topAuth := &cobra.Command{
+		Use: "auth",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
 	}
 	items := &cobra.Command{Use: "items"}
@@ -198,10 +198,10 @@ func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
 	}
 	items.AddCommand(itemSearch)
-	root.AddCommand(topSearch, items)
+	root.AddCommand(topAuth, items)
 
-	if got := classify(topSearch); got != commandFramework {
-		t.Fatalf("top-level search classify() = %v, want commandFramework", got)
+	if got := classify(topAuth); got != commandFramework {
+		t.Fatalf("top-level auth classify() = %v, want commandFramework", got)
 	}
 	if got := classify(itemSearch); got != commandNovel {
 		t.Fatalf("nested items search classify() = %v, want commandNovel", got)

--- a/internal/generator/templates/cobratree/classify.go.tmpl
+++ b/internal/generator/templates/cobratree/classify.go.tmpl
@@ -39,7 +39,7 @@ const (
 // mirroring the Cobra tree. Two cases qualify:
 //
 //  1. A typed MCP tool already covers the same capability (the typed tool's
-//     schema is strictly better than a shell-out). Examples: `sql`, `search`,
+//     schema is strictly better than a shell-out). Examples:
 //     `context`/`about`/`agent-context`, `api` (endpoint mirror tools cover it).
 //  2. The command is non-functional via MCP (interactive setup, shell-only
 //     ergonomics, trivial introspection, local-only feedback). Examples:
@@ -69,8 +69,6 @@ var frameworkCommands = map[string]bool{
 	"feedback":      true,
 	"help":          true,
 	"profile":       true,
-	"search":        true,
-	"sql":           true,
 	"version":       true,
 	"which":         true,
 }

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -17,7 +17,7 @@ import (
 	"{{modulePath}}/internal/mcp/bound"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -26,7 +26,12 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		}
 		args := req.GetArguments()
 		finalArgs := append([]string{}, prefixArgs...)
-		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
+		finalArgs = append(finalArgs, cliArgsFromMCP(args, blockedStructuredArgs)...)
+		positionalArgs, err := positionalArgsFromMCP(args, positionals, readOnly, positionalWriteSinks)
+		if err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
+		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
 			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
@@ -40,6 +45,38 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		}
 		return mcplib.NewToolResultText(bound.Text(out)), nil
 	}
+}
+
+func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
+	out := make([]string, 0, len(positionals))
+	for _, positional := range positionals {
+		value, ok := args[positional.InputName]
+		if !ok || value == nil {
+			continue
+		}
+		var text string
+		switch tv := value.(type) {
+		case string:
+			text = tv
+		case float64:
+			text = strconv.FormatFloat(tv, 'f', -1, 64)
+		case bool:
+			text = strconv.FormatBool(tv)
+		default:
+			text = fmt.Sprintf("%v", tv)
+		}
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		if text != "-" && strings.HasPrefix(text, "-") {
+			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
+		}
+		out = append(out, text)
+	}
+	if err := validatePositionalArgsForMCP(out, readOnly, positionalWriteSinks); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
@@ -63,6 +100,12 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 	return nil
 }
 
+// reservedStructuredArgs are MCP-only argument names that must never be
+// forwarded as CLI flags.
+var reservedStructuredArgs = map[string]bool{
+	"args": true,
+}
+
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
 // caller swap auth credentials, redirect the API base URL, select a different
@@ -70,7 +113,6 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 // malicious config file, or change the delivery target, all of which sit
 // outside the per-command surface the agent is supposed to be calling.
 var blockedRootFlags = map[string]bool{
-	"args":     true,
 	"base-url": true,
 	"client":   true,
 	"config":   true,
@@ -80,13 +122,13 @@ var blockedRootFlags = map[string]bool{
 	"token":    true,
 }
 
-func cliArgsFromMCP(args map[string]any) []string {
+func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
 		if strings.Contains(k, "=") {
 			continue
 		}
-		if blockedRootFlags[k] {
+		if blocked[k] {
 			continue
 		}
 		keys = append(keys, k)

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -68,6 +68,9 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
+		if positionalIndex != len(out) {
+			return nil, fmt.Errorf("structured positional %q cannot be used while earlier positional arguments are omitted; provide the preceding positional arguments or use the args field", positional.InputName)
+		}
 		if text != "-" && strings.HasPrefix(text, "-") {
 			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
 		}

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -34,7 +34,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
-			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
+			if err := validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
 				return mcplib.NewToolResultError(err.Error()), nil
 			}
 			finalArgs = append(finalArgs, tokens...)
@@ -83,6 +83,10 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
+	return validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, 0)
+}
+
+func validatePositionalArgsForMCPAtOffset(tokens []string, readOnly bool, positionalWriteSinks map[int]bool, offset int) error {
 	for _, t := range tokens {
 		if t != "-" && strings.HasPrefix(t, "-") {
 			return fmt.Errorf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)
@@ -92,13 +96,14 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 		return nil
 	}
 	for i, t := range tokens {
-		if !positionalWriteSinks[i] {
+		positionalIndex := offset + i
+		if !positionalWriteSinks[positionalIndex] {
 			continue
 		}
 		if strings.TrimSpace(t) == "" || t == "-" {
 			continue
 		}
-		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", i+1, t)
+		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", positionalIndex+1, t)
 	}
 	return nil
 }

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -49,7 +49,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
 	out := make([]string, 0, len(positionals))
-	for _, positional := range positionals {
+	for positionalIndex, positional := range positionals {
 		value, ok := args[positional.InputName]
 		if !ok || value == nil {
 			continue
@@ -71,9 +71,12 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		if text != "-" && strings.HasPrefix(text, "-") {
 			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
 		}
+		if readOnly && positionalWriteSinks[positionalIndex] && text != "-" {
+			return nil, fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", positionalIndex+1, text)
+		}
 		out = append(out, text)
 	}
-	if err := validatePositionalArgsForMCP(out, readOnly, positionalWriteSinks); err != nil {
+	if err := validatePositionalArgsForMCP(out, readOnly, nil); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +74,16 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCP(in, map[string]bool{
+		"args":     true,
+		"base-url": true,
+		"client":   true,
+		"config":   true,
+		"deliver":  true,
+		"home":     true,
+		"profile":  true,
+		"token":    true,
+	})
 	want := []string{"--limit", "10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
@@ -101,10 +112,43 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"limit":   float64(25),
 		"tags":    []any{"a", "b"},
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCP(in, map[string]bool{"args": true})
 	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
+	}
+}
+
+func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("profile", "", "root profile")
+	root.PersistentFlags().String("config", "", "root config")
+	root.PersistentFlags().String("json", "", "format output")
+
+	child := &cobra.Command{Use: "child"}
+	child.Flags().String("profile", "", "command profile")
+	root.AddCommand(child)
+
+	blocked := blockedStructuredArgsForCommand(child)
+	if blocked["profile"] {
+		t.Fatalf("command-local --profile was blocked as a root flag: %#v", blocked)
+	}
+	if !blocked["config"] {
+		t.Fatalf("inherited root --config was not blocked: %#v", blocked)
+	}
+	if blocked["json"] {
+		t.Fatalf("non-sensitive inherited --json should remain available: %#v", blocked)
+	}
+
+	got := cliArgsFromMCP(map[string]any{
+		"args":    "ignored",
+		"profile": "local-profile",
+		"config":  "/tmp/evil.yaml",
+		"json":    "true",
+	}, blocked)
+	want := []string{"--json", "true", "--profile", "local-profile"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
 }
 
@@ -205,6 +249,126 @@ func TestPositionalWriteSinkIndexesParsesAnnotation(t *testing.T) {
 	}
 	if got[1] {
 		t.Fatalf("positionalWriteSinkIndexes unexpectedly included index 1: %#v", got)
+	}
+}
+
+func TestPositionalsExposeNamedInputsAndRejectFlagLikeValues(t *testing.T) {
+	cmd := &cobra.Command{Use: "export <resource> [id]"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	if got, want := len(positionals), 2; got != want {
+		t.Fatalf("positionals length = %d, want %d: %#v", got, want, positionals)
+	}
+	if positionals[0].InputName != "resource" || !positionals[0].Required {
+		t.Fatalf("first positional = %#v, want required resource", positionals[0])
+	}
+	if positionals[1].InputName != "id" || positionals[1].Required {
+		t.Fatalf("second positional = %#v, want optional id", positionals[1])
+	}
+
+	got, err := positionalArgsFromMCP(map[string]any{"resource": "contacts", "id": "123"}, positionals, false, nil)
+	if err != nil {
+		t.Fatalf("positionalArgsFromMCP returned error: %v", err)
+	}
+	if want := []string{"contacts", "123"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("positionals = %v, want %v", got, want)
+	}
+
+	if _, err := positionalArgsFromMCP(map[string]any{"resource": "--config"}, positionals, false, nil); err == nil {
+		t.Fatal("flag-like structured positional succeeded, want error")
+	}
+}
+
+func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
+	cmd := &cobra.Command{Use: "export <resource> [id]"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	blocked := cliFlagBlockedArgs(map[string]bool{"args": true}, positionals)
+	got := cliArgsFromMCP(map[string]any{
+		"resource": "contacts",
+		"id":       "123",
+		"format":   "json",
+	}, blocked)
+	want := []string{"--format", "json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
+	}
+}
+
+func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("config", "", "root config")
+	root.PersistentFlags().Bool("json", false, "json output")
+
+	child := &cobra.Command{Use: "child <query>"}
+	child.Flags().String("config", "", "local config")
+	child.Flags().String("args", "", "reserved local args")
+	root.AddCommand(child)
+
+	blocked := blockedStructuredArgsForCommand(child)
+	positionals := positionalArgsForCommand(child, blocked)
+	tool := mcplib.NewTool("child", toolOptionsForFlags(child, blocked, positionals)...)
+	props := tool.InputSchema.Properties
+	if _, ok := props["json"]; !ok {
+		t.Fatalf("non-sensitive inherited --json missing from schema: %#v", props)
+	}
+	if _, ok := props["config"]; !ok {
+		t.Fatalf("command-local --config collision missing from schema: %#v", props)
+	}
+	if _, ok := props["query"]; !ok {
+		t.Fatalf("positional <query> missing from schema: %#v", props)
+	}
+	if _, ok := props["args"]; ok {
+		t.Fatalf("reserved args parameter should not be exposed as a flag schema: %#v", props)
+	}
+}
+
+func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEquivalent(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.AddCommand(
+		&cobra.Command{
+			Use: "context",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use: "auth",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use: "search <query>",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use:         "secret",
+			Annotations: map[string]string{"mcp:hidden": "true"},
+			RunE:        func(cmd *cobra.Command, args []string) error { return nil },
+		},
+	)
+
+	s := server.NewMCPServer("test", "0.0.0")
+	s.AddTool(mcplib.NewTool("context", mcplib.WithDescription("typed context")), func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		return mcplib.NewToolResultText("typed"), nil
+	})
+	RegisterAll(s, root, func() (string, error) { return "missing-binary", nil })
+
+	tools := s.ListTools()
+	if tools["context"].Tool.Description != "typed context" {
+		t.Fatalf("typed context tool was overwritten: %#v", tools["context"].Tool)
+	}
+	if _, ok := tools["search"]; !ok {
+		t.Fatalf("hand-built search without typed search equivalent was not mirrored: %#v", tools)
+	}
+	for _, excluded := range []string{"auth", "secret"} {
+		if _, ok := tools[excluded]; ok {
+			t.Fatalf("excluded command %q was mirrored: %#v", excluded, tools)
+		}
+	}
+
+	sWithTypedSearch := server.NewMCPServer("test", "0.0.0")
+	sWithTypedSearch.AddTool(mcplib.NewTool("search", mcplib.WithDescription("typed search")), func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		return mcplib.NewToolResultText("typed"), nil
+	})
+	RegisterAll(sWithTypedSearch, root, func() (string, error) { return "missing-binary", nil })
+	if got := sWithTypedSearch.ListTools()["search"].Tool.Description; got != "typed search" {
+		t.Fatalf("typed search tool was overwritten: %q", got)
 	}
 }
 

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -294,17 +294,53 @@ func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
 		t.Fatal("structured write sink with omitted optional positional succeeded, want error")
 	}
 
-	got, err := positionalArgsFromMCP(
+	if _, err := positionalArgsFromMCP(
 		map[string]any{"output-file": "-"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	); err == nil {
+		t.Fatal("stdout structured write sink with omitted optional positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"format": "json", "output-file": "-"},
 		positionals,
 		true,
 		map[int]bool{1: true},
 	)
 	if err != nil {
-		t.Fatalf("stdout structured write sink returned error: %v", err)
+		t.Fatalf("stdout structured write sink with contiguous positionals returned error: %v", err)
 	}
-	if want := []string{"-"}; !reflect.DeepEqual(got, want) {
+	if want := []string{"json", "-"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("structured write sink args = %v, want %v", got, want)
+	}
+}
+
+func TestStructuredPositionalsRejectGapsBeforeLaterArguments(t *testing.T) {
+	cmd := &cobra.Command{Use: "export [format] <output-file>"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+
+	if _, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "report.csv"},
+		positionals,
+		false,
+		nil,
+	); err == nil {
+		t.Fatal("later structured positional with omitted earlier positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"format": "csv", "output-file": "report.csv"},
+		positionals,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("contiguous structured positionals returned error: %v", err)
+	}
+	if want := []string{"csv", "report.csv"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("contiguous structured positionals = %v, want %v", got, want)
 	}
 }
 

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -278,6 +278,36 @@ func TestPositionalsExposeNamedInputsAndRejectFlagLikeValues(t *testing.T) {
 	}
 }
 
+func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
+	cmd := &cobra.Command{Use: "export [format] <output-file>"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	if got, want := len(positionals), 2; got != want {
+		t.Fatalf("positionals length = %d, want %d: %#v", got, want, positionals)
+	}
+
+	if _, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "out.json"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	); err == nil {
+		t.Fatal("structured write sink with omitted optional positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "-"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	)
+	if err != nil {
+		t.Fatalf("stdout structured write sink returned error: %v", err)
+	}
+	if want := []string{"-"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("structured write sink args = %v, want %v", got, want)
+	}
+}
+
 func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 	cmd := &cobra.Command{Use: "export <resource> [id]"}
 	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
@@ -325,15 +355,15 @@ func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEqui
 	root := &cobra.Command{Use: "root"}
 	root.AddCommand(
 		&cobra.Command{
-			Use: "context",
+			Use:  "context",
 			RunE: func(cmd *cobra.Command, args []string) error { return nil },
 		},
 		&cobra.Command{
-			Use: "auth",
+			Use:  "auth",
 			RunE: func(cmd *cobra.Command, args []string) error { return nil },
 		},
 		&cobra.Command{
-			Use: "search <query>",
+			Use:  "search <query>",
 			RunE: func(cmd *cobra.Command, args []string) error { return nil },
 		},
 		&cobra.Command{

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -308,6 +308,17 @@ func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
 	}
 }
 
+func TestRawArgsWriteSinkValidationUsesStructuredPositionalOffset(t *testing.T) {
+	tokens := SplitShellArgs("evil.txt")
+	sinks := map[int]bool{1: true}
+	if err := validatePositionalArgsForMCPAtOffset(tokens, true, sinks, 1); err == nil {
+		t.Fatal("raw args write sink with structured positional offset succeeded, want error")
+	}
+	if err := validatePositionalArgsForMCPAtOffset(SplitShellArgs("-"), true, sinks, 1); err != nil {
+		t.Fatalf("stdout raw args with structured positional offset returned error: %v", err)
+	}
+}
+
 func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 	cmd := &cobra.Command{Use: "export <resource> [id]"}
 	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))

--- a/internal/generator/templates/cobratree/typemap.go.tmpl
+++ b/internal/generator/templates/cobratree/typemap.go.tmpl
@@ -13,12 +13,22 @@ import (
 )
 
 var positionalPattern = regexp.MustCompile(`(?:^|\s)(?:<[^>]+>|\[[^\]]+\])`)
+var positionalTokenPattern = regexp.MustCompile(`(?:^|\s)(<[^>]+>|\[[^\]]+\])`)
 
-func toolOptionsForFlags(cmd *cobra.Command) []mcplib.ToolOption {
+type positionalArg struct {
+	InputName string
+	Display   string
+	Required  bool
+}
+
+func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg) []mcplib.ToolOption {
 	var opts []mcplib.ToolOption
 	seen := map[string]bool{}
 	addFlag := func(flag *pflag.Flag) {
 		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if reservedStructuredArgs[flag.Name] {
 			return
 		}
 		if seen[flag.Name] {
@@ -27,8 +37,20 @@ func toolOptionsForFlags(cmd *cobra.Command) []mcplib.ToolOption {
 		seen[flag.Name] = true
 		opts = append(opts, toolOptionForFlag(flag))
 	}
-	cmd.InheritedFlags().VisitAll(addFlag)
 	cmd.NonInheritedFlags().VisitAll(addFlag)
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if blocked[flag.Name] {
+			return
+		}
+		addFlag(flag)
+	})
+	for _, positional := range positionals {
+		if seen[positional.InputName] {
+			continue
+		}
+		seen[positional.InputName] = true
+		opts = append(opts, toolOptionForPositional(positional))
+	}
 	return opts
 }
 
@@ -52,6 +74,14 @@ func toolOptionForFlag(flag *pflag.Flag) mcplib.ToolOption {
 	}
 }
 
+func toolOptionForPositional(positional positionalArg) mcplib.ToolOption {
+	propOpts := []mcplib.PropertyOption{mcplib.Description("Positional argument " + positional.Display)}
+	if positional.Required {
+		propOpts = append(propOpts, mcplib.Required())
+	}
+	return mcplib.WithString(positional.InputName, propOpts...)
+}
+
 func flagDescription(flag *pflag.Flag) string {
 	usage := strings.TrimSpace(flag.Usage)
 	if usage == "" {
@@ -73,4 +103,85 @@ func isRequired(flag *pflag.Flag) bool {
 
 func commandTakesArgs(cmd *cobra.Command) bool {
 	return positionalPattern.MatchString(cmd.Use)
+}
+
+func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []positionalArg {
+	if cmd == nil {
+		return nil
+	}
+	flagNames := map[string]bool{}
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag != nil && !blocked[flag.Name] {
+			flagNames[flag.Name] = true
+		}
+	})
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag != nil {
+			flagNames[flag.Name] = true
+		}
+	})
+	var out []positionalArg
+	for _, match := range positionalTokenPattern.FindAllStringSubmatch(cmd.Use, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		raw := strings.TrimSpace(match[1])
+		if strings.Contains(raw, "--") {
+			continue
+		}
+		required := strings.HasPrefix(raw, "<")
+		name := strings.Trim(raw, "<>[]")
+		name = strings.TrimSuffix(name, "...")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		inputName := name
+		if reservedStructuredArgs[inputName] || flagNames[inputName] {
+			inputName = "positional-" + inputName
+		}
+		out = append(out, positionalArg{
+			InputName: inputName,
+			Display:   raw,
+			Required:  required,
+		})
+	}
+	return out
+}
+
+func blockedStructuredArgsForCommand(cmd *cobra.Command) map[string]bool {
+	blocked := map[string]bool{}
+	for name := range reservedStructuredArgs {
+		blocked[name] = true
+	}
+	if cmd == nil {
+		return blocked
+	}
+	localFlags := map[string]bool{}
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		localFlags[flag.Name] = true
+	})
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if blockedRootFlags[flag.Name] && !localFlags[flag.Name] {
+			blocked[flag.Name] = true
+		}
+	})
+	return blocked
+}
+
+func cliFlagBlockedArgs(blocked map[string]bool, positionals []positionalArg) map[string]bool {
+	out := map[string]bool{}
+	for name, value := range blocked {
+		out[name] = value
+	}
+	for _, positional := range positionals {
+		out[positional.InputName] = true
+	}
+	return out
 }

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -30,16 +30,22 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
+		if s.GetTool(toolName) != nil {
+			return
+		}
+		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
+		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
+		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
-		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
+		if commandTakesArgs(cmd) && len(positionals) == 0 {
+			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments to append to the command. Raw flags are rejected; use structured flag parameters instead.")))
 		}
 		readOnly := isMCPReadOnly(cmd)
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/internal/generator/templates/mcp_tools_test.go.tmpl
+++ b/internal/generator/templates/mcp_tools_test.go.tmpl
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/mcp/bound"
 {{- if or .VisionSet.Search .VisionSet.Store}}
@@ -94,6 +95,41 @@ func resetMCPPathEnv(t *testing.T) string {
 	}
 	t.Cleanup(restore)
 	return home
+}
+
+func TestMCPRegisterToolsPreservesTypedSpecialTools(t *testing.T) {
+	s := server.NewMCPServer("{{.Name}}", "test")
+	RegisterTools(s)
+
+	tools := s.ListTools()
+	if len(tools) == 0 {
+		t.Fatal("RegisterTools registered no tools")
+	}
+	contextTool, ok := tools["context"]
+	if !ok {
+		t.Fatalf("typed context tool missing from registered tools: %#v", tools)
+	}
+	if !strings.Contains(contextTool.Tool.Description, "Get API domain context") {
+		t.Fatalf("context tool appears to have been overwritten by command mirror: %q", contextTool.Tool.Description)
+	}
+{{- if .VisionSet.Search}}
+	searchTool, ok := tools["search"]
+	if !ok {
+		t.Fatalf("typed search tool missing from registered tools: %#v", tools)
+	}
+	if !strings.Contains(searchTool.Tool.Description, "Full-text search across all synced data") {
+		t.Fatalf("search tool appears to have been overwritten by command mirror: %q", searchTool.Tool.Description)
+	}
+{{- end}}
+{{- if .VisionSet.Store}}
+	sqlTool, ok := tools["sql"]
+	if !ok {
+		t.Fatalf("typed sql tool missing from registered tools: %#v", tools)
+	}
+	if !strings.Contains(sqlTool.Tool.Description, "Run read-only SQL against local database") {
+		t.Fatalf("sql tool appears to have been overwritten by command mirror: %q", sqlTool.Tool.Description)
+	}
+{{- end}}
 }
 
 {{- if .VisionSet.Search}}

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
@@ -30,16 +30,22 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
+		if s.GetTool(toolName) != nil {
+			return
+		}
+		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
+		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
+		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
-		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
+		if commandTakesArgs(cmd) && len(positionals) == 0 {
+			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments to append to the command. Raw flags are rejected; use structured flag parameters instead.")))
 		}
 		readOnly := isMCPReadOnly(cmd)
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/classify.go
@@ -39,7 +39,7 @@ const (
 // mirroring the Cobra tree. Two cases qualify:
 //
 //  1. A typed MCP tool already covers the same capability (the typed tool's
-//     schema is strictly better than a shell-out). Examples: `sql`, `search`,
+//     schema is strictly better than a shell-out). Examples:
 //     `context`/`about`/`agent-context`, `api` (endpoint mirror tools cover it).
 //  2. The command is non-functional via MCP (interactive setup, shell-only
 //     ergonomics, trivial introspection, local-only feedback). Examples:
@@ -69,8 +69,6 @@ var frameworkCommands = map[string]bool{
 	"feedback":      true,
 	"help":          true,
 	"profile":       true,
-	"search":        true,
-	"sql":           true,
 	"version":       true,
 	"which":         true,
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -17,7 +17,7 @@ import (
 	"printing-press-golden-pp-cli/internal/mcp/bound"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -26,7 +26,12 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		}
 		args := req.GetArguments()
 		finalArgs := append([]string{}, prefixArgs...)
-		finalArgs = append(finalArgs, cliArgsFromMCP(args)...)
+		finalArgs = append(finalArgs, cliArgsFromMCP(args, blockedStructuredArgs)...)
+		positionalArgs, err := positionalArgsFromMCP(args, positionals, readOnly, positionalWriteSinks)
+		if err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
+		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
 			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
@@ -40,6 +45,38 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, readOnl
 		}
 		return mcplib.NewToolResultText(bound.Text(out)), nil
 	}
+}
+
+func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
+	out := make([]string, 0, len(positionals))
+	for _, positional := range positionals {
+		value, ok := args[positional.InputName]
+		if !ok || value == nil {
+			continue
+		}
+		var text string
+		switch tv := value.(type) {
+		case string:
+			text = tv
+		case float64:
+			text = strconv.FormatFloat(tv, 'f', -1, 64)
+		case bool:
+			text = strconv.FormatBool(tv)
+		default:
+			text = fmt.Sprintf("%v", tv)
+		}
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		if text != "-" && strings.HasPrefix(text, "-") {
+			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
+		}
+		out = append(out, text)
+	}
+	if err := validatePositionalArgsForMCP(out, readOnly, positionalWriteSinks); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
@@ -63,6 +100,12 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 	return nil
 }
 
+// reservedStructuredArgs are MCP-only argument names that must never be
+// forwarded as CLI flags.
+var reservedStructuredArgs = map[string]bool{
+	"args": true,
+}
+
 // blockedRootFlags are root-level CLI flags that an MCP client must not be
 // able to override via structured tool parameters. Allowing them lets a
 // caller swap auth credentials, redirect the API base URL, select a different
@@ -70,7 +113,6 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 // malicious config file, or change the delivery target, all of which sit
 // outside the per-command surface the agent is supposed to be calling.
 var blockedRootFlags = map[string]bool{
-	"args":     true,
 	"base-url": true,
 	"client":   true,
 	"config":   true,
@@ -80,13 +122,13 @@ var blockedRootFlags = map[string]bool{
 	"token":    true,
 }
 
-func cliArgsFromMCP(args map[string]any) []string {
+func cliArgsFromMCP(args map[string]any, blocked map[string]bool) []string {
 	keys := make([]string, 0, len(args))
 	for k := range args {
 		if strings.Contains(k, "=") {
 			continue
 		}
-		if blockedRootFlags[k] {
+		if blocked[k] {
 			continue
 		}
 		keys = append(keys, k)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -68,6 +68,9 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
+		if positionalIndex != len(out) {
+			return nil, fmt.Errorf("structured positional %q cannot be used while earlier positional arguments are omitted; provide the preceding positional arguments or use the args field", positional.InputName)
+		}
 		if text != "-" && strings.HasPrefix(text, "-") {
 			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -34,7 +34,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
 			tokens := SplitShellArgs(raw)
-			if err := validatePositionalArgsForMCP(tokens, readOnly, positionalWriteSinks); err != nil {
+			if err := validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
 				return mcplib.NewToolResultError(err.Error()), nil
 			}
 			finalArgs = append(finalArgs, tokens...)
@@ -83,6 +83,10 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {
+	return validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, 0)
+}
+
+func validatePositionalArgsForMCPAtOffset(tokens []string, readOnly bool, positionalWriteSinks map[int]bool, offset int) error {
 	for _, t := range tokens {
 		if t != "-" && strings.HasPrefix(t, "-") {
 			return fmt.Errorf("flag-like argument %q not allowed in positional args field; use structured tool parameters instead", t)
@@ -92,13 +96,14 @@ func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWrit
 		return nil
 	}
 	for i, t := range tokens {
-		if !positionalWriteSinks[i] {
+		positionalIndex := offset + i
+		if !positionalWriteSinks[positionalIndex] {
 			continue
 		}
 		if strings.TrimSpace(t) == "" || t == "-" {
 			continue
 		}
-		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", i+1, t)
+		return fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", positionalIndex+1, t)
 	}
 	return nil
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -49,7 +49,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
 	out := make([]string, 0, len(positionals))
-	for _, positional := range positionals {
+	for positionalIndex, positional := range positionals {
 		value, ok := args[positional.InputName]
 		if !ok || value == nil {
 			continue
@@ -71,9 +71,12 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		if text != "-" && strings.HasPrefix(text, "-") {
 			return nil, fmt.Errorf("flag-like positional argument %q not allowed in structured positional %q; use structured flag parameters instead", text, positional.InputName)
 		}
+		if readOnly && positionalWriteSinks[positionalIndex] && text != "-" {
+			return nil, fmt.Errorf("positional argument %d writes to %q; file output is not available for read-only MCP tools", positionalIndex+1, text)
+		}
 		out = append(out, text)
 	}
-	if err := validatePositionalArgsForMCP(out, readOnly, positionalWriteSinks); err != nil {
+	if err := validatePositionalArgsForMCP(out, readOnly, nil); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -294,17 +294,53 @@ func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
 		t.Fatal("structured write sink with omitted optional positional succeeded, want error")
 	}
 
-	got, err := positionalArgsFromMCP(
+	if _, err := positionalArgsFromMCP(
 		map[string]any{"output-file": "-"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	); err == nil {
+		t.Fatal("stdout structured write sink with omitted optional positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"format": "json", "output-file": "-"},
 		positionals,
 		true,
 		map[int]bool{1: true},
 	)
 	if err != nil {
-		t.Fatalf("stdout structured write sink returned error: %v", err)
+		t.Fatalf("stdout structured write sink with contiguous positionals returned error: %v", err)
 	}
-	if want := []string{"-"}; !reflect.DeepEqual(got, want) {
+	if want := []string{"json", "-"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("structured write sink args = %v, want %v", got, want)
+	}
+}
+
+func TestStructuredPositionalsRejectGapsBeforeLaterArguments(t *testing.T) {
+	cmd := &cobra.Command{Use: "export [format] <output-file>"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+
+	if _, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "report.csv"},
+		positionals,
+		false,
+		nil,
+	); err == nil {
+		t.Fatal("later structured positional with omitted earlier positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"format": "csv", "output-file": "report.csv"},
+		positionals,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("contiguous structured positionals returned error: %v", err)
+	}
+	if want := []string{"csv", "report.csv"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("contiguous structured positionals = %v, want %v", got, want)
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -308,6 +308,17 @@ func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
 	}
 }
 
+func TestRawArgsWriteSinkValidationUsesStructuredPositionalOffset(t *testing.T) {
+	tokens := SplitShellArgs("evil.txt")
+	sinks := map[int]bool{1: true}
+	if err := validatePositionalArgsForMCPAtOffset(tokens, true, sinks, 1); err == nil {
+		t.Fatal("raw args write sink with structured positional offset succeeded, want error")
+	}
+	if err := validatePositionalArgsForMCPAtOffset(SplitShellArgs("-"), true, sinks, 1); err != nil {
+		t.Fatalf("stdout raw args with structured positional offset returned error: %v", err)
+	}
+}
+
 func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 	cmd := &cobra.Command{Use: "export <resource> [id]"}
 	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -278,6 +278,36 @@ func TestPositionalsExposeNamedInputsAndRejectFlagLikeValues(t *testing.T) {
 	}
 }
 
+func TestStructuredPositionalWriteSinkUsesOriginalCLIIndex(t *testing.T) {
+	cmd := &cobra.Command{Use: "export [format] <output-file>"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	if got, want := len(positionals), 2; got != want {
+		t.Fatalf("positionals length = %d, want %d: %#v", got, want, positionals)
+	}
+
+	if _, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "out.json"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	); err == nil {
+		t.Fatal("structured write sink with omitted optional positional succeeded, want error")
+	}
+
+	got, err := positionalArgsFromMCP(
+		map[string]any{"output-file": "-"},
+		positionals,
+		true,
+		map[int]bool{1: true},
+	)
+	if err != nil {
+		t.Fatalf("stdout structured write sink returned error: %v", err)
+	}
+	if want := []string{"-"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("structured write sink args = %v, want %v", got, want)
+	}
+}
+
 func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
 	cmd := &cobra.Command{Use: "export <resource> [id]"}
 	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +74,16 @@ func TestCliArgsFromMCP_BlocksRootFlags(t *testing.T) {
 		// Allowed per-command flag passes through.
 		"limit": float64(10),
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCP(in, map[string]bool{
+		"args":     true,
+		"base-url": true,
+		"client":   true,
+		"config":   true,
+		"deliver":  true,
+		"home":     true,
+		"profile":  true,
+		"token":    true,
+	})
 	want := []string{"--limit", "10"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP dropped/kept wrong keys: got %v, want %v", got, want)
@@ -101,10 +112,43 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 		"limit":   float64(25),
 		"tags":    []any{"a", "b"},
 	}
-	got := cliArgsFromMCP(in)
+	got := cliArgsFromMCP(in, map[string]bool{"args": true})
 	want := []string{"--limit", "25", "--query", "alpha", "--tags", "a,b", "--verbose"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cliArgsFromMCP per-command passthrough: got %v, want %v", got, want)
+	}
+}
+
+func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("profile", "", "root profile")
+	root.PersistentFlags().String("config", "", "root config")
+	root.PersistentFlags().String("json", "", "format output")
+
+	child := &cobra.Command{Use: "child"}
+	child.Flags().String("profile", "", "command profile")
+	root.AddCommand(child)
+
+	blocked := blockedStructuredArgsForCommand(child)
+	if blocked["profile"] {
+		t.Fatalf("command-local --profile was blocked as a root flag: %#v", blocked)
+	}
+	if !blocked["config"] {
+		t.Fatalf("inherited root --config was not blocked: %#v", blocked)
+	}
+	if blocked["json"] {
+		t.Fatalf("non-sensitive inherited --json should remain available: %#v", blocked)
+	}
+
+	got := cliArgsFromMCP(map[string]any{
+		"args":    "ignored",
+		"profile": "local-profile",
+		"config":  "/tmp/evil.yaml",
+		"json":    "true",
+	}, blocked)
+	want := []string{"--json", "true", "--profile", "local-profile"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP command-aware blocklist: got %v, want %v", got, want)
 	}
 }
 
@@ -205,6 +249,126 @@ func TestPositionalWriteSinkIndexesParsesAnnotation(t *testing.T) {
 	}
 	if got[1] {
 		t.Fatalf("positionalWriteSinkIndexes unexpectedly included index 1: %#v", got)
+	}
+}
+
+func TestPositionalsExposeNamedInputsAndRejectFlagLikeValues(t *testing.T) {
+	cmd := &cobra.Command{Use: "export <resource> [id]"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	if got, want := len(positionals), 2; got != want {
+		t.Fatalf("positionals length = %d, want %d: %#v", got, want, positionals)
+	}
+	if positionals[0].InputName != "resource" || !positionals[0].Required {
+		t.Fatalf("first positional = %#v, want required resource", positionals[0])
+	}
+	if positionals[1].InputName != "id" || positionals[1].Required {
+		t.Fatalf("second positional = %#v, want optional id", positionals[1])
+	}
+
+	got, err := positionalArgsFromMCP(map[string]any{"resource": "contacts", "id": "123"}, positionals, false, nil)
+	if err != nil {
+		t.Fatalf("positionalArgsFromMCP returned error: %v", err)
+	}
+	if want := []string{"contacts", "123"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("positionals = %v, want %v", got, want)
+	}
+
+	if _, err := positionalArgsFromMCP(map[string]any{"resource": "--config"}, positionals, false, nil); err == nil {
+		t.Fatal("flag-like structured positional succeeded, want error")
+	}
+}
+
+func TestCLIArgsFromMCPSkipsStructuredPositionals(t *testing.T) {
+	cmd := &cobra.Command{Use: "export <resource> [id]"}
+	positionals := positionalArgsForCommand(cmd, blockedStructuredArgsForCommand(cmd))
+	blocked := cliFlagBlockedArgs(map[string]bool{"args": true}, positionals)
+	got := cliArgsFromMCP(map[string]any{
+		"resource": "contacts",
+		"id":       "123",
+		"format":   "json",
+	}, blocked)
+	want := []string{"--format", "json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cliArgsFromMCP forwarded positionals as flags: got %v, want %v", got, want)
+	}
+}
+
+func TestToolOptionsHideBlockedRootFlagsButKeepLocalCollisions(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("config", "", "root config")
+	root.PersistentFlags().Bool("json", false, "json output")
+
+	child := &cobra.Command{Use: "child <query>"}
+	child.Flags().String("config", "", "local config")
+	child.Flags().String("args", "", "reserved local args")
+	root.AddCommand(child)
+
+	blocked := blockedStructuredArgsForCommand(child)
+	positionals := positionalArgsForCommand(child, blocked)
+	tool := mcplib.NewTool("child", toolOptionsForFlags(child, blocked, positionals)...)
+	props := tool.InputSchema.Properties
+	if _, ok := props["json"]; !ok {
+		t.Fatalf("non-sensitive inherited --json missing from schema: %#v", props)
+	}
+	if _, ok := props["config"]; !ok {
+		t.Fatalf("command-local --config collision missing from schema: %#v", props)
+	}
+	if _, ok := props["query"]; !ok {
+		t.Fatalf("positional <query> missing from schema: %#v", props)
+	}
+	if _, ok := props["args"]; ok {
+		t.Fatalf("reserved args parameter should not be exposed as a flag schema: %#v", props)
+	}
+}
+
+func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEquivalent(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.AddCommand(
+		&cobra.Command{
+			Use:  "context",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use:  "auth",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use:  "search <query>",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		},
+		&cobra.Command{
+			Use:         "secret",
+			Annotations: map[string]string{"mcp:hidden": "true"},
+			RunE:        func(cmd *cobra.Command, args []string) error { return nil },
+		},
+	)
+
+	s := server.NewMCPServer("test", "0.0.0")
+	s.AddTool(mcplib.NewTool("context", mcplib.WithDescription("typed context")), func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		return mcplib.NewToolResultText("typed"), nil
+	})
+	RegisterAll(s, root, func() (string, error) { return "missing-binary", nil })
+
+	tools := s.ListTools()
+	if tools["context"].Tool.Description != "typed context" {
+		t.Fatalf("typed context tool was overwritten: %#v", tools["context"].Tool)
+	}
+	if _, ok := tools["search"]; !ok {
+		t.Fatalf("hand-built search without typed search equivalent was not mirrored: %#v", tools)
+	}
+	for _, excluded := range []string{"auth", "secret"} {
+		if _, ok := tools[excluded]; ok {
+			t.Fatalf("excluded command %q was mirrored: %#v", excluded, tools)
+		}
+	}
+
+	sWithTypedSearch := server.NewMCPServer("test", "0.0.0")
+	sWithTypedSearch.AddTool(mcplib.NewTool("search", mcplib.WithDescription("typed search")), func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		return mcplib.NewToolResultText("typed"), nil
+	})
+	RegisterAll(sWithTypedSearch, root, func() (string, error) { return "missing-binary", nil })
+	if got := sWithTypedSearch.ListTools()["search"].Tool.Description; got != "typed search" {
+		t.Fatalf("typed search tool was overwritten: %q", got)
 	}
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
@@ -13,12 +13,22 @@ import (
 )
 
 var positionalPattern = regexp.MustCompile(`(?:^|\s)(?:<[^>]+>|\[[^\]]+\])`)
+var positionalTokenPattern = regexp.MustCompile(`(?:^|\s)(<[^>]+>|\[[^\]]+\])`)
 
-func toolOptionsForFlags(cmd *cobra.Command) []mcplib.ToolOption {
+type positionalArg struct {
+	InputName string
+	Display   string
+	Required  bool
+}
+
+func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg) []mcplib.ToolOption {
 	var opts []mcplib.ToolOption
 	seen := map[string]bool{}
 	addFlag := func(flag *pflag.Flag) {
 		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if reservedStructuredArgs[flag.Name] {
 			return
 		}
 		if seen[flag.Name] {
@@ -27,8 +37,20 @@ func toolOptionsForFlags(cmd *cobra.Command) []mcplib.ToolOption {
 		seen[flag.Name] = true
 		opts = append(opts, toolOptionForFlag(flag))
 	}
-	cmd.InheritedFlags().VisitAll(addFlag)
 	cmd.NonInheritedFlags().VisitAll(addFlag)
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if blocked[flag.Name] {
+			return
+		}
+		addFlag(flag)
+	})
+	for _, positional := range positionals {
+		if seen[positional.InputName] {
+			continue
+		}
+		seen[positional.InputName] = true
+		opts = append(opts, toolOptionForPositional(positional))
+	}
 	return opts
 }
 
@@ -52,6 +74,14 @@ func toolOptionForFlag(flag *pflag.Flag) mcplib.ToolOption {
 	}
 }
 
+func toolOptionForPositional(positional positionalArg) mcplib.ToolOption {
+	propOpts := []mcplib.PropertyOption{mcplib.Description("Positional argument " + positional.Display)}
+	if positional.Required {
+		propOpts = append(propOpts, mcplib.Required())
+	}
+	return mcplib.WithString(positional.InputName, propOpts...)
+}
+
 func flagDescription(flag *pflag.Flag) string {
 	usage := strings.TrimSpace(flag.Usage)
 	if usage == "" {
@@ -73,4 +103,85 @@ func isRequired(flag *pflag.Flag) bool {
 
 func commandTakesArgs(cmd *cobra.Command) bool {
 	return positionalPattern.MatchString(cmd.Use)
+}
+
+func positionalArgsForCommand(cmd *cobra.Command, blocked map[string]bool) []positionalArg {
+	if cmd == nil {
+		return nil
+	}
+	flagNames := map[string]bool{}
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag != nil && !blocked[flag.Name] {
+			flagNames[flag.Name] = true
+		}
+	})
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag != nil {
+			flagNames[flag.Name] = true
+		}
+	})
+	var out []positionalArg
+	for _, match := range positionalTokenPattern.FindAllStringSubmatch(cmd.Use, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		raw := strings.TrimSpace(match[1])
+		if strings.Contains(raw, "--") {
+			continue
+		}
+		required := strings.HasPrefix(raw, "<")
+		name := strings.Trim(raw, "<>[]")
+		name = strings.TrimSuffix(name, "...")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		inputName := name
+		if reservedStructuredArgs[inputName] || flagNames[inputName] {
+			inputName = "positional-" + inputName
+		}
+		out = append(out, positionalArg{
+			InputName: inputName,
+			Display:   raw,
+			Required:  required,
+		})
+	}
+	return out
+}
+
+func blockedStructuredArgsForCommand(cmd *cobra.Command) map[string]bool {
+	blocked := map[string]bool{}
+	for name := range reservedStructuredArgs {
+		blocked[name] = true
+	}
+	if cmd == nil {
+		return blocked
+	}
+	localFlags := map[string]bool{}
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		localFlags[flag.Name] = true
+	})
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if blockedRootFlags[flag.Name] && !localFlags[flag.Name] {
+			blocked[flag.Name] = true
+		}
+	})
+	return blocked
+}
+
+func cliFlagBlockedArgs(blocked map[string]bool, positionals []positionalArg) map[string]bool {
+	out := map[string]bool{}
+	for name, value := range blocked {
+		out[name] = value
+	}
+	for _, positional := range positionals {
+		out[positional.InputName] = true
+	}
+	return out
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -30,16 +30,22 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if toolName == "" {
 			return
 		}
+		if s.GetTool(toolName) != nil {
+			return
+		}
+		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
+		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
+		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
-		options = append(options, toolOptionsForFlags(cmd)...)
-		if commandTakesArgs(cmd) {
-			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments or raw CLI flags to append to the command.")))
+		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
+		if commandTakesArgs(cmd) && len(positionals) == 0 {
+			options = append(options, mcplib.WithString("args", mcplib.Description("Additional positional arguments to append to the command. Raw flags are rejected; use structured flag parameters instead.")))
 		}
 		readOnly := isMCPReadOnly(cmd)
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 


### PR DESCRIPTION
## Summary

Cobratree MCP mirroring now keeps the generated typed tool surface intact while making command mirrors more discoverable and safer:

- block only inherited sensitive root flags, preserving command-local flags that reuse names like `profile` or `config`
- preserve typed `context` / `search` / `sql` tools and mirror hand-built `search` / `sql` commands only when no typed equivalent already owns the tool name
- expose named Cobra positionals as structured MCP inputs, hide the fallback raw `args` field when structured positionals exist, and reject flag-like positional values at runtime
- add generated-output regression coverage for duplicate/special tool preservation, framework/hidden exclusions, root/local flag collisions, and positional schemas

Fixes #3097
Fixes #2506
Fixes #2986
Fixes #2517

## Validation

- `go test ./internal/generator -run 'TestMCPRegistersCobraTreeMirror|TestMCPNovelFeatureToolNameSanitization|TestMCPFrameworkCommandClassificationIsTopLevelOnly|TestGenerateMCPSQLToolUsesReadOnlyStore|TestGenerateMCPSQLToolExampleUsesFirstResourceType'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `go fmt ./...`
- `git diff --check`
- `git diff --cached --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required for this generator/template-only MCP surface change. CI should continue to watch generated-output compilation, golden drift, and downstream printed CLI MCP tool registration behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
