### PR TITLE
fix(cli): bound sync dogfood and profiler defaults

### DIFF
--- a/docs/SPEC-EXTENSIONS.md
+++ b/docs/SPEC-EXTENSIONS.md
@@ -46,6 +46,7 @@ in the same change as any new `Extensions["x-*"]` lookup in that file.
 | `x-requires-role` | operation | `Endpoint.RequiresRole` | No |
 | `x-happy-args` | operation | `Endpoint.HappyArgs` | No |
 | `x-pp-resource` | operation | resource name override | No |
+| `x-pp-pagination` | operation | `Endpoint.Pagination` | No |
 | `x-pp-safe-probe` | operation | *skill guidance only; not parsed in parser.go* | No |
 | `x-pp-sync-walker` | operation | `Endpoint.Walker` | No |
 | `x-pp-dispatch-param` | parameter | `Param.DispatchParam` | No |
@@ -1339,6 +1340,41 @@ paths:
     post:
       operationId: searchNotes
       x-pp-resource: notes_search
+      responses:
+        "200": {description: ok}
+```
+
+### `x-pp-pagination`
+
+Overrides pagination detection for one GET operation.
+
+Parsed field: `Endpoint.Pagination`
+
+Rules:
+- Optional.
+- Must be on an operation, not the root, `info`, or path item.
+- Must be a string.
+- Accepted value: `none`.
+- `none` tells generated sync not to send inferred cursor, page, offset, or
+  page-size query parameters for this endpoint, even when the operation exposes
+  page-looking filters such as `page`, `page_size`, or `limit`.
+- Use for list endpoints that return the whole collection in one response and
+  reject pagination keys as invalid filters.
+- Unsupported values emit a warning and fall back to normal pagination
+  detection.
+
+Example:
+
+```yaml
+paths:
+  /ip_addresses:
+    get:
+      operationId: listIPAddresses
+      x-pp-pagination: none
+      parameters:
+        - name: page_size
+          in: query
+          schema: {type: integer}
       responses:
         "200": {description: ok}
 ```

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9912,6 +9912,72 @@ func TestGeneratedOutput_DefaultSyncSkipsUnsatisfiedRequiredParams(t *testing.T)
 	runGoCommand(t, outputDir, "build", "./cmd/"+naming.CLI(apiSpec.Name))
 }
 
+func TestGeneratedSyncExcludesActionGetEndpoints(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "sync-actions",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.com",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/sync-actions-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"customers": {
+				Description: "Customers",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/customers.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"subscriptions_lookup": {
+				Description: "Subscription lookup",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/subscriptions/lookup.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"invoices_events": {
+				Description: "Invoice events",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/invoices/events.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncSrc := string(syncGo)
+	defaultResources := regexp.MustCompile(`(?s)func defaultSyncResources\(\) \[\]string \{(.*?)\n\}`).FindStringSubmatch(syncSrc)
+	require.Len(t, defaultResources, 2)
+	assert.Contains(t, defaultResources[1], `"customers"`)
+	assert.NotContains(t, defaultResources[1], `"subscriptions_lookup"`)
+	assert.NotContains(t, defaultResources[1], `"invoices_events"`)
+	assert.NotContains(t, syncSrc, `"/subscriptions/lookup.json"`)
+	assert.NotContains(t, syncSrc, `"/invoices/events.json"`)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./internal/cli")
+}
+
 func TestGeneratedOutput_WorkflowArchiveJSONKeepsSyncEventsOffStdout(t *testing.T) {
 	t.Parallel()
 
@@ -12386,12 +12452,16 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 		"sync.go must declare --max-pages with default 0")
 	assert.Contains(t, syncContent, `if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages")`,
 		"sync.go must bound dogfood syncs only when --max-pages was not explicitly set")
-	assert.Contains(t, syncContent, `maxPages = 10`,
-		"sync.go must keep a dogfood-only page cap")
+	assert.Contains(t, syncContent, `maxPages = 1`,
+		"sync.go must keep a dogfood-only paginate-once cap")
 	assert.NotContains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 100,`,
 		"sync.go must not retain the old finite 100-page default")
 	assert.NotContains(t, syncContent, `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
 		"sync.go must not retain the old 10-page default")
+	assert.Contains(t, syncContent, `const dogfoodMaxParentRows = 2`,
+		"sync.go must bound dependent parent fan-out under dogfood")
+	assert.Contains(t, syncContent, `parentRows = parentRows[:dogfoodMaxParentRows]`,
+		"sync.go must curtail wide parent tables before dependent fan-out")
 
 	// (b1) Flat-path cap-hit emits structured sync_warning with reason
 	// "max_pages_cap_hit". Use the literal %s embedded-quote shape — match
@@ -12898,8 +12968,8 @@ func TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv(t *testing.T) {
 		"GraphQL sync.go must declare --max-pages with default 0")
 	assert.Contains(t, string(syncGo), `if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages")`,
 		"GraphQL sync.go must bound dogfood syncs only when --max-pages was not explicitly set")
-	assert.Contains(t, string(syncGo), `maxPages = 10`,
-		"GraphQL sync.go dogfood cap must still bound generated syncs to 10 pages")
+	assert.Contains(t, string(syncGo), `maxPages = 1`,
+		"GraphQL sync.go dogfood cap must bound generated syncs to one page")
 	assert.NotContains(t, string(syncGo), `cmd.Flags().IntVar(&maxPages, "max-pages", 10,`,
 		"GraphQL sync.go must not retain the old 10-page default")
 	assert.Contains(t, string(syncGo), "capExitHit := false",
@@ -13991,6 +14061,19 @@ func TestGeneratedSyncGatesPaginationParamsPerResource(t *testing.T) {
 					},
 				},
 			},
+			"ip_addresses": {
+				Description: "IP addresses",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/ip_addresses",
+						Description: "List IP addresses",
+						Response:    spec.ResponseDef{Type: "array"},
+						Params:      []spec.Param{{Name: "page_size", Type: "integer"}, {Name: "page", Type: "integer"}},
+						Pagination:  &spec.Pagination{Type: "none"},
+					},
+				},
+			},
 			"budget_settings": {
 				Description: "Budget settings",
 				Endpoints: map[string]spec.Endpoint{
@@ -14026,6 +14109,8 @@ func TestGeneratedSyncGatesPaginationParamsPerResource(t *testing.T) {
 		"dependent transactions declares limit/offset and must opt into pagination params")
 	assert.NotContains(t, helperBody, `case "categories":`,
 		"categories declares no limit param and must not receive pagination params")
+	assert.NotContains(t, helperBody, `case "ip_addresses":`,
+		"pagination.type none must suppress otherwise recognizable pagination params")
 	assert.NotContains(t, helperBody, `case "budget_settings":`,
 		"/budgets/settings is non-paginated and must fall through to false")
 	assert.Contains(t, syncContent, `if resourceSupportsPagination(resource) {`,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -12462,6 +12462,12 @@ func TestGeneratedSyncMaxPagesAndStickyCursor(t *testing.T) {
 		"sync.go must bound dependent parent fan-out under dogfood")
 	assert.Contains(t, syncContent, `parentRows = parentRows[:dogfoodMaxParentRows]`,
 		"sync.go must curtail wide parent tables before dependent fan-out")
+	assert.Contains(t, syncContent,
+		`{"event":"sync_warning","resource":"%s","parent_table":"%s","reason":"dogfood_parent_rows_cap_hit"`,
+		"sync.go must emit a structured warning when dogfood caps dependent parent rows")
+	assert.Contains(t, syncContent,
+		"dogfood capped parent sync to %d of %d %s parents",
+		"sync.go must print a human-friendly warning when dogfood caps dependent parent rows")
 
 	// (b1) Flat-path cap-hit emits structured sync_warning with reason
 	// "max_pages_cap_hit". Use the literal %s embedded-quote shape — match

--- a/internal/generator/templates/graphql_sync.go.tmpl
+++ b/internal/generator/templates/graphql_sync.go.tmpl
@@ -103,7 +103,7 @@ Exit codes & warnings:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only: cap at page 1 and clear the resume cursor so

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -2572,7 +2572,13 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
 	}
 	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		originalParentRows := len(parentRows)
 		parentRows = parentRows[:dogfoodMaxParentRows]
+		if humanFriendly {
+			fmt.Fprintf(os.Stderr, "  %s: dogfood capped parent sync to %d of %d %s parents\n", dep.Name, len(parentRows), originalParentRows, dep.ParentTable)
+		} else {
+			fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent_table":"%s","reason":"dogfood_parent_rows_cap_hit","message":"dogfood capped dependent sync to %d of %d parent rows; run outside dogfood to verify full parent coverage"}`+"\n", dep.Name, dep.ParentTable, len(parentRows), originalParentRows)
+		}
 	}
 
 	if humanFriendly {

--- a/internal/generator/templates/sync.go.tmpl
+++ b/internal/generator/templates/sync.go.tmpl
@@ -52,6 +52,10 @@ import (
 // sync still completes for resources that DO have resolvable paths.
 var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
+{{- if .DependentSyncResources}}
+const dogfoodMaxParentRows = 2
+{{- end}}
+
 {{- if .EndpointTemplateVars}}
 
 // endpointTemplateVarSet enumerates the {placeholder}s the printed CLI's
@@ -272,7 +276,7 @@ Resource scoping:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only narrows to the first page of each resource
@@ -2566,6 +2570,9 @@ func syncDependentResource(ctx context.Context, c interface {
 			return syncResult{Resource: dep.Name, Duration: time.Since(started)}
 		}
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
+	}
+	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		parentRows = parentRows[:dogfoodMaxParentRows]
 	}
 
 	if humanFriendly {

--- a/internal/openapi/parser.go
+++ b/internal/openapi/parser.go
@@ -64,6 +64,7 @@ const (
 	extensionStreaming             = "x-streaming"
 	extensionPPQuery               = "x-pp-query"
 	extensionPPSyncable            = "x-pp-syncable"
+	extensionPPPagination          = "x-pp-pagination"
 	extensionSyncWalker            = "x-pp-sync-walker"
 	extensionHappyArgs             = "x-happy-args"
 	extensionDispatchParam         = "x-pp-dispatch-param"
@@ -3358,7 +3359,10 @@ func mapResources(doc *openapi3.T, out *spec.APISpec, basePath string) error {
 			endpoint.Response, endpoint.ResponsePath = mapResponse(op, targetResourceName+"_"+endpointName, out)
 			populateFieldSelectorDefaults(&endpoint, op)
 			if strings.ToUpper(method) == "GET" {
-				endpoint.Pagination = detectPagination(endpoint.Params, op)
+				endpoint.Pagination = readPaginationExtension(op.Extensions, fmt.Sprintf("%s %q", strings.ToUpper(method), path))
+				if endpoint.Pagination == nil {
+					endpoint.Pagination = detectPagination(endpoint.Params, op)
+				}
 				// Only single-resource fetches (GET /resource/{id}) can carry
 				// embedded paged sub-resources; list endpoints ARE the paged
 				// endpoint themselves and don't need a companion helper.
@@ -5298,6 +5302,30 @@ func readHappyArgsExtension(extensions map[string]any, context string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+func readPaginationExtension(extensions map[string]any, context string) *spec.Pagination {
+	if extensions == nil {
+		return nil
+	}
+	raw, ok := extensions[extensionPPPagination]
+	if !ok || raw == nil {
+		return nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		warnf("%s: %s must be a string, got %T; ignoring", context, extensionPPPagination, raw)
+		return nil
+	}
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return nil
+	}
+	if value == spec.PaginationTypeNone {
+		return &spec.Pagination{Type: spec.PaginationTypeNone}
+	}
+	warnf("%s: %s=%q is not supported; ignoring", context, extensionPPPagination, value)
+	return nil
 }
 
 // readWalkerExtension reads the `x-pp-sync-walker` extension from an

--- a/internal/openapi/parser_test.go
+++ b/internal/openapi/parser_test.go
@@ -11351,6 +11351,47 @@ func TestDetectPaginationRecognizesSkipAndPerPage(t *testing.T) {
 	assert.Equal(t, "perPage", pag.LimitParam)
 }
 
+func TestParseOperationPaginationNoneExtension(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := Parse([]byte(`
+openapi: 3.0.0
+info:
+  title: Pagination None API
+  version: "1.0"
+paths:
+  /ip_addresses:
+    get:
+      operationId: listIPAddresses
+      x-pp-pagination: none
+      parameters:
+        - name: page
+          in: query
+          schema: {type: integer}
+        - name: page_size
+          in: query
+          schema: {type: integer}
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+`))
+	require.NoError(t, err)
+	require.Contains(t, parsed.Resources, "ip-addresses")
+	endpoint := parsed.Resources["ip-addresses"].Endpoints["list"]
+	require.NotNil(t, endpoint.Pagination)
+	assert.Equal(t, spec.PaginationTypeNone, endpoint.Pagination.Type)
+	assert.Empty(t, endpoint.Pagination.CursorParam)
+	assert.Empty(t, endpoint.Pagination.LimitParam)
+}
+
 func TestParsePreservesOperationTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -538,7 +538,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 				} else if pathCallable && requiredScope {
 					addStandaloneCandidate()
 				}
-			} else if method == "GET" && (!strings.Contains(endpoint.Path, "{") || pathParamsAllTemplateVars(endpoint.Path, s) || endpoint.Syncable) && looksLikeCollectionEndpoint(endpointNameLower) && !isSamplerEndpoint(endpoint) && !isScalarItemArray(endpoint.Response) {
+			} else if method == "GET" && (!strings.Contains(endpoint.Path, "{") || pathParamsAllTemplateVars(endpoint.Path, s) || endpoint.Syncable) && looksLikeCollectionEndpoint(endpointNameLower) && (endpoint.Syncable || !isActionGetEndpoint(endpoint.Path)) && !isSamplerEndpoint(endpoint) && !isScalarItemArray(endpoint.Response) {
 				// Catch-all for simple GET collection endpoints that isListEndpoint
 				// didn't recognise (e.g., response is an untyped object with no
 				// wrapper field defined in the spec's types map).
@@ -555,13 +555,13 @@ func Profile(s *spec.APISpec) *APIProfile {
 			}
 
 			if endpoint.Pagination != nil {
-				if endpoint.Pagination.Type != spec.PaginationTypeIDWalk && endpoint.Pagination.CursorParam != "" {
+				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.CursorParam != "" {
 					cursorParams[endpoint.Pagination.CursorParam]++
 				}
-				if endpoint.Pagination.Type != "" && endpoint.Pagination.Type != spec.PaginationTypeIDWalk {
+				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.Type != "" {
 					cursorTypes[endpoint.Pagination.Type]++
 				}
-				if endpoint.Pagination.Type != spec.PaginationTypeIDWalk && endpoint.Pagination.LimitParam != "" {
+				if isRuntimePagination(endpoint.Pagination) && endpoint.Pagination.LimitParam != "" {
 					pageSizeParams[endpoint.Pagination.LimitParam]++
 				}
 			} else {
@@ -1008,6 +1008,9 @@ func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.T
 	if method != "GET" {
 		return false
 	}
+	if !endpoint.Syncable && isActionGetEndpoint(endpoint.Path) {
+		return false
+	}
 	if endpoint.Pagination != nil {
 		return true
 	}
@@ -1016,6 +1019,49 @@ func isListEndpoint(name string, endpoint spec.Endpoint, types map[string]spec.T
 	}
 
 	return looksLikeBasicGetListEndpoint(strings.ToLower(name))
+}
+
+var nonListActionSegments = map[string]bool{
+	"events": true,
+	"find":   true,
+	"lookup": true,
+	"search": true,
+}
+
+func isActionGetEndpoint(path string) bool {
+	segments := staticPathSegments(path)
+	segments = trimVersionPathSegments(segments)
+	if len(segments) < 2 {
+		return false
+	}
+	last := actionSegmentBase(segments[len(segments)-1])
+	return nonListActionSegments[last]
+}
+
+func trimVersionPathSegments(segments []string) []string {
+	for len(segments) > 0 && isVersionPathSegment(segments[0]) {
+		segments = segments[1:]
+	}
+	return segments
+}
+
+func isVersionPathSegment(segment string) bool {
+	if len(segment) < 2 || segment[0] != 'v' {
+		return false
+	}
+	for _, r := range segment[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func actionSegmentBase(segment string) string {
+	for _, suffix := range []string{"-json", "_json", ".json"} {
+		segment = strings.TrimSuffix(segment, suffix)
+	}
+	return segment
 }
 
 // scalarItemTypes are the response-array element type names the parser emits
@@ -2278,7 +2324,10 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 	cursorParam := ""
 	cursorType := ""
 	limitParam := ""
-	if endpoint.Pagination != nil && endpoint.Pagination.Type != spec.PaginationTypeIDWalk {
+	if paginationDisabled(endpoint.Pagination) {
+		return "", "", "", 100
+	}
+	if isRuntimePagination(endpoint.Pagination) {
 		cursorParam = strings.TrimSpace(endpoint.Pagination.CursorParam)
 		cursorType = strings.TrimSpace(endpoint.Pagination.Type)
 		limitParam = strings.TrimSpace(endpoint.Pagination.LimitParam)
@@ -2420,7 +2469,12 @@ func normalizeTemporalFieldName(name string) string {
 
 func isEndpointSinceParamName(name string) bool {
 	name = strings.ToLower(strings.TrimSpace(name))
-	return strings.Contains(name, "since") ||
+	normalized := normalizeTemporalFieldName(name)
+	if strings.Contains(normalized, "since") ||
+		strings.Contains(normalized, "updatedafter") ||
+		strings.Contains(normalized, "modifiedafter") ||
+		strings.Contains(normalized, "createdafter") ||
+		strings.Contains(name, "since") ||
 		strings.Contains(name, "updated_after") ||
 		strings.Contains(name, "modified_since") ||
 		strings.Contains(name, "updated_at") ||
@@ -2428,7 +2482,30 @@ func isEndpointSinceParamName(name string) bool {
 		name == "start_datetime" ||
 		name == "start_time" ||
 		name == "from_date" ||
-		name == "from_datetime"
+		name == "from_datetime" {
+		return true
+	}
+	base, op, ok := strings.Cut(name, "__")
+	if !ok {
+		return false
+	}
+	switch op {
+	case "gt", "gte", "lt", "lte":
+		return isTemporalComparisonBase(base)
+	default:
+		return false
+	}
+}
+
+func isTemporalComparisonBase(base string) bool {
+	normalized := normalizeTemporalFieldName(base)
+	switch normalized {
+	case "updated", "modified", "created", "updatedat", "modifiedat", "createdat", "updateddate", "modifieddate", "createddate":
+		return true
+	default:
+		base = strings.ToLower(strings.TrimSpace(base))
+		return strings.HasSuffix(base, "_at") || strings.HasSuffix(base, "_date")
+	}
 }
 
 func detectEndpointFieldSelector(endpoint spec.Endpoint) FieldSelector {
@@ -2447,6 +2524,9 @@ func detectEndpointFieldSelector(endpoint spec.Endpoint) FieldSelector {
 }
 
 func endpointSupportsPagination(endpoint spec.Endpoint) bool {
+	if paginationDisabled(endpoint.Pagination) {
+		return false
+	}
 	if endpoint.Pagination != nil &&
 		(strings.TrimSpace(endpoint.Pagination.LimitParam) != "" ||
 			strings.TrimSpace(endpoint.Pagination.CursorParam) != "") {
@@ -2461,6 +2541,14 @@ func endpointSupportsPagination(endpoint spec.Endpoint) bool {
 		}
 	}
 	return false
+}
+
+func paginationDisabled(p *spec.Pagination) bool {
+	return p != nil && p.Type == spec.PaginationTypeNone
+}
+
+func isRuntimePagination(p *spec.Pagination) bool {
+	return p != nil && p.Type != spec.PaginationTypeIDWalk && p.Type != spec.PaginationTypeNone
 }
 
 func applySyncCandidates(syncable map[string]syncableMeta, candidates map[string][]syncableCandidate) {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -2325,7 +2325,7 @@ func syncPaginationDefaultsFromEndpoint(endpoint spec.Endpoint) (string, string,
 	cursorType := ""
 	limitParam := ""
 	if paginationDisabled(endpoint.Pagination) {
-		return "", "", "", 100
+		return "", "", "", 0
 	}
 	if isRuntimePagination(endpoint.Pagination) {
 		cursorParam = strings.TrimSpace(endpoint.Pagination.CursorParam)
@@ -2474,9 +2474,6 @@ func isEndpointSinceParamName(name string) bool {
 		strings.Contains(normalized, "updatedafter") ||
 		strings.Contains(normalized, "modifiedafter") ||
 		strings.Contains(normalized, "createdafter") ||
-		strings.Contains(name, "since") ||
-		strings.Contains(name, "updated_after") ||
-		strings.Contains(name, "modified_since") ||
 		strings.Contains(name, "updated_at") ||
 		name == "start_date" ||
 		name == "start_datetime" ||

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -2310,6 +2310,42 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 					},
 				},
 			},
+			"documents": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v1/documents",
+						Response: spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{
+							{Name: "updatedAfter", Type: "string", Format: "date-time"},
+						},
+					},
+				},
+			},
+			"books": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v1/books",
+						Response: spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{
+							{Name: "updated__gt", Type: "string", Format: "date-time"},
+						},
+					},
+				},
+			},
+			"highlights": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/v1/highlights",
+						Response: spec.ResponseDef{Type: "array"},
+						Params: []spec.Param{
+							{Name: "num_highlights__gt", Type: "integer"},
+						},
+					},
+				},
+			},
 			"posts": {
 				Endpoints: map[string]spec.Endpoint{
 					"list": {
@@ -2360,6 +2396,15 @@ func TestProfileSyncableResourceSinceParamPropagation(t *testing.T) {
 	require.Contains(t, byName, "audit")
 	assert.Equal(t, "updated_after", byName["audit"].SinceParam, "spec-declared name (not the profile-wide guess) wins")
 	assert.Equal(t, "date", byName["audit"].SinceParamFormat, "date format should propagate so sync can send YYYY-MM-DD")
+
+	require.Contains(t, byName, "documents")
+	assert.Equal(t, "updatedAfter", byName["documents"].SinceParam, "camelCase updatedAfter should be recognized as an incremental filter")
+
+	require.Contains(t, byName, "books")
+	assert.Equal(t, "updated__gt", byName["books"].SinceParam, "temporal DRF comparison filters should be recognized")
+
+	require.Contains(t, byName, "highlights")
+	assert.Empty(t, byName["highlights"].SinceParam, "numeric DRF comparison filters must not be mistaken for temporal cursors")
 
 	require.Contains(t, byName, "posts")
 	assert.Equal(t, "modified_since", byName["posts"].SinceParam, "modified_since heuristic branch")
@@ -2978,6 +3023,19 @@ func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *test
 					},
 				},
 			},
+			"ip_addresses": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/ip_addresses",
+						Params:   []spec.Param{{Name: "page_size", Type: "integer"}, {Name: "page", Type: "integer"}},
+						Response: spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{
+							Type: "none",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -2998,6 +3056,76 @@ func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *test
 	assert.Equal(t, "page", byName["photos"].PaginationCursorParam)
 	assert.Equal(t, "per_page", byName["photos"].PaginationLimitParam)
 	assert.Equal(t, 25, byName["photos"].PaginationPageSize)
+
+	require.Contains(t, byName, "ip_addresses")
+	assert.False(t, byName["ip_addresses"].SupportsPagination, "pagination.type none must suppress inferred pagination params")
+	assert.Empty(t, byName["ip_addresses"].PaginationCursorParam)
+	assert.Empty(t, byName["ip_addresses"].PaginationLimitParam)
+}
+
+func TestProfileSyncableResourcesExcludeActionGetEndpoints(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "actions",
+		Resources: map[string]spec.Resource{
+			"customers": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/customers.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"subscriptions_lookup": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/subscriptions/lookup.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"invoices_events": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/invoices/events.json",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"products_search": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/products/search",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"orders_find": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:   "GET",
+						Path:     "/orders/find",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+	byName := map[string]SyncableResource{}
+	for _, resource := range profile.SyncableResources {
+		byName[resource.Name] = resource
+	}
+
+	require.Contains(t, byName, "customers")
+	assert.NotContains(t, byName, "subscriptions_lookup")
+	assert.NotContains(t, byName, "invoices_events")
+	assert.NotContains(t, byName, "products_search")
+	assert.NotContains(t, byName, "orders_find")
 }
 
 // Specs with no recognizable pagination shape must keep the historical

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -3061,6 +3061,7 @@ func TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams(t *test
 	assert.False(t, byName["ip_addresses"].SupportsPagination, "pagination.type none must suppress inferred pagination params")
 	assert.Empty(t, byName["ip_addresses"].PaginationCursorParam)
 	assert.Empty(t, byName["ip_addresses"].PaginationLimitParam)
+	assert.Equal(t, 0, byName["ip_addresses"].PaginationPageSize, "pagination.type none must not imply a page-size default")
 }
 
 func TestProfileSyncableResourcesExcludeActionGetEndpoints(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -2645,7 +2645,10 @@ type ResponseDiscriminator struct {
 	Mapping map[string]string `yaml:"mapping,omitempty" json:"mapping,omitempty"` // discriminator value -> schema/resource name
 }
 
-const PaginationTypeIDWalk = "id_walk"
+const (
+	PaginationTypeIDWalk = "id_walk"
+	PaginationTypeNone   = "none"
+)
 
 type Pagination struct {
 	Type           string `yaml:"type" json:"type"`                         // cursor, offset, page_token, page, id_walk

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -1678,7 +1678,13 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
 	}
 	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		originalParentRows := len(parentRows)
 		parentRows = parentRows[:dogfoodMaxParentRows]
+		if humanFriendly {
+			fmt.Fprintf(os.Stderr, "  %s: dogfood capped parent sync to %d of %d %s parents\n", dep.Name, len(parentRows), originalParentRows, dep.ParentTable)
+		} else {
+			fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent_table":"%s","reason":"dogfood_parent_rows_cap_hit","message":"dogfood capped dependent sync to %d of %d parent rows; run outside dogfood to verify full parent coverage"}`+"\n", dep.Name, dep.ParentTable, len(parentRows), originalParentRows)
+		}
 	}
 
 	if humanFriendly {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/sync.go
@@ -33,6 +33,8 @@ import (
 // sync still completes for resources that DO have resolvable paths.
 var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
+const dogfoodMaxParentRows = 2
+
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
 	Resource string
@@ -155,7 +157,7 @@ Resource scoping:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only narrows to the first page of each resource
@@ -1674,6 +1676,9 @@ func syncDependentResource(ctx context.Context, c interface {
 			return syncResult{Resource: dep.Name, Duration: time.Since(started)}
 		}
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
+	}
+	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		parentRows = parentRows[:dogfoodMaxParentRows]
 	}
 
 	if humanFriendly {

--- a/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-query-endpoint-api/query-endpoint-golden/internal/cli/sync.go
@@ -151,7 +151,7 @@ Resource scoping:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only narrows to the first page of each resource

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -33,6 +33,8 @@ import (
 // sync still completes for resources that DO have resolvable paths.
 var unresolvedPathKeyRE = regexp.MustCompile(`\{[a-zA-Z_][a-zA-Z0-9_]*\}`)
 
+const dogfoodMaxParentRows = 2
+
 // syncResult holds the outcome of syncing a single resource.
 type syncResult struct {
 	Resource string
@@ -155,7 +157,7 @@ Resource scoping:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only narrows to the first page of each resource
@@ -1645,6 +1647,9 @@ func syncDependentResource(ctx context.Context, c interface {
 			return syncResult{Resource: dep.Name, Duration: time.Since(started)}
 		}
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
+	}
+	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		parentRows = parentRows[:dogfoodMaxParentRows]
 	}
 
 	if humanFriendly {

--- a/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-sync-walker-api/sync-walker-golden/internal/cli/sync.go
@@ -1649,7 +1649,13 @@ func syncDependentResource(ctx context.Context, c interface {
 		return syncResult{Resource: dep.Name, Err: fmt.Errorf("querying parent table %s: %w", dep.ParentTable, err), Duration: time.Since(started)}
 	}
 	if cliutil.IsDogfoodEnv() && len(parentRows) > dogfoodMaxParentRows {
+		originalParentRows := len(parentRows)
 		parentRows = parentRows[:dogfoodMaxParentRows]
+		if humanFriendly {
+			fmt.Fprintf(os.Stderr, "  %s: dogfood capped parent sync to %d of %d %s parents\n", dep.Name, len(parentRows), originalParentRows, dep.ParentTable)
+		} else {
+			fmt.Fprintf(syncEvents, `{"event":"sync_warning","resource":"%s","parent_table":"%s","reason":"dogfood_parent_rows_cap_hit","message":"dogfood capped dependent sync to %d of %d parent rows; run outside dogfood to verify full parent coverage"}`+"\n", dep.Name, dep.ParentTable, len(parentRows), originalParentRows)
+		}
 	}
 
 	if humanFriendly {

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/sync.go
@@ -151,7 +151,7 @@ Resource scoping:
 			}
 
 			if cliutil.IsDogfoodEnv() && !cmd.Flags().Changed("max-pages") {
-				maxPages = 10
+				maxPages = 1
 			}
 
 			// --latest-only narrows to the first page of each resource


### PR DESCRIPTION
## Summary

Generated sync now stays inside live-dogfood runtime bounds and avoids sending invented pagination or temporal filters to endpoints that cannot support them.

This PR broadens profiler detection for camelCase and DRF-style temporal filters, adds an explicit OpenAPI `x-pp-pagination: none` escape hatch for strict non-paginated list endpoints, excludes inferred lookup/events/search/find action GETs from syncable list derivation, and tightens dogfood-only sync bounds to paginate once and cap dependent parent fan-out. Normal production sync remains unlimited by default unless the operator passes `--max-pages`.

Fixes #3308
Fixes #2915
Fixes #2939
Fixes #2892
Fixes #2905

## Validation

- `go fmt ./...`
- `go test ./internal/profiler -run 'TestProfileSyncableResourceSinceParamPropagation|TestProfileSyncableResourcePaginationDefaultsPreserveEndpointParams|TestProfileSyncableResourcesExcludeActionGetEndpoints'`
- `go test ./internal/openapi -run 'TestParseOperationPaginationNoneExtension'`
- `go test ./internal/generator -run 'TestGeneratedSyncBoundsPaginationAndWarnings|TestGeneratedGraphQLSyncForcesSingleWorkerUnderVerifyEnv|TestGeneratedSyncGatesPaginationParamsPerResource|TestGeneratedSyncExcludesActionGetEndpoints'`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./...`
- `golangci-lint run ./...`

## Post-Deploy Monitoring & Validation

- Watch fresh printed CLI dogfood runs for `sync` command timeout exits, especially `timeout -1`, `max_pages_cap_hit`, `resource_not_incremental`, and `pagination_cursor_missing` events.
- Spot-check generated CLIs with strict list endpoints annotated `x-pp-pagination: none` to confirm requests omit `page`, `page_size`, `limit`, and cursor params unless supplied by the operator.
- Healthy signal: live dogfood sync commands exit 0 within the 30s command budget while emitting truncation warnings instead of timing out.
- Failure signal: new sync regressions where expected list collections disappear from defaults, or dogfood sync still fans out across many parents.
- Validation window: next Wave 6 generated-CLI dogfood batch; owner: lane/parent coordinator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
