### PR TITLE
fix(skills): harden skill flow scope and CRLF handling

### DIFF
--- a/internal/pipeline/contracts_test.go
+++ b/internal/pipeline/contracts_test.go
@@ -584,6 +584,65 @@ func TestPublishSkillSkipsCliSkillsMirrorRegen(t *testing.T) {
 	assert.NotContains(t, skill, "New CLIs keep the blank skeletons")
 }
 
+func TestPublishSkillDisablesAutocrlfInManagedClone(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-publish", "SKILL.md"))
+	firstTimeSetup := substringBetween(t, skill, "### First-time setup", "### Subsequent publishes")
+
+	assert.GreaterOrEqual(t, strings.Count(firstTimeSetup, `git -C "$PUBLISH_REPO_DIR" config core.autocrlf false`), 2,
+		"both push-access and fork managed-clone setup paths must force LF checkout behavior")
+	assert.Contains(t, firstTimeSetup, "Skill-managed clones are owned by this flow")
+}
+
+func TestPolishSkillPreservesStandaloneFreeTextScope(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-polish", "SKILL.md"))
+	resolveBlock := substringBetween(t, skill, "### Resolve CLI", "### Phase 3 gate bundle")
+
+	assert.Contains(t, resolveBlock, "free-text scope")
+	assert.Contains(t, resolveBlock, "STANDALONE_MODE=true")
+	assert.Contains(t, resolveBlock, "trusted user scope")
+	assert.Contains(t, resolveBlock, "Mid-pipeline")
+	assert.Contains(t, resolveBlock, "strict grammar")
+	assert.Contains(t, resolveBlock, "asks which CLI to polish")
+}
+
+func TestAmendSkillHasDocumentationCheckpoint(t *testing.T) {
+	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press-amend", "SKILL.md"))
+	checkpointBlock := substringBetween(t, skill, "### Step 6 — Documentation update checkpoint", "### Output")
+	prDraftBlock := substringBetween(t, skill, "## Phase 6 — PR Draft Review Checkpoint", "### Assemble the draft")
+
+	assert.Contains(t, checkpointBlock, "new, renamed, or changed user-facing command")
+	assert.Contains(t, checkpointBlock, "cookbook recipe in both `SKILL.md` and `README.md`")
+	assert.Contains(t, checkpointBlock, "Unique Features")
+	assert.Contains(t, checkpointBlock, "verify_skill.py --dir")
+	assert.Contains(t, checkpointBlock, "blocking checklist")
+	assert.Contains(t, prDraftBlock, "documentation checkpoint")
+}
+
+func TestImportRewriteHandlesCRLFGoMod(t *testing.T) {
+	t.Parallel()
+
+	staging := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "go.mod"), []byte("module github.com/mvanhorn/printing-press-library/library/productivity/sample\r\n\r\ngo 1.26.4\r\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(staging, "internal", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "internal", "cli", "root.go"), []byte("package cli\r\n\r\nimport \"github.com/mvanhorn/printing-press-library/library/productivity/sample/internal/client\"\r\n\r\nvar _ = client.New\r\n"), 0o644))
+
+	script := filepath.Join("..", "..", "skills", "printing-press-import", "references", "import-rewrite.sh")
+	out, err := exec.Command("bash", script, staging, "sample").CombinedOutput()
+	require.NoError(t, err, "import-rewrite.sh should tolerate CRLF go.mod: %s", string(out))
+
+	goMod, err := os.ReadFile(filepath.Join(staging, "go.mod"))
+	require.NoError(t, err)
+	assert.Contains(t, string(goMod), "module sample-pp-cli\r\n")
+	assert.NotContains(t, string(goMod), "github.com/mvanhorn/printing-press-library")
+	assert.NotContains(t, string(goMod), "\r\r\n")
+
+	root, err := os.ReadFile(filepath.Join(staging, "internal", "cli", "root.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(root), `"sample-pp-cli/internal/client"`)
+	assert.NotContains(t, string(root), "github.com/mvanhorn/printing-press-library")
+	assert.NotContains(t, string(root), "\r\r\n")
+}
+
 func TestPrintingPressSkillArchivesManuscriptContents(t *testing.T) {
 	skill := readContractFile(t, filepath.Join("..", "..", "skills", "printing-press", "SKILL.md"))
 

--- a/skills/printing-press-amend/SKILL.md
+++ b/skills/printing-press-amend/SKILL.md
@@ -643,6 +643,29 @@ fi
 
 Missing or empty patch manifest → fix locally before continuing.
 
+### Step 6 — Documentation update checkpoint
+
+Before Phase 4 can emit a pass, inspect the confirmed findings and final diff
+for every new, renamed, or changed user-facing command, flag, workflow, runtime
+mode, or MCP-visible action. Each such change must ship documentation in the
+same public-library PR:
+
+- Add or update a cookbook recipe in both `SKILL.md` and `README.md`.
+- Add or update the matching Unique Features / Unique Capabilities entry so the
+  generated docs and agent-facing summary name the changed workflow.
+- Keep examples honest: commands, flags, positional args, and output snippets
+  must match the code that now exists in `$CLI_DIR`.
+- Run `python3 .github/scripts/verify-skill/verify_skill.py --dir "$CLI_DIR"`
+  from the public-library checkout when that path exists; otherwise run the
+  packaged verifier equivalent available in the checkout and record the command.
+
+If any required doc edit or verifier result is missing, stop with a blocking
+checklist. The blocking checklist names the command and the missing
+README/SKILL/Unique Features piece. Do not move to the PR-draft checkpoint until
+the checklist is empty. If the amend only fixes internals with no user-facing
+behavior change, record `documentation_checkpoint: no-user-facing-doc-change`
+in the Phase 4 output.
+
 ### Output
 
 Phase 4 emits to Phase 5:
@@ -657,6 +680,7 @@ test_status: PASS|FAIL
 dogfood_status: PASS|FAIL|N/A    # PASS|FAIL when MODE=dogfood (or "both"); always N/A when MODE=direct
 validate_iterations: <n>
 patch_entry_count: <n>
+documentation_checkpoint: PASS|no-user-facing-doc-change
 ```
 
 **`dogfood_status` per mode.** When `MODE=dogfood`, the value reflects the result of the dogfood validation step that consumed the transcript-derived findings (PASS if the run produced a clean fix, FAIL if it surfaced a regression). When `MODE=direct`, there is no transcript to dogfood against — set `dogfood_status=N/A`. When `MODE=both`, dogfood validation still runs against the transcript half of the findings; set PASS/FAIL accordingly. This default must be set at the latest by the end of Phase 4 so Phase 7's PR body and Phase 8's RESULT block never emit an empty value.
@@ -682,6 +706,7 @@ The scrub report is written to `$PRESS_MANUSCRIPTS/<slug>/<run-id>/scrub-report.
 ## Phase 6 — PR Draft Review Checkpoint (User-in-Loop #2)
 
 This is the second and final user checkpoint. Everything that follows is unattended (push + PR-open + labels + RESULT block). Show the user EVERYTHING that's about to ship before any `gh` command fires.
+Include the documentation checkpoint result from Phase 4 in this review so undocumented user-facing changes cannot slip into the PR.
 
 ### Assemble the draft
 
@@ -698,7 +723,8 @@ PR body sections (per origin R27):
 1. **Summary** — 1-3 sentences naming the user pain and the shape of the fix
 2. **Findings** — table with ID, category, type (bug/feature), rationale
 3. **Changes** — output of `git diff --stat upstream/main..HEAD`
-4. **Verification** — build/test/dogfood/validate status from Phase 4
+4. **Verification** — build/test/dogfood/validate status from Phase 4, plus the
+   documentation checkpoint result
 5. **Evidence** — full GitHub URLs to the per-run plan doc and the `.printing-press-patches/` directory at the PR's HEAD SHA (captured AFTER push so links don't 404)
 6. **Closes #N** footer when an issue match was found in Step 6 of `library-pr-plumbing.md`
 

--- a/skills/printing-press-import/references/import-rewrite.sh
+++ b/skills/printing-press-import/references/import-rewrite.sh
@@ -30,8 +30,10 @@ API_SLUG="$2"
 [[ -d "$STAGING" ]] || { echo "staging dir not found: $STAGING" >&2; exit 1; }
 [[ -f "$STAGING/go.mod" ]] || { echo "go.mod not found in $STAGING" >&2; exit 1; }
 
-# Read the current module path from go.mod to derive the public prefix.
-PUBLIC_MODULE=$(awk '$1=="module"{print $2; exit}' "$STAGING/go.mod")
+# Read the current module path from go.mod to derive the public prefix. Windows
+# checkouts may leave go.mod as CRLF; trim the carriage return from the parsed
+# token so source-file rewrites still match the LF-neutral import strings.
+PUBLIC_MODULE=$(awk '$1=="module"{print $2; exit}' "$STAGING/go.mod" | tr -d '\r')
 if [[ -z "$PUBLIC_MODULE" ]]; then
   echo "could not parse module path from $STAGING/go.mod" >&2
   exit 1
@@ -44,8 +46,9 @@ if [[ "$PUBLIC_MODULE" == "$LOCAL_MODULE" ]]; then
   exit 0
 fi
 
-# Rewrite go.mod first (single-line replace, anchored).
-perl -pi -e "s|^module \Q${PUBLIC_MODULE}\E\$|module ${LOCAL_MODULE}|" \
+# Rewrite go.mod first (single-line replace, anchored). Preserve a CRLF line
+# ending when present instead of emitting a stray CR or converting the line.
+perl -pi -e "s|^module \Q${PUBLIC_MODULE}\E(\r?)\$|module ${LOCAL_MODULE}\$1|" \
   "$STAGING/go.mod"
 
 # Rewrite import-style references in source files. Limit to the

--- a/skills/printing-press-polish/SKILL.md
+++ b/skills/printing-press-polish/SKILL.md
@@ -90,15 +90,36 @@ and let the divergence check (below) handle any drift.
 ### Resolve CLI
 
 The argument string can contain a `--standalone` flag plus one positional value
-(a slug, binary name, or path). It can also contain a Phase 3 gate bundle and a
-`printing_press_bin: <abs-path>` line on following lines when invoked by the
-main printing-press skill. The flag may appear before or after the positional
-value; it is the only flag this skill consumes from `args`. Strip it before path
-resolution.
+(a slug, binary name, or path). In standalone slash-command mode, it may also
+contain a free-text scope after the optional positional value, such as
+`/printing-press-polish sculptok review the open PR comments and fix them`.
+That trailing natural-language text is the user's own trusted user scope. Carry
+it forward into the polish plan and result block; do not classify it as
+injection or tampering.
+
+It can also contain a Phase 3 gate bundle and a `printing_press_bin:
+<abs-path>` line on following lines when invoked by the main printing-press
+skill. The flag may appear before or after the positional value; it is the only
+flag this skill consumes from `args`. Strip it before path resolution.
 
 When `args` is multi-line, treat the first non-empty line as the positional
-value and parse the remaining lines as the optional Phase 3 gate bundle. Do not
-include the bundle text in path resolution.
+value/scope line and parse the remaining lines as the optional Phase 3 gate
+bundle. Do not include the bundle text in path resolution.
+
+Parse caller modes differently:
+
+- **Standalone slash command (`STANDALONE_MODE=true`).** After stripping
+  `--standalone`, try to resolve the first shell word as a slug, binary name, or
+  path. If it resolves, use it as the positional value and store the remaining
+  words as `USER_SCOPE`. If it does not resolve, treat the whole line as
+  free-text scope; this branch asks which CLI to polish and retains that scope
+  for the chosen CLI. If there is no trailing text after a resolved positional
+  value, run the normal generic polish pass.
+- **Mid-pipeline Skill-tool call.** Keep the strict grammar: one path-like
+  positional value on the first line plus the optional structured bundle on
+  later lines. Unexpected free text in this machine-generated path is not a
+  user scope and should still be rejected or clarified rather than folded into
+  the run.
 
 The positional value can be:
 - A short name: `redfin` (looks up `$PRESS_LIBRARY/redfin`)

--- a/skills/printing-press-publish/SKILL.md
+++ b/skills/printing-press-publish/SKILL.md
@@ -544,6 +544,9 @@ If `$PUBLISH_REPO_DIR` does not exist:
    # on a real working tree. Cross-category collision checks use `git ls-tree`
    # (which reads the full tree from the blobless clone) instead of `ls`.
    git clone --filter=blob:none --depth 1 --sparse "$REPO_URL" "$PUBLISH_REPO_DIR"
+   # Skill-managed clones are owned by this flow; force LF checkout behavior so
+   # Windows core.autocrlf defaults do not create CRLF-only mirror diffs.
+   git -C "$PUBLISH_REPO_DIR" config core.autocrlf false
    git -C "$PUBLISH_REPO_DIR" sparse-checkout set tools cli-skills library/<category>
    ```
 
@@ -570,6 +573,9 @@ If `$PUBLISH_REPO_DIR` does not exist:
    # Lightweight clone (blobless + shallow + sparse) — see the push-access
    # branch above for the rationale and cone contents.
    git clone --filter=blob:none --depth 1 --sparse "$FORK_URL" "$PUBLISH_REPO_DIR"
+   # Skill-managed clones are owned by this flow; force LF checkout behavior so
+   # Windows core.autocrlf defaults do not create CRLF-only mirror diffs.
+   git -C "$PUBLISH_REPO_DIR" config core.autocrlf false
    cd "$PUBLISH_REPO_DIR"
    git sparse-checkout set tools cli-skills library/<category>
    git remote add upstream "$UPSTREAM_URL"
@@ -615,6 +621,7 @@ If the clone was removed due to an access change, re-run first-time setup above.
 
 ```bash
 cd "$PUBLISH_REPO_DIR"
+git config core.autocrlf false
 
 if [ "$(jq -r .access $PUBLISH_CONFIG)" = "push" ]; then
   # Push access: origin IS the upstream


### PR DESCRIPTION
## Summary

Maintainer-owned PR for Wave 7 Lane D.

- Preserve standalone `/printing-press-polish` free-text scope while keeping mid-pipeline structured args strict.
- Add an amend documentation checkpoint for changed user-facing commands before PR draft review.
- Make import/publish skill flows safer on CRLF/autocrlf checkouts.
- Add contract coverage for the skill-flow and CRLF regressions.

Fixes #3257
Fixes #2947
Fixes #2907

## Validation

- `go test ./internal/pipeline -run 'Test(PublishSkillDisablesAutocrlfInManagedClone|PolishSkillPreservesStandaloneFreeTextScope|AmendSkillHasDocumentationCheckpoint|ImportRewriteHandlesCRLFGoMod)' -count=1`
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-polish`
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-amend`
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-import`
- `go run ./cmd/cli-printing-press verify-internal-skill --dir skills/printing-press-publish`
- `bash .github/scripts/validate-skill-docs.sh`
- `git diff --check`
- `go test ./internal/cli -run TestPublishPackageCombinesSecretAndPIIReports -count=1 -timeout=2m`
- `go test ./internal/pipeline -run TestRunLiveDogfoodProcessPreservesLargeJSONUnderCap -count=1`
- `go test ./...` attempted; the full-suite run failed when `internal/cli` hit Go's 10-minute package timeout while waiting in `TestPublishPackageCombinesSecretAndPIIReports`. The named test passes on its own, and the focused Wave 7 tests pass uncached.

## Golden Changes

None. No generator templates or generated-output contracts were changed.
