### PR TITLE
fix(cli): harden response-path store extraction

### DIFF
--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -100,7 +100,7 @@ func TestGenerateBinaryStoreBackedPromotedThreadsHeader(t *testing.T) {
 		"store-backed binary GET must declare headerOverrides")
 	assert.Contains(t, endpointSrc, `"X-Printing-Press-Binary-Response": "true",`,
 		"store-backed binary GET must include the binary sentinel")
-	assert.Contains(t, endpointSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, cmd.ErrOrStderr())`,
+	assert.Contains(t, endpointSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, "", cmd.ErrOrStderr())`,
 		"store-backed binary GET must thread headerOverrides through the strategy-aware resolver")
 }
 

--- a/internal/generator/binary_paginated_promoted_test.go
+++ b/internal/generator/binary_paginated_promoted_test.go
@@ -100,7 +100,7 @@ func TestGenerateBinaryStoreBackedPromotedThreadsHeader(t *testing.T) {
 		"store-backed binary GET must declare headerOverrides")
 	assert.Contains(t, endpointSrc, `"X-Printing-Press-Binary-Response": "true",`,
 		"store-backed binary GET must include the binary sentinel")
-	assert.Contains(t, endpointSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, "", cmd.ErrOrStderr())`,
+	assert.Contains(t, endpointSrc, `resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "voices", false, path, params, headerOverrides, "", cmd.ErrOrStderr())`,
 		"store-backed binary GET must thread headerOverrides through the strategy-aware resolver")
 }
 

--- a/internal/generator/data_source_strategy_test.go
+++ b/internal/generator/data_source_strategy_test.go
@@ -27,10 +27,11 @@ func TestGeneratedReadCommandUsesDataSourceStrategy(t *testing.T) {
 
 	dataSourceSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
 	require.Contains(t, dataSourceSrc, "func resolveReadWithStrategy(")
+	require.Contains(t, dataSourceSrc, "func resolveReadWithStrategyAndResponsePath(")
 	require.Contains(t, dataSourceSrc, `no live equivalent for this command (requested %q)`)
 
 	commandSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
-	require.Contains(t, commandSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "local", "items"`)
+	require.Contains(t, commandSrc, `resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "local", "items"`)
 }
 
 func TestGeneratedLiveReadUsesStrategyAwareResolver(t *testing.T) {
@@ -52,7 +53,7 @@ func TestGeneratedLiveReadUsesStrategyAwareResolver(t *testing.T) {
 	require.Contains(t, dataSourceSrc, `no local data source for this command (requested %q)`)
 
 	commandSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_items.go")
-	require.Contains(t, commandSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "live", "items"`)
+	require.Contains(t, commandSrc, `resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "live", "items"`)
 }
 
 func TestGeneratedGraphQLListValidatesLocalStrategyBeforeLocalDispatch(t *testing.T) {
@@ -137,7 +138,7 @@ func TestGeneratedGraphQLGetHonorsLocalStrategy(t *testing.T) {
 	require.NoError(t, storeGen.Generate())
 
 	storeGetSrc := readGeneratedFile(t, storeOutputDir, "internal", "cli", "promoted_items.go")
-	require.Contains(t, storeGetSrc, `resolveReadWithStrategy(cmd.Context(), c, flags, "local", "items", false`)
+	require.Contains(t, storeGetSrc, `resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "local", "items", false`)
 
 	noStoreOutputDir := filepath.Join(t.TempDir(), "graphql-get-local-strategy-nostore-pp-cli")
 	noStoreGen := New(apiSpec, noStoreOutputDir)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -14209,7 +14209,7 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	// Vendor identifiers (gid, sid, uid, uuid, guid) precede `name` so
 	// APIs like Asana don't fall through to a display field — see #1394.
 	assert.Contains(t, storeContent,
-		`var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}`,
+		`var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}`,
 		"store.go genericIDFieldFallbacks must include vendor identifiers before name")
 	// Negative: kalshi-specific names must not be in the fallback list.
 	// We assert a robust shape: no occurrence of "ticker" inside the fallback
@@ -14241,6 +14241,12 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	assert.Contains(t, syncContent,
 		`"reason":"all_items_failed_id_extraction"`,
 		"sync.go must preserve the all_items_failed_id_extraction roll-up event")
+	assert.Contains(t, syncContent,
+		`Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal)`,
+		"sync.go must surface all-items-failed ID extraction as a warning result, not a success")
+	assert.Contains(t, syncContent,
+		`completed with warnings but no successful syncs`,
+		"sync.go all-warned summary must not claim the warning was only access-related")
 
 	// (d) F4b symptom probe at end-of-resource. Fires when consumed > 0
 	// AND totalCount (stored) == 0 AND extraction succeeded for at least
@@ -14279,7 +14285,7 @@ func TestGeneratedSyncIDFieldOverridesAndProbes(t *testing.T) {
 	// per-resource override, fallback-list, and numeric-ID tests execute against real code.
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
-	runGoCommand(t, outputDir, "test", "./internal/store/...", "-run", "TestUpsertBatch_(TemplatedIDFieldOverrideWins|GenericFallbackList|PreservesLargeIntegerResourceIDs|ExtractFailuresReturnedForPerItemMisses)")
+	runGoCommand(t, outputDir, "test", "./internal/store/...", "-run", "TestUpsertBatch_(TemplatedIDFieldOverrideWins|GenericFallbackList|SuffixFallbackAcceptsScopedCamelCaseID|UnwrapsIDBearingEnvelopeItems|PreservesLargeIntegerResourceIDs|ExtractFailuresReturnedForPerItemMisses)")
 	runGoCommand(t, outputDir, "test", "./internal/cli/...", "-run", "TestSyncSingleObject_PreservesLargeIntegerResourceIDs")
 }
 

--- a/internal/generator/promoted_poststore_test.go
+++ b/internal/generator/promoted_poststore_test.go
@@ -96,7 +96,7 @@ func TestPromotedHasStoreGetStillUsesResolveRead(t *testing.T) {
 	require.NoError(t, err)
 	got := string(src)
 
-	assert.Contains(t, got, "resolveReadWithStrategy(",
+	assert.Contains(t, got, "resolveReadWithStrategyAndResponsePath(",
 		"HasStore + GET must keep routing through the cached fast-path")
 	assert.NotContains(t, got, "c.Get(cmd.Context(), path, params)",
 		"HasStore + GET must not also emit a direct c.Get call (would mean both branches fired)")

--- a/internal/generator/response_path_runtime_test.go
+++ b/internal/generator/response_path_runtime_test.go
@@ -1,0 +1,116 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedReadCommandAppliesResponsePathToOutputAndWriteThrough(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("response-path-output")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"jobs": {
+			Description: "Jobs",
+			Endpoints: map[string]spec.Endpoint{
+				"recommended": {
+					Method:       "GET",
+					Path:         "/recommended",
+					Description:  "List recommended jobs",
+					Response:     spec.ResponseDef{Type: "array", Item: "Job"},
+					ResponsePath: "result.jobList",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Job": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "jobResult", Type: "object"},
+				{Name: "keyword", Type: "string"},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "response_path_runtime_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadCommandAppliesResponsePathToOutputAndWriteThrough(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/recommended" {
+			t.Fatalf("path = %q, want /recommended", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `+"`"+`{"success":true,"result":{"jobList":[{"id":"job-1","jobResult":{"jobTitle":"Engineer"},"keyword":"uplifted"}],"folders":[{"id":"folder-1","name":"Archive"}]}}`+"`"+`)
+	}))
+	defer server.Close()
+	t.Setenv("RESPONSE_PATH_OUTPUT_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"jobs", "recommended", "--json", "--select", "jobResult.jobTitle"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Engineer") {
+		t.Fatalf("response_path output was not projected before --select; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "folder-1") || strings.Contains(stdout.String(), "success") {
+		t.Fatalf("command output should render the response_path payload, not the raw envelope: %s", stdout.String())
+	}
+
+	db, err := openStoreForRead(context.Background(), "response-path-output-pp-cli")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected write-through cache to create the local store")
+	}
+	defer db.Close()
+
+	results, err := db.Search("uplifted", 10)
+	if err != nil {
+		t.Fatalf("search write-through cache: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("search found %d rows, want 1; stdout=%s stderr=%s", len(results), stdout.String(), stderr.String())
+	}
+	var row map[string]any
+	if err := json.Unmarshal(results[0], &row); err != nil {
+		t.Fatalf("decode cached row: %v", err)
+	}
+	if row["id"] != "job-1" || row["keyword"] != "uplifted" {
+		t.Fatalf("cached row = %#v, want response_path job row", row)
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestReadCommandAppliesResponsePathToOutputAndWriteThrough", "-count=1")
+}

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -360,7 +360,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -360,7 +360,7 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -643,6 +643,12 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			}
 {{- end}}
 
+{{- if and (or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")) .Endpoint.ResponsePath (not .HasStore)}}
+			if !flags.dryRun {
+				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
+			}
+
+{{- end}}
 {{- if .IsAsync}}
 			if asyncJobID := ExtractJobID(data, "{{.Async.JobIDField}}"); asyncJobID != "" {
 				_ = RecordJob(JobRow{

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -236,7 +236,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- else if eq $method "GET"}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -236,7 +236,7 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
 {{- else if eq $method "GET"}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")
@@ -366,6 +366,12 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 				if err != nil {
 					return err
 				}
+			}
+
+{{- end}}
+{{- if and (or (eq .Endpoint.Method "GET") (eq .Endpoint.Method "HEAD")) .Endpoint.ResponsePath (not .HasStore)}}
+			if !flags.dryRun {
+				data = applyResponsePath(data, {{printf "%q" .Endpoint.ResponsePath}})
 			}
 
 {{- end}}

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -130,11 +130,11 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 //     declares no per-endpoint header overrides. Without this parameter, store-backed
 //     reads on per-endpoint-versioned APIs silently get the wrong response shape
 //     (cal-com retro #334 F1).
-func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, hintWriter)
+func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
 }
 
-func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -147,6 +147,7 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
 	switch flags.dataSource {
@@ -159,11 +160,13 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			data = applyResponsePath(data, responsePath)
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
@@ -464,7 +467,7 @@ func writeMutationResponseToStore(ctx context.Context, resourceType string, data
 
 func mutationResponseEntityItems(resourceType string, data json.RawMessage, responsePath string) []json.RawMessage {
 	if responsePath != "" {
-		if pathData, ok := mutationResponseAtPath(data, responsePath); ok {
+		if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
 			data = pathData
 		}
 	}
@@ -528,14 +531,6 @@ func mutationResponsePayload(data json.RawMessage) json.RawMessage {
 	default:
 		return data
 	}
-}
-
-func mutationResponseAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
-	var root map[string]json.RawMessage
-	if err := json.Unmarshal(data, &root); err != nil {
-		return nil, false
-	}
-	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
 func mutationResponseHasID(resourceType string, data json.RawMessage) bool {

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -130,11 +130,19 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 //     declares no per-endpoint header overrides. Without this parameter, store-backed
 //     reads on per-endpoint-versioned APIs silently get the wrong response shape
 //     (cal-com retro #334 F1).
-func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
+func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithResponsePath(ctx, c, flags, resourceType, isList, path, params, headers, "", hintWriter)
 }
 
-func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolveReadWithResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyAndResponsePath(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
+}
+
+func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyAndResponsePath(ctx, c, flags, strategy, resourceType, isList, path, params, headers, "", hintWriter)
+}
+
+func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -324,7 +324,7 @@ func syncResource(ctx context.Context, c *client.Client, db *store.Store, resour
 				if !humanFriendly {
 					fmt.Fprintln(os.Stderr, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(os.Stderr, syncErrorJSON(resource, "", err))

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1466,6 +1466,24 @@ func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bo
 	return nil, false
 }
 
+func applyResponsePath(data json.RawMessage, responsePath string) json.RawMessage {
+	if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
+		return pathData
+	}
+	return data
+}
+
+func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
+	if strings.TrimSpace(responsePath) == "" {
+		return data, false
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false
+	}
+	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1477,9 +1477,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1336,7 +1336,7 @@ var resourceIDFieldOverrides = map[string]string{
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
@@ -1389,6 +1389,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
 			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
 				if s := scalarIDString(v); s != "" && s != "<nil>" {
 					return s
 				}
@@ -1459,6 +1467,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {
@@ -1543,6 +1571,13 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+				obj = unwrappedObj
+				item = unwrappedItem
+				id = ExtractResourceID(resourceType, obj)
+			}
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
@@ -1589,9 +1624,12 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 {{- end}}
 	}
 
-	// Warn when most items in a batch lack an extractable ID — this likely
-	// means the API uses a primary key field we don't recognize yet.
-	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
+	// Warn when every decoded item in a batch lacks an extractable ID — this
+	// likely means the API uses a primary key field we don't recognize yet.
+	// Partial misses still surface through extractFailures so sync can emit
+	// a structured primary_key_unresolved anomaly without spamming stderr for
+	// write-through cache batches that did persist useful rows.
+	if extractFailures > 0 && stored == 0 && len(items) > 0 {
 		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 {{- if $hasDomainTable}}
@@ -1606,6 +1644,29 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		return 0, extractFailures, err
 	}
 	return stored, extractFailures, nil
+}
+
+func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+	var candidate map[string]any
+	objectFields := 0
+	for _, value := range obj {
+		inner, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		objectFields++
+		if ExtractResourceID(resourceType, inner) != "" {
+			candidate = inner
+		}
+	}
+	if objectFields != 1 || candidate == nil {
+		return nil, nil, false
+	}
+	data, err := json.Marshal(candidate)
+	if err != nil {
+		return nil, nil, false
+	}
+	return candidate, data, true
 }
 
 {{- range .Tables}}

--- a/internal/generator/templates/store.go.tmpl
+++ b/internal/generator/templates/store.go.tmpl
@@ -1568,7 +1568,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
 				obj = unwrappedObj
 				item = unwrappedItem
 				id = ExtractResourceID(resourceType, obj)
@@ -1643,10 +1643,11 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	return stored, extractFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
+	candidateKey := ""
 	objectFields := 0
-	for _, value := range obj {
+	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
@@ -1654,13 +1655,18 @@ func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[s
 		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
+			candidateKey = key
 		}
 	}
-	if objectFields != 1 || candidate == nil {
+	if objectFields != 1 || candidate == nil || candidateKey == "" {
 		return nil, nil, false
 	}
-	data, err := json.Marshal(candidate)
-	if err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, nil, false
+	}
+	data, ok := raw[candidateKey]
+	if !ok {
 		return nil, nil, false
 	}
 	return candidate, data, true

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -275,6 +275,7 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	items := []json.RawMessage{
 		json.RawMessage(`{"customer":{"id":"cust-1","name":"Ada"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"id":"cust-2","name":"Grace"}}`),
+		json.RawMessage(`{"customer":{"id":"cust-large","external_id":9007199254740993,"name":"Big"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"description":"missing-id"}}`),
 		json.RawMessage(`{"kind":"customer","data":{"id":"cust-3"},"alternate":{"id":"other-1"}}`),
 	}
@@ -282,8 +283,8 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertBatch: %v", err)
 	}
-	if stored != 2 || extractFailures != 2 {
-		t.Fatalf("envelope unwrap stored=%d extractFailures=%d, want stored=2 extractFailures=2", stored, extractFailures)
+	if stored != 3 || extractFailures != 2 {
+		t.Fatalf("envelope unwrap stored=%d extractFailures=%d, want stored=3 extractFailures=2", stored, extractFailures)
 	}
 
 	row, err := s.Get("customers", "cust-1")
@@ -300,6 +301,14 @@ func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
 	}
 	if strings.Contains(string(row), `"kind"`) || !strings.Contains(string(row), `"name":"Grace"`) {
 		t.Fatalf("tagged envelope should store the flat inner object, got %s", row)
+	}
+
+	row, err = s.Get("customers", "cust-large")
+	if err != nil {
+		t.Fatalf("Get cust-large: %v", err)
+	}
+	if !strings.Contains(string(row), `"external_id":9007199254740993`) || strings.Contains(string(row), `9007199254740992`) {
+		t.Fatalf("envelope unwrap should preserve original large integer bytes, got %s", row)
 	}
 }
 

--- a/internal/generator/templates/store_upsert_batch_test.go.tmpl
+++ b/internal/generator/templates/store_upsert_batch_test.go.tmpl
@@ -185,7 +185,7 @@ func TestUpsertBatch_GenericFallbackList(t *testing.T) {
 	}
 	defer s.Close()
 
-	for _, key := range []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"} {
+	for _, key := range []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"} {
 		t.Run(key, func(t *testing.T) {
 			rt := "fallback_" + key
 			items := []json.RawMessage{
@@ -224,6 +224,82 @@ func TestUpsertBatch_GenericFallbackList(t *testing.T) {
 				t.Fatalf("extractFailures = %d, want 1 (%q drop must surface as extract failure)", extractFailures, key)
 			}
 		})
+	}
+}
+
+func TestUpsertBatch_SuffixFallbackAcceptsScopedCamelCaseID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"deploymentId": "dep-1", "status": "running"}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("deployments", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != 1 || extractFailures != 0 {
+		t.Fatalf("deploymentId fallback stored=%d extractFailures=%d, want stored=1 extractFailures=0", stored, extractFailures)
+	}
+	row, err := s.Get("deployments", "dep-1")
+	if err != nil {
+		t.Fatalf("Get deployment row: %v", err)
+	}
+	if !strings.Contains(string(row), `"deploymentId"`) || !strings.Contains(string(row), `"dep-1"`) {
+		t.Fatalf("cached row should preserve original object, got %s", row)
+	}
+
+	stored, extractFailures, err = s.UpsertBatch("deployments", []json.RawMessage{
+		json.RawMessage(`{"parentId": "parent-1", "status": "foreign-key-only"}`),
+	})
+	if err != nil {
+		t.Fatalf("UpsertBatch parentId: %v", err)
+	}
+	if stored != 0 || extractFailures != 1 {
+		t.Fatalf("parentId must not be promoted for deployments: stored=%d extractFailures=%d", stored, extractFailures)
+	}
+}
+
+func TestUpsertBatch_UnwrapsIDBearingEnvelopeItems(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "data.db")
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"customer":{"id":"cust-1","name":"Ada"}}`),
+		json.RawMessage(`{"kind":"customer","data":{"id":"cust-2","name":"Grace"}}`),
+		json.RawMessage(`{"kind":"customer","data":{"description":"missing-id"}}`),
+		json.RawMessage(`{"kind":"customer","data":{"id":"cust-3"},"alternate":{"id":"other-1"}}`),
+	}
+	stored, extractFailures, err := s.UpsertBatch("customers", items)
+	if err != nil {
+		t.Fatalf("UpsertBatch: %v", err)
+	}
+	if stored != 2 || extractFailures != 2 {
+		t.Fatalf("envelope unwrap stored=%d extractFailures=%d, want stored=2 extractFailures=2", stored, extractFailures)
+	}
+
+	row, err := s.Get("customers", "cust-1")
+	if err != nil {
+		t.Fatalf("Get cust-1: %v", err)
+	}
+	if strings.Contains(string(row), `"customer"`) || !strings.Contains(string(row), `"name":"Ada"`) {
+		t.Fatalf("single-key envelope should store the flat inner object, got %s", row)
+	}
+
+	row, err = s.Get("customers", "cust-2")
+	if err != nil {
+		t.Fatalf("Get cust-2: %v", err)
+	}
+	if strings.Contains(string(row), `"kind"`) || !strings.Contains(string(row), `"name":"Grace"`) {
+		t.Fatalf("tagged envelope should store the flat inner object, got %s", row)
 	}
 }
 

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -3195,9 +3195,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -487,7 +487,7 @@ Resource scoping:
 			}
 			if successCount == 0 {
 				if warnCount > 0 && errCount == 0 {
-					return fmt.Errorf("%d resource(s) skipped due to insufficient access", warnCount)
+					return fmt.Errorf("%d resource(s) completed with warnings but no successful syncs", warnCount)
 				}
 				if errCount > 0 {
 					return fmt.Errorf("%d resource(s) failed to sync", errCount)
@@ -1081,6 +1081,15 @@ func syncResource(ctx context.Context, c interface {
 
 	if !humanFriendly {
 		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+	}
+
+	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
+		return syncResult{
+			Resource: resource,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal),
+			Duration: time.Since(started),
+		}
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
@@ -2805,6 +2814,14 @@ func syncDependentResource(ctx context.Context, c interface {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
 	}
+	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
+		return syncResult{
+			Resource: dep.Name,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			Duration: time.Since(started),
+		}
+	}
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
@@ -2913,7 +2930,7 @@ const (
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
@@ -3095,6 +3112,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 				}
 			}
 		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
 	}
 	return ""
 }
@@ -3160,6 +3185,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -747,7 +747,7 @@ func syncResource(ctx context.Context, c interface {
 				if !humanFriendly {
 					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -2829,7 +2829,7 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
+			Warn:     fmt.Errorf("skipped due to insufficient access: %s (%s on all %d parents)", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}

--- a/internal/generator/writethrough_envelope_test.go
+++ b/internal/generator/writethrough_envelope_test.go
@@ -26,9 +26,33 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
+	"strings"
 	"testing"
 )
+
+func captureWriteThroughStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(data)
+}
 
 func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 	home := t.TempDir()
@@ -109,7 +133,33 @@ func TestWriteThroughCacheEnvelopeExtractionParity(t *testing.T) {
 		t.Fatalf("empty list envelope with a records wrapper must cache nothing, got %d", len(emptyRecords))
 	}
 }
+
+func TestWriteThroughCacheWarnsOnlyWhenNoRowsPersist(t *testing.T) {
+	home := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	ctx := context.Background()
+	stderr := captureWriteThroughStderr(t, func() {
+		writeThroughCache(ctx, "snapshots", json.RawMessage(`+"`"+`[{"symbol":"NIFTY"},{"symbol":"BANKNIFTY"}]`+"`"+`))
+	})
+	if !strings.Contains(stderr, "not cached locally") {
+		t.Fatalf("zero-persist write-through cache should warn, got stderr %q", stderr)
+	}
+
+	stderr = captureWriteThroughStderr(t, func() {
+		writeThroughCache(ctx, "mixedsnapshots", json.RawMessage(`+"`"+`[{"id":"ok-1"},{"symbol":"NIFTY"}]`+"`"+`))
+	})
+	if stderr != "" {
+		t.Fatalf("mixed write-through cache should not warn when at least one row persists, got stderr %q", stderr)
+	}
+}
 `), 0o644))
 
-	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestWriteThroughCacheEnvelopeExtractionParity", "-count=1")
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestWriteThroughCacheEnvelopeExtractionParity|TestWriteThroughCacheWarnsOnlyWhenNoRowsPersist", "-count=1")
 }

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -34,7 +34,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/customers_get.go
@@ -34,7 +34,7 @@ func newCustomersGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "customers", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -993,6 +993,24 @@ func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bo
 	return nil, false
 }
 
+func applyResponsePath(data json.RawMessage, responsePath string) json.RawMessage {
+	if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
+		return pathData
+	}
+	return data
+}
+
+func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
+	if strings.TrimSpace(responsePath) == "" {
+		return data, false
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false
+	}
+	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -34,7 +34,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/pages_get.go
@@ -34,7 +34,7 @@ func newPagesGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "pages", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -34,7 +34,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/playlists_get.go
@@ -34,7 +34,7 @@ func newPlaylistsGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "playlists", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -27,7 +27,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/health"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/promoted_health.go
@@ -27,7 +27,7 @@ func newHealthPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/health"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "health", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -32,7 +32,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_get.go
@@ -32,7 +32,7 @@ func newQuotesGetCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "quotes", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -25,7 +25,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
+++ b/testdata/golden/expected/generate-fastapi-operationids/fastapi-operationids-golden/internal/cli/quotes_list.go
@@ -25,7 +25,7 @@ func newQuotesListCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "quotes", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -860,6 +860,24 @@ func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bo
 	return nil, false
 }
 
+func applyResponsePath(data json.RawMessage, responsePath string) json.RawMessage {
+	if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
+		return pathData
+	}
+	return data
+}
+
+func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
+	if strings.TrimSpace(responsePath) == "" {
+		return data, false
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false
+	}
+	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 80
+    "total": 82
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -130,11 +130,11 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 //     declares no per-endpoint header overrides. Without this parameter, store-backed
 //     reads on per-endpoint-versioned APIs silently get the wrong response shape
 //     (cal-com retro #334 F1).
-func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, hintWriter)
+func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
 }
 
-func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -147,6 +147,7 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
 	switch flags.dataSource {
@@ -159,11 +160,13 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			data = applyResponsePath(data, responsePath)
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}
@@ -464,7 +467,7 @@ func writeMutationResponseToStore(ctx context.Context, resourceType string, data
 
 func mutationResponseEntityItems(resourceType string, data json.RawMessage, responsePath string) []json.RawMessage {
 	if responsePath != "" {
-		if pathData, ok := mutationResponseAtPath(data, responsePath); ok {
+		if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
 			data = pathData
 		}
 	}
@@ -528,14 +531,6 @@ func mutationResponsePayload(data json.RawMessage) json.RawMessage {
 	default:
 		return data
 	}
-}
-
-func mutationResponseAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
-	var root map[string]json.RawMessage
-	if err := json.Unmarshal(data, &root); err != nil {
-		return nil, false
-	}
-	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
 func mutationResponseHasID(resourceType string, data json.RawMessage) bool {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -130,11 +130,19 @@ func attachFreshness(prov DataProvenance, flags *rootFlags) DataProvenance {
 //     declares no per-endpoint header overrides. Without this parameter, store-backed
 //     reads on per-endpoint-versioned APIs silently get the wrong response shape
 //     (cal-com retro #334 F1).
-func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
-	return resolveReadWithStrategy(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
+func resolveRead(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithResponsePath(ctx, c, flags, resourceType, isList, path, params, headers, "", hintWriter)
 }
 
-func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+func resolveReadWithResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyAndResponsePath(ctx, c, flags, "auto", resourceType, isList, path, params, headers, responsePath, hintWriter)
+}
+
+func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyAndResponsePath(ctx, c, flags, strategy, resourceType, isList, path, params, headers, "", hintWriter)
+}
+
+func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -942,6 +942,24 @@ func rawAtPath(obj map[string]json.RawMessage, path string) (json.RawMessage, bo
 	return nil, false
 }
 
+func applyResponsePath(data json.RawMessage, responsePath string) json.RawMessage {
+	if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
+		return pathData
+	}
+	return data
+}
+
+func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawMessage, bool) {
+	if strings.TrimSpace(responsePath) == "" {
+		return data, false
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, false
+	}
+	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -27,7 +27,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/public/status"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "public", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "public", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/promoted_public.go
@@ -27,7 +27,7 @@ func newPublicPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/public/status"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "public", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "public", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -41,7 +41,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 				"X-Printing-Press-Binary-Response": "true",
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/reports_export_report-year.go
@@ -41,7 +41,7 @@ func newReportsExportReportYearCmd(flags *rootFlags) *cobra.Command {
 				"X-Printing-Press-Binary-Response": "true",
 			}
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "export", false, path, params, headerOverrides, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "export", false, path, params, headerOverrides, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -2130,9 +2130,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -339,7 +339,7 @@ Resource scoping:
 			}
 			if successCount == 0 {
 				if warnCount > 0 && errCount == 0 {
-					return fmt.Errorf("%d resource(s) skipped due to insufficient access", warnCount)
+					return fmt.Errorf("%d resource(s) completed with warnings but no successful syncs", warnCount)
 				}
 				if errCount > 0 {
 					return fmt.Errorf("%d resource(s) failed to sync", errCount)
@@ -753,6 +753,15 @@ func syncResource(ctx context.Context, c interface {
 
 	if !humanFriendly {
 		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+	}
+
+	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
+		return syncResult{
+			Resource: resource,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal),
+			Duration: time.Since(started),
+		}
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
@@ -1847,6 +1856,14 @@ func syncDependentResource(ctx context.Context, c interface {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
 	}
+	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
+		return syncResult{
+			Resource: dep.Name,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			Duration: time.Since(started),
+		}
+	}
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
@@ -1921,7 +1938,7 @@ var resourceIDFieldOverrides = map[string]string{
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
@@ -2030,6 +2047,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 				}
 			}
 		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
 	}
 	return ""
 }
@@ -2095,6 +2120,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -511,7 +511,7 @@ func syncResource(ctx context.Context, c interface {
 				if !humanFriendly {
 					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -1871,7 +1871,7 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
+			Warn:     fmt.Errorf("skipped due to insufficient access: %s (%s on all %d parents)", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1371,9 +1371,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1458,7 +1458,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
 				obj = unwrappedObj
 				item = unwrappedItem
 				id = ExtractResourceID(resourceType, obj)
@@ -1525,10 +1525,11 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	return stored, extractFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
+	candidateKey := ""
 	objectFields := 0
-	for _, value := range obj {
+	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
@@ -1536,13 +1537,18 @@ func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[s
 		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
+			candidateKey = key
 		}
 	}
-	if objectFields != 1 || candidate == nil {
+	if objectFields != 1 || candidate == nil || candidateKey == "" {
 		return nil, nil, false
 	}
-	data, err := json.Marshal(candidate)
-	if err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, nil, false
+	}
+	data, ok := raw[candidateKey]
+	if !ok {
 		return nil, nil, false
 	}
 	return candidate, data, true

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/store/store.go
@@ -1234,7 +1234,7 @@ var resourceIDFieldOverrides = map[string]string{
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
@@ -1283,6 +1283,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
 			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
 				if s := scalarIDString(v); s != "" && s != "<nil>" {
 					return s
 				}
@@ -1353,6 +1361,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {
@@ -1433,6 +1461,13 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+				obj = unwrappedObj
+				item = unwrappedItem
+				id = ExtractResourceID(resourceType, obj)
+			}
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
@@ -1473,9 +1508,12 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		}
 	}
 
-	// Warn when most items in a batch lack an extractable ID — this likely
-	// means the API uses a primary key field we don't recognize yet.
-	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
+	// Warn when every decoded item in a batch lacks an extractable ID — this
+	// likely means the API uses a primary key field we don't recognize yet.
+	// Partial misses still surface through extractFailures so sync can emit
+	// a structured primary_key_unresolved anomaly without spamming stderr for
+	// write-through cache batches that did persist useful rows.
+	if extractFailures > 0 && stored == 0 && len(items) > 0 {
 		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 	// Surface typed-table failures without aborting the batch. Generic rows
@@ -1488,6 +1526,29 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		return 0, extractFailures, err
 	}
 	return stored, extractFailures, nil
+}
+
+func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+	var candidate map[string]any
+	objectFields := 0
+	for _, value := range obj {
+		inner, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		objectFields++
+		if ExtractResourceID(resourceType, inner) != "" {
+			candidate = inner
+		}
+	}
+	if objectFields != 1 || candidate == nil {
+		return nil, nil, false
+	}
+	data, err := json.Marshal(candidate)
+	if err != nil {
+		return nil, nil, false
+	}
+	return candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -501,7 +501,7 @@ func syncResource(ctx context.Context, c interface {
 				if !humanFriendly {
 					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -306,7 +306,7 @@ Resource scoping:
 			}
 			if successCount == 0 {
 				if warnCount > 0 && errCount == 0 {
-					return fmt.Errorf("%d resource(s) skipped due to insufficient access", warnCount)
+					return fmt.Errorf("%d resource(s) completed with warnings but no successful syncs", warnCount)
 				}
 				if errCount > 0 {
 					return fmt.Errorf("%d resource(s) failed to sync", errCount)
@@ -778,6 +778,15 @@ func syncResource(ctx context.Context, c interface {
 
 	if !humanFriendly {
 		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+	}
+
+	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
+		return syncResult{
+			Resource: resource,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal),
+			Duration: time.Since(started),
+		}
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
@@ -1560,7 +1569,7 @@ const (
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
@@ -1683,6 +1692,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 				}
 			}
 		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
 	}
 	return ""
 }
@@ -1748,6 +1765,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -1775,9 +1775,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1313,9 +1313,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1178,7 +1178,7 @@ var resourceIDFieldOverrides = map[string]string{}
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
@@ -1225,6 +1225,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
 			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
 				if s := scalarIDString(v); s != "" && s != "<nil>" {
 					return s
 				}
@@ -1295,6 +1303,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {
@@ -1375,6 +1403,13 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+				obj = unwrappedObj
+				item = unwrappedItem
+				id = ExtractResourceID(resourceType, obj)
+			}
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
@@ -1417,9 +1452,12 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		}
 	}
 
-	// Warn when most items in a batch lack an extractable ID — this likely
-	// means the API uses a primary key field we don't recognize yet.
-	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
+	// Warn when every decoded item in a batch lacks an extractable ID — this
+	// likely means the API uses a primary key field we don't recognize yet.
+	// Partial misses still surface through extractFailures so sync can emit
+	// a structured primary_key_unresolved anomaly without spamming stderr for
+	// write-through cache batches that did persist useful rows.
+	if extractFailures > 0 && stored == 0 && len(items) > 0 {
 		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 	// Surface typed-table failures without aborting the batch. Generic rows
@@ -1432,6 +1470,29 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		return 0, extractFailures, err
 	}
 	return stored, extractFailures, nil
+}
+
+func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+	var candidate map[string]any
+	objectFields := 0
+	for _, value := range obj {
+		inner, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		objectFields++
+		if ExtractResourceID(resourceType, inner) != "" {
+			candidate = inner
+		}
+	}
+	if objectFields != 1 || candidate == nil {
+		return nil, nil, false
+	}
+	data, err := json.Marshal(candidate)
+	if err != nil {
+		return nil, nil, false
+	}
+	return candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/store/store.go
@@ -1400,7 +1400,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
 				obj = unwrappedObj
 				item = unwrappedItem
 				id = ExtractResourceID(resourceType, obj)
@@ -1469,10 +1469,11 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	return stored, extractFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
+	candidateKey := ""
 	objectFields := 0
-	for _, value := range obj {
+	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
@@ -1480,13 +1481,18 @@ func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[s
 		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
+			candidateKey = key
 		}
 	}
-	if objectFields != 1 || candidate == nil {
+	if objectFields != 1 || candidate == nil || candidateKey == "" {
 		return nil, nil, false
 	}
-	data, err := json.Marshal(candidate)
-	if err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, nil, false
+	}
+	data, ok := raw[candidateKey]
+	if !ok {
 		return nil, nil, false
 	}
 	return candidate, data, true

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -27,7 +27,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/games"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "games", true, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "games", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_games.go
@@ -27,7 +27,7 @@ func newGamesPromotedCmd(flags *rootFlags) *cobra.Command {
 
 			path := "/games"
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "games", true, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "games", true, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -41,7 +41,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 			path = replacePathParam(path, "game_key", args[0])
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "leagues", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "leagues", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/promoted_leagues.go
@@ -41,7 +41,7 @@ func newLeaguesPromotedCmd(flags *rootFlags) *cobra.Command {
 			}
 			path = replacePathParam(path, "game_key", args[0])
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "leagues", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "leagues", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -339,7 +339,7 @@ Resource scoping:
 			}
 			if successCount == 0 {
 				if warnCount > 0 && errCount == 0 {
-					return fmt.Errorf("%d resource(s) skipped due to insufficient access", warnCount)
+					return fmt.Errorf("%d resource(s) completed with warnings but no successful syncs", warnCount)
 				}
 				if errCount > 0 {
 					return fmt.Errorf("%d resource(s) failed to sync", errCount)
@@ -753,6 +753,15 @@ func syncResource(ctx context.Context, c interface {
 
 	if !humanFriendly {
 		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+	}
+
+	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
+		return syncResult{
+			Resource: resource,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal),
+			Duration: time.Since(started),
+		}
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
@@ -1832,6 +1841,14 @@ func syncDependentResource(ctx context.Context, c interface {
 			fmt.Fprintf(syncEvents, `{"event":"sync_anomaly","resource":"%s","consumed":%d,"stored":0,"extract_failures":%d,"reason":"stored_count_zero_after_extraction"}`+"\n", dep.Name, depConsumedTotal, depExtractFailureTotal)
 		}
 	}
+	if depConsumedTotal > 0 && totalCount == 0 && depExtractFailureTotal >= depConsumedTotal {
+		return syncResult{
+			Resource: dep.Name,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", dep.Name, depConsumedTotal),
+			Duration: time.Since(started),
+		}
+	}
 
 	// If every parent was access-denied and nothing was synced, surface as a
 	// warning so the run-level summary and exit code reflect insufficient access.
@@ -1905,7 +1922,7 @@ var resourceIDFieldOverrides = map[string]string{
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
@@ -2012,6 +2029,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 				}
 			}
 		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
 	}
 	return ""
 }
@@ -2077,6 +2102,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -511,7 +511,7 @@ func syncResource(ctx context.Context, c interface {
 				if !humanFriendly {
 					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))
@@ -1856,7 +1856,7 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{
 			Resource: dep.Name,
 			Count:    0,
-			Warn:     fmt.Errorf("skipped %s: %s on all %d parents", dep.Name, firstDenial.Reason, len(parentRows)),
+			Warn:     fmt.Errorf("skipped due to insufficient access: %s (%s on all %d parents)", dep.Name, firstDenial.Reason, len(parentRows)),
 			Duration: time.Since(started),
 		}
 	}

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -2112,9 +2112,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1122,7 +1122,7 @@ var resourceIDFieldOverrides = map[string]string{
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // resourceParentKeyColumns identifies generated dependent resources whose
 // local mirror rows need the parent context in the storage key. Without this,
@@ -1171,6 +1171,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 	for _, base := range resourceIDBaseNames(resourceType) {
 		for _, suffix := range []string{"_id", "_code", "_key", "_slug"} {
 			if v, ok := obj[base+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
 				if s := scalarIDString(v); s != "" && s != "<nil>" {
 					return s
 				}
@@ -1241,6 +1249,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {
@@ -1321,6 +1349,13 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+				obj = unwrappedObj
+				item = unwrappedItem
+				id = ExtractResourceID(resourceType, obj)
+			}
+		}
+		if id == "" {
 			skippedCount++
 			extractFailures++
 			continue
@@ -1361,9 +1396,12 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		}
 	}
 
-	// Warn when most items in a batch lack an extractable ID — this likely
-	// means the API uses a primary key field we don't recognize yet.
-	if skippedCount > 0 && len(items) > 0 && skippedCount*2 > len(items) {
+	// Warn when every decoded item in a batch lacks an extractable ID — this
+	// likely means the API uses a primary key field we don't recognize yet.
+	// Partial misses still surface through extractFailures so sync can emit
+	// a structured primary_key_unresolved anomaly without spamming stderr for
+	// write-through cache batches that did persist useful rows.
+	if extractFailures > 0 && stored == 0 && len(items) > 0 {
 		fmt.Fprintf(os.Stderr, "warning: %d/%d %s items returned but not cached locally (no extractable ID field; offline lookup against these rows will be incomplete; live queries unaffected)\n", skippedCount, len(items), resourceType)
 	}
 	// Surface typed-table failures without aborting the batch. Generic rows
@@ -1376,6 +1414,29 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		return 0, extractFailures, err
 	}
 	return stored, extractFailures, nil
+}
+
+func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+	var candidate map[string]any
+	objectFields := 0
+	for _, value := range obj {
+		inner, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		objectFields++
+		if ExtractResourceID(resourceType, inner) != "" {
+			candidate = inner
+		}
+	}
+	if objectFields != 1 || candidate == nil {
+		return nil, nil, false
+	}
+	data, err := json.Marshal(candidate)
+	if err != nil {
+		return nil, nil, false
+	}
+	return candidate, data, true
 }
 
 func (s *Store) SaveSyncState(resourceType, cursor string, count int) error {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1346,7 +1346,7 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 		// spec declares x-resource-id).
 		id := ExtractResourceID(resourceType, obj)
 		if id == "" {
-			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, obj); ok {
+			if unwrappedObj, unwrappedItem, ok := unwrapIDBearingEnvelopeItem(resourceType, item, obj); ok {
 				obj = unwrappedObj
 				item = unwrappedItem
 				id = ExtractResourceID(resourceType, obj)
@@ -1413,10 +1413,11 @@ func (s *Store) UpsertBatch(resourceType string, items []json.RawMessage) (int, 
 	return stored, extractFailures, nil
 }
 
-func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[string]any, json.RawMessage, bool) {
+func unwrapIDBearingEnvelopeItem(resourceType string, item json.RawMessage, obj map[string]any) (map[string]any, json.RawMessage, bool) {
 	var candidate map[string]any
+	candidateKey := ""
 	objectFields := 0
-	for _, value := range obj {
+	for key, value := range obj {
 		inner, ok := value.(map[string]any)
 		if !ok {
 			continue
@@ -1424,13 +1425,18 @@ func unwrapIDBearingEnvelopeItem(resourceType string, obj map[string]any) (map[s
 		objectFields++
 		if ExtractResourceID(resourceType, inner) != "" {
 			candidate = inner
+			candidateKey = key
 		}
 	}
-	if objectFields != 1 || candidate == nil {
+	if objectFields != 1 || candidate == nil || candidateKey == "" {
 		return nil, nil, false
 	}
-	data, err := json.Marshal(candidate)
-	if err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, nil, false
+	}
+	data, ok := raw[candidateKey]
+	if !ok {
 		return nil, nil, false
 	}
 	return candidate, data, true

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/store/store.go
@@ -1259,9 +1259,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -26,7 +26,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 			}
 			c = c.WithTier("enterprise")
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_enterprise.go
@@ -26,7 +26,7 @@ func newItemsEnterpriseCmd(flags *rootFlags) *cobra.Command {
 			}
 			c = c.WithTier("enterprise")
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -26,7 +26,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 			}
 			c = c.WithTier("paid")
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/items_premium.go
@@ -26,7 +26,7 @@ func newItemsPremiumCmd(flags *rootFlags) *cobra.Command {
 			}
 			c = c.WithTier("paid")
 			params := map[string]string{}
-			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, cmd.ErrOrStderr())
+			data, prov, err := resolveReadWithStrategy(cmd.Context(), c, flags, "auto", "items", false, path, params, nil, "", cmd.ErrOrStderr())
 			if err != nil {
 				return classifyAPIError(err, flags)
 			}

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -1690,9 +1690,6 @@ func lowerCamelResourceIDBase(base string) string {
 		return base
 	}
 	for i := range parts {
-		if parts[i] == "" {
-			continue
-		}
 		if i == 0 {
 			parts[i] = strings.ToLower(parts[i])
 			continue

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -478,7 +478,7 @@ func syncResource(ctx context.Context, c interface {
 				if !humanFriendly {
 					fmt.Fprintln(syncEvents, syncWarningJSON(resource, "", w.Status, w.Reason, w.Message))
 				}
-				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped %s: %s", resource, w.Reason), Duration: time.Since(started)}
+				return syncResult{Resource: resource, Count: totalCount, Warn: fmt.Errorf("skipped due to insufficient access: %s (%s)", resource, w.Reason), Duration: time.Since(started)}
 			}
 			if !humanFriendly {
 				fmt.Fprintln(syncEvents, syncErrorJSON(resource, "", err))

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -306,7 +306,7 @@ Resource scoping:
 			}
 			if successCount == 0 {
 				if warnCount > 0 && errCount == 0 {
-					return fmt.Errorf("%d resource(s) skipped due to insufficient access", warnCount)
+					return fmt.Errorf("%d resource(s) completed with warnings but no successful syncs", warnCount)
 				}
 				if errCount > 0 {
 					return fmt.Errorf("%d resource(s) failed to sync", errCount)
@@ -720,6 +720,15 @@ func syncResource(ctx context.Context, c interface {
 
 	if !humanFriendly {
 		fmt.Fprintf(syncEvents, `{"event":"sync_complete","resource":"%s","total":%d,"duration_ms":%d}`+"\n", resource, totalCount, time.Since(started).Milliseconds())
+	}
+
+	if consumedTotal > 0 && totalCount == 0 && extractFailureTotal >= consumedTotal {
+		return syncResult{
+			Resource: resource,
+			Count:    0,
+			Warn:     fmt.Errorf("%s consumed %d items but stored 0 because no item had an extractable primary key", resource, consumedTotal),
+			Duration: time.Since(started),
+		}
 	}
 
 	return syncResult{Resource: resource, Count: totalCount, Duration: time.Since(started)}
@@ -1491,7 +1500,7 @@ var resourceIDFieldOverrides = map[string]string{}
 // identifier names (gid, sid, uid, uuid, guid) take precedence over `name`
 // so APIs like Asana (gid) and Twilio (sid) don't fall through to a display
 // field and upsert on names — see #1394.
-var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "name", "slug", "key", "code"}
+var genericIDFieldFallbacks = []string{"id", "ID", "gid", "sid", "uid", "uuid", "guid", "api_id", "name", "slug", "key", "code"}
 
 // pageItemKeys is scanned in priority order; lowercase REST-convention keys
 // come first, PascalCase .NET variants second. Without the PascalCase row,
@@ -1598,6 +1607,14 @@ func suffixIDFieldFallback(resourceType string, obj map[string]any) string {
 				}
 			}
 		}
+		camelBase := lowerCamelResourceIDBase(base)
+		for _, suffix := range []string{"Id", "Code", "Key", "Slug"} {
+			if v, ok := obj[camelBase+suffix]; ok {
+				if s := scalarIDString(v); s != "" && s != "<nil>" {
+					return s
+				}
+			}
+		}
 	}
 	return ""
 }
@@ -1663,6 +1680,26 @@ func depluralizeResourceStem(r string) string {
 		return strings.TrimSuffix(r, "s") // languages -> language, cases -> case
 	}
 	return r
+}
+
+func lowerCamelResourceIDBase(base string) string {
+	parts := strings.FieldsFunc(base, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	if len(parts) == 0 {
+		return base
+	}
+	for i := range parts {
+		if parts[i] == "" {
+			continue
+		}
+		if i == 0 {
+			parts[i] = strings.ToLower(parts[i])
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + strings.ToLower(parts[i][1:])
+	}
+	return strings.Join(parts, "")
 }
 
 func scalarIDString(value any) string {


### PR DESCRIPTION
## Summary
- applies `response_path` before command output and opportunistic write-through cache/store ingestion for read commands
- hardens generated store/sync ID extraction with `api_id`, scoped lower-camel suffix fallbacks, and safe single-object envelope unwrapping
- makes all-items primary-key extraction failures surface as warnings instead of silent successful syncs, while reducing noisy partial write-through warnings

## Fixed Issues
Fixes #3295
Fixes #2896
Fixes #2904
Fixes #3013
Fixes #2591
Fixes #2921

## Validation
- `go test ./internal/generator -run 'TestGeneratedSyncIDFieldOverridesAndProbes|TestGeneratedReadCommandAppliesResponsePathToOutputAndWriteThrough|TestWriteThroughCacheEnvelopeExtractionParity|TestGenerateStoreUpsertBatchWarningUsesNotCachedLocallyWording|TestGeneratedGraphQLImportIsNotREST|TestGenerateWithNoAuth' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodProcessRetriesTransientAuth401|TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap|TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged' -count=1 -v`
- `go test ./internal/pipeline -run 'TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap|TestLiveDogfoodHappyArgsHonorsPPHappyArgs' -count=1 -v`
- `go test ./internal/generator -run '^TestGenerateWithNoAuth$' -count=1 -v`

Notes:
- `go test ./...` was run twice. After fixing a real generated GraphQL compile gap, both full runs still failed only in unrelated live-dogfood timing/process tests under concurrent package execution; the named failures passed when rerun directly.
- `go test -p 1 ./...` avoided the pipeline timing failures, but `internal/generator` hit an intermittent generated CLI `govulncheck ./...` validation failure; `TestGenerateWithNoAuth` passed immediately afterward, including `PASS govulncheck ./...`.

## Deferred
- No selected issue intentionally deferred. Full composite-key support from #1349 remains out of scope for #3295; this PR only adds diagnostics/safety nets in the response/store ID extraction lane.
