### PR TITLE
fix(cli): harden provenance and sniff edge cases

### DIFF
--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/discovery"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -1775,6 +1776,8 @@ func encodeSampleJSON(sample SampleFile) ([]byte, error) {
 	return []byte(buf.String()), nil
 }
 
+const maxSampleFilenameBytes = 120
+
 // sampleFilename returns method__path-slug__hash.json. The hash is the
 // first 8 hex chars of sha256(METHOD + " " + normalizedPath), with host
 // included only for host-preserved groups so same-path groups cannot
@@ -1799,7 +1802,32 @@ func sampleFilename(group EndpointGroup) string {
 		hashKey = host + " " + hashKey
 	}
 	h := sha256.Sum256([]byte(hashKey))
-	return fmt.Sprintf("%s__%s__%s.json", method, slug, hex.EncodeToString(h[:4]))
+	hash := hex.EncodeToString(h[:4])
+	prefix := method + "__"
+	suffix := "__" + hash + ".json"
+	slug = truncateSampleFilenameSlug(slug, maxSampleFilenameBytes-len(prefix)-len(suffix))
+	return prefix + slug + suffix
+}
+
+func truncateSampleFilenameSlug(slug string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return "sample"
+	}
+	if len(slug) <= maxBytes {
+		return slug
+	}
+	for len(slug) > maxBytes {
+		_, size := utf8.DecodeLastRuneInString(slug)
+		if size <= 0 {
+			break
+		}
+		slug = slug[:len(slug)-size]
+	}
+	slug = strings.TrimRight(slug, "._-")
+	if slug == "" {
+		return "sample"
+	}
+	return slug
 }
 
 // buildSampleFile selects a representative entry from the group, redacts

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -1177,6 +1177,18 @@ func TestSampleFilename_StripsBraces(t *testing.T) {
 	assert.Contains(t, got, "orders_orderId_items_itemId")
 }
 
+func TestSampleFilename_TruncatesLongPathSlug(t *testing.T) {
+	t.Parallel()
+
+	got := sampleFilename(EndpointGroup{
+		Method:         "GET",
+		NormalizedPath: "/" + strings.Repeat("playlist_segment_", 40) + "playlist.m3u8",
+	})
+
+	assert.LessOrEqual(t, len(got), 120)
+	assert.Regexp(t, `^get__.*__[0-9a-f]{8}\.json$`, got)
+}
+
 func TestSelectSampleEntry_PrefersMostRecentSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/browser_sniff.go
+++ b/internal/cli/browser_sniff.go
@@ -68,7 +68,7 @@ func newBrowserSniffCmd() *cobra.Command {
 			if analysisOutputPath == "" {
 				analysisOutputPath = browsersniff.DefaultTrafficAnalysisPath(outputPath)
 			}
-			if samplesOutputPath == "" {
+			if samplesOutputPath == "" && !cmd.Flags().Changed("samples-output") {
 				samplesOutputPath = browsersniff.DefaultSamplesPath(outputPath)
 			}
 

--- a/internal/cli/browser_sniff_test.go
+++ b/internal/cli/browser_sniff_test.go
@@ -52,6 +52,27 @@ func TestBrowserSniffCmdWritesSpecAndExplicitTrafficAnalysis(t *testing.T) {
 	assert.Contains(t, string(data), `"endpoint_clusters"`)
 }
 
+func TestBrowserSniffCmdEmptySamplesOutputDisablesSamples(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "spec.yaml")
+	analysisPath := filepath.Join(dir, "traffic-analysis.json")
+	cmd := newBrowserSniffCmd()
+	cmd.SetArgs([]string{
+		"--har", filepath.Join("..", "..", "testdata", "sniff", "sample-enriched.json"),
+		"--output", outputPath,
+		"--analysis-output", analysisPath,
+		"--samples-output=",
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	require.FileExists(t, outputPath)
+	require.FileExists(t, analysisPath)
+	assert.NoDirExists(t, browsersniff.DefaultSamplesPath(outputPath))
+}
+
 func TestBrowserSniffCmdDerivesTrafficAnalysisPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/bundle.go
+++ b/internal/cli/bundle.go
@@ -263,15 +263,15 @@ func resolvePlatform(s string) (string, string, error) {
 
 // buildMCPBBinary invokes `go build` on cmd/<name>/main.go inside cliDir,
 // targeting the requested GOOS/GOARCH and writing to outputPath. We pass
-// -trimpath and -ldflags="-s -w" to match the bundle conventions Claude
-// Desktop's prebuilt examples use; users who need debug builds can
+// -trimpath and a blank build id to avoid embedding operator-local paths while
+// retaining the size-oriented ldflags Claude Desktop examples use. Users can
 // --skip-build and pass their own binary.
 func buildMCPBBinary(cliDir, mcpName, outputPath, goos, goarch string) error {
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("creating bin dir: %w", err)
 	}
 	pkg := "./cmd/" + mcpName
-	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w", "-o", outputPath, pkg)
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w -buildid=", "-o", outputPath, pkg)
 	cmd.Dir = cliDir
 	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/cli/bundle_test.go
+++ b/internal/cli/bundle_test.go
@@ -268,6 +268,43 @@ func TestNewBundleCmdWindowsPlatformBuildsToExeStagingPaths(t *testing.T) {
 	assert.Contains(t, entries, "bin/demo-pp-cli.exe")
 }
 
+func TestBuildMCPBBinaryUsesReproducibleBuildFlags(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake go shim uses POSIX shell")
+	}
+
+	dir := t.TempDir()
+	fakeBin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
+	fakeGo := filepath.Join(fakeBin, "go")
+	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+if [ -z "$out" ]; then
+  echo "missing -o" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$out")"
+printf 'fake binary' > "$out"
+chmod 755 "$out"
+`), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GO_CALLS", callsPath)
+
+	require.NoError(t, buildMCPBBinary(dir, "demo-pp-mcp", filepath.Join(dir, "bin", "demo-pp-mcp"), "linux", "amd64"))
+
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(calls), "build -trimpath -ldflags=-s -w -buildid= -o ")
+}
+
 func TestAutoBundleForHostSuccessPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake go shim uses POSIX shell")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -298,6 +298,7 @@ func New(s *spec.APISpec, outputDir string) *Generator {
 		"authSetCredentialsAvailable":         authSetCredentialsAvailable,
 		"authErrorCheckHint":                  authErrorCheckHint,
 		"authSetupHint":                       authSetupHint,
+		"authBrowserLoginAvailable":           authBrowserLoginAvailable,
 		"authEnvPlaceholder":                  authEnvPlaceholder,
 		"authEnvPlaceholderByName":            authEnvPlaceholderByName,
 		"authEnvHintComment":                  authEnvHintComment,
@@ -1594,6 +1595,9 @@ func authSetupHint(auth spec.AuthConfig, cliName string) string {
 	case "oauth2":
 		return fmt.Sprintf("Run '%s-pp-cli auth login' to re-authenticate.", cliName)
 	}
+	if authBrowserLoginAvailable(auth) {
+		return fmt.Sprintf("Run '%s-pp-cli auth login' to re-authenticate.", cliName)
+	}
 
 	envVars := requiredRequestAuthEnvVars(auth)
 	if len(envVars) == 0 && auth.IsAuthEnvVarORCase() {
@@ -1636,6 +1640,11 @@ func authSetupHint(auth spec.AuthConfig, cliName string) string {
 		return "Set Basic credentials with: export " + strings.Join(exports, " ")
 	}
 	return "Set credentials with: export " + strings.Join(exports, " ")
+}
+
+func authBrowserLoginAvailable(auth spec.AuthConfig) bool {
+	return strings.TrimSpace(auth.AuthorizationURL) != "" &&
+		auth.EffectiveOAuth2Grant() == spec.OAuth2GrantAuthorizationCode
 }
 
 func authEnvDomainVendor(envNameUpper, placeholder string) string {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -10410,6 +10410,44 @@ func TestGeneratedAuthHints_DoNotDuplicateRecoveryCommands(t *testing.T) {
 
 		requireGeneratedCompiles(t, outputDir)
 	})
+
+	t.Run("browser login bearer token hints use auth login", func(t *testing.T) {
+		t.Parallel()
+
+		apiSpec := minimalSpec("browserbearer")
+		apiSpec.Auth = spec.AuthConfig{
+			Type:             "bearer_token",
+			Header:           "Authorization",
+			Format:           "Bearer {token}",
+			EnvVars:          []string{"BROWSERBEARER_TOKEN"},
+			AuthorizationURL: "https://login.example.com/oauth/authorize",
+			TokenURL:         "https://login.example.com/oauth/token",
+			OAuth2Grant:      spec.OAuth2GrantAuthorizationCode,
+		}
+
+		outputDir := filepath.Join(t.TempDir(), "browserbearer-pp-cli")
+		require.NoError(t, New(apiSpec, outputDir).Generate())
+
+		auth := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+		assert.Contains(t, auth, `Use:   "login"`)
+		assert.NotContains(t, auth, `Use:   "set-token <token>"`)
+
+		helpers := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
+		helpers401 := generatedSourceBlock(t, helpers, `case strings.Contains(msg, "HTTP 401"):`, `case strings.Contains(msg, "HTTP 403"):`)
+		assert.Contains(t, helpers401, "auth login")
+		assert.NotContains(t, helpers401, "auth set-token")
+
+		tools := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+		tools401 := generatedSourceBlock(t, tools, `case strings.Contains(msg, "HTTP 401"):`, `case strings.Contains(msg, "HTTP 403"):`)
+		assert.Contains(t, tools401, "auth login")
+		assert.NotContains(t, tools401, "auth set-token")
+
+		client := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
+		assert.Contains(t, client, "auth login")
+		assert.NotContains(t, client, "auth set-token <token>")
+
+		requireGeneratedCompiles(t, outputDir)
+	})
 }
 
 func generatedSourceBlock(t *testing.T, body, start, end string) string {

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -2015,7 +2015,7 @@ func authPlaceholderCredentialError(cfg *config.Config) error {
 	return authPlaceholderCredentialErrorWithSetup(cfg, "{{.Name}}-pp-cli auth login or {{.Name}}-pp-cli auth set-token <token>")
 {{- else if eq .Auth.EffectiveOAuth2Grant "device_code"}}
 	return authPlaceholderCredentialErrorWithSetup(cfg, "{{.Name}}-pp-cli auth login --device-code or {{.Name}}-pp-cli auth set-token <token>")
-{{- else if eq .Auth.Type "oauth2"}}
+{{- else if or (eq .Auth.Type "oauth2") (authBrowserLoginAvailable .Auth)}}
 	return authPlaceholderCredentialErrorWithSetup(cfg, "{{.Name}}-pp-cli auth login")
 {{- else}}
 	return authPlaceholderCredentialErrorWithSetup(cfg, "{{- with .Auth.CanonicalEnvVar}}export {{.Name}}=<your-token> or {{end}}{{.Name}}-pp-cli auth set-token <token>")

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -73,14 +73,14 @@ func (g *Generator) Validate() error {
 		{
 			name: "go build ./...",
 			run: func() error {
-				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "build", "./...")
+				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "build", "-trimpath", "-ldflags=-buildid=", "./...")
 				return err
 			},
 		},
 		{
 			name: "build runnable binary",
 			run: func() error {
-				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "build", "-o", binPath, "./cmd/"+naming.CLI(g.Spec.Name))
+				_, err := runCommand(g.OutputDir, qualityGateTimeout, "go", "build", "-trimpath", "-ldflags=-buildid=", "-o", binPath, "./cmd/"+naming.CLI(g.Spec.Name))
 				return err
 			},
 		},

--- a/internal/generator/validate_test.go
+++ b/internal/generator/validate_test.go
@@ -117,3 +117,45 @@ exit 0
 	assert.NotContains(t, string(calls), "-show")
 	assert.NotContains(t, string(calls), "verbose")
 }
+
+func TestValidateBuildRunnableBinaryUsesReproducibleBuildFlags(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell go binary is Unix-only")
+	}
+	outputDir := filepath.Join(t.TempDir(), "validate-pp-cli")
+	gen := New(minimalSpec("validate"), outputDir)
+	require.NoError(t, gen.Generate())
+
+	fakeBin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "go-calls.txt")
+	fakeGo := filepath.Join(fakeBin, "go")
+	require.NoError(t, os.WriteFile(fakeGo, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GO_CALLS"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+if [ -n "$out" ]; then
+  mkdir -p "$(dirname "$out")"
+  cat > "$out" <<'SCRIPT'
+#!/bin/sh
+echo ok
+exit 0
+SCRIPT
+  chmod 755 "$out"
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GO_CALLS", callsPath)
+
+	require.NoError(t, gen.Validate())
+
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(calls), "build -trimpath -ldflags=-buildid= -o ")
+}

--- a/internal/pipeline/climanifest.go
+++ b/internal/pipeline/climanifest.go
@@ -1122,6 +1122,9 @@ func WriteManifestForGenerate(p GenerateManifestParams) error {
 	if p.Spec != nil && p.Spec.Version != "" {
 		m.APIVersion = p.Spec.Version
 	}
+	if p.Spec != nil && strings.TrimSpace(p.Spec.SpecSource) != "" {
+		m.SpecSource = strings.TrimSpace(p.Spec.SpecSource)
+	}
 	if p.Spec != nil && p.Spec.IsLocalSQLiteSource() {
 		m.SpecFormat = spec.SourceLocalSQLite
 	}

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1359,6 +1359,26 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.Equal(t, "4.11.0", got.Version)
 	})
 
+	t.Run("falls back to valid placeholder when versions are not semver", func(t *testing.T) {
+		prevVersion := version.Version
+		version.Version = "dev"
+		t.Cleanup(func() { version.Version = prevVersion })
+
+		dir := t.TempDir()
+		writeManifest(t, dir, CLIManifest{
+			APIName:              "demo",
+			MCPBinary:            "demo-pp-mcp",
+			MCPReady:             "full",
+			APIVersion:           "2026-04",
+			PrintingPressVersion: "dev",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Equal(t, "0.0.0", got.Version)
+	})
+
 	t.Run("api_key auth emits required user_config fields", func(t *testing.T) {
 		dir := t.TempDir()
 		writeManifest(t, dir, CLIManifest{

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -1328,6 +1328,22 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.Equal(t, "0.1.0", got.Version)
 	})
 
+	t.Run("falls back when API version is not semver", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifest(t, dir, CLIManifest{
+			APIName:              "demo",
+			MCPBinary:            "demo-pp-mcp",
+			MCPReady:             "full",
+			APIVersion:           "2026-04",
+			PrintingPressVersion: "4.11.0",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Equal(t, "4.11.0", got.Version)
+	})
+
 	t.Run("falls back to printing press version", func(t *testing.T) {
 		dir := t.TempDir()
 		writeManifest(t, dir, CLIManifest{

--- a/internal/pipeline/climanifest_test.go
+++ b/internal/pipeline/climanifest_test.go
@@ -764,6 +764,20 @@ func TestWriteManifestForGenerateWithSpecURL(t *testing.T) {
 	assert.False(t, got.GeneratedAt.IsZero())
 }
 
+func TestWriteManifestForGenerateRecordsSpecSourceFromSpec(t *testing.T) {
+	dir := t.TempDir()
+
+	err := WriteManifestForGenerate(GenerateManifestParams{
+		APIName:   "sniffed-api",
+		OutputDir: dir,
+		Spec:      &spec.APISpec{Name: "sniffed-api", SpecSource: "sniffed"},
+	})
+	require.NoError(t, err)
+
+	got := readManifest(t, dir)
+	assert.Equal(t, "sniffed", got.SpecSource)
+}
+
 func TestWriteManifestForGenerateRecordsAuthPreference(t *testing.T) {
 	dir := t.TempDir()
 
@@ -1298,7 +1312,23 @@ func TestWriteMCPBManifest(t *testing.T) {
 		assert.True(t, os.IsNotExist(statErr))
 	})
 
-	t.Run("uses generate-time placeholder instead of printing press version", func(t *testing.T) {
+	t.Run("uses API version before printing press version", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifest(t, dir, CLIManifest{
+			APIName:              "demo",
+			MCPBinary:            "demo-pp-mcp",
+			MCPReady:             "full",
+			APIVersion:           "0.1.0",
+			PrintingPressVersion: "4.11.0",
+		})
+
+		require.NoError(t, WriteMCPBManifest(dir))
+		got := readMCPBManifest(t, dir)
+
+		assert.Equal(t, "0.1.0", got.Version)
+	})
+
+	t.Run("falls back to printing press version", func(t *testing.T) {
 		dir := t.TempDir()
 		writeManifest(t, dir, CLIManifest{
 			APIName:              "demo",
@@ -1310,7 +1340,7 @@ func TestWriteMCPBManifest(t *testing.T) {
 		require.NoError(t, WriteMCPBManifest(dir))
 		got := readMCPBManifest(t, dir)
 
-		assert.Equal(t, "0.0.0", got.Version)
+		assert.Equal(t, "4.11.0", got.Version)
 	})
 
 	t.Run("api_key auth emits required user_config fields", func(t *testing.T) {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -29,6 +30,8 @@ const (
 // defaultMCPBPlatforms is the set of host platforms our generated bundles
 // target. Matches goreleaser's default Go cross-compile matrix.
 var defaultMCPBPlatforms = []string{"darwin", "linux", "win32"}
+
+var semverVersionRE = regexp.MustCompile(`^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 
 // minClaudeDesktopVersion is the minimum Claude Desktop release that
 // understands the MCPB bundle format we emit. 1.0.0 is the version that
@@ -229,13 +232,17 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 // time. Release packaging may still stamp the final public-library version
 // into the ZIP without mutating this generate-time manifest.
 func bundleVersion(m CLIManifest) string {
-	if v := strings.TrimSpace(m.APIVersion); v != "" {
+	if v := strings.TrimSpace(m.APIVersion); isSemverVersion(v) {
 		return v
 	}
 	if v := strings.TrimSpace(m.PrintingPressVersion); v != "" {
 		return v
 	}
 	return version.Version
+}
+
+func isSemverVersion(v string) bool {
+	return semverVersionRE.MatchString(v)
 }
 
 // manifestDescription preserves hand-edited bundle descriptions while letting

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -235,10 +235,13 @@ func bundleVersion(m CLIManifest) string {
 	if v := strings.TrimSpace(m.APIVersion); isSemverVersion(v) {
 		return v
 	}
-	if v := strings.TrimSpace(m.PrintingPressVersion); v != "" {
+	if v := strings.TrimSpace(m.PrintingPressVersion); isSemverVersion(v) {
 		return v
 	}
-	return version.Version
+	if v := strings.TrimSpace(version.Version); isSemverVersion(v) {
+		return v
+	}
+	return "0.0.0"
 }
 
 func isSemverVersion(v string) bool {

--- a/internal/pipeline/mcpb_manifest.go
+++ b/internal/pipeline/mcpb_manifest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/version"
 )
 
 // MCPB-bundle constants. Promoted from string literals so a typo here can't
@@ -203,7 +204,7 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 		// The generated on-disk manifest does not know the printed CLI's
 		// release tag yet. Release packaging can stamp the bundle version
 		// into the ZIP without mutating this generate-time manifest.
-		Version:     bundleVersion(),
+		Version:     bundleVersion(m),
 		Description: manifestDescription(existing, m, displayName),
 		Author:      MCPBAuthor{Name: "CLI Printing Press"},
 		License:     "Apache-2.0",
@@ -224,11 +225,17 @@ func buildMCPBManifest(dir string, m CLIManifest) MCPBManifest {
 	}
 }
 
-// bundleVersion returns a semver-shaped generate-time placeholder. The MCPB
-// manifest's version is the printed CLI bundle version, which is not known
-// until release packaging passes it to BuildMCPBBundle.
-func bundleVersion() string {
-	return "0.0.0"
+// bundleVersion returns the best known printed CLI bundle version at generate
+// time. Release packaging may still stamp the final public-library version
+// into the ZIP without mutating this generate-time manifest.
+func bundleVersion(m CLIManifest) string {
+	if v := strings.TrimSpace(m.APIVersion); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(m.PrintingPressVersion); v != "" {
+		return v
+	}
+	return version.Version
 }
 
 // manifestDescription preserves hand-edited bundle descriptions while letting

--- a/internal/pipeline/runtime_exec.go
+++ b/internal/pipeline/runtime_exec.go
@@ -33,13 +33,17 @@ func buildCLITo(dir, binaryPath string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", binaryPath, "./"+filepath.Base(cmdDir))
+	cmd := exec.CommandContext(ctx, "go", buildCLIArgs(binaryPath, "./"+filepath.Base(cmdDir))...)
 	cmd.Dir = filepath.Dir(cmdDir)
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("go build: %s\n%s", err, string(out))
 	}
 	return nil
+}
+
+func buildCLIArgs(binaryPath, pkg string) []string {
+	return []string{"build", "-trimpath", "-ldflags=-buildid=", "-o", binaryPath, pkg}
 }
 
 func findCLICommandDir(dir string) (string, error) {

--- a/internal/pipeline/runtime_test.go
+++ b/internal/pipeline/runtime_test.go
@@ -1170,6 +1170,12 @@ func main() {}
 	assert.FileExists(t, binaryPath)
 }
 
+func TestBuildCLIArgsUseReproducibleBuildFlags(t *testing.T) {
+	args := buildCLIArgs("out-bin", "./cmd/sample-pp-cli")
+
+	assert.Equal(t, []string{"build", "-trimpath", "-ldflags=-buildid=", "-o", "out-bin", "./cmd/sample-pp-cli"}, args)
+}
+
 // TestExtractPositionalPlaceholders covers the placeholder extractor used
 // by inferPositionalArgs. The bracketed-flag-descriptor cases are the
 // retro #301 F2 regression: cobra Use strings like


### PR DESCRIPTION
## Intent

Fix a cluster of Wave 6 provenance, build reproducibility, browser-sniff, and auth-hint sharp edges in the Printing Press so fresh generated CLIs carry truthful metadata and safer generated behavior.

Issue:

Fixes #2930
Fixes #2927
Fixes #2919
Fixes #2918
Fixes #2988

## Approach

MCPB manifests now use the best known non-placeholder version: the target API version first, then the Printing Press version, then the running binary version. Generated and promoted CLI builds now use `-trimpath` plus a blank Go build id, including MCPB prebuilt binaries, so packaging avoids embedding local paths and unstable build ids.

Generate-time manifests now persist a spec-provided `spec_source`, browser-sniff treats an explicitly empty `--samples-output=` as “do not write samples,” and sample filenames keep their full-path hash while bounding the slug length. Auth recovery hints now prefer `auth login` when a bearer-token-shaped auth config is actually backed by browser authorization-code login, avoiding references to unavailable `auth set-token` flows.

## Scope

Primary area: generator, CLI packaging, pipeline manifests, browser-sniff samples, and generated auth hints.

Why this belongs in this repo: these are Printing Press generator/runtime behaviors that affect future printed CLIs and bundles; no printed CLI was patched directly.

## Catalog Justification

Embedded catalog fit: N/A

Distinct blueprint pattern: N/A

Closest existing entries checked: N/A

Source provenance: N/A

Auth and tenant assumptions: N/A

Safe default surface: N/A

Generation path: N/A

Stale-body check: N/A

## Risk

The main risk is generated-output drift in build command flags and auth hint text. The auth-hint branch is gated on authorization-code browser login metadata, and the browser-sniff change intentionally avoids broader discovery classification work reserved for later follow-up.

## Output Contract

Generated auth hints are covered by emitted-code assertions and a compiled generated CLI test. Build flag changes are covered at validation/build invocation boundaries, and golden plus generated-output verification passed without fixture updates.

## Verification

- [x] Generator/template change: verified generated output, including emitted-code assertions or compiled generated CLI output
- [x] Generator/template change: covered the affected fallback or variant shape, not only happy-path fixtures
- [x] Generator/template change: checked emitted definitions and call sites for matching gates
- [x] `go test ./internal/pipeline ./internal/generator ./internal/browsersniff ./internal/cli -run 'TestWriteMCPBManifest|TestWriteManifestForGenerateRecordsSpecSourceFromSpec|TestValidateBuildRunnableBinaryUsesReproducibleBuildFlags|TestBuildCLIArgsUseReproducibleBuildFlags|TestBuildMCPBBinaryUsesReproducibleBuildFlags|TestSampleFilename_TruncatesLongPathSlug|TestBrowserSniffCmdEmptySamplesOutputDisablesSamples|TestGeneratedAuthHints_DoNotDuplicateRecoveryCommands'`
- [x] `scripts/golden.sh verify`
- [x] `scripts/verify-generator-output.sh`
- [x] `go fmt ./...`
- [x] `go test -timeout 20m ./...`

## AI / Automation Disclosure

- [ ] No AI or automation was used
- [ ] Human-reviewed: AI or automation was used, and a human reviewed the work for intent, fit, and obvious issues before submission
- [ ] AI-reviewed only: an AI agent reviewed the work, but no human reviewed it before submission
- [x] Fully automated: generated and submitted without human review for this specific change

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)