### PR TITLE
fix(cli): support POST HTML table sniffing

### DIFF
--- a/internal/browsersniff/schema.go
+++ b/internal/browsersniff/schema.go
@@ -93,6 +93,7 @@ func InferRequestSchema(body string, contentType string) []spec.Param {
 				Name:        key,
 				Type:        inferScalarStringType(value),
 				Required:    true,
+				Default:     value,
 				Description: "",
 			})
 		}

--- a/internal/browsersniff/schema_test.go
+++ b/internal/browsersniff/schema_test.go
@@ -102,9 +102,9 @@ func TestInferRequestSchema(t *testing.T) {
 			body:        "q=hello&page=1&limit=20",
 			contentType: "application/x-www-form-urlencoded",
 			want: []spec.Param{
-				{Name: "limit", Type: "integer", Required: true, Description: ""},
-				{Name: "page", Type: "integer", Required: true, Description: ""},
-				{Name: "q", Type: "string", Required: true, Description: ""},
+				{Name: "limit", Type: "integer", Required: true, Default: "20", Description: ""},
+				{Name: "page", Type: "integer", Required: true, Default: "1", Description: ""},
+				{Name: "q", Type: "string", Required: true, Default: "hello", Description: ""},
 			},
 		},
 		{

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -1006,7 +1006,7 @@ func htmlResponseItem(extract *spec.HTMLExtract) string {
 func inferHTMLExtract(group EndpointGroup) *spec.HTMLExtract {
 	prefixes := inferHTMLLinkPrefixes(group.Entries)
 	mode := spec.HTMLExtractModePage
-	if groupLooksHTMLTable(group) {
+	if strings.EqualFold(group.Method, "POST") && groupLooksHTMLTable(group) {
 		mode = spec.HTMLExtractModeTable
 	} else if len(prefixes) > 0 && !strings.Contains(group.NormalizedPath, "{") {
 		mode = spec.HTMLExtractModeLinks

--- a/internal/browsersniff/specgen.go
+++ b/internal/browsersniff/specgen.go
@@ -618,27 +618,33 @@ func buildEndpoint(group EndpointGroup, auth spec.AuthConfig) (spec.Endpoint, []
 	if len(params) == 0 && len(responseFields) > 0 {
 		params = responseFields
 	}
+	requestContentType := inferRequestContentType(group.Entries)
 
 	endpoint := spec.Endpoint{
-		Method:       group.Method,
-		Path:         group.NormalizedPath,
-		Description:  fmt.Sprintf("%s %s", group.Method, group.NormalizedPath),
-		Params:       params,
-		Body:         body,
-		ObservedAuth: observedAuthHeaders(group.Entries),
+		Method:             group.Method,
+		Path:               group.NormalizedPath,
+		Description:        fmt.Sprintf("%s %s", group.Method, group.NormalizedPath),
+		Params:             params,
+		Body:               body,
+		RequestContentType: requestContentType,
+		ObservedAuth:       observedAuthHeaders(group.Entries),
 		Response: spec.ResponseDef{
 			Type: responseType,
 			Item: deriveResponseItemName(group.NormalizedPath),
 		},
 	}
 	if groupLooksHTML(group) {
+		htmlExtract := inferHTMLExtract(group)
 		endpoint.ResponseFormat = spec.ResponseFormatHTML
 		endpoint.Response = spec.ResponseDef{
 			Type: htmlResponseType(group),
-			Item: "html",
+			Item: htmlResponseItem(htmlExtract),
 		}
-		endpoint.HTMLExtract = inferHTMLExtract(group)
+		endpoint.HTMLExtract = htmlExtract
 		endpoint.Description = htmlEndpointDescription(group)
+		if strings.EqualFold(group.Method, "POST") {
+			endpoint.Meta = map[string]string{"mcp:read-only": "true"}
+		}
 	}
 	return endpoint, responseFields
 }
@@ -868,7 +874,13 @@ func mostCommonHTMLSurfaceHost(entries []EnrichedEntry) string {
 
 func isUsefulHTMLSurfaceEntry(entry EnrichedEntry, targetHost string) bool {
 	method := strings.ToUpper(strings.TrimSpace(entry.Method))
-	if method != "" && method != "GET" && method != "HEAD" {
+	if method == "" {
+		method = "GET"
+	}
+	if method != "GET" && method != "HEAD" && method != "POST" {
+		return false
+	}
+	if method == "POST" && !strings.Contains(strings.ToLower(getHeaderValue(entry.RequestHeaders, "Content-Type")), "form-urlencoded") {
 		return false
 	}
 	if entry.ResponseStatus < 200 || entry.ResponseStatus >= 400 {
@@ -894,6 +906,9 @@ func isUsefulHTMLSurfaceEntry(entry EnrichedEntry, targetHost string) bool {
 		return false
 	}
 	lower := strings.ToLower(body)
+	if method == "POST" {
+		return looksLikeHTMLTableFragment(lower)
+	}
 	return strings.Contains(lower, "<title") ||
 		strings.Contains(lower, "<meta") ||
 		strings.Contains(lower, "<a ")
@@ -973,22 +988,79 @@ func groupLooksHTML(group EndpointGroup) bool {
 }
 
 func htmlResponseType(group EndpointGroup) string {
-	if inferHTMLExtract(group).EffectiveMode() == spec.HTMLExtractModeLinks {
+	switch inferHTMLExtract(group).EffectiveMode() {
+	case spec.HTMLExtractModeLinks, spec.HTMLExtractModeTable:
 		return "array"
+	default:
+		return "object"
 	}
-	return "object"
+}
+
+func htmlResponseItem(extract *spec.HTMLExtract) string {
+	if extract != nil && extract.EffectiveMode() == spec.HTMLExtractModeTable {
+		return "html_table_row"
+	}
+	return "html"
 }
 
 func inferHTMLExtract(group EndpointGroup) *spec.HTMLExtract {
 	prefixes := inferHTMLLinkPrefixes(group.Entries)
 	mode := spec.HTMLExtractModePage
-	if len(prefixes) > 0 && !strings.Contains(group.NormalizedPath, "{") {
+	if groupLooksHTMLTable(group) {
+		mode = spec.HTMLExtractModeTable
+	} else if len(prefixes) > 0 && !strings.Contains(group.NormalizedPath, "{") {
 		mode = spec.HTMLExtractModeLinks
 	}
 	return &spec.HTMLExtract{
 		Mode:         mode,
 		LinkPrefixes: prefixes,
 		Limit:        50,
+	}
+}
+
+func groupLooksHTMLTable(group EndpointGroup) bool {
+	for _, entry := range group.Entries {
+		if looksLikeHTMLTableFragment(strings.ToLower(entry.ResponseBody)) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeHTMLTableFragment(lowerBody string) bool {
+	return strings.Contains(lowerBody, "<table") &&
+		strings.Contains(lowerBody, "<tr") &&
+		(strings.Contains(lowerBody, "<td") || strings.Contains(lowerBody, "<th"))
+}
+
+func inferRequestContentType(entries []EnrichedEntry) string {
+	var chosen string
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.RequestBody) == "" {
+			continue
+		}
+		contentType := normalizeRequestContentType(getHeaderValue(entry.RequestHeaders, "Content-Type"))
+		if contentType == "" {
+			continue
+		}
+		if chosen == "" {
+			chosen = contentType
+			continue
+		}
+		if chosen != contentType {
+			return ""
+		}
+	}
+	return chosen
+}
+
+func normalizeRequestContentType(contentType string) string {
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	switch contentType {
+	case "application/x-www-form-urlencoded", "multipart/form-data", "application/json":
+		return contentType
+	default:
+		return ""
 	}
 }
 

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -129,6 +129,40 @@ func TestAnalyzeCapture_PrefersCanonicalCollectionEnvelope(t *testing.T) {
 	assert.Equal(t, "title", apiSpec.Types["SearchItem"].Fields[1].Name)
 }
 
+func TestAnalyzeCapture_PromotesPostFormHTMLTableFragment(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://www.example.com/contracts",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "POST",
+				URL:                 "https://www.example.com/nba/contracts/_/position/g",
+				RequestHeaders:      map[string]string{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8", "X-Requested-With": "XMLHttpRequest"},
+				RequestBody:         "ajax=table",
+				ResponseStatus:      200,
+				ResponseContentType: "text/html; charset=utf-8",
+				ResponseBody:        `<table><thead><tr><th>Player</th><th>Salary</th></tr></thead><tbody><tr><td>Ada Lovelace</td><td>$100</td></tr><tr><td>Grace Hopper</td><td>$200</td></tr></tbody></table>`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	endpoint, found := findEndpointByPath(apiSpec, "/nba/contracts/_/position/g")
+	require.True(t, found, "expected POST HTML table endpoint to be promoted")
+	assert.Equal(t, "POST", endpoint.Method)
+	assert.Equal(t, "application/x-www-form-urlencoded", endpoint.RequestContentType)
+	assert.Equal(t, spec.ResponseFormatHTML, endpoint.ResponseFormat)
+	require.NotNil(t, endpoint.HTMLExtract)
+	assert.Equal(t, spec.HTMLExtractModeTable, endpoint.HTMLExtract.Mode)
+	assert.Equal(t, spec.ResponseDef{Type: "array", Item: "html_table_row"}, endpoint.Response)
+	assert.Equal(t, map[string]string{"mcp:read-only": "true"}, endpoint.Meta)
+	require.Len(t, endpoint.Body, 1)
+	assert.Equal(t, "ajax", endpoint.Body[0].Name)
+	assert.Equal(t, "table", endpoint.Body[0].Default)
+	require.NoError(t, apiSpec.Validate())
+}
+
 func TestAnalyzeCapture_ParameterizesCompactSingleSampleIdentifiers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/browsersniff/specgen_test.go
+++ b/internal/browsersniff/specgen_test.go
@@ -163,6 +163,30 @@ func TestAnalyzeCapture_PromotesPostFormHTMLTableFragment(t *testing.T) {
 	require.NoError(t, apiSpec.Validate())
 }
 
+func TestAnalyzeCapture_GetHTMLWithTableStillPrefersLinks(t *testing.T) {
+	t.Parallel()
+
+	apiSpec, err := AnalyzeCapture(&EnrichedCapture{
+		TargetURL: "https://www.example.com/results",
+		Entries: []EnrichedEntry{
+			{
+				Method:              "GET",
+				URL:                 "https://www.example.com/products",
+				ResponseStatus:      200,
+				ResponseContentType: "text/html; charset=utf-8",
+				ResponseBody:        `<html><body><a href="/products/1">Item 1</a><table><tr><th>Name</th></tr><tr><td>Widget</td></tr></table></body></html>`,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	endpoint, found := findEndpointByPath(apiSpec, "/products")
+	require.True(t, found, "expected GET HTML endpoint")
+	require.NotNil(t, endpoint.HTMLExtract)
+	assert.Equal(t, spec.HTMLExtractModeLinks, endpoint.HTMLExtract.Mode)
+	assert.Equal(t, spec.ResponseDef{Type: "array", Item: "html"}, endpoint.Response)
+}
+
 func TestAnalyzeCapture_ParameterizesCompactSingleSampleIdentifiers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -3289,12 +3289,113 @@ resources:
 		"--output", outputDir,
 		"--validate=false",
 		"--force",
+		"--traffic-analysis", analysisPath,
 		"--transport", "browser-chrome",
 	})
 
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires live browser page-context execution")
+	assert.NoFileExists(t, filepath.Join(outputDir, "README.md"))
+}
+
+func TestGenerateCmdAllowsBrowserRequiredWithReachabilityOverride(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	analysisPath := filepath.Join(dir, "sample-spec-traffic-analysis.json")
+	outputDir := filepath.Join(dir, "overrideapp")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: overrideapp
+description: Override app API
+version: 0.1.0
+base_url: https://api.example.com
+spec_source: sniffed
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/overrideapp-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+`), 0o644))
+	require.NoError(t, os.WriteFile(analysisPath, []byte(`{
+  "version": "1",
+  "reachability": {"mode": "browser_required", "confidence": 0.9},
+  "generation_hints": ["reachability_override_browser_required_to_browser_http"]
+}`), 0o600))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+		"--traffic-analysis", analysisPath,
+		"--transport", "browser-chrome",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.FileExists(t, filepath.Join(outputDir, "README.md"))
+	clientGo, err := os.ReadFile(filepath.Join(outputDir, "internal", "client", "client.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(clientGo), `"github.com/enetx/surf"`)
+}
+
+func TestGenerateCmdRejectsConflictingReachabilityOverrideTransport(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	analysisPath := filepath.Join(dir, "sample-spec-traffic-analysis.json")
+	outputDir := filepath.Join(dir, "conflictapp")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(`name: conflictapp
+description: Conflict app API
+version: 0.1.0
+base_url: https://api.example.com
+spec_source: sniffed
+auth:
+  type: none
+config:
+  format: toml
+  path: ~/.config/conflictapp-pp-cli/config.toml
+resources:
+  items:
+    description: Manage items
+    endpoints:
+      list:
+        method: GET
+        path: /items
+        description: List items
+`), 0o644))
+	require.NoError(t, os.WriteFile(analysisPath, []byte(`{
+  "version": "1",
+  "reachability": {"mode": "browser_required", "confidence": 0.9},
+  "generation_hints": ["reachability_override_browser_required_to_browser_http"]
+}`), 0o600))
+
+	cmd := newGenerateCmd()
+	cmd.SetArgs([]string{
+		"--spec", specPath,
+		"--output", outputDir,
+		"--validate=false",
+		"--force",
+		"--traffic-analysis", analysisPath,
+		"--transport", "standard",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reachability override")
+	assert.Contains(t, err.Error(), "conflicts")
 	assert.NoFileExists(t, filepath.Join(outputDir, "README.md"))
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -663,8 +663,10 @@ func runGenerateProject(apiSpec *spec.APISpec, absOut string, opts generateProje
 	if err != nil {
 		return generateProjectResult{}, &ExitError{Code: ExitInputError, Err: err}
 	}
-	if opts.rejectUnshippablePageContextTraffic && trafficAnalysisRequiresUnshippablePageContext(trafficAnalysis) {
-		return generateProjectResult{}, &ExitError{Code: ExitInputError, Err: fmt.Errorf("traffic analysis says this target requires live browser page-context execution; persistent browser transport is not a shippable printed CLI runtime. Re-run discovery for a Surf/direct/browser-clearance replayable surface instead")}
+	if opts.rejectUnshippablePageContextTraffic {
+		if err := validateTrafficAnalysisPageContextGate(trafficAnalysis, apiSpec.HTTPTransport); err != nil {
+			return generateProjectResult{}, &ExitError{Code: ExitInputError, Err: err}
+		}
 	}
 	// ApplyReachabilityDefaults runs first so its HAR-driven HTTP-version
 	// mapping wins for browser_http / browser_clearance_http modes.
@@ -987,6 +989,9 @@ func applyHTTPTransportDefault(apiSpec *spec.APISpec, analysis *browsersniff.Tra
 	if apiSpec == nil || apiSpec.HTTPTransport != "" {
 		return
 	}
+	if trafficAnalysisReachabilityOverrideMode(analysis) == "standard_http" {
+		return
+	}
 	if trafficAnalysisExplicitlyRecommendsBrowserHTTP3Transport(analysis) {
 		apiSpec.HTTPTransport = spec.HTTPTransportBrowserChromeH3
 		return
@@ -1001,6 +1006,20 @@ func applyHTTPTransportDefault(apiSpec *spec.APISpec, analysis *browsersniff.Tra
 		// shipped CLIs on origins these heuristics flag behaving identically.
 		apiSpec.HTTPTransport = spec.HTTPTransportBrowserChromeH2
 	}
+}
+
+func validateTrafficAnalysisPageContextGate(analysis *browsersniff.TrafficAnalysis, httpTransport string) error {
+	if !trafficAnalysisRequiresUnshippablePageContext(analysis) {
+		return nil
+	}
+	overrideMode := trafficAnalysisReachabilityOverrideMode(analysis)
+	if overrideMode == "" {
+		return fmt.Errorf("traffic analysis says this target requires live browser page-context execution; persistent browser transport is not a shippable printed CLI runtime. Re-run discovery for a Surf/direct/browser-clearance replayable surface instead")
+	}
+	if !trafficAnalysisReachabilityOverrideMatchesTransport(overrideMode, httpTransport) {
+		return fmt.Errorf("traffic analysis reachability override %q conflicts with --transport/http_transport %q", overrideMode, httpTransport)
+	}
+	return nil
 }
 
 func trafficAnalysisRequiresUnshippablePageContext(analysis *browsersniff.TrafficAnalysis) bool {
@@ -1027,8 +1046,50 @@ func trafficAnalysisRequiresUnshippablePageContext(analysis *browsersniff.Traffi
 	return false
 }
 
+func trafficAnalysisReachabilityOverrideMode(analysis *browsersniff.TrafficAnalysis) string {
+	if analysis == nil {
+		return ""
+	}
+	const prefix = "reachability_override_browser_required_to_"
+	for _, hint := range analysis.GenerationHints {
+		hint = strings.ToLower(strings.TrimSpace(hint))
+		if !strings.HasPrefix(hint, prefix) {
+			continue
+		}
+		mode := strings.TrimSpace(strings.TrimPrefix(hint, prefix))
+		switch mode {
+		case "browser_http", "browser_clearance_http", "standard_http":
+			return mode
+		}
+	}
+	return ""
+}
+
+func trafficAnalysisReachabilityOverrideMatchesTransport(mode string, httpTransport string) bool {
+	httpTransport = strings.TrimSpace(httpTransport)
+	if httpTransport == "" {
+		return true
+	}
+	switch mode {
+	case "standard_http":
+		return httpTransport == spec.HTTPTransportStandard
+	case "browser_http", "browser_clearance_http":
+		switch httpTransport {
+		case spec.HTTPTransportBrowserHTTP, spec.HTTPTransportBrowserChrome, spec.HTTPTransportBrowserChromeH2, spec.HTTPTransportBrowserChromeH3:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
 func trafficAnalysisRecommendsBrowserTransport(analysis *browsersniff.TrafficAnalysis) bool {
 	if analysis == nil {
+		return false
+	}
+	if trafficAnalysisReachabilityOverrideMode(analysis) == "standard_http" {
 		return false
 	}
 	if analysis.Reachability != nil {

--- a/internal/generator/form_test.go
+++ b/internal/generator/form_test.go
@@ -128,7 +128,7 @@ func TestGenerateReadOnlyFormHTMLTableEndpoint(t *testing.T) {
 		require.NoError(t, r.ParseForm())
 		assert.Equal(t, "table", r.Form.Get("ajax"))
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write([]byte(`<table><thead><tr><th>Player</th><th>Salary</th></tr></thead><tbody><tr><td>Ada Lovelace</td><td>$100</td></tr><tr><td>Grace Hopper</td><td>$200</td></tr></tbody></table>`))
+		_, _ = w.Write([]byte(`<table><thead><tr><th>Player</th><th>Salary</th></tr></thead><tbody><tr><td>Ada Lovelace</td><td>$100</td><td><table><tr><td>layout</td><td>ignored</td></tr></table></td></tr><tr><td>Grace Hopper</td><td>$200</td></tr></tbody></table>`))
 	})
 	httpServer := httptest.NewServer(server)
 	t.Cleanup(httpServer.Close)

--- a/internal/generator/form_test.go
+++ b/internal/generator/form_test.go
@@ -1,6 +1,11 @@
 package generator
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -63,6 +68,8 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	clientSrc := readGeneratedFile(t, outputDir, "internal", "client", "client.go")
 	assert.Contains(t, clientSrc, `func (c *Client) PostForm(ctx context.Context, path string, fields url.Values) (json.RawMessage, int, error)`)
 	assert.Contains(t, clientSrc, `func (c *Client) PostFormWithHeaders(ctx context.Context, path string, fields url.Values, headers map[string]string) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `func (c *Client) PostQueryFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error)`)
+	assert.Contains(t, clientSrc, `return c.doRead(ctx, "POST", path, params, formRequestBody{Fields: fields}, nil)`)
 	assert.Contains(t, clientSrc, `type formRequestBody struct {`)
 	assert.Contains(t, clientSrc, `func encodeFormBody(body formRequestBody) ([]byte, string, error)`)
 	assert.Contains(t, clientSrc, `body.Fields.Encode()`)
@@ -85,12 +92,13 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 	venuesSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_venues.go")
 	assert.Contains(t, venuesSrc, `if !json.Valid([]byte(bodyStructData))`)
 	assert.Contains(t, venuesSrc, `fields.Set("struct_data", bodyStructData)`)
-	assert.Contains(t, venuesSrc, `c.PostFormWithParams(cmd.Context(), path, params, fields)`)
+	assert.Contains(t, venuesSrc, `c.PostQueryFormWithParams(cmd.Context(), path, params, fields)`)
+	assert.NotContains(t, venuesSrc, `c.PostFormWithParams(cmd.Context(), path, params, fields)`)
 
 	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
 	assert.Contains(t, mcpSrc, `RequestContentType: "application/x-www-form-urlencoded"`)
 	assert.Contains(t, mcpSrc, `formFields := url.Values{}`)
-	assert.Contains(t, mcpSrc, `data, _, err = c.PostFormWithParams(ctx, path, params, formFields)`)
+	assert.Contains(t, mcpSrc, `data, _, err = c.PostQueryFormWithParams(ctx, path, params, formFields)`)
 
 	// An array/object body param binds to its native JSON type even on an
 	// x-www-form-urlencoded endpoint (not WithString), then flows through
@@ -103,6 +111,83 @@ func TestGenerateFormRequestBodyUsesFormClient(t *testing.T) {
 
 	runGoCommand(t, outputDir, "mod", "tidy")
 	runGoCommand(t, outputDir, "build", "./...")
+}
+
+func TestGenerateReadOnlyFormHTMLTableEndpoint(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan struct{}, 1)
+	server := http.NewServeMux()
+	server.HandleFunc("/contracts", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requests <- struct{}{}:
+		default:
+		}
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "table", r.Form.Get("ajax"))
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<table><thead><tr><th>Player</th><th>Salary</th></tr></thead><tbody><tr><td>Ada Lovelace</td><td>$100</td></tr><tr><td>Grace Hopper</td><td>$200</td></tr></tbody></table>`))
+	})
+	httpServer := httptest.NewServer(server)
+	t.Cleanup(httpServer.Close)
+
+	apiSpec := minimalSpec("formhtml")
+	apiSpec.BaseURL = httpServer.URL
+	apiSpec.Resources = map[string]spec.Resource{
+		"contracts": {
+			Description: "Contract tables",
+			Endpoints: map[string]spec.Endpoint{
+				"list": {
+					Method:             "POST",
+					Path:               "/contracts",
+					Description:        "List contract rows",
+					RequestContentType: "application/x-www-form-urlencoded",
+					ResponseFormat:     spec.ResponseFormatHTML,
+					HTMLExtract:        &spec.HTMLExtract{Mode: spec.HTMLExtractModeTable},
+					Response:           spec.ResponseDef{Type: "array", Item: "html_table_row"},
+					Meta:               map[string]string{"mcp:read-only": "true"},
+					Body: []spec.Param{
+						{Name: "ajax", Type: "string", Default: "table", Description: "Captured table fragment mode"},
+					},
+				},
+			},
+		},
+	}
+
+	outputDir := filepath.Join(t.TempDir(), naming.CLI(apiSpec.Name))
+	require.NoError(t, New(apiSpec, outputDir).Generate())
+
+	endpointSrc := readGeneratedFile(t, outputDir, "internal", "cli", "promoted_contracts.go")
+	assert.Contains(t, endpointSrc, `c.PostQueryFormWithParams(cmd.Context(), path, params, fields)`)
+	assert.Contains(t, endpointSrc, `"mcp:read-only": "true"`)
+	assert.NotContains(t, endpointSrc, `c.PostFormWithParams(cmd.Context(), path, params, fields)`)
+
+	mcpSrc := readGeneratedFile(t, outputDir, "internal", "mcp", "tools.go")
+	assert.Contains(t, mcpSrc, `data, _, err = c.PostQueryFormWithParams(ctx, path, params, formFields)`)
+
+	runGoCommand(t, outputDir, "mod", "tidy")
+	binaryPath := filepath.Join(outputDir, "formhtml-pp-cli")
+	runGoCommand(t, outputDir, "build", "-o", binaryPath, "./cmd/formhtml-pp-cli")
+
+	cmd := exec.Command(binaryPath, "contracts", "list", "--json")
+	cmd.Env = append(os.Environ(), "PRINTING_PRESS_VERIFY=1", "FORMHTML_BASE_URL="+httpServer.URL)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	select {
+	case <-requests:
+	default:
+		t.Fatal("read-only form POST should bypass verify-mode mutation short-circuit")
+	}
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(out, &rows), string(out))
+	require.Len(t, rows, 2)
+	assert.Equal(t, "Ada Lovelace", rows[0]["Player"])
+	assert.Equal(t, "$100", rows[0]["Salary"])
+	assert.Equal(t, "Grace Hopper", rows[1]["Player"])
+	assert.Equal(t, "$200", rows[1]["Salary"])
 }
 
 // TestGenerateNonFormSpecOmitsFormHelpers asserts the negative case: a spec
@@ -120,6 +205,7 @@ func TestGenerateNonFormSpecOmitsFormHelpers(t *testing.T) {
 	// Form-helper method declarations must be absent (HTTPClient.PostForm
 	// from net/http is fine — only the *Client receiver method is gated).
 	assert.NotContains(t, clientSrc, `func (c *Client) PostForm`)
+	assert.NotContains(t, clientSrc, `func (c *Client) PostQueryForm`)
 	assert.NotContains(t, clientSrc, `func (c *Client) PutForm`)
 	assert.NotContains(t, clientSrc, `func (c *Client) PatchForm`)
 	assert.NotContains(t, clientSrc, "formRequestBody")

--- a/internal/generator/templates/client.go.tmpl
+++ b/internal/generator/templates/client.go.tmpl
@@ -908,6 +908,19 @@ func (c *Client) PostFormWithParamsAndHeaders(ctx context.Context, path string, 
 	return c.do(ctx, "POST", path, params, formRequestBody{Fields: fields}, headers)
 }
 
+// PostQueryFormWithParams is a form-encoded POST that does not mutate remote
+// state. It is the form-body counterpart to PostQueryWithParams for POST
+// search/table endpoints that return read-only data.
+func (c *Client) PostQueryFormWithParams(ctx context.Context, path string, params map[string]string, fields url.Values) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, formRequestBody{Fields: fields}, nil)
+}
+
+// PostQueryFormWithParamsAndHeaders is the headers-aware counterpart to
+// PostQueryFormWithParams.
+func (c *Client) PostQueryFormWithParamsAndHeaders(ctx context.Context, path string, params map[string]string, fields url.Values, headers map[string]string) (json.RawMessage, int, error) {
+	return c.doRead(ctx, "POST", path, params, formRequestBody{Fields: fields}, headers)
+}
+
 {{ end }}
 
 func (c *Client) Delete(ctx context.Context, path string) (json.RawMessage, int, error) {

--- a/internal/generator/templates/command_endpoint.go.tmpl
+++ b/internal/generator/templates/command_endpoint.go.tmpl
@@ -405,9 +405,17 @@ func new{{cmdIdent .FuncPrefix .EndpointName}}Cmd(flags *rootFlags) *cobra.Comma
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PostQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else}}
 			data, statusCode, err := c.PostFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if .IsReadOnly}}
+			data, statusCode, err := c.PostQueryFormWithParams(cmd.Context(), path, params, fields)
 {{- else}}
 			data, statusCode, err := c.PostFormWithParams(cmd.Context(), path, params, fields)
+{{- end}}
 {{- end}}
 {{- else}}
 			var body map[string]any

--- a/internal/generator/templates/command_promoted.go.tmpl
+++ b/internal/generator/templates/command_promoted.go.tmpl
@@ -283,9 +283,17 @@ func new{{cmdIdent .PromotedName}}PromotedCmd(flags *rootFlags) *cobra.Command {
 			fields := url.Values{}
 {{formBodyMaps .Endpoint.Body "\t\t\t"}}
 {{- if or .Endpoint.HeaderOverrides .Endpoint.UsesBinaryResponse}}
+{{- if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PostQueryFormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParamsAndHeaders(cmd.Context(), path, params, fields, headerOverrides)
+{{- end}}
+{{- else}}
+{{- if and .IsReadOnly (eq (upper .Endpoint.Method) "POST")}}
+			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.PostQueryFormWithParams(cmd.Context(), path, params, fields)
 {{- else}}
 			data, {{if $canWriteBack}}statusCode{{else}}_{{end}}, err := c.{{pascal (lower .Endpoint.Method)}}FormWithParams(cmd.Context(), path, params, fields)
+{{- end}}
 {{- end}}
 {{- else}}
 			// HasStore + non-GET falls through to a live API call here

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 	stdhtml "html"
 {{- end }}
 	"net/url"
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 	"regexp"
 	"strconv"
 {{- end }}
@@ -31,7 +31,7 @@ type htmlExtractionOptions struct {
 	JSONPath       string // for mode: embedded-json — dot-notation walk
 }
 
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 
 type htmlExtractedPage struct {
 	Title        string     `json:"title,omitempty"`
@@ -48,6 +48,13 @@ type htmlLink struct {
 	Image string `json:"image,omitempty"`
 	URL   string `json:"url,omitempty"`
 	Slug  string `json:"slug,omitempty"`
+}
+
+type htmlTableRow map[string]string
+
+type htmlTableRawRow struct {
+	cells     []string
+	hasHeader bool
 }
 
 // htmlRawTextTags lists the four HTML5 elements whose content is parsed as
@@ -80,6 +87,10 @@ func extractHTMLResponse(raw []byte, opts htmlExtractionOptions) (json.RawMessag
 {{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
 	case "links", "page", "":
 		return extractHTMLPageOrLinks(raw, opts)
+{{- end }}
+{{- if .HasHTMLExtractMode "table" }}
+	case "table":
+		return extractHTMLTable(raw, opts)
 {{- end }}
 	default:
 		return nil, fmt.Errorf("unsupported html_extract mode: %q", opts.Mode)
@@ -140,6 +151,105 @@ func extractHTMLPageOrLinks(raw []byte, opts htmlExtractionOptions) (json.RawMes
 		data, err := json.Marshal(page)
 		return json.RawMessage(data), err
 	}
+}
+
+{{- end }}
+{{- if .HasHTMLExtractMode "table" }}
+
+func extractHTMLTable(raw []byte, opts htmlExtractionOptions) (json.RawMessage, error) {
+	doc, err := parseHTMLDocument(raw, opts.ContentType)
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML table response: %w", err)
+	}
+
+	rows := firstHTMLTableRows(doc)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	data, err := json.Marshal(rows)
+	return json.RawMessage(data), err
+}
+
+func firstHTMLTableRows(root *xhtml.Node) []htmlTableRow {
+	var table *xhtml.Node
+	walkHTML(root, func(n *xhtml.Node) {
+		if table == nil && n.Type == xhtml.ElementNode && strings.EqualFold(n.Data, "table") {
+			table = n
+		}
+	})
+	if table == nil {
+		return nil
+	}
+
+	rawRows := htmlTableRows(table)
+	if len(rawRows) == 0 {
+		return nil
+	}
+
+	headers := rawRows[0].cells
+	start := 1
+	if !rawRows[0].hasHeader {
+		headers = syntheticTableHeaders(len(headers))
+		start = 0
+	}
+
+	rows := make([]htmlTableRow, 0, len(rawRows)-start)
+	for _, rawRow := range rawRows[start:] {
+		row := htmlTableRow{}
+		for i, value := range rawRow.cells {
+			if i >= len(headers) {
+				break
+			}
+			key := headers[i]
+			if key == "" {
+				key = fmt.Sprintf("column_%d", i+1)
+			}
+			row[key] = value
+		}
+		if len(row) > 0 {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func htmlTableRows(table *xhtml.Node) []htmlTableRawRow {
+	var rows []htmlTableRawRow
+	walkHTML(table, func(n *xhtml.Node) {
+		if n.Type != xhtml.ElementNode || !strings.EqualFold(n.Data, "tr") {
+			return
+		}
+		var cells []string
+		hasHeader := false
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type != xhtml.ElementNode {
+				continue
+			}
+			if !strings.EqualFold(child.Data, "th") && !strings.EqualFold(child.Data, "td") {
+				continue
+			}
+			if strings.EqualFold(child.Data, "th") {
+				hasHeader = true
+			}
+			cells = append(cells, cleanHTMLText(nodeTextSuppressing(child)))
+		}
+		if len(cells) > 0 {
+			rows = append(rows, htmlTableRawRow{cells: cells, hasHeader: hasHeader})
+		}
+	})
+	return rows
+}
+
+func syntheticTableHeaders(count int) []string {
+	headers := make([]string, count)
+	for i := range headers {
+		headers[i] = fmt.Sprintf("column_%d", i+1)
+	}
+	return headers
 }
 
 {{- end }}
@@ -298,7 +408,7 @@ func walkHTML(n *xhtml.Node, visit func(*xhtml.Node)) {
 	}
 }
 
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 
 func applyMeta(page *htmlExtractedPage, n *xhtml.Node) {
 	name := strings.ToLower(attrValue(n, "name"))
@@ -406,7 +516,7 @@ func htmlExtractionRequestURL(base string, path string, params map[string]string
 	return full.String()
 }
 
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 
 func htmlLinkMatchesPrefixes(path string, prefixes []string) bool {
 	if len(prefixes) == 0 {
@@ -479,7 +589,7 @@ func nodeText(n *xhtml.Node) string {
 	return strings.Join(parts, " ")
 }
 
-{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") }}
+{{- if or (.HasHTMLExtractMode "page") (.HasHTMLExtractMode "links") (.HasHTMLExtractMode "table") }}
 
 // nodeTextSuppressing walks n's descendants and concatenates TextNode content,
 // skipping subtrees rooted at noscript/script/style/template elements. The

--- a/internal/generator/templates/html_extract.go.tmpl
+++ b/internal/generator/templates/html_extract.go.tmpl
@@ -223,6 +223,9 @@ func htmlTableRows(table *xhtml.Node) []htmlTableRawRow {
 		if n.Type != xhtml.ElementNode || !strings.EqualFold(n.Data, "tr") {
 			return
 		}
+		if htmlRowBelongsToNestedTable(n, table) {
+			return
+		}
 		var cells []string
 		hasHeader := false
 		for child := n.FirstChild; child != nil; child = child.NextSibling {
@@ -242,6 +245,18 @@ func htmlTableRows(table *xhtml.Node) []htmlTableRawRow {
 		}
 	})
 	return rows
+}
+
+func htmlRowBelongsToNestedTable(row, outerTable *xhtml.Node) bool {
+	for p := row.Parent; p != nil; p = p.Parent {
+		if p == outerTable {
+			return false
+		}
+		if p.Type == xhtml.ElementNode && strings.EqualFold(p.Data, "table") {
+			return true
+		}
+	}
+	return false
 }
 
 func syntheticTableHeaders(count int) []string {

--- a/internal/generator/templates/mcp_tools.go.tmpl
+++ b/internal/generator/templates/mcp_tools.go.tmpl
@@ -549,7 +549,15 @@ func makeAPIHandler(method, pathTemplate string, readOnly bool, binaryResponse b
 {{- if $hasFormRequest}}
 			if formEncoded {
 				if len(headers) > 0 {
+					if readOnly {
+						data, _, err = c.PostQueryFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+						break
+					}
 					data, _, err = c.PostFormWithParamsAndHeaders(ctx, path, params, formFields, headers)
+					break
+				}
+				if readOnly {
+					data, _, err = c.PostQueryFormWithParams(ctx, path, params, formFields)
 					break
 				}
 				data, _, err = c.PostFormWithParams(ctx, path, params, formFields)

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -91,6 +91,7 @@ const (
 const (
 	HTMLExtractModePage         = "page"
 	HTMLExtractModeLinks        = "links"
+	HTMLExtractModeTable        = "table"
 	HTMLExtractModeEmbeddedJSON = "embedded-json"
 )
 
@@ -4596,17 +4597,17 @@ func validateEndpointResponseFormat(e Endpoint) error {
 		return nil
 	}
 	switch strings.ToUpper(strings.TrimSpace(e.Method)) {
-	case "GET", "HEAD":
+	case "GET", "HEAD", "POST":
 	default:
-		return fmt.Errorf("html response_format is only supported for GET/HEAD endpoints")
+		return fmt.Errorf("html response_format is only supported for GET/HEAD/POST endpoints")
 	}
 	if e.HTMLExtract == nil {
 		return nil
 	}
 	switch e.HTMLExtract.Mode {
-	case "", HTMLExtractModePage, HTMLExtractModeLinks, HTMLExtractModeEmbeddedJSON:
+	case "", HTMLExtractModePage, HTMLExtractModeLinks, HTMLExtractModeTable, HTMLExtractModeEmbeddedJSON:
 	default:
-		return fmt.Errorf("html_extract.mode must be one of: page, links, embedded-json")
+		return fmt.Errorf("html_extract.mode must be one of: page, links, table, embedded-json")
 	}
 	if e.HTMLExtract.Limit < 0 {
 		return fmt.Errorf("html_extract.limit must be >= 0")

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -4112,9 +4112,23 @@ func TestHTMLResponseExtractionValidation(t *testing.T) {
 	badFormat.Resources["posts"].Endpoints["list"] = ep
 	require.ErrorContains(t, badFormat.Validate(), "response_format must be one of")
 
+	postSpec := validHTMLSpec()
+	ep = postSpec.Resources["posts"].Endpoints["list"]
+	ep.Method = "POST"
+	postSpec.Resources["posts"].Endpoints["list"] = ep
+	require.NoError(t, postSpec.Validate())
+
+	tableSpec := validHTMLSpec()
+	ep = tableSpec.Resources["posts"].Endpoints["list"]
+	ep.Method = "POST"
+	ep.HTMLExtract.Mode = HTMLExtractModeTable
+	ep.Response = ResponseDef{Type: "array", Item: "html_table_row"}
+	tableSpec.Resources["posts"].Endpoints["list"] = ep
+	require.NoError(t, tableSpec.Validate())
+
 	badMethod := validHTMLSpec()
 	ep = badMethod.Resources["posts"].Endpoints["list"]
-	ep.Method = "POST"
+	ep.Method = "PUT"
 	badMethod.Resources["posts"].Endpoints["list"] = ep
 	require.ErrorContains(t, badMethod.Validate(), "html response_format is only supported")
 }


### PR DESCRIPTION
## Summary

- Promote useful POST `application/x-www-form-urlencoded` HTML table fragments from browser-sniff captures as read-only HTML/table endpoints, preserving captured form defaults and request content type.
- Allow POST `response_format: html` specs and add generated table extraction plus read-only form POST client paths that bypass verify-mode mutation short-circuiting.
- Honor `reachability_override_browser_required_to_*` generation hints for `browser_required` sniff results, with explicit conflict errors for mismatched transports.

## Issue Coverage

Fixes #3182.
Fixes #2514.
Fixes #2995.

Deferred #3244: validating or warning on non-existent derived endpoint paths needs a broader live crawl/probe pass and was kept out of this POST HTML/browser-sniff slice.

## Tests

- `go fmt ./...`
- `go test ./internal/spec ./internal/browsersniff ./internal/cli ./internal/generator -run 'TestHTMLResponseExtractionValidation|TestInferRequestSchema|TestAnalyzeCapture_PromotesPostFormHTMLTableFragment|TestGenerateCmd(AllowsBrowserRequiredWithReachabilityOverride|RejectsConflictingReachabilityOverrideTransport|RejectsPageContextTrafficAnalysisEvenWithTransportOverride)|TestGenerate(FormRequestBodyUsesFormClient|ReadOnlyFormHTMLTableEndpoint|NonFormSpecOmitsFormHelpers)|TestGenerateHTMLExtractionPerModeGating' -count=1`
- `go test ./internal/cli ./internal/generator -run 'TestGenerateCmd(AllowsBrowserRequiredWithReachabilityOverride|RejectsConflictingReachabilityOverrideTransport|RejectsPageContextTrafficAnalysisEvenWithTransportOverride)|TestGenerate(ReadOnlyFormHTMLTableEndpoint|FormRequestBodyUsesFormClient|NonFormSpecOmitsFormHelpers)' -count=1`
- `scripts/golden.sh verify`
- `scripts/verify-generator-output.sh`

Full `go test ./...` was attempted, but this worktree hit the repo's known idle full-suite hang pattern; per lane guidance I stopped waiting and relied on the focused package tests plus golden/generated-output verification above.
