### PR TITLE
fix(cli): correct generated pagination defaults

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3475,6 +3475,7 @@ type visionRenderData struct {
 	SyncableResources            []profiler.SyncableResource
 	DependentSyncResources       []profiler.DependentResource
 	PaginationSupportedResources []string
+	PaginationDefaultResources   []paginationDefaultEntry
 	SpecTimestampFields          []string
 	SearchableFields             map[string][]string
 	Tables                       []TableDef
@@ -3496,6 +3497,51 @@ type resourceIDFieldOverrideEntry struct {
 
 type criticalResourceEntry struct {
 	Name string
+}
+
+type paginationDefaultEntry struct {
+	Name        string
+	CursorParam string
+	CursorType  string
+	LimitParam  string
+	Limit       int
+}
+
+func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []paginationDefaultEntry {
+	defaults := map[string]paginationDefaultEntry{}
+	add := func(name, cursorParam, cursorType, limitParam string, limit int, supportsPagination bool) {
+		if !supportsPagination || name == "" {
+			return
+		}
+		if _, exists := defaults[name]; exists {
+			return
+		}
+		defaults[name] = paginationDefaultEntry{
+			Name:        name,
+			CursorParam: cursorParam,
+			CursorType:  cursorType,
+			LimitParam:  limitParam,
+			Limit:       limit,
+		}
+	}
+	for _, resource := range syncable {
+		add(resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+	}
+	for _, resource := range dependent {
+		add(resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+	}
+
+	names := make([]string, 0, len(defaults))
+	for name := range defaults {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]paginationDefaultEntry, len(names))
+	for i, name := range names {
+		entries[i] = defaults[name]
+	}
+	return entries
 }
 
 func resourceIDFieldOverrideEntries(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []resourceIDFieldOverrideEntry {
@@ -3685,6 +3731,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		SyncableResources:            g.profile.SyncableResources,
 		DependentSyncResources:       g.profile.DependentSyncResources,
 		PaginationSupportedResources: paginationSupportedResources(g.profile.SyncableResources, g.profile.DependentSyncResources),
+		PaginationDefaultResources:   paginationDefaultEntries(g.profile.SyncableResources, g.profile.DependentSyncResources),
 		SpecTimestampFields:          specDateTimeFieldNames(g.Spec),
 		SearchableFields:             g.profile.SearchableFields,
 		Tables:                       schema,

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3500,6 +3500,7 @@ type criticalResourceEntry struct {
 }
 
 type paginationDefaultEntry struct {
+	Key         string
 	Name        string
 	CursorParam string
 	CursorType  string
@@ -3509,14 +3510,15 @@ type paginationDefaultEntry struct {
 
 func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []paginationDefaultEntry {
 	defaults := map[string]paginationDefaultEntry{}
-	add := func(name, cursorParam, cursorType, limitParam string, limit int, supportsPagination bool) {
-		if !supportsPagination || name == "" {
+	add := func(key, name, cursorParam, cursorType, limitParam string, limit int, supportsPagination bool) {
+		if !supportsPagination || key == "" || name == "" {
 			return
 		}
-		if _, exists := defaults[name]; exists {
+		if _, exists := defaults[key]; exists {
 			return
 		}
-		defaults[name] = paginationDefaultEntry{
+		defaults[key] = paginationDefaultEntry{
+			Key:         key,
 			Name:        name,
 			CursorParam: cursorParam,
 			CursorType:  cursorType,
@@ -3525,21 +3527,21 @@ func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []
 		}
 	}
 	for _, resource := range syncable {
-		add(resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+		add(resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
 	}
 	for _, resource := range dependent {
-		add(resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
+		add(resource.ParentResource+"/"+resource.Name, resource.Name, resource.PaginationCursorParam, resource.PaginationCursorType, resource.PaginationLimitParam, resource.PaginationPageSize, resource.SupportsPagination)
 	}
 
-	names := make([]string, 0, len(defaults))
-	for name := range defaults {
-		names = append(names, name)
+	keys := make([]string, 0, len(defaults))
+	for key := range defaults {
+		keys = append(keys, key)
 	}
-	sort.Strings(names)
+	sort.Strings(keys)
 
-	entries := make([]paginationDefaultEntry, len(names))
-	for i, name := range names {
-		entries[i] = defaults[name]
+	entries := make([]paginationDefaultEntry, len(keys))
+	for i, key := range keys {
+		entries[i] = defaults[key]
 	}
 	return entries
 }

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13731,6 +13731,40 @@ func TestGeneratedSyncUsesPerResourcePaginationDefaults(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./internal/cli")
 }
 
+func TestPaginationDefaultEntriesDistinguishDependentContext(t *testing.T) {
+	entries := paginationDefaultEntries(
+		[]profiler.SyncableResource{{
+			Name:                  "tasks",
+			SupportsPagination:    true,
+			PaginationCursorParam: "after",
+			PaginationCursorType:  "cursor",
+			PaginationLimitParam:  "limit",
+			PaginationPageSize:    100,
+		}},
+		[]profiler.DependentResource{{
+			Name:                  "tasks",
+			ParentResource:        "projects",
+			SupportsPagination:    true,
+			PaginationCursorParam: "offset",
+			PaginationCursorType:  "offset",
+			PaginationLimitParam:  "per_page",
+			PaginationPageSize:    25,
+		}},
+	)
+
+	byKey := map[string]paginationDefaultEntry{}
+	for _, entry := range entries {
+		byKey[entry.Key] = entry
+	}
+
+	require.Contains(t, byKey, "tasks")
+	require.Contains(t, byKey, "projects/tasks")
+	assert.Equal(t, "after", byKey["tasks"].CursorParam)
+	assert.Equal(t, "offset", byKey["projects/tasks"].CursorParam)
+	assert.Equal(t, "per_page", byKey["projects/tasks"].LimitParam)
+	assert.Equal(t, 25, byKey["projects/tasks"].Limit)
+}
+
 func TestGeneratedSyncUsesPOSTForRPCStyleListResources(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -13663,6 +13663,74 @@ func TestGeneratedSyncGatesPaginationParamsPerResource(t *testing.T) {
 	runGoCommand(t, outputDir, "build", "./...")
 }
 
+func TestGeneratedSyncUsesPerResourcePaginationDefaults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "per-resource-pagination",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/per-resource-pagination-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"assets": {
+				Description: "Assets",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/assets",
+						Description: "List assets",
+						Response:    spec.ResponseDef{Type: "array"},
+						Params:      []spec.Param{{Name: "limit", Type: "integer", Default: 50}, {Name: "skip", Type: "integer"}},
+						Pagination:  &spec.Pagination{Type: "offset", CursorParam: "skip", LimitParam: "limit"},
+					},
+				},
+			},
+			"photos": {
+				Description: "Photos",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/photos",
+						Description: "List photos",
+						Response:    spec.ResponseDef{Type: "array"},
+						Params:      []spec.Param{{Name: "page", Type: "integer"}, {Name: "per_page", Type: "integer", Default: 25}},
+						Pagination:  &spec.Pagination{Type: "page", CursorParam: "page", LimitParam: "per_page"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+
+	assert.Contains(t, syncContent, `pageSize := determinePaginationDefaults(resource)`)
+	assert.Contains(t, syncContent, `func determinePaginationDefaults(resource string) paginationDefaults`)
+	assert.Contains(t, syncContent, `case "assets":`)
+	assert.Contains(t, syncContent, `cursorParam: "skip"`)
+	assert.Contains(t, syncContent, `cursorType:  "offset"`)
+	assert.Contains(t, syncContent, `limitParam:  "limit"`)
+	assert.Contains(t, syncContent, `limit:       50`)
+	assert.Contains(t, syncContent, `case "photos":`)
+	assert.Contains(t, syncContent, `cursorParam: "page"`)
+	assert.Contains(t, syncContent, `cursorType:  "page"`)
+	assert.Contains(t, syncContent, `limitParam:  "per_page"`)
+	assert.Contains(t, syncContent, `limit:       25`)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
 func TestGeneratedSyncUsesPOSTForRPCStyleListResources(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/paginated_truncate_test.go
+++ b/internal/generator/paginated_truncate_test.go
@@ -211,7 +211,7 @@ func TestPaginatedGetWarnsWhenAllHasNoAdvanceSignal(t *testing.T) {
 		json.RawMessage(` + "`" + `[{"id":"one"}]` + "`" + `),
 	}}
 	stderr := capturePaginatedStderr(t, func() {
-		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "page", "page", "limit", "", "")
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"1"}, nil, true, "cursor", "cursor", "limit", "", "")
 		if err != nil {
 			t.Fatalf("paginatedGet returned error: %v", err)
 		}
@@ -336,6 +336,60 @@ func TestPaginatedGetAdvancesOffsetAfterFullPageWithoutHasMore(t *testing.T) {
 	}
 	if client.params[1]["offset"] != "2" {
 		t.Fatalf("second request offset = %q, want 2", client.params[1]["offset"])
+	}
+}
+
+func TestPaginatedGetAdvancesPageAfterFullPageWithoutHasMore(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"},{"id":"two"}]}` + "`" + `),
+		json.RawMessage(` + "`" + `{"items":[{"id":"three"}]}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"per_page":"2"}, nil, true, "page", "page", "per_page", "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d items, want 3; data=%s", len(got), data)
+		}
+	})
+	if len(client.params) != 2 {
+		t.Fatalf("got %d requests, want 2", len(client.params))
+	}
+	if client.params[1]["page"] != "2" {
+		t.Fatalf("second request page = %q, want 2", client.params[1]["page"])
+	}
+	if strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+		t.Fatalf("stderr should not warn when page pagination advances client-side: %s", stderr)
+	}
+}
+
+func TestPaginatedGetDoesNotWarnWhenOffsetShortPageHasNoSignal(t *testing.T) {
+	client := &paginatedTestClient{responses: []json.RawMessage{
+		json.RawMessage(` + "`" + `{"items":[{"id":"one"}]}` + "`" + `),
+	}}
+	stderr := capturePaginatedStderr(t, func() {
+		data, err := paginatedGet(context.Background(), client, "/orders", map[string]string{"limit":"2", "offset":"0"}, nil, true, "offset", "offset", "limit", "", "")
+		if err != nil {
+			t.Fatalf("paginatedGet returned error: %v", err)
+		}
+		var got []map[string]string
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d items, want 1; data=%s", len(got), data)
+		}
+	})
+	if len(client.params) != 1 {
+		t.Fatalf("got %d requests, want 1", len(client.params))
+	}
+	if strings.Contains(stderr, ` + "`" + `"reason":"pagination_signal_missing"` + "`" + `) {
+		t.Fatalf("stderr should not warn after a short offset page: %s", stderr)
 	}
 }
 

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1107,7 +1107,7 @@ func paginatedGet(ctx context.Context, c interface {
 						}
 					}
 				}
-				if !hasExplicitNoMore {
+				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
 					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
@@ -1126,7 +1126,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {
@@ -1139,7 +1139,7 @@ func paginatedGet(ctx context.Context, c interface {
 }
 
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
-	if paginationType != "offset" || itemCount == 0 {
+	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
 	limit, err := strconv.Atoi(params[limitParam])

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1099,7 +1099,7 @@ type paginationDefaults struct {
 func determinePaginationDefaults(resource string) paginationDefaults {
 	switch resource {
 {{- range .PaginationDefaultResources}}
-	case "{{.Name}}":
+	case "{{.Key}}":
 		return paginationDefaults{
 			cursorParam: "{{if .CursorParam}}{{.CursorParam}}{{else}}{{$.Pagination.CursorParam}}{{end}}",
 			cursorType:  "{{if .CursorType}}{{.CursorType}}{{else}}{{$.Pagination.CursorType}}{{end}}",
@@ -2508,7 +2508,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults(dep.Name)
+	pageSize := determinePaginationDefaults(dep.ParentTable + "/" + dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(dep.Name)

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -643,7 +643,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	cursor := existingCursor
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(resource)
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(resource)
 	pageLimit := pageSize.limit
@@ -1096,7 +1096,18 @@ type paginationDefaults struct {
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
-func determinePaginationDefaults() paginationDefaults {
+func determinePaginationDefaults(resource string) paginationDefaults {
+	switch resource {
+{{- range .PaginationDefaultResources}}
+	case "{{.Name}}":
+		return paginationDefaults{
+			cursorParam: "{{if .CursorParam}}{{.CursorParam}}{{else}}{{$.Pagination.CursorParam}}{{end}}",
+			cursorType:  "{{if .CursorType}}{{.CursorType}}{{else}}{{$.Pagination.CursorType}}{{end}}",
+			limitParam:  "{{if .LimitParam}}{{.LimitParam}}{{else}}{{$.Pagination.PageSizeParam}}{{end}}",
+			limit:       {{if .Limit}}{{.Limit}}{{else}}{{if $.Pagination.DefaultPageSize}}{{$.Pagination.DefaultPageSize}}{{else}}100{{end}}{{end}},
+		}
+{{- end}}
+	}
 	return paginationDefaults{
 		cursorParam: "{{if .Pagination.CursorParam}}{{.Pagination.CursorParam}}{{else}}after{{end}}",
 		cursorType:  "{{.Pagination.CursorType}}",
@@ -2497,7 +2508,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 {{- if $hasIDWalk}}
 	idWalk, usesIDWalk := syncResourceIDWalkConfig(dep.Name)

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -7510,7 +7510,7 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 	var pag spec.Pagination
 
 	// Detect limit param
-	for _, name := range []string{"limit", "maxresults", "pagesize", "page_size", "max_results", "per_page", "page[size]"} {
+	for _, name := range []string{"limit", "maxresults", "pagesize", "page_size", "max_results", "perpage", "per_page", "page[size]"} {
 		if orig, ok := originalCase[name]; ok {
 			pag.LimitParam = orig
 			break
@@ -7536,7 +7536,7 @@ func detectPagination(params []spec.Param, op *openapi3.Operation) *spec.Paginat
 		}
 	}
 	if pag.Type == "" {
-		for _, name := range []string{"offset"} {
+		for _, name := range []string{"offset", "skip"} {
 			if orig, ok := originalCase[name]; ok {
 				pag.CursorParam = orig
 				pag.Type = "offset"

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11145,6 +11145,18 @@ func TestDetectPaginationOffsetBeatsPage(t *testing.T) {
 	assert.Equal(t, "offset", pag.Type)
 }
 
+func TestDetectPaginationRecognizesSkipAndPerPage(t *testing.T) {
+	t.Parallel()
+
+	pag := detectPagination([]spec.Param{
+		{Name: "skip"}, {Name: "perPage"},
+	}, nil)
+	require.NotNil(t, pag)
+	assert.Equal(t, "skip", pag.CursorParam)
+	assert.Equal(t, "offset", pag.Type)
+	assert.Equal(t, "perPage", pag.LimitParam)
+}
+
 func TestParsePreservesOperationTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2130,17 +2130,17 @@ func detectIDWalkParams(endpoint spec.Endpoint) (string, string, int) {
 		return "", "", 0
 	}
 	pageSize := 100
-	if defaultSize, ok := paginationLimitDefault(endpoint); ok {
+	if defaultSize, ok := paginationLimitDefault(endpoint, resolvedLimitParam); ok {
 		pageSize = defaultSize
 	}
 	return filterParam, resolvedLimitParam, pageSize
 }
 
-func paginationLimitDefault(endpoint spec.Endpoint) (int, bool) {
-	if endpoint.Pagination == nil || strings.TrimSpace(endpoint.Pagination.LimitParam) == "" {
+func paginationLimitDefault(endpoint spec.Endpoint, limitParam string) (int, bool) {
+	if strings.TrimSpace(limitParam) == "" {
 		return 0, false
 	}
-	limitName := strings.ToLower(endpoint.Pagination.LimitParam)
+	limitName := strings.ToLower(limitParam)
 	params := append(append([]spec.Param{}, endpoint.Params...), endpoint.Body...)
 	for _, param := range params {
 		if strings.ToLower(param.Name) != limitName {
@@ -2190,7 +2190,7 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 		cursorType = inferPaginationType(cursorParam)
 	}
 	pageSize := 100
-	if defaultSize, ok := paginationLimitDefault(endpoint); ok {
+	if defaultSize, ok := paginationLimitDefault(endpoint, limitParam); ok {
 		pageSize = defaultSize
 	}
 	return cursorParam, cursorType, limitParam, pageSize

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -133,6 +133,12 @@ type SyncableResource struct {
 	// sending synthetic limit/offset params to strict non-paginated list
 	// endpoints.
 	SupportsPagination bool
+	// Pagination* fields preserve the chosen list endpoint's concrete paging
+	// contract so generated sync does not reuse a different resource's default.
+	PaginationCursorParam string
+	PaginationCursorType  string
+	PaginationLimitParam  string
+	PaginationPageSize    int
 
 	// UsesHTMLResponse and HTMLExtract mirror the chosen list endpoint's
 	// response_format/html_extract contract so sync can normalize HTML into
@@ -202,6 +208,11 @@ type DependentResource struct {
 	// paths so dependent syncs skip synthetic limit/offset params on endpoints
 	// that do not declare page-size pagination.
 	SupportsPagination bool
+	// Pagination* mirrors SyncableResource for child sync paths.
+	PaginationCursorParam string
+	PaginationCursorType  string
+	PaginationLimitParam  string
+	PaginationPageSize    int
 
 	// UsesHTMLResponse and HTMLExtract mirror SyncableResource for child sync
 	// paths.
@@ -823,11 +834,11 @@ func dataFit(v bool) int {
 var (
 	pageSizeParamCandidates = map[string]bool{
 		"limit": true, "per_page": true, "page_size": true, "pagesize": true,
-		"first": true, "count": true, "max_results": true, "maxrecords": true,
-		"max_records": true, "page[size]": true,
+		"perpage": true, "first": true, "count": true, "max_results": true,
+		"maxrecords": true, "max_records": true, "page[size]": true,
 	}
 	cursorParamCandidates = map[string]bool{
-		"after": true, "cursor": true, "page_token": true, "offset": true,
+		"after": true, "cursor": true, "page_token": true, "offset": true, "skip": true,
 		"page": true, "before": true, "starting_after": true, "page[cursor]": true,
 	}
 )
@@ -1387,26 +1398,30 @@ func dependentResourceFromEntry(entry parameterizedEntry, knownParents map[strin
 	}
 
 	return DependentResource{
-		Name:               ctx.name,
-		ParentResource:     ctx.parentResource,
-		ParentIDParam:      dependentParentIDParam(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam),
-		Path:               entry.meta.Path,
-		Method:             entry.meta.Method,
-		Tier:               entry.meta.Tier,
-		PathParams:         dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, ""),
-		IDField:            entry.meta.IDField,
-		Critical:           entry.meta.Critical,
-		SinceParam:         entry.meta.SinceParam,
-		SinceParamFormat:   entry.meta.SinceParamFormat,
-		SupportsPagination: entry.meta.SupportsPagination,
-		UsesHTMLResponse:   entry.meta.UsesHTMLResponse,
-		HTMLExtract:        entry.meta.HTMLExtract,
-		BodyFields:         entry.meta.BodyFields,
-		IDWalkFilterParam:  entry.meta.IDWalkFilterParam,
-		IDWalkLimitParam:   entry.meta.IDWalkLimitParam,
-		IDWalkPageSize:     entry.meta.IDWalkPageSize,
-		FieldSelector:      entry.meta.FieldSelector,
-		Discriminator:      entry.meta.Discriminator,
+		Name:                  ctx.name,
+		ParentResource:        ctx.parentResource,
+		ParentIDParam:         dependentParentIDParam(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam),
+		Path:                  entry.meta.Path,
+		Method:                entry.meta.Method,
+		Tier:                  entry.meta.Tier,
+		PathParams:            dependentPathParams(entry.meta.Path, ctx.parentPathSegment, ctx.firstParam, ""),
+		IDField:               entry.meta.IDField,
+		Critical:              entry.meta.Critical,
+		SinceParam:            entry.meta.SinceParam,
+		SinceParamFormat:      entry.meta.SinceParamFormat,
+		SupportsPagination:    entry.meta.SupportsPagination,
+		PaginationCursorParam: entry.meta.PaginationCursorParam,
+		PaginationCursorType:  entry.meta.PaginationCursorType,
+		PaginationLimitParam:  entry.meta.PaginationLimitParam,
+		PaginationPageSize:    entry.meta.PaginationPageSize,
+		UsesHTMLResponse:      entry.meta.UsesHTMLResponse,
+		HTMLExtract:           entry.meta.HTMLExtract,
+		BodyFields:            entry.meta.BodyFields,
+		IDWalkFilterParam:     entry.meta.IDWalkFilterParam,
+		IDWalkLimitParam:      entry.meta.IDWalkLimitParam,
+		IDWalkPageSize:        entry.meta.IDWalkPageSize,
+		FieldSelector:         entry.meta.FieldSelector,
+		Discriminator:         entry.meta.Discriminator,
 	}, true
 }
 
@@ -1602,27 +1617,31 @@ func applySpecWalkers(s *spec.APISpec, deps []DependentResource, syncable map[st
 			}
 			meta := metaFromEndpoint(s, resourceName, r, e, types, resourceNameIndex)
 			deps = append(deps, DependentResource{
-				Name:               spec.ToSnakeCase(resourceName),
-				ParentResource:     parent,
-				ParentIDParam:      keyParam,
-				Path:               e.Path,
-				Method:             meta.Method,
-				Tier:               meta.Tier,
-				PathParams:         dependentPathParams(e.Path, parent, keyParam, keyField),
-				IDField:            meta.IDField,
-				Critical:           meta.Critical,
-				SinceParam:         meta.SinceParam,
-				SinceParamFormat:   meta.SinceParamFormat,
-				SupportsPagination: meta.SupportsPagination,
-				UsesHTMLResponse:   meta.UsesHTMLResponse,
-				HTMLExtract:        meta.HTMLExtract,
-				BodyFields:         meta.BodyFields,
-				IDWalkFilterParam:  meta.IDWalkFilterParam,
-				IDWalkLimitParam:   meta.IDWalkLimitParam,
-				IDWalkPageSize:     meta.IDWalkPageSize,
-				FieldSelector:      meta.FieldSelector,
-				Discriminator:      meta.Discriminator,
-				KeyField:           keyField,
+				Name:                  spec.ToSnakeCase(resourceName),
+				ParentResource:        parent,
+				ParentIDParam:         keyParam,
+				Path:                  e.Path,
+				Method:                meta.Method,
+				Tier:                  meta.Tier,
+				PathParams:            dependentPathParams(e.Path, parent, keyParam, keyField),
+				IDField:               meta.IDField,
+				Critical:              meta.Critical,
+				SinceParam:            meta.SinceParam,
+				SinceParamFormat:      meta.SinceParamFormat,
+				SupportsPagination:    meta.SupportsPagination,
+				PaginationCursorParam: meta.PaginationCursorParam,
+				PaginationCursorType:  meta.PaginationCursorType,
+				PaginationLimitParam:  meta.PaginationLimitParam,
+				PaginationPageSize:    meta.PaginationPageSize,
+				UsesHTMLResponse:      meta.UsesHTMLResponse,
+				HTMLExtract:           meta.HTMLExtract,
+				BodyFields:            meta.BodyFields,
+				IDWalkFilterParam:     meta.IDWalkFilterParam,
+				IDWalkLimitParam:      meta.IDWalkLimitParam,
+				IDWalkPageSize:        meta.IDWalkPageSize,
+				FieldSelector:         meta.FieldSelector,
+				Discriminator:         meta.Discriminator,
+				KeyField:              keyField,
 			})
 			byPath[lookupKey] = len(deps) - 1
 		}
@@ -1857,25 +1876,29 @@ func resolveParentResourceName(walkParent, paramName string, knownParents map[st
 // is still selecting between candidates (e.g., flat vs. paginated). It is
 // converted into a SyncableResource at the end of Profile().
 type syncableMeta struct {
-	Path               string
-	Method             string
-	Tier               string
-	SkipDefaultSync    bool
-	IDField            string
-	Critical           bool
-	SinceParam         string
-	SinceParamFormat   string
-	SupportsPagination bool
-	UsesHTMLResponse   bool
-	HTMLExtract        *spec.HTMLExtract
-	BodyFields         []SyncBodyField
-	IDWalkFilterParam  string
-	IDWalkLimitParam   string
-	IDWalkPageSize     int
-	FieldSelector      FieldSelector
-	Discriminator      DiscriminatorDispatch
-	ResponseItem       string
-	QueryEntity        string
+	Path                  string
+	Method                string
+	Tier                  string
+	SkipDefaultSync       bool
+	IDField               string
+	Critical              bool
+	SinceParam            string
+	SinceParamFormat      string
+	SupportsPagination    bool
+	PaginationCursorParam string
+	PaginationCursorType  string
+	PaginationLimitParam  string
+	PaginationPageSize    int
+	UsesHTMLResponse      bool
+	HTMLExtract           *spec.HTMLExtract
+	BodyFields            []SyncBodyField
+	IDWalkFilterParam     string
+	IDWalkLimitParam      string
+	IDWalkPageSize        int
+	FieldSelector         FieldSelector
+	Discriminator         DiscriminatorDispatch
+	ResponseItem          string
+	QueryEntity           string
 }
 
 type syncableCandidate struct {
@@ -1899,26 +1922,31 @@ type parameterizedEntry struct {
 func metaFromEndpoint(s *spec.APISpec, resourceName string, resource spec.Resource, e spec.Endpoint, types map[string]spec.TypeDef, resourceNameIndex map[string]string) syncableMeta {
 	idWalkFilterParam, idWalkLimitParam, idWalkPageSize := detectIDWalkParams(e)
 	sinceParam, sinceParamFormat := detectEndpointSinceParamAndFormat(e, types)
+	paginationCursorParam, paginationCursorType, paginationLimitParam, paginationPageSize := syncPaginationDefaultsFromEndpoint(e)
 	return syncableMeta{
-		Path:               e.Path,
-		Method:             strings.ToUpper(e.Method),
-		Tier:               s.EffectiveTier(resource, e),
-		SkipDefaultSync:    isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
-		IDField:            e.IDField,
-		Critical:           e.Critical,
-		SinceParam:         sinceParam,
-		SinceParamFormat:   sinceParamFormat,
-		SupportsPagination: endpointSupportsPagination(e),
-		UsesHTMLResponse:   e.UsesHTMLResponse(),
-		HTMLExtract:        e.HTMLExtract,
-		BodyFields:         syncBodyFieldsFromEndpoint(e),
-		IDWalkFilterParam:  idWalkFilterParam,
-		IDWalkLimitParam:   idWalkLimitParam,
-		IDWalkPageSize:     idWalkPageSize,
-		FieldSelector:      detectEndpointFieldSelector(e),
-		Discriminator:      discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
-		ResponseItem:       e.Response.Item,
-		QueryEntity:        queryEntityForEndpoint(s, e),
+		Path:                  e.Path,
+		Method:                strings.ToUpper(e.Method),
+		Tier:                  s.EffectiveTier(resource, e),
+		SkipDefaultSync:       isAuthTaggedEndpoint(e) || hasTypedResponseWithoutRuntimeID(resourceName, e, types),
+		IDField:               e.IDField,
+		Critical:              e.Critical,
+		SinceParam:            sinceParam,
+		SinceParamFormat:      sinceParamFormat,
+		SupportsPagination:    endpointSupportsPagination(e),
+		PaginationCursorParam: paginationCursorParam,
+		PaginationCursorType:  paginationCursorType,
+		PaginationLimitParam:  paginationLimitParam,
+		PaginationPageSize:    paginationPageSize,
+		UsesHTMLResponse:      e.UsesHTMLResponse(),
+		HTMLExtract:           e.HTMLExtract,
+		BodyFields:            syncBodyFieldsFromEndpoint(e),
+		IDWalkFilterParam:     idWalkFilterParam,
+		IDWalkLimitParam:      idWalkLimitParam,
+		IDWalkPageSize:        idWalkPageSize,
+		FieldSelector:         detectEndpointFieldSelector(e),
+		Discriminator:         discriminatorDispatchForEndpoint(e, types, resourceNameIndex),
+		ResponseItem:          e.Response.Item,
+		QueryEntity:           queryEntityForEndpoint(s, e),
 	}
 }
 
@@ -2138,6 +2166,67 @@ func paginationLimitDefault(endpoint spec.Endpoint) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string, string, int) {
+	cursorParam := ""
+	cursorType := ""
+	limitParam := ""
+	if endpoint.Pagination != nil && endpoint.Pagination.Type != spec.PaginationTypeIDWalk {
+		cursorParam = strings.TrimSpace(endpoint.Pagination.CursorParam)
+		cursorType = strings.TrimSpace(endpoint.Pagination.Type)
+		limitParam = strings.TrimSpace(endpoint.Pagination.LimitParam)
+	}
+	if cursorParam == "" || limitParam == "" {
+		inferredCursor, inferredLimit := inferPaginationParamsFromEndpoint(endpoint)
+		if cursorParam == "" {
+			cursorParam = inferredCursor
+		}
+		if limitParam == "" {
+			limitParam = inferredLimit
+		}
+	}
+	if cursorType == "" {
+		cursorType = inferPaginationType(cursorParam)
+	}
+	pageSize := 100
+	if defaultSize, ok := paginationLimitDefault(endpoint); ok {
+		pageSize = defaultSize
+	}
+	return cursorParam, cursorType, limitParam, pageSize
+}
+
+func inferPaginationParamsFromEndpoint(endpoint spec.Endpoint) (string, string) {
+	var cursorParam string
+	var limitParam string
+	for _, param := range endpoint.Params {
+		if param.PathParam || param.Positional {
+			continue
+		}
+		lower := strings.ToLower(param.Name)
+		if cursorParam == "" && cursorParamCandidates[lower] {
+			cursorParam = param.Name
+		}
+		if limitParam == "" && pageSizeParamCandidates[lower] {
+			limitParam = param.Name
+		}
+	}
+	return cursorParam, limitParam
+}
+
+func inferPaginationType(cursorParam string) string {
+	switch strings.ToLower(strings.TrimSpace(cursorParam)) {
+	case "":
+		return ""
+	case "page", "page_number", "pagenumber":
+		return "page"
+	case "offset", "skip":
+		return "offset"
+	case "page_token", "pagetoken":
+		return "page_token"
+	default:
+		return "cursor"
+	}
 }
 
 func detectEndpointSinceParamAndFormat(endpoint spec.Endpoint, types map[string]spec.TypeDef) (string, string) {
@@ -2512,25 +2601,29 @@ func sortedSyncableResources(m map[string]syncableMeta) []SyncableResource {
 	for i, name := range names {
 		meta := m[name]
 		resources[i] = SyncableResource{
-			Name:               name,
-			Path:               meta.Path,
-			Method:             meta.Method,
-			Tier:               meta.Tier,
-			SkipDefaultSync:    meta.SkipDefaultSync,
-			IDField:            meta.IDField,
-			Critical:           meta.Critical,
-			SinceParam:         meta.SinceParam,
-			SinceParamFormat:   meta.SinceParamFormat,
-			SupportsPagination: meta.SupportsPagination,
-			UsesHTMLResponse:   meta.UsesHTMLResponse,
-			HTMLExtract:        meta.HTMLExtract,
-			BodyFields:         meta.BodyFields,
-			IDWalkFilterParam:  meta.IDWalkFilterParam,
-			IDWalkLimitParam:   meta.IDWalkLimitParam,
-			IDWalkPageSize:     meta.IDWalkPageSize,
-			FieldSelector:      meta.FieldSelector,
-			Discriminator:      meta.Discriminator,
-			QueryEntity:        meta.QueryEntity,
+			Name:                  name,
+			Path:                  meta.Path,
+			Method:                meta.Method,
+			Tier:                  meta.Tier,
+			SkipDefaultSync:       meta.SkipDefaultSync,
+			IDField:               meta.IDField,
+			Critical:              meta.Critical,
+			SinceParam:            meta.SinceParam,
+			SinceParamFormat:      meta.SinceParamFormat,
+			SupportsPagination:    meta.SupportsPagination,
+			PaginationCursorParam: meta.PaginationCursorParam,
+			PaginationCursorType:  meta.PaginationCursorType,
+			PaginationLimitParam:  meta.PaginationLimitParam,
+			PaginationPageSize:    meta.PaginationPageSize,
+			UsesHTMLResponse:      meta.UsesHTMLResponse,
+			HTMLExtract:           meta.HTMLExtract,
+			BodyFields:            meta.BodyFields,
+			IDWalkFilterParam:     meta.IDWalkFilterParam,
+			IDWalkLimitParam:      meta.IDWalkLimitParam,
+			IDWalkPageSize:        meta.IDWalkPageSize,
+			FieldSelector:         meta.FieldSelector,
+			Discriminator:         meta.Discriminator,
+			QueryEntity:           meta.QueryEntity,
 		}
 	}
 	return resources

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2832,6 +2832,62 @@ func TestProfilePagination_ExplicitBlockWinsOverInference(t *testing.T) {
 	assert.Equal(t, "bar", profile.Pagination.PageSizeParam, "explicit limit_param must win")
 }
 
+func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "mixed-pagination",
+		Resources: map[string]spec.Resource{
+			"assets": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/assets",
+						Params:   []spec.Param{{Name: "limit", Type: "integer", Default: 50}, {Name: "skip", Type: "integer"}},
+						Response: spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{
+							Type:        "offset",
+							CursorParam: "skip",
+							LimitParam:  "limit",
+						},
+					},
+				},
+			},
+			"photos": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/photos",
+						Params:   []spec.Param{{Name: "page", Type: "integer"}, {Name: "per_page", Type: "integer", Default: 25}},
+						Response: spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{
+							Type:        "page",
+							CursorParam: "page",
+							LimitParam:  "per_page",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := map[string]SyncableResource{}
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
+
+	require.Contains(t, byName, "assets")
+	assert.Equal(t, "offset", byName["assets"].PaginationCursorType)
+	assert.Equal(t, "skip", byName["assets"].PaginationCursorParam)
+	assert.Equal(t, "limit", byName["assets"].PaginationLimitParam)
+	assert.Equal(t, 50, byName["assets"].PaginationPageSize)
+
+	require.Contains(t, byName, "photos")
+	assert.Equal(t, "page", byName["photos"].PaginationCursorType)
+	assert.Equal(t, "page", byName["photos"].PaginationCursorParam)
+	assert.Equal(t, "per_page", byName["photos"].PaginationLimitParam)
+	assert.Equal(t, 25, byName["photos"].PaginationPageSize)
+}
+
 // Specs with no recognizable pagination shape must keep the historical
 // after/limit defaults so existing golden output doesn't churn.
 func TestProfilePagination_NoPaginationParamsKeepsDefaults(t *testing.T) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2776,7 +2776,7 @@ func TestProfilePagination_InfersFromPlainParamsWhenNoExplicitBlock(t *testing.T
 					"list": {
 						Method:   "GET",
 						Path:     "/agents",
-						Params:   []spec.Param{{Name: "offset", Type: "int"}, {Name: "count", Type: "int"}},
+						Params:   []spec.Param{{Name: "offset", Type: "int"}, {Name: "count", Type: "int", Default: 25}},
 						Response: spec.ResponseDef{Type: "array"},
 					},
 				},
@@ -2795,8 +2795,15 @@ func TestProfilePagination_InfersFromPlainParamsWhenNoExplicitBlock(t *testing.T
 	}
 
 	profile := Profile(s)
+	byName := map[string]SyncableResource{}
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
 	assert.Equal(t, "offset", profile.Pagination.CursorParam, "plain offset param must be picked up")
 	assert.Equal(t, "count", profile.Pagination.PageSizeParam, "plain count param must be picked up as limit")
+	require.Contains(t, byName, "agents")
+	assert.Equal(t, 25, byName["agents"].PaginationPageSize,
+		"inferred limit param must still read the spec-declared default")
 }
 
 // Explicit pagination: blocks must continue to win over plain-param inference.

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -153,6 +153,43 @@ resources:
 	assert.True(t, param.DispatchParamSet)
 }
 
+func TestParsePagePagination(t *testing.T) {
+	t.Parallel()
+
+	yamlSpec := []byte(`
+name: page-pagination
+base_url: https://api.example.com
+auth:
+  type: none
+resources:
+  photos:
+    endpoints:
+      list:
+        method: GET
+        path: /photos
+        params:
+          - name: page
+            type: integer
+          - name: per_page
+            type: integer
+            default: 25
+        pagination:
+          type: page
+          cursor_param: page
+          limit_param: per_page
+        response:
+          type: array
+`)
+	s, err := ParseBytes(yamlSpec)
+	require.NoError(t, err)
+
+	list := s.Resources["photos"].Endpoints["list"]
+	require.NotNil(t, list.Pagination)
+	assert.Equal(t, "page", list.Pagination.Type)
+	assert.Equal(t, "page", list.Pagination.CursorParam)
+	assert.Equal(t, "per_page", list.Pagination.LimitParam)
+}
+
 func TestParseEndpointExampleAndHappyArgs(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -637,7 +637,7 @@ func paginatedGet(ctx context.Context, c interface {
 						}
 					}
 				}
-				if !hasExplicitNoMore {
+				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
 					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
@@ -656,7 +656,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {
@@ -669,7 +669,7 @@ func paginatedGet(ctx context.Context, c interface {
 }
 
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
-	if paginationType != "offset" || itemCount == 0 {
+	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
 	limit, err := strconv.Atoi(params[limitParam])

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -630,7 +630,7 @@ func paginatedGet(ctx context.Context, c interface {
 						}
 					}
 				}
-				if !hasExplicitNoMore {
+				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
 					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
@@ -649,7 +649,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {
@@ -662,7 +662,7 @@ func paginatedGet(ctx context.Context, c interface {
 }
 
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
-	if paginationType != "offset" || itemCount == 0 {
+	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
 	limit, err := strconv.Atoi(params[limitParam])

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -712,7 +712,7 @@ func paginatedGet(ctx context.Context, c interface {
 						}
 					}
 				}
-				if !hasExplicitNoMore {
+				if !hasExplicitNoMore && nextCursorPath == "" && hasMoreField == "" {
 					if next, ok := nextFullPageOffsetCursor(clean, cursorParam, paginationType, limitParam, itemCount); ok {
 						if page >= paginatedGetMaxPages {
 							emitPaginatedGetMaxPagesWarning()
@@ -731,7 +731,7 @@ func paginatedGet(ctx context.Context, c interface {
 		break
 	}
 
-	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" {
+	if fetchAll && page == 1 && nextCursorPath == "" && hasMoreField == "" && paginationType != "offset" && paginationType != "page" {
 		emitMissingPaginationSignalWarning()
 	}
 	if humanFriendly {
@@ -744,7 +744,7 @@ func paginatedGet(ctx context.Context, c interface {
 }
 
 func nextFullPageOffsetCursor(params map[string]string, cursorParam, paginationType, limitParam string, itemCount int) (string, bool) {
-	if paginationType != "offset" || itemCount == 0 {
+	if (paginationType != "offset" && paginationType != "page") || itemCount == 0 {
 		return "", false
 	}
 	limit, err := strconv.Atoi(params[limitParam])

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -777,7 +777,7 @@ func determinePaginationDefaults(resource string) paginationDefaults {
 			limitParam:  "limit",
 			limit:       25,
 		}
-	case "tasks":
+	case "projects/tasks":
 		return paginationDefaults{
 			cursorParam: "cursor",
 			cursorType:  "cursor",
@@ -1616,7 +1616,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults(dep.Name)
+	pageSize := determinePaginationDefaults(dep.ParentTable + "/" + dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 	depSinceTS := sinceTS
 	if depSinceTS != "" && depSinceParam == "" {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -468,7 +468,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	cursor := existingCursor
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(resource)
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -768,7 +768,23 @@ type paginationDefaults struct {
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
-func determinePaginationDefaults() paginationDefaults {
+func determinePaginationDefaults(resource string) paginationDefaults {
+	switch resource {
+	case "projects":
+		return paginationDefaults{
+			cursorParam: "cursor",
+			cursorType:  "cursor",
+			limitParam:  "limit",
+			limit:       25,
+		}
+	case "tasks":
+		return paginationDefaults{
+			cursorParam: "cursor",
+			cursorType:  "cursor",
+			limitParam:  "limit",
+			limit:       50,
+		}
+	}
 	return paginationDefaults{
 		cursorParam: "cursor",
 		cursorType:  "cursor",
@@ -1600,7 +1616,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 	depSinceTS := sinceTS
 	if depSinceTS != "" && depSinceParam == "" {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -435,7 +435,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	cursor := existingCursor
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(resource)
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -793,7 +793,9 @@ type paginationDefaults struct {
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
-func determinePaginationDefaults() paginationDefaults {
+func determinePaginationDefaults(resource string) paginationDefaults {
+	switch resource {
+	}
 	return paginationDefaults{
 		cursorParam: "after",
 		cursorType:  "",

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1587,7 +1587,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults(dep.Name)
+	pageSize := determinePaginationDefaults(dep.ParentTable + "/" + dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 	depSinceTS := sinceTS
 	if depSinceTS != "" && depSinceParam == "" {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -468,7 +468,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	cursor := existingCursor
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(resource)
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -768,7 +768,9 @@ type paginationDefaults struct {
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
-func determinePaginationDefaults() paginationDefaults {
+func determinePaginationDefaults(resource string) paginationDefaults {
+	switch resource {
+	}
 	return paginationDefaults{
 		cursorParam: "after",
 		cursorType:  "",
@@ -1585,7 +1587,7 @@ func syncDependentResource(ctx context.Context, c interface {
 	var totalCount int
 	var deniedParents int
 	var firstDenial *accessWarning
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(dep.Name)
 	depSinceParam := syncResourceSinceParam(dep.Name)
 	depSinceTS := sinceTS
 	if depSinceTS != "" && depSinceParam == "" {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -435,7 +435,7 @@ func syncResource(ctx context.Context, c interface {
 	}
 
 	cursor := existingCursor
-	pageSize := determinePaginationDefaults()
+	pageSize := determinePaginationDefaults(resource)
 	var progressCount int64
 	pagesFetched := 0
 	lastNextCursor := ""
@@ -735,7 +735,16 @@ type paginationDefaults struct {
 
 // determinePaginationDefaults returns the pagination parameter names to use.
 // Values are detected from the API spec by the profiler at generation time.
-func determinePaginationDefaults() paginationDefaults {
+func determinePaginationDefaults(resource string) paginationDefaults {
+	switch resource {
+	case "items":
+		return paginationDefaults{
+			cursorParam: "cursor",
+			cursorType:  "cursor",
+			limitParam:  "limit",
+			limit:       100,
+		}
+	}
 	return paginationDefaults{
 		cursorParam: "cursor",
 		cursorType:  "cursor",


### PR DESCRIPTION
## Summary
- preserve each generated sync resource's pagination cursor, cursor type, limit param, and page size instead of reusing global defaults
- make page/offset `--all` advance after full pages without explicit has-more/cursor signals, while avoiding false missing-signal warnings on short pages
- recognize `skip` and `perPage` pagination shapes from OpenAPI/internal specs and cover page pagination authoring

Fixes #3175.
Fixes #3196.
Fixes #2998.
Fixes #2961.
Fixes #2949.

## Validation
- `go fmt ./...`
- `go test ./...`
- `go test ./internal/generator -count=1`
- `go test ./internal/profiler ./internal/openapi ./internal/spec -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`

## Post-Deploy Monitoring & Validation
No additional production monitoring required: this changes generated CLI code paths and parser/profiler behavior. Healthy signal is CI passing `go test ./...`, `scripts/golden.sh verify`, and generated-output verification on the PR. Failure signal is a regression in generated sync pagination defaults or paginated `--all` behavior in a new/updated golden fixture; rollback is reverting this PR. Validation owner: maintainer reviewing this PR during the normal CI window.

## Known Residuals
None.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-111827?logo=openai&logoColor=white)