### PR TITLE
fix(cli): improve phase five and skill validation feedback

### DIFF
--- a/internal/cli/verify_skill_bundled.py
+++ b/internal/cli/verify_skill_bundled.py
@@ -813,6 +813,48 @@ def _split_before_shell_operator(line: str) -> str:
     return line
 
 
+def _strip_trailing_shell_comment(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if escaped:
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                escaped = True
+                i += 1
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
+            return line[:i].rstrip()
+        i += 1
+    return line
+
+
 def _shell_operator_cut_index(line: str, operator_index: int) -> int:
     # Redirections may be prefixed by a file descriptor, e.g. `2>err`.
     if line[operator_index] in "><":
@@ -915,10 +957,7 @@ def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None =
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            # Strip trailing comment
-            cmt = line.find(" #")
-            if cmt != -1:
-                line = line[:cmt].strip()
+            line = _strip_trailing_shell_comment(line)
             if not line.startswith(cli_binary + " "):
                 continue
             # Strip shell command substitutions $(...) and backtick forms

--- a/internal/cli/verify_skill_test.go
+++ b/internal/cli/verify_skill_test.go
@@ -282,6 +282,39 @@ func Execute() error {
 	require.Contains(t, string(out), "All checks passed")
 }
 
+func TestVerifySkill_QuotedHashIsNotTreatedAsComment(t *testing.T) {
+	t.Parallel()
+
+	bin := buildPrintingPressBinary(t)
+	dir := t.TempDir()
+
+	skill := "---\nname: pp-fixture\n---\n\n# Fixture\n\n```bash\n" +
+		"fixture-pp-cli compare \"topic #tag\" expected\n" +
+		"fixture-pp-cli compare 'topic #tag' expected\n" +
+		"fixture-pp-cli compare literal expected # trailing comment\n" +
+		"```\n"
+	writeVerifySkillFixture(t, dir, map[string]string{
+		"compare.go": `package cli
+import "github.com/spf13/cobra"
+func newCompareCmd() *cobra.Command {
+	return &cobra.Command{Use: "compare <left> <right>"}
+}
+`,
+		"root.go": `package cli
+import "github.com/spf13/cobra"
+func Execute() error {
+	rootCmd := &cobra.Command{Use: "fixture-pp-cli"}
+	rootCmd.AddCommand(newCompareCmd())
+	return rootCmd.Execute()
+}
+`,
+	}, skill)
+
+	out, err := exec.Command(bin, "verify-skill", "--dir", dir, "--only", "positional-args").CombinedOutput()
+	require.NoError(t, err, "quoted # arguments must remain positional while unquoted trailing comments are stripped: %s", string(out))
+	require.Contains(t, string(out), "All checks passed")
+}
+
 func TestVerifySkill_PositionalArgsStillFailWithoutShellOperator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -117,10 +117,10 @@ func validatePhase5MarkerFile(path string, manifest CLIManifest, skipFile bool) 
 func validatePhase5Marker(marker Phase5GateMarker, manifest CLIManifest, skipFile bool) Phase5GateValidation {
 	status := strings.ToLower(strings.TrimSpace(marker.Status))
 	result := Phase5GateValidation{Status: status}
+	var issues []string
 
 	if marker.SchemaVersion != 1 {
-		result.Detail = fmt.Sprintf("unsupported phase5 marker schema_version %d", marker.SchemaVersion)
-		return result
+		issues = append(issues, fmt.Sprintf("unsupported phase5 marker schema_version %d", marker.SchemaVersion))
 	}
 	// Stale-marker protection: when the manifest carries identity, the
 	// marker must carry the same identity. An empty marker.APIName/RunID is
@@ -130,33 +130,27 @@ func validatePhase5Marker(marker Phase5GateMarker, manifest CLIManifest, skipFil
 	// rotation.
 	if manifest.APIName != "" {
 		if marker.APIName == "" {
-			result.Detail = "phase5 marker missing api_name (manifest identifies the CLI)"
-			return result
-		}
-		if marker.APIName != manifest.APIName {
-			result.Detail = fmt.Sprintf("phase5 marker api_name %q does not match manifest api_name %q", marker.APIName, manifest.APIName)
-			return result
+			issues = append(issues, "phase5 marker missing api_name (manifest identifies the CLI)")
+		} else if marker.APIName != manifest.APIName {
+			issues = append(issues, fmt.Sprintf("phase5 marker api_name %q does not match manifest api_name %q", marker.APIName, manifest.APIName))
 		}
 	}
 	if manifest.RunID != "" {
 		if marker.RunID == "" {
-			result.Detail = "phase5 marker missing run_id (manifest identifies the run)"
-			return result
-		}
-		if marker.RunID != manifest.RunID {
-			result.Detail = fmt.Sprintf("phase5 marker run_id %q does not match manifest run_id %q", marker.RunID, manifest.RunID)
-			return result
+			issues = append(issues, "phase5 marker missing run_id (manifest identifies the run)")
+		} else if marker.RunID != manifest.RunID {
+			issues = append(issues, fmt.Sprintf("phase5 marker run_id %q does not match manifest run_id %q", marker.RunID, manifest.RunID))
 		}
 	}
 
 	switch status {
 	case "pass":
 		if skipFile {
-			result.Detail = fmt.Sprintf("%s must use status skip, got pass", Phase5SkipFilename)
-			return result
+			issues = append(issues, fmt.Sprintf("%s must use status skip, got pass", Phase5SkipFilename))
 		}
-		if detail := validatePhase5PassMarker(marker); detail != "" {
-			result.Detail = detail
+		issues = append(issues, validatePhase5PassMarkerIssues(marker)...)
+		if len(issues) > 0 {
+			result.Detail = strings.Join(issues, "; ")
 			return result
 		}
 		if ok, detail := phase5AcceptancePassed(marker); !ok {
@@ -166,15 +160,22 @@ func validatePhase5Marker(marker Phase5GateMarker, manifest CLIManifest, skipFil
 		result.Passed = true
 		return result
 	case "fail":
+		if skipFile {
+			issues = append(issues, fmt.Sprintf("%s must use status skip, got fail", Phase5SkipFilename))
+		}
+		if len(issues) > 0 {
+			result.Detail = strings.Join(issues, "; ")
+			return result
+		}
 		result.Detail = "phase5 gate status is fail"
 		return result
 	case "skip":
 		if !skipFile {
-			result.Detail = fmt.Sprintf("%s must use status pass or fail, got skip", Phase5AcceptanceFilename)
-			return result
+			issues = append(issues, fmt.Sprintf("%s must use status pass or fail, got skip", Phase5AcceptanceFilename))
 		}
-		if detail := validatePhase5SkipMarker(marker); detail != "" {
-			result.Detail = detail
+		issues = append(issues, validatePhase5SkipMarkerIssues(marker)...)
+		if len(issues) > 0 {
+			result.Detail = strings.Join(issues, "; ")
 			return result
 		}
 		if ok, detail := phase5SkipAllowed(marker, manifest); !ok {
@@ -184,27 +185,41 @@ func validatePhase5Marker(marker Phase5GateMarker, manifest CLIManifest, skipFil
 		result.Passed = true
 		return result
 	default:
-		result.Detail = fmt.Sprintf("unknown phase5 gate status %q", marker.Status)
+		issues = append(issues, phase5UnknownStatusDetail(marker.Status, skipFile))
+		if skipFile {
+			issues = append(issues, validatePhase5SkipMarkerIssues(marker)...)
+		} else {
+			issues = append(issues, validatePhase5PassMarkerIssues(marker)...)
+		}
+		result.Detail = strings.Join(issues, "; ")
 		return result
 	}
 }
 
 func validatePhase5PassMarker(marker Phase5GateMarker) string {
+	return strings.Join(validatePhase5PassMarkerIssues(marker), "; ")
+}
+
+func validatePhase5PassMarkerIssues(marker Phase5GateMarker) []string {
 	// api_name and run_id are identity tags: the cross-check in
 	// validatePhase5Marker enforces consistency when both marker and
 	// manifest carry them, so requiring them here would reject markers
 	// written before the manifest exists (e.g., dogfood --write-acceptance
 	// run prior to `lock promote`).
+	var issues []string
 	switch {
 	case phase5Level(marker) == "":
-		return "phase5 acceptance marker missing level"
-	case marker.MatrixSize <= 0:
-		return "phase5 acceptance marker missing matrix_size"
-	case marker.TestsPassed <= 0:
-		return "phase5 acceptance marker missing tests_passed"
-	default:
-		return ""
+		issues = append(issues, "phase5 acceptance marker missing level")
+	case !phase5AcceptedAcceptanceLevel(phase5Level(marker)):
+		issues = append(issues, unknownPhase5AcceptanceLevelDetail(marker.Level))
 	}
+	if marker.MatrixSize <= 0 {
+		issues = append(issues, "phase5 acceptance marker missing matrix_size")
+	}
+	if marker.TestsPassed <= 0 {
+		issues = append(issues, "phase5 acceptance marker missing tests_passed")
+	}
+	return issues
 }
 
 func phase5AcceptancePassed(marker Phase5GateMarker) (bool, string) {
@@ -243,7 +258,7 @@ func phase5AcceptancePassed(marker Phase5GateMarker) (bool, string) {
 		}
 		return true, ""
 	default:
-		return false, fmt.Sprintf("unknown phase5 acceptance level %q (accepted: %s; prefer `cli-printing-press dogfood --live --write-acceptance` to generate %s)", marker.Level, strings.Join(phase5AcceptedAcceptanceLevels, ", "), Phase5AcceptanceFilename)
+		return false, unknownPhase5AcceptanceLevelDetail(marker.Level)
 	}
 }
 
@@ -251,17 +266,43 @@ func phase5Level(marker Phase5GateMarker) string {
 	return strings.ToLower(strings.TrimSpace(marker.Level))
 }
 
-func validatePhase5SkipMarker(marker Phase5GateMarker) string {
-	switch {
-	case strings.TrimSpace(marker.APIName) == "":
-		return "phase5 skip marker missing api_name"
-	case strings.TrimSpace(marker.RunID) == "":
-		return "phase5 skip marker missing run_id"
-	case strings.TrimSpace(marker.SkipReason) == "":
-		return "phase5 skip marker missing skip_reason"
-	default:
-		return ""
+func phase5AcceptedAcceptanceLevel(level string) bool {
+	for _, accepted := range phase5AcceptedAcceptanceLevels {
+		if level == accepted {
+			return true
+		}
 	}
+	return false
+}
+
+func phase5UnknownStatusDetail(status string, skipFile bool) string {
+	accepted := []string{"pass", "fail"}
+	if skipFile {
+		accepted = []string{"skip"}
+	}
+	return fmt.Sprintf("unknown phase5 gate status %q (accepted: %s)", status, strings.Join(accepted, ", "))
+}
+
+func unknownPhase5AcceptanceLevelDetail(level string) string {
+	return fmt.Sprintf("unknown phase5 acceptance level %q (accepted: %s; prefer `cli-printing-press dogfood --live --write-acceptance` to generate %s)", level, strings.Join(phase5AcceptedAcceptanceLevels, ", "), Phase5AcceptanceFilename)
+}
+
+func validatePhase5SkipMarker(marker Phase5GateMarker) string {
+	return strings.Join(validatePhase5SkipMarkerIssues(marker), "; ")
+}
+
+func validatePhase5SkipMarkerIssues(marker Phase5GateMarker) []string {
+	var issues []string
+	if strings.TrimSpace(marker.APIName) == "" {
+		issues = append(issues, "phase5 skip marker missing api_name")
+	}
+	if strings.TrimSpace(marker.RunID) == "" {
+		issues = append(issues, "phase5 skip marker missing run_id")
+	}
+	if strings.TrimSpace(marker.SkipReason) == "" {
+		issues = append(issues, "phase5 skip marker missing skip_reason")
+	}
+	return issues
 }
 
 func phase5SkipAllowed(marker Phase5GateMarker, manifest CLIManifest) (bool, string) {

--- a/internal/pipeline/phase5_gate.go
+++ b/internal/pipeline/phase5_gate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -196,10 +197,6 @@ func validatePhase5Marker(marker Phase5GateMarker, manifest CLIManifest, skipFil
 	}
 }
 
-func validatePhase5PassMarker(marker Phase5GateMarker) string {
-	return strings.Join(validatePhase5PassMarkerIssues(marker), "; ")
-}
-
 func validatePhase5PassMarkerIssues(marker Phase5GateMarker) []string {
 	// api_name and run_id are identity tags: the cross-check in
 	// validatePhase5Marker enforces consistency when both marker and
@@ -267,12 +264,7 @@ func phase5Level(marker Phase5GateMarker) string {
 }
 
 func phase5AcceptedAcceptanceLevel(level string) bool {
-	for _, accepted := range phase5AcceptedAcceptanceLevels {
-		if level == accepted {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(phase5AcceptedAcceptanceLevels, level)
 }
 
 func phase5UnknownStatusDetail(status string, skipFile bool) string {
@@ -285,10 +277,6 @@ func phase5UnknownStatusDetail(status string, skipFile bool) string {
 
 func unknownPhase5AcceptanceLevelDetail(level string) string {
 	return fmt.Sprintf("unknown phase5 acceptance level %q (accepted: %s; prefer `cli-printing-press dogfood --live --write-acceptance` to generate %s)", level, strings.Join(phase5AcceptedAcceptanceLevels, ", "), Phase5AcceptanceFilename)
-}
-
-func validatePhase5SkipMarker(marker Phase5GateMarker) string {
-	return strings.Join(validatePhase5SkipMarkerIssues(marker), "; ")
 }
 
 func validatePhase5SkipMarkerIssues(marker Phase5GateMarker) []string {

--- a/internal/pipeline/phase5_gate_test.go
+++ b/internal/pipeline/phase5_gate_test.go
@@ -305,6 +305,29 @@ func TestValidatePhase5Gate_ManualLevelDocumentsAcceptedValues(t *testing.T) {
 	assert.Contains(t, result.Detail, "dogfood --live --write-acceptance")
 }
 
+func TestValidatePhase5Gate_ReportsMultipleAcceptanceMarkerIssues(t *testing.T) {
+	proofsDir := t.TempDir()
+	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none"}
+	writePhase5GateMarker(t, proofsDir, Phase5AcceptanceFilename, Phase5GateMarker{
+		SchemaVersion: 2,
+		Status:        "maybe",
+		Level:         "smoke",
+		AuthContext:   Phase5AuthContext{Type: "none"},
+	})
+
+	result := ValidatePhase5Gate(proofsDir, manifest)
+	require.False(t, result.Passed)
+	assert.Contains(t, result.Detail, "unsupported phase5 marker schema_version 2")
+	assert.Contains(t, result.Detail, "phase5 marker missing api_name")
+	assert.Contains(t, result.Detail, "phase5 marker missing run_id")
+	assert.Contains(t, result.Detail, `unknown phase5 gate status "maybe"`)
+	assert.Contains(t, result.Detail, "accepted: pass, fail")
+	assert.Contains(t, result.Detail, `unknown phase5 acceptance level "smoke"`)
+	assert.Contains(t, result.Detail, "accepted: quick, full")
+	assert.Contains(t, result.Detail, "missing matrix_size")
+	assert.Contains(t, result.Detail, "missing tests_passed")
+}
+
 func TestValidatePhase5Gate_UnknownLevelDocumentsAcceptedValues(t *testing.T) {
 	proofsDir := t.TempDir()
 	manifest := CLIManifest{APIName: "test", CLIName: "test-pp-cli", RunID: "run-1", AuthType: "none"}

--- a/scripts/verify-skill/verify_skill.py
+++ b/scripts/verify-skill/verify_skill.py
@@ -813,6 +813,48 @@ def _split_before_shell_operator(line: str) -> str:
     return line
 
 
+def _strip_trailing_shell_comment(line: str) -> str:
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if escaped:
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                escaped = True
+                i += 1
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if escaped:
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\":
+            escaped = True
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
+            return line[:i].rstrip()
+        i += 1
+    return line
+
+
 def _shell_operator_cut_index(line: str, operator_index: int) -> int:
     # Redirections may be prefixed by a file descriptor, e.g. `2>err`.
     if line[operator_index] in "><":
@@ -915,10 +957,7 @@ def extract_cli_invocations(skill: Path, cli_binary: str, cli_dir: Path | None =
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            # Strip trailing comment
-            cmt = line.find(" #")
-            if cmt != -1:
-                line = line[:cmt].strip()
+            line = _strip_trailing_shell_comment(line)
             if not line.startswith(cli_binary + " "):
                 continue
             # Strip shell command substitutions $(...) and backtick forms


### PR DESCRIPTION
## Summary

Phase 5 acceptance validation now reports the full set of obvious marker problems in one pass, including accepted values for status and acceptance-level fields, so repair loops do not have to discover one missing field at a time.

`verify-skill` now strips shell comments with quote awareness, preserving `#` inside single- or double-quoted arguments while still honoring normal unquoted trailing comments.

## Validation

- `python3 -m py_compile scripts/verify-skill/verify_skill.py internal/cli/verify_skill_bundled.py`
- `python3 scripts/verify-skill/test_resolve_command_path.py`
- `go test ./internal/pipeline -run 'TestValidatePhase5Gate_(ReportsMultipleAcceptanceMarkerIssues|ManualLevelDocumentsAcceptedValues|UnknownLevelDocumentsAcceptedValues)'`
- `go test ./internal/cli -run 'TestVerifySkill_(QuotedHashIsNotTreatedAsComment|BundledScriptMatchesSource)'`
- `go test ./internal/pipeline`
- `go test ./internal/cli`
- `go test ./...`

Fixes #3052
Fixes #3002

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
