### PR TITLE
fix(cli): register parent-scoped sync templates

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2099,6 +2099,7 @@ func (g *Generator) prepareOutput() error {
 		g.profile = profiler.Profile(g.Spec)
 		g.resetHTMLSyncStubCache()
 	}
+	promoteSyncPathTemplateVars(g.Spec, g.profile)
 	if err := g.validateFreshnessCommandCoverage(); err != nil {
 		return err
 	}
@@ -3574,6 +3575,54 @@ func paginationDefaultEntries(syncable []profiler.SyncableResource, dependent []
 		entries[i] = defaults[key]
 	}
 	return entries
+}
+
+func promoteSyncPathTemplateVars(api *spec.APISpec, profile *profiler.APIProfile) {
+	if api == nil || profile == nil {
+		return
+	}
+	seen := make(map[string]struct{}, len(api.EndpointTemplateVars))
+	for _, name := range api.EndpointTemplateVars {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			seen[trimmed] = struct{}{}
+		}
+	}
+	for _, resource := range profile.SyncableResources {
+		if !resource.SkipDefaultSync {
+			continue
+		}
+		for _, name := range pathTemplateVarNames(resource.Path) {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			api.EndpointTemplateVars = append(api.EndpointTemplateVars, name)
+		}
+	}
+	slices.Sort(api.EndpointTemplateVars)
+}
+
+func pathTemplateVarNames(path string) []string {
+	var names []string
+	seen := map[string]struct{}{}
+	for i := 0; i < len(path); i++ {
+		if path[i] != '{' {
+			continue
+		}
+		j := strings.IndexByte(path[i:], '}')
+		if j < 0 {
+			break
+		}
+		name := strings.TrimSpace(path[i+1 : i+j])
+		if name != "" {
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				names = append(names, name)
+			}
+		}
+		i += j
+	}
+	return names
 }
 
 func resourceIDFieldOverrideEntries(syncable []profiler.SyncableResource, dependent []profiler.DependentResource) []resourceIDFieldOverrideEntry {

--- a/internal/generator/sync_unresolved_path_key_test.go
+++ b/internal/generator/sync_unresolved_path_key_test.go
@@ -213,7 +213,8 @@ func TestGenerateSyncRegistersParentScopedPathTemplateCollection(t *testing.T) {
 		"sync should expose --path-context so callers can provide the parent template value")
 	assert.Contains(t, syncContent, `"adAccountId": true`,
 		"the parent template variable should be treated as runtime-resolvable when --path-context supplies it")
-	assert.NotContains(t, syncContent, "func defaultSyncResources() []string {\n\treturn []string{\n\t\t\"campaigns\",",
+	defaultResourcesBody := generatedFunctionBody(t, syncContent, "func defaultSyncResources() []string")
+	assert.NotContains(t, defaultResourcesBody, `"campaigns"`,
 		"parent-scoped collections should not run by default without explicit context")
 
 	runGoCommandRequired(t, outputDir, "mod", "tidy")

--- a/internal/generator/sync_unresolved_path_key_test.go
+++ b/internal/generator/sync_unresolved_path_key_test.go
@@ -158,3 +158,64 @@ func TestGenerateSyncFlatAPIUnaffected(t *testing.T) {
 	assert.Contains(t, syncContent, `"users": "/users"`,
 		"flat users resource should have a clean path with no placeholders")
 }
+
+func TestGenerateSyncRegistersParentScopedPathTemplateCollection(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := &spec.APISpec{
+		Name:    "account-scoped",
+		Version: "0.1.0",
+		BaseURL: "https://api.example.test/v1",
+		Auth:    spec.AuthConfig{Type: "none"},
+		Config: spec.ConfigSpec{
+			Format: "toml",
+			Path:   "~/.config/account-scoped-pp-cli/config.toml",
+		},
+		Resources: map[string]spec.Resource{
+			"me": {
+				Description: "Current account",
+				Endpoints: map[string]spec.Endpoint{
+					"adaccounts": {
+						Method:      "GET",
+						Path:        "/me/adaccounts",
+						Description: "List ad accounts",
+						Response:    spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"campaigns": {
+				Description: "Campaigns under a caller-provided account",
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:      "GET",
+						Path:        "/{adAccountId}/campaigns",
+						Description: "List campaigns for an ad account",
+						Response:    spec.ResponseDef{Type: "array"},
+						Pagination:  &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true}
+	require.NoError(t, gen.Generate())
+
+	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoError(t, err)
+	syncContent := string(syncGo)
+
+	assert.Contains(t, syncContent, `"campaigns": "/{adAccountId}/campaigns"`,
+		"parent-scoped collection should be registered in syncResourcePath instead of failing as unknown")
+	assert.Contains(t, syncContent, `cmd.Flags().StringArrayVar(&pathContextFlags, "path-context", nil`,
+		"sync should expose --path-context so callers can provide the parent template value")
+	assert.Contains(t, syncContent, `"adAccountId": true`,
+		"the parent template variable should be treated as runtime-resolvable when --path-context supplies it")
+	assert.NotContains(t, syncContent, "func defaultSyncResources() []string {\n\treturn []string{\n\t\t\"campaigns\",",
+		"parent-scoped collections should not run by default without explicit context")
+
+	runGoCommandRequired(t, outputDir, "mod", "tidy")
+	runGoCommandRequired(t, outputDir, "test", "./internal/cli", "-count=1")
+}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -513,7 +513,7 @@ func Profile(s *spec.APISpec) *APIProfile {
 							meta.Path = expandedPath
 							syncable[expandedName] = meta
 						}
-					} else if strings.Contains(endpoint.Path, "{") && !resolvable && !endpoint.Syncable && !hasRequiredDependentScopeParams(endpoint) {
+					} else if strings.Contains(endpoint.Path, "{") && !resolvable && !endpoint.Syncable && !hasRequiredDependentScopeParams(endpoint) && isPathTemplateCollection(endpoint.Path) {
 						// Parameterized paginated paths can't sync standalone — track
 						// them for dependent-resource detection below. Carry the
 						// endpoint's metadata so x-resource-id and x-critical
@@ -656,6 +656,9 @@ func Profile(s *spec.APISpec) *APIProfile {
 	}
 	p.NeedsSearch = len(listResources) >= 3 && float64(searchEndpointCount)/float64(len(listResources)) < 0.5
 
+	p.DependentSyncResources = detectDependentResources(parameterized, syncable, shardedSubResources)
+	p.DependentSyncResources = applySpecWalkers(s, p.DependentSyncResources, syncable, s.Types, resourceNameIndex)
+	addUnresolvedPathTemplateCollections(syncable, parameterized, p.DependentSyncResources)
 	p.SyncableResources = sortedSyncableResources(syncable)
 	// Flat resources carry "none" this round — forward-looking metadata for the
 	// follow-up flat/tenant reconcile. Set explicitly so the value is "none",
@@ -663,8 +666,6 @@ func Profile(s *spec.APISpec) *APIProfile {
 	for i := range p.SyncableResources {
 		p.SyncableResources[i].ReconcileMode = "none"
 	}
-	p.DependentSyncResources = detectDependentResources(parameterized, syncable, shardedSubResources)
-	p.DependentSyncResources = applySpecWalkers(s, p.DependentSyncResources, syncable, s.Types, resourceNameIndex)
 	// Populate reconcile metadata for each dependent resource.
 	// per_parent is safe only for a single-path-param dependent with a PK.
 	for i := range p.DependentSyncResources {
@@ -1458,6 +1459,25 @@ func detectDependentResources(parameterized map[string]parameterizedEntry, synca
 	return deps
 }
 
+func addUnresolvedPathTemplateCollections(syncable map[string]syncableMeta, parameterized map[string]parameterizedEntry, deps []DependentResource) {
+	dependentPaths := make(map[string]struct{}, len(deps))
+	for _, dep := range deps {
+		dependentPaths[dep.Path] = struct{}{}
+	}
+	for _, key := range sortedKeys(parameterized) {
+		entry := parameterized[key]
+		if _, ok := dependentPaths[entry.meta.Path]; ok {
+			continue
+		}
+		if !isPathTemplateCollection(entry.meta.Path) {
+			continue
+		}
+		meta := entry.meta
+		meta.SkipDefaultSync = true
+		addSyncableIfUnique(syncable, strings.ToLower(entry.name), meta)
+	}
+}
+
 func sortDependentResources(deps []DependentResource, knownDepths map[string]int) {
 	depthByResource := make(map[string]int, len(knownDepths)+len(deps))
 	maps.Copy(depthByResource, knownDepths)
@@ -1937,6 +1957,14 @@ func pathSegments(path string) []string {
 		return nil
 	}
 	return strings.Split(strings.Trim(path, "/"), "/")
+}
+
+func isPathTemplateCollection(path string) bool {
+	segments := pathSegments(path)
+	if len(segments) == 0 || !strings.Contains(path, "{") {
+		return false
+	}
+	return !isPathPlaceholder(segments[len(segments)-1])
 }
 
 func nextStaticSegmentIndex(segments []string, start int) int {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -206,6 +206,85 @@ func TestProfileSiblingListEndpoints(t *testing.T) {
 	assert.Equal(t, "/portfolio/settlements", syncPaths["portfolio-settlements"])
 }
 
+func TestProfileParentScopedPathTemplateCollectionRegistersSyncResource(t *testing.T) {
+	s := &spec.APISpec{
+		Name: "ads",
+		Resources: map[string]spec.Resource{
+			"me": {
+				Endpoints: map[string]spec.Endpoint{
+					"adaccounts": {
+						Method:   "GET",
+						Path:     "/me/adaccounts",
+						Response: spec.ResponseDef{Type: "array"},
+					},
+				},
+			},
+			"campaigns": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": {
+						Method:     "GET",
+						Path:       "/{adAccountId}/campaigns",
+						Response:   spec.ResponseDef{Type: "array"},
+						Pagination: &spec.Pagination{CursorParam: "after", LimitParam: "limit"},
+					},
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	syncPaths := make(map[string]string)
+	skipDefault := make(map[string]bool)
+	for _, resource := range profile.SyncableResources {
+		syncPaths[resource.Name] = resource.Path
+		skipDefault[resource.Name] = resource.SkipDefaultSync
+	}
+
+	assert.Equal(t, "/{adAccountId}/campaigns", syncPaths["campaigns"])
+	assert.True(t, skipDefault["campaigns"], "parent-scoped path templates should be opt-in via --resources plus --path-context")
+	assert.Empty(t, profile.DependentSyncResources, "external parent path templates are syncable with explicit context, not dependent fan-out")
+}
+
+func TestProfileDependentResourcesPreferCollectionOverNestedDetailPaths(t *testing.T) {
+	paginated := func(path string) spec.Endpoint {
+		return spec.Endpoint{
+			Method:     "GET",
+			Path:       path,
+			Response:   spec.ResponseDef{Type: "array"},
+			Pagination: &spec.Pagination{CursorParam: "cursor", LimitParam: "limit"},
+		}
+	}
+	s := &spec.APISpec{
+		Name: "plane",
+		Resources: map[string]spec.Resource{
+			"projects": {
+				Endpoints: map[string]spec.Endpoint{
+					"list": paginated("/projects/"),
+				},
+			},
+			"projects_issues": {
+				Endpoints: map[string]spec.Endpoint{
+					"list":       paginated("/projects/{project_id}/issues/"),
+					"link":       paginated("/projects/{project_id}/issues/{issue_id}/links/{pk}/"),
+					"activities": paginated("/projects/{project_id}/issues/{issue_id}/activities/{pk}/"),
+				},
+			},
+		},
+	}
+
+	profile := Profile(s)
+
+	pathsByName := make(map[string][]string)
+	for _, dep := range profile.DependentSyncResources {
+		pathsByName[dep.Name] = append(pathsByName[dep.Name], dep.Path)
+	}
+
+	assert.Equal(t, []string{"/projects/{project_id}/issues/"}, pathsByName["projects_issues"])
+	assert.NotContains(t, pathsByName["projects_issues"], "/projects/{project_id}/issues/{issue_id}/links/{pk}/")
+	assert.NotContains(t, pathsByName["projects_issues"], "/projects/{project_id}/issues/{issue_id}/activities/{pk}/")
+}
+
 func TestProfileDiscriminatorDispatchFromResponseTypeEnum(t *testing.T) {
 	s := &spec.APISpec{
 		Name: "mixed-network",


### PR DESCRIPTION
## Summary

Parent-scoped collection endpoints can now be sync-registered without flattening them into the wrong parent-child model. A collection like `/{adAccountId}/campaigns` is accepted as an explicit `--resources campaigns` sync target, omitted from default sync until context is supplied, and gets `--path-context`/template-var runtime substitution emitted automatically.

The profiler now ignores nested detail path templates whose final segment is a path parameter, so one dependent resource name no longer maps to several competing templates like `/issues/` and `/issues/{issue_id}/links/{pk}/`.

## Issues

- Fixes mvanhorn/cli-printing-press#2682
- Fixes mvanhorn/cli-printing-press#2600
- Covers mvanhorn/cli-printing-press#3327 via the existing generated child-resource parent-FK tests, which pass on this branch; no additional store schema weakening was needed.

## Validation

- `go test ./internal/profiler -count=1`
- `go test ./internal/generator -run 'TestGenerateSync(RegisterParentScopedPathTemplateCollection|SkipsUnresolvedPathKeys|FlatAPIUnaffected)|TestGenerateStoreSubResourceUpsertBatchTestSatisfiesNotNullFK|TestGenerateDependentSyncInjectsSubResourceParentFK|TestGenerateDependentSyncCompiles|TestGeneratedSyncStoreBatch4TemplateFixes' -count=1`
- `go test ./internal/generator -run 'TestGenerateNoEndpointTemplateVarsByteCompat|TestGenerateEndpointTemplateVarsRuntimeSubstitution|TestGenerateInfersEndpointTemplateVarsFromBaseURL' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go fmt ./...`

`go test ./...` was attempted twice and exited with code 143 shortly after `cmd/ble-probe`. A sequential package pass reached `internal/cli`; a verbose bounded `go test ./internal/cli -count=1 -timeout 2m -v` continued progressing through publish-package PII tests and was also terminated with code 143 without a Go assertion failure.
