### PR TITLE
fix(cli): gate generated command surfaces

### DIFF
--- a/internal/generator/doctor_paths_test.go
+++ b/internal/generator/doctor_paths_test.go
@@ -107,6 +107,53 @@ func TestGeneratedDoctorAuthNoneOmitsCredentialLocations(t *testing.T) {
 	require.NotContains(t, payload, "credentials_location_warning")
 }
 
+func TestGeneratedDoctorDistinguishesEmptyCacheFromFresh(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := readOnlyCollectionSpec("doctor-empty-cache")
+	apiSpec.Cache.Enabled = true
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	testSrc := strings.ReplaceAll(`package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectCacheReportEmptyStore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	dbPath := defaultDBPath("__CLI_NAME__")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
+		t.Fatalf("seed empty DB file: %v", err)
+	}
+
+	report := collectCacheReport(context.Background(), "")
+	if got := report["status"]; got != "empty" {
+		t.Fatalf("status = %v, want empty; report=%v", got, report)
+	}
+	if _, ok := report["fresh_resources"]; ok {
+		t.Fatalf("empty store must not report fresh resources: %v", report)
+	}
+}
+`, "__CLI_NAME__", naming.CLI(apiSpec.Name))
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "internal", "cli", "cache_empty_test.go"), []byte(testSrc), 0o644))
+
+	runGoCommand(t, outputDir, "test", "./internal/cli", "-run", "TestCollectCacheReportEmptyStore", "-count=1")
+}
+
 func TestGeneratedDoctorAgentcookieSuppressesMultiLocationWarn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -767,6 +767,7 @@ type HelperFlags struct {
 	HasResponseUnwrap    bool // at least one generated command can call extractResponseData
 	HasMutationEndpoints bool // spec has any non-GET/HEAD endpoint → emit partial-failure helpers + --allow-partial-failure flag
 	HasRequiredRoles     bool // spec has per-endpoint requires_role gates → emit persona helpers
+	HasCreateCommands    bool // spec has POST/PUT/PATCH write endpoints → emit create retry helpers
 }
 
 // computeHelperFlags scans the spec's resources to determine which helpers are needed.
@@ -775,7 +776,7 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 	for _, r := range s.Resources {
 		var scan func(spec.Resource)
 		scan = func(resource spec.Resource) {
-			for _, e := range resource.Endpoints {
+			for name, e := range resource.Endpoints {
 				if strings.EqualFold(e.Method, "DELETE") {
 					flags.HasDelete = true
 				}
@@ -787,6 +788,9 @@ func computeHelperFlags(s *spec.APISpec) HelperFlags {
 				}
 				if endpointNeedsClientLimit(e) {
 					flags.HasClientLimit = true
+				}
+				if endpointIsCreateCommand(e, name) {
+					flags.HasCreateCommands = true
 				}
 				if len(endpointClientSideFilters(s, e)) > 0 {
 					flags.HasClientFilters = true
@@ -839,13 +843,12 @@ type helpersTemplateData struct {
 	HelperFlags
 }
 
-// doctorTemplateData wraps APISpec with a HasStore flag so the doctor
-// template can gate its cache-health section. Doctor is emitted for every
-// CLI — with or without a local store — so the template needs explicit
-// knowledge of whether internal/store exists.
+// doctorTemplateData wraps APISpec with flags for store-aware credential
+// resolution and generated cache-health checks.
 type doctorTemplateData struct {
 	*spec.APISpec
 	HasStore       bool
+	HasCacheReport bool
 	HasAuthCommand bool
 }
 
@@ -926,6 +929,7 @@ type readmeTemplateData struct {
 	HasDataLayer       bool
 	HasAsyncJobs       bool
 	HasWriteCommands   bool
+	HasCreateCommands  bool
 	HasDelete          bool
 	HasAuth            bool
 	// HasAuthCommand mirrors Generator.shouldEmitAuth() so doc templates can
@@ -991,6 +995,7 @@ func (g *Generator) readmeData() *readmeTemplateData {
 		HasDataLayer:          g.VisionSet.Store,
 		HasAsyncJobs:          len(g.AsyncJobs) > 0,
 		HasWriteCommands:      hasWriteCommands(g.Spec.Resources),
+		HasCreateCommands:     hasCreateCommands(g.Spec.Resources),
 		HasDelete:             computeHelperFlags(g.Spec).HasDelete,
 		HasAuth:               hasAuth(g.Spec.Auth),
 		HasAuthCommand:        g.shouldEmitAuth(),
@@ -1686,6 +1691,15 @@ func hasWriteCommands(resources map[string]spec.Resource) bool {
 	return false
 }
 
+func hasCreateCommands(resources map[string]spec.Resource) bool {
+	for _, resource := range resources {
+		if resourceHasCreateCommand(resource) {
+			return true
+		}
+	}
+	return false
+}
+
 func resourceHasWriteCommand(resource spec.Resource) bool {
 	for name, endpoint := range resource.Endpoints {
 		if endpointIsWriteCommand(endpoint, name) {
@@ -1694,6 +1708,20 @@ func resourceHasWriteCommand(resource spec.Resource) bool {
 	}
 	for _, sub := range resource.SubResources {
 		if resourceHasWriteCommand(sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceHasCreateCommand(resource spec.Resource) bool {
+	for name, endpoint := range resource.Endpoints {
+		if endpointIsCreateCommand(endpoint, name) {
+			return true
+		}
+	}
+	for _, sub := range resource.SubResources {
+		if resourceHasCreateCommand(sub) {
 			return true
 		}
 	}
@@ -1787,6 +1815,18 @@ func endpointIsWriteCommand(endpoint spec.Endpoint, opName string) bool {
 		return false
 	}
 	return !bodyIsAllFilterShape(endpoint.Body)
+}
+
+func endpointIsCreateCommand(endpoint spec.Endpoint, opName string) bool {
+	if !endpointIsWriteCommand(endpoint, opName) {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(endpoint.Method)) {
+	case "POST", "PUT", "PATCH":
+		return true
+	default:
+		return false
+	}
 }
 
 // endpointIsReadCommand is the inverse of endpointIsWriteCommand.
@@ -2091,7 +2131,7 @@ func (g *Generator) prepareOutput() error {
 		g.profile = profiler.Profile(g.Spec)
 		g.resetHTMLSyncStubCache()
 	}
-	g.VisionSet = constrainVisionTemplates(g.Spec, g.VisionSet)
+	g.VisionSet = constrainVisionTemplates(g.Spec, g.VisionSet, g.profile)
 	if g.Spec.Learn.Enabled && !g.VisionSet.Store {
 		return fmt.Errorf("learn.enabled requires VisionSet.Store=true; the learn package depends on internal/store")
 	}
@@ -2191,6 +2231,7 @@ func (g *Generator) renderSingleFiles() error {
 			data = &doctorTemplateData{
 				APISpec:        g.Spec,
 				HasStore:       g.VisionSet.Store,
+				HasCacheReport: g.hasGeneratedSyncImplementation(),
 				HasAuthCommand: g.shouldEmitAuth(),
 			}
 		case "cliutil_paths.go.tmpl":
@@ -4412,6 +4453,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 		HasAsyncJobs          bool
 		AsyncJobCount         int
 		HasAuthCommand        bool
+		HasCreateCommands     bool
 		HasDelete             bool
 		HasMutationEndpoints  bool
 		HasAutoRefresh        bool
@@ -4431,6 +4473,7 @@ func (g *Generator) renderRootProjectFiles(promotedCommands []PromotedCommand, p
 		HasAsyncJobs:          len(g.AsyncJobs) > 0,
 		AsyncJobCount:         len(g.AsyncJobs),
 		HasAuthCommand:        hasAuthCommand,
+		HasCreateCommands:     hasCreateCommands(g.Spec.Resources),
 		HasDelete:             helperFlags.HasDelete,
 		HasMutationEndpoints:  helperFlags.HasMutationEndpoints,
 		HasAutoRefresh:        g.hasAutoRefresh(),

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -19634,8 +19634,10 @@ func TestGenerateParentGroupersEmitReadOnlyAnnotation(t *testing.T) {
 
 	parentSrc, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "items.go"))
 	require.NoError(t, err)
-	assert.Regexp(t, `Annotations:\s+map\[string\]string\{"mcp:read-only":\s*"true"\}`, string(parentSrc),
+	assert.Contains(t, string(parentSrc), `"mcp:read-only": "true"`,
 		"parent groupers must always emit mcp:read-only=true so cobratree/tools-audit treat them as read-only")
+	assert.Contains(t, string(parentSrc), `"pp:typed-exit-codes": "0,2"`,
+		"parent groupers intentionally exit 2 for bare usage, so generated commands must declare that typed exit code")
 	assert.Regexp(t, `RunE:\s+parentNoSubcommandRunE\(flags\)`, string(parentSrc),
 		"test fixture must exercise a parent grouper command, not a promoted single-endpoint command")
 }

--- a/internal/generator/graphql_import_test.go
+++ b/internal/generator/graphql_import_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/graphql"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +57,13 @@ func TestGeneratedRESTImportStaysREST(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("restimportapi")
+	apiSpec.Resources["items"].Endpoints["create"] = spec.Endpoint{
+		Method:      "POST",
+		Path:        "/items",
+		Description: "Create item",
+		Body:        []spec.Param{{Name: "name", Type: "string", Required: true}},
+		Response:    spec.ResponseDef{Type: "object"},
+	}
 	require.False(t, isGraphQLSpec(apiSpec), "minimalSpec must be a REST spec")
 
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))

--- a/internal/generator/html_sync_stub_test.go
+++ b/internal/generator/html_sync_stub_test.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
@@ -11,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateHTMLMajoritySyncUsesStub(t *testing.T) {
+func TestGenerateHTMLMajoritySyncOmittedWhenOnlyPageModeCandidates(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := minimalSpec("html-majority")
@@ -64,17 +63,14 @@ func TestGenerateHTMLMajoritySyncUsesStub(t *testing.T) {
 	gen.VisionSet = VisionTemplateSet{Store: true, Sync: true, MCP: true}
 	require.NoError(t, gen.Generate())
 
-	syncSrc := readGeneratedFile(t, outputDir, "internal", "cli", "sync.go")
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
 	helpersSrc := readGeneratedFile(t, outputDir, "internal", "cli", "helpers.go")
 	workflowSrc := readGeneratedFile(t, outputDir, "internal", "cli", "channel_workflow.go")
 	readmeSrc := readGeneratedFile(t, outputDir, "README.md")
 	skillSrc := readGeneratedFile(t, outputDir, "SKILL.md")
 
-	assert.LessOrEqual(t, len(strings.Split(strings.TrimSpace(syncSrc), "\n")), 50)
-	assert.Contains(t, syncSrc, "func newSyncCmd(flags *rootFlags) *cobra.Command")
-	assert.Contains(t, syncSrc, `"mcp:hidden": "true"`)
-	assert.Contains(t, syncSrc, "generic spec-driven sync template does not fit predominantly HTML page-mode endpoints")
-	assert.NotContains(t, syncSrc, "syncOneResource")
+	assert.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	assert.NotContains(t, rootSrc, "newSyncCmd(flags)")
 	assert.NotContains(t, helpersSrc, "func syncErrorJSON(")
 	assert.NotContains(t, helpersSrc, "func parseSyncUserParams(")
 	assert.NotContains(t, helpersSrc, "func parseSyncKVFlags(")

--- a/internal/generator/sync_param_passthrough_test.go
+++ b/internal/generator/sync_param_passthrough_test.go
@@ -513,38 +513,20 @@ func noBulkListSpec(name string) *spec.APISpec {
 	return apiSpec
 }
 
-// TestGenerateSyncEmitsEmptyHintWhenNoBulkList covers issue #1156. When a spec
+// TestGenerateSyncOmittedWhenNoBulkList covers issue #1156. When a spec
 // has no bulk-list endpoint (only parameterized detail pages and required-
-// query searches), defaultSyncResources renders empty and the runtime sync
-// command is a no-op. The template must emit a clear hint so users and agents
-// understand the silence and can find the population path (single-fetch
-// commands writing to the store).
-func TestGenerateSyncEmitsEmptyHintWhenNoBulkList(t *testing.T) {
+// query searches), there is no mirror-population path for generic sync, so the
+// generator omits the command instead of exposing a no-op surface.
+func TestGenerateSyncOmittedWhenNoBulkList(t *testing.T) {
 	t.Parallel()
 
 	apiSpec := noBulkListSpec("nobulk")
 	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
 	require.NoError(t, New(apiSpec, outputDir).Generate())
 
-	syncGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "cli", "sync.go"))
-	require.NoError(t, err)
-	syncSrc := string(syncGo)
-
-	// Sanity: the structural precondition matches Allrecipes shape with both
-	// syncable and dependent slices empty, so defaultSyncResources renders
-	// with an empty body.
-	assert.Regexp(t,
-		`func defaultSyncResources\(\) \[\]string \{\s*return \[\]string\{\}\s*\}`,
-		syncSrc,
-		"defaultSyncResources should be empty for a spec with no bulk-list endpoints",
-	)
-
-	// The runtime hint surfaces in both modes so JSON-driven agents and human
-	// callers both see the explanation instead of a silent total_records:0.
-	assert.Contains(t, syncSrc, "no default sync resources",
-		"sync should print a stderr hint when defaultSyncResources is empty")
-	assert.Contains(t, syncSrc, `"reason":"no_bulk_list_endpoints"`,
-		"sync should emit a sync_warning JSON event when defaultSyncResources is empty")
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	assert.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	assert.NotContains(t, rootSrc, "newSyncCmd(flags)")
 }
 
 // TestGenerateSyncSkipsEmptyHintWhenBulkListExists ensures the template hint

--- a/internal/generator/sync_unresolved_path_key_test.go
+++ b/internal/generator/sync_unresolved_path_key_test.go
@@ -55,6 +55,7 @@ func TestGenerateSyncSkipsUnresolvedPathKeys(t *testing.T) {
 						Method:      "GET",
 						Path:        "/parent/{external_team_uuid}/items",
 						Description: "List items under an external parent",
+						Syncable:    true,
 						Response:    spec.ResponseDef{Type: "array"},
 					},
 				},

--- a/internal/generator/syncable_store_gate_test.go
+++ b/internal/generator/syncable_store_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mvanhorn/cli-printing-press/v4/internal/naming"
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/stretchr/testify/require"
 )
@@ -60,13 +61,36 @@ func TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache(t *testing.T) {
 	require.NoError(t, gen.Generate())
 
 	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "search.go"))
 	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
 	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
 	require.NotContains(t, rootSrc, "newSyncCmd(flags)")
+	require.NotContains(t, rootSrc, "newSearchCmd(flags)")
 	require.NotContains(t, doctorSrc, `report["cache"]`)
 	require.NotContains(t, doctorSrc, "collectCacheReport")
 
 	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestConstrainVisionTemplatesKeepsStreamingSyncWhenProfileHasNoBulkResources(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := zeroSyncableQuerySpec("streaming-zero-syncable")
+	apiSpec.Auth = spec.AuthConfig{Type: "none"}
+	apiSpec.Streaming = spec.StreamingConfig{
+		Transport:      spec.StreamingTransportWebSocket,
+		URL:            "wss://api.example.com/v1/ws",
+		SubscribeShape: `{"type":"subscribe","channels":["events"]}`,
+		Framing:        spec.StreamingFramingNDJSON,
+	}
+	visionSet := constrainVisionTemplates(
+		apiSpec,
+		VisionTemplateSet{Store: true, Search: true, Sync: true, MCP: true},
+		&profiler.APIProfile{},
+	)
+
+	require.True(t, visionSet.Store)
+	require.True(t, visionSet.Sync)
 }
 
 func TestGenerateReadOnlyAPIWithoutCreateOmitsImportAndIdempotent(t *testing.T) {

--- a/internal/generator/syncable_store_gate_test.go
+++ b/internal/generator/syncable_store_gate_test.go
@@ -49,6 +49,62 @@ func TestGeneratePostOnlyAPIStillSkipsLocalDataLayer(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "post-only API must not reserve internal/store")
 }
 
+func TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := zeroSyncableQuerySpec("zero-syncable-query")
+	apiSpec.Cache.Enabled = true
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Import: true, Store: true, Search: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "sync.go"))
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	doctorSrc := readGeneratedFile(t, outputDir, "internal", "cli", "doctor.go")
+	require.NotContains(t, rootSrc, "newSyncCmd(flags)")
+	require.NotContains(t, doctorSrc, `report["cache"]`)
+	require.NotContains(t, doctorSrc, "collectCacheReport")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGenerateReadOnlyAPIWithoutCreateOmitsImportAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := readOnlyCollectionSpec("readonly-no-create")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	gen := New(apiSpec, outputDir)
+	gen.VisionSet = VisionTemplateSet{Import: true, Store: true, Search: true, Sync: true, MCP: true}
+	require.NoError(t, gen.Generate())
+
+	require.NoFileExists(t, filepath.Join(outputDir, "internal", "cli", "import.go"))
+
+	rootSrc := readGeneratedFile(t, outputDir, "internal", "cli", "root.go")
+	readmeSrc := readGeneratedFile(t, outputDir, "README.md")
+	skillSrc := readGeneratedFile(t, outputDir, "SKILL.md")
+	require.NotContains(t, rootSrc, "newImportCmd(flags)")
+	require.NotContains(t, rootSrc, "idempotent")
+	require.NotContains(t, readmeSrc, "--idempotent")
+	require.NotContains(t, skillSrc, "--idempotent")
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
+func TestGeneratedBareParentDeclaresTypedExitCodeTwo(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := smallReadWriteSyncableOutputSpec("typed-parent-exit")
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	parentSrc := readGeneratedFile(t, outputDir, "internal", "cli", "deliveries.go")
+	require.Contains(t, parentSrc, `"mcp:read-only": "true"`)
+	require.Contains(t, parentSrc, `"pp:typed-exit-codes": "0,2"`)
+
+	requireGeneratedCompiles(t, outputDir)
+}
+
 func smallReadWriteSyncableOutputSpec(name string) *spec.APISpec {
 	apiSpec := minimalSpec(name)
 	apiSpec.Resources = map[string]spec.Resource{
@@ -124,6 +180,76 @@ func postOnlyOutputSpec(name string) *spec.APISpec {
 			Fields: []spec.TypeField{
 				{Name: "success", Type: "boolean"},
 				{Name: "error_message", Type: "string"},
+			},
+		},
+	}
+	return apiSpec
+}
+
+func zeroSyncableQuerySpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"recipes": {
+			Description: "Search HTML pages",
+			Endpoints: map[string]spec.Endpoint{
+				"get": {
+					Method:         "GET",
+					Path:           "/recipe/{recipe_id}/{slug}",
+					Description:    "Get recipe page",
+					ResponseFormat: spec.ResponseFormatHTML,
+					HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+					Params: []spec.Param{
+						{Name: "recipe_id", Type: "string", Required: true, PathParam: true},
+						{Name: "slug", Type: "string", Required: true, PathParam: true},
+					},
+					Response: spec.ResponseDef{Type: "object"},
+				},
+				"query": {
+					Method:         "GET",
+					Path:           "/search",
+					Description:    "Search pages",
+					ResponseFormat: spec.ResponseFormatHTML,
+					HTMLExtract:    &spec.HTMLExtract{Mode: spec.HTMLExtractModePage},
+					Params: []spec.Param{
+						{Name: "q", Type: "string", Required: true},
+					},
+					Response: spec.ResponseDef{Type: "array"},
+				},
+			},
+		},
+	}
+	return apiSpec
+}
+
+func readOnlyCollectionSpec(name string) *spec.APISpec {
+	apiSpec := minimalSpec(name)
+	apiSpec.Resources = map[string]spec.Resource{
+		"widgets": {
+			Description: "Read widgets",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:      "GET",
+					Path:        "/widgets",
+					Description: "List widgets",
+					Response:    spec.ResponseDef{Type: "array"},
+				},
+				"get": {
+					Method:      "GET",
+					Path:        "/widgets/{id}",
+					Description: "Get widget",
+					Params: []spec.Param{
+						{Name: "id", Type: "string", Required: true, PathParam: true, Positional: true},
+					},
+					Response: spec.ResponseDef{Type: "object"},
+				},
+			},
+		},
+	}
+	apiSpec.Types = map[string]spec.TypeDef{
+		"Widget": {
+			Fields: []spec.TypeField{
+				{Name: "id", Type: "string"},
+				{Name: "name", Type: "string"},
 			},
 		},
 	}

--- a/internal/generator/templates/command_parent.go.tmpl
+++ b/internal/generator/templates/command_parent.go.tmpl
@@ -14,7 +14,7 @@ func new{{cmdIdent .FuncPrefix}}Cmd(flags *rootFlags) *cobra.Command {
 {{- if .Hidden}}
 		Hidden: true,
 {{- end}}
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:typed-exit-codes": "0,2"},
 		RunE: parentNoSubcommandRunE(flags),
 	}
 {{range $eName, $endpoint := .Resource.Endpoints}}

--- a/internal/generator/templates/doctor.go.tmpl
+++ b/internal/generator/templates/doctor.go.tmpl
@@ -6,7 +6,7 @@
 package cli
 
 import (
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 	"context"
 {{- end}}
 {{- if .Auth.RequiresBrowserSession}}
@@ -16,7 +16,7 @@ import (
 {{- if or .Auth.RequiresBrowserSession .Auth.VerifyQuery}}
 	"encoding/json"
 {{- end}}
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 	"database/sql"
 {{- end}}
 	"errors"
@@ -25,7 +25,7 @@ import (
 {{- if .BearerRefresh.Enabled}}
 	"net/http"
 {{- end}}
-{{- if or .Auth.EnvVarSpecs .Auth.EnvVars .Auth.AdditionalHeaders .HasStore .Auth.RequiresBrowserSession .HasTierRouting}}
+{{- if or .Auth.EnvVarSpecs .Auth.EnvVars .Auth.AdditionalHeaders .HasCacheReport .Auth.RequiresBrowserSession .HasTierRouting}}
 	"os"
 {{- end}}
 {{- if or (eq .Auth.Type "cookie") (eq .Auth.Type "composed")}}
@@ -38,7 +38,7 @@ import (
 	"regexp"
 {{- end}}
 	"strings"
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 	"time"
 {{- else if .BearerRefresh.Enabled}}
 	"time"
@@ -47,7 +47,7 @@ import (
 	"{{modulePath}}/internal/client"
 	"{{modulePath}}/internal/cliutil"
 	"{{modulePath}}/internal/config"
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 	"{{modulePath}}/internal/store"
 {{- end}}
 	"github.com/spf13/cobra"
@@ -671,8 +671,8 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				report["api"] = "not configured (set base_url in config file)"
 			}
 
-{{- if .HasStore}}
-			// Cache health: only reported when this CLI has a local store.
+{{- if .HasCacheReport}}
+			// Cache health: only reported when this CLI has generated sync.
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
@@ -778,7 +778,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 				fmt.Fprintf(w, "  %v\n", instructions)
 			}
 {{- end}}
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 			// Cache section: render after the primary health block so it
 			// sits next to version info, mirroring the JSON report layout.
 			if cacheAny, ok := report["cache"]; ok {
@@ -1169,7 +1169,7 @@ func doctorExitForFailOn(failOn string, report map[string]any) error {
 	}
 	return nil
 }
-{{- if .HasStore}}
+{{- if .HasCacheReport}}
 
 // collectCacheReport opens the local store, reads per-resource sync state,
 // and returns a map summarising cache health. Never panics on missing DB
@@ -1260,8 +1260,8 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 
 	switch {
 	case !haveAny && len(resources) == 0:
-		report["status"] = "unknown"
-		report["hint"] = "sync_state is empty; run '{{.Name}}-pp-cli sync' to hydrate."
+		report["status"] = "empty"
+		report["hint"] = "Cache is empty; run '{{.Name}}-pp-cli sync' to hydrate."
 	case fresh:
 		report["status"] = "fresh"
 	default:
@@ -1281,6 +1281,8 @@ func renderCacheReport(w io.Writer, rep map[string]any) {
 	case "error":
 		indicator = red("FAIL")
 	case "unknown":
+		indicator = yellow("INFO")
+	case "empty":
 		indicator = yellow("INFO")
 	}
 	fmt.Fprintf(w, "  %s Cache: %s\n", indicator, status)

--- a/internal/generator/templates/helpers.go.tmpl
+++ b/internal/generator/templates/helpers.go.tmpl
@@ -858,9 +858,11 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
+{{- if .HasCreateCommands}}
 		if flags != nil && flags.idempotent {
 			return writeNoop(flags, "already_exists", "already exists (no-op)")
 		}
+{{- end}}
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified

--- a/internal/generator/templates/readme.md.tmpl
+++ b/internal/generator/templates/readme.md.tmpl
@@ -528,7 +528,9 @@ This CLI is designed for AI agent consumption:
 - **Filterable** - `--select id,name` returns only fields you need
 - **Previewable** - `--dry-run` shows the request without sending
 {{- if .HasWriteCommands}}
-- **Explicit retries** - add `--idempotent` to create retries{{if .HasDelete}} and `--ignore-missing` to delete retries{{end}} when a no-op success is acceptable
+{{- if or .HasCreateCommands .HasDelete}}
+- **Explicit retries** - {{if .HasCreateCommands}}add `--idempotent` to create retries{{if .HasDelete}} and {{end}}{{end}}{{if .HasDelete}}add `--ignore-missing` to delete retries{{end}} when a no-op success is acceptable
+{{- end}}
 - **Confirmable** - `--yes` for explicit confirmation of destructive actions
 - **Piped input** - write commands can accept structured input when their help lists `--stdin`
 {{- else}}

--- a/internal/generator/templates/root.go.tmpl
+++ b/internal/generator/templates/root.go.tmpl
@@ -29,7 +29,9 @@ type rootFlags struct {
 	dryRun       bool
 	noCache      bool
 	noInput      bool
+{{- if .HasCreateCommands}}
 	idempotent   bool
+{{- end}}
 {{- if .HasDelete}}
 	ignoreMissing bool
 {{- end}}
@@ -231,7 +233,9 @@ Run '{{.Name}}-pp-cli doctor' to verify auth and connectivity.{{backtick}},
 	rootCmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "Show request without sending")
 	rootCmd.PersistentFlags().BoolVar(&flags.noCache, "no-cache", false, "Bypass response cache")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
+{{- if .HasCreateCommands}}
 	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
+{{- end}}
 {{- if .HasDelete}}
 	rootCmd.PersistentFlags().BoolVar(&flags.ignoreMissing, "ignore-missing", false, "Treat missing delete targets as a successful no-op")
 {{- end}}

--- a/internal/generator/templates/skill.md.tmpl
+++ b/internal/generator/templates/skill.md.tmpl
@@ -316,7 +316,9 @@ Add `--agent` to any command. Expands to: `--json --compact --no-input --no-colo
 {{- if not .HasWriteCommands}}
 - **Read-only** — do not use this CLI for create, update, delete, publish, comment, upvote, invite, order, send, or other mutating requests
 {{- else}}
-- **Explicit retries** — use `--idempotent` only when an already-existing create should count as success{{if .HasDelete}}, and `--ignore-missing` only when a missing delete target should count as success{{end}}
+{{- if or .HasCreateCommands .HasDelete}}
+- **Explicit retries** — {{if .HasCreateCommands}}use `--idempotent` only when an already-existing create should count as success{{if .HasDelete}}, and {{end}}{{end}}{{if .HasDelete}}use `--ignore-missing` only when a missing delete target should count as success{{end}}
+{{- end}}
 {{- end}}
 {{- if .HasDataLayer}}
 

--- a/internal/generator/vision_templates.go
+++ b/internal/generator/vision_templates.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/mvanhorn/cli-printing-press/v4/internal/profiler"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/spec"
 	"github.com/mvanhorn/cli-printing-press/v4/internal/vision"
 )
@@ -161,15 +162,64 @@ func SelectVisionTemplates(plan *vision.VisionaryPlan) VisionTemplateSet {
 	return set
 }
 
-func constrainVisionTemplates(api *spec.APISpec, set VisionTemplateSet) VisionTemplateSet {
+func constrainVisionTemplates(api *spec.APISpec, set VisionTemplateSet, profile *profiler.APIProfile) VisionTemplateSet {
 	if api != nil && api.Streaming.Enabled() {
 		set.Store = true
 		set.Sync = true
 	}
+	if profile != nil && !hasSyncCommandResources(profile) {
+		set.Sync = false
+	}
 	if set.Export && len(exportableResources(api)) == 0 {
 		set.Export = false
 	}
+	if set.Import && !hasCreateCommands(api.Resources) {
+		set.Import = false
+	}
 	return set
+}
+
+func hasSyncCommandResources(profile *profiler.APIProfile) bool {
+	if profile == nil {
+		return false
+	}
+	for _, resource := range profile.SyncableResources {
+		if !isVestigialSyncResource(resource) {
+			return true
+		}
+	}
+	for _, resource := range profile.DependentSyncResources {
+		if !isVestigialDependentSyncResource(resource) {
+			return true
+		}
+	}
+	return false
+}
+
+func isVestigialSyncResource(resource profiler.SyncableResource) bool {
+	if resource.UsesHTMLResponse && resource.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage {
+		return true
+	}
+	return resource.SkipDefaultSync && looksLikeLiveQueryPath(resource.Path)
+}
+
+func isVestigialDependentSyncResource(resource profiler.DependentResource) bool {
+	if resource.UsesHTMLResponse && resource.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage {
+		return true
+	}
+	return false
+}
+
+func looksLikeLiveQueryPath(path string) bool {
+	for _, segment := range strings.FieldsFunc(strings.ToLower(path), func(r rune) bool {
+		return r == '/' || r == '?' || r == '&' || r == '='
+	}) {
+		switch segment {
+		case "search", "query", "find", "lookup":
+			return true
+		}
+	}
+	return false
 }
 
 func exportableResources(api *spec.APISpec) []string {

--- a/internal/generator/vision_templates.go
+++ b/internal/generator/vision_templates.go
@@ -163,12 +163,21 @@ func SelectVisionTemplates(plan *vision.VisionaryPlan) VisionTemplateSet {
 }
 
 func constrainVisionTemplates(api *spec.APISpec, set VisionTemplateSet, profile *profiler.APIProfile) VisionTemplateSet {
-	if api != nil && api.Streaming.Enabled() {
+	streamingEnabled := api != nil && api.Streaming.Enabled()
+	if streamingEnabled {
 		set.Store = true
 		set.Sync = true
 	}
-	if profile != nil && !hasSyncCommandResources(profile) {
+	if profile != nil && !hasSyncCommandResources(profile) && !streamingEnabled {
+		syncWasRequested := set.Sync
 		set.Sync = false
+		if syncWasRequested {
+			// Local query surfaces depend on sync-populated rows. Keep the store
+			// itself because explicit store-only CLIs, insights, and HTML channel
+			// workflows can still use it without the generic sync command.
+			set.Search = false
+			set.Analytics = false
+		}
 	}
 	if set.Export && len(exportableResources(api)) == 0 {
 		set.Export = false
@@ -200,6 +209,8 @@ func isVestigialSyncResource(resource profiler.SyncableResource) bool {
 	if resource.UsesHTMLResponse && resource.HTMLExtract.EffectiveMode() == spec.HTMLExtractModePage {
 		return true
 	}
+	// Path-template resources that are excluded from default sync and look like
+	// live query/search endpoints are not viable bulk store population sources.
 	return resource.SkipDefaultSync && looksLikeLiveQueryPath(resource.Path)
 }
 

--- a/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-embedded-paged-api/embedded-paged-api/internal/cli/helpers.go
@@ -483,9 +483,6 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		if flags != nil && flags.idempotent {
-			return writeNoop(flags, "already_exists", "already exists (no-op)")
-		}
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/doctor.go
@@ -335,7 +335,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			} else if cfg != nil && cfg.BaseURL == "" {
 				report["api"] = "not configured (set base_url in config file)"
 			}
-			// Cache health: only reported when this CLI has a local store.
+			// Cache health: only reported when this CLI has generated sync.
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
@@ -725,8 +725,8 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 
 	switch {
 	case !haveAny && len(resources) == 0:
-		report["status"] = "unknown"
-		report["hint"] = "sync_state is empty; run 'printing-press-rich-pp-cli sync' to hydrate."
+		report["status"] = "empty"
+		report["hint"] = "Cache is empty; run 'printing-press-rich-pp-cli sync' to hydrate."
 	case fresh:
 		report["status"] = "fresh"
 	default:
@@ -746,6 +746,8 @@ func renderCacheReport(w io.Writer, rep map[string]any) {
 	case "error":
 		indicator = red("FAIL")
 	case "unknown":
+		indicator = yellow("INFO")
+	case "empty":
 		indicator = yellow("INFO")
 	}
 	fmt.Fprintf(w, "  %s Cache: %s\n", indicator, status)

--- a/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
+++ b/testdata/golden/expected/generate-golden-api-rich-auth/printing-press-rich-auth/internal/cli/helpers.go
@@ -482,9 +482,6 @@ func classifyAPIError(err error, flags *rootFlags) error {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "HTTP 409"):
-		if flags != nil && flags.idempotent {
-			return writeNoop(flags, "already_exists", "already exists (no-op)")
-		}
 		classified := apiErr(err)
 		writeAPIErrorEnvelope(flags, classified, ExitCode(classified))
 		return classified

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/doctor.go
@@ -283,7 +283,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			} else if cfg != nil && cfg.BaseURL == "" {
 				report["api"] = "not configured (set base_url in config file)"
 			}
-			// Cache health: only reported when this CLI has a local store.
+			// Cache health: only reported when this CLI has generated sync.
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
@@ -673,8 +673,8 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 
 	switch {
 	case !haveAny && len(resources) == 0:
-		report["status"] = "unknown"
-		report["hint"] = "sync_state is empty; run 'printing-press-golden-pp-cli sync' to hydrate."
+		report["status"] = "empty"
+		report["hint"] = "Cache is empty; run 'printing-press-golden-pp-cli sync' to hydrate."
 	case fresh:
 		report["status"] = "fresh"
 	default:
@@ -694,6 +694,8 @@ func renderCacheReport(w io.Writer, rep map[string]any) {
 	case "error":
 		indicator = red("FAIL")
 	case "unknown":
+		indicator = yellow("INFO")
+	case "empty":
 		indicator = yellow("INFO")
 	}
 	fmt.Fprintf(w, "  %s Cache: %s\n", indicator, status)

--- a/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar.go
+++ b/testdata/golden/expected/generate-golden-api/printing-press-golden/internal/cli/projects_avatar.go
@@ -11,7 +11,7 @@ func newProjectsAvatarCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "avatar",
 		Short:       "Upload avatar for projects",
-		Annotations: map[string]string{"mcp:read-only": "true"},
+		Annotations: map[string]string{"mcp:read-only": "true", "pp:typed-exit-codes": "0,2"},
 		RunE:        parentNoSubcommandRunE(flags),
 	}
 

--- a/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
+++ b/testdata/golden/expected/generate-learn-loop-api/learn-loop-example/internal/cli/root.go
@@ -21,17 +21,16 @@ import (
 )
 
 type rootFlags struct {
-	asJSON     bool
-	compact    bool
-	csv        bool
-	plain      bool
-	quiet      bool
-	dryRun     bool
-	noCache    bool
-	noInput    bool
-	idempotent bool
-	yes        bool
-	agent      bool
+	asJSON  bool
+	compact bool
+	csv     bool
+	plain   bool
+	quiet   bool
+	dryRun  bool
+	noCache bool
+	noInput bool
+	yes     bool
+	agent   bool
 	// noLearn disables both teach (write) and recall (read) for this
 	// invocation. Mirrors the LEARN_LOOP_EXAMPLE_NO_LEARN env var.
 	noLearn       bool
@@ -168,7 +167,6 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "Show request without sending")
 	rootCmd.PersistentFlags().BoolVar(&flags.noCache, "no-cache", false, "Bypass response cache")
 	rootCmd.PersistentFlags().BoolVar(&flags.noInput, "no-input", false, "Disable all interactive prompts (for CI/agents)")
-	rootCmd.PersistentFlags().BoolVar(&flags.idempotent, "idempotent", false, "Treat already-existing create results as a successful no-op")
 	rootCmd.PersistentFlags().StringVar(&flags.selectFields, "select", "", "Comma-separated fields to include in output (e.g. --select id,name,status)")
 	rootCmd.PersistentFlags().BoolVar(&flags.yes, "yes", false, "Skip confirmation prompts (for agents and scripts)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
@@ -253,7 +251,6 @@ Run 'learn-loop-example-pp-cli doctor' to verify auth and connectivity.`,
 	rootCmd.AddCommand(newFeedbackCmd(flags))
 	rootCmd.AddCommand(newWhichCmd(flags))
 	rootCmd.AddCommand(newExportCmd(flags))
-	rootCmd.AddCommand(newImportCmd(flags))
 	rootCmd.AddCommand(newSearchCmd(flags))
 	rootCmd.AddCommand(newSyncCmd(flags))
 	rootCmd.AddCommand(newWorkflowCmd(flags))

--- a/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
+++ b/testdata/golden/expected/generate-tier-routing-api/tier-routing-golden/internal/cli/doctor.go
@@ -305,7 +305,7 @@ func newDoctorCmd(flags *rootFlags) *cobra.Command {
 			} else if cfg != nil && cfg.BaseURL == "" {
 				report["api"] = "not configured (set base_url in config file)"
 			}
-			// Cache health: only reported when this CLI has a local store.
+			// Cache health: only reported when this CLI has generated sync.
 			// Surfaces rows + last_synced_at per resource, schema version,
 			// and a fresh/stale/unknown verdict so agents can introspect
 			// whether to trust the cached data before issuing queries.
@@ -695,8 +695,8 @@ func collectCacheReport(ctx context.Context, staleAfterSpec string) map[string]a
 
 	switch {
 	case !haveAny && len(resources) == 0:
-		report["status"] = "unknown"
-		report["hint"] = "sync_state is empty; run 'tier-routing-golden-pp-cli sync' to hydrate."
+		report["status"] = "empty"
+		report["hint"] = "Cache is empty; run 'tier-routing-golden-pp-cli sync' to hydrate."
 	case fresh:
 		report["status"] = "fresh"
 	default:
@@ -716,6 +716,8 @@ func renderCacheReport(w io.Writer, rep map[string]any) {
 	case "error":
 		indicator = red("FAIL")
 	case "unknown":
+		indicator = yellow("INFO")
+	case "empty":
 		indicator = yellow("INFO")
 	}
 	fmt.Fprintf(w, "  %s Cache: %s\n", indicator, status)


### PR DESCRIPTION
## Summary

Fixes Wave 7 Lane C command-surface gates:

- Fixes #2971 by suppressing vestigial generated `sync` surfaces and doctor cache sections when specs have no useful generic mirror population path.
- Fixes #2933 by omitting generated `import` and `--idempotent` create retry surfaces when specs have no create commands.
- Fixes #2942 by reporting an empty migrated cache/store as `empty` instead of `fresh` or `unknown`.
- Fixes #2669 by adding `pp:typed-exit-codes: 0,2` to generated bare parent commands.

## Validation

- `go test ./internal/generator -run 'TestGeneratedSyncUsesPOSTForRPCStyleListResources|TestGenerateZeroSyncableAPIOmitsSyncAndDoctorCache|TestGenerateReadOnlyAPIWithoutCreateOmitsImportAndIdempotent|TestGeneratedBareParentDeclaresTypedExitCodeTwo|TestGeneratedDoctorDistinguishesEmptyCacheFromFresh|TestGenerateHTMLMajoritySyncOmittedWhenOnlyPageModeCandidates|TestGenerateSyncOmittedWhenNoBulkList|TestGenerateHTMLMajorityWithJSONSyncKeepsGenericSync' -count=1 -timeout 10m`
- `go test ./internal/openapi -run '^TestGenerateDataEnvelopeAllOfBodyFlags$' -count=1 -timeout 10m`
- `go test ./internal/generator -run 'TestGenerateParentGroupersEmitReadOnlyAnnotation|TestGeneratedRESTImportStaysREST|TestGenerateSyncSkipsUnresolvedPathKeys' -count=1 -timeout 10m`
- `go test ./internal/generator -count=1 -timeout 20m`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`
- `go test ./... -timeout 20m`

## Golden changes

Intentional generated-output updates cover removed idempotent helper branches for no-create fixtures, doctor empty-cache wording/status, typed exit annotations on parent commands, and removal of import/idempotent surfaces from the read-only learn-loop fixture.
