### PR TITLE
fix(cli): harden scorer verify gates

### DIFF
--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -703,9 +703,7 @@ func resolveCommandPositionals(command liveDogfoodCommand, happyArgs []string, a
 		// where the prefix has at least one character (len > 2). Broader than
 		// generator.go exampleValue's predicate — no spec type info is available
 		// from CLI help text, so the string-type fence applied there is omitted.
-		isIDShape := nameLower == "id" ||
-			(strings.HasSuffix(nameLower, "id") && len(nameLower) > 2)
-		if !isIDShape {
+		if !isIDShapePlaceholderName(nameLower) {
 			return nil, true, fmt.Sprintf("non-id positional %q at depth %d", name, i), ""
 		}
 

--- a/internal/pipeline/runtime.go
+++ b/internal/pipeline/runtime.go
@@ -618,6 +618,9 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 		if !cliHasSyncCommand(cliDir) {
 			return true, "SKIP (CLI has no sync command)"
 		}
+		if !cliHasLocalStore(cliDir) {
+			return true, "SKIP (CLI has no local store)"
+		}
 	}
 
 	env := envFn()
@@ -681,6 +684,9 @@ func runDataPipelineTest(binary, cliDir, mode string, envFn func() []string, exp
 		// No domain tables found — ambiguous (could be minimal CLI or unusual naming).
 		// Don't fail the pipeline gate; report for human review.
 		return true, "WARN: sync completed but no domain tables found in sqlite_master"
+	}
+	if mode == "mock" && strings.TrimSpace(cliDir) != "" && !cliHasSyncableResources(cliDir) {
+		return true, fmt.Sprintf("PASS: %d domain tables created (mock mode; no syncable resources declared)", len(tables))
 	}
 
 	var bestShortTable string
@@ -773,6 +779,16 @@ func unknownSyncFlag(err error) (string, bool) {
 
 func cliHasSyncCommand(cliDir string) bool {
 	return hasRegisteredCommandFileWithPrefix(filepath.Join(cliDir, "internal", "cli"), "sync")
+}
+
+func cliHasLocalStore(cliDir string) bool {
+	return fileExists(filepath.Join(cliDir, "internal", "store", "store.go"))
+}
+
+func cliHasSyncableResources(cliDir string) bool {
+	content := readAllGoFiles(filepath.Join(cliDir, "internal", "cli"))
+	content += readAllGoFiles(filepath.Join(cliDir, "internal", "store"))
+	return hasNonEmptySyncResources(content)
 }
 
 func isAuxiliaryPipelineTable(table string, totalTables int) bool {

--- a/internal/pipeline/runtime_commands.go
+++ b/internal/pipeline/runtime_commands.go
@@ -321,9 +321,6 @@ func chooseUsagePlaceholderName(raw string) string {
 			return name
 		}
 	}
-	if len(parts) == 0 {
-		return strings.ToLower(strings.TrimSpace(raw))
-	}
 	return strings.ToLower(strings.TrimSpace(parts[0]))
 }
 

--- a/internal/pipeline/runtime_commands.go
+++ b/internal/pipeline/runtime_commands.go
@@ -284,8 +284,10 @@ func resolvePositionalValue(name string, paramDefaults map[string]string) string
 var flagDescriptorRe = regexp.MustCompile(`\[\s*-+[^\]]*\]|\[[^\]]*=[^\]]*\]`)
 
 // positionalPlaceholderRe extracts <name> and [name] placeholders from the
-// scrubbed Usage suffix. Runs after flagDescriptorRe.
-var positionalPlaceholderRe = regexp.MustCompile(`[<\[]([a-zA-Z][\w-]*)[>\]]`)
+// scrubbed Usage suffix. Pipe alternatives such as <id|uuid> are one Cobra
+// positional; they resolve to the first id-shaped alternative when present.
+// Runs after flagDescriptorRe.
+var positionalPlaceholderRe = regexp.MustCompile(`[<\[]([a-zA-Z][\w-]*(?:\|[a-zA-Z][\w-]*)*)[>\]]`)
 
 // extractPositionalPlaceholders returns the placeholder names found in a
 // cobra Usage suffix (the part after `Usage:\n  cli-name cmd-name`).
@@ -302,13 +304,31 @@ func extractPositionalPlaceholders(usageSuffix string) []string {
 	}
 	var names []string
 	for _, match := range matches {
-		name := strings.ToLower(match[1])
+		name := chooseUsagePlaceholderName(match[1])
 		if name == "flags" || name == "command" {
 			continue
 		}
 		names = append(names, name)
 	}
 	return names
+}
+
+func chooseUsagePlaceholderName(raw string) string {
+	parts := strings.Split(raw, "|")
+	for _, part := range parts {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if isIDShapePlaceholderName(name) {
+			return name
+		}
+	}
+	if len(parts) == 0 {
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+	return strings.ToLower(strings.TrimSpace(parts[0]))
+}
+
+func isIDShapePlaceholderName(name string) bool {
+	return name == "id" || (strings.HasSuffix(name, "id") && len(name) > 2)
 }
 
 func syntheticArgValue(name string) string {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -250,6 +250,17 @@ func TestRunDataPipelineTestMockModeRequiresRows(t *testing.T) {
 		assert.Equal(t, "FAIL: sync rejected flag --full", detail)
 	})
 
+	t.Run("skips no-store CLIs whose sync command is not the data pipeline", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "browser-sniff"}))
+		binary := buildUnknownFlagSyncDataPipelineProbeBinary(t)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "SKIP (CLI has no local store)", detail)
+	})
+
 	t.Run("passes when an auxiliary table is empty before populated data table", func(t *testing.T) {
 		binary := buildAuxiliaryFirstDataPipelineProbeBinary(t, 0, 2)
 
@@ -329,12 +340,37 @@ func TestRunDataPipelineTestSkipsUnsyncableCLIs(t *testing.T) {
 	t.Run("runs normal sync CLIs", func(t *testing.T) {
 		dir := seedDataPipelineCLIDir(t, true)
 		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))
+		seedDataPipelineStore(t, dir, true)
 		binary := buildDataPipelineProbeBinary(t, 2)
 
 		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
 
 		assert.True(t, pass)
 		assert.Contains(t, detail, "items has 2 rows")
+	})
+
+	t.Run("mock mode skips row requirement for stores without syncable resources", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "browser-sniff"}))
+		seedDataPipelineStore(t, dir, false)
+		binary := buildDataPipelineProbeBinary(t, 0)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.True(t, pass)
+		assert.Equal(t, "PASS: 1 domain tables created (mock mode; no syncable resources declared)", detail)
+	})
+
+	t.Run("mock mode still fails zero rows when syncable resources exist", func(t *testing.T) {
+		dir := seedDataPipelineCLIDir(t, true)
+		require.NoError(t, WriteCLIManifest(dir, CLIManifest{SpecFormat: "openapi3"}))
+		seedDataPipelineStore(t, dir, true)
+		binary := buildDataPipelineProbeBinary(t, 0)
+
+		pass, detail := runDataPipelineTest(binary, dir, "mock", os.Environ, 2)
+
+		assert.False(t, pass)
+		assert.Contains(t, detail, "1 domain tables created but 0 rows after sync")
 	})
 }
 
@@ -881,6 +917,31 @@ func newItemsCmd(flags any) {}
 	return dir
 }
 
+func seedDataPipelineStore(t *testing.T, dir string, syncableResources bool) {
+	t.Helper()
+
+	storeDir := filepath.Join(dir, "internal", "store")
+	require.NoError(t, os.MkdirAll(storeDir, 0o755))
+	content := `package store
+
+func Open() {}
+`
+	if syncableResources {
+		content += `
+func defaultSyncResources() []string {
+	return []string{"items"}
+}
+`
+	} else {
+		content += `
+func defaultSyncResources() []string {
+	return []string{}
+}
+`
+	}
+	writeTestFile(t, filepath.Join(storeDir, "store.go"), content)
+}
+
 func buildAuxiliaryFirstDataPipelineProbeBinary(t *testing.T, settingsRows, itemRows int) string {
 	t.Helper()
 
@@ -1230,6 +1291,16 @@ func TestExtractPositionalPlaceholders(t *testing.T) {
 			name:  "lowercases names",
 			usage: " <Region> [flags]",
 			want:  []string{"region"},
+		},
+		{
+			name:  "pipe alternative chooses first id-shaped option",
+			usage: " <name|id|uuid> [flags]",
+			want:  []string{"id"},
+		},
+		{
+			name:  "pipe alternative falls back to first option",
+			usage: " <query|text> [flags]",
+			want:  []string{"query"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -111,6 +111,7 @@ const (
 	DimAuthProtocol          = "auth_protocol"
 	DimSyncCorrectness       = "sync_correctness"
 	DimTypeFidelity          = "type_fidelity"
+	DimDeadCode              = "dead_code"
 	DimLiveAPIVerification   = "live_api_verification"
 	// HTTP-API-shaped dimensions that do not apply to a BLE device CLI (no remote
 	// API, no sync->sql->search pipeline, no response cache). Marked N/A for
@@ -1390,7 +1391,7 @@ func scorecardTierMax(sc *Scorecard, base int, optionalDimensions ...string) int
 }
 
 func scorecardDimensionMax(name string) int {
-	if name == DimTypeFidelity || name == "dead_code" {
+	if name == DimTypeFidelity || name == DimDeadCode {
 		return 5
 	}
 	return 10
@@ -3707,14 +3708,14 @@ func buildGapReport(s SteinerScore, unscored []string) []string {
 		{"data_pipeline_integrity", s.DataPipelineIntegrity},
 		{"sync_correctness", s.SyncCorrectness},
 		{"type_fidelity", s.TypeFidelity},
-		{"dead_code", s.DeadCode},
+		{DimDeadCode, s.DeadCode},
 	}
 	for _, d := range dimensions {
 		if _, skip := unscoredSet[d.name]; skip {
 			continue
 		}
 		max := 10
-		if d.name == DimTypeFidelity || d.name == "dead_code" {
+		if d.name == DimTypeFidelity || d.name == DimDeadCode {
 			max = 5
 		}
 		if d.score < max/2 {

--- a/internal/pipeline/scorecard.go
+++ b/internal/pipeline/scorecard.go
@@ -110,6 +110,7 @@ const (
 	DimPathValidity          = "path_validity"
 	DimAuthProtocol          = "auth_protocol"
 	DimSyncCorrectness       = "sync_correctness"
+	DimTypeFidelity          = "type_fidelity"
 	DimLiveAPIVerification   = "live_api_verification"
 	// HTTP-API-shaped dimensions that do not apply to a BLE device CLI (no remote
 	// API, no sync->sql->search pipeline, no response cache). Marked N/A for
@@ -277,6 +278,8 @@ func scoreDomainDimensions(sc *Scorecard, outputDir string, spec *openAPISpecInf
 		// BLE device CLIs have no sync->sql->search data pipeline; the HTTP-shaped
 		// pipeline and sync checks don't apply. Mark N/A rather than scoring 0.
 		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimDataPipelineIntegrity, DimSyncCorrectness)
+	} else if !hasScorecardLocalStore(outputDir) {
+		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimDataPipelineIntegrity, DimSyncCorrectness)
 	} else {
 		sc.Steinberger.DataPipelineIntegrity = scoreDataPipelineIntegrity(outputDir)
 		if isLocalDatastoreCLIDir(outputDir) {
@@ -287,6 +290,8 @@ func scoreDomainDimensions(sc *Scorecard, outputDir string, spec *openAPISpecInf
 	}
 	if isDevice {
 		sc.Steinberger.TypeFidelity = scoreTypeFidelityDevice(outputDir)
+	} else if !hasScorecardLocalStore(outputDir) {
+		sc.UnscoredDimensions = append(sc.UnscoredDimensions, DimTypeFidelity)
 	} else {
 		sc.Steinberger.TypeFidelity = scoreTypeFidelity(outputDir, spec)
 	}
@@ -1358,7 +1363,7 @@ func recomputeScorecardTotals(sc *Scorecard) {
 		sc.Steinberger.LiveAPIVerification,
 	)
 
-	tier2Max := scorecardTierMax(sc, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol, DimSyncCorrectness, DimDataPipelineIntegrity)
+	tier2Max := scorecardTierMax(sc, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol, DimSyncCorrectness, DimDataPipelineIntegrity, DimTypeFidelity)
 	tier2Normalized := 0
 	if tier2Max > 0 {
 		tier2Normalized = (tier2Raw * 50) / tier2Max
@@ -1378,10 +1383,21 @@ func scorecardTierMax(sc *Scorecard, base int, optionalDimensions ...string) int
 	max := base
 	for _, name := range optionalDimensions {
 		if sc.IsDimensionUnscored(name) {
-			max -= 10
+			max -= scorecardDimensionMax(name)
 		}
 	}
 	return max
+}
+
+func scorecardDimensionMax(name string) int {
+	if name == DimTypeFidelity || name == "dead_code" {
+		return 5
+	}
+	return 10
+}
+
+func hasScorecardLocalStore(dir string) bool {
+	return fileExists(filepath.Join(dir, "internal", "store", "store.go"))
 }
 
 func scoreBreadth(dir string) int {
@@ -3698,7 +3714,7 @@ func buildGapReport(s SteinerScore, unscored []string) []string {
 			continue
 		}
 		max := 10
-		if d.name == "type_fidelity" || d.name == "dead_code" {
+		if d.name == DimTypeFidelity || d.name == "dead_code" {
 			max = 5
 		}
 		if d.score < max/2 {
@@ -3838,6 +3854,10 @@ func writeScorecardMD(sc *Scorecard, pipelineDir string) error {
 		{"Dead Code", s.DeadCode},
 	}
 	for _, d := range typeDimensions {
+		if sc.IsDimensionUnscored(strings.ToLower(strings.ReplaceAll(d.name, " ", "_"))) {
+			fmt.Fprintf(&b, "| %s | N/A |\n", d.name)
+			continue
+		}
 		bar := strings.Repeat("#", d.score) + strings.Repeat(".", 5-d.score)
 		fmt.Fprintf(&b, "| %s | %d/5 %s |\n", d.name, d.score, bar)
 	}

--- a/internal/pipeline/scorecard_tier2_test.go
+++ b/internal/pipeline/scorecard_tier2_test.go
@@ -1415,9 +1415,34 @@ func runLinks() string {
 		pipelineDir := t.TempDir()
 		sc, err := RunScorecard(dir, pipelineDir, "", nil)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{"mcp_description_quality", "mcp_token_efficiency", "mcp_remote_transport", "mcp_tool_design", "mcp_surface_strategy", "cache_freshness", "path_validity", "auth_protocol", "live_api_verification"}, sc.UnscoredDimensions)
+		assert.ElementsMatch(t, []string{"mcp_description_quality", "mcp_token_efficiency", "mcp_remote_transport", "mcp_tool_design", "mcp_surface_strategy", "cache_freshness", "path_validity", "auth_protocol", "data_pipeline_integrity", "sync_correctness", "type_fidelity", "live_api_verification"}, sc.UnscoredDimensions)
 		assert.NotContains(t, sc.GapReport, "path_validity scored 0/10 - needs improvement")
 		assert.NotContains(t, sc.GapReport, "auth_protocol scored 0/10 - needs improvement")
+	})
+
+	t.Run("no store omits store pipeline dimensions from scoring", func(t *testing.T) {
+		dir := t.TempDir()
+		writeScorecardFixture(t, dir, "internal/cli/root.go", `package cli
+func initRoot() { rootCmd.AddCommand(newSyncCmd()) }
+`)
+		writeScorecardFixture(t, dir, "internal/cli/sync.go", `package cli
+import "github.com/spf13/cobra"
+func newSyncCmd() *cobra.Command { return &cobra.Command{Use: "sync"} }
+`)
+		writeScorecardFixture(t, dir, "internal/cli/snapshot.go", `package cli
+import "github.com/spf13/cobra"
+func newSnapshotCmd() *cobra.Command { return &cobra.Command{Use: "snapshot"} }
+`)
+
+		pipelineDir := t.TempDir()
+		sc, err := RunScorecard(dir, pipelineDir, "", nil)
+		assert.NoError(t, err)
+		assert.Contains(t, sc.UnscoredDimensions, DimDataPipelineIntegrity)
+		assert.Contains(t, sc.UnscoredDimensions, DimSyncCorrectness)
+		assert.Contains(t, sc.UnscoredDimensions, DimTypeFidelity)
+		assert.NotContains(t, sc.GapReport, "data_pipeline_integrity scored 0/10 - needs improvement")
+		assert.NotContains(t, sc.GapReport, "sync_correctness scored 0/10 - needs improvement")
+		assert.NotContains(t, sc.GapReport, "type_fidelity scored 0/5 - needs improvement")
 	})
 
 	t.Run("hidden endpoint mirrors omit mcp description quality from scoring", func(t *testing.T) {
@@ -1496,7 +1521,9 @@ func runLinks() string {
 			scBearer.Steinberger.SyncCorrectness +
 			scBearer.Steinberger.TypeFidelity +
 			scBearer.Steinberger.DeadCode
-		expectedDelta := (sharedTier2Raw * 50 / 40) - (sharedTier2Raw * 50 / 50)
+		noAuthMax := scorecardTierMax(scNoAuth, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol, DimSyncCorrectness, DimDataPipelineIntegrity, DimTypeFidelity)
+		bearerMax := scorecardTierMax(scBearer, 60, DimLiveAPIVerification, DimPathValidity, DimAuthProtocol, DimSyncCorrectness, DimDataPipelineIntegrity, DimTypeFidelity)
+		expectedDelta := (sharedTier2Raw * 50 / noAuthMax) - (sharedTier2Raw * 50 / bearerMax)
 		assert.Equal(t, scBearer.Steinberger.Total+expectedDelta, scNoAuth.Steinberger.Total)
 	})
 
@@ -2476,7 +2503,7 @@ func runLinks() string {
 		body := string(data)
 		assert.True(t, strings.Contains(body, `"path_validity":0`))
 		assert.True(t, strings.Contains(body, `"auth_protocol":0`))
-		assert.True(t, strings.Contains(body, `"unscored_dimensions":["mcp_description_quality","mcp_token_efficiency","mcp_remote_transport","mcp_tool_design","mcp_surface_strategy","cache_freshness","path_validity","auth_protocol","live_api_verification"]`))
+		assert.True(t, strings.Contains(body, `"unscored_dimensions":["mcp_description_quality","mcp_token_efficiency","mcp_remote_transport","mcp_tool_design","mcp_surface_strategy","cache_freshness","path_validity","auth_protocol","data_pipeline_integrity","sync_correctness","type_fidelity","live_api_verification"]`))
 	})
 }
 

--- a/internal/pipeline/verify.go
+++ b/internal/pipeline/verify.go
@@ -170,7 +170,7 @@ func (v *Verifier) PathProof() []PathProofResult {
 		command := strings.TrimSuffix(base, ".go")
 
 		pathMatches := verifyPathAssignRe.FindAllStringSubmatchIndex(src, -1)
-		clientMatches := verifyClientCallRe.FindAllStringSubmatch(src, -1)
+		clientMatches := verifyClientCallRe.FindAllStringSubmatchIndex(src, -1)
 
 		if len(pathMatches) == 0 && len(clientMatches) == 0 {
 			continue
@@ -202,10 +202,11 @@ func (v *Verifier) PathProof() []PathProofResult {
 		}
 
 		for _, m := range clientMatches {
-			method := strings.ToUpper(m[1])
-			url := m[2]
+			method := strings.ToUpper(src[m[2]:m[3]])
+			url := src[m[4]:m[5]]
 			r := PathProofResult{
 				File:         base,
+				Line:         lineNumberAtOffset(src, m[0]),
 				Command:      command,
 				Path:         url,
 				ExtractedURL: url,

--- a/internal/pipeline/verify.go
+++ b/internal/pipeline/verify.go
@@ -21,14 +21,16 @@ type Verifier struct {
 }
 
 type PathProofResult struct {
-	File         string `json:"file"`
-	Command      string `json:"command"`
-	Path         string `json:"path"`
-	ExtractedURL string `json:"extracted_url"`
-	Method       string `json:"method"`
-	Valid        bool   `json:"valid"`
-	InSpec       bool   `json:"in_spec"`
-	SpecPath     string `json:"spec_path,omitempty"`
+	File                   string   `json:"file"`
+	Line                   int      `json:"line,omitempty"`
+	Command                string   `json:"command"`
+	Path                   string   `json:"path"`
+	ExtractedURL           string   `json:"extracted_url"`
+	Method                 string   `json:"method"`
+	Valid                  bool     `json:"valid"`
+	InSpec                 bool     `json:"in_spec"`
+	SpecPath               string   `json:"spec_path,omitempty"`
+	UnresolvedPlaceholders []string `json:"unresolved_placeholders,omitempty"`
 }
 
 type FlagProofResult struct {
@@ -116,6 +118,7 @@ func (v *Verifier) CompileGate() error {
 var (
 	verifyPathAssignRe = regexp.MustCompile(`(?m)\bpath\s*(?::=|=|:)\s*"([^"]+)"`)
 	verifyClientCallRe = regexp.MustCompile(`c\.(Get|Post|Patch|Delete|Put)\s*\(\s*"([^"]+)"`)
+	verifyPathParamRe  = regexp.MustCompile(`\{([A-Za-z_][A-Za-z0-9_-]*)\}`)
 )
 
 var verifyInfraFiles = map[string]struct{}{
@@ -166,7 +169,7 @@ func (v *Verifier) PathProof() []PathProofResult {
 		src := string(content)
 		command := strings.TrimSuffix(base, ".go")
 
-		pathMatches := verifyPathAssignRe.FindAllStringSubmatch(src, -1)
+		pathMatches := verifyPathAssignRe.FindAllStringSubmatchIndex(src, -1)
 		clientMatches := verifyClientCallRe.FindAllStringSubmatch(src, -1)
 
 		if len(pathMatches) == 0 && len(clientMatches) == 0 {
@@ -174,13 +177,15 @@ func (v *Verifier) PathProof() []PathProofResult {
 		}
 
 		for _, m := range pathMatches {
-			url := m[1]
+			url := src[m[2]:m[3]]
 			r := PathProofResult{
 				File:         base,
+				Line:         lineNumberAtOffset(src, m[0]),
 				Command:      command,
 				Path:         url,
 				ExtractedURL: url,
 			}
+			r.UnresolvedPlaceholders = unresolvedPathPlaceholders(src, url)
 			if len(specPatterns) > 0 {
 				r.InSpec = pathMatchesSpec(url, specPatterns)
 				r.Valid = r.InSpec
@@ -189,6 +194,9 @@ func (v *Verifier) PathProof() []PathProofResult {
 				}
 			} else {
 				r.Valid = true
+			}
+			if len(r.UnresolvedPlaceholders) > 0 {
+				r.Valid = false
 			}
 			results = append(results, r)
 		}
@@ -203,6 +211,7 @@ func (v *Verifier) PathProof() []PathProofResult {
 				ExtractedURL: url,
 				Method:       method,
 			}
+			r.UnresolvedPlaceholders = unresolvedPathPlaceholders(src, url)
 			if len(specPatterns) > 0 {
 				r.InSpec = pathMatchesSpec(url, specPatterns)
 				r.Valid = r.InSpec
@@ -212,11 +221,60 @@ func (v *Verifier) PathProof() []PathProofResult {
 			} else {
 				r.Valid = true
 			}
+			if len(r.UnresolvedPlaceholders) > 0 {
+				r.Valid = false
+			}
 			results = append(results, r)
 		}
 	}
 
 	return results
+}
+
+func unresolvedPathPlaceholders(src, url string) []string {
+	matches := verifyPathParamRe.FindAllStringSubmatch(url, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	var unresolved []string
+	for _, match := range matches {
+		name := match[1]
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		if pathPlaceholderSubstituted(src, name) {
+			continue
+		}
+		unresolved = append(unresolved, name)
+	}
+	return unresolved
+}
+
+func pathPlaceholderSubstituted(src, name string) bool {
+	quoted := regexp.QuoteMeta(name)
+	checks := []*regexp.Regexp{
+		regexp.MustCompile(`replacePathParam\s*\(\s*[^,\n]+,\s*"` + quoted + `"`),
+		regexp.MustCompile(`strings\.Replace(All)?\s*\(\s*[^,\n]+,\s*"\{` + quoted + `\}"`),
+	}
+	for _, check := range checks {
+		if check.MatchString(src) {
+			return true
+		}
+	}
+	return false
+}
+
+func lineNumberAtOffset(src string, offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	return strings.Count(src[:offset], "\n") + 1
 }
 
 func (v *Verifier) FlagProof() []FlagProofResult {

--- a/internal/pipeline/verify_report.go
+++ b/internal/pipeline/verify_report.go
@@ -130,6 +130,14 @@ func collectVerificationIssues(report *VerificationReport) []string {
 
 	for _, p := range report.Paths {
 		if !p.Valid {
+			if len(p.UnresolvedPlaceholders) > 0 {
+				location := p.File
+				if p.Line > 0 {
+					location = fmt.Sprintf("%s:%d", p.File, p.Line)
+				}
+				issues = append(issues, fmt.Sprintf("unresolved path placeholders in %s: %s", location, strings.Join(p.UnresolvedPlaceholders, ", ")))
+				continue
+			}
 			issues = append(issues, fmt.Sprintf("hallucinated path: %s (not in spec)", p.Path))
 		}
 	}

--- a/internal/pipeline/verify_test.go
+++ b/internal/pipeline/verify_test.go
@@ -76,6 +76,11 @@ func runAccounts() {
 	_ = c.Get(path)
 }
 `)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "direct.go"), `package cli
+func runDirect() {
+	_ = c.Get("/direct/{id}")
+}
+`)
 
 	specPath := filepath.Join(dir, "spec.yaml")
 	writeTestFile(t, specPath, `openapi: 3.0.0
@@ -93,21 +98,27 @@ paths:
       responses:
         "200":
           description: ok
-`)
+  /direct/{id}:
+    get:
+      responses:
+        "200":
+          description: ok`)
 
 	v, err := NewVerifier(dir, specPath)
 	require.NoError(t, err)
 
 	results := v.PathProof()
-	require.Len(t, results, 2)
+	require.Len(t, results, 3)
 
-	var feed, accounts PathProofResult
+	var feed, accounts, direct PathProofResult
 	for _, r := range results {
 		switch r.File {
 		case "feed.go":
 			feed = r
 		case "accounts.go":
 			accounts = r
+		case "direct.go":
+			direct = r
 		}
 	}
 	assert.False(t, feed.Valid)
@@ -116,6 +127,9 @@ paths:
 	assert.True(t, accounts.Valid, "one substitution covers repeated account_id placeholders")
 	assert.Equal(t, 3, accounts.Line)
 	assert.Empty(t, accounts.UnresolvedPlaceholders)
+	assert.False(t, direct.Valid)
+	assert.Equal(t, 3, direct.Line)
+	assert.Equal(t, []string{"id"}, direct.UnresolvedPlaceholders)
 }
 
 func TestNewVerifierAcceptsYAMLSpec(t *testing.T) {

--- a/internal/pipeline/verify_test.go
+++ b/internal/pipeline/verify_test.go
@@ -23,6 +23,7 @@ func TestPathProof_DetectsHallucinatedEndpoint(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "users_get.go"), `package cli
 func usersGet() {
 	path = "/users/{id}"
+	path = replacePathParam(path, "id", args[0])
 }
 `)
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "bogus_get.go"), `package cli
@@ -58,6 +59,65 @@ func bogusGet() {
 	assert.Equal(t, 1, invalidCount, "one path should be hallucinated")
 }
 
+func TestPathProof_DetectsUnresolvedPathTemplatePlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	setupVerifierDirs(t, dir)
+
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "feed.go"), `package cli
+func runFeed() {
+	path := "/feeds/{type}/{month}"
+	_ = c.Get(path)
+}
+`)
+	writeTestFile(t, filepath.Join(dir, "internal", "cli", "accounts.go"), `package cli
+func runAccounts() {
+	path := "/accounts/{account_id}/workers/{account_id}"
+	path = replacePathParam(path, "account_id", args[0])
+	_ = c.Get(path)
+}
+`)
+
+	specPath := filepath.Join(dir, "spec.yaml")
+	writeTestFile(t, specPath, `openapi: 3.0.0
+info:
+  title: Template API
+  version: "1.0"
+paths:
+  /feeds/{type}/{month}:
+    get:
+      responses:
+        "200":
+          description: ok
+  /accounts/{account_id}/workers/{account_id}:
+    get:
+      responses:
+        "200":
+          description: ok
+`)
+
+	v, err := NewVerifier(dir, specPath)
+	require.NoError(t, err)
+
+	results := v.PathProof()
+	require.Len(t, results, 2)
+
+	var feed, accounts PathProofResult
+	for _, r := range results {
+		switch r.File {
+		case "feed.go":
+			feed = r
+		case "accounts.go":
+			accounts = r
+		}
+	}
+	assert.False(t, feed.Valid)
+	assert.Equal(t, 3, feed.Line)
+	assert.Equal(t, []string{"type", "month"}, feed.UnresolvedPlaceholders)
+	assert.True(t, accounts.Valid, "one substitution covers repeated account_id placeholders")
+	assert.Equal(t, 3, accounts.Line)
+	assert.Empty(t, accounts.UnresolvedPlaceholders)
+}
+
 func TestNewVerifierAcceptsYAMLSpec(t *testing.T) {
 	dir := t.TempDir()
 	setupVerifierDirs(t, dir)
@@ -65,6 +125,7 @@ func TestNewVerifierAcceptsYAMLSpec(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "users_get.go"), `package cli
 func usersGet() {
 	path = "/users/{id}"
+	path = replacePathParam(path, "id", args[0])
 }
 `)
 
@@ -435,6 +496,7 @@ func TestRunVerification_FullIntegration(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "users_get.go"), `package cli
 func usersGet() {
 	path = "/users/{id}"
+	path = replacePathParam(path, "id", args[0])
 }
 `)
 	writeTestFile(t, filepath.Join(dir, "internal", "cli", "bogus_get.go"), `package cli

--- a/testdata/golden/fixtures/verify-runtime-matrix/mock-pass-pp-cli/internal/store/store.go
+++ b/testdata/golden/fixtures/verify-runtime-matrix/mock-pass-pp-cli/internal/store/store.go
@@ -1,0 +1,5 @@
+package store
+
+func defaultSyncResources() []string {
+	return []string{"items"}
+}


### PR DESCRIPTION
## Summary

Scorer and verify gates now distinguish real defects from CLI shapes that cannot satisfy generated sync assumptions. Live dogfood resolves pipe-alternative positionals such as `<id|uuid>`, verify skips no-store `sync` commands and mock-only no-resource stores without hiding broken syncable JSON stores, and scorecard drops no-store pipeline/type dimensions from the denominator instead of forcing low scores.

The static path proof now catches command files that leave `{param}` tokens unresolved in outbound paths, including paths that otherwise match the spec, and reports the source `file:line`. Repeated placeholders such as `{account_id}` are still accepted when one substitution call covers the unique placeholder.

Closes #3310.
Closes #2910.
Closes #2722.
Closes #2687.
Refs #2908.

## Validation

- `go test ./internal/pipeline -run 'TestExtractPositionalPlaceholders|TestRunDataPipelineTest|TestRunScorecard_UnscoredSpecDimensions|TestPathProof_DetectsUnresolvedPathTemplatePlaceholders'`
- `go test ./internal/cli -run 'TestPythonUTF8Env|TestVerifySkill'`
- `go test ./internal/pipeline`
- `go test ./internal/cli`
- `go test ./...`
- `scripts/golden.sh verify`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
