### PR TITLE
fix(generator): auth0 SPA unused os import

### DIFF
--- a/internal/generator/auth0_spa_test.go
+++ b/internal/generator/auth0_spa_test.go
@@ -86,6 +86,31 @@ func TestGenerateAuth0SPAEmitsCDPLoginCmd(t *testing.T) {
 		"`--help` should mention the CDP capture path so users understand what --auth0-spa does")
 }
 
+func TestGenerateAuth0SPAWithoutEnvVarOmitsUnusedOSImport(t *testing.T) {
+	t.Parallel()
+
+	apiSpec := minimalSpec("factor75")
+	apiSpec.BaseURL = "https://api.example.com"
+	apiSpec.Auth = spec.AuthConfig{
+		Type:    "bearer_token",
+		Subtype: spec.AuthSubtypeAuth0SPAInMemory,
+		Header:  "Authorization",
+	}
+
+	outputDir := filepath.Join(t.TempDir(), "factor75-pp-cli")
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	authGo := readGeneratedFile(t, outputDir, "internal", "cli", "auth.go")
+	assert.NotContains(t, authGo, "\"os\"",
+		"auth0_spa_in_memory auth.go should omit os when no generated branch references os")
+
+	if testing.Short() {
+		t.Skip("skipping build check in -short mode (downloads chromedp)")
+	}
+	runGoCommand(t, outputDir, "mod", "tidy")
+	runGoCommand(t, outputDir, "build", "./cmd/factor75-pp-cli")
+}
+
 // TestGenerateBearerTokenWithoutSubtypeUsesSimpleTemplate ensures that a
 // plain bearer_token spec (no Auth0 SPA subtype) still routes to the
 // auth_simple template — the CDP path is opt-in by detection, not the

--- a/internal/generator/templates/auth_browser.go.tmpl
+++ b/internal/generator/templates/auth_browser.go.tmpl
@@ -36,7 +36,9 @@ import (
 {{- if $hasCookieBrowserAuth}}
 	"net/http"
 {{- end}}
+{{- if or $hasCookieBrowserAuth $hasBrowserCapture $canonicalEnvVar}}
 	"os"
+{{- end}}
 {{- if or $hasCookieBrowserAuth $hasBrowserCapture}}
 	"os/exec"
 	"path/filepath"


### PR DESCRIPTION
## Summary
- make the generated auth.go os import conditional for Auth0 SPA specs
- add a regression fixture with no env var so the unused-import case is covered by a generated build smoke

Fixes #3338.

## Tests
- go test ./internal/generator -run 'TestGenerateAuth0SPAWithoutEnvVarOmitsUnusedOSImport|TestGenerateAuth0SPAEmitsCDPLoginCmd|TestGenerateBearerTokenWithoutSubtypeUsesSimpleTemplate' -count=1