### PR TITLE
fix(cli): harden generated read and search extraction

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3763,7 +3763,7 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		SearchQueryParam:             g.profile.SearchQueryParam,
 		SearchEndpointMethod:         g.profile.SearchEndpointMethod,
 		SearchBodyFields:             g.profile.SearchBodyFields,
-		SearchResponsePaths:          searchResponsePaths(g.Spec),
+		SearchResponsePaths:          searchResponsePaths(g.Spec, g.profile.SearchEndpointPath, g.profile.SearchEndpointMethod),
 		SearchExampleType:            searchExampleType(g.Spec),
 		GraphQLFieldPaths:            gqlFieldPaths,
 		AgentMoneyWorkflow:           detectAgentMoneyWorkflow(g.Spec, g.PromotedEndpointNames),
@@ -3772,13 +3772,21 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 	}
 }
 
-func searchResponsePaths(apiSpec *spec.APISpec) []string {
-	if apiSpec == nil {
+func searchResponsePaths(apiSpec *spec.APISpec, searchEndpointPath, searchEndpointMethod string) []string {
+	searchEndpointPath = strings.TrimSpace(searchEndpointPath)
+	if apiSpec == nil || searchEndpointPath == "" {
 		return nil
 	}
+	searchEndpointMethod = strings.ToUpper(strings.TrimSpace(searchEndpointMethod))
 	seen := map[string]bool{}
 	for _, resource := range apiSpec.Resources {
 		for _, endpoint := range resource.Endpoints {
+			if endpoint.Path != searchEndpointPath {
+				continue
+			}
+			if searchEndpointMethod != "" && strings.ToUpper(endpoint.Method) != searchEndpointMethod {
+				continue
+			}
 			path := strings.TrimSpace(endpoint.ResponsePath)
 			if path != "" {
 				seen[path] = true

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -3503,6 +3503,8 @@ type visionRenderData struct {
 	SearchQueryParam             string
 	SearchEndpointMethod         string
 	SearchBodyFields             []profiler.SearchBodyField
+	SearchResponsePaths          []string
+	SearchExampleType            string
 	GraphQLFieldPaths            map[string]string
 	AgentMoneyWorkflow           AgentMoneyWorkflow
 	HTMLSyncStub                 bool
@@ -3761,11 +3763,41 @@ func (g *Generator) visionRenderData(schema []TableDef) visionRenderData {
 		SearchQueryParam:             g.profile.SearchQueryParam,
 		SearchEndpointMethod:         g.profile.SearchEndpointMethod,
 		SearchBodyFields:             g.profile.SearchBodyFields,
+		SearchResponsePaths:          searchResponsePaths(g.Spec),
+		SearchExampleType:            searchExampleType(g.Spec),
 		GraphQLFieldPaths:            gqlFieldPaths,
 		AgentMoneyWorkflow:           detectAgentMoneyWorkflow(g.Spec, g.PromotedEndpointNames),
 		HTMLSyncStub:                 g.shouldEmitHTMLSyncStub(),
 		HTMLPageModeResources:        htmlPageModeResourceEntries(g.Spec, g.profile.SyncableResources, g.profile.DependentSyncResources),
 	}
+}
+
+func searchResponsePaths(apiSpec *spec.APISpec) []string {
+	if apiSpec == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, resource := range apiSpec.Resources {
+		for _, endpoint := range resource.Endpoints {
+			path := strings.TrimSpace(endpoint.ResponsePath)
+			if path != "" {
+				seen[path] = true
+			}
+		}
+	}
+	paths := slices.Sorted(maps.Keys(seen))
+	return paths
+}
+
+func searchExampleType(apiSpec *spec.APISpec) string {
+	if apiSpec == nil {
+		return ""
+	}
+	names := slices.Sorted(maps.Keys(apiSpec.Resources))
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
 }
 
 const htmlSyncStubThreshold = 0.7

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -8214,20 +8214,10 @@ func TestWrapWithProvenance_BareArrayUnchanged(t *testing.T) {
 	}
 }
 
-func TestWrapWithProvenance_NonJSONEmbeddedAsString(t *testing.T) {
+func TestWrapWithProvenance_NonJSONRejected(t *testing.T) {
 	prov := DataProvenance{Source: "live"}
-	wrapped, err := wrapWithProvenance(json.RawMessage(` + "`<rss><channel/></rss>`" + `), prov)
-	if err != nil {
-		t.Fatalf("wrapWithProvenance: %v", err)
-	}
-	var out struct {
-		Results string ` + "`json:\"results\"`" + `
-	}
-	if err := json.Unmarshal(wrapped, &out); err != nil {
-		t.Fatalf("non-JSON payload must embed as a string: %v\noutput: %s", err, wrapped)
-	}
-	if out.Results != ` + "`<rss><channel/></rss>`" + ` {
-		t.Fatalf("want raw payload preserved, got %q", out.Results)
+	if _, err := wrapWithProvenance(json.RawMessage(` + "`<rss><channel/></rss>`" + `), prov); err == nil {
+		t.Fatalf("wrapWithProvenance accepted non-JSON payload")
 	}
 }
 `

--- a/internal/generator/query_endpoint_sync_test.go
+++ b/internal/generator/query_endpoint_sync_test.go
@@ -57,8 +57,8 @@ func TestGeneratedQueryEndpointSyncEmitsConstructs(t *testing.T) {
 	// Response-envelope unwrap: the entity-named envelope key is query-only,
 	// not added to the global extractor list used by ordinary resources.
 	assert.Contains(t, syncContent, `var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}`)
-	assert.Contains(t, syncContent, `var queryDataEnvelopeKeys = []string{"data", "Data", "result", "Result", "QueryResponse"}`)
-	assert.Contains(t, syncContent, `extractPageItems(data, pageSize.cursorParam, dataEnvelopeKeysForResource(resource, path))`)
+	assert.Contains(t, syncContent, `return []string{"QueryResponse"}`)
+	assert.Contains(t, syncContent, `extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)`)
 
 	requireGeneratedCompiles(t, outputDir)
 }

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -1,0 +1,320 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedWrapWithProvenanceRejectsNonJSON(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("provenance-nonjson")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "provenance_nonjson_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWrapWithProvenanceRejectsNonJSON(t *testing.T) {
+	_, err := wrapWithProvenance(json.RawMessage("<html><form>login</form></html>"), DataProvenance{Source: "live"})
+	if err == nil {
+		t.Fatalf("wrapWithProvenance accepted non-JSON live data")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Fatalf("HTML live body should be classified as an auth/session problem, got: %v", err)
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestWrapWithProvenanceRejectsNonJSON", "-count=1")
+}
+
+func TestGeneratedLiveReadGuardsHTMLBeforeCache(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("read-html-guard")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	dataSourceSrc := readGeneratedFile(t, outputDir, "internal", "cli", "data_source.go")
+	require.Contains(t, dataSourceSrc, "assertLiveJSONBody(data)")
+	require.Less(t,
+		strings.Index(dataSourceSrc, "assertLiveJSONBody(data)"),
+		strings.Index(dataSourceSrc, "writeThroughCache(ctx, resourceType, data)"),
+		"live auto reads must reject HTML/non-JSON before write-through caching")
+}
+
+func TestGeneratedSyncExtractionHonorsResponsePath(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("sync-response-path")
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       "GET",
+					Path:         "/widgets",
+					Description:  "List widgets",
+					Response:     spec.ResponseDef{Type: "array", Item: "Widget"},
+					ResponsePath: "response.data",
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Widget": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "name", Type: "string"},
+		}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	require.Contains(t, syncSrc, `responsePathForResource(resource, path)`)
+	require.Contains(t, syncSrc, `extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)`)
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "sync_response_path_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractPageItemsHonorsResponsePath(t *testing.T) {
+	body := json.RawMessage(`+"`"+`{"message":"ok","response":{"data":[{"id":"w1"},{"id":"w2"}]}}`+"`"+`)
+	items, _, _ := extractPageItems(body, "cursor", "response.data")
+	if len(items) != 2 {
+		t.Fatalf("response_path extraction got %d items, want 2", len(items))
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestExtractPageItemsHonorsResponsePath", "-count=1")
+}
+
+func TestGeneratedSearchExtractionHonorsResponsePaths(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("search-response-path")
+	apiSpec.Resources = map[string]spec.Resource{
+		"photos": {
+			Description: "Photos",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:       "GET",
+					Path:         "/photos",
+					Description:  "List photos",
+					Response:     spec.ResponseDef{Type: "array", Item: "Photo"},
+					ResponsePath: "photos",
+				},
+				"search": {
+					Method: "GET",
+					Path:   "/photos/search",
+					Params: []spec.Param{{Name: "query", Type: "string"}},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Photo": {Fields: []spec.TypeField{
+			{Name: "id", Type: "string"},
+			{Name: "description", Type: "string"},
+		}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	searchSrc := readGeneratedFile(t, outputDir, "internal", "cli", "search.go")
+	require.Contains(t, searchSrc, `extractSearchResults(data, searchResponsePaths...)`)
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "search_response_path_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractSearchResultsHonorsResponsePath(t *testing.T) {
+	results := extractSearchResults(json.RawMessage(`+"`"+`{"photos":[{"id":"p1"},{"id":"p2"}],"page":1}`+"`"+`), "photos")
+	if len(results) != 2 {
+		t.Fatalf("response_path search extraction got %d results, want 2", len(results))
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestExtractSearchResultsHonorsResponsePath", "-count=1")
+}
+
+func TestGeneratedSearchKeepsFTSHitsWithDomainIdentifier(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("search-domain-id")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "search_domain_id_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSearchFilterKeepsNonEmptyDomainKeyedRows(t *testing.T) {
+	row := json.RawMessage(`+"`"+`{"codigo":"1102","descricao":"Compra para comercializacao"}`+"`"+`)
+	if isNilOrEmpty(row) {
+		t.Fatalf("FTS-matched row with non-empty scalar fields was dropped")
+	}
+	if !isNilOrEmpty(json.RawMessage(`+"`"+`{"id":null,"name":null}`+"`"+`)) {
+		t.Fatalf("null-shell row should still be suppressed")
+	}
+	if isNilOrEmpty(json.RawMessage(`+"`"+`{"score":0.9,"document":{"codigo":"1102","descricao":"Compra"}}`+"`"+`)) {
+		t.Fatalf("search wrapper result should still pass through")
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestSearchFilterKeepsNonEmptyDomainKeyedRows", "-count=1")
+}
+
+func TestGeneratedSearchHelpSpecializesToLocalOnlyAndRealTypes(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("readwise-like")
+	apiSpec.Resources = map[string]spec.Resource{
+		"books": {
+			Description: "Books",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/books", Description: "List books", Response: spec.ResponseDef{Type: "array", Item: "Book"}},
+			},
+		},
+		"highlights": {
+			Description: "Highlights",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {Method: "GET", Path: "/highlights", Description: "List highlights", Response: spec.ResponseDef{Type: "array", Item: "Highlight"}},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Book":      {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "title", Type: "string"}}},
+		"Highlight": {Fields: []spec.TypeField{{Name: "id", Type: "string"}, {Name: "text", Type: "string"}}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, Search: true}
+	require.NoError(t, gen.Generate())
+
+	searchSrc := readGeneratedFile(t, outputDir, "internal", "cli", "search.go")
+	require.Contains(t, searchSrc, `Short: "Search locally synced data"`)
+	require.NotContains(t, searchSrc, "payment failed")
+	require.NotContains(t, searchSrc, "--type transactions")
+	require.Contains(t, searchSrc, `--type books`)
+	require.NotContains(t, searchSrc, "live API")
+	require.NotContains(t, searchSrc, "API search endpoint if the API has one")
+}
+
+func TestGeneratedPromotedArrayResponseEmitsResults(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("promoted-array")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Resources = map[string]spec.Resource{
+		"geo": {
+			Description: "Geocoding",
+			Endpoints: map[string]spec.Endpoint{
+				"geocode": {
+					Method:      "GET",
+					Path:        "/geocode",
+					Description: "Geocode an address",
+					Response:    spec.ResponseDef{Type: "array", Item: "Geocode"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Geocode": {Fields: []spec.TypeField{
+			{Name: "lat", Type: "number"},
+			{Name: "lng", Type: "number"},
+		}},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	testPath := filepath.Join(outputDir, "internal", "cli", "promoted_array_response_test.go")
+	require.NoError(t, os.WriteFile(testPath, []byte(`package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPromotedArrayResponseEmitsResults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/geocode" {
+			t.Fatalf("path = %q, want /geocode", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `+"`"+`[{"lat":1.25,"lng":2.5}]`+"`"+`)
+	}))
+	defer server.Close()
+	t.Setenv("PROMOTED_ARRAY_BASE_URL", server.URL)
+
+	root := RootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"geo", "geocode", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute command: %v; stderr=%s", err, stderr.String())
+	}
+	var out struct {
+		Results []map[string]float64 `+"`json:\"results\"`"+`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if len(out.Results) != 1 || out.Results[0]["lat"] != 1.25 || out.Results[0]["lng"] != 2.5 {
+		t.Fatalf("results = %#v; stdout=%s stderr=%s", out.Results, stdout.String(), stderr.String())
+	}
+}
+`), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestPromotedArrayResponseEmitsResults", "-count=1")
+}

--- a/internal/generator/read_search_extraction_test.go
+++ b/internal/generator/read_search_extraction_test.go
@@ -103,10 +103,13 @@ import (
 )
 
 func TestExtractPageItemsHonorsResponsePath(t *testing.T) {
-	body := json.RawMessage(`+"`"+`{"message":"ok","response":{"data":[{"id":"w1"},{"id":"w2"}]}}`+"`"+`)
-	items, _, _ := extractPageItems(body, "cursor", "response.data")
+	body := json.RawMessage(`+"`"+`{"message":"ok","response":{"data":[{"id":"w1"},{"id":"w2"}],"next_cursor":"page-2","has_more":true}}`+"`"+`)
+	items, cursor, hasMore := extractPageItems(body, "cursor", "response.data")
 	if len(items) != 2 {
 		t.Fatalf("response_path extraction got %d items, want 2", len(items))
+	}
+	if cursor != "page-2" || !hasMore {
+		t.Fatalf("response_path cursor = %q/%v, want page-2/true", cursor, hasMore)
 	}
 }
 `), 0o644))
@@ -127,12 +130,13 @@ func TestGeneratedSearchExtractionHonorsResponsePaths(t *testing.T) {
 					Path:         "/photos",
 					Description:  "List photos",
 					Response:     spec.ResponseDef{Type: "array", Item: "Photo"},
-					ResponsePath: "photos",
+					ResponsePath: "catalog.items",
 				},
 				"search": {
-					Method: "GET",
-					Path:   "/photos/search",
-					Params: []spec.Param{{Name: "query", Type: "string"}},
+					Method:       "GET",
+					Path:         "/photos/search",
+					Params:       []spec.Param{{Name: "query", Type: "string"}},
+					ResponsePath: "photos",
 				},
 			},
 		},

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -360,7 +360,11 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 {{- end}}
 {{- end}}
 {{- if .HasStore}}
+{{- if eq .Endpoint.ResponseFormat "html"}}
+			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
+{{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+{{- end}}
 {{- else}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -236,7 +236,11 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 {{- end}}
 {{- end}}
 {{- if and .HasStore (eq (upper .Endpoint.Method) "GET")}}
+{{- if eq .Endpoint.ResponseFormat "html"}}
+			data, prov, err := resolveReadWithStrategyResponsePathAndJSONGuard(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, false, cmd.ErrOrStderr())
+{{- else}}
 			data, prov, err := resolveReadWithStrategyAndResponsePath(cmd.Context(), c, flags, "{{$dataSourceStrategy}}", "{{lower .ResourceName}}", {{localReadIsList $supportsAllPagination .APISpec .EndpointName .Endpoint}}, path, params, {{if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}headerOverrides{{else}}nil{{end}}, {{printf "%q" .Endpoint.ResponsePath}}, cmd.ErrOrStderr())
+{{- end}}
 {{- else if eq $method "GET"}}
 {{- if eq $dataSourceStrategy "local"}}
 			return fmt.Errorf("data_source_strategy local requires the local store data layer")

--- a/internal/generator/templates/data_source.go.tmpl
+++ b/internal/generator/templates/data_source.go.tmpl
@@ -143,6 +143,10 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 }
 
 func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyResponsePathAndJSONGuard(ctx, c, flags, strategy, resourceType, isList, path, params, headers, responsePath, true, hintWriter)
+}
+
+func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -154,6 +158,11 @@ func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Clien
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err != nil {
 			return nil, DataProvenance{}, err
+		}
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
@@ -168,12 +177,22 @@ func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Clien
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
+		}
 		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			if guardLiveJSON {
+				if err := assertLiveJSONBody(data); err != nil {
+					return nil, DataProvenance{}, err
+				}
+			}
 			data = applyResponsePath(data, responsePath)
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
@@ -212,6 +231,9 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if err := assertLiveJSONBody(data); err != nil {
+			return nil, DataProvenance{}, err
+		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
 	switch flags.dataSource {
@@ -224,11 +246,17 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if err := assertLiveJSONBody(data); err != nil {
+			return nil, DataProvenance{}, err
+		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -1491,6 +1491,31 @@ func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawM
 	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
+func responsePayloadParentAtPath(data json.RawMessage, responsePath string) (map[string]json.RawMessage, bool) {
+	path := strings.TrimPrefix(strings.TrimSpace(responsePath), "$.")
+	if path == "" {
+		return nil, false
+	}
+	var current map[string]json.RawMessage
+	if err := json.Unmarshal(data, &current); err != nil {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) == 1 {
+		return current, true
+	}
+	for _, part := range parts[:len(parts)-1] {
+		raw, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -2640,14 +2640,28 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
+func nonJSONPayloadError(data json.RawMessage) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + {{printf "%q" (authSetupHint .Auth .Name)}}))
+	}
+	if len(trimmed) == 0 {
+		return apiErr(fmt.Errorf("API returned an empty response body; expected JSON"))
+	}
+	return apiErr(fmt.Errorf("API returned a non-JSON response; expected JSON"))
+}
+
+func assertLiveJSONBody(data json.RawMessage) error {
+	if json.Valid(data) {
+		return nil
+	}
+	return nonJSONPayloadError(data)
+}
+
 // wrapWithProvenance wraps response data in a provenance envelope:
-// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
-// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
-// text), it embeds as a JSON string so json.Marshal doesn't choke on
-// "invalid character '<'" while still passing the raw payload through to
-// the consumer. Single-key array envelopes from the API (e.g.
-// {"results": [...]}, {"data": [...]}) are unwrapped first so the output
-// shape is the same regardless of the API's wrapper key.
+// {"results": ..., "meta": {...}}. Single-key array envelopes from the API
+// (e.g. {"results": [...]}, {"data": [...]}) are unwrapped first so the
+// output shape is the same regardless of the API's wrapper key.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -2666,7 +2680,7 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if json.Valid(data) {
 		results = json.RawMessage(unwrapSingleKeyArray(data))
 	} else {
-		results = string(data)
+		return nil, nonJSONPayloadError(data)
 	}
 	envelope := map[string]any{
 		"results": results,

--- a/internal/generator/templates/search.go.tmpl
+++ b/internal/generator/templates/search.go.tmpl
@@ -12,59 +12,57 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// isNilOrEmpty checks whether a JSON object has nil or empty values for
-// common identifier fields (title, name, identifier, id).
-// Also checks nested "document" objects for search result wrappers.
+// isNilOrEmpty checks whether a JSON search hit is only an empty shell.
 func isNilOrEmpty(raw json.RawMessage) bool {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return true
 	}
-	// Check top-level fields
-	for _, key := range []string{"title", "name", "identifier", "id"} {
-		if v, ok := obj[key]; ok {
-			if v == nil {
-				continue
-			}
-			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-				return false
-			}
-			// Non-string, non-nil value (e.g. numeric ID) — keep it
-			if _, ok := v.(string); !ok {
-				return false
-			}
-		}
-	}
-	// Check nested "document" for search result wrappers like {score, document: {name, ...}}
-	if doc, ok := obj["document"]; ok {
-		if docMap, ok := doc.(map[string]interface{}); ok {
-			for _, key := range []string{"title", "name", "identifier", "id", "slug"} {
-				if v, ok := docMap[key]; ok && v != nil {
-					if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-						return false
-					}
-					if _, ok := v.(string); !ok {
-						return false
-					}
-				}
-			}
-		}
-	}
-	// If the object has a "score" field, it's likely a search result — keep it
 	if _, ok := obj["score"]; ok {
 		return false
 	}
-	return true
+	return !hasAnyNonEmptySearchValue(obj)
+}
+
+func hasAnyNonEmptySearchValue(v any) bool {
+	switch typed := v.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case bool, float64:
+		return true
+	case []any:
+		for _, item := range typed {
+			if hasAnyNonEmptySearchValue(item) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, item := range typed {
+			if hasAnyNonEmptySearchValue(item) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 {{- /* extractSearchResults tries common response wrapper paths to extract result arrays */}}
 
 // extractSearchResults unwraps API search responses by checking common envelope paths.
-func extractSearchResults(data json.RawMessage) []json.RawMessage {
+func extractSearchResults(data json.RawMessage, responsePaths ...string) []json.RawMessage {
 	// Try direct array first
 	var items []json.RawMessage
 	if json.Unmarshal(data, &items) == nil {
 		return items
+	}
+	for _, responsePath := range responsePaths {
+		if pathData, ok := responsePayloadAtPath(data, responsePath); ok {
+			if json.Unmarshal(pathData, &items) == nil {
+				return items
+			}
+		}
 	}
 	// Try common wrapper paths: data, results, items
 	var wrapped map[string]json.RawMessage
@@ -85,9 +83,17 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 	var resourceType string
 	var limit int
 	var dbPath string
+{{- if .SearchEndpointPath}}
+	searchResponsePaths := []string{
+{{- range .SearchResponsePaths}}
+		{{printf "%q" .}},
+{{- end}}
+	}
+{{- end}}
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
+{{- if .SearchEndpointPath}}
 		Short: "Full-text search across synced data or live API",
 		Long: `Search data using FTS5 full-text search on locally synced data,
 or hit the API's search endpoint when available.
@@ -100,13 +106,35 @@ In local mode: searches locally synced data only.`,
   {{.Name}}-pp-cli search "error timeout"
 
   # Force local search only
-  {{.Name}}-pp-cli search "payment failed" --data-source local
+  {{.Name}}-pp-cli search "status" --data-source local
 
+{{- if .SearchExampleType}}
   # Search a specific resource type locally
-  {{.Name}}-pp-cli search "critical" --type transactions --data-source local
+  {{.Name}}-pp-cli search "status" --type {{.SearchExampleType}} --data-source local
 
+{{- end}}
   # JSON output for piping
   {{.Name}}-pp-cli search "critical" --json --limit 20`,
+{{- else}}
+		Short: "Search locally synced data",
+		Long: `Search locally synced data using FTS5 full-text search.
+
+This API has no dedicated search endpoint, so live mode is unavailable.
+Run sync first to populate the local search index.`,
+		Example: `  # Search locally synced data
+  {{.Name}}-pp-cli search "status"
+
+  # Force local search explicitly
+  {{.Name}}-pp-cli search "status" --data-source local
+
+{{- if .SearchExampleType}}
+  # Search a specific resource type locally
+  {{.Name}}-pp-cli search "status" --type {{.SearchExampleType}} --data-source local
+
+{{- end}}
+  # JSON output for piping
+  {{.Name}}-pp-cli search "status" --json --limit 20`,
+{{- end}}
 		Annotations: map[string]string{"mcp:hidden": "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -135,7 +163,7 @@ In local mode: searches locally synced data only.`,
 {{- end}}
 				if getErr == nil {
 					// Live search succeeded
-					results := extractSearchResults(data)
+					results := extractSearchResults(data, searchResponsePaths...)
 					prov := DataProvenance{Source: "live"}
 					return outputSearchResults(cmd, flags, results, limit, prov)
 				}

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -793,7 +793,7 @@ func syncResource(ctx context.Context, c interface {
 {{ end}}
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam{{if .QuerySync}}, dataEnvelopeKeysForResource(resource, path){{end}})
+		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -852,7 +852,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 {
-			if isEmptyPageResponse(data{{if .QuerySync}}, dataEnvelopeKeysForResource(resource, path){{end}}) {
+			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				break
 			}
 			// Single object response - try to store as-is
@@ -916,11 +916,11 @@ func syncResource(ctx context.Context, c interface {
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
 {{- if $hasIDWalk}}
-		if resourceSupportsPagination(resource) && !usesIDWalk && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data{{if .QuerySync}}, dataEnvelopeKeysForResource(resource, path){{end}}) {
+		if resourceSupportsPagination(resource) && !usesIDWalk && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 {{- else}}
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data{{if .QuerySync}}, dataEnvelopeKeysForResource(resource, path){{end}}) {
+		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 {{- end}}
@@ -1479,7 +1479,7 @@ func determineDateRangeParam() string {
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
-func extractPageItems(data json.RawMessage, cursorParam string{{if .QuerySync}}, envelopeKeyOverrides ...[]string{{end}}) ([]json.RawMessage, string, bool) {
+func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -1492,12 +1492,35 @@ func extractPageItems(data json.RawMessage, cursorParam string{{if .QuerySync}},
 		return nil, "", false
 	}
 
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if items, ok := extractObjectArray(pathData); ok {
+			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			return items, nextCursor, hasMore
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if items, ok := extractItemsFromEnvelope(inner); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				if nextCursor == "" {
+					nextCursor = outerCursor
+				}
+				hasMore = hasMore || outerHasMore
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
 	}
 
-	for _, key := range {{if .QuerySync}}envelopeKeysOrDefault(envelopeKeyOverrides){{else}}dataEnvelopeKeys{{end}} {
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -1728,7 +1751,7 @@ func isDryRunResponse(data json.RawMessage) bool {
 	return json.Unmarshal(raw, &v) == nil && v
 }
 
-func isEmptyPageResponse(data json.RawMessage{{if .QuerySync}}, envelopeKeyOverrides ...[]string{{end}}) bool {
+func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {
 		return len(direct) == 0
@@ -1743,7 +1766,28 @@ func isEmptyPageResponse(data json.RawMessage{{if .QuerySync}}, envelopeKeyOverr
 		return true
 	}
 
-	for _, key := range {{if .QuerySync}}envelopeKeysOrDefault(envelopeKeyOverrides){{else}}dataEnvelopeKeys{{end}} {
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if isJSONNull(pathData) {
+			if envelopeReportsFailure(envelope) {
+				return true
+			}
+			continue
+		}
+		var direct []json.RawMessage
+		if json.Unmarshal(pathData, &direct) == nil && !isJSONNull(pathData) {
+			return len(direct) == 0
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil && isEmptyPageEnvelope(inner) {
+			return true
+		}
+	}
+
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -1949,12 +1993,12 @@ func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
 }
 
-func pageMayHaveMore(data json.RawMessage{{if .QuerySync}}, envelopeKeyOverrides ...[]string{{end}}) bool {
-	hasMore, parsed := pageExplicitHasMore(data{{if .QuerySync}}, envelopeKeyOverrides...{{end}})
+func pageMayHaveMore(data json.RawMessage, responsePaths ...string) bool {
+	hasMore, parsed := pageExplicitHasMore(data, responsePaths...)
 	return !parsed || hasMore
 }
 
-func pageExplicitHasMore(data json.RawMessage{{if .QuerySync}}, envelopeKeyOverrides ...[]string{{end}}) (bool, bool) {
+func pageExplicitHasMore(data json.RawMessage, responsePaths ...string) (bool, bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return false, false
@@ -1962,7 +2006,19 @@ func pageExplicitHasMore(data json.RawMessage{{if .QuerySync}}, envelopeKeyOverr
 	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
 		return hasMore, true
 	}
-	for _, key := range {{if .QuerySync}}envelopeKeysOrDefault(envelopeKeyOverrides){{else}}dataEnvelopeKeys{{end}} {
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -2722,7 +2778,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 {{ end}}
-			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
 
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
@@ -2757,7 +2813,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
-				if isEmptyPageResponse(data{{if .QuerySync}}, dataEnvelopeKeysForResource(dep.Name, path){{end}}) {
+				if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 					outcome.complete = true // parent legitimately has zero children
 				} else {
 					outcome.reason = "empty_non_list_response"
@@ -2832,11 +2888,11 @@ func syncDependentResource(ctx context.Context, c interface {
 				}
 			}
 {{- if $hasIDWalk}}
-			if resourceSupportsPagination(dep.Name) && !usesIDWalk && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+			if resourceSupportsPagination(dep.Name) && !usesIDWalk && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(dep.Name, path)...) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 {{- else}}
-			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(dep.Name, path)...) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 {{- end}}
@@ -3058,24 +3114,25 @@ var pageItemKeys = []string{
 }
 
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
-{{- if .QuerySync}}
 
-var queryDataEnvelopeKeys = []string{"data", "Data", "result", "Result"{{if .QuerySync.EnvelopeKey}}, {{printf "%q" .QuerySync.EnvelopeKey}}{{end}}}
-
-func dataEnvelopeKeysForResource(resource, path string) []string {
-	if _, ok := queryEntity[resource]; ok && path == queryPath {
-		return queryDataEnvelopeKeys
-	}
-	return dataEnvelopeKeys
-}
-
-func envelopeKeysOrDefault(overrides [][]string) []string {
-	if len(overrides) > 0 && len(overrides[0]) > 0 {
-		return overrides[0]
-	}
-	return dataEnvelopeKeys
-}
+func responsePathForResource(resource, path string) []string {
+	switch resource + "\x00" + path {
+{{- range $resourceName, $resource := .Resources}}
+{{- range $endpointName, $endpoint := $resource.Endpoints}}
+{{- if $endpoint.ResponsePath}}
+	case {{printf "%q" (printf "%s\x00%s" $resourceName $endpoint.Path)}}:
+		return []string{ {{printf "%q" $endpoint.ResponsePath}} }
 {{- end}}
+{{- end}}
+{{- end}}
+	}
+{{- if and .QuerySync .QuerySync.EnvelopeKey}}
+	if _, ok := queryEntity[resource]; ok && path == queryPath {
+		return []string{ {{printf "%q" .QuerySync.EnvelopeKey}} }
+	}
+{{- end}}
+	return nil
+}
 
 var pageMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -1498,7 +1498,15 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractObjectArray(pathData); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := "", false
+			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+			}
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			if nextCursor == "" {
+				nextCursor = outerCursor
+			}
+			hasMore = hasMore || outerHasMore
 			return items, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -1011,6 +1011,31 @@ func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawM
 	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
+func responsePayloadParentAtPath(data json.RawMessage, responsePath string) (map[string]json.RawMessage, bool) {
+	path := strings.TrimPrefix(strings.TrimSpace(responsePath), "$.")
+	if path == "" {
+		return nil, false
+	}
+	var current map[string]json.RawMessage
+	if err := json.Unmarshal(data, &current); err != nil {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) == 1 {
+		return current, true
+	}
+	for _, part := range parts[:len(parts)-1] {
+		raw, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -2129,14 +2129,28 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
+func nonJSONPayloadError(data json.RawMessage) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + "Set your API key with: export EMBEDDED_PAGED_API_KEY=\"your-token-here\""))
+	}
+	if len(trimmed) == 0 {
+		return apiErr(fmt.Errorf("API returned an empty response body; expected JSON"))
+	}
+	return apiErr(fmt.Errorf("API returned a non-JSON response; expected JSON"))
+}
+
+func assertLiveJSONBody(data json.RawMessage) error {
+	if json.Valid(data) {
+		return nil
+	}
+	return nonJSONPayloadError(data)
+}
+
 // wrapWithProvenance wraps response data in a provenance envelope:
-// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
-// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
-// text), it embeds as a JSON string so json.Marshal doesn't choke on
-// "invalid character '<'" while still passing the raw payload through to
-// the consumer. Single-key array envelopes from the API (e.g.
-// {"results": [...]}, {"data": [...]}) are unwrapped first so the output
-// shape is the same regardless of the API's wrapper key.
+// {"results": ..., "meta": {...}}. Single-key array envelopes from the API
+// (e.g. {"results": [...]}, {"data": [...]}) are unwrapped first so the
+// output shape is the same regardless of the API's wrapper key.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -2155,7 +2169,7 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if json.Valid(data) {
 		results = json.RawMessage(unwrapSingleKeyArray(data))
 	} else {
-		results = string(data)
+		return nil, nonJSONPayloadError(data)
 	}
 	envelope := map[string]any{
 		"results": results,

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -1996,14 +1996,28 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
+func nonJSONPayloadError(data json.RawMessage) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + "Set your API key with: export RICH_AUTH_API_KEY=\"your-token-here\""))
+	}
+	if len(trimmed) == 0 {
+		return apiErr(fmt.Errorf("API returned an empty response body; expected JSON"))
+	}
+	return apiErr(fmt.Errorf("API returned a non-JSON response; expected JSON"))
+}
+
+func assertLiveJSONBody(data json.RawMessage) error {
+	if json.Valid(data) {
+		return nil
+	}
+	return nonJSONPayloadError(data)
+}
+
 // wrapWithProvenance wraps response data in a provenance envelope:
-// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
-// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
-// text), it embeds as a JSON string so json.Marshal doesn't choke on
-// "invalid character '<'" while still passing the raw payload through to
-// the consumer. Single-key array envelopes from the API (e.g.
-// {"results": [...]}, {"data": [...]}) are unwrapped first so the output
-// shape is the same regardless of the API's wrapper key.
+// {"results": ..., "meta": {...}}. Single-key array envelopes from the API
+// (e.g. {"results": [...]}, {"data": [...]}) are unwrapped first so the
+// output shape is the same regardless of the API's wrapper key.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -2022,7 +2036,7 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if json.Valid(data) {
 		results = json.RawMessage(unwrapSingleKeyArray(data))
 	} else {
-		results = string(data)
+		return nil, nonJSONPayloadError(data)
 	}
 	envelope := map[string]any{
 		"results": results,

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -878,6 +878,31 @@ func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawM
 	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
+func responsePayloadParentAtPath(data json.RawMessage, responsePath string) (map[string]json.RawMessage, bool) {
+	path := strings.TrimPrefix(strings.TrimSpace(responsePath), "$.")
+	if path == "" {
+		return nil, false
+	}
+	var current map[string]json.RawMessage
+	if err := json.Unmarshal(data, &current); err != nil {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) == 1 {
+		return current, true
+	}
+	for _, part := range parts[:len(parts)-1] {
+		raw, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 84
+    "total": 85
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/dogfood.json
+++ b/testdata/golden/expected/generate-golden-api/dogfood.json
@@ -16,7 +16,7 @@
   },
   "dead_functions": {
     "dead": 0,
-    "total": 82
+    "total": 84
   },
   "dir": "<ARTIFACT_DIR>/generate-golden-api/printing-press-golden",
   "example_check": {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/data_source.go
@@ -143,6 +143,10 @@ func resolveReadWithStrategy(ctx context.Context, c *client.Client, flags *rootF
 }
 
 func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
+	return resolveReadWithStrategyResponsePathAndJSONGuard(ctx, c, flags, strategy, resourceType, isList, path, params, headers, responsePath, true, hintWriter)
+}
+
+func resolveReadWithStrategyResponsePathAndJSONGuard(ctx context.Context, c *client.Client, flags *rootFlags, strategy string, resourceType string, isList bool, path string, params map[string]string, headers map[string]string, responsePath string, guardLiveJSON bool, hintWriter io.Writer) (json.RawMessage, DataProvenance, error) {
 	if err := validateDataSourceStrategy(flags, strategy); err != nil {
 		return nil, DataProvenance{}, err
 	}
@@ -154,6 +158,11 @@ func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Clien
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err != nil {
 			return nil, DataProvenance{}, err
+		}
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 		}
 		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
@@ -168,12 +177,22 @@ func resolveReadWithStrategyAndResponsePath(ctx context.Context, c *client.Clien
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if guardLiveJSON {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
+		}
 		data = applyResponsePath(data, responsePath)
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := c.GetWithHeaders(ctx, path, params, headers)
 		if err == nil {
+			if guardLiveJSON {
+				if err := assertLiveJSONBody(data); err != nil {
+					return nil, DataProvenance{}, err
+				}
+			}
 			data = applyResponsePath(data, responsePath)
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
@@ -212,6 +231,9 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if err := assertLiveJSONBody(data); err != nil {
+			return nil, DataProvenance{}, err
+		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 	}
 	switch flags.dataSource {
@@ -224,11 +246,17 @@ func resolvePaginatedReadWithStrategy(ctx context.Context, c *client.Client, fla
 		if err != nil {
 			return nil, DataProvenance{}, err
 		}
+		if err := assertLiveJSONBody(data); err != nil {
+			return nil, DataProvenance{}, err
+		}
 		return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 
 	default: // "auto"
 		data, err := paginatedGet(ctx, c, path, params, headers, fetchAll, cursorParam, paginationType, limitParam, nextCursorPath, hasMoreField)
 		if err == nil {
+			if err := assertLiveJSONBody(data); err != nil {
+				return nil, DataProvenance{}, err
+			}
 			writeThroughCache(ctx, resourceType, data)
 			return data, attachFreshness(DataProvenance{Source: "live"}, flags), nil
 		}

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -2078,14 +2078,28 @@ func printProvenance(cmd *cobra.Command, count int, prov DataProvenance) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "%s%d results (cached, synced %s)\n", prefix, count, age)
 }
 
+func nonJSONPayloadError(data json.RawMessage) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '<' {
+		return authErr(fmt.Errorf("not authenticated or session expired; API returned HTML instead of JSON. " + "Set your API key with: export PRINTING_PRESS_GOLDEN_API_KEY=\"your-token-here\""))
+	}
+	if len(trimmed) == 0 {
+		return apiErr(fmt.Errorf("API returned an empty response body; expected JSON"))
+	}
+	return apiErr(fmt.Errorf("API returned a non-JSON response; expected JSON"))
+}
+
+func assertLiveJSONBody(data json.RawMessage) error {
+	if json.Valid(data) {
+		return nil
+	}
+	return nonJSONPayloadError(data)
+}
+
 // wrapWithProvenance wraps response data in a provenance envelope:
-// {"results": ..., "meta": {...}}. When data is valid JSON, it embeds as
-// the parsed shape; when data is non-JSON (e.g., XML/RSS responses, plain
-// text), it embeds as a JSON string so json.Marshal doesn't choke on
-// "invalid character '<'" while still passing the raw payload through to
-// the consumer. Single-key array envelopes from the API (e.g.
-// {"results": [...]}, {"data": [...]}) are unwrapped first so the output
-// shape is the same regardless of the API's wrapper key.
+// {"results": ..., "meta": {...}}. Single-key array envelopes from the API
+// (e.g. {"results": [...]}, {"data": [...]}) are unwrapped first so the
+// output shape is the same regardless of the API's wrapper key.
 func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMessage, error) {
 	meta := map[string]any{"source": prov.Source}
 	if prov.SyncedAt != nil {
@@ -2104,7 +2118,7 @@ func wrapWithProvenance(data json.RawMessage, prov DataProvenance) (json.RawMess
 	if json.Valid(data) {
 		results = json.RawMessage(unwrapSingleKeyArray(data))
 	} else {
-		results = string(data)
+		return nil, nonJSONPayloadError(data)
 	}
 	envelope := map[string]any{
 		"results": results,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/helpers.go
@@ -960,6 +960,31 @@ func responsePayloadAtPath(data json.RawMessage, responsePath string) (json.RawM
 	return rawAtPath(root, strings.TrimPrefix(responsePath, "$."))
 }
 
+func responsePayloadParentAtPath(data json.RawMessage, responsePath string) (map[string]json.RawMessage, bool) {
+	path := strings.TrimPrefix(strings.TrimSpace(responsePath), "$.")
+	if path == "" {
+		return nil, false
+	}
+	var current map[string]json.RawMessage
+	if err := json.Unmarshal(data, &current); err != nil {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) == 1 {
+		return current, true
+	}
+	for _, part := range parts[:len(parts)-1] {
+		raw, ok := current[part]
+		if !ok {
+			return nil, false
+		}
+		if err := json.Unmarshal(raw, &current); err != nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
 // printJSONFiltered marshals a Go-typed value through the same output
 // pipeline endpoint-mirror commands use. Hand-written novel commands that
 // build a typed slice/struct call this so --select, --compact, --csv, and

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -545,7 +545,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -577,7 +577,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 {
-			if isEmptyPageResponse(data) {
+			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				break
 			}
 			// Single object response - try to store as-is
@@ -640,7 +640,7 @@ func syncResource(ctx context.Context, c interface {
 
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 
@@ -867,7 +867,7 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
-func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessage, string, bool) {
+func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -878,6 +878,29 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return nil, "", false
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if items, ok := extractObjectArray(pathData); ok {
+			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			return items, nextCursor, hasMore
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if items, ok := extractItemsFromEnvelope(inner); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				if nextCursor == "" {
+					nextCursor = outerCursor
+				}
+				hasMore = hasMore || outerHasMore
+				return items, nextCursor, hasMore
+			}
+		}
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
@@ -1004,7 +1027,7 @@ func isDryRunResponse(data json.RawMessage) bool {
 	return json.Unmarshal(raw, &v) == nil && v
 }
 
-func isEmptyPageResponse(data json.RawMessage) bool {
+func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {
 		return len(direct) == 0
@@ -1017,6 +1040,27 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 
 	if isEmptyPageEnvelope(envelope) {
 		return true
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if isJSONNull(pathData) {
+			if envelopeReportsFailure(envelope) {
+				return true
+			}
+			continue
+		}
+		var direct []json.RawMessage
+		if json.Unmarshal(pathData, &direct) == nil && !isJSONNull(pathData) {
+			return len(direct) == 0
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil && isEmptyPageEnvelope(inner) {
+			return true
+		}
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1225,18 +1269,30 @@ func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
 }
 
-func pageMayHaveMore(data json.RawMessage) bool {
-	hasMore, parsed := pageExplicitHasMore(data)
+func pageMayHaveMore(data json.RawMessage, responsePaths ...string) bool {
+	hasMore, parsed := pageExplicitHasMore(data, responsePaths...)
 	return !parsed || hasMore
 }
 
-func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+func pageExplicitHasMore(data json.RawMessage, responsePaths ...string) (bool, bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return false, false
 	}
 	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
 		return hasMore, true
+	}
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
 	}
 	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
@@ -1783,7 +1839,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				return syncResult{Resource: dep.Name, Count: 0, Duration: time.Since(started)}
 			}
 
-			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
 
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
@@ -1813,7 +1869,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
-				if isEmptyPageResponse(data) {
+				if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 					outcome.complete = true // parent legitimately has zero children
 				} else {
 					outcome.reason = "empty_non_list_response"
@@ -1887,7 +1943,7 @@ func syncDependentResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(dep.Name, path)...) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 			pagesFetched++
@@ -2069,6 +2125,12 @@ var pageItemKeys = []string{
 }
 
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
+
+func responsePathForResource(resource, path string) []string {
+	switch resource + "\x00" + path {
+	}
+	return nil
+}
 
 var pageMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -886,7 +886,15 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractObjectArray(pathData); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := "", false
+			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+			}
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			if nextCursor == "" {
+				nextCursor = outerCursor
+			}
+			hasMore = hasMore || outerHasMore
 			return items, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -531,7 +531,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, dataEnvelopeKeysForResource(resource, path))
+		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -583,7 +583,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 {
-			if isEmptyPageResponse(data, dataEnvelopeKeysForResource(resource, path)) {
+			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				break
 			}
 			// Single object response - try to store as-is
@@ -646,7 +646,7 @@ func syncResource(ctx context.Context, c interface {
 
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, dataEnvelopeKeysForResource(resource, path)) {
+		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 
@@ -870,7 +870,7 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
-func extractPageItems(data json.RawMessage, cursorParam string, envelopeKeyOverrides ...[]string) ([]json.RawMessage, string, bool) {
+func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -883,12 +883,35 @@ func extractPageItems(data json.RawMessage, cursorParam string, envelopeKeyOverr
 		return nil, "", false
 	}
 
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if items, ok := extractObjectArray(pathData); ok {
+			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			return items, nextCursor, hasMore
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if items, ok := extractItemsFromEnvelope(inner); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				if nextCursor == "" {
+					nextCursor = outerCursor
+				}
+				hasMore = hasMore || outerHasMore
+				return items, nextCursor, hasMore
+			}
+		}
+	}
+
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
 		nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
 		return items, nextCursor, hasMore
 	}
 
-	for _, key := range envelopeKeysOrDefault(envelopeKeyOverrides) {
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -1007,7 +1030,7 @@ func isDryRunResponse(data json.RawMessage) bool {
 	return json.Unmarshal(raw, &v) == nil && v
 }
 
-func isEmptyPageResponse(data json.RawMessage, envelopeKeyOverrides ...[]string) bool {
+func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {
 		return len(direct) == 0
@@ -1022,7 +1045,28 @@ func isEmptyPageResponse(data json.RawMessage, envelopeKeyOverrides ...[]string)
 		return true
 	}
 
-	for _, key := range envelopeKeysOrDefault(envelopeKeyOverrides) {
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if isJSONNull(pathData) {
+			if envelopeReportsFailure(envelope) {
+				return true
+			}
+			continue
+		}
+		var direct []json.RawMessage
+		if json.Unmarshal(pathData, &direct) == nil && !isJSONNull(pathData) {
+			return len(direct) == 0
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil && isEmptyPageEnvelope(inner) {
+			return true
+		}
+	}
+
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -1228,12 +1272,12 @@ func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
 }
 
-func pageMayHaveMore(data json.RawMessage, envelopeKeyOverrides ...[]string) bool {
-	hasMore, parsed := pageExplicitHasMore(data, envelopeKeyOverrides...)
+func pageMayHaveMore(data json.RawMessage, responsePaths ...string) bool {
+	hasMore, parsed := pageExplicitHasMore(data, responsePaths...)
 	return !parsed || hasMore
 }
 
-func pageExplicitHasMore(data json.RawMessage, envelopeKeyOverrides ...[]string) (bool, bool) {
+func pageExplicitHasMore(data json.RawMessage, responsePaths ...string) (bool, bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return false, false
@@ -1241,7 +1285,19 @@ func pageExplicitHasMore(data json.RawMessage, envelopeKeyOverrides ...[]string)
 	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
 		return hasMore, true
 	}
-	for _, key := range envelopeKeysOrDefault(envelopeKeyOverrides) {
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
+	}
+	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
 		if !ok {
 			continue
@@ -1608,20 +1664,17 @@ var pageItemKeys = []string{
 
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
 
-var queryDataEnvelopeKeys = []string{"data", "Data", "result", "Result", "QueryResponse"}
-
-func dataEnvelopeKeysForResource(resource, path string) []string {
+func responsePathForResource(resource, path string) []string {
+	switch resource + "\x00" + path {
+	case "gadgets\x00/query":
+		return []string{"QueryResponse.Gadget"}
+	case "widgets\x00/query":
+		return []string{"QueryResponse.Widget"}
+	}
 	if _, ok := queryEntity[resource]; ok && path == queryPath {
-		return queryDataEnvelopeKeys
+		return []string{"QueryResponse"}
 	}
-	return dataEnvelopeKeys
-}
-
-func envelopeKeysOrDefault(overrides [][]string) []string {
-	if len(overrides) > 0 && len(overrides[0]) > 0 {
-		return overrides[0]
-	}
-	return dataEnvelopeKeys
+	return nil
 }
 
 var pageMetadataArrayKeys = map[string]bool{

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -889,7 +889,15 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractObjectArray(pathData); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := "", false
+			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+			}
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			if nextCursor == "" {
+				nextCursor = outerCursor
+			}
+			hasMore = hasMore || outerHasMore
 			return items, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -545,7 +545,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -577,7 +577,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 {
-			if isEmptyPageResponse(data) {
+			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				break
 			}
 			// Single object response - try to store as-is
@@ -640,7 +640,7 @@ func syncResource(ctx context.Context, c interface {
 
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 
@@ -849,7 +849,7 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
-func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessage, string, bool) {
+func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -860,6 +860,29 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return nil, "", false
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if items, ok := extractObjectArray(pathData); ok {
+			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			return items, nextCursor, hasMore
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if items, ok := extractItemsFromEnvelope(inner); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				if nextCursor == "" {
+					nextCursor = outerCursor
+				}
+				hasMore = hasMore || outerHasMore
+				return items, nextCursor, hasMore
+			}
+		}
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
@@ -986,7 +1009,7 @@ func isDryRunResponse(data json.RawMessage) bool {
 	return json.Unmarshal(raw, &v) == nil && v
 }
 
-func isEmptyPageResponse(data json.RawMessage) bool {
+func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {
 		return len(direct) == 0
@@ -999,6 +1022,27 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 
 	if isEmptyPageEnvelope(envelope) {
 		return true
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if isJSONNull(pathData) {
+			if envelopeReportsFailure(envelope) {
+				return true
+			}
+			continue
+		}
+		var direct []json.RawMessage
+		if json.Unmarshal(pathData, &direct) == nil && !isJSONNull(pathData) {
+			return len(direct) == 0
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil && isEmptyPageEnvelope(inner) {
+			return true
+		}
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1207,18 +1251,30 @@ func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
 }
 
-func pageMayHaveMore(data json.RawMessage) bool {
-	hasMore, parsed := pageExplicitHasMore(data)
+func pageMayHaveMore(data json.RawMessage, responsePaths ...string) bool {
+	hasMore, parsed := pageExplicitHasMore(data, responsePaths...)
 	return !parsed || hasMore
 }
 
-func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+func pageExplicitHasMore(data json.RawMessage, responsePaths ...string) (bool, bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return false, false
 	}
 	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
 		return hasMore, true
+	}
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
 	}
 	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
@@ -1754,7 +1810,7 @@ func syncDependentResource(ctx context.Context, c interface {
 				return syncResult{Resource: dep.Name, Count: 0, Duration: time.Since(started)}
 			}
 
-			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+			items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(dep.Name, path)...)
 
 			// Page-int paginator fallback: mirrors syncResource so dependent
 			// resources on integer ?page=N APIs also advance past page 1.
@@ -1784,7 +1840,7 @@ func syncDependentResource(ctx context.Context, c interface {
 			}
 
 			if len(items) == 0 {
-				if isEmptyPageResponse(data) {
+				if isEmptyPageResponse(data, responsePathForResource(dep.Name, path)...) {
 					outcome.complete = true // parent legitimately has zero children
 				} else {
 					outcome.reason = "empty_non_list_response"
@@ -1858,7 +1914,7 @@ func syncDependentResource(ctx context.Context, c interface {
 					}
 				}
 			}
-			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+			if resourceSupportsPagination(dep.Name) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(dep.Name, path)...) {
 				emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, dep.Name, parentID)
 			}
 			pagesFetched++
@@ -2039,6 +2095,12 @@ var pageItemKeys = []string{
 }
 
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
+
+func responsePathForResource(resource, path string) []string {
+	switch resource + "\x00" + path {
+	}
+	return nil
+}
 
 var pageMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -868,7 +868,15 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractObjectArray(pathData); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := "", false
+			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+			}
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			if nextCursor == "" {
+				nextCursor = outerCursor
+			}
+			hasMore = hasMore || outerHasMore
 			return items, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -508,7 +508,7 @@ func syncResource(ctx context.Context, c interface {
 
 		// Try to extract items from the response.
 		// Strategy: try array first, then common wrapper keys.
-		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam)
+		items, nextCursor, hasMore := extractPageItems(data, pageSize.cursorParam, responsePathForResource(resource, path)...)
 
 		// Page-int paginator fallback: when the API paginates by integer
 		// ?page=N and emits no body cursor, treat a full page as a signal
@@ -540,7 +540,7 @@ func syncResource(ctx context.Context, c interface {
 		}
 
 		if len(items) == 0 {
-			if isEmptyPageResponse(data) {
+			if isEmptyPageResponse(data, responsePathForResource(resource, path)...) {
 				break
 			}
 			// Single object response - try to store as-is
@@ -603,7 +603,7 @@ func syncResource(ctx context.Context, c interface {
 
 		totalCount += stored
 		atomic.AddInt64(&progressCount, int64(stored))
-		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data) {
+		if resourceSupportsPagination(resource) && nextCursor == "" && pageSize.cursorParam != "offset" && len(items) >= pageSize.limit && pageMayHaveMore(data, responsePathForResource(resource, path)...) {
 			emitSyncMissingPaginationCursorWarning(syncEvents, humanFriendly, resource, "")
 		}
 
@@ -821,7 +821,7 @@ func formatSyncSinceValue(value string, paramFormat string) string {
 // 2. Common wrapper keys: "data", "results", "items", "records", "nodes", "entries"
 // 3. JSend-style nested data envelopes: {"data":{"<resource>":[...]}}
 // It also extracts the next cursor from common response fields.
-func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessage, string, bool) {
+func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ...string) ([]json.RawMessage, string, bool) {
 	// Strategy 1: direct array
 	var items []json.RawMessage
 	if err := json.Unmarshal(data, &items); err == nil {
@@ -832,6 +832,29 @@ func extractPageItems(data json.RawMessage, cursorParam string) ([]json.RawMessa
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return nil, "", false
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if items, ok := extractObjectArray(pathData); ok {
+			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			return items, nextCursor, hasMore
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if items, ok := extractItemsFromEnvelope(inner); ok {
+				nextCursor, hasMore := extractPaginationFromEnvelope(inner, cursorParam)
+				outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+				if nextCursor == "" {
+					nextCursor = outerCursor
+				}
+				hasMore = hasMore || outerHasMore
+				return items, nextCursor, hasMore
+			}
+		}
 	}
 
 	if items, ok := extractItemsByKnownKeys(envelope); ok {
@@ -958,7 +981,7 @@ func isDryRunResponse(data json.RawMessage) bool {
 	return json.Unmarshal(raw, &v) == nil && v
 }
 
-func isEmptyPageResponse(data json.RawMessage) bool {
+func isEmptyPageResponse(data json.RawMessage, responsePaths ...string) bool {
 	var direct []json.RawMessage
 	if err := json.Unmarshal(data, &direct); err == nil && !isJSONNull(data) {
 		return len(direct) == 0
@@ -971,6 +994,27 @@ func isEmptyPageResponse(data json.RawMessage) bool {
 
 	if isEmptyPageEnvelope(envelope) {
 		return true
+	}
+
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		if isJSONNull(pathData) {
+			if envelopeReportsFailure(envelope) {
+				return true
+			}
+			continue
+		}
+		var direct []json.RawMessage
+		if json.Unmarshal(pathData, &direct) == nil && !isJSONNull(pathData) {
+			return len(direct) == 0
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil && isEmptyPageEnvelope(inner) {
+			return true
+		}
 	}
 
 	for _, key := range dataEnvelopeKeys {
@@ -1179,18 +1223,30 @@ func pageAllowsPageIntFallback(data json.RawMessage) bool {
 	return pageMayHaveMore(data)
 }
 
-func pageMayHaveMore(data json.RawMessage) bool {
-	hasMore, parsed := pageExplicitHasMore(data)
+func pageMayHaveMore(data json.RawMessage, responsePaths ...string) bool {
+	hasMore, parsed := pageExplicitHasMore(data, responsePaths...)
 	return !parsed || hasMore
 }
 
-func pageExplicitHasMore(data json.RawMessage) (bool, bool) {
+func pageExplicitHasMore(data json.RawMessage, responsePaths ...string) (bool, bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return false, false
 	}
 	if hasMore, parsed := envelopeExplicitHasMore(envelope); parsed {
 		return hasMore, true
+	}
+	for _, responsePath := range responsePaths {
+		pathData, ok := responsePayloadAtPath(data, responsePath)
+		if !ok {
+			continue
+		}
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(pathData, &inner) == nil {
+			if hasMore, parsed := envelopeExplicitHasMore(inner); parsed {
+				return hasMore, true
+			}
+		}
 	}
 	for _, key := range dataEnvelopeKeys {
 		raw, ok := envelope[key]
@@ -1545,6 +1601,12 @@ var pageItemKeys = []string{
 }
 
 var dataEnvelopeKeys = []string{"data", "Data", "result", "Result"}
+
+func responsePathForResource(resource, path string) []string {
+	switch resource + "\x00" + path {
+	}
+	return nil
+}
 
 var pageMetadataArrayKeys = map[string]bool{
 	"errors": true, "Errors": true,

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -840,7 +840,15 @@ func extractPageItems(data json.RawMessage, cursorParam string, responsePaths ..
 			continue
 		}
 		if items, ok := extractObjectArray(pathData); ok {
-			nextCursor, hasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			nextCursor, hasMore := "", false
+			if parentEnvelope, ok := responsePayloadParentAtPath(data, responsePath); ok {
+				nextCursor, hasMore = extractPaginationFromEnvelope(parentEnvelope, cursorParam)
+			}
+			outerCursor, outerHasMore := extractPaginationFromEnvelope(envelope, cursorParam)
+			if nextCursor == "" {
+				nextCursor = outerCursor
+			}
+			hasMore = hasMore || outerHasMore
 			return items, nextCursor, hasMore
 		}
 		var inner map[string]json.RawMessage


### PR DESCRIPTION
## Summary

Generated CLIs now fail loudly when live JSON read paths receive HTML or other non-JSON payloads, and extraction paths now honor declared response wrappers across read-adjacent surfaces instead of silently returning empty results. Sync and framework search try spec `response_path` values before generic envelopes, promoted array responses are covered explicitly, and local FTS results are kept when rows use domain-specific identifier fields rather than the old English-only key allow-list.

Search help is now capability-aware: CLIs without a live search endpoint describe local FTS behavior and use real resource types in examples instead of payment-domain placeholders.

Fixes #3174.
Fixes #2997.
Fixes #3056.
Fixes #2941.
Fixes #2985.

## Validation

- `go test ./internal/generator -run 'TestGenerated(WrapWithProvenanceRejectsNonJSON|LiveReadGuardsHTMLBeforeCache|SyncExtractionHonorsResponsePath|SearchExtractionHonorsResponsePaths|SearchKeepsFTSHitsWithDomainIdentifier|SearchHelpSpecializesToLocalOnlyAndRealTypes|PromotedArrayResponseEmitsResults)$' -count=1`
- `scripts/verify-generator-output.sh`
- `scripts/golden.sh verify`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
