### PR TITLE
fix(cli): preserve implemented novel command scaffolds

### DIFF
--- a/internal/cli/printing_press_skill_test.go
+++ b/internal/cli/printing_press_skill_test.go
@@ -45,7 +45,7 @@ func TestPrintingPressSkillTranscendenceCollectorSliceInit(t *testing.T) {
 	require.NoError(t, err)
 
 	content := string(data)
-	require.Contains(t, content, "results := make([]yourRowType, 0)")
+	require.Contains(t, content, "results := make([]yourRowType, 0, len(rawRows))")
 	require.Contains(t, content, "empty marshals")
 	require.NotContains(t, content, "var results []yourRowType")
 

--- a/internal/generator/templates/novel_feature_command.go.tmpl
+++ b/internal/generator/templates/novel_feature_command.go.tmpl
@@ -1,5 +1,6 @@
 // Copyright {{currentYear}} {{copyrightHolder}}. Licensed under Apache-2.0. See LICENSE.
-// Novel command scaffold. Implement the RunE body; generate --force preserves this file.
+// Novel command scaffold. Implement the RunE body before shipping.
+// generate --force preserves implemented bodies; untouched TODO scaffolds may refresh.
 
 package cli
 

--- a/internal/pipeline/regenmerge/merge_into_fresh.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh.go
@@ -90,7 +90,7 @@ func MergeIntoFreshTree(snapshotDir, freshDir string, report *MergeReport, opts 
 			}
 			fc.Applied = true
 		case VerdictTemplatedWithAdditions, VerdictTemplatedBodyDrift, VerdictTemplatedValueDrift:
-			if opts.NovelOnly && !preserveTemplatedDriftInNovelOnly(freshDir, fc.Path) {
+			if opts.NovelOnly && !preserveTemplatedDriftInNovelOnly(snapshotDir, freshDir, fc.Path) {
 				continue
 			}
 			if err := copyPreserveFile(snapshotDir, freshDir, fc.Path); err != nil {
@@ -669,12 +669,13 @@ func pruneCollidingSpec(spec ast.Spec, collisions declSet) (ast.Spec, bool) {
 	return spec, false
 }
 
-func preserveTemplatedDriftInNovelOnly(freshDir, rel string) bool {
+func preserveTemplatedDriftInNovelOnly(snapshotDir, freshDir, rel string) bool {
 	rel = filepath.ToSlash(rel)
 	if _, ok := novelOnlyEditableHookPaths[rel]; ok {
 		return true
 	}
-	return isNovelCommandScaffoldTest(freshDir, rel)
+	return isNovelCommandScaffoldTest(freshDir, rel) ||
+		isHandAuthoredNovelCommandScaffold(snapshotDir, freshDir, rel)
 }
 
 // novelOnlyEditableHookPaths lists generator-emitted files whose intended
@@ -684,7 +685,32 @@ var novelOnlyEditableHookPaths = map[string]struct{}{
 	"internal/store/extras.go": {},
 }
 
+const novelCommandScaffoldMarker = "Novel command scaffold"
+const novelCommandScaffoldTODO = "TODO: implement novel feature"
 const novelCommandScaffoldTestMarker = "cli-printing-press: novel-scaffold-test"
+
+func isHandAuthoredNovelCommandScaffold(snapshotDir, freshDir, rel string) bool {
+	if !strings.HasPrefix(rel, "internal/cli/") || !strings.HasSuffix(rel, ".go") || strings.HasSuffix(rel, "_test.go") {
+		return false
+	}
+	snapshotPath := filepath.Join(snapshotDir, rel)
+	freshPath := filepath.Join(freshDir, rel)
+	freshData, err := os.ReadFile(freshPath)
+	if err != nil {
+		return false
+	}
+	if hasGeneratedMarkerBytes(freshData) || !bytes.Contains(freshData, []byte(novelCommandScaffoldMarker)) {
+		return false
+	}
+	snapshotData, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		return false
+	}
+	if bytes.Contains(snapshotData, []byte(novelCommandScaffoldTODO)) {
+		return false
+	}
+	return !bytes.Equal(snapshotData, freshData)
+}
 
 func isNovelCommandScaffoldTest(freshDir, rel string) bool {
 	if !strings.HasPrefix(rel, "internal/cli/") || !strings.HasSuffix(rel, "_test.go") {

--- a/internal/pipeline/regenmerge/merge_into_fresh_test.go
+++ b/internal/pipeline/regenmerge/merge_into_fresh_test.go
@@ -678,6 +678,139 @@ func TestNovelCallHelpWires(t *testing.T) {}
 		"NovelOnly force-regen must preserve hand-authored tests replacing a markerless novel command scaffold")
 }
 
+func TestMergeIntoFreshTreeNovelOnlyPreservesHandAuthoredNovelCommandBody(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	rel := "internal/cli/call.go"
+	require.NoError(t, os.MkdirAll(filepath.Join(snap, "internal", "cli"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snap, rel), []byte(`// Copyright 2026 owner. Licensed under Apache-2.0. See LICENSE.
+// Novel command scaffold. Implement the RunE body; generate --force preserves this file.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNovelCallCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "call",
+		Short: "Call an actor.",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), "implemented")
+			return nil
+		},
+	}
+	return cmd
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), []byte(`// Copyright 2026 owner. Licensed under Apache-2.0. See LICENSE.
+// Novel command scaffold. Implement the RunE body; generate --force preserves this file.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNovelCallCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "call",
+		Short: "Call an actor.",
+		Annotations: map[string]string{"mcp:read-only": "true"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRunOK(flags) {
+				return nil
+			}
+			return fmt.Errorf("TODO: implement novel feature %q", "call")
+		},
+	}
+	return cmd
+}
+`), 0o644))
+
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true, NovelOnly: true}))
+
+	got, err := os.ReadFile(filepath.Join(fresh, rel))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), `"implemented"`,
+		"NovelOnly force-regen must preserve a hand-authored novel command body")
+	assert.NotContains(t, string(got), "TODO: implement novel feature",
+		"NovelOnly force-regen must not overwrite an implementation with the scaffold")
+}
+
+func TestMergeIntoFreshTreeNovelOnlyRefreshesUntouchedNovelCommandScaffold(t *testing.T) {
+	t.Parallel()
+
+	snap, fresh := makeMergeFixture(t)
+	rel := "internal/cli/call.go"
+	require.NoError(t, os.MkdirAll(filepath.Join(snap, "internal", "cli"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snap, rel), []byte(`// Copyright 2026 owner. Licensed under Apache-2.0. See LICENSE.
+// Novel command scaffold. Implement the RunE body; generate --force preserves this file.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNovelCallCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "call",
+		Short: "Old scaffold text.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("TODO: implement novel feature %q", "call")
+		},
+	}
+	return cmd
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, rel), []byte(`// Copyright 2026 owner. Licensed under Apache-2.0. See LICENSE.
+// Novel command scaffold. Implement the RunE body; generate --force preserves this file.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNovelCallCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "call",
+		Short: "Fresh scaffold text.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("TODO: implement novel feature %q", "call")
+		},
+	}
+	return cmd
+}
+`), 0o644))
+
+	report, err := Classify(snap, fresh, Options{Force: true})
+	require.NoError(t, err)
+	require.NoError(t, MergeIntoFreshTree(snap, fresh, report, Options{Force: true, NovelOnly: true}))
+
+	got, err := os.ReadFile(filepath.Join(fresh, rel))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "Fresh scaffold text.",
+		"NovelOnly force-regen should keep fresh output for untouched scaffolds")
+	assert.NotContains(t, string(got), "Old scaffold text.")
+}
+
 func TestMergeIntoFreshTreeNovelOnlyDoesNotPreserveOrdinaryGeneratedTestDrift(t *testing.T) {
 	t.Parallel()
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3584,6 +3584,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 
 The generic `resources` table is keyed by `resource_type`. Flat resources synced from `/<resource>` land as `resource_type='<resource>'`. **Hierarchical resources** synced from `/<parents>/{id}/<resource>` land as `resource_type='<parent>_<resource>'` — e.g., `projects_tasks` (Asana), `repos_issues` / `repos_pulls` (GitHub) — *not* the bare `<resource>` name. A novel feature that filters by the bare name returns zero rows against a real DB. Use `IN (...)` to catch both shapes so the same code works whether the API exposes the resource flat or only parent-scoped.
 
+SQLite store queries must use a **drain-first** pattern. SQLite uses a single connection by default, so never issue another query while a `*sql.Rows` is open. If the command needs follow-up lookups, parent-to-child expansion, or ID-to-name/email resolution, scan the first result set into plain structs/slices, check `rows.Err()`, close `rows`, and only then run follow-up `QueryContext` / `QueryRowContext` calls.
+
 ```go
 // Declare these alongside the cmd literal, before return cmd:
 //   var dbPath string
@@ -3631,14 +3633,34 @@ RunE: func(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("query: %w", err)
 	}
-	defer rows.Close()
 	// Scan each row. id/data on the resources table are NOT NULL so bare
 	// strings are safe; ANY optional field selected via json_extract or
 	// pulled from a typed FTS/upsert table can be NULL — use sql.Null*
 	// scan targets (or COALESCE in the SQL) for those, see the NULL-safe
 	// scans paragraph below.
-	results := make([]yourRowType, 0) // scan rows into this slice; make([]T, 0) keeps empty JSON as [] not null
-	// (loop over rows here: results = append(results, scannedRow))
+	rawRows := make([]yourRawRowType, 0) // make([]T, 0) keeps empty JSON as [] not null
+	for rows.Next() {
+		var row yourRawRowType
+		// Scan only columns from this result set here. Do NOT query again
+		// inside this loop; drain and close rows first.
+		if err := rows.Scan(&row.ID, &row.Data); err != nil {
+			return fmt.Errorf("scan row: %w", err)
+		}
+		rawRows = append(rawRows, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close rows: %w", err)
+	}
+	results := make([]yourRowType, 0, len(rawRows))
+	for _, raw := range rawRows {
+		// Follow-up queries are safe here because the parent *sql.Rows is closed.
+		// Resolve IDs, expand child rows, or perform local joins, then append.
+		_ = raw
+	}
 	if flags.asJSON || (!isTerminal(cmd.OutOrStdout()) && !humanFriendly) {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -3652,6 +3674,8 @@ RunE: func(cmd *cobra.Command, args []string) error {
 For flat-only resources, the typed FTS/upsert tables the generator emits (e.g., `tasks_fts`, `projects`) work too — `SELECT id, data FROM <typed-table>` is the fast path. The `IN (...)` pattern above is the safe default whenever the resource may be hierarchical; `cli-printing-press dogfood --json` shows the actual `resource_type` distribution so you can confirm without running raw SQL.
 
 For features that combine both (cache an API response in the store, or fall through to live when the local store is stale), nest one skeleton inside the other and use the `--data-source auto/local/live` flag pattern from the generated `sync` command.
+
+**Store write transaction guardrail:** `store.Upsert` and `store.UpsertBatch` open their own write transaction. Do not call them from inside an open `db.DB().BeginTx` / `tx.Prepare` / `tx.Exec` write transaction; SQLite WAL permits only one writer and the nested write can busy-wait, fail, or corrupt the outer statement state. If a novel command writes both custom tables and `resources`, either use transaction-scoped helpers that operate on the same `*sql.Tx`, or commit/rollback the custom-table transaction before calling `store.Upsert` / `store.UpsertBatch`. Never discard these errors with `_`; a busy-timeout is data loss.
 
 **Shared helpers available to novel code:** The generator emits `internal/cliutil/` in every CLI. When authoring novel commands, prefer `cliutil.FanoutRun` for any aggregation command (any `--site`/`--source`/`--region` CSV fan-out) and `cliutil.CleanText` for any text extracted from HTML or schema.org JSON-LD. Re-implementing these inline is how recipe-goat's trending silent-drop and `&#39;` entity bugs shipped.
 
@@ -3695,7 +3719,7 @@ For an extension to be durable, put it in its own file beside the emitted one:
 - **Custom request headers** (vendor fingerprint, `X-CSRF`, app-version, signed timestamps): create `internal/client/<api>_headers.go` exporting a func that builds the header map; novel code passes that map to `client.GetWithHeaders` / `PostWithHeaders` when it calls the API. The generated `client.go` has no global request mutator, so this pattern only covers requests made directly from novel code — it does not intercept calls from generated endpoint commands. Do not edit the templated header block in `client.go`.
 - **Custom auth flow** (browser-sniffed sessions, vendor SSO, refresh hooks beyond OAuth2): create `internal/cli/<api>_auth.go` (package `cli`, same as the generated `auth.go`) with the API-specific token capture or refresh, and wire it from a novel command rather than editing the templated `auth.go` constructor functions (`newAuthLoginCmd`, `newAuthSetupCmd`, etc.). If the custom flow implements OAuth2 Authorization Code + PKCE, read [references/oauth2-pkce-cli-checklist.md](references/oauth2-pkce-cli-checklist.md) before writing or reviewing the command.
 - **Extended store schema** (typed tables beyond `resources`, vendor JSON columns, full-text indexes): create `internal/store/<api>_migrations.go` running its own `CREATE TABLE ... IF NOT EXISTS` from a lazy init invoked by the novel commands that need it. Do not edit the migration slice in `store.go`.
-- **New novel command:** put the command body in its own `internal/cli/<feature>.go` file — it survives regen as a whole hand-authored unit. The `AddCommand` call wiring it into the Cobra tree still goes in `root.go` per the Phase 3 novel-command skeleton above; `cli-printing-press generate --force` re-injects it via the lost-registration merge path. Use standalone `regen-merge` when you want to inspect the merge report before applying. Spec-declared commands are picked up by the generator's typed-tool path and need no hand-wired `AddCommand` at all.
+- **New novel command:** put the command body in its own `internal/cli/<feature>.go` file. Generated TODO scaffolds may refresh on `generate --force`; once you replace the TODO body with a real implementation, regen preserves that hand-authored file instead of re-emitting the scaffold. The `AddCommand` call wiring it into the Cobra tree still goes in `root.go` per the Phase 3 novel-command skeleton above; `cli-printing-press generate --force` re-injects it via the lost-registration merge path. Use standalone `regen-merge` when you want to inspect the merge report before applying. Spec-declared commands are picked up by the generator's typed-tool path and need no hand-wired `AddCommand` at all.
 
 If an extension genuinely cannot live in a separate file (a `case` branch in a templated method switch, an inline modification to a generated handler with no registry hook), file a generator issue requesting the hook rather than depending on repeated conflict-prone merges. The `AddCommand` case above is covered by the merge path.
 

--- a/skills/printing-press/SKILL.md
+++ b/skills/printing-press/SKILL.md
@@ -3644,6 +3644,7 @@ RunE: func(cmd *cobra.Command, args []string) error {
 		// Scan only columns from this result set here. Do NOT query again
 		// inside this loop; drain and close rows first.
 		if err := rows.Scan(&row.ID, &row.Data); err != nil {
+			_ = rows.Close()
 			return fmt.Errorf("scan row: %w", err)
 		}
 		rawRows = append(rawRows, row)

--- a/skills/printing-press/references/novel-features-subagent.md
+++ b/skills/printing-press/references/novel-features-subagent.md
@@ -226,6 +226,22 @@ Use `""` for commands that scan all local resources. The helpers write only to
 stderr, so JSON/stdout output stays stable; `--max-age 0` disables stale-read
 hints.
 
+Local-store query plans must also call out SQLite's open-rows constraint. SQLite
+uses a single connection by default, so a command must not issue a follow-up
+`QueryContext` or `QueryRowContext` while iterating a parent `*sql.Rows`. Plan
+store-query features with the drain-first pattern: scan the first result set
+into plain structs/slices, check `rows.Err()`, close `rows`, then run any
+ID-to-name resolution, parent-to-child expansion, or local join follow-up
+queries.
+
+For local-store write features, do not plan a `store.Upsert` or
+`store.UpsertBatch` call inside an open `db.DB().BeginTx` write transaction.
+Those helpers begin their own write transaction, and SQLite WAL only permits one
+writer. Either use helpers that write through the same `*sql.Tx`, or commit the
+custom-table transaction before calling the pooled store upsert helpers. Treat
+upsert errors as command failures; discarding them can silently drop cached
+resources after a busy timeout.
+
 Every hand-written novel command must also declare its data-source strategy in
 the command source file:
 


### PR DESCRIPTION
## Summary

Novel command implementations now survive force regeneration once the TODO scaffold body has been replaced, while untouched TODO scaffolds can still refresh from the latest template. This closes the code-loss path where `generate --force` could silently replace a hand-authored RunE with the generated TODO body.

The Printing Press skill guidance now steers novel/store work away from two SQLite hazards seen in recent printed CLIs: commands must drain and close `*sql.Rows` before follow-up local-store queries, and custom-table write transactions must not call `store.Upsert` / `store.UpsertBatch` before the outer transaction has committed.

Closes mvanhorn/cli-printing-press#3304.
Closes mvanhorn/cli-printing-press#3305.
Closes mvanhorn/cli-printing-press#3166.

## Validation

- `go test ./internal/pipeline/regenmerge`
- `go test ./internal/generator -run 'TestGeneratorEmitsNovelFeatureCommandStubs|TestGeneratorSanitizesNovelFeatureCommandStubFilenames|TestGeneratorMigratesLegacyNovelFeatureBuildTagFilenames|TestGeneratorOmitsExampleWhenNovelFeatureHasNoExample|TestGeneratorEmitsBoundCtxHelperForNovelCommands'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`
- `git diff --check`

Known validation residual: `go test ./...` was attempted twice. Both runs failed only in `internal/pipeline` live-dogfood tests, with different failing tests each time. The first failing test, `TestLiveDogfoodHappyArgsHonorsPPHappyArgs`, passed with `go test ./internal/pipeline -run TestLiveDogfoodHappyArgsHonorsPPHappyArgs -count=1 -v`; the second, `TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged`, passed with `go test ./internal/pipeline -run TestResolveCommandPositionalsMixedStoreAndCompanionSourceIsUntagged -count=1 -v`.

## Post-Deploy Monitoring & Validation

No additional production monitoring required. This affects generator merge behavior and authoring guidance, so validation is covered by regenmerge regression tests, generator-output verification, and golden verification.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
