### PR TITLE
fix(cli): reduce scorer dogfood false failures

### DIFF
--- a/internal/pipeline/dogfood.go
+++ b/internal/pipeline/dogfood.go
@@ -336,7 +336,7 @@ func RunDogfood(dir, specPath string, opts ...DogfoodOption) (*DogfoodReport, er
 			report.AuthCheck = checkAuth(dir, spec.Auth)
 		}
 		report.BrowserSessionCheck = checkBrowserSessionAuth(dir, spec.Auth)
-		report.OAuthScopeCoverage = checkOAuthScopeCoverage(dir, spec.OAuthScopeRequirements)
+		report.OAuthScopeCoverage = checkOAuthScopeCoverage(dir, spec.OAuthScopeRequirements, spec.Auth)
 	} else {
 		report.AuthCheck = AuthCheckResult{
 			Match:  true,
@@ -1507,11 +1507,21 @@ func authFormatSchemePrefix(format string) (string, bool) {
 	return fields[0] + " ", true
 }
 
-func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement) OAuthScopeCoverageResult {
+func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement, auth apispec.AuthConfig) OAuthScopeCoverageResult {
 	if len(requirements) == 0 {
 		return OAuthScopeCoverageResult{
 			Skipped: true,
 			Detail:  "no OAuth-scoped endpoints in spec",
+		}
+	}
+	if !oauthScopeCoverageApplies(auth) {
+		authType := strings.TrimSpace(auth.Type)
+		if authType == "" {
+			authType = "none"
+		}
+		return OAuthScopeCoverageResult{
+			Skipped: true,
+			Detail:  fmt.Sprintf("resolved auth type %s does not use OAuth scopes", authType),
 		}
 	}
 
@@ -1543,6 +1553,15 @@ func checkOAuthScopeCoverage(dir string, requirements []oauthScopeRequirement) O
 		result.Detail = fmt.Sprintf("%d OAuth-scoped endpoint(s) lack a generated auth scope", len(result.Violations))
 	}
 	return result
+}
+
+func oauthScopeCoverageApplies(auth apispec.AuthConfig) bool {
+	switch strings.ToLower(strings.TrimSpace(auth.Type)) {
+	case "api_key", "basic", "none", "cookie", "composed":
+		return false
+	default:
+		return true
+	}
 }
 
 func oauthScopeRequirementCovered(requirement oauthScopeRequirement, generated map[string]bool) bool {

--- a/internal/pipeline/dogfood_test.go
+++ b/internal/pipeline/dogfood_test.go
@@ -590,6 +590,74 @@ components:
 	assert.Equal(t, []string{"yt-analytics.readonly"}, report.OAuthScopeCoverage.Violations[0].RequiredScopes)
 }
 
+func TestRunDogfoodOAuthScopeCoverageSkipsResolvedAPIKeyAuth(t *testing.T) {
+	dir, specPath := writeOAuthScopeCoverageFixture(t, `package cli
+func authLogin() {}
+`, `openapi: 3.0.0
+info:
+  title: Videos API
+  version: "1.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /videos:
+    get:
+      operationId: listVideos
+      responses:
+        "200":
+          description: ok
+  /analytics:
+    get:
+      operationId: listAnalytics
+      security:
+        - OAuth2: [yt-analytics.readonly]
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            yt-analytics.readonly: Analytics read access
+`)
+	require.NoError(t, WriteCLIManifest(dir, CLIManifest{
+		SchemaVersion:  CurrentCLIManifestSchemaVersion,
+		APIName:        "videos",
+		CLIName:        "videos-pp-cli",
+		AuthType:       "api_key",
+		AuthPreference: "ApiKeyAuth",
+	}))
+	writeTestFile(t, filepath.Join(dir, "internal", "client", "client.go"), `package client
+func addAuth(req interface{ HeaderSet(string, string) }, authHeader string) {
+	req.HeaderSet("X-API-Key", authHeader)
+}
+func wire(req *request, authHeader string) {
+	req.Header.Set("X-API-Key", authHeader)
+}
+type request struct{ Header header }
+type header struct{}
+func (header) Set(string, string) {}
+`)
+
+	report, err := RunDogfood(dir, specPath)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, "FAIL", report.Verdict, report.Issues)
+	assert.True(t, report.OAuthScopeCoverage.Skipped)
+	assert.Empty(t, report.OAuthScopeCoverage.Violations)
+	assert.Contains(t, report.OAuthScopeCoverage.Detail, "resolved auth type api_key")
+	assert.NotContains(t, report.Issues, "OAuth scope coverage missing for 1 endpoint(s)")
+}
+
 func TestLoadOpenAPISpecCollectsRootOAuthScopeRequirements(t *testing.T) {
 	dir := t.TempDir()
 	specPath := filepath.Join(dir, "spec.yaml")

--- a/internal/pipeline/live_dogfood.go
+++ b/internal/pipeline/live_dogfood.go
@@ -64,6 +64,7 @@ const reasonFileFixtureRequired = "file fixture required"
 const reasonRequiredParamFixture = "blocked-fixture: required API parameter"
 const reasonFeatureAbsentFixture = "blocked-fixture: feature absent for runner credentials"
 const reasonNoErrorPathProbeAnnotation = "no-error-path-probe annotation"
+const reasonInteractiveCommand = "interactive command requires human input"
 
 // dogfoodEnvVar is the env signal every live-dogfood subprocess
 // inherits. Generated commands with a long-running happy path detect
@@ -1260,6 +1261,18 @@ func runLiveDogfoodCommand(command liveDogfoodCommand, ctx resolveCtx) []LiveDog
 	mutating := liveDogfoodCommandMutates(command)
 	useDryRun := mutating && commandSupportsDryRun(command.Help)
 
+	if annotationIsTrueValue(command.Annotations[interactiveAnnotation]) {
+		results = append(results,
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestHappy, reasonInteractiveCommand),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestJSON, reasonInteractiveCommand),
+			skippedLiveDogfoodResult(commandName, LiveDogfoodTestError, reasonInteractiveCommand),
+		)
+		if useDryRun {
+			results = append(results, skippedLiveDogfoodResult(commandName, LiveDogfoodTestErrorReal, reasonInteractiveCommand))
+		}
+		return results
+	}
+
 	tierSkip := liveDogfoodRequiresTierSkipReason(command.Annotations, ctx.authTier)
 	if tierSkip != "" {
 		results = append(results,
@@ -1615,6 +1628,7 @@ const (
 	destructiveAuthAnnotation  = "pp:destructive-auth"
 	noErrorPathProbeAnnotation = "pp:no-error-path-probe"
 	requiresTierAnnotation     = "pp:requires-tier"
+	interactiveAnnotation      = "pp:interactive"
 	liveDogfoodMaxOutputBytes  = 10 << 20
 )
 

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2661,6 +2661,78 @@ func TestRunLiveDogfoodSkipsFeatureAbsentNotFound(t *testing.T) {
 	assert.Equal(t, "blocked-fixture: feature absent for runner credentials", jsonResult.Reason)
 }
 
+func TestRunLiveDogfoodSkipsPPInteractiveAnnotation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodInteractiveFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	help := findResultByCommandKind(report, "oauth connect", LiveDogfoodTestHelp)
+	require.NotNil(t, help)
+	assert.Equal(t, LiveDogfoodStatusPass, help.Status)
+	for _, kind := range []LiveDogfoodTestKind{LiveDogfoodTestHappy, LiveDogfoodTestJSON, LiveDogfoodTestError} {
+		got := findResultByCommandKind(report, "oauth connect", kind)
+		require.NotNil(t, got)
+		assert.Equal(t, LiveDogfoodStatusSkip, got.Status)
+		assert.Equal(t, "interactive command requires human input", got.Reason)
+	}
+}
+
+func writeLiveDogfoodInteractiveFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	script := `#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"oauth","subcommands":[
+      {"name":"connect","annotations":{"pp:interactive":"true"}}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "oauth" ] && [ "$2" = "connect" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Connect OAuth.
+
+Usage:
+  fixture-pp-cli oauth connect [flags]
+
+Examples:
+  fixture-pp-cli oauth connect
+
+Flags:
+      --json    Output JSON
+HELP
+  exit 0
+fi
+
+echo "interactive command should not run: $*" >&2
+exit 99
+`
+	writeStubBinary(t, dir, binaryName, script)
+	return dir, binaryName
+}
+
 func TestBuildSiblingMap(t *testing.T) {
 	commands := []liveDogfoodCommand{
 		{Path: []string{"projects", "list"}},

--- a/internal/pipeline/live_dogfood_test.go
+++ b/internal/pipeline/live_dogfood_test.go
@@ -2687,6 +2687,34 @@ func TestRunLiveDogfoodSkipsPPInteractiveAnnotation(t *testing.T) {
 	}
 }
 
+func TestRunLiveDogfoodSkipsMutatingPPInteractiveRealErrorPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as the fake binary; skip on Windows")
+	}
+
+	dir, binaryName := writeLiveDogfoodMutatingInteractiveFixture(t)
+	report, err := RunLiveDogfood(LiveDogfoodOptions{
+		CLIDir:     dir,
+		BinaryName: binaryName,
+		Level:      "full",
+		Timeout:    2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "PASS", report.Verdict, report.Tests)
+
+	for _, kind := range []LiveDogfoodTestKind{
+		LiveDogfoodTestHappy,
+		LiveDogfoodTestJSON,
+		LiveDogfoodTestError,
+		LiveDogfoodTestErrorReal,
+	} {
+		got := findResultByCommandKind(report, "widgets create", kind)
+		require.NotNil(t, got, "missing %s result", kind)
+		assert.Equal(t, LiveDogfoodStatusSkip, got.Status)
+		assert.Equal(t, "interactive command requires human input", got.Reason)
+	}
+}
+
 func writeLiveDogfoodInteractiveFixture(t *testing.T) (dir string, binaryName string) {
 	t.Helper()
 
@@ -2727,6 +2755,54 @@ HELP
 fi
 
 echo "interactive command should not run: $*" >&2
+exit 99
+`
+	writeStubBinary(t, dir, binaryName, script)
+	return dir, binaryName
+}
+
+func writeLiveDogfoodMutatingInteractiveFixture(t *testing.T) (dir string, binaryName string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	binaryName = "fixture-pp-cli"
+	writeTestManifestForLiveDogfood(t, dir)
+
+	script := `#!/bin/sh
+set -u
+
+if [ "$1" = "agent-context" ]; then
+  cat <<'JSON'
+{
+  "commands": [
+    {"name":"widgets","subcommands":[
+      {"name":"create","annotations":{"pp:interactive":"true","pp:method":"POST"}}
+    ]}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "widgets" ] && [ "$2" = "create" ] && [ "${3:-}" = "--help" ]; then
+  cat <<'HELP'
+Create widget.
+
+Usage:
+  fixture-pp-cli widgets create [flags]
+
+Examples:
+  fixture-pp-cli widgets create --name demo --dry-run
+
+Flags:
+      --dry-run    Preview without writing
+      --json       Output JSON
+      --name string
+HELP
+  exit 0
+fi
+
+echo "mutating interactive command should not run: $*" >&2
 exit 99
 `
 	writeStubBinary(t, dir, binaryName, script)

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -315,17 +315,19 @@ const (
 //  2. If any file carries the `// pp:client-call` marker, the command
 //     is exempted as a real API call hidden behind an abstraction.
 //     Return (_, exemptClientDirective, true).
-//  3. If any file declares // pp:data-source computed and does not look
+//  3. If any file declares // pp:data-source local and does not look
+//     like a TODO stub, the command is accepted as intentionally local.
+//  4. If any file declares // pp:data-source computed and does not look
 //     like a TODO stub, the command is exempted as intentional pure
 //     computation.
-//  4. If any file shows a store signal, the command is exempted as a
+//  5. If any file shows a store signal, the command is exempted as a
 //     local-SQLite feature. Return (_, exemptStore, true).
-//  5. If any file shows a client signal, the command is fine. Return
+//  6. If any file shows a client signal, the command is fine. Return
 //     (_, exemptNone, true).
-//  6. Otherwise the command is suspicious. Return a ReimplementationFinding
+//  7. Otherwise the command is suspicious. Return a ReimplementationFinding
 //     naming the primary file and a reason. Return (finding, exemptNone, false).
 //
-// The trivial-body regex is consulted only when rule 5 fires, to pick
+// The trivial-body regex is consulted only when rule 6 fires, to pick
 // between "empty stub" and "hand-rolled response" as the reason.
 func classifyReimplementation(leaf string, files []string, fileContent map[string]string, storeHelpers, clientHelpers map[string]bool) (ReimplementationFinding, exemptionKind, bool) {
 	hasClient := false
@@ -359,6 +361,9 @@ func classifyReimplementation(leaf string, files []string, fileContent map[strin
 		}
 		if callsStoreHelper(content, storeHelpers) {
 			return ReimplementationFinding{File: f}, exemptStore, true
+		}
+		if localDataSource(content) && !hasAnyTODOStub {
+			return ReimplementationFinding{File: f}, exemptNone, true
 		}
 		commandScan := scanCommandHandler(content, leaf)
 		clientScanContent := content
@@ -429,6 +434,11 @@ func dataSourceStrategyFinding(files []string, fileContent map[string]string) (R
 func computedDataSource(content string) bool {
 	m := dataSourceDirectiveRe.FindStringSubmatch(content)
 	return len(m) > 1 && strings.EqualFold(strings.TrimSpace(m[1]), "computed")
+}
+
+func localDataSource(content string) bool {
+	m := dataSourceDirectiveRe.FindStringSubmatch(content)
+	return len(m) > 1 && strings.EqualFold(strings.TrimSpace(m[1]), "local")
 }
 
 func isGeneratedPrintingPressFile(content string) bool {
@@ -570,7 +580,7 @@ func hasBlockClientSignal(body *ast.BlockStmt, imports map[string]clientImportKi
 		if !ok {
 			return true
 		}
-		if isPrimitiveClientCall(call.Fun) || isImportedClientCall(call.Fun, imports, allowAnySiblingSelector) {
+		if isPrimitiveClientCall(call.Fun) || isImportedClientCall(call.Fun, imports, allowAnySiblingSelector) || isSidecarExecCall(call) {
 			found = true
 			return false
 		}
@@ -590,6 +600,34 @@ func isPrimitiveClientCall(expr ast.Expr) bool {
 		return true
 	}
 	return outboundHTTPCallRe.MatchString(strings.Join(parts, ".") + "(")
+}
+
+func isSidecarExecCall(call *ast.CallExpr) bool {
+	parts := selectorParts(call.Fun)
+	if len(parts) != 2 || parts[0] != "exec" {
+		return false
+	}
+	binaryArg := 0
+	switch parts[1] {
+	case "Command":
+		binaryArg = 0
+	case "CommandContext":
+		binaryArg = 1
+	default:
+		return false
+	}
+	if len(call.Args) <= binaryArg {
+		return false
+	}
+	lit, ok := call.Args[binaryArg].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(strings.TrimSpace(value), "-pp-mcp")
 }
 
 func isImportedClientCall(expr ast.Expr, imports map[string]clientImportKind, allowAnySiblingSelector bool) bool {

--- a/internal/pipeline/reimplementation_check.go
+++ b/internal/pipeline/reimplementation_check.go
@@ -59,6 +59,10 @@ type ReimplementationCheckResult struct {
 	// via // pp:data-source computed. These commands intentionally compute
 	// from embedded policy/math tables instead of calling an API or store.
 	ExemptedViaComputedDataSource int `json:"exempted_via_computed_data_source,omitempty"`
+	// ExemptedViaLocalDataSource is the number of commands that passed
+	// via // pp:data-source local without a store package signal. These
+	// commands intentionally read local files or other local-only state.
+	ExemptedViaLocalDataSource int `json:"exempted_via_local_data_source,omitempty"`
 	// Suspicious is the list of commands whose files show no client
 	// call and no store access - the candidate hand-rolled responses.
 	Suspicious []ReimplementationFinding `json:"suspicious,omitempty"`
@@ -251,6 +255,9 @@ func checkReimplementation(cliDir, researchDir string) ReimplementationCheckResu
 		case exemptComputedDataSource:
 			result.ExemptedViaComputedDataSource++
 			continue
+		case exemptLocalDataSource:
+			result.ExemptedViaLocalDataSource++
+			continue
 		}
 		if !ok {
 			finding.Command = nf.Command
@@ -304,6 +311,7 @@ const (
 	exemptAnnotation
 	exemptClientDirective
 	exemptComputedDataSource
+	exemptLocalDataSource
 )
 
 // classifyReimplementation returns the best classification across the
@@ -363,7 +371,7 @@ func classifyReimplementation(leaf string, files []string, fileContent map[strin
 			return ReimplementationFinding{File: f}, exemptStore, true
 		}
 		if localDataSource(content) && !hasAnyTODOStub {
-			return ReimplementationFinding{File: f}, exemptNone, true
+			return ReimplementationFinding{File: f}, exemptLocalDataSource, true
 		}
 		commandScan := scanCommandHandler(content, leaf)
 		clientScanContent := content

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -141,6 +141,41 @@ func newIRMAACmd(flags *rootFlags) *cobra.Command {
 	}
 }
 
+func TestCheckReimplementation_LocalDataSourceWithoutClient_Passes(t *testing.T) {
+	files := map[string]string{
+		"preset.go": `package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// pp:data-source local
+func newPresetCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "preset",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := os.ReadFile("presets.json")
+			return err
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "Preset", Command: "preset"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if len(got.MissingDataSourceStrategy) != 0 {
+		t.Fatalf("MissingDataSourceStrategy: want 0, got %d (%v)", len(got.MissingDataSourceStrategy), got.MissingDataSourceStrategy)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
 func TestCheckReimplementation_ComputedDataSourceTODOStillFlagged(t *testing.T) {
 	files := map[string]string{
 		"irmaa.go": `package cli
@@ -1290,6 +1325,40 @@ func newSearchCmd(flags *rootFlags) *cobra.Command {
 	}
 	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
 		{Name: "Search", Command: "search"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_SidecarExec_Passes(t *testing.T) {
+	files := map[string]string{
+		"mcp_serve.go": `package cli
+
+import (
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// pp:data-source live
+func newMCPServeCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return exec.CommandContext(cmd.Context(), "fixture-pp-mcp", "serve").Run()
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "MCP serve", Command: "mcp serve"},
 	})
 
 	got := checkReimplementation(cliDir, pipelineDir)

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -77,6 +77,9 @@ func newDigestCmd(flags *rootFlags) *cobra.Command {
 	if len(got.Suspicious) != 0 {
 		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
 	}
+	if got.ExemptedViaLocalDataSource != 1 {
+		t.Fatalf("ExemptedViaLocalDataSource: want 1, got %d", got.ExemptedViaLocalDataSource)
+	}
 }
 
 func TestCheckReimplementation_DataSourceStrategyAnnotation(t *testing.T) {
@@ -1352,6 +1355,40 @@ func newMCPServeCmd(flags *rootFlags) *cobra.Command {
 		Use: "serve",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return exec.CommandContext(cmd.Context(), "fixture-pp-mcp", "serve").Run()
+		},
+	}
+}
+`,
+	}
+	cliDir, pipelineDir := seedReimplementationFixture(t, files, []NovelFeature{
+		{Name: "MCP serve", Command: "mcp serve"},
+	})
+
+	got := checkReimplementation(cliDir, pipelineDir)
+	if got.Checked != 1 {
+		t.Fatalf("Checked: want 1, got %d", got.Checked)
+	}
+	if len(got.Suspicious) != 0 {
+		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
+	}
+}
+
+func TestCheckReimplementation_SidecarExecWithoutContext_Passes(t *testing.T) {
+	files := map[string]string{
+		"mcp_serve.go": `package cli
+
+import (
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// pp:data-source live
+func newMCPServeCmd(flags *rootFlags) *cobra.Command {
+	return &cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return exec.Command("fixture-pp-mcp", "serve").Run()
 		},
 	}
 }

--- a/internal/pipeline/reimplementation_check_test.go
+++ b/internal/pipeline/reimplementation_check_test.go
@@ -77,9 +77,6 @@ func newDigestCmd(flags *rootFlags) *cobra.Command {
 	if len(got.Suspicious) != 0 {
 		t.Fatalf("Suspicious: want 0, got %d (%v)", len(got.Suspicious), got.Suspicious)
 	}
-	if got.ExemptedViaLocalDataSource != 1 {
-		t.Fatalf("ExemptedViaLocalDataSource: want 1, got %d", got.ExemptedViaLocalDataSource)
-	}
 }
 
 func TestCheckReimplementation_DataSourceStrategyAnnotation(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfood and scorer checks now avoid false failures for legitimate printed-CLI surfaces that were previously indistinguishable from broken stubs.

- The reimplementation check now accepts explicit local-only `pp:data-source local` commands and MCP sidecar execs while keeping hardcoded response fixtures flagged.
- Live dogfood still verifies `--help`, but skips happy/json/error probes for commands annotated `pp:interactive` instead of trying to drive a browser or TTY flow.
- OAuth scope coverage now consults the resolved auth scheme, so API-key/basic-style CLIs are not failed for OAuth scopes declared by an alternate spec auth flow.

## Issue Coverage

Fixes mvanhorn/cli-printing-press#2707
Fixes mvanhorn/cli-printing-press#2477
Fixes mvanhorn/cli-printing-press#3006
Refs mvanhorn/cli-printing-press#2657: existing synthetic-ID 404 skip behavior was confirmed by focused validation; no new code was needed here.
Refs mvanhorn/cli-printing-press#2488: the live stateful sync -> analytics -> search pass remains deferred as a larger workflow feature.

## Validation

- `go test ./internal/pipeline -run 'TestCheckReimplementation_|TestRunDogfoodOAuthScopeCoverage|TestRunLiveDogfoodSkipsPPInteractiveAnnotation|TestRunLiveDogfoodSkipsAnnotatedSyntheticID404|TestRunLiveDogfoodResolveSuccess(CacheHit|CompanionLimit)' -count=1`
- `git diff --check`
- `go test ./...` was started, but stopped per known full-suite hang behavior after the long-running process exceeded 7 minutes; focused pipeline/scorer tests above passed after rebase.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
