### PR TITLE
fix(cli): treat nested help as success

### DIFF
--- a/internal/generator/help_exit_test.go
+++ b/internal/generator/help_exit_test.go
@@ -1,0 +1,76 @@
+package generator
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedNestedHelpExitsZeroAndUsageErrorsExitTwo(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("help-exit")
+	apiSpec.Resources["items"] = spec.Resource{
+		Description: "Manage items",
+		Endpoints: map[string]spec.Endpoint{
+			"list": {Method: "GET", Path: "/items", Description: "List items"},
+			"compare": {
+				Method:      "GET",
+				Path:        "/items/{left_id}/compare/{right_id}",
+				Description: "Compare two items",
+				Params: []spec.Param{
+					{Name: "left_id", Type: "string", Required: true, Positional: true, PathParam: true},
+					{Name: "right_id", Type: "string", Required: true, Positional: true, PathParam: true},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "help-exit-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+	requireGeneratedCompiles(t, outputDir)
+
+	binPath := filepath.Join(outputDir, "help-exit-pp-cli")
+	runGoCommandRequired(t, outputDir, "build", "-o", "./help-exit-pp-cli", "./cmd/help-exit-pp-cli")
+
+	assertExitCode(t, 0, binPath, "items", "list", "--help")
+	assertExitCode(t, 0, binPath, "auth", "status", "--help")
+	assertExitCode(t, 2, binPath, "--bogus-flag")
+	assertExitCode(t, 2, binPath, "items", "compare", "left-only", "--json")
+}
+
+func TestGeneratedRootTreatsPflagHelpSentinelAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("help-sentinel")
+	outputDir := filepath.Join(t.TempDir(), "help-sentinel-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	require.Contains(t, rootSrc, `"errors"`)
+	require.Contains(t, rootSrc, `"github.com/spf13/pflag"`)
+	require.Contains(t, rootSrc, "errors.Is(err, pflag.ErrHelp)")
+	require.Less(t,
+		strings.Index(rootSrc, "errors.Is(err, pflag.ErrHelp)"),
+		strings.Index(rootSrc, "isCobraUsageError(err)"),
+		"help sentinel must be handled before Cobra usage errors are wrapped as exit code 2",
+	)
+}
+
+func assertExitCode(t *testing.T, want int, binaryPath string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, args...)
+	output, err := cmd.CombinedOutput()
+	if want == 0 {
+		require.NoError(t, err, "args %v output:\n%s", args, string(output))
+		return
+	}
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "args %v output:\n%s", args, string(output))
+	require.Equal(t, want, exitErr.ExitCode(), "args %v output:\n%s", args, string(output))
+}

--- a/internal/generator/help_exit_test.go
+++ b/internal/generator/help_exit_test.go
@@ -51,9 +51,11 @@ func TestGeneratedRootTreatsPflagHelpSentinelAsSuccess(t *testing.T) {
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
 	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	goMod := readGeneratedFile(t, outputDir, "go.mod")
 	require.Contains(t, rootSrc, `"errors"`)
 	require.Contains(t, rootSrc, `"github.com/spf13/pflag"`)
 	require.Contains(t, rootSrc, "errors.Is(err, pflag.ErrHelp)")
+	require.Contains(t, goMod, "github.com/spf13/pflag v1.0.6")
 	require.Less(t,
 		strings.Index(rootSrc, "errors.Is(err, pflag.ErrHelp)"),
 		strings.Index(rootSrc, "isCobraUsageError(err)"),

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -155,21 +155,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 				return err
 			}
 {{- end}}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-{{- if .EffectiveTier}}
-			c = c.WithTier({{printf "%q" .EffectiveTier}})
-{{- end}}
-
 			path := "{{.EffectivePath}}"
-{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
-			if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
-				return err
-			}
-			path = strings.ReplaceAll(path, "{publication_id}", c.Config.TemplateVars["publication_id"])
-{{- end}}
 {{- range .Endpoint.Params}}
 {{- if .Positional}}
 {{- $pi := positionalIndex $.Endpoint .Name}}
@@ -182,6 +168,19 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			path = replacePathParam(path, "{{.Name}}", args[{{$pi}}])
 {{- end}}
 {{- end}}
+{{- end}}
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
+{{- if .EffectiveTier}}
+			c = c.WithTier({{printf "%q" .EffectiveTier}})
+{{- end}}
+{{- if substackPublicationIDTemplatePath .APISpec .EffectivePath}}
+			if err := resolveSubstackPublicationIDTemplate(cmd.Context(), c, flags); err != nil {
+				return err
+			}
+			path = strings.ReplaceAll(path, "{publication_id}", c.Config.TemplateVars["publication_id"])
 {{- end}}
 {{- range .Endpoint.Params}}
 {{- if and .PathParam (not .Positional)}}

--- a/internal/generator/templates/go.mod.tmpl
+++ b/internal/generator/templates/go.mod.tmpl
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 {{- end}}
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 {{- if .HasHTMLExtraction}}
 	golang.org/x/net v0.55.0
 {{- end}}

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type rootFlags struct {
@@ -83,6 +85,9 @@ func Execute() error {
 	rootCmd := newRootCmd(&flags)
 
 	err := rootCmd.Execute()
+	if errors.Is(err, pflag.ErrHelp) {
+		return nil
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")
@@ -536,4 +541,3 @@ func (f *rootFlags) printTable(w *cobra.Command, headers []string, rows [][]stri
 	}
 	return tw.Flush()
 }
-

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -24,16 +24,15 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/customers/{id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
 			}
 			path = replacePathParam(path, "id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -24,16 +24,15 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/pages/{id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
 			}
 			path = replacePathParam(path, "id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -24,16 +24,15 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/playlists/{id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("id is required\nUsage: %s <%s>", cmd.CommandPath(), "id"))
 			}
 			path = replacePathParam(path, "id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_create.go
@@ -23,12 +23,11 @@ func newQuotesCreateCmd(flags *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !stdinBody {
 			}
+			path := "/api/quotes/generate"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/api/quotes/generate"
 			params := map[string]string{}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_delete.go
@@ -22,16 +22,15 @@ func newQuotesDeleteCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
 			}
 			path = replacePathParam(path, "quote_id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			data, statusCode, err := c.DeleteWithParams(cmd.Context(), path, params)
 			if err != nil {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -22,16 +22,15 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
 			}
 			path = replacePathParam(path, "quote_id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -19,12 +19,11 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  fastapi-operationids-golden-pp-cli quotes list",
 		Annotations: map[string]string{"pp:endpoint": "quotes.list", "pp:method": "GET", "pp:path": "/api/quotes", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/api/quotes"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/api/quotes"
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update-status.go
@@ -26,16 +26,15 @@ func newQuotesUpdateStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 			if !stdinBody {
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
 			}
 			path = replacePathParam(path, "quote_id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_update.go
@@ -26,16 +26,15 @@ func newQuotesUpdateCmd(flags *rootFlags) *cobra.Command {
 			}
 			if !stdinBody {
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/api/quotes/{quote_id}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("quote_id is required\nUsage: %s <%s>", cmd.CommandPath(), "quote_id"))
 			}
 			path = replacePathParam(path, "quote_id", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"fastapi-operationids-golden-pp-cli/internal/cliutil"
 	"fastapi-operationids-golden-pp-cli/internal/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type rootFlags struct {
@@ -66,6 +68,9 @@ func Execute() error {
 	rootCmd := newRootCmd(&flags)
 
 	err := rootCmd.Execute()
+	if errors.Is(err, pflag.ErrHelp) {
+		return nil
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")

--- a/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
+++ b/testdata/golden/expected/generate-golden-api-cookie-auth/golden-api-cookie-auth/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.4
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 )
 require modernc.org/sqlite v1.37.0
 require github.com/mark3labs/mcp-go v0.47.0

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	github.com/pelletier/go-toml/v2 v2.2.4
 )
 require modernc.org/sqlite v1.37.0

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar_upload-project.go
@@ -26,16 +26,15 @@ func newProjectsAvatarUploadProjectCmd(flags *rootFlags) *cobra.Command {
 			if len(args) == 0 {
 				return cmd.Help()
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/projects/{projectId}/avatar"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
 			}
 			path = replacePathParam(path, "projectId", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			if flagOverwrite != false {
 				params["overwrite"] = formatCLIParamValue(flagOverwrite)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_create.go
@@ -38,12 +38,11 @@ func newProjectsCreateCmd(flags *rootFlags) *cobra.Command {
 					return fmt.Errorf("required flag \"%s\" not set", "visibility")
 				}
 			}
+			path := "/projects"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/projects"
 			params := map[string]string{}
 			var body map[string]any
 			if stdinBody {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_list.go
@@ -36,12 +36,11 @@ func newProjectsListCmd(flags *rootFlags) *cobra.Command {
 					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flagStatus, "status", allowedStatus)
 				}
 			}
+			path := "/projects"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/projects"
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "projects", path, map[string]string{
 				"status": formatCLIParamValue(flagStatus),
 				"limit":  formatCLIParamValue(flagLimit),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_list-project.go
@@ -40,16 +40,15 @@ func newProjectsTasksListProjectCmd(flags *rootFlags) *cobra.Command {
 					return fmt.Errorf("invalid value %q for --%s: must be one of %v", flagPriority, "priority", allowedPriority)
 				}
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/projects/{projectId}/tasks"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
 			}
 			path = replacePathParam(path, "projectId", args[0])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "tasks", path, map[string]string{
 				"priority": formatCLIParamValue(flagPriority),
 				"limit":    formatCLIParamValue(flagLimit),

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_tasks_update-project.go
@@ -31,11 +31,6 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 			}
 			if !stdinBody {
 			}
-			c, err := flags.newClient()
-			if err != nil {
-				return err
-			}
-
 			path := "/projects/{projectId}/tasks/{taskId}"
 			if len(args) < 1 || args[0] == "" {
 				return usageErr(fmt.Errorf("projectId is required\nUsage: %s <%s>", cmd.CommandPath(), "projectId"))
@@ -45,6 +40,10 @@ func newProjectsTasksUpdateProjectCmd(flags *rootFlags) *cobra.Command {
 				return usageErr(fmt.Errorf("taskId is required\nUsage: %s <%s>", cmd.CommandPath(), "taskId"))
 			}
 			path = replacePathParam(path, "taskId", args[1])
+			c, err := flags.newClient()
+			if err != nil {
+				return err
+			}
 			params := map[string]string{}
 			if flagNotify != false {
 				params["notify"] = formatCLIParamValue(flagNotify)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -30,12 +30,11 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 			if !cmd.Flags().Changed("year") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "year")
 			}
+			path := "/reports/{year}/export"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/reports/{year}/export"
 			path = replacePathParam(path, "year", formatCLIParamValue(flagYear))
 			headerOverrides := map[string]string{
 				"Accept":                           "application/octet-stream",

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"printing-press-golden-pp-cli/internal/client"
 	"printing-press-golden-pp-cli/internal/cliutil"
 	"printing-press-golden-pp-cli/internal/config"
@@ -65,6 +67,9 @@ func Execute() error {
 	rootCmd := newRootCmd(&flags)
 
 	err := rootCmd.Execute()
+	if errors.Is(err, pflag.ErrHelp) {
+		return nil
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")

--- a/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
+++ b/testdata/golden/expected/generate-graphql-shared-endpoint/graphql-shared-golden/internal/cli/things_list.go
@@ -23,12 +23,11 @@ func newThingsListCmd(flags *rootFlags) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !stdinBody {
 			}
+			path := "/graphql"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/graphql"
 			_ = path
 			params := map[string]string{}
 			var body map[string]any

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"learn-loop-example-pp-cli/internal/client"
 	"learn-loop-example-pp-cli/internal/cliutil"
 	"learn-loop-example-pp-cli/internal/config"
@@ -63,6 +65,9 @@ func Execute() error {
 	rootCmd := newRootCmd(&flags)
 
 	err := rootCmd.Execute()
+	if errors.Is(err, pflag.ErrHelp) {
+		return nil
+	}
 	if err != nil && strings.Contains(err.Error(), "unknown flag") {
 		msg := err.Error()
 		// Extract the flag name from the error message (e.g., "unknown flag: --foob")

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_create.go
@@ -35,12 +35,11 @@ func newStoresCreateCmd(flags *rootFlags) *cobra.Command {
 					return fmt.Errorf("required flag \"%s\" not set", "store-code")
 				}
 			}
+			path := "/stores"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/stores"
 			params := map[string]string{}
 			if flagDryRun != false {
 				params["$dry_run"] = formatCLIParamValue(flagDryRun)

--- a/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
+++ b/testdata/golden/expected/generate-public-param-names/public-param-golden/internal/cli/stores_find.go
@@ -38,12 +38,11 @@ func newStoresFindCmd(flags *rootFlags) *cobra.Command {
 			if !cmd.Flags().Changed("location-id") && !flags.dryRun {
 				return fmt.Errorf("required flag \"%s\" not set", "location-id")
 			}
+			path := "/power/store-locator"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
-
-			path := "/power/store-locator"
 			params := map[string]string{}
 			if flagS != "" {
 				params["s"] = formatCLIParamValue(flagS)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -19,13 +19,12 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  tier-routing-golden-pp-cli items enterprise",
 		Annotations: map[string]string{"pp:endpoint": "items.enterprise", "pp:method": "GET", "pp:path": "/items/enterprise", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/items/enterprise"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
 			c = c.WithTier("enterprise")
-
-			path := "/items/enterprise"
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_list.go
@@ -20,13 +20,12 @@ func newItemsListCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  tier-routing-golden-pp-cli items list",
 		Annotations: map[string]string{"pp:endpoint": "items.list", "pp:method": "GET", "pp:path": "/items", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/items"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
 			c = c.WithTier("free")
-
-			path := "/items"
 			data, prov, err := resolvePaginatedReadWithStrategy(cmd.Context(), c, flags, "auto", "items", path, map[string]string{}, nil, flagAll, "cursor", "cursor", "limit", "", "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -19,13 +19,12 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 		Example:     "  tier-routing-golden-pp-cli items premium",
 		Annotations: map[string]string{"pp:endpoint": "items.premium", "pp:method": "GET", "pp:path": "/items/premium", "mcp:read-only": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/items/premium"
 			c, err := flags.newClient()
 			if err != nil {
 				return err
 			}
 			c = c.WithTier("paid")
-
-			path := "/items/premium"
 			params := map[string]string{}
 			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, cmd.ErrOrStderr())
 			if err != nil {


### PR DESCRIPTION
## Summary
Nested generated help requests now remain successful even if Cobra/pflag returns the help sentinel from a subcommand path. Generated `Execute()` handles `pflag.ErrHelp` before wrapping Cobra usage errors, so agents probing `<cli> <subcommand> --help` do not see a false failure while real usage mistakes still exit 2.

This also adds a generated-binary regression test for endpoint and framework nested help paths, plus unknown-flag and missing positional-arg usage errors.

Fixes #2595

## Validation
- `go test ./internal/generator -run 'TestGenerated(RootTreatsPflagHelpSentinelAsSuccess|NestedHelpExitsZeroAndUsageErrorsExitTwo)' -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`
- `go fmt ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
