### PR TITLE
fix(cli): preserve mcp mirror positional args

### DIFF
--- a/internal/generator/mcp_novel_features_test.go
+++ b/internal/generator/mcp_novel_features_test.go
@@ -161,6 +161,7 @@ func TestMCPFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 import (
 	"testing"
 
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
 )
 
@@ -192,31 +193,51 @@ func TestFrameworkCommandClassificationIsTopLevelOnly(t *testing.T) {
 		Use: "auth",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
 	}
-	items := &cobra.Command{Use: "items"}
-	itemSearch := &cobra.Command{
+	library := &cobra.Command{Use: "library"}
+	librarySearch := &cobra.Command{
 		Use: "search",
 		RunE: func(cmd *cobra.Command, args []string) error { return nil },
 	}
-	items.AddCommand(itemSearch)
-	root.AddCommand(topAuth, items)
+	topVersion := &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	libraryAuth := &cobra.Command{
+		Use: "auth",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	library.AddCommand(librarySearch, libraryAuth)
+	root.AddCommand(topAuth, topVersion, library)
 
 	if got := classify(topAuth); got != commandFramework {
 		t.Fatalf("top-level auth classify() = %v, want commandFramework", got)
 	}
-	if got := classify(itemSearch); got != commandNovel {
-		t.Fatalf("nested items search classify() = %v, want commandNovel", got)
+	if got := classify(topVersion); got != commandFramework {
+		t.Fatalf("top-level version classify() = %v, want commandFramework", got)
 	}
-	var mirrored []string
-	walk(root, nil, func(cmd *cobra.Command, path []string) {
-		if classify(cmd) == commandNovel && cmd.Runnable() {
-			mirrored = append(mirrored, toolNameForPath(path))
+	if got := classify(librarySearch); got != commandNovel {
+		t.Fatalf("nested library search classify() = %v, want commandNovel", got)
+	}
+	if got := classify(libraryAuth); got != commandNovel {
+		t.Fatalf("nested library auth classify() = %v, want commandNovel", got)
+	}
+	if got := toolNameForPath([]string{"library", "search"}); got != "library_search" {
+		t.Fatalf("nested search tool name = %q, want library_search", got)
+	}
+
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterAll(s, root, func() (string, error) { return "missing-binary", nil })
+	tools := s.ListTools()
+	if _, ok := tools["library_search"]; !ok {
+		t.Fatalf("nested library search was not mirrored: %#v", tools)
+	}
+	if _, ok := tools["library_auth"]; !ok {
+		t.Fatalf("nested library auth was not mirrored: %#v", tools)
+	}
+	for _, excluded := range []string{"auth", "version"} {
+		if _, ok := tools[excluded]; ok {
+			t.Fatalf("top-level framework command %q was mirrored: %#v", excluded, tools)
 		}
-	})
-	if got := toolNameForPath([]string{"items", "search"}); got != "items_search" {
-		t.Fatalf("nested search tool name = %q, want items_search", got)
-	}
-	if len(mirrored) != 1 || mirrored[0] != "items_search" {
-		t.Fatalf("mirrored tools = %v, want only items_search", mirrored)
 	}
 }
 `)

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -17,7 +17,7 @@ import (
 	"{{modulePath}}/internal/mcp/bound"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, allowedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -25,6 +25,9 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 			return mcplib.NewToolResultError(fmt.Sprintf("companion CLI binary not found: %v\nTried sibling lookup, {{envPrefix .Name}}_CLI_PATH env var, and PATH.", lookupErr)), nil
 		}
 		args := req.GetArguments()
+		if err := validateMCPArgumentNames(args, allowedStructuredArgs); err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
 		finalArgs := append([]string{}, prefixArgs...)
 		finalArgs = append(finalArgs, cliArgsFromMCP(args, blockedStructuredArgs)...)
 		positionalArgs, err := positionalArgsFromMCP(args, positionals, readOnly, positionalWriteSinks)
@@ -33,11 +36,11 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		}
 		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
-			tokens := SplitShellArgs(raw)
-			if err := validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
+			rawPositionals := positionalArgsFromRawArgsField(raw, positionals, len(positionalArgs))
+			if err := validatePositionalArgsForMCPAtOffset(rawPositionals, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
 				return mcplib.NewToolResultError(err.Error()), nil
 			}
-			finalArgs = append(finalArgs, tokens...)
+			finalArgs = append(finalArgs, rawPositionals...)
 		}
 		out, err := RunCLICommand(ctx, lookupPath, finalArgs)
 		if err != nil {
@@ -45,6 +48,26 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		}
 		return mcplib.NewToolResultText(bound.Text(out)), nil
 	}
+}
+
+func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) error {
+	if len(args) == 0 || len(allowed) == 0 {
+		return nil
+	}
+	var unknown []string
+	for k := range args {
+		if !allowed[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	if len(unknown) == 1 {
+		return fmt.Errorf("unknown MCP parameter %q; use the tool schema's named parameters", unknown[0])
+	}
+	return fmt.Errorf("unknown MCP parameters %q; use the tool schema's named parameters", strings.Join(unknown, ", "))
 }
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
@@ -83,6 +106,17 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		return nil, err
 	}
 	return out, nil
+}
+
+func positionalArgsFromRawArgsField(raw string, positionals []positionalArg, structuredCount int) []string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return nil
+	}
+	if len(positionals) == 1 && structuredCount == 0 {
+		return []string{text}
+	}
+	return SplitShellArgs(raw)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {

--- a/internal/generator/templates/cobratree/shellout.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout.go.tmpl
@@ -51,7 +51,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 }
 
 func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) error {
-	if len(args) == 0 || len(allowed) == 0 {
+	if len(args) == 0 {
 		return nil
 	}
 	var unknown []string
@@ -67,7 +67,15 @@ func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) erro
 	if len(unknown) == 1 {
 		return fmt.Errorf("unknown MCP parameter %q; use the tool schema's named parameters", unknown[0])
 	}
-	return fmt.Errorf("unknown MCP parameters %q; use the tool schema's named parameters", strings.Join(unknown, ", "))
+	return fmt.Errorf("unknown MCP parameters %s; use the tool schema's named parameters", quoteMCPParameterNames(unknown))
+}
+
+func quoteMCPParameterNames(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = strconv.Quote(name)
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -5,7 +5,9 @@ package cobratree
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -449,6 +451,103 @@ func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEqui
 	}
 }
 
+func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "query",
+		Display:   "<query>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"areas", "search"},
+		map[string]bool{"args": true, "query": true},
+		map[string]bool{"args": true, "query": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"args": "New York City"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"areas", "search", "New York City"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutStructuredPositionalPreservesWhitespace(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "friend",
+		Display:   "<friend>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"fairness", "nudge"},
+		map[string]bool{"args": true, "friend": true},
+		map[string]bool{"args": true, "friend": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"friend": "Jane Q Public"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"fairness", "nudge", "Jane Q Public"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutRejectsUnknownStructuredParameters(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "term",
+		Display:   "<term>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"search"},
+		map[string]bool{"args": true, "term": true},
+		map[string]bool{"args": true, "term": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "Eli Escobar"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handler accepted unknown parameter, result=%s", toolResultText(result))
+	}
+	if got := toolResultText(result); !strings.Contains(got, `unknown MCP parameter "query"`) {
+		t.Fatalf("tool error = %q, want unknown parameter message", got)
+	}
+}
+
 func TestRunCLICommandKeepsStdoutSeparateFromStderr(t *testing.T) {
 	bin := writeShelloutHelper(t, "success")
 	got, err := RunCLICommand(context.Background(), bin, []string{"alpha", "beta"})
@@ -528,4 +627,53 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+func writeArgvHelper(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "argvhelper.go")
+	body := `package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func main() {
+	_ = json.NewEncoder(os.Stdout).Encode(os.Args[1:])
+}
+`
+	if err := os.WriteFile(src, []byte(body), 0o644); err != nil {
+		t.Fatalf("write argv helper source: %v", err)
+	}
+	bin := filepath.Join(dir, "argvhelper")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build argv helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func decodeArgvResult(t *testing.T, result *mcplib.CallToolResult) []string {
+	t.Helper()
+	var got []string
+	if err := json.Unmarshal([]byte(toolResultText(result)), &got); err != nil {
+		t.Fatalf("decode argv result: %v; text=%q", err, toolResultText(result))
+	}
+	return got
+}
+
+func toolResultText(result *mcplib.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	text, ok := result.Content[0].(mcplib.TextContent)
+	if !ok {
+		return ""
+	}
+	return text.Text
 }

--- a/internal/generator/templates/cobratree/shellout_test.go.tmpl
+++ b/internal/generator/templates/cobratree/shellout_test.go.tmpl
@@ -121,6 +121,29 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 	}
 }
 
+func TestValidateMCPArgumentNamesRejectsArgsWhenNoParamsAllowed(t *testing.T) {
+	err := validateMCPArgumentNames(map[string]any{"query": "alpha"}, nil)
+	if err == nil {
+		t.Fatal("validateMCPArgumentNames accepted an unknown arg for a parameter-free command")
+	}
+	if got, want := err.Error(), `unknown MCP parameter "query"; use the tool schema's named parameters`; got != want {
+		t.Fatalf("validateMCPArgumentNames error = %q, want %q", got, want)
+	}
+}
+
+func TestValidateMCPArgumentNamesQuotesEachUnknownArg(t *testing.T) {
+	err := validateMCPArgumentNames(map[string]any{
+		"zeta":  true,
+		"alpha": "x",
+	}, map[string]bool{})
+	if err == nil {
+		t.Fatal("validateMCPArgumentNames accepted unknown args")
+	}
+	if got, want := err.Error(), `unknown MCP parameters "alpha", "zeta"; use the tool schema's named parameters`; got != want {
+		t.Fatalf("validateMCPArgumentNames error = %q, want %q", got, want)
+	}
+}
+
 func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
 	root.PersistentFlags().String("profile", "", "root profile")

--- a/internal/generator/templates/cobratree/typemap.go.tmpl
+++ b/internal/generator/templates/cobratree/typemap.go.tmpl
@@ -54,6 +54,32 @@ func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positional
 	return opts
 }
 
+func allowedStructuredArgsForCommand(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg, allowRawArgs bool) map[string]bool {
+	allowed := map[string]bool{}
+	if allowRawArgs {
+		allowed["args"] = true
+	}
+	seen := map[string]bool{}
+	addFlag := func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if reservedStructuredArgs[flag.Name] || blocked[flag.Name] || seen[flag.Name] {
+			return
+		}
+		seen[flag.Name] = true
+		allowed[flag.Name] = true
+	}
+	if cmd != nil {
+		cmd.NonInheritedFlags().VisitAll(addFlag)
+		cmd.InheritedFlags().VisitAll(addFlag)
+	}
+	for _, positional := range positionals {
+		allowed[positional.InputName] = true
+	}
+	return allowed
+}
+
 func toolOptionForFlag(flag *pflag.Flag) mcplib.ToolOption {
 	propOpts := []mcplib.PropertyOption{mcplib.Description(flagDescription(flag))}
 	if isRequired(flag) {

--- a/internal/generator/templates/cobratree/walker.go.tmpl
+++ b/internal/generator/templates/cobratree/walker.go.tmpl
@@ -36,6 +36,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
 		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
 		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
+		allowedStructuredArgs := allowedStructuredArgsForCommand(cmd, blockedStructuredArgs, positionals, commandTakesArgs(cmd))
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
 		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
 		if commandTakesArgs(cmd) && len(positionals) == 0 {
@@ -45,7 +46,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, allowedStructuredArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-device-ble/ble-temperature-sensor/internal/mcp/cobratree/walker.go
@@ -36,6 +36,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
 		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
 		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
+		allowedStructuredArgs := allowedStructuredArgsForCommand(cmd, blockedStructuredArgs, positionals, commandTakesArgs(cmd))
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
 		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
 		if commandTakesArgs(cmd) && len(positionals) == 0 {
@@ -45,7 +46,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, allowedStructuredArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -17,7 +17,7 @@ import (
 	"printing-press-golden-pp-cli/internal/mcp/bound"
 )
 
-func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
+func shellOutToCLI(cliPath func() (string, error), commandPath []string, blockedStructuredArgs map[string]bool, allowedStructuredArgs map[string]bool, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) server.ToolHandlerFunc {
 	lookupPath, lookupErr := cliPath()
 	prefixArgs := append([]string{}, commandPath...)
 	return func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -25,6 +25,9 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 			return mcplib.NewToolResultError(fmt.Sprintf("companion CLI binary not found: %v\nTried sibling lookup, PRINTING_PRESS_GOLDEN_CLI_PATH env var, and PATH.", lookupErr)), nil
 		}
 		args := req.GetArguments()
+		if err := validateMCPArgumentNames(args, allowedStructuredArgs); err != nil {
+			return mcplib.NewToolResultError(err.Error()), nil
+		}
 		finalArgs := append([]string{}, prefixArgs...)
 		finalArgs = append(finalArgs, cliArgsFromMCP(args, blockedStructuredArgs)...)
 		positionalArgs, err := positionalArgsFromMCP(args, positionals, readOnly, positionalWriteSinks)
@@ -33,11 +36,11 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		}
 		finalArgs = append(finalArgs, positionalArgs...)
 		if raw, _ := args["args"].(string); strings.TrimSpace(raw) != "" {
-			tokens := SplitShellArgs(raw)
-			if err := validatePositionalArgsForMCPAtOffset(tokens, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
+			rawPositionals := positionalArgsFromRawArgsField(raw, positionals, len(positionalArgs))
+			if err := validatePositionalArgsForMCPAtOffset(rawPositionals, readOnly, positionalWriteSinks, len(positionalArgs)); err != nil {
 				return mcplib.NewToolResultError(err.Error()), nil
 			}
-			finalArgs = append(finalArgs, tokens...)
+			finalArgs = append(finalArgs, rawPositionals...)
 		}
 		out, err := RunCLICommand(ctx, lookupPath, finalArgs)
 		if err != nil {
@@ -45,6 +48,26 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 		}
 		return mcplib.NewToolResultText(bound.Text(out)), nil
 	}
+}
+
+func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) error {
+	if len(args) == 0 || len(allowed) == 0 {
+		return nil
+	}
+	var unknown []string
+	for k := range args {
+		if !allowed[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	if len(unknown) == 1 {
+		return fmt.Errorf("unknown MCP parameter %q; use the tool schema's named parameters", unknown[0])
+	}
+	return fmt.Errorf("unknown MCP parameters %q; use the tool schema's named parameters", strings.Join(unknown, ", "))
 }
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {
@@ -83,6 +106,17 @@ func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, rea
 		return nil, err
 	}
 	return out, nil
+}
+
+func positionalArgsFromRawArgsField(raw string, positionals []positionalArg, structuredCount int) []string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return nil
+	}
+	if len(positionals) == 1 && structuredCount == 0 {
+		return []string{text}
+	}
+	return SplitShellArgs(raw)
 }
 
 func validatePositionalArgsForMCP(tokens []string, readOnly bool, positionalWriteSinks map[int]bool) error {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout.go
@@ -51,7 +51,7 @@ func shellOutToCLI(cliPath func() (string, error), commandPath []string, blocked
 }
 
 func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) error {
-	if len(args) == 0 || len(allowed) == 0 {
+	if len(args) == 0 {
 		return nil
 	}
 	var unknown []string
@@ -67,7 +67,15 @@ func validateMCPArgumentNames(args map[string]any, allowed map[string]bool) erro
 	if len(unknown) == 1 {
 		return fmt.Errorf("unknown MCP parameter %q; use the tool schema's named parameters", unknown[0])
 	}
-	return fmt.Errorf("unknown MCP parameters %q; use the tool schema's named parameters", strings.Join(unknown, ", "))
+	return fmt.Errorf("unknown MCP parameters %s; use the tool schema's named parameters", quoteMCPParameterNames(unknown))
+}
+
+func quoteMCPParameterNames(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = strconv.Quote(name)
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func positionalArgsFromMCP(args map[string]any, positionals []positionalArg, readOnly bool, positionalWriteSinks map[int]bool) ([]string, error) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -5,7 +5,9 @@ package cobratree
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -449,6 +451,103 @@ func TestRegisterAllPreservesTypedToolsAndExposesHandBuiltSearchWithoutTypedEqui
 	}
 }
 
+func TestShellOutSinglePositionalArgsFieldPreservesWhitespace(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "query",
+		Display:   "<query>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"areas", "search"},
+		map[string]bool{"args": true, "query": true},
+		map[string]bool{"args": true, "query": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"args": "New York City"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"areas", "search", "New York City"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutStructuredPositionalPreservesWhitespace(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "friend",
+		Display:   "<friend>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"fairness", "nudge"},
+		map[string]bool{"args": true, "friend": true},
+		map[string]bool{"args": true, "friend": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"friend": "Jane Q Public"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned tool error: %s", toolResultText(result))
+	}
+	got := decodeArgvResult(t, result)
+	want := []string{"fairness", "nudge", "Jane Q Public"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("shellout argv = %#v, want %#v", got, want)
+	}
+}
+
+func TestShellOutRejectsUnknownStructuredParameters(t *testing.T) {
+	bin := writeArgvHelper(t)
+	positionals := []positionalArg{positionalArg{
+		InputName: "term",
+		Display:   "<term>",
+		Required:  true,
+	}}
+	handler := shellOutToCLI(
+		func() (string, error) { return bin, nil },
+		[]string{"search"},
+		map[string]bool{"args": true, "term": true},
+		map[string]bool{"args": true, "term": true},
+		positionals,
+		false,
+		nil,
+	)
+
+	result, err := handler(context.Background(), mcplib.CallToolRequest{Params: mcplib.CallToolParams{
+		Arguments: map[string]any{"query": "Eli Escobar"},
+	}})
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handler accepted unknown parameter, result=%s", toolResultText(result))
+	}
+	if got := toolResultText(result); !strings.Contains(got, `unknown MCP parameter "query"`) {
+		t.Fatalf("tool error = %q, want unknown parameter message", got)
+	}
+}
+
 func TestRunCLICommandKeepsStdoutSeparateFromStderr(t *testing.T) {
 	bin := writeShelloutHelper(t, "success")
 	got, err := RunCLICommand(context.Background(), bin, []string{"alpha", "beta"})
@@ -528,4 +627,53 @@ func writeShelloutHelper(t *testing.T, mode string) string {
 		t.Fatalf("write helper: %v", err)
 	}
 	return path
+}
+
+func writeArgvHelper(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "argvhelper.go")
+	body := `package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func main() {
+	_ = json.NewEncoder(os.Stdout).Encode(os.Args[1:])
+}
+`
+	if err := os.WriteFile(src, []byte(body), 0o644); err != nil {
+		t.Fatalf("write argv helper source: %v", err)
+	}
+	bin := filepath.Join(dir, "argvhelper")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build argv helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func decodeArgvResult(t *testing.T, result *mcplib.CallToolResult) []string {
+	t.Helper()
+	var got []string
+	if err := json.Unmarshal([]byte(toolResultText(result)), &got); err != nil {
+		t.Fatalf("decode argv result: %v; text=%q", err, toolResultText(result))
+	}
+	return got
+}
+
+func toolResultText(result *mcplib.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	text, ok := result.Content[0].(mcplib.TextContent)
+	if !ok {
+		return ""
+	}
+	return text.Text
 }

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/shellout_test.go
@@ -121,6 +121,29 @@ func TestCliArgsFromMCP_AllowsPerCommandFlags(t *testing.T) {
 	}
 }
 
+func TestValidateMCPArgumentNamesRejectsArgsWhenNoParamsAllowed(t *testing.T) {
+	err := validateMCPArgumentNames(map[string]any{"query": "alpha"}, nil)
+	if err == nil {
+		t.Fatal("validateMCPArgumentNames accepted an unknown arg for a parameter-free command")
+	}
+	if got, want := err.Error(), `unknown MCP parameter "query"; use the tool schema's named parameters`; got != want {
+		t.Fatalf("validateMCPArgumentNames error = %q, want %q", got, want)
+	}
+}
+
+func TestValidateMCPArgumentNamesQuotesEachUnknownArg(t *testing.T) {
+	err := validateMCPArgumentNames(map[string]any{
+		"zeta":  true,
+		"alpha": "x",
+	}, map[string]bool{})
+	if err == nil {
+		t.Fatal("validateMCPArgumentNames accepted unknown args")
+	}
+	if got, want := err.Error(), `unknown MCP parameters "alpha", "zeta"; use the tool schema's named parameters`; got != want {
+		t.Fatalf("validateMCPArgumentNames error = %q, want %q", got, want)
+	}
+}
+
 func TestBlockedStructuredArgsOnlyDropsInheritedRootFlags(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
 	root.PersistentFlags().String("profile", "", "root profile")

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/typemap.go
@@ -54,6 +54,32 @@ func toolOptionsForFlags(cmd *cobra.Command, blocked map[string]bool, positional
 	return opts
 }
 
+func allowedStructuredArgsForCommand(cmd *cobra.Command, blocked map[string]bool, positionals []positionalArg, allowRawArgs bool) map[string]bool {
+	allowed := map[string]bool{}
+	if allowRawArgs {
+		allowed["args"] = true
+	}
+	seen := map[string]bool{}
+	addFlag := func(flag *pflag.Flag) {
+		if flag == nil || flag.Hidden || flag.Deprecated != "" {
+			return
+		}
+		if reservedStructuredArgs[flag.Name] || blocked[flag.Name] || seen[flag.Name] {
+			return
+		}
+		seen[flag.Name] = true
+		allowed[flag.Name] = true
+	}
+	if cmd != nil {
+		cmd.NonInheritedFlags().VisitAll(addFlag)
+		cmd.InheritedFlags().VisitAll(addFlag)
+	}
+	for _, positional := range positionals {
+		allowed[positional.InputName] = true
+	}
+	return allowed
+}
+
 func toolOptionForFlag(flag *pflag.Flag) mcplib.ToolOption {
 	propOpts := []mcplib.PropertyOption{mcplib.Description(flagDescription(flag))}
 	if isRequired(flag) {

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/mcp/cobratree/walker.go
@@ -36,6 +36,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		blockedStructuredArgs := blockedStructuredArgsForCommand(cmd)
 		positionals := positionalArgsForCommand(cmd, blockedStructuredArgs)
 		blockedCLIArgs := cliFlagBlockedArgs(blockedStructuredArgs, positionals)
+		allowedStructuredArgs := allowedStructuredArgsForCommand(cmd, blockedStructuredArgs, positionals, commandTakesArgs(cmd))
 		options := []mcplib.ToolOption{mcplib.WithDescription(descriptionFor(cmd))}
 		options = append(options, toolOptionsForFlags(cmd, blockedStructuredArgs, positionals)...)
 		if commandTakesArgs(cmd) && len(positionals) == 0 {
@@ -45,7 +46,7 @@ func RegisterAll(s *server.MCPServer, root *cobra.Command, cliPath func() (strin
 		if readOnly {
 			options = append(options, mcplib.WithReadOnlyHintAnnotation(true), mcplib.WithDestructiveHintAnnotation(false))
 		}
-		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
+		s.AddTool(mcplib.NewTool(toolName, options...), shellOutToCLI(cliPath, path, blockedCLIArgs, allowedStructuredArgs, positionals, readOnly, positionalWriteSinkIndexes(cmd)))
 	})
 }
 


### PR DESCRIPTION
## Summary

Cobratree mirrored commands now preserve multi-word positional values when agents call a single free-text positional through the fallback `args` field, so commands with `cobra.ExactArgs(1)` receive one argv value instead of a whitespace-split list. The mirror also rejects unknown MCP parameters before shelling out, which turns invented fields like `query` into a clear tool error instead of forwarding them as bogus CLI flags.

The framework-depth regression coverage now proves nested commands such as `library search` and `library auth` are mirrored while top-level framework commands remain skipped.

Fixes #3328
Fixes #2893
Fixes #2566

## Validation

- `go test ./internal/generator -run 'TestMCP(RegistersCobraTreeMirror|NovelFeatureToolNameSanitization|FrameworkCommandClassificationIsTopLevelOnly)' -count=1`
- `scripts/golden.sh verify` (failed before fixture update with expected cobratree diffs)
- `GOLDEN_ALLOW_DIRTY=1 scripts/golden.sh update`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./internal/generator -count=1`
- `go test $(go list ./... | grep -v '/internal/cli$')`
- `go test ./internal/cli -v -count=1`
- `go test ./...`

## Goldens

Updated intentional generated cobratree fixtures for `generate-golden-api` and the BLE device walker fixture to reflect the new allowed-argument plumbing, fallback positional handling, and runtime tests.
